### PR TITLE
[emma] Round-2: squared rel-L2 aux loss (numerically stable, no sqrt)

### DIFF
--- a/train.py
+++ b/train.py
@@ -585,6 +585,7 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
+    aux_rel_l2_weight: float = 0.0
     compile_model: bool = True
     debug: bool = False
 
@@ -1241,6 +1242,28 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def squared_rel_l2_loss(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Squared relative-L2 auxiliary loss. No sqrt — numerically stable.
+
+    ratio = sum_valid(||pred - target||^2) / sum_valid(||target||^2 + eps)
+    Returns mean over batch.
+    """
+    if pred.numel() == 0 or not bool(mask.any()):
+        return pred.sum() * 0.0
+    pred_f = pred.float()
+    target_f = target.float()
+    mask_f = mask.float()
+    eps = pred_f.new_tensor(1e-8)
+    diff_sq = ((pred_f - target_f) ** 2).sum(dim=-1)  # [B, N]
+    tgt_sq = (target_f ** 2).sum(dim=-1)  # [B, N]
+    diff_sq = diff_sq * mask_f
+    tgt_sq = tgt_sq * mask_f
+    per_sample = diff_sq.sum(dim=1) / (tgt_sq.sum(dim=1) + eps)  # [B] — no sqrt
+    return per_sample.mean().to(pred.dtype)
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1263,6 +1286,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    aux_rel_l2_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1304,11 +1328,29 @@ def train_loss(
             surface_target_used = surface_target
         surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        base_loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        loss = base_loss
+        aux_surface = None
+        aux_volume = None
+        if aux_rel_l2_weight > 0.0:
+            aux_surface = squared_rel_l2_loss(
+                surface_pred_norm, surface_target, batch.surface_mask
+            )
+            aux_volume = squared_rel_l2_loss(
+                out["volume_preds"], volume_target, batch.volume_mask
+            )
+            loss = loss + aux_rel_l2_weight * (aux_surface + aux_volume)
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
+        "base_mse_loss": float(base_loss.detach().cpu().item()),
     }
+    if aux_surface is not None:
+        metrics["aux_rel_l2_surface"] = float(aux_surface.detach().cpu().item())
+        metrics["aux_rel_l2_volume"] = float(aux_volume.detach().cpu().item())
+        metrics["aux_rel_l2_loss"] = float(
+            (aux_rel_l2_weight * (aux_surface + aux_volume)).detach().cpu().item()
+        )
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1723,6 +1765,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                aux_rel_l2_weight=config.aux_rel_l2_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1782,6 +1825,16 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "base_mse_loss" in batch_loss_metrics:
+                train_log["train/base_mse_loss"] = batch_loss_metrics["base_mse_loss"]
+            if "aux_rel_l2_loss" in batch_loss_metrics:
+                train_log["train/aux_rel_l2_loss"] = batch_loss_metrics["aux_rel_l2_loss"]
+                train_log["train/aux_rel_l2_surface"] = batch_loss_metrics[
+                    "aux_rel_l2_surface"
+                ]
+                train_log["train/aux_rel_l2_volume"] = batch_loss_metrics[
+                    "aux_rel_l2_volume"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

The relative-L2 auxiliary loss from Round-1 PR #6 is theoretically sound — aligning the training loss with the AB-UPT evaluation metric (`abupt_axis_mean_rel_l2_pct`) should help. But the implementation was numerically unstable: the `sqrt()` backward path hits singularities when surface target norms are small in denormalized space, causing Inf gradients that even skip-step cannot rescue.

**Key insight from PR #6 (emma's own result):** smaller weights (0.01) diverged *earlier* than larger weights (0.05), which proves weight magnitude is NOT the controlling variable. The instability lives in the backward path through `sqrt((diff_sum + ε)/(tgt_sum + ε))`.

**Fix:** Drop the `sqrt()`. Return `ratio.mean()` instead of `ratio.sqrt().mean()`. The minimizer is **identical** — both are minimized when `||pred - target||² / ||target||²` is small — but the squared formulation has a smooth backward path with no singularities. This is the cleanest diagnostic for whether sqrt is the issue.

**Secondary benefit:** the squared loss has larger gradient signal for outlier samples (proportional to `ratio` not `sqrt(ratio)`), which may actually improve optimization in the tail of the distribution.

This PR also uses the gilbert PR #9 winning base config (vol_w=2.0, bs=8, val_every=1) so we are **guaranteed a test_primary/* row** even if the auxiliary loss does nothing — the stability baseline is the gilbert config, not a fresh default run.

## Instructions

In `target/train.py`, add a `--aux-rel-l2-weight` CLI flag (default 0.0) and the squared relative-L2 auxiliary loss as follows:

**1. Add CLI argument (in the argparse block):**
```python
parser.add_argument("--aux-rel-l2-weight", type=float, default=0.0,
    help="Weight for squared relative-L2 auxiliary loss (0 = disabled)")
```

**2. Add the loss function (module-level, before the training loop):**
```python
def squared_rel_l2_loss(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
    """
    Squared relative-L2 auxiliary loss. No sqrt — numerically stable.
    ratio = sum_valid(||pred - target||^2) / sum_valid(||target||^2 + eps)
    Returns mean over batch.
    """
    eps = pred.new_tensor(1e-8)
    diff_sq = ((pred - target) ** 2).sum(dim=-1)   # [B, N]
    tgt_sq  = (target ** 2).sum(dim=-1)              # [B, N]
    # mask out padded points
    diff_sq = diff_sq * mask
    tgt_sq  = tgt_sq  * mask
    n_valid = mask.sum(dim=1).clamp(min=1)
    per_sample = diff_sq.sum(dim=1) / (tgt_sq.sum(dim=1) + eps)  # [B] — no sqrt
    return per_sample.mean()
```

**3. In the training loop, after computing the base MSE loss, add the auxiliary term when `config.aux_rel_l2_weight > 0`:**
```python
if config.aux_rel_l2_weight > 0.0:
    aux_s = squared_rel_l2_loss(surface_preds, surface_targets, surface_mask)
    aux_v = squared_rel_l2_loss(volume_preds,  volume_targets,  volume_mask)
    aux_loss = config.aux_rel_l2_weight * (aux_s + aux_v)
    loss = loss + aux_loss
    # log separately for diagnostics
    log_dict["train/aux_rel_l2_loss"] = aux_loss.item()
```

**4. Run two arms to bracket the weight:**
- **Arm A:** `--aux-rel-l2-weight 0.1` (baseline gilbert config + squared aux loss)
- **Arm B:** `--aux-rel-l2-weight 0.5` (higher weight — squared ratio has smaller magnitude than sqrt ratio, so higher weight is appropriate)

Use `--wandb-group round2-squared-rel-l2` so both arms are grouped.

**Run command for each arm (substitute the weight):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --aux-rel-l2-weight 0.1 \
  --wandb-group round2-squared-rel-l2
```

**Diagnostic to add:** log `train/aux_rel_l2_loss` and `train/base_mse_loss` separately (as above) — the ratio tells us whether the auxiliary term is contributing meaningfully.

**If both arms diverge:** the squared formulation is also unstable and this approach is a dead end. In that case, try running the gilbert config with no aux loss as a sanity check to confirm the base training is healthy.

**If only one arm diverges:** report which weight worked and I will assign a follow-up with the working weight + gradient clipping once PR #22 (gilbert) lands.

## Baseline (current yi best — PR #9, run y2gigs61)

| Metric | Current best | AB-UPT target |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **17.3933** | — |
| `surface_pressure_rel_l2_pct` | **11.0733** | 3.82 |
| `wall_shear_rel_l2_pct` | **18.3180** | 7.29 |
| `volume_pressure_rel_l2_pct` | **15.2059** | 6.08 |
| `wall_shear_x_rel_l2_pct` | **15.6465** | 5.35 |
| `wall_shear_y_rel_l2_pct` | **21.8605** | 3.65 |
| `wall_shear_z_rel_l2_pct` | **23.1803** | 3.63 |

Beat `abupt_axis_mean_rel_l2_pct < 17.39` to set a new baseline. Note: FiLM PR #8 (frieren) is pending merge with 16.53 — so the effective bar is **16.53** once merged.

## Reproduce baseline (gilbert PR #9 config)
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
