### PR TITLE
[thorfinn] Round-2: per-axis tau_y/z loss upweighting on 6L base

### DIFF
--- a/train.py
+++ b/train.py
@@ -479,6 +479,8 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    wallshear_y_weight: float = 1.0
+    wallshear_z_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1163,6 +1165,35 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def weighted_masked_mse_per_channel(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    channel_weights: Iterable[float],
+) -> tuple[torch.Tensor, list[float]]:
+    """Per-channel weighted masked MSE for surface predictions.
+
+    pred, target: [B, N, C]. mask: [B, N] bool.
+    Returns the weighted scalar loss plus an unweighted per-channel mean for
+    diagnostic logging. With all weights == 1 this is numerically equivalent
+    to F.mse_loss(pred[mask], target[mask]).
+    """
+    weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
+    if not bool(mask.any()):
+        per_axis = [0.0] * int(weights.numel())
+        return pred.sum() * 0.0, per_axis
+    diff_sq = (pred - target).pow(2)  # [B, N, C]
+    mask_f = mask.unsqueeze(-1).to(pred.dtype)
+    valid = mask_f.sum().clamp_min(1)
+    n_channels = diff_sq.shape[-1]
+    weighted_diff = diff_sq * weights.view(1, 1, -1)
+    weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
+    per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
+    per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
+    return weighted_loss, per_axis_mean
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1185,6 +1216,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    wallshear_y_weight: float = 1.0,
+    wallshear_z_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1224,12 +1257,21 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
+            surface_pred_used,
+            surface_target_used,
+            batch.surface_mask,
+            channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+        )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
     metrics = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
+        "loss_cp": per_axis_unweighted[0],
+        "loss_tau_x": per_axis_unweighted[1],
+        "loss_tau_y": per_axis_unweighted[2],
+        "loss_tau_z": per_axis_unweighted[3],
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
@@ -1636,6 +1678,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                wallshear_y_weight=config.wallshear_y_weight,
+                wallshear_z_weight=config.wallshear_z_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1688,6 +1732,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
                 "train/volume_loss": batch_loss_metrics["volume_loss"],
+                "train/loss_cp": batch_loss_metrics["loss_cp"],
+                "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
+                "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
+                "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,


### PR DESCRIPTION
## Hypothesis

The 6L baseline (abupt=13.15) still shows large gaps on wall-shear axes:
`tau_y=16.23` and `tau_z=16.75` are 4.4× and 4.6× the AB-UPT targets (3.65, 3.63).
Meanwhile `surface_pressure=7.64` is only 2× AB-UPT.

The hypothesis: **the model is allocating too much capacity to surface pressure**
(the easiest axis) relative to wall-shear components. Adding per-axis loss weights
that up-weight tau_y and tau_z relative to tau_x and surface_pressure should steer
gradient signal toward the hardest prediction axes.

The surface predictions are 4-channel: [cp, tau_x, tau_y, tau_z]. The current loss
treats all 4 channels equally. Adding channel-wise weights lets us boost the loss
contribution of tau_y and tau_z (the worst axes) independently.

This requires a small code change — add per-channel weights to the surface loss.

## Instructions

**1. Add config fields to `Config`:**

```python
wallshear_y_weight: float = 1.0   # relative loss weight for tau_y channel
wallshear_z_weight: float = 1.0   # relative loss weight for tau_z channel
```

**2. Modify the surface loss computation** in `compute_loss` (or wherever surface
MSE is assembled). Find the section computing surface prediction error:

```python
# Current (approximate):
surf_diff = (surf_pred - surf_true) ** 2  # [B, N, 4]
surf_loss = (surf_diff * mask).mean()
```

Replace with:

```python
# Per-channel weights: [cp=1.0, tau_x=1.0, tau_y=W_y, tau_z=W_z]
ch_weights = torch.ones(4, device=surf_pred.device, dtype=surf_pred.dtype)
ch_weights[2] = config.wallshear_y_weight   # tau_y index = 2
ch_weights[3] = config.wallshear_z_weight   # tau_z index = 3

surf_diff = (surf_pred - surf_true) ** 2    # [B, N, 4]
surf_diff_weighted = surf_diff * ch_weights.unsqueeze(0).unsqueeze(0)  # broadcast
surf_loss = (surf_diff_weighted * mask.unsqueeze(-1).float()).sum() \
            / mask.float().sum().clamp_min(1) / 4.0
```

Cast `ch_weights` to match the dtype of `surf_pred` (which is bf16 in AMP). The
division by 4.0 keeps the total loss scale comparable to the unweighted version.

Log the per-axis raw losses (unweighted) as separate W&B keys for diagnostics:
`train/loss_cp`, `train/loss_tau_x`, `train/loss_tau_y`, `train/loss_tau_z`.

**3. Add CLI flag wiring:**

```python
parser.add_argument("--wallshear-y-weight", type=float, default=1.0)
parser.add_argument("--wallshear-z-weight", type=float, default=1.0)
```

**4. Run 3 arms** (3 GPUs, weight combinations chosen based on the ~4.5× tau_y/z
gap vs 2× surface_pressure gap — we need ~2-3× more gradient for tau_y/z):

| GPU | `--wallshear-y-weight` | `--wallshear-z-weight` | `--wandb-name` |
|---|---:|---:|---|
| 0 | 2.0 | 2.0 | `thorfinn-yw2-zw2` |
| 1 | 3.0 | 3.0 | `thorfinn-yw3-zw3` |
| 2 | 2.0 | 3.0 | `thorfinn-yw2-zw3` |

**Run command (template):**

```bash
cd target/
python train.py \
  --wallshear-y-weight <W_Y> \
  --wallshear-z-weight <W_Z> \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --clip-grad-norm 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group thorfinn-per-axis-wallshear-6l \
  --wandb-name thorfinn-<SLUG>
```

**Key metrics to watch:**
- `test_primary/wall_shear_y_rel_l2_pct` and `test_primary/wall_shear_z_rel_l2_pct`
  — the primary target axes.
- `test_primary/abupt_axis_mean_rel_l2_pct` — does boosting tau_y/z hurt the mean?
- `train/loss_tau_y` vs `train/loss_tau_x` — confirm the channel weights are engaged.

## Baseline (current yi best — PR #14 senku 6L/256d)

| Metric | 6L yi best (`et4ajeqj`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **13.47** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | 3.63 |

Note: haku's PR #10 (per-axis wallshear loss weighting) is still WIP on the 4L
base. This is the 6L version — do not duplicate haku's approach, but if you see
their PR #10 results before submitting, incorporate any findings into your analysis.

## Results

Add a PR comment with:
1. For each arm: all `test_primary/*_rel_l2_pct` and `full_val_primary/*`.
2. Per-axis raw losses `train/loss_tau_y` and `train/loss_tau_z` — are they decreasing?
3. Per-epoch val trajectory for all 3 arms.
4. W&B run IDs and URLs.
5. Verdict: do tau_y/tau_z improve, and does abupt_axis_mean improve (or does
   boosting tau_y/z hurt surface_pressure enough to offset)?

## Constraints

- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
