### PR TITLE
[nezuko] Round-2: ANP cross-attention surface decoder (A01)

### DIFF
--- a/train.py
+++ b/train.py
@@ -183,7 +183,12 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        return_slice_tokens: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
@@ -197,7 +202,13 @@ class TransolverAttention(nn.Module):
         out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
         out_x = _apply_token_mask(out_x, attn_mask)
         out_x = self.proj_dropout(self.proj(out_x))
-        return _apply_token_mask(out_x, attn_mask)
+        out_x = _apply_token_mask(out_x, attn_mask)
+        if return_slice_tokens:
+            slice_tokens_flat = out_slice.permute(0, 2, 1, 3).contiguous().view(
+                out_slice.shape[0], out_slice.shape[2], self.hidden_dim
+            )
+            return out_x, slice_tokens_flat
+        return out_x
 
 
 class TransformerBlock(nn.Module):
@@ -223,12 +234,25 @@ class TransformerBlock(nn.Module):
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
         self.drop_path = DropPath(drop_path_prob)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        return_slice_tokens: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
+        if return_slice_tokens:
+            attn_out, slice_tokens = self.attention(
+                self.norm1(x), attn_mask=attn_mask, return_slice_tokens=True
+            )
+            x = x + self.drop_path(attn_out)
+        else:
+            x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
         x = _apply_token_mask(x, attn_mask)
         x = x + self.drop_path(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
+        if return_slice_tokens:
+            return x, slice_tokens
         return x
 
 
@@ -264,10 +288,156 @@ class Transformer(nn.Module):
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        return_slice_tokens: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        last_idx = len(self.blocks) - 1
+        slice_tokens_last: torch.Tensor | None = None
+        for i, block in enumerate(self.blocks):
+            if return_slice_tokens and i == last_idx:
+                x, slice_tokens_last = block(x, attn_mask=attn_mask, return_slice_tokens=True)
+            else:
+                x = block(x, attn_mask=attn_mask)
+        if return_slice_tokens:
+            return x, slice_tokens_last
         return x
+
+
+class ANPCrossAttentionLayer(nn.Module):
+    """Pre-norm cross-attention layer for the ANP-style surface decoder.
+
+    Q = per-point surface embeddings; K/V = backbone slice-token anchors.
+    A learnable scalar gate (init=1.0, full pass-through) scales the cross-attn
+    residual: Q/K/V receive normal gradient from step 0 vs. zero-init pathology
+    (softmax saturating to uniform, q/k gradients ~1e-12 in bf16) seen in PR #35.
+    """
+
+    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.0):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.scale = self.head_dim ** -0.5
+        self.q_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.kv_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.proj_dropout = nn.Dropout(dropout)
+        for module in (self.q_proj, self.k_proj, self.v_proj, self.out_proj):
+            _init_linear(module)
+        self.gate = nn.Parameter(torch.ones(1))
+
+    def forward(
+        self, q_in: torch.Tensor, kv_in: torch.Tensor
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        q_x = self.q_norm(q_in)
+        kv_x = self.kv_norm(kv_in)
+        b, l, _ = q_x.shape
+        s = kv_x.shape[1]
+        h = self.num_heads
+        d = self.head_dim
+        q = self.q_proj(q_x).view(b, l, h, d).transpose(1, 2)
+        k = self.k_proj(kv_x).view(b, s, h, d).transpose(1, 2)
+        v = self.v_proj(kv_x).view(b, s, h, d).transpose(1, 2)
+        attn_logits = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+        attn = F.softmax(attn_logits, dim=-1)
+        with torch.no_grad():
+            attn_d = attn.detach().float()
+            log_attn = (attn_d + 1e-9).log()
+            entropy_per_head = -(attn_d * log_attn).sum(dim=-1).mean(dim=(0, 2))
+            mean_entropy = entropy_per_head.mean()
+            head_entropy_std = (
+                entropy_per_head.std(unbiased=False) if h > 1 else torch.zeros_like(mean_entropy)
+            )
+            top_k = min(4, s)
+            top_mass = attn_d.topk(top_k, dim=-1).values.sum(dim=-1).mean()
+        out = torch.matmul(attn, v)
+        out = out.transpose(1, 2).contiguous().view(b, l, self.hidden_dim)
+        out = self.proj_dropout(self.out_proj(out)) * self.gate
+        return out, {
+            "entropy": mean_entropy,
+            "head_entropy_std": head_entropy_std,
+            "top4_mass": top_mass,
+            "gate": self.gate.detach().squeeze(),
+        }
+
+
+class ANPSurfaceDecoder(nn.Module):
+    """ANP-style cross-attention decoder for surface predictions.
+
+    Stacks num_layers cross-attention layers (Q = per-point surface embeddings,
+    K/V = backbone slice-token anchors), each with a residual connection. A
+    learnable per-anchor positional embedding `slice_pos_embed` is added to
+    the slice tokens before the first cross-attn layer, breaking the
+    slice-token uniformity floor that otherwise zeroes Q/K gradients (PR #35).
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int,
+        output_dim: int,
+        num_slices: int,
+        num_layers: int = 2,
+        num_heads: int = 8,
+        dropout: float = 0.0,
+        use_slice_pos_embed: bool = True,
+        detach_slice_tokens: bool = False,
+    ):
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError("num_layers must be >= 1")
+        self.num_layers = num_layers
+        self.num_slices = num_slices
+        self.detach_slice_tokens = detach_slice_tokens
+        self.layers = nn.ModuleList(
+            [
+                ANPCrossAttentionLayer(hidden_dim, num_heads, dropout=dropout)
+                for _ in range(num_layers)
+            ]
+        )
+        if use_slice_pos_embed:
+            self.slice_pos_embed = nn.Parameter(torch.randn(1, num_slices, hidden_dim) * 0.02)
+        else:
+            self.register_parameter("slice_pos_embed", None)
+        self.norm_final = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.out = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+        self.out.apply(_init_linear)
+
+    def forward(
+        self,
+        surface_q: torch.Tensor,
+        slice_kv: torch.Tensor,
+        surface_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        if self.detach_slice_tokens:
+            slice_kv = slice_kv.detach()
+        if self.slice_pos_embed is not None:
+            slice_kv = slice_kv + self.slice_pos_embed.to(dtype=slice_kv.dtype)
+        x = surface_q
+        diagnostics: dict[str, torch.Tensor] = {}
+        for i, layer in enumerate(self.layers):
+            attn_out, diag = layer(x, slice_kv)
+            x = x + attn_out
+            diagnostics[f"anp_attn_entropy_layer{i}"] = diag["entropy"]
+            diagnostics[f"anp_head_entropy_std_layer{i}"] = diag["head_entropy_std"]
+            diagnostics[f"anp_top4_mass_layer{i}"] = diag["top4_mass"]
+            diagnostics[f"anp_gate_layer{i}"] = diag["gate"]
+        x = self.norm_final(x)
+        out = self.out(x)
+        out = out * surface_mask.unsqueeze(-1).to(dtype=out.dtype, device=out.device)
+        return out, diagnostics
 
 
 class SurfaceTransolver(nn.Module):
@@ -288,6 +458,12 @@ class SurfaceTransolver(nn.Module):
         mlp_ratio: int = 4,
         slice_num: int = 96,
         stochastic_depth_prob: float = 0.0,
+        use_anp_surface_decoder: bool = False,
+        anp_surface_decoder_layers: int = 2,
+        anp_surface_decoder_heads: int = 8,
+        anp_surface_decoder_dropout: float = 0.0,
+        anp_use_slice_pos_embed: bool = True,
+        anp_detach_slice_tokens: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -319,7 +495,22 @@ class SurfaceTransolver(nn.Module):
             stochastic_depth_prob=stochastic_depth_prob,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        self.use_anp_surface_decoder = use_anp_surface_decoder
+        if use_anp_surface_decoder:
+            self.surface_out = None
+            self.anp_surface_decoder = ANPSurfaceDecoder(
+                hidden_dim=n_hidden,
+                output_dim=self.surface_output_dim,
+                num_slices=slice_num,
+                num_layers=anp_surface_decoder_layers,
+                num_heads=anp_surface_decoder_heads,
+                dropout=anp_surface_decoder_dropout,
+                use_slice_pos_embed=anp_use_slice_pos_embed,
+                detach_slice_tokens=anp_detach_slice_tokens,
+            )
+        else:
+            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.anp_surface_decoder = None
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -382,7 +573,13 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        slice_tokens_last: torch.Tensor | None = None
+        if self.use_anp_surface_decoder and surface_x is not None:
+            hidden, slice_tokens_last = self.backbone(
+                hidden, attn_mask=attn_mask, return_slice_tokens=True
+            )
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -391,8 +588,14 @@ class SurfaceTransolver(nn.Module):
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
+        anp_diagnostics: dict[str, torch.Tensor] = {}
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_anp_surface_decoder:
+                surface_preds, anp_diagnostics = self.anp_surface_decoder(
+                    surface_hidden, slice_tokens_last, surface_mask
+                )
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -403,13 +606,16 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out_dict: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        for key, value in anp_diagnostics.items():
+            out_dict[f"diag_{key}"] = value
+        return out_dict
 
 
 class EMA:
@@ -503,6 +709,13 @@ class Config:
     log_weight_histograms: bool = False
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
+    clip_grad_norm: float = 0.0
+    use_anp_surface_decoder: bool = False
+    anp_surface_decoder_layers: int = 2
+    anp_surface_decoder_heads: int = 8
+    anp_surface_decoder_dropout: float = 0.0
+    anp_use_slice_pos_embed: bool = True
+    anp_detach_slice_tokens: bool = False
     compile_model: bool = True
     debug: bool = False
 
@@ -643,6 +856,12 @@ def build_model(config: Config) -> SurfaceTransolver:
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
         stochastic_depth_prob=config.stochastic_depth_prob,
+        use_anp_surface_decoder=config.use_anp_surface_decoder,
+        anp_surface_decoder_layers=config.anp_surface_decoder_layers,
+        anp_surface_decoder_heads=config.anp_surface_decoder_heads,
+        anp_surface_decoder_dropout=config.anp_surface_decoder_dropout,
+        anp_use_slice_pos_embed=config.anp_use_slice_pos_embed,
+        anp_detach_slice_tokens=config.anp_detach_slice_tokens,
     )
 
 
@@ -1227,6 +1446,9 @@ def train_loss(
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    for key, value in out.items():
+        if key.startswith("diag_") and isinstance(value, torch.Tensor) and value.numel() == 1:
+            metrics[key] = float(value.detach().cpu().item())
     return loss, metrics
 
 
@@ -1649,6 +1871,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            if config.clip_grad_norm > 0:
+                pre_clip_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), max_norm=config.clip_grad_norm
+                )
+                if should_log_gradients:
+                    gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
+                    gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
             if ema is not None:
                 ema.update(model)
@@ -1675,6 +1904,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            for diag_key, diag_value in batch_loss_metrics.items():
+                if diag_key.startswith("diag_"):
+                    train_log[f"train/{diag_key.removeprefix('diag_')}"] = diag_value
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -710,6 +710,8 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
+    grad_skip_threshold: float = 0.0
+    grad_skip_nonfinite: bool = True
     use_anp_surface_decoder: bool = False
     anp_surface_decoder_layers: int = 2
     anp_surface_decoder_heads: int = 8
@@ -1871,16 +1873,48 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
-            if config.clip_grad_norm > 0:
-                pre_clip_norm = torch.nn.utils.clip_grad_norm_(
-                    model.parameters(), max_norm=config.clip_grad_norm
+            grad_tensors = [p.grad for p in model.parameters() if p.grad is not None]
+            if grad_tensors:
+                pre_clip_total_norm = torch.norm(
+                    torch.stack([g.detach().norm(2) for g in grad_tensors]),
+                    2,
                 )
-                if should_log_gradients:
-                    gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
-                    gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
-            optimizer.step()
-            if ema is not None:
-                ema.update(model)
+            else:
+                pre_clip_total_norm = torch.zeros((), device=device)
+            pre_clip_norm_finite = bool(torch.isfinite(pre_clip_total_norm))
+            pre_clip_norm_value = (
+                float(pre_clip_total_norm) if pre_clip_norm_finite else float("inf")
+            )
+            skip_step = False
+            skip_reason = ""
+            if config.grad_skip_nonfinite and not pre_clip_norm_finite:
+                skip_step = True
+                skip_reason = "nonfinite"
+            elif (
+                config.grad_skip_threshold > 0
+                and pre_clip_norm_finite
+                and pre_clip_norm_value > config.grad_skip_threshold
+            ):
+                skip_step = True
+                skip_reason = "spike"
+            if skip_step:
+                optimizer.zero_grad(set_to_none=True)
+            else:
+                if config.clip_grad_norm > 0:
+                    torch.nn.utils.clip_grad_norm_(
+                        model.parameters(),
+                        max_norm=config.clip_grad_norm,
+                        error_if_nonfinite=False,
+                    )
+                optimizer.step()
+                if ema is not None:
+                    ema.update(model)
+            if should_log_gradients:
+                gradient_metrics["train/grad/pre_clip_norm"] = pre_clip_norm_value
+                gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
+                gradient_metrics["train/grad/skip_threshold"] = (
+                    config.grad_skip_threshold
+                )
             weight_metrics = (
                 collect_weight_metrics(
                     model,
@@ -1896,6 +1930,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
                 "train/volume_loss": batch_loss_metrics["volume_loss"],
+                "train/grad/pre_clip_norm_step": pre_clip_norm_value,
+                "train/grad/step_skipped": float(skip_step),
+                "train/grad/step_skipped_nonfinite": float(
+                    skip_step and skip_reason == "nonfinite"
+                ),
+                "train/grad/step_skipped_spike": float(
+                    skip_step and skip_reason == "spike"
+                ),
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,

--- a/train.py
+++ b/train.py
@@ -711,6 +711,7 @@ class Config:
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
     grad_skip_threshold: float = 0.0
+    grad_skip_warmup_steps: int = 0
     grad_skip_nonfinite: bool = True
     use_anp_surface_decoder: bool = False
     anp_surface_decoder_layers: int = 2
@@ -1892,6 +1893,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 skip_reason = "nonfinite"
             elif (
                 config.grad_skip_threshold > 0
+                and global_step >= config.grad_skip_warmup_steps
                 and pre_clip_norm_finite
                 and pre_clip_norm_value > config.grad_skip_threshold
             ):


### PR DESCRIPTION
## Hypothesis

Replace Transolver's per-point MLP projection head on the surface stream with a
**cross-attention ANP (Attentive Neural Process) decoder**. Instead of decoding each
surface point independently from its local slice token, surface query points attend
globally to the full set of slice tokens produced by the encoder. This gives the
model a global context at decode time — every predicted surface value is conditioned
on all slice representations simultaneously.

**Why this should work:**
- Wall shear stress (`tau_x/y/z`) has high spatial correlation across the car
  surface — a value at the roof affects the wake, which affects the rear. An MLP
  that operates point-by-point cannot exploit this. Cross-attention can.
- **Prior art is extremely strong:** noam branch PR #2379 (MERGED) swapped the
  surface decoder for an ANP cross-attention head on TandemFoil and got
  **−70% in-domain pressure error, −48% OOD**. This is the single largest
  architectural win in the programme's history on any dataset.
- DrivAerML has richer 3D geometry than the 2D foil case; the global context
  signal should be at least as strong.

**Primary targets:** `wall_shear` (7.29% AB-UPT floor), `tau_x/y/z`.

## Instructions

You are replacing the surface MLP head inside the `train.py` model. The backbone
(Transolver encoder with slice attention) is unchanged — only the surface decoder
changes.

### Step 1: Understand the current surface head

Find where `train.py` decodes surface point predictions. It will look roughly like:

```python
# After Transolver forward pass (simplified):
# surface_feats: [B, N_surface, D]  — per-point features from backbone
surface_out = self.surface_head(surface_feats)  # MLP → [B, N_surface, 4]
```

The slice tokens from the Transolver encoder are the context. Find where they are
computed — they are typically the intermediate representations after the slice-pooling
step, before the final per-point scatter. They have shape `[B, S, D]` where
`S = model_slices` (128 in the default config).

### Step 2: Add the ANP cross-attention decoder module

Add this class to `train.py` (before the main model class):

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class ANPSurfaceDecoder(nn.Module):
    """
    Cross-attention ANP surface decoder.
    Queries: surface point embeddings [B, N_q, D_q]
    Context (keys/values): Transolver slice tokens [B, S, D]
    Output: [B, N_q, out_dim]
    """
    def __init__(self, query_dim: int, context_dim: int, hidden_dim: int,
                 out_dim: int, num_heads: int = 8, num_layers: int = 2,
                 dropout: float = 0.0):
        super().__init__()
        assert hidden_dim % num_heads == 0

        # Project surface point features to query space
        self.query_proj = nn.Linear(query_dim, hidden_dim)
        # Project slice tokens to key/value space
        self.kv_proj = nn.Linear(context_dim, hidden_dim * 2)

        self.layers = nn.ModuleList([
            nn.MultiheadAttention(hidden_dim, num_heads, dropout=dropout,
                                  batch_first=True)
            for _ in range(num_layers)
        ])
        self.norms = nn.ModuleList([
            nn.LayerNorm(hidden_dim) for _ in range(num_layers)
        ])
        # Small MLP projector → output
        self.out_proj = nn.Sequential(
            nn.LayerNorm(hidden_dim),
            nn.Linear(hidden_dim, hidden_dim),
            nn.GELU(),
            nn.Linear(hidden_dim, out_dim),
        )

    def forward(self, surface_feats, slice_tokens):
        """
        surface_feats: [B, N_q, query_dim]   — per-point surface features
        slice_tokens:  [B, S, context_dim]   — Transolver slice representations
        returns:       [B, N_q, out_dim]
        """
        q = self.query_proj(surface_feats)          # [B, N_q, H]
        kv = self.kv_proj(slice_tokens)              # [B, S, 2H]
        k, v = kv.chunk(2, dim=-1)                  # each [B, S, H]

        for attn, norm in zip(self.layers, self.norms):
            # Cross-attention: queries attend to slice-token context
            attn_out, _ = attn(q, k, v)
            q = norm(q + attn_out)                  # residual + norm

        return self.out_proj(q)                      # [B, N_q, out_dim]
```

### Step 3: Wire it into the model

In the main model's `__init__`, replace the surface MLP head:

```python
# Remove:
# self.surface_head = nn.Sequential(nn.Linear(D, D), nn.ReLU(), nn.Linear(D, 4))

# Add:
self.surface_decoder = ANPSurfaceDecoder(
    query_dim=model_hidden_dim,    # matches backbone output dim
    context_dim=model_hidden_dim,  # slice token dim = model hidden dim
    hidden_dim=model_hidden_dim,   # keep same width
    out_dim=4,                     # surface outputs: p_s + tau_x + tau_y + tau_z
    num_heads=model_heads,         # reuse --model-heads flag
    num_layers=2,                  # 2 cross-attention layers
)
```

In the model's `forward`, pass the slice tokens to the decoder:

```python
# Instead of:
# surface_out = self.surface_head(surface_feats)

# Do:
surface_out = self.surface_decoder(surface_feats, slice_tokens)
```

**How to find `slice_tokens`:** In the Transolver, slice tokens are the intermediate
`[B, S, D]` tensors after the slice-pooling attention step but before scatter back
to points. If the backbone does not expose them as a separate output, you may need
to add a return value from the backbone's `forward` or store them as an attribute
during the forward pass. Trace through the code until you find the slice pooling
step.

### Step 4: Run the experiment

Use the PR #9 winning config as the base:

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group nezuko-anp-decoder
```

**Important:** if PR #22 (gilbert, gradient clipping) has not yet merged onto `yi`,
add this line between `loss.backward()` and `optimizer.step()` in your branch to
pre-empt the instability your EMA diagnostic uncovered:

```python
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
```

Note it in your results comment so we can confirm it matches PR #22 when that lands.

### Failure mode and mitigation

If the cross-attention OOM at 65k surface points × 128 slice tokens, the context
is much smaller than the query set, so OOM should not be an issue (128 keys, not
65k). But if you see memory pressure, try reducing `--train-surface-points 50000`
first before touching the architecture.

If `val_primary` is worse than the MLP baseline at epoch 1, check:
1. Is `slice_tokens` actually the slice pooling output (not the per-point scattered
   features)? The shape should be `[B, 128, 256]`, not `[B, 65536, 256]`.
2. Are the cross-attention layer norms initialized to something reasonable?
   Consider adding identity-initialized projection weights.

## Baseline

Current yi best: **PR #9 gilbert**, run `y2gigs61`, 6 epochs, best_epoch=3.
PR #8 frieren (FiLM, `hltti2ec`) is verified at 16.53 and will be the new yi best
once a merge-conflict rebase completes — treat 16.53 as your working target.

| Metric | yi best (PR #9) | FiLM pending (PR #8) | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | 17.39 | **16.53** | — |
| `surface_pressure_rel_l2_pct` | 11.07 | 10.38 | 3.82 |
| `wall_shear_rel_l2_pct` | 18.32 | 17.29 | 7.29 |
| `volume_pressure_rel_l2_pct` | 15.21 | 14.91 | 6.08 |
| `wall_shear_x_rel_l2_pct` | 15.65 | 14.76 | 5.35 |
| `wall_shear_y_rel_l2_pct` | 21.86 | 20.59 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 23.18 | 22.00 | 3.63 |

Beat 16.53 on `abupt_axis_mean_rel_l2_pct` to set a new yi best.

**Reproduce (base config):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## What to report

Post your W&B run ID(s) and the full `test_primary/*` table in a comment. Report:
- Did you need to expose `slice_tokens` as a separate output from the backbone?
- What was the parameter count delta vs the MLP head?
- Was GPU memory usage significantly different?
- Did you observe the same epoch-1 divergence pattern? (Given your EMA diagnostic,
  this is especially relevant — note if gradient clipping changed the trajectory.)
