### PR TITLE
[fern] Round-5b: AdamW+RFF+compile + per-axis tau_y/tau_z weighting (re-assignment after #71 mishap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -50,6 +50,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     make_loaders,
     masked_mse,
+    masked_per_channel_mse,
     metric_namespace,
     parse_kill_thresholds,
     primary_metric_log,
@@ -58,6 +59,18 @@ from trainer_runtime import (
     should_update_best_checkpoint,
     timeout_budget_minutes,
     unwrap_model,
+)
+
+
+# Per-channel loss weights for surface predictions (4 channels: pressure, tau_x, tau_y, tau_z).
+# tau_y/tau_z are the binding constraints on `abupt` (PR #72: gap ×3.8/×3.9 vs AB-UPT).
+# Up-weight tau_y and tau_z 2x to redirect optimization pressure where it matters.
+_SURFACE_PER_CHANNEL_LOSS_WEIGHTS: tuple[float, ...] = (1.0, 1.0, 2.0, 2.0)
+_SURFACE_PER_CHANNEL_NAMES: tuple[str, ...] = (
+    "surface_pressure",
+    "wall_shear_x",
+    "wall_shear_y",
+    "wall_shear_z",
 )
 
 
@@ -199,19 +212,38 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        per_channel_weights = torch.tensor(
+            _SURFACE_PER_CHANNEL_LOSS_WEIGHTS,
+            device=out["surface_preds"].device,
+            dtype=out["surface_preds"].dtype,
+        )
+        surface_loss = masked_mse(
+            out["surface_preds"],
+            surface_target,
+            batch.surface_mask,
+            per_channel_weights=per_channel_weights,
+        )
+        surface_per_channel = masked_per_channel_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )
+        surface_base_mse = surface_per_channel.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        base_mse_loss = surface_base_mse + volume_loss
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_base_mse": float(surface_base_mse.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    surface_per_channel_list = surface_per_channel.detach().cpu().tolist()
+    for name, value in zip(_SURFACE_PER_CHANNEL_NAMES, surface_per_channel_list):
+        metrics[f"surface_mse_{name}"] = float(value)
+    return loss, metrics
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -356,11 +388,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/loss": float(loss.detach().cpu().item()),
                             "train/base_mse_loss": batch_loss_metrics["base_mse_loss"],
                             "train/surface_loss": batch_loss_metrics["surface_loss"],
+                            "train/surface_base_mse": batch_loss_metrics["surface_base_mse"],
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    for name in _SURFACE_PER_CHANNEL_NAMES:
+                        key = f"surface_mse_{name}"
+                        train_log[f"train/{key}"] = batch_loss_metrics[key]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -828,8 +828,48 @@ def masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     return values.sum() * 0.0
 
 
-def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-    return masked_mean((pred - target).square(), mask)
+def masked_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    per_channel_weights: torch.Tensor | None = None,
+) -> torch.Tensor:
+    sq_err = (pred - target).square()
+    if per_channel_weights is None:
+        return masked_mean(sq_err, mask)
+    expanded_mask = mask
+    while expanded_mask.ndim < sq_err.ndim:
+        expanded_mask = expanded_mask.unsqueeze(-1)
+    expanded_mask = expanded_mask.to(device=sq_err.device, dtype=sq_err.dtype)
+    weights = per_channel_weights.to(device=sq_err.device, dtype=sq_err.dtype)
+    weights_view = weights.view(*([1] * (sq_err.ndim - 1)), -1)
+    weighted_masked_sum = (sq_err * weights_view * expanded_mask).sum()
+    denominator = expanded_mask.expand_as(sq_err).sum()
+    if bool(denominator.detach().cpu().item() > 0):
+        return weighted_masked_sum / denominator.clamp_min(1.0)
+    return sq_err.sum() * 0.0
+
+
+def masked_per_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    """Per-channel MSE diagnostic: returns a 1-D tensor of length C.
+
+    For each channel c, returns mean over masked points of (pred_c - target_c)^2.
+    """
+    sq_err = (pred - target).square()
+    expanded_mask = mask
+    while expanded_mask.ndim < sq_err.ndim:
+        expanded_mask = expanded_mask.unsqueeze(-1)
+    expanded_mask = expanded_mask.to(device=sq_err.device, dtype=sq_err.dtype)
+    n_channels = sq_err.shape[-1]
+    other_dims = tuple(range(sq_err.ndim - 1))
+    per_channel_sum = (sq_err * expanded_mask).sum(dim=other_dims)
+    per_channel_count = expanded_mask.expand_as(sq_err).sum(dim=other_dims).clamp_min(1.0)
+    return per_channel_sum / per_channel_count
 
 
 def squared_relative_l2_loss(


### PR DESCRIPTION
## Hypothesis

Per-channel wall_shear loss weighting (tau_y ×2, tau_z ×2, tau_x ×1) on the stable AdamW + RFF + compile base forces the model to attend proportionally more to the tau_y/tau_z binding gaps (currently ×3.8/×3.9 vs AB-UPT reference). Tested on AdamW (not Lion) to ensure stable training — Lion+per-axis-weights diverged at epoch 4 in PR #54, but the per-axis breakdown confirmed the loss-level mechanism worked (tau_y/tau_x ratio improved from 1.45 to 1.33 despite divergence).

Single delta from PR #46: add per-channel weighting `[1.0, 2.0, 2.0]` to wall_shear [x, y, z] channels. Base is AdamW + RFF sigma=1.0 + compile.

Note: PR #71 was opened with this same assignment but auto-merged due to an advisor branch-management mistake (the experiments-log commit landed on the assignment branch). Re-creating here as a fresh assignment.

## Instructions

**Step 1: Add per-channel wall_shear weighting in `trainer_runtime.py`**

Re-add the per-channel weighting you implemented in PR #54. The key change is `masked_mse(per_channel_weights=...)` that accepts a tensor of per-axis weights applied to each channel before loss reduction.

For wall_shear (which has 3 channels: tau_x, tau_y, tau_z), apply weights:
- tau_x: 1.0 (default)
- tau_y: **2.0** (binding gap ×3.8 vs AB-UPT)
- tau_z: **2.0** (binding gap ×3.9 vs AB-UPT)

Verify via unit test before training:
- `weighted_loss == (1.0*mse_x + 2.0*mse_y + 2.0*mse_z) / 3.0`
- Unweighted path still matches `mean([mse_x, mse_y, mse_z])`

Surface pressure and volume pressure weights stay at 1.0.

**Step 2: Run the training command**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --wandb-name "fern/round5b-adamw-rff-tauyz" \
  --wandb-group "tay-round5b-adamw-rff-tauyz" \
  --optimizer adamw --lr 5e-5 --weight-decay 5e-4 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --compile-model \
  --volume-loss-weight 2.0 --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

(Per-channel weights are hardcoded in your `masked_mse` modification — no new CLI flag required.)

**Expected:** ~16 epochs in 270 min (compiled). Should match PR #46 trajectory to epoch 5, then per-axis weighting should bend tau_y/tau_z downward relative to tau_x. Report per-axis breakdown in results.

## Baseline metrics (SOTA tanjiro arm B, W&B `vnb7oheo`)

| Metric | tay SOTA | PR #46 (AdamW+RFF+compile) | AB-UPT ref |
|---|---:|---:|---:|
| `abupt` mean | **11.303** | 14.550 | — |
| `surface_pressure` | 6.216 | 8.628 | 3.82 |
| `wall_shear` | 11.315 | 14.882 | 7.29 |
| `volume_pressure` | 12.755 | 15.032 | 6.08 |
| `tau_x` | 9.563 | 12.901 | 5.35 |
| `tau_y` | **13.831** | 17.281 | 3.65 |
| `tau_z` | **14.147** | 18.907 | 3.63 |

Target: beat PR #46 (abupt 14.550). Aim for < 13.5 if tau_y/tau_z weighting closes even part of the gap.
