### PR TITLE
[chihiro] Round-1: large model scale-up (4L/512d/8h/128sl)

### DIFF
--- a/train.py
+++ b/train.py
@@ -503,6 +503,7 @@ class Config:
     log_weight_histograms: bool = False
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
+    clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
 
@@ -1649,6 +1650,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            if config.clip_grad_norm > 0:
+                pre_clip_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), max_norm=config.clip_grad_norm
+                )
+                if should_log_gradients:
+                    gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
+                    gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
             if ema is not None:
                 ema.update(model)


### PR DESCRIPTION
## Hypothesis

Scale the Transolver backbone to 4 layers / 512 hidden / 8 heads / 128 slices — the
approximate architecture used in the prior `wandb/senpai` radford-branch champion
run, which achieved surface_rel_l2 ≈ 3.6% on val. With 96 GB VRAM per GPU and
`batch_size=2`, this model should fit comfortably on 4 GPUs without any changes to
the training loop. Larger width increases the capacity to model both surface and
volume fields simultaneously, which should improve all six target metrics.

No code changes needed — only CLI flags.

## Instructions

No modifications to `train.py` are needed.

```bash
cd target/
python train.py \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --model-mlp-ratio 4 \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --ema-decay 0.9995 \
  --wandb-group round1-large-model \
  --wandb-name chihiro-4L-512d-8h
```

- We use the stronger lr/wd/points/ema config from `codex/optimized-lineage` as the
  base, since we are testing the effect of model scale, not the entire config.
- All other flags stay at defaults.

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against: PR #3 (askeladd, 4L/256d — same base config but smaller) to isolate
the effect of 512d vs 256d width.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six per-target `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*` numbers.
3. Wall-clock run time, epoch count, GPU memory peak (from W&B or `nvidia-smi`).
4. W&B run ID and URL.
5. Training stability: grad norm range, any spikes or saturation.
6. Suggested follow-ups if this works well (e.g. even wider, or add cosine LR on top).

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
