### PR TITLE
[alphonse] Round-1b: Fix torch.compile bug + recalibrate (compiled)

### DIFF
--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -290,7 +290,7 @@ def make_loaders(
             num_replicas=distributed_state.world_size,
             rank=distributed_state.rank,
             shuffle=True,
-            drop_last=False,
+            drop_last=True,
         )
         train_shuffle = False
     train_loader = DataLoader(
@@ -298,6 +298,7 @@ def make_loaders(
         batch_size=config.batch_size,
         shuffle=train_shuffle,
         sampler=train_sampler,
+        drop_last=True,
         **loader_kwargs(config),
     )
     val_loaders = {
@@ -925,8 +926,9 @@ def accumulate_eval_batch(
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
     volume_target_norm = transform.apply_volume(batch.volume_y)
+    eval_module = unwrap_model(model)
     with autocast_context(device, amp_mode):
-        out = model(
+        out = eval_module(
             surface_x=batch.surface_x,
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,


### PR DESCRIPTION
## Hypothesis

The first tay/DDP8 calibration (PR #30) ran only 9 epochs instead of the
expected 14–16 because `--no-compile-model` was required as a workaround for
the `torch.compile + drop_last=False` crash. Fixing this single interaction
restores ~50% of the training budget for **all** present and future experiments.

**The bug:** `compile_model=True` (default, `train.py`) + `drop_last=False` on
the train DataLoader (`trainer_runtime.py:293`) means the last batch of each
epoch is partial. `torch._inductor` symbolic-shape codegen cannot reconcile
the smaller last-batch shape against the cached graph; all 8 ranks abort at
the epoch-boundary step with:

```
torch._inductor.exc.InductorError: AssertionError: For s24 + 65536,
  expected [s24] to have been codegen-ed.
```

**The fix:** set `drop_last=True` on the train DataLoader in
`trainer_runtime.py:293`. With 400 train cases and effective batch 32 this
means skipping ≤31 cases per epoch (<8%) — negligible for a 400-case dataset.
This is a single-line change, fully backward-compatible (the partial-batch skip
only applies during training, not validation/test).

After the fix, re-run the yi PR #4 calibration **with `--compile-model`
enabled** (default, no flag needed after the fix) to get the true tay/DDP8
baseline at proper epoch count.

## Instructions

### Step 1 — Fix the compile bug in `trainer_runtime.py`

Find the train DataLoader construction (line ~293) and change `drop_last=False`
to `drop_last=True`:

```python
# trainer_runtime.py ~line 293
# Before:
train_loader = DataLoader(train_dataset, ..., drop_last=False, ...)
# After:
train_loader = DataLoader(train_dataset, ..., drop_last=True, ...)
```

Verify the fix locally with a dry-run or simply check that training starts and
reaches step 2721 (= 400/32 = 12 full batches at bs=4 × 8 GPUs) cleanly.

**Do NOT add --no-compile-model to the run command** — if the fix is correct,
the run should complete with `--compile-model` (the default) without crashing.

### Step 2 — Re-run yi PR #4 calibration

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --wandb-name "alphonse/calibrate-compile-fixed-512d" \
  --wandb-group "tay-round1-calibrate-compiled" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

(No `--no-compile-model` — the fix should make it unnecessary.)

### Diagnostics

- **First epoch completes cleanly**: step 2722 fires without InductorError. If
  it crashes again, check `trainer_runtime.py` diff to confirm `drop_last=True`
  landed correctly.
- **Steps per epoch**: with `drop_last=True` and 400/32 = 12.5 → 12 full
  batches per GPU (per DDP rank), expect 12 × some_factor steps. Actually with
  DDP8 and bs=4, each GPU processes 50 cases per epoch = 50/4 = 12.5 steps,
  so drop_last means 12 steps per GPU per epoch. Much fewer steps than PR #30
  (which had 2721 steps/epoch); this will reach more epochs inside the budget.
- **Expected epochs in budget**: ~270 min / ~12 min per compiled epoch ≈ 22
  epochs. val_abupt at epoch 22 should be significantly below 18.70.

### Expected results

| Metric | PR #30 (uncompiled, 9 ep) | This PR (compiled, ~16–22 ep) | Target |
|---|---:|---:|---:|
| test_abupt | 19.81 | ~15–17 | beat yi 15.82 |
| test_ps | 12.86 | ~10–12 | — |
| test_ws | 21.27 | ~17–19 | — |
| test_pv | 15.91 | ~13–15 | — |

The slope at end of PR #30 was still strongly negative (−0.37/1k steps for
abupt), so 2× more steps should get us well below 16.

## Current baseline to beat

| Metric | tay best (PR #30) | yi best | AB-UPT |
|---|---:|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **19.81** | 15.82 | — |
| `test_primary/surface_pressure_rel_l2_pct` | **12.86** | 9.99 | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **21.27** | 16.60 | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **15.91** | 14.21 | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **18.24** | 14.27 | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **25.50** | 19.49 | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **26.53** | 21.12 | 3.63 |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`.
