### PR TITLE
[violet] Round-1: surface-area-weighted MSE loss (physics-consistent)

### DIFF
--- a/train.py
+++ b/train.py
@@ -476,6 +476,8 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    use_area_weighted_loss: bool = False  # weight surface MSE by surface_x[..., 6] (area)
+    area_weight_clip: float = 10.0  # cap normalized area weight at this multiple of mean (0 disables)
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1169,6 +1171,66 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def _area_weighted_surface_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    areas: torch.Tensor,
+    *,
+    weight_clip: float = 0.0,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Surface MSE weighted by per-element area, scale-matched to plain F.mse_loss.
+
+    Each valid token's normalized weight has mean 1.0 per sample (so the loss
+    matches the unweighted MSE magnitude when areas are uniform). Optionally
+    clips weights to ``weight_clip * mean`` to cap heavy-tailed contributions.
+    """
+
+    if not bool(mask.any()):
+        zero = pred.sum() * 0.0
+        return zero, {
+            "area_w_mean": 0.0,
+            "area_w_max": 0.0,
+            "area_w_p99": 0.0,
+            "area_w_clipped_fraction": 0.0,
+        }
+
+    mask_f = mask.unsqueeze(-1).to(pred.dtype)  # [B, N, 1]
+    areas = areas.to(pred.dtype).clamp(min=0)
+    areas_masked = areas * mask_f
+    n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)
+    total_area = areas_masked.sum(dim=1, keepdim=True).clamp(min=1e-6)
+    area_w = areas * n_valid / total_area  # mean 1.0 over valid points per sample
+
+    clipped_count = torch.zeros((), device=pred.device, dtype=pred.dtype)
+    if weight_clip > 0:
+        cap = float(weight_clip)
+        over = (area_w > cap) & mask.unsqueeze(-1)
+        clipped_count = over.to(pred.dtype).sum()
+        area_w = torch.minimum(area_w, area_w.new_tensor(cap))
+
+    diff = (pred - target) ** 2  # [B, N, 4]
+    weighted = diff * area_w * mask_f
+    num_channels = float(diff.shape[-1])
+    surface_loss = weighted.sum() / (mask_f.sum() * num_channels).clamp(min=1)
+
+    valid = mask.unsqueeze(-1)
+    area_w_valid = area_w[valid]
+    area_w_mean = float(area_w_valid.float().mean().detach().cpu().item())
+    area_w_max = float(area_w_valid.float().max().detach().cpu().item())
+    p99 = torch.quantile(area_w_valid.float(), 0.99) if area_w_valid.numel() > 0 else area_w_valid.new_zeros(())
+    area_w_p99 = float(p99.detach().cpu().item())
+    clipped_fraction = float(
+        (clipped_count / mask_f.sum().clamp(min=1)).detach().cpu().item()
+    )
+    return surface_loss, {
+        "area_w_mean": area_w_mean,
+        "area_w_max": area_w_max,
+        "area_w_p99": area_w_p99,
+        "area_w_clipped_fraction": clipped_fraction,
+    }
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1179,6 +1241,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    use_area_weighted_loss: bool = False,
+    area_weight_clip: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1218,15 +1282,36 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        unweighted_surface_loss = masked_mse(
+            surface_pred_used, surface_target_used, batch.surface_mask
+        )
+        if use_area_weighted_loss:
+            areas = batch.surface_x[..., 6:7]
+            surface_loss, area_diag = _area_weighted_surface_loss(
+                surface_pred_used,
+                surface_target_used,
+                batch.surface_mask,
+                areas,
+                weight_clip=area_weight_clip,
+            )
+        else:
+            surface_loss = unweighted_surface_loss
+            area_diag = {}
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
     metrics = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
+        "surface_loss_unweighted": float(unweighted_surface_loss.detach().cpu().item()),
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if use_area_weighted_loss:
+        metrics["area_loss_to_uniform_ratio"] = (
+            metrics["surface_loss"] / max(metrics["surface_loss_unweighted"], 1e-12)
+        )
+        for key, value in area_diag.items():
+            metrics[key] = value
     return loss, metrics
 
 
@@ -1599,6 +1684,62 @@ def main(argv: Iterable[str] | None = None) -> None:
     with config_path.open("w") as f:
         yaml.safe_dump(asdict(config), f)
 
+    if config.use_area_weighted_loss:
+        try:
+            sample_batch = next(iter(train_loader))
+            sample_areas_full = sample_batch.surface_x[..., 6].float()
+            sample_mask = sample_batch.surface_mask.bool()
+            valid_areas = sample_areas_full[sample_mask].clamp(min=0)
+            if valid_areas.numel() > 0:
+                quantiles = torch.tensor(
+                    [0.01, 0.10, 0.50, 0.90, 0.95, 0.99, 0.999],
+                    dtype=torch.float32,
+                )
+                area_qs = torch.quantile(valid_areas, quantiles)
+                # Per-sample normalized weights for weight-distribution diagnostics
+                mask_f = sample_mask.unsqueeze(-1).float()
+                areas_3d = sample_areas_full.unsqueeze(-1).clamp(min=0)
+                areas_masked = areas_3d * mask_f
+                n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)
+                total_area = areas_masked.sum(dim=1, keepdim=True).clamp(min=1e-6)
+                w = (areas_3d * n_valid / total_area)[sample_mask.unsqueeze(-1)]
+                w_qs = torch.quantile(w, quantiles)
+                startup_log: dict[str, object] = {
+                    "train/area_dist/min": float(valid_areas.min().item()),
+                    "train/area_dist/max": float(valid_areas.max().item()),
+                    "train/area_dist/mean": float(valid_areas.mean().item()),
+                    "train/area_dist/std": float(valid_areas.std().item()),
+                    "train/area_dist/p01": float(area_qs[0].item()),
+                    "train/area_dist/p10": float(area_qs[1].item()),
+                    "train/area_dist/p50": float(area_qs[2].item()),
+                    "train/area_dist/p90": float(area_qs[3].item()),
+                    "train/area_dist/p95": float(area_qs[4].item()),
+                    "train/area_dist/p99": float(area_qs[5].item()),
+                    "train/area_dist/p999": float(area_qs[6].item()),
+                    "train/area_w_dist/min": float(w.min().item()),
+                    "train/area_w_dist/max": float(w.max().item()),
+                    "train/area_w_dist/mean": float(w.mean().item()),
+                    "train/area_w_dist/p99": float(w_qs[5].item()),
+                    "train/area_w_dist/p999": float(w_qs[6].item()),
+                    "train/area_w_dist/fraction_above_clip": float(
+                        (w > max(config.area_weight_clip, 0.0)).float().mean().item()
+                    ) if config.area_weight_clip > 0 else 0.0,
+                    "train/area_dist/hist": wandb.Histogram(valid_areas.cpu().numpy()),
+                    "train/area_w_dist/hist": wandb.Histogram(w.cpu().numpy()),
+                    "global_step": 0,
+                }
+                wandb.log(startup_log)
+                print(
+                    f"Area dist: min={startup_log['train/area_dist/min']:.4g} "
+                    f"p50={startup_log['train/area_dist/p50']:.4g} "
+                    f"p99={startup_log['train/area_dist/p99']:.4g} "
+                    f"max={startup_log['train/area_dist/max']:.4g} "
+                    f"| weight max={startup_log['train/area_w_dist/max']:.2f} "
+                    f"p99={startup_log['train/area_w_dist/p99']:.2f}"
+                )
+        except StopIteration:
+            print("WARN: train loader empty, skipping area distribution log.")
+
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
     global_step = 0
@@ -1630,6 +1771,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                use_area_weighted_loss=config.use_area_weighted_loss,
+                area_weight_clip=config.area_weight_clip,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1666,6 +1809,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_log: dict[str, object] = {
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
+                "train/surface_loss_unweighted": batch_loss_metrics["surface_loss_unweighted"],
                 "train/volume_loss": batch_loss_metrics["volume_loss"],
                 "global_step": global_step,
                 **gradient_metrics,
@@ -1675,6 +1819,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            for diag_key in (
+                "area_w_mean",
+                "area_w_max",
+                "area_w_p99",
+                "area_w_clipped_fraction",
+                "area_loss_to_uniform_ratio",
+            ):
+                if diag_key in batch_loss_metrics:
+                    train_log[f"train/{diag_key}"] = batch_loss_metrics[diag_key]
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -478,6 +478,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     use_area_weighted_loss: bool = False  # weight surface MSE by surface_x[..., 6] (area)
     area_weight_clip: float = 10.0  # cap normalized area weight at this multiple of mean (0 disables)
+    max_grad_norm: float = 1.0  # global grad-norm clip; <= 0 disables (bug-fix: previously absent)
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1792,6 +1793,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            if config.max_grad_norm > 0:
+                grad_norm_pre_clip = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), config.max_grad_norm
+                )
+                gradient_metrics["train/grad/global_norm_pre_clip"] = float(grad_norm_pre_clip)
+                gradient_metrics["train/grad/clipped"] = float(
+                    grad_norm_pre_clip > config.max_grad_norm
+                )
             optimizer.step()
             if ema is not None:
                 ema.update(model)


### PR DESCRIPTION
## Hypothesis

Weight the surface loss by the surface element area (`surface_area`, already in
`surface_x` channel 6). Currently each surface point contributes equally to the
loss regardless of area, but this is physically inconsistent — large-area cells
should contribute more to integrated drag/lift force. Area-weighted loss aligns
training directly with the physics: errors on large-area patches matter more.
This is a change to the loss computation only and uses geometry data already
available in the existing feature tensor.

## Instructions

**1. Add config field to `Config`:**

```python
use_area_weighted_loss: bool = False   # weight surface MSE by element area
```

**2. Modify the surface loss computation** in the training loop. Find where the
surface MSE loss is computed on masked tokens. Replace the unweighted MSE with:

```python
if cfg.use_area_weighted_loss:
    # surface_x: [B, N, 7], channel 6 = area
    areas = batch.surface_x[..., 6:7].float()   # [B, N, 1]
    areas = areas.clamp(min=0)                   # no negative areas
    # Normalize weights per sample so total area = 1 (avoid scale shift)
    area_sum = (areas * batch.surface_mask.unsqueeze(-1).float()).sum(dim=1, keepdim=True).clamp(min=1e-6)
    area_w = areas / area_sum  # [B, N, 1] normalized per sample

    diff = (surface_pred_norm - surface_y_norm) ** 2  # [B, N, 4]
    # Apply area weight and mask
    weighted = diff * area_w * batch.surface_mask.unsqueeze(-1).float()
    surface_loss = weighted.sum() / (batch.surface_mask.float().sum().clamp(min=1))
else:
    # existing unweighted path
    ...
```

**Run command:**

```bash
cd target/
python train.py \
  --use-area-weighted-loss \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --wandb-group round1-area-weighted \
  --wandb-name violet-area-weighted-loss
```

Note: if the area distribution is very skewed (a few huge cells dominate), consider
capping weights at the 95th percentile and logging the area distribution histogram
to W&B at the start of the run.

## Baseline

No prior `yi` runs exist. Targets to beat (AB-UPT, lower is better):

| Metric | AB-UPT target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
| `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
| `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
| `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |

Compare against PR #3 (askeladd). Both surface and volume metrics are of interest.

## Results (fill in after run)

Add a PR comment with:
1. `test_primary/abupt_axis_mean_rel_l2_pct` and all six `test_primary/*_rel_l2_pct`.
2. `full_val_primary/*`.
3. W&B run ID and URL.
4. Surface area distribution summary (min/max/mean/std) to confirm the weights are
   reasonable.
5. Were there areas with extreme weights that you needed to clip?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
