### PR TITLE
[tanjiro] Round-1b: Lion optimizer (drop-in AdamW replacement) at 4L/512d/8h

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch>=0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -112,6 +112,9 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     compile_model: bool = True
+    optimizer: str = "adamw"
+    lion_beta1: float = 0.9
+    lion_beta2: float = 0.99
     debug: bool = False
 
 
@@ -138,6 +141,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
+    optimizer_name = config.optimizer.lower()
+    if optimizer_name == "adamw":
+        return torch.optim.AdamW(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+    if optimizer_name == "lion":
+        from lion_pytorch import Lion
+
+        return Lion(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
 
 
 def build_model(config: Config) -> SurfaceTransolver:
@@ -225,7 +249,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-        optimizer = torch.optim.AdamW(base_model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))


### PR DESCRIPTION
## Hypothesis

The fundamental optimizer for all yi/tay runs has been AdamW. Round 1
results show that with all-yi-orthogonal-wins composed, val_abupt
plateaus around 24-28 — the optimization landscape may be a
limiting factor.

**Lion optimizer** (Chen et al., 2023, "Symbolic Discovery of
Optimization Algorithms") is a 2nd-generation symbolic-discovered
optimizer that uses sign-based momentum updates and consistently
beats AdamW on transformer training across vision, language, and
graph domains. It uses ~50% less memory than AdamW (no second
moment), so the saved memory can buy us larger batches or longer
training within the same budget.

Drop-in replacement of AdamW with Lion is a single-delta hypothesis:
modifies only `train.py` (the optimizer init), not `model.py`. It
composes orthogonally with all Round 1 levers, so a clean win here
stacks with the calibration baseline.

**Why this is a good reassignment for tanjiro**: your previous PR
required deep model.py surgery and got stuck in eval-path bugs. This
hypothesis touches train.py only — a 10-line change. You can be
running training in 30 minutes.

## Instructions

Replace the AdamW optimizer in `train.py` with Lion. Keep all other
configuration identical to alphonse's calibration arm (4L/512d/8h,
bs=4, ema=0.9995, vol_w=2.0).

### Implementation

1. **Install Lion**: Lion is in `lion-pytorch` (pip) or `transformers`
   (HuggingFace bundled). Use the `lion-pytorch` package — it's a
   single-file dependency. Install via `pip install lion-pytorch`.

2. **Optimizer swap** in `train.py` where `torch.optim.AdamW(...)` is
   constructed:
   ```python
   from lion_pytorch import Lion
   optimizer = Lion(
       parameters_with_groups,
       lr=lr,                    # see below for choice
       weight_decay=weight_decay * 10,  # Lion paper: scale wd by 10x
       betas=(0.9, 0.99),        # Lion default
       use_triton=False,         # use vanilla PyTorch impl (more reliable)
   )
   ```

3. **CLI flag**: `--optimizer lion` (default `adamw` for backward compat).
   When `lion` is selected, use the Lion init above. When `adamw`,
   keep current AdamW behavior.

4. **LR adjustment**: Lion's recommended lr is **3x lower** than
   AdamW's, and weight decay is **10x higher**. So for our calibration
   baseline lr=5e-5, weight_decay=5e-4, use:
   - **Lion**: lr=1.7e-5, weight_decay=5e-3
   This is the recommended translation from the Lion paper.

5. **Two arms in one wandb group** to verify the lr-translation:
   - **Arm A**: lr=1.7e-5, wd=5e-3 (paper-recommended translation)
   - **Arm B**: lr=5e-5, wd=5e-4 (same as AdamW — sanity check; expected to over-step)

   If Arm A is significantly better than Arm B, that's the right
   translation; if Arm B is better, the paper's recommendation
   doesn't apply to our regime and we keep that.

### Reproduce

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-name "tanjiro/lion-lr1.7e-5-wd5e-3-512d" \
  --wandb-group "tanjiro-lion-lr-sweep" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 1.7e-5 --weight-decay 5e-3 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --optimizer lion \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

For Arm B (sanity check — same lr/wd as AdamW):
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-name "tanjiro/lion-lr5e-5-wd5e-4-512d" \
  --wandb-group "tanjiro-lion-lr-sweep" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --optimizer lion \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

### Diagnostics

Lion training is generally more stable than AdamW (single-moment update,
not second-moment scale-aware). Expect:
- Train loss curve smoother than AdamW.
- Train grad-norm comparable, but optimizer-state memory ~half AdamW's.
- If lr is too high, loss explodes early (within first 1000 steps).

### Failure modes to watch

- **Wrong lr**: Lion's update magnitude is `lr · sign(...)`, so it's
  effectively constant per-parameter. If you keep AdamW's lr, you may
  need to clip more aggressively. Watch `train/grad/global_norm_pre_clip`
  in the first 500 steps.
- **NaN early**: Lion + 4L Transolver should be stable. If NaN appears,
  drop lr by 2x and retry.
- **Slow convergence**: Lion sometimes needs more steps than AdamW to
  reach the same val. If after 1 epoch (~step 2722) val_abupt is still
  >70, abort and investigate.

## Reporting

- W&B group link covering both arms. Compare to alphonse calibration.
- Per-axis decomposition (ps, ws, pv, tau_x, tau_y, tau_z) at the
  best-validation checkpoint.
- Param-state memory delta (Lion uses ~half of AdamW's optimizer state).
- Final test_primary metrics for both arms.

## Baseline

Tay alphonse calibration (running, current val_abupt=24.3 at step
13609) is the live comparator. The full per-axis profile to beat
(latest at step 13609):

| Target | This-repo metric | alphonse @13609 | yi best | AB-UPT |
|---|---|---:|---:|---:|
| `abupt` | val_primary/abupt_axis_mean_rel_l2_pct | 24.26 | 16.64 | (n/a) |
| `surface_pressure` | val_primary/surface_pressure_rel_l2_pct | 17.37 | n/a | 3.82 |
| `wall_shear` | val_primary/wall_shear_rel_l2_pct | 27.14 | n/a | 7.29 |
| `volume_pressure` | val_primary/volume_pressure_rel_l2_pct | 13.52 | n/a | 6.08 |
| `tau_x` | val_primary/wall_shear_x_rel_l2_pct | 23.18 | 14.27 | 5.35 |
| `tau_y` | val_primary/wall_shear_y_rel_l2_pct | 32.73 | 19.49 | 3.65 |
| `tau_z` | val_primary/wall_shear_z_rel_l2_pct | 34.51 | 21.12 | 3.63 |

Predicted: Lion at the recommended translated lr should produce
parity with AdamW or 5-15% improvement, especially on `volume_pressure`
which has the most non-stationary loss landscape.

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`.
