### PR TITLE
[alphonse] Bugfix: NaN-safe best-checkpoint guard (prevent NaN EMA overwriting valid checkpoint)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1810,7 +1810,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             log_metrics["early_stop/triggered"] = 1.0
         wandb.log(log_metrics)
 
-        improved = primary_val < best_val
+        primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0
+        improved = primary_val_is_valid and primary_val < best_val
         if improved:
             best_val = primary_val
             best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}


### PR DESCRIPTION
## Hypothesis

`train.py` has a correctness bug in the best-checkpoint guard: when the EMA model becomes NaN (due to gradient explosion without clipping), `_finite_mean()` filters out all NaN values and returns `0.0` as the primary validation metric. Since `0.0 < best_val` (typically ~15-35), `improved=True` fires and the NaN EMA model *overwrites* a previously valid best checkpoint. This was discovered by alphonse (PR #2) and confirmed by violet (PR #38).

The fix is one line: guard `improved` behind `math.isfinite(primary_val)`. This is a pure bug fix — no experiment, no new flags, just correctness.

## Instructions

In `target/train.py`, locate the checkpoint-save block around line 1813:

```python
improved = primary_val < best_val
```

Replace with:

```python
primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0
improved = primary_val_is_valid and primary_val < best_val
```

`math` is already imported. No other changes needed.

**Verify the fix with a smoke test:** add a temporary unit test that confirms `_finite_mean([float('nan'), float('nan')])` returns 0.0 (the bug condition) and that `math.isfinite(0.0) and 0.0 > 0.0` returns False (the fix). Then remove the test comment before submitting.

**Run command (same as the winning 6L base to confirm no regression):**

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group alphonse-nan-guard-bugfix \
  --wandb-name alphonse-nan-guard-smoke
```

This is a single-arm run on 1 GPU. Use 3 remaining GPUs for any other experiments as needed. Report whether metrics are consistent with the 6L baseline (abupt≈13.15).

## Baseline (current yi best — PR #14, senku 6L)

| Metric | yi best (`et4ajeqj`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **13.47** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | 3.63 |

**Reproduce (6L base):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Results

Add a PR comment with:
1. Confirmation that the fix is applied and the code diff.
2. Smoke-test result: `test_primary/abupt_axis_mean_rel_l2_pct` from the verification run.
3. Confirmation that W&B run completed with no NaN metrics in `test_primary/*`.

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
