### PR TITLE
[norman] Round-2: FiLM geometry conditioning on 6L base

### DIFF
--- a/train.py
+++ b/train.py
@@ -233,9 +233,16 @@ class TransformerBlock(nn.Module):
 
 
 class GeomEncoder(nn.Module):
-    """Mean-pooled MLP encoder over surface points to a per-case geometry token."""
+    """Mean-pooled MLP encoder over surface points to a per-case geometry token.
 
-    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
+    When ``output_norm`` is True, applies LayerNorm to the output. This bounds the
+    geom-token magnitude so the downstream FiLM Linear cannot push tanh into
+    saturation: with an unbounded encoder the model can learn ever-larger geom
+    tokens that drive `(1 + clip*tanh(...))` to ±clip per case (memorizing case
+    identity), which manifests as train-loss-down / val-loss-up divergence.
+    """
+
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int, output_norm: bool = False):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(in_dim, hidden_dim),
@@ -243,34 +250,39 @@ class GeomEncoder(nn.Module):
             nn.Linear(hidden_dim, out_dim),
         )
         self.net.apply(_init_linear)
+        self.out_norm = nn.LayerNorm(out_dim, eps=1e-6) if output_norm else nn.Identity()
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-        # x: [B, N, in_dim], mask: [B, N] (1=valid, 0=padding)
         mask_f = mask.to(dtype=x.dtype).unsqueeze(-1)
         x_masked = x * mask_f
-        n_valid = mask_f.sum(dim=1).clamp(min=1.0)  # [B, 1]
-        x_mean = x_masked.sum(dim=1) / n_valid  # [B, in_dim]
-        return self.net(x_mean)  # [B, out_dim]
+        n_valid = mask_f.sum(dim=1).clamp(min=1.0)
+        x_mean = x_masked.sum(dim=1) / n_valid
+        return self.out_norm(self.net(x_mean))
 
 
 class FiLMLayer(nn.Module):
-    """FiLM with AdaLN-zero init: gamma=0, beta=0 at start so output equals input.
+    """AdaLN-zero FiLM: gamma=0, beta=0 at start so output equals input.
 
-    Applies h' = h * (1 + gamma) + beta where (gamma, beta) come from a linear
-    projection of the per-case geometry token. Final linear is zero-initialized
-    so the layer is identity at training start (residual modulation).
+    When gamma_clip > 0, gamma and beta are tanh-bounded to (-clip, +clip).
+    This prevents per-layer gamma compounding from blowing activations up over
+    deep stacks (the unbounded form diverged at 6L; clip keeps each layer's
+    multiplicative factor in (1-clip, 1+clip) so the worst-case 6L compound
+    stays well-bounded).
     """
 
-    def __init__(self, geom_dim: int, hidden_dim: int):
+    def __init__(self, geom_dim: int, hidden_dim: int, gamma_clip: float = 0.0):
         super().__init__()
         self.to_gamma_beta = nn.Linear(geom_dim, 2 * hidden_dim)
         nn.init.zeros_(self.to_gamma_beta.weight)
         nn.init.zeros_(self.to_gamma_beta.bias)
+        self.gamma_clip = float(gamma_clip)
 
     def forward(self, h: torch.Tensor, geom: torch.Tensor) -> torch.Tensor:
-        # h: [B, N, hidden_dim], geom: [B, geom_dim]
-        gb = self.to_gamma_beta(geom)  # [B, 2*hidden_dim]
+        gb = self.to_gamma_beta(geom)
         gamma, beta = gb.chunk(2, dim=-1)
+        if self.gamma_clip > 0.0:
+            gamma = self.gamma_clip * torch.tanh(gamma)
+            beta = self.gamma_clip * torch.tanh(beta)
         return h * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
 
 
@@ -285,6 +297,7 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
         film_geom_dim: int = 0,
+        film_gamma_clip: float = 0.0,
     ):
         super().__init__()
         if depth <= 1:
@@ -308,7 +321,7 @@ class Transformer(nn.Module):
         )
         self.film_layers = (
             nn.ModuleList(
-                [FiLMLayer(film_geom_dim, hidden_dim) for _ in range(depth)]
+                [FiLMLayer(film_geom_dim, hidden_dim, gamma_clip=film_gamma_clip) for _ in range(depth)]
             )
             if film_geom_dim > 0
             else None
@@ -348,6 +361,8 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        film_gamma_clip: float = 0.0,
+        film_geom_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,6 +374,8 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.film_gamma_clip = film_gamma_clip
+        self.film_geom_norm = film_geom_norm
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -372,7 +389,12 @@ class SurfaceTransolver(nn.Module):
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.geom_encoder = (
-            GeomEncoder(self.surface_input_dim, film_encoder_dim * 2, film_encoder_dim)
+            GeomEncoder(
+                self.surface_input_dim,
+                film_encoder_dim * 2,
+                film_encoder_dim,
+                output_norm=film_geom_norm,
+            )
             if use_film
             else None
         )
@@ -385,6 +407,7 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
             film_geom_dim=film_encoder_dim if use_film else 0,
+            film_gamma_clip=film_gamma_clip if use_film else 0.0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -570,6 +593,8 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    film_gamma_clip: float = 0.0
+    film_geom_norm: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -729,6 +754,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        film_gamma_clip=config.film_gamma_clip,
+        film_geom_norm=config.film_geom_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Frieren's PR #8 showed geometry FiLM conditioning cut error nearly in half at the
1-epoch 4L/256d baseline (abupt: 30.47 → 16.53, −46%). The GeomEncoder + FiLMLayer
architecture conditions every transformer block on a global geometry embedding
computed from the surface point cloud, allowing the model to specialize per car shape.

This is the most promising untested composition: **FiLM on the 6L base (abupt=13.15)**.
If FiLM gives even 10-20% of its prior relative gain, we drop below 12 on abupt.
The cosine EMA (PR #13) is already on yi — use it.

Frieren's PR #8 is pending rebase and will land soon, but we want this result now.
**Implement FiLM from scratch on yi following frieren's proven design.**

## Instructions

Add `GeomEncoder` and `FiLMLayer` classes to `train.py`, plus a `Config` flag.

**1. Add to `Config` (near other model config fields):**

```python
use_film: bool = False
film_encoder_dim: int = 64
```

**2. Add these two classes** (after the `TargetTransform` class, before `compute_loss`):

```python
class GeomEncoder(torch.nn.Module):
    """Mean-pooled MLP encoder over surface points → geometry token."""
    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
        super().__init__()
        self.net = torch.nn.Sequential(
            torch.nn.Linear(in_dim, hidden_dim),
            torch.nn.GELU(),
            torch.nn.Linear(hidden_dim, out_dim),
        )

    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
        # x: [B, N, in_dim], mask: [B, N]
        x_masked = x * mask.unsqueeze(-1).float()
        n_valid = mask.float().sum(dim=1, keepdim=True).clamp(min=1)
        x_mean = x_masked.sum(dim=1) / n_valid  # [B, in_dim]
        return self.net(x_mean)  # [B, out_dim]


class FiLMLayer(torch.nn.Module):
    """FiLM: gamma+beta from geometry token applied to hidden state."""
    def __init__(self, geom_dim: int, hidden_dim: int):
        super().__init__()
        # Zero-init so FiLM starts as identity (safe with deep networks)
        self.to_gamma_beta = torch.nn.Linear(geom_dim, 2 * hidden_dim)
        torch.nn.init.zeros_(self.to_gamma_beta.weight)
        torch.nn.init.zeros_(self.to_gamma_beta.bias)

    def forward(self, h: torch.Tensor, geom: torch.Tensor) -> torch.Tensor:
        # h: [B, N, hidden_dim], geom: [B, geom_dim]
        gb = self.to_gamma_beta(geom)  # [B, 2*hidden_dim]
        gamma, beta = gb.chunk(2, dim=-1)
        return h * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
```

**3. Instantiate after the main model is built** (find where `model = ...` is called,
add immediately after):

```python
if config.use_film:
    geom_encoder = GeomEncoder(
        in_dim=7,  # surface_x has 7 channels: xyz + normals + area
        hidden_dim=config.film_encoder_dim * 2,
        out_dim=config.film_encoder_dim,
    ).to(device)
    film_layer_surface = FiLMLayer(config.film_encoder_dim, config.model_hidden_dim).to(device)
    film_layer_volume = FiLMLayer(config.film_encoder_dim, config.model_hidden_dim).to(device)
    film_params = (
        list(geom_encoder.parameters())
        + list(film_layer_surface.parameters())
        + list(film_layer_volume.parameters())
    )
    # Add FiLM params to the optimizer (append to optimizer param groups)
    optimizer.add_param_group({"params": film_params, "lr": config.lr,
                                "weight_decay": config.weight_decay})
    # Also add to EMA if using EMA
    if config.use_ema:
        ema.add_module("film_geom_encoder", geom_encoder)
        ema.add_module("film_surface", film_layer_surface)
        ema.add_module("film_volume", film_layer_volume)
```

If the EMA class does not have an `add_module` method, instead pass all model
parameters (backbone + film) together to EMA at construction. Check the EMA
implementation and adapt accordingly — the key requirement is that FiLM weights
are included in the EMA shadow.

**4. Apply FiLM in the training and eval forward pass.** Find the section where
`model(...)` is called and `out` dict is returned. After the model call, add:

```python
if config.use_film:
    geom_tok = geom_encoder(batch.surface_x, batch.surface_mask)
    out["surface_preds"] = film_layer_surface(out["surface_preds"], geom_tok)
    out["volume_preds"] = film_layer_volume(out["volume_preds"], geom_tok)
```

Apply this in **both** training loop and validation/test loops. When using EMA
inference (during val/test), use the EMA shadows of the film modules.

**5. Add CLI flag wiring** (in the argparse section, following the pattern of other flags):

```python
parser.add_argument("--use-film", action="store_true", default=False)
parser.add_argument("--no-use-film", dest="use_film", action="store_false")
parser.add_argument("--film-encoder-dim", type=int, default=64)
```

**6. Log FiLM diagnostics** in the train loop:

```python
if config.use_film and global_step % config.gradient_log_every == 0:
    with torch.no_grad():
        geom_norm = geom_tok.norm(dim=-1).mean().item()
        wandb.log({"train/film/geom_token_norm_mean": geom_norm}, step=global_step)
```

**Run command:**

```bash
cd target/
python train.py \
  --use-film \
  --film-encoder-dim 64 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group norman-film-6l \
  --wandb-name norman-film-6l-256d
```

If 2 GPUs are free, also run a **no-FiLM control** to measure the FiLM delta cleanly:

```bash
cd target/
python train.py \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group norman-film-6l \
  --wandb-name norman-nofilm-6l-256d
```

## Baseline (current yi best — PR #14 senku 6L/256d)

| Metric | 6L yi best (`et4ajeqj`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **13.47** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | 3.63 |

## Results

Add a PR comment with:
1. All `test_primary/*_rel_l2_pct` and `full_val_primary/*` for the FiLM run.
2. If control run was done: paired FiLM vs no-FiLM delta table.
3. `train/film/geom_token_norm_mean` trajectory — confirm FiLM is active.
4. W&B run IDs and URLs.
5. Verdict: does FiLM compound with 6L depth?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
