### PR TITLE
[edward] Round-1: cosine LR schedule + linear warmup on optimized-lineage base

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,6 +578,10 @@ class Config:
     ema_start_step: int = 50
     ema_decay_start: float = 0.0
     ema_decay_end: float = 0.9999
+    lr_warmup_epochs: int = 0
+    lr_cosine_t_max: int = 0
+    lr_cosine_eta_min: float = 1e-6
+    lr_warmup_start_factor: float = 0.05
     gradient_log_every: int = 1
     log_gradient_histograms: bool = True
     weight_log_every: int = 1
@@ -1630,7 +1634,24 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    cosine_t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=cosine_t_max, eta_min=config.lr_cosine_eta_min
+    )
+    if config.lr_warmup_epochs > 0:
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=config.lr_warmup_start_factor,
+            end_factor=1.0,
+            total_iters=config.lr_warmup_epochs,
+        )
+        scheduler = torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup_scheduler, cosine_scheduler],
+            milestones=[config.lr_warmup_epochs],
+        )
+    else:
+        scheduler = cosine_scheduler
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
     if kill_thresholds:
@@ -1684,6 +1705,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
+    wandb.define_metric("train/lr", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1828,6 +1850,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         log_metrics = {
             "train/epoch_loss": epoch_train_loss,
             "lr": scheduler.get_last_lr()[0],
+            "train/lr": scheduler.get_last_lr()[0],
             "epoch_time_s": dt,
             "global_step": global_step,
         }


### PR DESCRIPTION
## Hypothesis

Add a cosine-annealing LR schedule with a 5% linear warmup to the optimized-lineage
base config. The prior `wandb/senpai` radford-branch programme found that co-tuning
`lr=4.8e-4 + cosine T_max=36` was the **single highest-impact** change, shifting
val surface_rel_l2 from ~3.83% → ~3.62%. A cosine schedule helps the model escape
early noise, then smoothly anneal into a sharp minimum, which is especially valuable
for CFD field regression where fine spatial structure is learned late in training.

This requires a **small code change** to `train.py` to add the scheduler.

## Instructions

In `train.py`, after the optimizer is constructed, add a cosine-annealing LR
scheduler with linear warmup. Here is the precise change to make:

1. Add these two config fields to the `Config` dataclass (after `ema_start_step`):

```python
lr_warmup_epochs: int = 0        # epochs of linear warmup (0 = off)
lr_cosine_t_max: int = 0         # T_max for CosineAnnealingLR (0 = off, use epochs)
```

2. After the optimizer is created (look for `optimizer = torch.optim.AdamW(...)`),
   insert the scheduler construction:

```python
if cfg.lr_warmup_epochs > 0:
    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
        optimizer,
        start_factor=0.05,
        end_factor=1.0,
        total_iters=cfg.lr_warmup_epochs,
    )
t_max = cfg.lr_cosine_t_max if cfg.lr_cosine_t_max > 0 else cfg.epochs
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
    optimizer, T_max=t_max, eta_min=1e-6
)
if cfg.lr_warmup_epochs > 0:
    lr_scheduler = torch.optim.lr_scheduler.SequentialLR(
        optimizer,
        schedulers=[warmup_scheduler, cosine_scheduler],
        milestones=[cfg.lr_warmup_epochs],
    )
else:
    lr_scheduler = cosine_scheduler
```

3. In the epoch training loop, after each epoch completes (after the validation
   block), call `lr_scheduler.step()`.

4. Log the current LR each epoch so we can see the schedule in W&B:
   ```python
   wandb.log({"train/lr": lr_scheduler.get_last_lr()[0]}, step=global_step)
   ```

Run with:

```bash
cd target/
python train.py \
  --lr 4e-4 \
  --lr-warmup-epochs 3 \
  --lr-cosine-t-max 0 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-cosine-lr \
  --wandb-name edward-cosine-lr-warmup
```

Notes:
- `--lr-cosine-t-max 0` means T_max = total epochs (governed by `SENPAI_MAX_EPOCHS`).
- `--lr 4e-4` is slightly higher than the 2e-4 floor since cosine annealing will
  drive it down naturally.
- All other flags at optimized-lineage base values (4L/256d, 65k pts, ema 0.9995).

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd, same base config without LR schedule) to isolate
the effect of the cosine schedule.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six per-target `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*` numbers.
3. W&B run ID and URL, and a link to the `train/lr` curve.
4. Comparison to askeladd's PR #3 metrics if available.
5. Training stability: grad norms, loss curve smoothness.

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
