### PR TITLE
[haku] Round-1: per-axis wall-shear channel loss weights (2x vs 3x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -505,6 +505,7 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
+    grad_clip_skip_threshold: float = 0.0
     compile_model: bool = True
     debug: bool = False
 
@@ -1706,16 +1707,38 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            skip_step = False
+            skip_reason = ""
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), max_norm=config.clip_grad_norm
                 )
+                pre_clip_val = float(pre_clip_norm)
+                if not math.isfinite(pre_clip_val):
+                    skip_step = True
+                    skip_reason = "nonfinite"
+                elif (
+                    config.grad_clip_skip_threshold > 0.0
+                    and pre_clip_val > config.grad_clip_skip_threshold
+                ):
+                    skip_step = True
+                    skip_reason = "above_threshold"
                 if should_log_gradients:
-                    gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
-                    gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
-            optimizer.step()
-            if ema is not None:
-                ema.update(model)
+                    gradient_metrics["train/grad/pre_clip_norm"] = pre_clip_val
+                    gradient_metrics["train/grad/clip_threshold"] = float(config.clip_grad_norm)
+                    gradient_metrics["train/grad/skip_threshold"] = float(
+                        config.grad_clip_skip_threshold
+                    )
+            if skip_step:
+                gradient_metrics["train/grad/skipped_step"] = 1.0
+                gradient_metrics[f"train/grad/skip_{skip_reason}"] = 1.0
+                optimizer.zero_grad(set_to_none=True)
+            else:
+                if config.clip_grad_norm > 0:
+                    gradient_metrics["train/grad/skipped_step"] = 0.0
+                optimizer.step()
+                if ema is not None:
+                    ema.update(model)
             weight_metrics = (
                 collect_weight_metrics(
                     model,
@@ -1851,7 +1874,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             log_metrics["early_stop/triggered"] = 1.0
         wandb.log(log_metrics)
 
-        improved = primary_val < best_val
+        primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0
+        improved = primary_val_is_valid and primary_val < best_val
         if improved:
             best_val = primary_val
             best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}

--- a/train.py
+++ b/train.py
@@ -476,6 +476,7 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    surface_channel_weights: str = ""
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1170,6 +1171,38 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def masked_channel_weighted_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    channel_weights: torch.Tensor,
+) -> torch.Tensor:
+    if not bool(mask.any()):
+        return pred.sum() * 0.0
+    cw = channel_weights.to(dtype=pred.dtype, device=pred.device)
+    diff = (pred - target) ** 2
+    diff = diff * cw.view(1, 1, -1)
+    mask_f = mask.unsqueeze(-1).to(dtype=pred.dtype)
+    n_channels = diff.shape[-1]
+    denom = (mask_f.sum() * n_channels).clamp(min=1.0)
+    return (diff * mask_f).sum() / denom
+
+
+def parse_surface_channel_weights(spec: str, expected_channels: int) -> list[float] | None:
+    spec = spec.strip()
+    if not spec:
+        return None
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if len(parts) != expected_channels:
+        raise ValueError(
+            f"surface_channel_weights expected {expected_channels} comma-separated values, got {len(parts)}: {spec!r}"
+        )
+    weights = [float(p) for p in parts]
+    if any(w < 0 for w in weights):
+        raise ValueError(f"surface_channel_weights must be non-negative, got {weights}")
+    return weights
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1180,6 +1213,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    surface_channel_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1219,7 +1253,15 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        if surface_channel_weights is None:
+            surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        else:
+            surface_loss = masked_channel_weighted_mse(
+                surface_pred_used,
+                surface_target_used,
+                batch.surface_mask,
+                surface_channel_weights,
+            )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
     metrics = {
@@ -1532,6 +1574,19 @@ def main(argv: Iterable[str] | None = None) -> None:
         volume_y_std=stats["volume_y_std"].to(device),
     )
 
+    surface_channel_weights_list = parse_surface_channel_weights(
+        config.surface_channel_weights, SURFACE_Y_DIM
+    )
+    surface_channel_weights_tensor: torch.Tensor | None = None
+    if surface_channel_weights_list is not None:
+        surface_channel_weights_tensor = torch.tensor(
+            surface_channel_weights_list, dtype=torch.float32, device=device
+        )
+        print(
+            "Surface channel weights "
+            f"({', '.join(SURFACE_TARGET_NAMES)}): {surface_channel_weights_list}"
+        )
+
     model = build_model(config).to(device)
     if config.compile_model:
         model = torch.compile(model)
@@ -1631,6 +1686,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                surface_channel_weights=surface_channel_weights_tensor,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()


### PR DESCRIPTION
## Hypothesis

Add per-channel loss weights for the surface targets so that the wall-shear channels
(tau_x, tau_y, tau_z) are upweighted relative to surface pressure. The current MSE
loss treats all 4 surface channels equally (1 cp + 3 wall-shear), but the AB-UPT
benchmark shows wall-shear is roughly 2x harder than pressure (7.29% vs 3.82%).
This gradient imbalance means the model sees 1/4 of signal from each wall-shear axis.
Increasing the wall-shear contribution to ~2–3x should redirect training gradient
toward the harder target without any architectural changes.

No code changes needed beyond adding channel-weight support to the loss computation.

## Instructions

**1. Add config fields to `Config`:**

```python
surface_channel_weights: str = ""    # comma-separated 4 weights for [cp, tau_x, tau_y, tau_z], e.g. "1,2,2,2"
```

**2. Parse and apply in the loss computation.** Find where the surface MSE loss is
computed (look for something like `loss = mse_loss(surface_pred_norm, surface_y_norm)`
or similar). Replace with:

```python
if cfg.surface_channel_weights:
    cw = torch.tensor(
        [float(w) for w in cfg.surface_channel_weights.split(",")],
        dtype=surface_pred_norm.dtype, device=surface_pred_norm.device,
    )  # [4]
    diff = (surface_pred_norm - surface_y_norm) ** 2  # [B, N, 4]
    diff = diff * cw.view(1, 1, 4)
    # Apply mask
    surface_loss = (diff * batch.surface_mask.unsqueeze(-1).float()).sum() / \
                   (batch.surface_mask.float().sum() * 4).clamp(min=1)
else:
    # existing MSE path unchanged
    ...
```

Adjust for however the existing loss is structured (masked mean vs sum, etc.).

**Run two configurations in parallel** (2 GPUs each, or sequentially):

**Run A — wall-shear weight 2x:**
```bash
cd target/
python train.py \
  --surface-channel-weights "1,2,2,2" \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-wallshear-weight \
  --wandb-name haku-wallshear-w2
```

**Run B — wall-shear weight 3x:**
```bash
cd target/
python train.py \
  --surface-channel-weights "1,3,3,3" \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-wallshear-weight \
  --wandb-name haku-wallshear-w3
```

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd). Focus on whether `wall_shear_rel_l2_pct` drops
and whether `surface_pressure` regresses.

## Results (fill in after run)

Add a PR comment comparing Run A vs Run B:
1. Both run IDs and W&B URLs.
2. All six `test_primary/*_rel_l2_pct` for each run.
3. Did wall_shear improve? By how much? Did pressure regress?
4. Which weight was the best trade-off?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
