### PR TITLE
[tanjiro] Round-1: SDF-gated volume attention for near-wall p_v bias

### DIFF
--- a/train.py
+++ b/train.py
@@ -380,6 +380,7 @@ class SurfaceTransolver(nn.Module):
         film_encoder_dim: int = 64,
         sdf_gate_volume: bool = False,
         sdf_gate_sigma: float = 0.05,
+        sdf_gate_mode: str = "gaussian",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -389,6 +390,11 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         self.sdf_gate_volume = sdf_gate_volume
         self.sdf_gate_sigma = sdf_gate_sigma
+        if sdf_gate_mode not in ("gaussian", "quantile"):
+            raise ValueError(
+                f"sdf_gate_mode must be 'gaussian' or 'quantile', got {sdf_gate_mode!r}"
+            )
+        self.sdf_gate_mode = sdf_gate_mode
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
@@ -443,13 +449,41 @@ class SurfaceTransolver(nn.Module):
         *,
         surface_tokens: int,
         volume_x: torch.Tensor | None,
+        volume_mask: torch.Tensor | None,
         reference: torch.Tensor,
     ) -> torch.Tensor | None:
         if not self.sdf_gate_volume or volume_x is None or volume_x.shape[-1] <= self.space_dim:
             return None
         sdf_vals = volume_x[..., self.space_dim].abs()
         sigma = max(float(self.sdf_gate_sigma), 1e-6)
-        volume_gate = torch.exp(-0.5 * (sdf_vals / sigma) ** 2).to(
+        if self.sdf_gate_mode == "quantile":
+            # Rank-space gate: scale-invariant, exact target fraction.
+            # Padded tokens get +inf so they sort to the end and do not pollute
+            # ranks of valid tokens. Per-sample normalization by N_valid keeps
+            # the rank in [0, 1] for valid tokens regardless of padding ratio.
+            if volume_mask is not None:
+                valid = volume_mask.to(dtype=torch.bool)
+                masked_sdf = torch.where(
+                    valid, sdf_vals, torch.full_like(sdf_vals, float("inf"))
+                )
+                n_valid = valid.sum(dim=1, keepdim=True).clamp(min=2)
+            else:
+                masked_sdf = sdf_vals
+                n_valid = torch.full(
+                    (sdf_vals.shape[0], 1),
+                    sdf_vals.shape[1],
+                    device=sdf_vals.device,
+                    dtype=torch.long,
+                ).clamp(min=2)
+            sorted_indices = masked_sdf.argsort(dim=1)
+            ranks = sorted_indices.argsort(dim=1).to(sdf_vals.dtype)
+            rank_norm = ranks / (n_valid - 1).to(ranks.dtype)
+            volume_gate = torch.exp(-0.5 * (rank_norm / sigma) ** 2)
+            if volume_mask is not None:
+                volume_gate = volume_gate.masked_fill(~valid, 0.0)
+        else:
+            volume_gate = torch.exp(-0.5 * (sdf_vals / sigma) ** 2)
+        volume_gate = volume_gate.to(
             device=reference.device,
             dtype=reference.dtype,
         )
@@ -510,6 +544,7 @@ class SurfaceTransolver(nn.Module):
         slice_gate = self._build_slice_gate(
             surface_tokens=surface_tokens,
             volume_x=volume_x,
+            volume_mask=volume_mask,
             reference=hidden,
         )
         hidden = self.backbone(
@@ -619,6 +654,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     sdf_gate_volume: bool = False
     sdf_gate_sigma: float = 0.05
+    sdf_gate_mode: str = "gaussian"
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -795,6 +831,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         film_encoder_dim=config.film_encoder_dim,
         sdf_gate_volume=config.sdf_gate_volume,
         sdf_gate_sigma=config.sdf_gate_sigma,
+        sdf_gate_mode=config.sdf_gate_mode,
     )
 
 
@@ -1823,9 +1860,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if mask_bool.any():
                         sdf_finite = sdf_vals[mask_bool].float().detach().cpu()
                         sigma = max(float(config.sdf_gate_sigma), 1e-6)
-                        gate_vals = torch.exp(-0.5 * (sdf_finite / sigma) ** 2)
+                        if config.sdf_gate_mode == "quantile":
+                            ranks = sdf_finite.argsort().argsort().to(torch.float32)
+                            denom = max(int(sdf_finite.numel()) - 1, 1)
+                            rank_norm = ranks / float(denom)
+                            gate_vals = torch.exp(-0.5 * (rank_norm / sigma) ** 2)
+                        else:
+                            gate_vals = torch.exp(-0.5 * (sdf_finite / sigma) ** 2)
                         sdf_init_log: dict[str, object] = {
                             "global_step": global_step,
+                            "sdf_gate/init_mode": config.sdf_gate_mode,
+                            "sdf_gate/init_sigma": sigma,
                             "sdf_gate/init_abs_sdf_mean": float(sdf_finite.mean().item()),
                             "sdf_gate/init_abs_sdf_std": float(sdf_finite.std().item()),
                             "sdf_gate/init_abs_sdf_min": float(sdf_finite.min().item()),

--- a/train.py
+++ b/train.py
@@ -167,8 +167,17 @@ class TransolverAttention(nn.Module):
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
+        # ALiBi-style learnable scalar that converts per-token gate values into
+        # an additive pre-softmax slice logit bias. Init 0 so the gate is a
+        # null-op at start; training decides whether the bias helps.
+        self.slice_gate_alpha = nn.Parameter(torch.zeros(1))
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        slice_gate: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
@@ -179,12 +188,27 @@ class TransolverAttention(nn.Module):
                 device=slice_weights.device,
                 dtype=slice_weights.dtype,
             )
+        if slice_gate is not None:
+            # Post-softmax token-level multiplicative bias: high-gate tokens
+            # contribute more to slice aggregation. (1 + alpha*gate) ensures
+            # alpha=0 → identity, far-field gate=0 → multiplier=1 (preserved).
+            slice_weights = slice_weights * (
+                1.0 + self.slice_gate_alpha * slice_gate[:, None, :, None].to(
+                    device=slice_weights.device,
+                    dtype=slice_weights.dtype,
+                )
+            )
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        slice_gate: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, slice_gate=slice_gate)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         out_slice = F.scaled_dot_product_attention(
@@ -223,9 +247,14 @@ class TransformerBlock(nn.Module):
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
         self.drop_path = DropPath(drop_path_prob)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        slice_gate: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
+        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask, slice_gate=slice_gate))
         x = _apply_token_mask(x, attn_mask)
         x = x + self.drop_path(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
@@ -319,9 +348,10 @@ class Transformer(nn.Module):
         x: torch.Tensor,
         attn_mask: torch.Tensor | None = None,
         geom_token: torch.Tensor | None = None,
+        slice_gate: torch.Tensor | None = None,
     ) -> torch.Tensor:
         for index, block in enumerate(self.blocks):
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, slice_gate=slice_gate)
             if self.film_layers is not None and geom_token is not None:
                 x = self.film_layers[index](x, geom_token)
                 x = _apply_token_mask(x, attn_mask)
@@ -348,6 +378,8 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        sdf_gate_volume: bool = False,
+        sdf_gate_sigma: float = 0.05,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -355,6 +387,8 @@ class SurfaceTransolver(nn.Module):
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
+        self.sdf_gate_volume = sdf_gate_volume
+        self.sdf_gate_sigma = sdf_gate_sigma
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
@@ -403,6 +437,26 @@ class SurfaceTransolver(nn.Module):
         if project_features is not None and x.shape[-1] > self.space_dim:
             hidden = hidden + project_features(x[:, :, self.space_dim :])
         return bias(hidden) + placeholder
+
+    def _build_slice_gate(
+        self,
+        *,
+        surface_tokens: int,
+        volume_x: torch.Tensor | None,
+        reference: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if not self.sdf_gate_volume or volume_x is None or volume_x.shape[-1] <= self.space_dim:
+            return None
+        sdf_vals = volume_x[..., self.space_dim].abs()
+        sigma = max(float(self.sdf_gate_sigma), 1e-6)
+        volume_gate = torch.exp(-0.5 * (sdf_vals / sigma) ** 2).to(
+            device=reference.device,
+            dtype=reference.dtype,
+        )
+        if surface_tokens == 0:
+            return volume_gate
+        surface_gate = volume_gate.new_zeros(volume_gate.shape[0], surface_tokens)
+        return torch.cat([surface_gate, volume_gate], dim=1)
 
     def forward(
         self,
@@ -453,7 +507,17 @@ class SurfaceTransolver(nn.Module):
         geom_token: torch.Tensor | None = None
         if self.use_film and self.geom_encoder is not None and surface_x is not None:
             geom_token = self.geom_encoder(surface_x, surface_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask, geom_token=geom_token)
+        slice_gate = self._build_slice_gate(
+            surface_tokens=surface_tokens,
+            volume_x=volume_x,
+            reference=hidden,
+        )
+        hidden = self.backbone(
+            hidden,
+            attn_mask=attn_mask,
+            geom_token=geom_token,
+            slice_gate=slice_gate,
+        )
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -553,6 +617,8 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    sdf_gate_volume: bool = False
+    sdf_gate_sigma: float = 0.05
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -727,6 +793,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        sdf_gate_volume=config.sdf_gate_volume,
+        sdf_gate_sigma=config.sdf_gate_sigma,
     )
 
 
@@ -1595,6 +1663,36 @@ def log_model_artifact(
     print(f"Logged model artifact '{artifact_name}'")
 
 
+def collect_sdf_gate_metrics(model: nn.Module) -> dict[str, float]:
+    """Snapshot the per-block learnable SDF gate scalars."""
+    base_model = getattr(model, "_orig_mod", model)
+    metrics: dict[str, float] = {}
+    backbone = getattr(base_model, "backbone", None)
+    if backbone is None:
+        return metrics
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return metrics
+    values: list[float] = []
+    for idx, block in enumerate(blocks):
+        attention = getattr(block, "attention", None)
+        if attention is None:
+            continue
+        alpha = getattr(attention, "slice_gate_alpha", None)
+        if alpha is None:
+            continue
+        scalar = float(alpha.detach().float().reshape(-1)[0].item())
+        metrics[f"sdf_gate/alpha_block_{idx}"] = scalar
+        values.append(scalar)
+    if values:
+        metrics["sdf_gate/alpha_mean"] = float(sum(values) / len(values))
+        metrics["sdf_gate/alpha_max_abs"] = float(max(abs(v) for v in values))
+    sigma = getattr(base_model, "sdf_gate_sigma", None)
+    if sigma is not None:
+        metrics["sdf_gate/sigma"] = float(sigma)
+    return metrics
+
+
 def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
     print(
         f"{prefix:<14s} "
@@ -1683,6 +1781,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("sdf_gate/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
@@ -1696,6 +1795,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_metrics: dict[str, float] = {}
     global_step = 0
     early_stop_reason: str | None = None
+    sdf_distribution_logged = False
     timeout_hit = False
     train_start = time.time()
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
@@ -1714,6 +1814,37 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if config.sdf_gate_volume and not sdf_distribution_logged:
+                volume_x = getattr(batch, "volume_x", None)
+                volume_mask = getattr(batch, "volume_mask", None)
+                if volume_x is not None and volume_mask is not None and volume_x.shape[-1] > 3:
+                    sdf_vals = volume_x[..., 3].abs()
+                    mask_bool = volume_mask.bool()
+                    if mask_bool.any():
+                        sdf_finite = sdf_vals[mask_bool].float().detach().cpu()
+                        sigma = max(float(config.sdf_gate_sigma), 1e-6)
+                        gate_vals = torch.exp(-0.5 * (sdf_finite / sigma) ** 2)
+                        sdf_init_log: dict[str, object] = {
+                            "global_step": global_step,
+                            "sdf_gate/init_abs_sdf_mean": float(sdf_finite.mean().item()),
+                            "sdf_gate/init_abs_sdf_std": float(sdf_finite.std().item()),
+                            "sdf_gate/init_abs_sdf_min": float(sdf_finite.min().item()),
+                            "sdf_gate/init_abs_sdf_max": float(sdf_finite.max().item()),
+                        }
+                        quantile_levels = (0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99)
+                        quantile_vals = sdf_finite.quantile(torch.tensor(list(quantile_levels))).tolist()
+                        for q, v in zip(quantile_levels, quantile_vals):
+                            sdf_init_log[f"sdf_gate/init_abs_sdf_q{int(q * 100):02d}"] = v
+                        sdf_init_log["sdf_gate/init_gate_mean"] = float(gate_vals.mean().item())
+                        sdf_init_log["sdf_gate/init_gate_frac_above_0p5"] = float((gate_vals > 0.5).float().mean().item())
+                        sdf_init_log["sdf_gate/init_gate_frac_above_0p1"] = float((gate_vals > 0.1).float().mean().item())
+                        try:
+                            sdf_init_log["sdf_gate/init_abs_sdf_hist"] = wandb.Histogram(sdf_finite.numpy())
+                            sdf_init_log["sdf_gate/init_gate_hist"] = wandb.Histogram(gate_vals.numpy())
+                        except Exception:
+                            pass
+                        wandb.log(sdf_init_log)
+                        sdf_distribution_logged = True
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1831,6 +1962,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             "epoch_time_s": dt,
             "global_step": global_step,
         }
+        if config.sdf_gate_volume:
+            log_metrics.update(collect_sdf_gate_metrics(model))
         if early_stop_reason is not None:
             log_metrics["early_stop/triggered"] = 1.0
             wandb.log(log_metrics)


### PR DESCRIPTION
## Hypothesis

Add SDF-distance gating to the volume attention mechanism: bias the slice-attention
routing scores toward volume points that are close to the surface (small |SDF|),
where pressure gradients are largest and predicting `volume_pressure` is hardest.
The `volume_sdf` channel is already available in `volume_x` (channel 3). Currently,
the Transolver treats all volume points equally in its slice-attention pooling, but
near-wall volume points are physically critical for drag and lift. Directing more
attention capacity toward them should improve `volume_pressure_rel_l2_pct` (6.08%)
without adding parameters.

## Instructions

**1. Add config fields to `Config`:**

```python
sdf_gate_volume: bool = False     # gate volume slice-attention by SDF proximity
sdf_gate_sigma: float = 0.1       # bandwidth (in normalized SDF units) for Gaussian gate
```

**2. Locate the volume branch of the Transolver model in `train.py`.** Find where
the volume tokens pass through slice-attention (look for `TransolverAttention` or
equivalent called on `volume_x`). The slice routing computes attention scores
between input tokens and slice tokens; modify it to multiply these scores by an
SDF proximity weight.

The SDF gate: a Gaussian proximity weight based on absolute SDF value:

```python
def sdf_gate(sdf: torch.Tensor, sigma: float) -> torch.Tensor:
    """Compute soft gate favoring near-wall points (small |SDF|).
    
    sdf:   [B, N, 1]  signed distance (channel 3 of volume_x)
    returns: [B, N, 1]  gate values in (0, 1], highest near surface
    """
    return torch.exp(-0.5 * (sdf.abs() / sigma) ** 2)
```

Inside the volume branch forward pass, before or after the slice-token pooling step,
multiply the per-point features (or attention logits) by this gate:

```python
if self.sdf_gate_volume:
    # volume_x: [B, N, 4], channel 3 is SDF
    sdf_vals = volume_x[..., 3:4]  # [B, N, 1]
    gate = sdf_gate(sdf_vals, self.sdf_gate_sigma)  # [B, N, 1]
    # Scale point features before attention (emphasize near-wall points)
    volume_x = volume_x * (1.0 + gate)  # additive gate to preserve far-field
```

The simplest integration: scale `volume_x` before it enters the backbone. This does
not require modifying the attention internals — just the input features.

Pass `sdf_gate_volume` and `sdf_gate_sigma` to the model constructor and store them
as attributes so the gate can be applied inside `model.forward()`.

**Run command:**

```bash
cd target/
python train.py \
  --sdf-gate-volume \
  --sdf-gate-sigma 0.1 \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-sdf-gate \
  --wandb-name tanjiro-sdf-gate-s01
```

Note: the SDF values in the dataset are normalized. The default `sigma=0.1` means
we gate at ~0.1 standard deviations from zero in normalized space. Adjust if the
SDF distribution is much wider (log the SDF histogram or check W&B feature stats).

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd). Focus on `volume_pressure_rel_l2_pct`.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*`.
3. W&B run ID and URL.
4. SDF distribution in your training data (check `volume_x[:, :, 3]` stats in W&B).
   If sigma=0.1 was too narrow, report what a better value would be.
5. Did `volume_pressure` specifically improve vs PR #3?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
