### PR TITLE
[askeladd] Round-1: full yi composition stack (512d + cosine-EMA + tangential + vol_w=2.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    cosine_ema_decay,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -54,6 +55,7 @@ from trainer_runtime import (
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
+    project_tangential,
     run_final_evaluation,
     should_update_best_checkpoint,
     timeout_budget_minutes,
@@ -99,7 +101,10 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_start: float = 0.0
+    ema_decay_end: float = 0.9999
     eval_raw_vs_ema: bool = False
+    use_tangential_wallshear_loss: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
@@ -160,6 +165,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    use_tangential_wallshear_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -171,19 +177,63 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_pred_norm = out["surface_preds"]
+        normal_rms_value = float("nan")
+        if use_tangential_wallshear_loss:
+            # Wall-shear stds are non-uniform, so projecting in normalized space
+            # does NOT equal physical-space tangent projection. Denormalize the
+            # vector wall-shear channels, project onto the per-point tangent
+            # plane, then renormalize before the MSE.
+            normals = batch.surface_x[..., 3:6]
+            ws_std = transform.surface_y_std[1:4].to(surface_pred_norm.device)
+            ws_mean = transform.surface_y_mean[1:4].to(surface_pred_norm.device)
+            ws_pred_norm = surface_pred_norm[..., 1:4]
+            ws_true_norm = surface_target[..., 1:4]
+            ws_pred_phys = ws_pred_norm * ws_std + ws_mean
+            ws_true_phys = ws_true_norm * ws_std + ws_mean
+            ws_pred_tan = project_tangential(ws_pred_phys, normals)
+            ws_true_tan = project_tangential(ws_true_phys, normals)
+            ws_pred_tan_norm = (ws_pred_tan - ws_mean) / ws_std
+            ws_true_tan_norm = (ws_true_tan - ws_mean) / ws_std
+            surface_pred_used = torch.cat(
+                [surface_pred_norm[..., :1], ws_pred_tan_norm.to(surface_pred_norm.dtype)],
+                dim=-1,
+            )
+            surface_target_used = torch.cat(
+                [surface_target[..., :1], ws_true_tan_norm.to(surface_target.dtype)],
+                dim=-1,
+            )
+            if bool(batch.surface_mask.any()):
+                n_hat = torch.nn.functional.normalize(normals.float(), dim=-1, eps=1e-8)
+                normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
+                normal_rms_value = float(
+                    normal_dot[batch.surface_mask]
+                    .square()
+                    .mean()
+                    .sqrt()
+                    .detach()
+                    .cpu()
+                    .item()
+                )
+        else:
+            surface_pred_used = surface_pred_norm
+            surface_target_used = surface_target
+        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if use_tangential_wallshear_loss:
+        metrics["wallshear_pred_normal_rms"] = normal_rms_value
+    return loss, metrics
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -296,6 +346,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -333,6 +384,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if "wallshear_pred_normal_rms" in batch_loss_metrics:
+                        train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
+                            "wallshear_pred_normal_rms"
+                        ]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
@@ -374,6 +429,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     else:
                         optimizer.step()
                         if ema is not None:
+                            if config.ema_decay_start > 0.0:
+                                ema_decay_now = cosine_ema_decay(
+                                    global_step=global_step,
+                                    total_steps=total_estimated_steps,
+                                    decay_start=config.ema_decay_start,
+                                    decay_end=config.ema_decay_end,
+                                )
+                                ema.set_decay(ema_decay_now)
+                                train_log["train/ema_decay"] = ema_decay_now
                             ema.update(base_model)
                         weight_metrics = (
                             collect_weight_metrics(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -45,6 +45,9 @@ class EMA:
         }
         self.backup: dict[str, torch.Tensor] | None = None
 
+    def set_decay(self, new_decay: float) -> None:
+        self.decay = float(new_decay)
+
     @torch.no_grad()
     def update(self, model: nn.Module) -> None:
         self.step_counter += 1
@@ -816,6 +819,21 @@ def check_kill_thresholds(
     return None
 
 
+def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
+    """Project per-point 3-vectors onto the local tangent plane.
+
+    Args:
+        vec: [B, N, 3] vector field in physical units (matches `normals` frame).
+        normals: [B, N, 3] unit-norm surface normals (will be renormalized for safety).
+
+    Returns vec - (vec . n_hat) * n_hat. fp32 internally for bf16 stability.
+    """
+    vec_f = vec.float()
+    n_hat = torch.nn.functional.normalize(normals.float(), dim=-1, eps=1e-8)
+    dot = (vec_f * n_hat).sum(dim=-1, keepdim=True)
+    return (vec_f - dot * n_hat).to(vec.dtype)
+
+
 def masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     expanded_mask = mask
     while expanded_mask.ndim < values.ndim:
@@ -1243,6 +1261,22 @@ def timeout_budget_minutes(env: Mapping[str, str] = os.environ) -> tuple[float, 
     val_budget_minutes = float(env.get("SENPAI_VAL_BUDGET_MINUTES", str(default_val_budget)))
     train_timeout_minutes = max(0.0, timeout_minutes - max(0.0, val_budget_minutes))
     return timeout_minutes, val_budget_minutes, train_timeout_minutes
+
+
+def cosine_ema_decay(
+    *,
+    global_step: int,
+    total_steps: int,
+    decay_start: float,
+    decay_end: float,
+) -> float:
+    """Cosine-anneal EMA decay from `decay_start` to `decay_end` over `total_steps`.
+
+    Standard cosine increasing schedule: progress=0 -> decay_start, progress=1 -> decay_end.
+    """
+    progress = min(max(global_step / max(total_steps, 1), 0.0), 1.0)
+    cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
+    return decay_start + cos_val * (decay_end - decay_start)
 
 
 def build_lr_scheduler(


### PR DESCRIPTION
## Hypothesis

Compose **all** of yi's confirmed-orthogonal Round-1 wins into one run. The
yi advisor verified five wins individually but never landed the full
stacked composition on a merged tay-equivalent baseline. yi's prediction
for the full composition was `abupt_axis_mean ≈ 12-13`, a 20%+ improvement
over the best single-delta result.

The five compounding levers (each verified independently in yi):

1. **Width 512d / heads 8 / slices 128** (yi PR #4 chihiro, MERGED): −4.3%
   on abupt mean.
2. **Cosine EMA decay 0.99 → 0.9999** (yi PR #13 norman): −9.0% on every
   axis. Largest non-architectural lever in yi.
3. **Tangential wall-shear projection loss** (yi PR #11 kohaku, MERGED on
   yi but NOT on tay): physics-aware projection of predicted/target
   wall-shear onto surface tangent plane before MSE. Yi note: `tau_z`
   projected normal RMS grew 2.4× per epoch without it.
4. **Volume loss weight 2.0** (yi PR #9 gilbert, MERGED on yi): focuses
   gradient on the hardest target.
5. **Protocol fixes**: `--validation-every 1`, `--gradient-log-every 100`,
   `--weight-log-every 100`, `--no-log-gradient-histograms`.

These are all orthogonal axes — width adds capacity, EMA improves
checkpoint quality, projection removes unphysical signal from the loss,
and vol_w rebalances the gradient. Stacking them should compound, not
cannibalize.

## Instructions

This will likely require **code edits**, since cosine EMA scheduling
(`--ema-decay-start` / `--ema-decay-end`) and the tangential wall-shear
projection loss may not be in tay's `train.py` / `trainer_runtime.py`. Port
both from yi (yi PR #11 for projection, yi PR #13 for cosine EMA) and run
the composition.

Your tasks in order:

1. **Inspect** tay's `trainer_runtime.py` and `train.py` to see what's
   already wired up. yi's `--ema-decay 0.9995` is supported as a fixed
   decay. yi's `--ema-decay-start` / `--ema-decay-end` cosine schedule is
   probably **not** present. Same for tangential wall-shear projection
   (probably absent — the merged kohaku change lives only on yi).
2. **Port the cosine EMA schedule** if missing. Reference yi commit
   trail (look at `origin/norman/round1-progressive-ema-decay` for the
   reference implementation). Add `--ema-decay-start`, `--ema-decay-end`,
   keep backward-compat with single-`--ema-decay`.
3. **Port the tangential wall-shear projection loss** as `--use-tangential-wallshear-loss`
   default `False`. Reference yi commit trail (look at
   `origin/kohaku/round1-tangential-wallshear-loss`). Project in
   denormalized space (denormalize → project onto tangent plane defined by
   `surface_normals` → renormalize), then MSE. Add the
   `train/wallshear_pred_normal_rms` diagnostic.
4. **Run one composition training:**

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --wandb-name "askeladd/yi-full-composition-stack-ddp8" \
  --wandb-group "tay-round1-composition" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --use-tangential-wallshear-loss \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

If you cannot finish both ports in budget, prioritize the cosine EMA port
(yi's −9% lever) over the projection port (yi's physics-correctness lever
on wall-shear axes only).

**Per-axis attention:** report all six AB-UPT-aligned axes; the
expectation is improvement everywhere relative to alphonse's calibration
run, with biggest deltas on `volume_pressure` (cosine EMA + width) and
`wall_shear_*` axes (projection loss).

## Reporting

PR comment:
- W&B run id + group link
- All `test_primary/*` axes + `abupt_axis_mean`
- Best epoch / total epochs / wall time
- Diff against alphonse's calibration run (numbers + pp deltas)
- Comment on which compositional ingredient appeared to drive the gain
  (e.g. trace train/wallshear_pred_normal_rms across the run; trace EMA
  decay value over training)
- Any divergence / instability flags

## Baseline

Reference yi best (different project): 15.82 abupt_axis_mean. Reference
alphonse's tay calibration is the primary comparator (his run will likely
finish around the same time as yours; comment your numbers next to his).

| Target | This-repo metric | AB-UPT |
|---|---|---:|
| Surface pressure `p_s` | `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| Vector wall shear `tau` | `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| Volume pressure `p_v` | `test_primary/volume_pressure_rel_l2_pct` | **6.08** |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`.
