### PR TITLE
[emma] DrivAerML 60k Points + Fourier PE

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,6 +72,23 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression."""
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -236,7 +253,7 @@ class SurfaceTransolver(nn.Module):
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        self.pos_embed = FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (


### PR DESCRIPTION
# [emma] DrivAerML More Training Points: 60k Surface/Volume + 4L/256d + no-EMA + Fourier

## Hypothesis

The default training setup uses 40k surface points and 40k volume points per sample. DrivAerML contains dense CFD meshes with ~300k+ surface points per geometry. Increasing the sampled point count to 60k gives the model more spatial context per training step, potentially capturing finer geometric details and flow features that are missed with sparser sampling.

**Prediction:** 60k points will improve especially `surface_pressure_rel_l2_pct` and `wall_shear_*` metrics since more surface sample coverage reduces sampling bias on complex vehicle geometry regions (wheel arches, underbody, rear diffuser).

**Trade-off:** Each step will be ~1.5x slower. With 50 epochs the wall-clock time will increase, but the quality improvement should outweigh the cost.

## Model Architecture Change (Required)

Replace `ContinuousSincosEmbed` with `FourierEmbed` in `model.py`. Add the following class **before** the `SurfaceTransolver` class:

```python
import math

class FourierEmbed(nn.Module):
    """Fourier positional encoding with geometric frequency progression."""
    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
        super().__init__()
        freqs = 2.0 ** torch.arange(num_freqs).float()
        self.register_buffer("freqs", freqs)
        raw_dim = input_dim * num_freqs * 2
        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()

    def forward(self, coords: torch.Tensor) -> torch.Tensor:
        coords = coords.float()
        angles = coords.unsqueeze(-1) * self.freqs * math.pi
        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
        emb = emb.flatten(start_dim=-2)
        return self.proj(emb)
```

In `SurfaceTransolver.__init__`, replace:
```python
self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
```
with:
```python
self.pos_embed = FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)
```

## Training Command

```bash
torchrun --nproc_per_node=4 train.py \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
  --epochs 50 --lr-cosine-t-max 30 \
  --train-surface-points 60000 --train-volume-points 60000 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
  --wandb-group bengio-stream1-emma --agent emma
```

**If batch-size 2 with 60k points causes OOM, fall back to:**
```bash
torchrun --nproc_per_node=4 train.py \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 1 \
  --epochs 50 --lr-cosine-t-max 30 \
  --train-surface-points 60000 --train-volume-points 60000 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
  --wandb-group bengio-stream1-emma --agent emma
```

## Baseline Targets to Beat (AB-UPT Reference)

| Metric | AB-UPT Target |
|--------|--------------|
| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |

**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)

## Success Criteria

- Report final `val_primary/abupt_axis_mean_rel_l2_pct` compared to alphonse (40k points)
- Report all `test_primary/*` metrics
- Report whether batch_size=2 was feasible or if you had to fall back to batch_size=1
- Report training wall-clock time per epoch to quantify the compute overhead
