### PR TITLE
[askeladd] Round-2: squared rel-L2 aux loss on 6L base (w sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -552,6 +552,7 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    aux_rel_l2_weight: float = 0.0
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
@@ -1293,6 +1294,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    aux_rel_l2_weight: float = 0.0,
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
@@ -1343,6 +1345,16 @@ def train_loss(
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        aux_rel_l2_value: float | None = None
+        if aux_rel_l2_weight > 0.0:
+            surf_pred_f = surface_pred_norm.float()
+            surf_true_f = surface_target.float()
+            mask_f = batch.surface_mask.float().unsqueeze(-1)
+            num = ((surf_pred_f - surf_true_f) ** 2 * mask_f).sum()
+            den = (surf_true_f ** 2 * mask_f).sum().clamp_min(1e-8)
+            aux_rel_l2 = num / den
+            loss = loss + aux_rel_l2_weight * aux_rel_l2
+            aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1351,6 +1363,8 @@ def train_loss(
         "loss_tau_y": per_axis_unweighted[2],
         "loss_tau_z": per_axis_unweighted[3],
     }
+    if aux_rel_l2_value is not None:
+        metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1764,6 +1778,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
+                aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
@@ -1830,6 +1845,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "aux_rel_l2_loss" in batch_loss_metrics:
+                train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
+                    "aux_rel_l2_loss"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

Emma's PR #24 showed that a squared relative-L2 auxiliary loss (no sqrt in the
denominator) improved abupt from 16.64 → 14.81 on the 4L/256d base at w=0.5. The
insight: standard relative-L2 has a singularity in the backward pass when target
magnitudes approach zero, which is common for near-zero wall-shear in recirculation
zones. Squaring before division avoids this singularity and produces smoother
gradients.

Emma's PR #24 is pending rebase. We want to test this on the 6L base (abupt=13.15)
now — implement it from scratch and test whether the aux loss further improves
the already stronger 6L model.

## Instructions

Add a squared relative-L2 auxiliary loss flag to `train.py`.

**1. Add to `Config`:**

```python
aux_rel_l2_weight: float = 0.0   # weight for squared rel-L2 auxiliary loss
```

**2. Add the auxiliary loss computation** in the `compute_loss` function (or
wherever the main loss is assembled), after the primary loss terms:

```python
if config.aux_rel_l2_weight > 0.0:
    # Squared relative-L2 — no sqrt, avoids singularity near zero
    # Apply to surface predictions (both pressure and wall-shear)
    surf_pred = out["surface_preds"]   # [B, N, 4]
    surf_true = batch.surface_y        # [B, N, 4]
    surf_mask = batch.surface_mask     # [B, N]
    
    # Cast to fp32 for numerical stability
    surf_pred_f = surf_pred.float()
    surf_true_f = surf_true.float()
    mask_f = surf_mask.float().unsqueeze(-1)  # [B, N, 1]
    
    num = ((surf_pred_f - surf_true_f) ** 2 * mask_f).sum()
    den = (surf_true_f ** 2 * mask_f).sum().clamp_min(1e-8)
    aux_loss = num / den
    
    loss = loss + config.aux_rel_l2_weight * aux_loss
    metrics["aux_rel_l2_loss"] = aux_loss.item()
```

Add `"aux_rel_l2_loss"` to the train logging dict so it appears in W&B as
`train/aux_rel_l2_loss`.

**3. Add CLI flag wiring:**

```python
parser.add_argument("--aux-rel-l2-weight", type=float, default=0.0)
```

**4. Sweep 3 weight values** using 3 of your 4 GPUs:

| GPU | `--aux-rel-l2-weight` | `--wandb-name` |
|---|---:|---|
| 0 | 0.1 | `askeladd-sq-aux-w01` |
| 1 | 0.5 | `askeladd-sq-aux-w05` |
| 2 | 1.0 | `askeladd-sq-aux-w10` |

(Emma found w=0.5 worked, w=0.1 diverged on the 4L base. On 6L the model may be
more stable, so w=0.1 deserves a retry, and w=1.0 tests a stronger push.)

**Run command (template):**

```bash
cd target/
python train.py \
  --aux-rel-l2-weight <WEIGHT> \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group askeladd-sq-aux-6l \
  --wandb-name askeladd-sq-aux-w<SLUG>
```

**Kill threshold** (abort if clearly failing):
```
--kill-thresholds "8000:val_primary/abupt_axis_mean_rel_l2_pct>=20"
```

## Baseline (current yi best — PR #14 senku 6L/256d)

| Metric | 6L yi best (`et4ajeqj`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **13.47** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | 3.63 |

**Reference: emma PR #24 result on 4L base:**
- w=0.5: abupt=14.81 (W&B `zv791js1`) — best trajectory 23.06→17.75→15.13→13.85→14.59 (best epoch 4)
- w=0.1: diverged

## Results

Add a PR comment with:
1. For each arm: all `test_primary/*_rel_l2_pct` and `full_val_primary/*`.
2. `train/aux_rel_l2_loss` trajectory per arm — confirm the aux loss term is
   contributing (should be ~10-15% of total loss at steady state based on emma's run).
3. Per-epoch val trajectory for all 3 arms.
4. W&B run IDs and URLs.
5. Best weight: which w wins, and does it beat the 6L baseline (13.15)?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
