### PR TITLE
[fern] Round-2: B04 Mamba-2 SSM Morton-sorted surface decoder

### DIFF
--- a/train.py
+++ b/train.py
@@ -63,6 +63,162 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+def _spread_bits(x: torch.Tensor) -> torch.Tensor:
+    """Spread the lowest 10 bits of x into every 3rd position (Morton encode)."""
+    x = x & 0x3FF
+    x = (x | (x << 16)) & 0x30000FF
+    x = (x | (x << 8)) & 0x0300F00F
+    x = (x | (x << 4)) & 0x30C30C3
+    x = (x | (x << 2)) & 0x9249249
+    return x
+
+
+def morton_sort(xyz: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    """Per-sample sort indices for 3D Morton (Z-order) traversal.
+
+    xyz: [B, N, 3] floats; coords are quantized to 10 bits per axis.
+    mask: optional [B, N] mask of valid (=1) tokens. If provided, the
+        per-sample min/max ignore padded entries so padding cannot shrink
+        the valid coordinate range.
+    Returns: [B, N] int64 sort indices (apply with .gather along dim=1).
+    """
+    if mask is not None:
+        m3 = mask.bool().unsqueeze(-1)
+        big = torch.full_like(xyz, float("inf"))
+        small = torch.full_like(xyz, float("-inf"))
+        xyz_for_min = torch.where(m3, xyz, big)
+        xyz_for_max = torch.where(m3, xyz, small)
+    else:
+        xyz_for_min = xyz
+        xyz_for_max = xyz
+    mn = xyz_for_min.amin(dim=1, keepdim=True)
+    mx = xyz_for_max.amax(dim=1, keepdim=True)
+    xyz_n = ((xyz - mn) / (mx - mn + 1e-8) * 1023).long().clamp(0, 1023)
+    ix = _spread_bits(xyz_n[..., 0])
+    iy = _spread_bits(xyz_n[..., 1])
+    iz = _spread_bits(xyz_n[..., 2])
+    code = ix | (iy << 1) | (iz << 2)
+    return code.argsort(dim=1)
+
+
+class S4DSurfacePostProcessor(nn.Module):
+    """Diagonal S4 (S4D-Lin) sequence mixer for Morton-sorted surface tokens.
+
+    Stand-in for the unavailable Mamba-2 SSD block (mamba-ssm requires nvcc which
+    is not present in this environment). Implements a single gated diagonal
+    state-space layer applied along the Morton-sorted surface sequence:
+
+        h := h + out_proj( SSM(in_proj(LN(h))) * silu(v) )
+
+    The SSM is parameterized as A = exp(log_A_re + i*A_im) with B,C as real
+    learnable projections; the kernel is computed in fp32 via Vandermonde and
+    applied as a length-2N FFT convolution. Padding tokens are zeroed before
+    the SSM and re-zeroed in the residual to prevent garbage propagation.
+    """
+
+    def __init__(self, hidden_dim: int, d_state: int = 64):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.d_state = d_state
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.in_proj = nn.Linear(hidden_dim, 2 * hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+
+        log_A_re_init = torch.linspace(math.log(0.99), math.log(0.5), d_state)
+        log_A_re_init = log_A_re_init.unsqueeze(0).expand(hidden_dim, -1).contiguous()
+        A_im_init = torch.arange(d_state, dtype=torch.float32) * (math.pi / max(d_state, 1))
+        A_im_init = A_im_init.unsqueeze(0).expand(hidden_dim, -1).contiguous()
+        self.log_A_re = nn.Parameter(log_A_re_init)
+        self.A_im = nn.Parameter(A_im_init)
+        self.B = nn.Parameter(torch.randn(hidden_dim, d_state) * 0.02)
+        self.C = nn.Parameter(torch.randn(hidden_dim, d_state) * 0.02)
+        self.D = nn.Parameter(torch.zeros(hidden_dim))
+
+        nn.init.trunc_normal_(self.in_proj.weight, std=0.02)
+        nn.init.zeros_(self.in_proj.bias)
+        nn.init.trunc_normal_(self.out_proj.weight, std=0.02)
+        nn.init.zeros_(self.out_proj.bias)
+
+    def _ssm_kernel_impl(
+        self,
+        log_A_re: torch.Tensor,
+        A_im: torch.Tensor,
+        BC: torch.Tensor,
+        n_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        # K[t, d] = sum_s BC[d,s] * exp(t*log_A_re[d,s]) * cos(t*A_im[d,s])
+        n = n_idx.shape[0]
+        chunks: list[torch.Tensor] = []
+        chunk_size = max(1, min(n, 1024))
+        for start in range(0, n, chunk_size):
+            end = min(start + chunk_size, n)
+            n_c = n_idx[start:end].view(-1, 1, 1)
+            decay = torch.exp(n_c * log_A_re.unsqueeze(0))
+            phase = torch.cos(n_c * A_im.unsqueeze(0))
+            chunks.append((BC.unsqueeze(0) * decay * phase).sum(-1))
+        return torch.cat(chunks, dim=0).T.contiguous()
+
+    def _ssm_kernel(self, n: int, device: torch.device) -> torch.Tensor:
+        log_A_re = self.log_A_re.float().clamp(max=0.0)
+        A_im = self.A_im.float()
+        BC = self.B.float() * self.C.float()
+        n_idx = torch.arange(n, device=device, dtype=torch.float32)
+        if self.training and torch.is_grad_enabled():
+            return torch.utils.checkpoint.checkpoint(
+                self._ssm_kernel_impl,
+                log_A_re,
+                A_im,
+                BC,
+                n_idx,
+                use_reentrant=False,
+            )
+        return self._ssm_kernel_impl(log_A_re, A_im, BC, n_idx)
+
+    def _ssm_conv(self, u: torch.Tensor) -> torch.Tensor:
+        # u: [B, N, D]
+        n = u.shape[1]
+        kernel = self._ssm_kernel(n, u.device)
+        L = 2 * n
+        kernel_f = torch.fft.rfft(kernel, n=L, dim=-1)
+        u_fp32 = u.permute(0, 2, 1).float()
+        u_f = torch.fft.rfft(u_fp32, n=L, dim=-1)
+        y = torch.fft.irfft(kernel_f.unsqueeze(0) * u_f, n=L, dim=-1)[..., :n]
+        y = y + u_fp32 * self.D.float().view(1, -1, 1)
+        return y.permute(0, 2, 1).to(u.dtype)
+
+    def _forward_impl(
+        self,
+        h: torch.Tensor,
+        surf_xyz: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        b_size, n, dim = h.shape
+        sort_idx = morton_sort(surf_xyz, mask=mask)
+        unsort_idx = sort_idx.argsort(dim=1)
+        sort_idx_e = sort_idx.unsqueeze(-1).expand(-1, -1, dim)
+        h_s = h.gather(1, sort_idx_e)
+        mask_s_h = mask.gather(1, sort_idx).to(h.dtype).unsqueeze(-1)
+        h_s = h_s * mask_s_h
+        x_v = self.in_proj(self.norm(h_s))
+        x, v = x_v.chunk(2, dim=-1)
+        x_mixed = self._ssm_conv(x) * F.silu(v)
+        h_s = h_s + self.out_proj(x_mixed) * mask_s_h
+        unsort_idx_e = unsort_idx.unsqueeze(-1).expand(-1, -1, dim)
+        return h_s.gather(1, unsort_idx_e)
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        surf_xyz: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.training and h.requires_grad:
+            return torch.utils.checkpoint.checkpoint(
+                self._forward_impl, h, surf_xyz, mask, use_reentrant=False
+            )
+        return self._forward_impl(h, surf_xyz, mask)
+
+
 class DropPath(nn.Module):
     """Stochastic depth: drop entire residual branch with probability `drop_prob`."""
 
@@ -288,6 +444,8 @@ class SurfaceTransolver(nn.Module):
         mlp_ratio: int = 4,
         slice_num: int = 96,
         stochastic_depth_prob: float = 0.0,
+        use_mamba_surface: bool = False,
+        mamba_d_state: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -321,6 +479,12 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.use_mamba_surface = use_mamba_surface
+        self.surface_post = (
+            S4DSurfacePostProcessor(hidden_dim=n_hidden, d_state=mamba_d_state)
+            if use_mamba_surface
+            else None
+        )
 
     def _encode_group(
         self,
@@ -390,6 +554,14 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.surface_post is not None and surface_x is not None and surface_tokens > 0:
+            surface_hidden = self.surface_post(
+                surface_hidden,
+                surface_x[..., : self.space_dim],
+                surface_mask,
+            )
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
@@ -489,6 +661,8 @@ class Config:
     model_slices: int = 96
     model_dropout: float = 0.0
     stochastic_depth_prob: float = 0.0
+    use_mamba_surface: bool = False
+    mamba_d_state: int = 64
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -644,6 +818,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
         stochastic_depth_prob=config.stochastic_depth_prob,
+        use_mamba_surface=config.use_mamba_surface,
+        mamba_d_state=config.mamba_d_state,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Add a **Mamba-2 state-space sequence mixer** as a post-processing block on the
surface branch of the Transolver, applied after the shared transformer backbone
and before the surface prediction head. Surface points sorted by Morton Z-order
code give a natural sequential structure; Mamba-2 can model the long-range
aerodynamic correlations (e.g., front-hood pressure propagating to the wake)
that attention's slice grouping approximates but truncates.

**Why SSMs for surfaces:**

1. **Long-range structure.** Transolver groups points into slices (N/slices = 65536/128 = 512 points/slice), and each slice attends only to other slices via global aggregation. Mamba-2 processes the full sorted sequence with O(N) complexity — every point influences every other through the SSM state.

2. **Aerodynamically-motivated ordering.** The car's aerodynamic field has a strongly sequential structure along the flow direction (−x to +x). Morton sort groups spatially proximate points, giving Mamba-2 a "physics-structured" token order rather than random permutation. This lets the SSM state carry local geometric context forward along the sequence.

3. **Complementary to attention.** FiLM (PR #8) improves geometry conditioning per-block. Mamba-2 adds a new *sequence mixing* axis — the SSM can propagate long-range information the slice attention misses.

4. **No additional labeled data needed.** Pure architectural change, no pretraining.

**Reference:** Dao & Gu, "Transformers are SSMs: Generalized Models and Efficient Algorithms Through Structured State Space Duality" (ICML 2024) — Mamba-2 (SSD). Implementation: `pip install mamba-ssm` (includes `mamba2` block with CUDA-accelerated selective scan).

---

## Instructions

This is a moderately complex architectural change. Read carefully.

### Step 0 — Install mamba-ssm

At the top of your training job:

```bash
pip install mamba-ssm --quiet  # needs CUDA 11.6+, triton
# Test: python -c "from mamba_ssm import Mamba2; print('OK')"
```

If `mamba-ssm` install fails (CUDA version mismatch, triton build error), fall
back to the **S4D-Lin simplified SSM** in Step 2b below. Do not spend more than
15 min on the install; report what you tried.

### Step 1 — Add config fields

```python
use_mamba_surface: bool = False        # add Mamba-2 post-processor to surface path
mamba_d_state: int = 64               # SSM state dimension
mamba_d_conv: int = 4                 # local conv width inside Mamba block
mamba_expand: int = 2                 # inner-dim expansion factor (d_inner = hidden_dim * expand)
```

### Step 2a — Implement the Mamba surface post-processor (full Mamba-2)

```python
class MambaSurfacePostProcessor(torch.nn.Module):
    """
    Applies 1 Mamba-2 block to Morton-sorted surface tokens, then unsorts.
    Acts as a post-Transolver sequence mixer on the surface path only.
    """
    def __init__(self, hidden_dim: int, d_state: int, d_conv: int, expand: int):
        super().__init__()
        from mamba_ssm import Mamba2
        d_inner = hidden_dim * expand
        self.norm = torch.nn.LayerNorm(hidden_dim)
        self.mamba = Mamba2(
            d_model=hidden_dim,
            d_state=d_state,
            d_conv=d_conv,
            expand=expand,
        )

    def forward(self, h: torch.Tensor, surf_xyz: torch.Tensor,
                mask: torch.Tensor) -> torch.Tensor:
        """
        h:        [B, N, D] surface hidden states from Transolver backbone
        surf_xyz: [B, N, 3] surface xyz coordinates (raw meters; used for sort only)
        mask:     [B, N]    1=valid, 0=padding
        Returns: [B, N, D] same shape, sequence-mixed
        """
        B, N, D = h.shape

        # 1. Morton sort per sample
        sort_idx    = morton_sort(surf_xyz)          # [B, N] int64
        unsort_idx  = sort_idx.argsort(dim=1)        # inverse permutation

        h_sorted = h.gather(1, sort_idx.unsqueeze(-1).expand_as(h))

        # 2. Zero-pad masked tokens (mamba must not see garbage)
        h_sorted = h_sorted * mask.gather(1, sort_idx).unsqueeze(-1).float()

        # 3. Mamba-2 block (residual connection)
        h_sorted = h_sorted + self.mamba(self.norm(h_sorted))

        # 4. Unsort back to original order
        return h_sorted.gather(1, unsort_idx.unsqueeze(-1).expand_as(h_sorted))
```

### Step 2b — Fallback: simplified diagonal S4 (if mamba-ssm fails)

If `mamba-ssm` is unavailable, implement a simplified **diagonal selective SSM**
(S4D-Lin) from scratch. This is ~40 lines and has no external dependencies:

```python
class S4DSurfacePostProcessor(torch.nn.Module):
    """Diagonal S4 state-space mixer as Mamba-2 fallback."""
    def __init__(self, hidden_dim: int, d_state: int = 64):
        super().__init__()
        self.norm    = torch.nn.LayerNorm(hidden_dim)
        self.in_proj = torch.nn.Linear(hidden_dim, 2 * hidden_dim)
        self.out_proj= torch.nn.Linear(hidden_dim, hidden_dim)
        # Learnable diagonal SSM parameters (complex-valued, init near unit circle)
        log_A_re     = torch.zeros(hidden_dim, d_state)
        log_A_im     = torch.arange(d_state).float().unsqueeze(0).expand(hidden_dim, -1) * (math.pi / d_state)
        self.log_A_re= torch.nn.Parameter(log_A_re)
        self.A_im    = torch.nn.Parameter(log_A_im)
        self.B       = torch.nn.Parameter(torch.randn(hidden_dim, d_state) * 0.01)
        self.C       = torch.nn.Parameter(torch.randn(hidden_dim, d_state) * 0.01)
        self.D       = torch.nn.Parameter(torch.zeros(hidden_dim))

    def ssm_conv(self, u: torch.Tensor) -> torch.Tensor:
        # u: [B, N, D]. Compute SSM output via direct convolution (not recurrence).
        B_b, N, D = u.shape
        # Construct SSM kernel via Vandermonde: K[n] = C @ (A^n) @ B
        n_idx = torch.arange(N, device=u.device, dtype=torch.float32)
        A = torch.exp(self.log_A_re + 1j * self.A_im)         # [D, S], complex
        B = self.B.to(torch.complex64)                         # [D, S]
        C = self.C.to(torch.complex64)                         # [D, S]
        # Vandermonde: [N, D, S]
        V = A.unsqueeze(0) ** n_idx.view(N, 1, 1)
        K = (V * B.unsqueeze(0) * C.unsqueeze(0)).sum(-1).real  # [N, D]
        K = K.T  # [D, N] (SSM impulse response)
        # Causal convolution via FFT
        L = 2 * N
        K_f = torch.fft.rfft(K, n=L, dim=-1)                  # [D, L/2+1]
        u_t = u.permute(0, 2, 1)                               # [B, D, N]
        u_f = torch.fft.rfft(u_t.float(), n=L, dim=-1)        # [B, D, L/2+1]
        y_f = K_f.unsqueeze(0) * u_f
        y   = torch.fft.irfft(y_f, n=L, dim=-1)[:, :, :N]    # [B, D, N]
        return y.permute(0, 2, 1).to(u.dtype) + u * self.D

    def forward(self, h, surf_xyz, mask):
        B_b, N, D = h.shape
        sort_idx   = morton_sort(surf_xyz)
        unsort_idx = sort_idx.argsort(dim=1)
        h_s = h.gather(1, sort_idx.unsqueeze(-1).expand_as(h))
        h_s = h_s * mask.gather(1, sort_idx).unsqueeze(-1).float()
        # Gated SSM
        xv = self.in_proj(self.norm(h_s))
        x, v = xv.chunk(2, dim=-1)
        x = self.ssm_conv(x) * torch.nn.functional.silu(v)
        h_s = h_s + self.out_proj(x)
        return h_s.gather(1, unsort_idx.unsqueeze(-1).expand_as(h_s))
```

### Step 3 — Morton sort helper

```python
def _spread_bits(x: torch.Tensor) -> torch.Tensor:
    """Spread 10 bits of x into every 3rd bit position (for 30-bit Morton code)."""
    x = x & 0x3FF          # keep 10 bits
    x = (x | (x << 16)) & 0x30000FF
    x = (x | (x <<  8)) & 0x0300F00F
    x = (x | (x <<  4)) & 0x30C30C3
    x = (x | (x <<  2)) & 0x9249249
    return x

def morton_sort(xyz: torch.Tensor) -> torch.Tensor:
    """
    Sort N surface points per sample by 3D Morton (Z-order) code.
    xyz: [B, N, 3] float, any range — will be quantized to 10-bit integers.
    Returns: [B, N] int64 sort indices (apply with .gather).
    """
    # Normalize each coord to [0, 1023] per-sample
    mn = xyz.amin(dim=1, keepdim=True)
    mx = xyz.amax(dim=1, keepdim=True)
    xyz_n = ((xyz - mn) / (mx - mn + 1e-8) * 1023).long().clamp(0, 1023)
    ix = _spread_bits(xyz_n[..., 0])
    iy = _spread_bits(xyz_n[..., 1])
    iz = _spread_bits(xyz_n[..., 2])
    code = ix | (iy << 1) | (iz << 2)  # [B, N]
    return code.argsort(dim=1)
```

### Step 4 — Wire into train.py

In `train.py`, **after the Transolver backbone processes surface tokens** (i.e.,
right before the surface prediction head's linear layer), insert:

```python
if cfg.use_mamba_surface:
    surface_h = mamba_surface_pp(
        surface_h,          # [B, N, D] surface hidden states from backbone
        batch.surface_x[..., :3],  # xyz coords for Morton sort
        batch.surface_mask,
    )
```

Where `mamba_surface_pp` is instantiated once before the training loop:

```python
if cfg.use_mamba_surface:
    MambaClass = MambaSurfacePostProcessor  # or S4DSurfacePostProcessor fallback
    mamba_surface_pp = MambaClass(
        cfg.model_hidden_dim,
        cfg.mamba_d_state,
        cfg.mamba_d_conv,
        cfg.mamba_expand,
    ).to(device)
    # Include its parameters in the optimizer
    optimizer.add_param_group({
        "params": mamba_surface_pp.parameters(),
        "lr": cfg.lr,
        "weight_decay": cfg.weight_decay,
    })
    # Include in EMA if using EMA
    if cfg.use_ema:
        ema.register(mamba_surface_pp)
```

Crucially: the surface hidden states must be accessible at the insertion point.
Read `train.py` carefully to find where they are (look for the point where the
backbone's per-point surface representations are collected before the final
linear projection to field values).

### Step 5 — Run command (single arm first)

Start with the default hyperparameters on the 256d base config.

```bash
cd target/
python train.py \
  --use-mamba-surface \
  --mamba-d-state 64 \
  --mamba-d-conv 4 \
  --mamba-expand 2 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group b04-mamba2-surface \
  --wandb-name fern-mamba2-d64-e2
```

Cosine EMA (`--ema-decay-start`/`--ema-decay-end`) requires code from
`norman/round1-progressive-ema-decay` (PR #13, pending merge). Port if not yet
on `yi` (`git cherry-pick <relevant commits>` from norman's branch), or omit and
use `--ema-decay 0.9995` alone if that's easier.

If the first arm is stable and beats baseline, run a second arm with `--mamba-d-state 128` for a parameter count comparison.

### Step 6 — Report

In your results comment, include:
1. Full `test_primary/*` table vs baseline
2. `model_params` vs baseline (Mamba block adds `~D * d_state * 4` params)
3. Training stability — grad-norm trajectory, any spikes
4. Epoch-by-epoch val trajectory
5. Whether `mamba-ssm` was available or you used the S4D fallback
6. VRAM usage and iteration speed (Mamba blocks should be fast)

---

## Baseline to beat

Current merged yi baseline (PR #4 chihiro, W&B run `pejudvyd`):

| Metric | yi best | AB-UPT |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **16.64** | — |
| `surface_pressure_rel_l2_pct` | 10.65 | 3.82 |
| `wall_shear_rel_l2_pct` | 17.66 | 7.29 |
| `volume_pressure_rel_l2_pct` | 14.37 | 6.08 |
| `wall_shear_x_rel_l2_pct` | 14.87 | 5.35 |
| `wall_shear_y_rel_l2_pct` | 19.89 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 21.73 | 3.63 |

Pending merges (may update `yi` while your run is in flight):
- PR #8 frieren FiLM: abupt=16.53
- PR #13 norman cosine EMA: abupt=15.82

**Reproduce (PR #9 base config, 256d — use this as your base):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
