### PR TITLE
[kohaku] Normal-component suppression on top of tangential projection

### DIFF
--- a/train.py
+++ b/train.py
@@ -553,6 +553,7 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    normal_suppression_weight: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1263,6 +1264,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    normal_suppression_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1276,6 +1278,8 @@ def train_loss(
         )
         surface_pred_norm = out["surface_preds"]
         normal_rms = float("nan")
+        normal_suppression_loss_val = float("nan")
+        normal_suppression_term: torch.Tensor | None = None
         if use_tangential_wallshear_loss:
             # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
             # in normalized space does not equal physical-space tangent projection.
@@ -1296,13 +1300,22 @@ def train_loss(
             if bool(batch.surface_mask.any()):
                 n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
                 normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
+                mask_f = batch.surface_mask.float()
+                denom = mask_f.sum().clamp_min(1.0)
+                normal_sq = normal_dot.square() * mask_f
+                normal_suppression_term = normal_sq.sum() / denom
+                normal_suppression_loss_val = float(
+                    normal_suppression_term.detach().cpu().item()
+                )
                 normal_rms = float(
-                    normal_dot[batch.surface_mask].square().mean().sqrt().detach().cpu().item()
+                    normal_suppression_term.detach().sqrt().cpu().item()
                 )
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
         surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        if normal_suppression_weight > 0.0 and normal_suppression_term is not None:
+            surface_loss = surface_loss + normal_suppression_weight * normal_suppression_term.to(surface_loss.dtype)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
     metrics: dict[str, float] = {
@@ -1311,6 +1324,8 @@ def train_loss(
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+        if normal_suppression_weight > 0.0:
+            metrics["wallshear_normal_suppression_loss"] = normal_suppression_loss_val
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -1723,6 +1738,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                normal_suppression_weight=config.normal_suppression_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1782,6 +1798,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "wallshear_normal_suppression_loss" in batch_loss_metrics:
+                train_log["train/wallshear_normal_suppression_loss"] = batch_loss_metrics[
+                    "wallshear_normal_suppression_loss"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

Your tangential wall-shear projection loss (PR #11) is now the merged yi
baseline (`abupt_axis_mean=35.12`). But your own diagnostic
`train/wallshear_pred_normal_rms` showed the predicted normal component grows
~2.4× during a single epoch (0.52 → 1.21 in physical Pa) — exactly the failure
mode the researcher pass predicted. With the projection removing gradient
signal in the normal direction, the model has no incentive to suppress
unphysical normal components, so capacity is being wasted on a degree of
freedom that's physically constrained to zero on a no-slip wall.

**Adding an explicit normal-component penalty fixes this directly.** A small
auxiliary loss `λ * mean((ws_pred_phys · n_hat)^2 · mask)` drives the
predicted normal component back toward zero, freeing capacity for tangential
prediction. The right `λ` is unknown a priori, so we sweep.

This experiment also serves as **the first multi-epoch run with the
projection loss**: PR #11 only completed 1 epoch (timeout pre-fix). With your
timeout fix and `--validation-every 1` we should now reach 4–5 epochs and see
whether projection continues to help past epoch 1, or whether the train→val
divergence pattern (norman/nezuko) reasserts itself even with the projection.

## Instructions

You are starting from `yi` HEAD (`4ef11f8`), which already includes:

- Your tangential projection code (`use_tangential_wallshear_loss`).
- Your `project_tangential` helper.
- The `train/wallshear_pred_normal_rms` diagnostic.
- The per-step timeout fix (your contribution from PR #12 → `af92e9a`).

**1. Add a config flag:**

```python
normal_suppression_weight: float = 0.0   # λ for ((ws_pred_phys · n_hat)^2) penalty
```

**2. Add the regularizer to the loss path** — wherever the surface loss is
computed and you compute `ws_pred_phys` for the projection. After the
projection step, before reduction:

```python
if cfg.normal_suppression_weight > 0.0:
    # ws_pred_phys: [B, N, 3] in physical (Pa) units (you already compute this for the projection)
    # n_hat:        [B, N, 3] normalized surface normals (you already compute this)
    normal_dot = (ws_pred_phys * n_hat).sum(dim=-1)        # [B, N]
    # masked mean over surface points
    mask = batch.surface_mask.float()                      # [B, N]
    denom = mask.sum().clamp_min(1.0)
    normal_loss = (normal_dot.pow(2) * mask).sum() / denom
    surface_loss = surface_loss + cfg.normal_suppression_weight * normal_loss
```

**Cast to fp32** for the squaring step (same precaution you applied in
`project_tangential`) — `bf16 ** 2` underflows badly for small dot products.

**Log the regularizer separately** as `train/wallshear_normal_suppression_loss`
and the diagnostic `train/wallshear_pred_normal_rms` you already added — this
is exactly the metric we want to see decrease as λ goes up.

**3. Sweep λ across 4 arms in parallel** (4 GPUs, one arm each):

| GPU | `--normal-suppression-weight` | `--wandb-name` |
|---|---:|---|
| 0 | 0.0 | `kohaku-normsupp-l00` |
| 1 | 0.01 | `kohaku-normsupp-l001` |
| 2 | 0.1 | `kohaku-normsupp-l01` |
| 3 | 1.0 | `kohaku-normsupp-l1` |

The `λ=0` arm is the **explicit control** — it reproduces PR #11 (merged
baseline) but on a multi-epoch budget thanks to the timeout fix. This lets us
both:

(a) Confirm projection-only continues to help past epoch 1 (or expose the
divergence pattern reasserting with the projection in play).
(b) Measure the marginal value of the suppression term cleanly.

**Run command (template — set `CUDA_VISIBLE_DEVICES` and λ per arm):**

```bash
cd target/
python train.py \
  --use-tangential-wallshear-loss \
  --normal-suppression-weight <LAMBDA> \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --validation-every 1 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --agent kohaku \
  --wandb-group kohaku-normsupp-sweep \
  --wandb-name kohaku-normsupp-<SLUG>
```

## Baseline (current yi best — PR #11, merged 2026-04-29)

| Metric | yi best (`uy0ds6iz`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **35.12** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **10.07** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **43.05** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **14.99** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **30.85** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **42.06** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **77.65** | 3.63 |

Any λ that drops `test_primary/abupt_axis_mean_rel_l2_pct` below 35.12 is a
new yi best. Wall-shear axes are the largest gap to AB-UPT, so we expect (and
hope) the suppression regularizer pushes those numbers down.

## Results (fill in after run)

Add a PR comment with:

1. For each of the 4 arms: every `test_primary/*_rel_l2_pct` and
   `full_val_primary/*_rel_l2_pct` row (lower is better).
2. **Trajectory plot**: per-epoch `val_primary/abupt_axis_mean_rel_l2_pct`
   for all 4 arms on one axis. Include the W&B chart link.
3. **Diagnostic plot**: `train/wallshear_pred_normal_rms` per step for all 4
   arms — this is the smoking-gun we are targeting. Did λ=0.01, 0.1, 1.0 in
   fact suppress the normal component to near zero? Did the suppression
   match the relative weighting we expect?
4. `best_epoch` for each arm.
5. **Verdict**: which λ wins, and is it a new yi best vs the merged PR #11
   baseline?
6. **Multi-epoch projection check**: does the λ=0 arm continue to improve
   past epoch 1 (i.e., is projection-only still helping over more epochs),
   or does it plateau like norman/nezuko did with `best_epoch=1`?
7. W&B run IDs and URLs for all arms.

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES` — your
  timeout fix on `yi` is the right way to use the budget.
- `test_primary/*` must **not** be NaN.
- Keep the existing tangential projection on (`--use-tangential-wallshear-loss`)
  — this experiment is **on top of** the merged baseline, not a replacement.
