### PR TITLE
[fern] Round-2: Multi-scale RFF (3 frequency bands) for tau_y/tau_z

### DIFF
--- a/model.py
+++ b/model.py
@@ -71,6 +71,36 @@ class RFFEncoding(nn.Module):
         return torch.cat([proj.sin(), proj.cos()], dim=-1)
 
 
+class MultiScaleRFF(nn.Module):
+    """Concatenate ``RFFEncoding`` outputs at multiple frequency scales.
+
+    Motivated by spectral-bias theory (Tancik et al. 2020): a single sigma
+    cannot simultaneously represent low- and high-frequency spatial variation.
+    Concatenating bands with different sigmas exposes both regimes to the
+    downstream linear projection without changing depth.
+
+    Output dim is ``2 * num_features * len(sigmas)``.
+    """
+
+    def __init__(self, in_dim: int, num_features: int, sigmas: list[float]):
+        super().__init__()
+        if len(sigmas) == 0:
+            raise ValueError("MultiScaleRFF requires at least one sigma value")
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigmas = list(sigmas)
+        self.encoders = nn.ModuleList(
+            [RFFEncoding(in_dim, num_features, sigma=float(s)) for s in self.sigmas]
+        )
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features * len(self.sigmas)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.cat([enc(x) for enc in self.encoders], dim=-1)
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -253,6 +283,8 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        rff_surface_sigmas: list[float] | None = None,
+        rff_volume_sigmas: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -262,6 +294,10 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
+        surface_sigmas = list(rff_surface_sigmas) if rff_surface_sigmas else [rff_sigma]
+        volume_sigmas = list(rff_volume_sigmas) if rff_volume_sigmas else [rff_sigma]
+        self.rff_surface_sigmas = surface_sigmas
+        self.rff_volume_sigmas = volume_sigmas
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -270,20 +306,18 @@ class SurfaceTransolver(nn.Module):
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
 
         if rff_num_features > 0:
-            self.surface_rff = RFFEncoding(
-                in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
-            )
-            self.volume_rff = RFFEncoding(
-                in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
-            )
-            rff_out_dim = 2 * rff_num_features
+            self.surface_rff = self._build_rff(space_dim, rff_num_features, surface_sigmas)
+            self.volume_rff = self._build_rff(space_dim, rff_num_features, volume_sigmas)
+            surface_rff_out_dim = self.surface_rff.output_dim
+            volume_rff_out_dim = self.volume_rff.output_dim
         else:
             self.surface_rff = None
             self.volume_rff = None
-            rff_out_dim = 0
+            surface_rff_out_dim = 0
+            volume_rff_out_dim = 0
 
-        surface_proj_in = surface_extra_dim + rff_out_dim
-        volume_proj_in = volume_extra_dim + rff_out_dim
+        surface_proj_in = surface_extra_dim + surface_rff_out_dim
+        volume_proj_in = volume_extra_dim + volume_rff_out_dim
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )
@@ -303,6 +337,12 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+    @staticmethod
+    def _build_rff(in_dim: int, num_features: int, sigmas: list[float]) -> nn.Module:
+        if len(sigmas) == 1:
+            return RFFEncoding(in_dim=in_dim, num_features=num_features, sigma=sigmas[0])
+        return MultiScaleRFF(in_dim=in_dim, num_features=num_features, sigmas=sigmas)
 
     def _encode_group(
         self,

--- a/train.py
+++ b/train.py
@@ -93,6 +93,8 @@ class Config:
     model_dropout: float = 0.0
     rff_num_features: int = 0
     rff_sigma: float = 1.0
+    rff_sigmas: str = ""
+    rff_volume_sigmas: str = ""
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -128,6 +130,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
         ),
+        "rff_sigmas": (
+            "Comma-separated RFF sigma values for surface coords (and volume coords "
+            "when --rff-volume-sigmas is empty). When >1 value, the model uses "
+            "MultiScaleRFF, concatenating one RFFEncoding per sigma. Each band gets "
+            "--rff-num-features features. Falls back to [--rff-sigma] when empty."
+        ),
+        "rff_volume_sigmas": (
+            "Comma-separated RFF sigma values for volume coords. Falls back to "
+            "--rff-sigmas (then --rff-sigma) when empty. Lets surface and volume "
+            "use different multi-scale frequency bands, since their coordinate "
+            "ranges differ by ~50x on DrivAerML."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -142,7 +156,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _parse_sigma_list(sigma_str: str) -> list[float] | None:
+    sigma_str = (sigma_str or "").strip()
+    if not sigma_str:
+        return None
+    return [float(token.strip()) for token in sigma_str.split(",") if token.strip()]
+
+
 def build_model(config: Config) -> SurfaceTransolver:
+    surface_sigmas = _parse_sigma_list(config.rff_sigmas)
+    volume_sigmas = _parse_sigma_list(config.rff_volume_sigmas) or surface_sigmas
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -152,6 +175,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        rff_surface_sigmas=surface_sigmas,
+        rff_volume_sigmas=volume_sigmas,
     )
 
 


### PR DESCRIPTION
# [fern] Round-2: Multi-scale RFF — 3 frequency bands for tau_y / tau_z

## Hypothesis

Round-1 showed that Random Fourier Feature (RFF) coordinate encoding with sigma=1.0 lifted `test_abupt` from 19.81 → **17.77** (−10.3%). Fern's own analysis identified the key weakness: the single sigma=1.0 works well for meter-scale surface coordinates (domain ~[−1, 4] m), but **overshoots for far-field volume coordinates** (domain ~[−40, 80] m) — high-frequency Fourier features saturate in that regime, providing near-zero gradient signal.

Meanwhile, the primary gap to yi's SOTA lies in `tau_y` (21.81 vs 19.49) and `tau_z` (23.54 vs 21.12) — wall-shear components that depend on fine-scale surface details **and** meso-scale pressure gradients. These two components live at different spatial scales simultaneously; a single sigma cannot serve both.

**Multi-scale RFF** concatenates multiple frequency bands in one forward pass, giving the model simultaneous access to:

| Band | Surface sigma | Surface scale | Volume sigma | Volume scale |
|------|--------------|---------------|-------------|--------------|
| Low (global shape) | 0.1 | ~10 m | 0.01 | ~100 m |
| Mid (meso transitions) | 1.0 | ~1 m | 0.1 | ~10 m |
| High (fine detail) | 10.0 | ~0.1 m | 1.0 | ~1 m |

This is motivated by spectral bias theory (Rahimi & Recht 2007; Tancik et al. NeurIPS 2020 "Fourier Features Let Networks Learn High Frequency Functions"): a network trained with a single-scale positional encoding cannot simultaneously represent both low- and high-frequency spatial variation. Concatenating multiple bands breaks this limitation without increasing model depth.

The hypothesis: multi-scale RFF will close at least 1–2 abupt points on the new 17.77 baseline, primarily through improvement in `tau_y` and `tau_z`.

---

## Current Baseline (PR #33 — tay SOTA)

| Metric | tay PR #33 | yi best | AB-UPT |
|---|---:|---:|---:|
| `abupt` | **17.77** | 15.82 | — |
| `surface_pressure` | 11.20 | 9.99 | 3.82 |
| `wall_shear` | 18.68 | 16.60 | 7.29 |
| `volume_pressure` | 16.13 | 14.21 | 6.08 |
| `tau_x` | 16.20 | 14.27 | 5.35 |
| `tau_y` | 21.81 | 19.49 | 3.65 |
| `tau_z` | 23.54 | 21.12 | 3.63 |

Beat **17.77** on `test_abupt` to set a new SOTA.

Expected outcome: **−1.0 to −2.0 abupt** → target range **~15.8–16.8**.

---

## Implementation Instructions

### 1. Add `MultiScaleRFF` to `model.py`

Locate the existing `RFFEncoding` class (around line 49). Immediately **after** it, add:

```python
class MultiScaleRFF(nn.Module):
    """Concatenate RFF encodings at multiple frequency scales.

    Args:
        in_features: spatial coordinate dimensionality (e.g. 3 for xyz).
        num_features: number of Fourier features per sigma (before *2).
        sigmas: list of length-scale parameters; one RFFEncoding per sigma.

    Output dim = 2 * num_features * len(sigmas)
    """
    def __init__(self, in_features: int, num_features: int, sigmas: list[float]):
        super().__init__()
        self.encoders = nn.ModuleList([
            RFFEncoding(in_features, num_features, sigma=s)
            for s in sigmas
        ])
        self.out_features = 2 * num_features * len(sigmas)

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: (..., in_features)  →  (..., out_features)
        return torch.cat([enc(x) for enc in self.encoders], dim=-1)
```

### 2. Add CLI arguments to `train.py`

Find the argument-parser block and add three new arguments (keep `--rff-sigma` for backward compatibility):

```python
parser.add_argument(
    "--rff-sigmas",
    type=str,
    default=None,
    help="Comma-separated list of RFF sigma values (overrides --rff-sigma when >1 value). "
         "E.g. '0.1,1.0,10.0'. Each sigma gets --rff-num-features features.",
)
parser.add_argument(
    "--rff-volume-sigmas",
    type=str,
    default=None,
    help="Optional comma-separated sigma list for volume coords (defaults to --rff-sigmas). "
         "E.g. '0.01,0.1,1.0'.",
)
```

### 3. Wire `MultiScaleRFF` into the model construction

In the block where `RFFEncoding` is instantiated for the surface / volume encoders, apply the following logic:

```python
def _parse_sigmas(sigma_str: str | None, fallback: float) -> list[float]:
    if sigma_str is not None:
        return [float(s.strip()) for s in sigma_str.split(",")]
    return [fallback]

surface_sigmas = _parse_sigmas(args.rff_sigmas, args.rff_sigma)
volume_sigmas  = _parse_sigmas(args.rff_volume_sigmas or args.rff_sigmas, args.rff_sigma)

if args.rff_num_features > 0:
    if len(surface_sigmas) > 1:
        surface_coord_encoder = MultiScaleRFF(3, args.rff_num_features, surface_sigmas)
    else:
        surface_coord_encoder = RFFEncoding(3, args.rff_num_features, sigma=surface_sigmas[0])

    if len(volume_sigmas) > 1:
        volume_coord_encoder = MultiScaleRFF(3, args.rff_num_features, volume_sigmas)
    else:
        volume_coord_encoder = RFFEncoding(3, args.rff_num_features, sigma=volume_sigmas[0])
```

**Important:** The output dimension of `MultiScaleRFF` is `2 * num_features * n_sigmas`. With `--rff-num-features 32` and 3 sigmas, each encoder outputs **192** features (vs 64 in Round-1). Verify that the downstream linear projection that consumes the coord encoding is either (a) dynamically sized from `encoder.out_features`, or (b) updated to accept 192. Check how `RFFEncoding.out_features` is currently consumed and apply the same pattern for `MultiScaleRFF.out_features`.

### 4. Run the experiment

Use exactly this command (single arm — do not sweep; concatenation is the entire hypothesis):

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --volume-loss-weight 2.0 --batch-size 4 --validation-every 1 \
  --lr 5e-5 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --rff-num-features 32 \
  --rff-sigmas "0.1,1.0,10.0" \
  --rff-volume-sigmas "0.01,0.1,1.0" \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms --no-compile-model \
  --wandb-group fern-multiscale-rff
```

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

---

## Results Template

Please report results in a PR comment using the following format:

```
## Results

| Metric | Round-1 baseline (PR #33) | This run | Delta |
|---|---:|---:|---:|
| `test_abupt` | 17.77 | | |
| `surface_pressure` | 11.20 | | |
| `wall_shear` | 18.68 | | |
| `volume_pressure` | 16.13 | | |
| `tau_x` | 16.20 | | |
| `tau_y` | 21.81 | | |
| `tau_z` | 23.54 | | |

W&B run: <link>
Epoch of best checkpoint: 

## Analysis
<what improved, what didn't, suggested follow-ups>
```

---

## Notes

- **Single arm only** this round. Run the full 3-sigma concatenation directly — do not run an ablation sweep (that comes in Round 3 if this wins).
- `--rff-sigma` (singular) is still required in the code for backward compat; leave it in place, default `1.0`.
- If you hit a shape mismatch at the linear projection, print `encoder.out_features` and compare against the model's expected input dim. The fix is almost always to make the projection layer read from `encoder.out_features` rather than a hard-coded constant.
- If training diverges (loss spikes), try dropping `--lr` to `2e-5` before anything else.
