### PR TITLE
[frieren] Round-1b: squared rel-L2 loss (drop outer sqrt)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,11 +54,16 @@ from trainer_runtime import (
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
+    relative_l2_loss,
     run_final_evaluation,
     should_update_best_checkpoint,
+    squared_relative_l2_loss,
     timeout_budget_minutes,
     unwrap_model,
 )
+
+
+LOSS_FORMS = ("mse", "rel_l2", "squared_rel_l2")
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +122,7 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    loss_form: str = "mse"
     debug: bool = False
 
 
@@ -131,6 +137,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
         ),
+        "loss_form": (
+            f"Training loss form. One of {LOSS_FORMS}. 'mse' is the per-element "
+            "masked MSE baseline. 'rel_l2' is per-case sqrt(sum_pts((y-y_hat)²)/sum_pts(y²)) "
+            "averaged across cases. 'squared_rel_l2' drops the outer sqrt for smoother "
+            "gradients. Eval metrics (test_primary/*, val_primary/*) always use the "
+            "standard rel-L2 sqrt form regardless of this flag."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -139,6 +152,8 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         if isinstance(value, bool):
             parser.add_argument(arg_name, action="store_true", default=value, help=help_value)
             parser.add_argument(f"--no-{field.name.replace('_', '-')}", action="store_false", dest=field.name)
+        elif field.name == "loss_form":
+            parser.add_argument(arg_name, type=str, choices=LOSS_FORMS, default=value, help=help_value)
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
@@ -188,6 +203,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    loss_form: str = "mse",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -199,12 +215,23 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        surface_mse = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        volume_mse = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        if loss_form == "mse":
+            surface_loss = surface_mse
+            volume_loss = volume_mse
+        elif loss_form == "rel_l2":
+            surface_loss = relative_l2_loss(out["surface_preds"], surface_target, batch.surface_mask)
+            volume_loss = relative_l2_loss(out["volume_preds"], volume_target, batch.volume_mask)
+        elif loss_form == "squared_rel_l2":
+            surface_loss = squared_relative_l2_loss(out["surface_preds"], surface_target, batch.surface_mask)
+            volume_loss = squared_relative_l2_loss(out["volume_preds"], volume_target, batch.volume_mask)
+        else:
+            raise ValueError(f"Unknown loss_form: {loss_form!r}; expected one of {LOSS_FORMS}")
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
+        base_mse_loss = surface_mse + volume_mse
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
@@ -324,6 +351,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    loss_form=config.loss_form,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -849,6 +849,24 @@ def squared_relative_l2_loss(
     return pred.sum() * 0.0
 
 
+def relative_l2_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    mask_float = mask.to(device=pred.device, dtype=pred.dtype)
+    diff_sq = (pred.float() - target.float()).square().sum(dim=-1) * mask_float
+    target_sq = target.float().square().sum(dim=-1) * mask_float
+    denominator = target_sq.sum(dim=1)
+    valid = denominator > 0
+    if bool(valid.any()):
+        ratio = diff_sq.sum(dim=1)[valid] / denominator[valid].clamp_min(1e-12)
+        return ratio.clamp_min(0.0).sqrt().mean()
+    return pred.sum() * 0.0
+
+
 EVAL_KEYS = (
     "surface_pressure",
     "wall_shear",


### PR DESCRIPTION
## Hypothesis

The current rel-L2 loss in trainer_runtime.py uses the standard square-root
form: `sqrt(mean((y - ŷ)²) / mean(y²))`. This loss has a known issue: the
sqrt has infinite gradient at zero error, and bad numerical conditioning
when the per-batch error is small. It also loses scale invariance compared
to its squared variant.

**Hypothesis**: replace rel-L2 with **squared rel-L2** —
`mean((y - ŷ)²) / mean(y²)` — i.e. drop the outer sqrt. Properties:
- Smooth gradient everywhere (no 1/sqrt singularity at zero error)
- Better-conditioned backward pass (lower gradient variance late in training)
- Same minimum location and scale-invariance properties
- Single-delta change, composes orthogonally with all Round-1 levers

This is from the Round 2 queue and was used as the loss in several recent
CFD surrogate papers (Pfaff et al., Sanchez-Gonzalez et al.) where it
outperformed rel-L2 on small datasets like DrivAerML (400 train cases).

The improvement is expected to be largest on the hardest-to-predict axes
(tau_y, tau_z) where the rel-L2 gradient is currently noisy late in
training due to the small denominator.

## Instructions

### Step 1 — Find the rel-L2 loss in `trainer_runtime.py`

Search for `rel_l2` or `relative_l2` in `trainer_runtime.py`. It will likely
look like:

```python
rel_l2 = ((y - y_pred) ** 2).mean() / (y ** 2).mean()
loss = rel_l2.sqrt()  # or torch.sqrt(rel_l2)
```

### Step 2 — Add a `squared_rel_l2` loss option

Add a CLI flag `--loss-form` with choices `["rel_l2", "squared_rel_l2"]`
(default `rel_l2` for backward compatibility). When `squared_rel_l2` is
selected, return `rel_l2` directly without the sqrt:

```python
loss_squared = ((y - y_pred) ** 2).mean() / (y ** 2).mean()
if loss_form == "squared_rel_l2":
    loss = loss_squared
else:
    loss = loss_squared.sqrt()
```

Apply this consistently across all loss components (surface, wall_shear,
volume) — i.e., each per-target loss either has the sqrt or doesn't,
matching the flag.

### Step 3 — Eval metrics stay rel-L2

**Important**: the *eval-time* metrics (`test_primary/*`,`val_primary/*`)
must keep the standard rel-L2 form (with sqrt) — that's how AB-UPT scoring
works and how we compare against the public reference. Only the
**training-time loss** changes.

### Step 4 — Reproduce

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --wandb-name "frieren/squared-rel-l2-loss-512d" \
  --wandb-group "tay-round1-loss-form" \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --loss-form squared_rel_l2 \
  --no-compile-model \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

(Use `--no-compile-model` until alphonse's PR #40 lands the compile fix.)

### Diagnostics

- **Train loss at end** should be ~10× smaller in absolute number (no sqrt)
  but the ratio of train_loss to val rel-L2 is what matters
- **`train/grad/global_norm_pre_clip`** — expected to be lower late in
  training (the squared loss has smaller gradients near the minimum); if
  it's much *higher*, that's a sign the learning rate needs adjustment
- **`train/grad/clipped`** rate — currently 1.0 (clipping every step) on
  rel-L2; this should drop with squared loss, indicating better-conditioned
  optimization

### Failure modes to watch

- **LR mismatch**: squared rel-L2 has effectively smaller gradients late in
  training. If val_abupt plateaus higher than alphonse, try lr=1e-4 (2× the
  current 5e-5) — the smaller gradient may need a higher LR
- **Loss NaN**: if `mean(y²)` ever rounds to zero in float32, rel_l2 → inf.
  Should not happen for non-trivial fields but watch for it
- **Worse than baseline**: if test_abupt > 19.81, the loss reformulation
  isn't paying off at 9 epochs. Report and we move on; squared rel-L2
  often takes more epochs to manifest

## Reporting

- W&B run id + group link (use `--wandb-group tay-round1-loss-form`)
- Per-axis decomposition (ps, ws, pv, tau_x, tau_y, tau_z) at best-val
- Comparison table vs alphonse calibration
- Train/val loss ratio over time (squared vs rel-L2 conditioning)

## Baseline to beat

alphonse PR #30 calibration:

| Metric | tay best (PR #30) | yi best | AB-UPT |
|---|---:|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **19.81** | 15.82 | — |
| `test_primary/surface_pressure_rel_l2_pct` | **12.86** | 9.99 | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **21.27** | 16.60 | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **15.91** | 14.21 | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **18.24** | 14.27 | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **25.50** | 19.49 | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **26.53** | 21.12 | 3.63 |

**Predicted**: 1–4% improvement on test_abupt (target ~17–19), with the
biggest gains on tau_y/tau_z where the rel-L2 gradient was most noisy.

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`.
