### PR TITLE
[norman] Round-1: progressive EMA decay anneal 0.99→0.9999 (cosine schedule)

### DIFF
--- a/train.py
+++ b/train.py
@@ -424,6 +424,9 @@ class EMA:
         }
         self.backup: dict[str, torch.Tensor] | None = None
 
+    def set_decay(self, new_decay: float) -> None:
+        self.decay = float(new_decay)
+
     @torch.no_grad()
     def update(self, model: nn.Module) -> None:
         self.step_counter += 1
@@ -497,6 +500,8 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_start: float = 0.0
+    ema_decay_end: float = 0.9999
     gradient_log_every: int = 1
     log_gradient_histograms: bool = True
     weight_log_every: int = 1
@@ -1658,7 +1663,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
+            ema_decay_now: float | None = None
             if ema is not None:
+                if config.ema_decay_start > 0.0:
+                    progress = min(global_step / max(total_estimated_steps, 1), 1.0)
+                    cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
+                    ema_decay_now = config.ema_decay_start + cos_val * (
+                        config.ema_decay_end - config.ema_decay_start
+                    )
+                    ema.set_decay(ema_decay_now)
                 ema.update(model)
             weight_metrics = (
                 collect_weight_metrics(
@@ -1683,6 +1696,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            if ema_decay_now is not None:
+                train_log["train/ema_decay"] = ema_decay_now
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Anneal the EMA decay coefficient from 0.99 (start) up to 0.9999 (end) over the
course of training. The current fixed `ema_decay=0.9995` treats early noisy checkpoints
the same as late stable ones. Diffusion model training has established that starting
with a fast-updating EMA (low decay) helps track the model early when it is moving
quickly, then switching to very slow decay (high decay = very stable averaging) at
the end produces a sharper, better-calibrated EMA checkpoint. This should improve
`full_val_primary/abupt_axis_mean_rel_l2_pct` and `test_primary/*` without any model
architecture change.

## Instructions

**1. Add config fields to `Config`:**

```python
ema_decay_start: float = 0.0      # initial EMA decay (0 = use ema_decay fixed, i.e. off)
ema_decay_end: float = 0.9999     # final EMA decay when annealing
```

**2. Modify the `EMA` class** (find it in `train.py`) to accept a schedulable decay:

Add a method to update decay dynamically:
```python
def set_decay(self, new_decay: float):
    self.decay = new_decay
```

**3. In the training loop**, after each optimizer step (where EMA is updated), compute
the current annealed decay:

```python
if cfg.ema_decay_start > 0.0 and cfg.use_ema:
    # Cosine anneal from ema_decay_start to ema_decay_end
    progress = min(global_step / max_steps, 1.0)  # max_steps = total optimizer steps
    cos_val = (1 - math.cos(math.pi * progress)) / 2.0
    current_ema_decay = cfg.ema_decay_start + cos_val * (cfg.ema_decay_end - cfg.ema_decay_start)
    ema.set_decay(current_ema_decay)
    wandb.log({"train/ema_decay": current_ema_decay}, step=global_step)
```

Import `math` at the top if not already imported.

**Run command:**

```bash
cd target/
python train.py \
  --use-ema \
  --ema-decay 0.9995 \
  --ema-decay-start 0.99 \
  --ema-decay-end 0.9999 \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --wandb-group round1-ema-schedule \
  --wandb-name norman-ema-99-9999
```

Note: when `ema_decay_start > 0`, the decay ramps from 0.99→0.9999 via cosine
schedule. The `--ema-decay 0.9995` is a fallback if the schedule flag is absent.

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd, fixed EMA 0.9995). Difference should be visible in
`full_val_primary/abupt_axis_mean_rel_l2_pct` and `test_primary/*`.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*`.
3. W&B run ID and URL. Share the `train/ema_decay` curve screenshot.
4. Raw checkpoint loss vs EMA checkpoint loss at the end (gap should be larger than
   fixed-decay).

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
