### PR TITLE
[kohaku] Round-1: tangential wall-shear projection loss (physics-aware)

### DIFF
--- a/train.py
+++ b/train.py
@@ -442,6 +442,7 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    use_tangential_wallshear_loss: bool = False
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1121,6 +1122,18 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
+    """Project per-point 3-vectors onto the local tangent plane.
+
+    vec, normals: [B, N, 3] in matching coordinate frames.
+    Returns vec - (vec . n_hat) * n_hat. fp32 internally for bf16 stability.
+    """
+    vec_f = vec.float()
+    n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+    dot = (vec_f * n_hat).sum(dim=-1, keepdim=True)
+    return (vec_f - dot * n_hat).to(vec.dtype)
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1130,6 +1143,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    use_tangential_wallshear_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1141,13 +1155,44 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_pred_norm = out["surface_preds"]
+        normal_rms = float("nan")
+        if use_tangential_wallshear_loss:
+            # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
+            # in normalized space does not equal physical-space tangent projection.
+            # Denormalize -> project in physical space -> renormalize.
+            normals = batch.surface_x[..., 3:6]
+            ws_std = transform.surface_y_std[1:4]
+            ws_mean = transform.surface_y_mean[1:4]
+            ws_pred_norm = surface_pred_norm[..., 1:4]
+            ws_true_norm = surface_target[..., 1:4]
+            ws_pred_phys = ws_pred_norm * ws_std + ws_mean
+            ws_true_phys = ws_true_norm * ws_std + ws_mean
+            ws_pred_tan = project_tangential(ws_pred_phys, normals)
+            ws_true_tan = project_tangential(ws_true_phys, normals)
+            ws_pred_tan_norm = (ws_pred_tan - ws_mean) / ws_std
+            ws_true_tan_norm = (ws_true_tan - ws_mean) / ws_std
+            surface_pred_used = torch.cat([surface_pred_norm[..., :1], ws_pred_tan_norm], dim=-1)
+            surface_target_used = torch.cat([surface_target[..., :1], ws_true_tan_norm], dim=-1)
+            if bool(batch.surface_mask.any()):
+                n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+                normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
+                normal_rms = float(
+                    normal_dot[batch.surface_mask].square().mean().sqrt().detach().cpu().item()
+                )
+        else:
+            surface_pred_used = surface_pred_norm
+            surface_target_used = surface_target
+        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
-    return loss, {
+    metrics = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
     }
+    if use_tangential_wallshear_loss:
+        metrics["wallshear_pred_normal_rms"] = normal_rms
+    return loss, metrics
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -1546,6 +1591,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
+                use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1587,6 +1633,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 **gradient_metrics,
                 **weight_metrics,
             }
+            if "wallshear_pred_normal_rms" in batch_loss_metrics:
+                train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
+                    "wallshear_pred_normal_rms"
+                ]
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Add a tangential wall-shear projection loss: before computing the wall-shear MSE,
project the predicted (and target) wall-shear vectors onto the surface tangent plane
using the surface normals already available in `surface_x` (channels 3–5: nx, ny, nz).
Physically, wall-shear stress on a no-slip surface must lie in the tangent plane —
the normal component should be zero. If the model predicts a spurious normal-direction
component, the current MSE penalizes it as if it were a prediction error on the true
tangential shear, which pollutes the gradient signal. Projecting first removes this
unphysical error mode and focuses the loss on the directions that actually matter.

## Instructions

**1. Add a config flag to `Config`:**

```python
use_tangential_wallshear_loss: bool = False   # project wall-shear onto tangent plane before loss
```

**2. Add a helper function:**

```python
def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
    """Project wall-shear vectors onto surface tangent plane.
    
    vec:     [B, N, 3]  predicted or target wall-shear
    normals: [B, N, 3]  unit surface normals (from surface_x channels 3:6)
    returns: [B, N, 3]  tangential component  (vec - (vec·n)n)
    """
    n = torch.nn.functional.normalize(normals, dim=-1)  # ensure unit
    dot = (vec * n).sum(dim=-1, keepdim=True)  # [B, N, 1]
    return vec - dot * n
```

**3. In the loss computation**, when computing wall-shear MSE in **normalized** space,
apply the projection using the surface normals:

```python
if cfg.use_tangential_wallshear_loss:
    # surface_x has shape [B, N, 7]: channels 3:6 are normals
    normals = batch.surface_x[..., 3:6]  # [B, N, 3]
    # Transform normals to normalized target space is not needed —
    # the projection is geometric and scale-invariant.
    # Apply to channels 1:4 of surface_pred_norm (wall-shear) and surface_y_norm
    ws_pred = project_tangential(surface_pred_norm[..., 1:4], normals)
    ws_true = project_tangential(surface_y_norm[..., 1:4],   normals)
    surface_pred_proj = torch.cat([surface_pred_norm[..., :1], ws_pred], dim=-1)
    surface_y_proj    = torch.cat([surface_y_norm[..., :1],    ws_true], dim=-1)
    # Use projected versions for MSE (cp channel unchanged)
    surface_loss = masked_mse(surface_pred_proj, surface_y_proj, batch.surface_mask)
else:
    surface_loss = masked_mse(surface_pred_norm, surface_y_norm, batch.surface_mask)
```

Adjust `masked_mse` to whatever the existing surface loss function is in the code.
The **test/val metrics** are computed on the raw predictions (denormalized), not the
projected ones — don't change how metrics are computed, only the loss.

**Run command:**

```bash
cd target/
python train.py \
  --use-tangential-wallshear-loss \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-tangential-loss \
  --wandb-name kohaku-tangential-wallshear
```

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd), focusing on the three wall-shear axes.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*`.
3. W&B run ID and URL.
4. Per-axis wall-shear improvement vs PR #3 (which axis benefited most?).
5. Did `surface_pressure` stay stable?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
