### PR TITLE
[fern] Round-1: Gaussian random Fourier coord features + 4L/512d/8h

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,31 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+class RFFEncoding(nn.Module):
+    """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
+
+    Lifts ``in_dim`` raw coordinates into a ``2 * num_features`` basis via a fixed
+    random Gaussian projection followed by sin/cos. ``B`` is registered as a
+    buffer so it is non-trainable but follows the model across devices and is
+    broadcast across DDP ranks (DDP default ``broadcast_buffers=True``).
+    """
+
+    def __init__(self, in_dim: int, num_features: int = 32, sigma: float = 1.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigma = sigma
+        self.register_buffer("B", torch.randn(in_dim, num_features) * sigma)
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        proj = 2.0 * math.pi * (x @ self.B.to(dtype=x.dtype))
+        return torch.cat([proj.sin(), proj.cos()], dim=-1)
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -226,6 +251,8 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        rff_num_features: int = 0,
+        rff_sigma: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,17 +260,35 @@ class SurfaceTransolver(nn.Module):
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
+        self.rff_num_features = rff_num_features
+        self.rff_sigma = rff_sigma
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
+
+        if rff_num_features > 0:
+            self.surface_rff = RFFEncoding(
+                in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
+            )
+            self.volume_rff = RFFEncoding(
+                in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
+            )
+            rff_out_dim = 2 * rff_num_features
+        else:
+            self.surface_rff = None
+            self.volume_rff = None
+            rff_out_dim = 0
+
+        surface_proj_in = surface_extra_dim + rff_out_dim
+        volume_proj_in = volume_extra_dim + rff_out_dim
         self.project_surface_features = (
-            LinearProjection(surface_extra_dim, n_hidden) if surface_extra_dim > 0 else None
+            LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )
         self.project_volume_features = (
-            LinearProjection(volume_extra_dim, n_hidden) if volume_extra_dim > 0 else None
+            LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
@@ -263,14 +308,23 @@ class SurfaceTransolver(nn.Module):
         self,
         x: torch.Tensor,
         *,
+        rff: nn.Module | None,
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
-        if project_features is not None and x.shape[-1] > self.space_dim:
-            hidden = hidden + project_features(x[:, :, self.space_dim :])
+        feature_parts: list[torch.Tensor] = []
+        if x.shape[-1] > self.space_dim:
+            feature_parts.append(x[:, :, self.space_dim :])
+        if rff is not None:
+            feature_parts.append(rff(pos))
+        if project_features is not None and feature_parts:
+            features = (
+                feature_parts[0] if len(feature_parts) == 1 else torch.cat(feature_parts, dim=-1)
+            )
+            hidden = hidden + project_features(features)
         return bias(hidden) + placeholder
 
     def forward(
@@ -298,6 +352,7 @@ class SurfaceTransolver(nn.Module):
             tokens.append(
                 self._encode_group(
                     surface_x,
+                    rff=self.surface_rff,
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
@@ -310,6 +365,7 @@ class SurfaceTransolver(nn.Module):
             tokens.append(
                 self._encode_group(
                     volume_x,
+                    rff=self.volume_rff,
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,

--- a/train.py
+++ b/train.py
@@ -91,6 +91,8 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    rff_num_features: int = 0
+    rff_sigma: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -148,6 +150,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        rff_num_features=config.rff_num_features,
+        rff_sigma=config.rff_sigma,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The Transolver backbone receives raw `(x, y, z)` coordinates plus normals
and a single SDF value as features. Coordinate inputs are spectrally
biased — early MLPs learn smooth coordinate functions slowly because all
spatial scales are encoded in the same low-frequency basis. **Gaussian
random Fourier features (RFF)** apply a fixed random projection
`gamma * 2π * (x · B)` (with `B` Gaussian-distributed) before the trig
transform, lifting the input into a high-frequency basis where the model
can fit fine geometric details quickly. RFF is well-established in
implicit neural representations (NeRF, Tancik et al. 2020) and was the
proven coordinate-encoding winner on `radford` (per yi research notes).

On DrivAerML this should help most where the model needs to capture
fine-scale surface variation (`surface_pressure`, wall shear) — i.e. the
exact axes furthest from AB-UPT.

## Instructions

Add Gaussian RFF coord encoding for both surface and volume inputs at
fixed dimensionality. Compose with the 4L/512d/8h Transolver config.

### Implementation

In `model.py` or a new `model_rff.py`, add:

```python
class RFFEncoding(nn.Module):
    def __init__(self, in_dim: int, num_features: int = 32, sigma: float = 1.0):
        super().__init__()
        # Fixed random projection — not trainable
        self.register_buffer("B", torch.randn(in_dim, num_features) * sigma)
    def forward(self, x):
        # x: [..., in_dim] -> [..., 2 * num_features]
        proj = 2 * math.pi * (x @ self.B)
        return torch.cat([proj.sin(), proj.cos()], dim=-1)
```

Apply RFF only to the **coordinate channels** of surface and volume
inputs:
- Surface input: `[x, y, z, nx, ny, nz, area]` (channels 0-2 are coords).
- Volume input: `[x, y, z, sdf]` (channels 0-2 are coords).

Concatenate `RFF(coords)` with the original feature tensor (so the model
keeps access to raw coords, normals, area, sdf).

Wire two CLI flags:
- `--rff-num-features 32` (per-axis count → output is 64 per axis = 192
  total before sin/cos = 384 after).
- `--rff-sigma 1.0` (controls bandwidth).

**Sweep `--rff-sigma` ∈ {0.5, 1.0, 2.0}** in a 3-arm wandb group. Sigma
controls the bandwidth — too low and RFF gives no benefit over identity;
too high and the model can't converge because every coordinate looks
random. Tancik 2020 found `sigma ≈ 1.0` works well at meter-scale
coordinates.

### Reproduce (single arm, sigma=1.0)

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --wandb-name "fern/rff-coord-sigma1.0" \
  --wandb-group "fern-rff-sigma-sweep" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

Then submit two more arms with `--rff-sigma 0.5` and `--rff-sigma 2.0`.
If 8-GPU DDP fits all three sequentially in the time budget, run all
three; otherwise pick `sigma=1.0` plus the closer of `0.5`/`2.0` based on
loss curve diagnostics.

### Diagnostics

- Compare `val_primary/surface_pressure_rel_l2_pct` per epoch — RFF should
  lift this faster than the no-RFF comparator (alphonse's calibration).
- Watch param count delta — RFF buffer is non-trainable, so trainable
  count should be unchanged. Total tensor count grows.
- Confirm coords are properly normalized **before** RFF (else `sigma`
  interpretation depends on case-scale variance).

## Reporting

- W&B group link covering all arms run.
- Per-axis `test_primary/*` table for the best arm vs alphonse calibration.
- Comment on which axis benefited most (predict `surface_pressure` and
  `wall_shear`).
- Param count delta + wall time delta vs no-RFF.

## Baseline

Tay alphonse calibration is the live comparator. Reference yi merged
config (no RFF): `abupt_axis_mean = 16.64`.

| Target | This-repo metric | AB-UPT |
|---|---|---:|
| `surface_pressure_rel_l2_pct` | `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
| `wall_shear_rel_l2_pct` | `test_primary/wall_shear_rel_l2_pct` | **7.29** |
| `volume_pressure_rel_l2_pct` | `test_primary/volume_pressure_rel_l2_pct` | **6.08** |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`.
