### PR TITLE
[chihiro] Round-2: width×FiLM×cosine-EMA composition at 512d

### DIFF
--- a/train.py
+++ b/train.py
@@ -232,6 +232,41 @@ class TransformerBlock(nn.Module):
         return x
 
 
+class GeomEncoder(nn.Module):
+    """Mean-pooled MLP encoder over surface points to a per-case geometry token."""
+
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, out_dim),
+        )
+        self.net.apply(_init_linear)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        mask_f = mask.to(dtype=x.dtype).unsqueeze(-1)
+        x_masked = x * mask_f
+        n_valid = mask_f.sum(dim=1).clamp(min=1.0)
+        x_mean = x_masked.sum(dim=1) / n_valid
+        return self.net(x_mean)
+
+
+class FiLMLayer(nn.Module):
+    """FiLM with AdaLN-zero init: gamma=0, beta=0 at start so output equals input."""
+
+    def __init__(self, geom_dim: int, hidden_dim: int):
+        super().__init__()
+        self.to_gamma_beta = nn.Linear(geom_dim, 2 * hidden_dim)
+        nn.init.zeros_(self.to_gamma_beta.weight)
+        nn.init.zeros_(self.to_gamma_beta.bias)
+
+    def forward(self, h: torch.Tensor, geom: torch.Tensor) -> torch.Tensor:
+        gb = self.to_gamma_beta(geom)
+        gamma, beta = gb.chunk(2, dim=-1)
+        return h * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+
+
 class Transformer(nn.Module):
     def __init__(
         self,
@@ -242,6 +277,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
+        film_geom_dim: int = 0,
     ):
         super().__init__()
         if depth <= 1:
@@ -263,10 +299,25 @@ class Transformer(nn.Module):
                 for i in range(depth)
             ]
         )
+        self.film_layers = (
+            nn.ModuleList(
+                [FiLMLayer(film_geom_dim, hidden_dim) for _ in range(depth)]
+            )
+            if film_geom_dim > 0
+            else None
+        )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        for block in self.blocks:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        geom_token: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        for index, block in enumerate(self.blocks):
             x = block(x, attn_mask=attn_mask)
+            if self.film_layers is not None and geom_token is not None:
+                x = self.film_layers[index](x, geom_token)
+                x = _apply_token_mask(x, attn_mask)
         return x
 
 
@@ -288,6 +339,8 @@ class SurfaceTransolver(nn.Module):
         mlp_ratio: int = 4,
         slice_num: int = 96,
         stochastic_depth_prob: float = 0.0,
+        use_film: bool = False,
+        film_encoder_dim: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -297,6 +350,8 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+        self.use_film = use_film
+        self.film_encoder_dim = film_encoder_dim
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -309,6 +364,11 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        self.geom_encoder = (
+            GeomEncoder(self.surface_input_dim, film_encoder_dim * 2, film_encoder_dim)
+            if use_film
+            else None
+        )
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -317,6 +377,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
+            film_geom_dim=film_encoder_dim if use_film else 0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -382,7 +443,10 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        geom_token: torch.Tensor | None = None
+        if self.use_film and self.geom_encoder is not None and surface_x is not None:
+            geom_token = self.geom_encoder(surface_x, surface_mask)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, geom_token=geom_token)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -423,6 +487,9 @@ class EMA:
             if param.requires_grad
         }
         self.backup: dict[str, torch.Tensor] | None = None
+
+    def set_decay(self, new_decay: float) -> None:
+        self.decay = float(new_decay)
 
     @torch.no_grad()
     def update(self, model: nn.Module) -> None:
@@ -497,6 +564,10 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_start: float = 0.0
+    ema_decay_end: float = 0.9999
+    use_film: bool = False
+    film_encoder_dim: int = 64
     gradient_log_every: int = 1
     log_gradient_histograms: bool = True
     weight_log_every: int = 1
@@ -644,6 +715,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
         stochastic_depth_prob=config.stochastic_depth_prob,
+        use_film=config.use_film,
+        film_encoder_dim=config.film_encoder_dim,
     )
 
 
@@ -1658,7 +1731,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
+            ema_decay_now: float | None = None
             if ema is not None:
+                if config.ema_decay_start > 0.0:
+                    progress = min(global_step / max(total_estimated_steps, 1), 1.0)
+                    cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
+                    ema_decay_now = config.ema_decay_start + cos_val * (
+                        config.ema_decay_end - config.ema_decay_start
+                    )
+                    ema.set_decay(ema_decay_now)
                 ema.update(model)
             weight_metrics = (
                 collect_weight_metrics(
@@ -1683,6 +1764,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            if ema_decay_now is not None:
+                train_log["train/ema_decay"] = ema_decay_now
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Your PR #4 (4L/512d/8h, `pejudvyd`) proved that doubling model width from 256d→512d
yields a clean +4.3% improvement on every axis vs the merged baseline, with `volume_pressure`
winning most (14.37 vs 15.21). Two other independent wins — per-block FiLM geometry
conditioning (PR #8, frieren, −4.9% abupt at 256d) and progressive cosine EMA anneal
(PR #13, norman, −9.0% abupt at 256d) — are verified but pending rebase onto yi.

**Hypothesis:** these three gains are orthogonal and should compose. FiLM adds per-car
geometry specialization (targets surface tokens), cosine EMA improves late-training
checkpoint quality (targets epoch selection), and 512d adds volumetric capacity
(targets volume pressure). Stacking all three on the 512d base should push
`abupt_axis_mean` below 14, potentially toward 12–13.

**Expected gain from composition:**
- 256d baseline: 17.39 (merged PR #9)
- FiLM alone (256d): 16.53 (−4.9%)
- Cosine EMA alone (256d): 15.82 (−9.0%)
- Width alone (512d, your PR #4): 16.64 (−4.3%)
- Composition estimate: ~12.5–13.5 (linear combination of improvements, likely with
  some interaction)

## Instructions

Start from `yi` (already has your 512d code from PR #4 squash-merge). You need to
port two code changes from other student branches, then run on the 512d config.

### Step 1 — Port cosine EMA from `norman/round1-progressive-ema-decay`

Look at PR #13 / branch `norman/round1-progressive-ema-decay` for the implementation.
The key changes are:

**Add to `Config`:**
```python
ema_decay_start: float = 0.0      # initial EMA decay (0.0 = disabled, use fixed ema_decay)
ema_decay_end: float = 0.9999     # final EMA decay at end of training
```

**In the EMA class,** add a `set_decay(new_decay: float)` method that sets `self.decay = new_decay`.

**In the training loop** (after each optimizer step, where EMA is currently updated):
```python
if cfg.ema_decay_start > 0.0 and cfg.use_ema:
    progress = min(global_step / max_steps, 1.0)
    cos_val = (1 - math.cos(math.pi * progress)) / 2.0
    current_ema_decay = cfg.ema_decay_start + cos_val * (cfg.ema_decay_end - cfg.ema_decay_start)
    ema.set_decay(current_ema_decay)
```

Wire `max_steps = total_steps_across_all_epochs` (compute from dataset size, batch size, epochs at job start).

### Step 2 — Port FiLM from `frieren/round1-geometry-film-conditioning`

Look at PR #8 / branch `frieren/round1-geometry-film-conditioning` for the full
implementation. The key pieces:

**Add to `Config`:**
```python
use_film: bool = False
film_encoder_dim: int = 64
```

**Add classes:**
- `GeomEncoder`: mean-pooled MLP over surface points → single geometry token per case
- `FiLMLayer`: `to_gamma_beta = Linear(geom_dim, 2*hidden_dim)` applied as `h * (1 + gamma) + beta`

**In the training loop**, if `cfg.use_film`, encode the surface geometry ONCE per batch,
then modulate each Transolver block's hidden state after each attention layer.

Use AdaLN-zero init: initialize `to_gamma_beta.weight` and `to_gamma_beta.bias` to zero
so FiLM starts as identity (gamma=0, beta=0 → no modification). This is critical for
training stability with FiLM.

### Step 3 — Compose on 512d config

Run with ALL of the following:

```bash
cd target/
python train.py \
  --model-hidden-dim 512 --model-heads 8 --model-layers 4 --model-slices 128 \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.9995 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --use-film \
  --use-tangential-wallshear-loss \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group b06-width-film-ema-composition
```

**Why `lr=5e-5`:** your PR #4 established that 512d diverges at `lr=2e-4`. Keep `5e-5`.
**Why `bs=4`:** largest batch fitting 96GB at 512d. Keep it.
**Why tangential projection:** already on yi (from PR #11 kohaku), adds the physics-aware
wall-shear constraint at zero extra cost. Adds no new code.

### Step 4 — Report

In your PR results comment, report:
1. Full `test_primary/*` table
2. Epoch-by-epoch val trajectory (confirm val improves monotonically — if best_epoch=1,
   flag it immediately, gradient clipping PR #22 may be needed)
3. VRAM peak usage and iteration speed (it/s)
4. Any gradient norm spikes visible in W&B

## Baseline to beat

Current merged yi baseline (PR #4 chihiro, W&B run `pejudvyd`):

| Metric | yi best (target to beat) | AB-UPT public |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **16.64** | — |
| `surface_pressure_rel_l2_pct` | 10.65 | 3.82 |
| `wall_shear_rel_l2_pct` | 17.66 | 7.29 |
| `volume_pressure_rel_l2_pct` | 14.37 | 6.08 |
| `wall_shear_x_rel_l2_pct` | 14.87 | 5.35 |
| `wall_shear_y_rel_l2_pct` | 19.89 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 21.73 | 3.63 |

Lower is better. Your run already established the 512d baseline at 16.64 — your target
here is to get composition synergy below the sum-of-parts.

**Pending merges in flight** (will update yi soon):
- PR #8 frieren FiLM (16.53 at 256d) — rebasing now
- PR #13 norman cosine EMA (15.82 at 256d) — rebasing now

If these merge before you start, their code will be on yi and you can skip the manual
port above — just use the flags `--use-film` and `--ema-decay-start 0.99 --ema-decay-end 0.9999`
directly. Check `python train.py --help` to confirm flag availability before porting.
