### PR TITLE
thorfinn: round7 — 768d width scaling on AdamW+RFF+compile stable base

### DIFF
--- a/instructions/thorfinn-round7-adamw-rff-768d-compile.md
+++ b/instructions/thorfinn-round7-adamw-rff-768d-compile.md
@@ -1,0 +1,32 @@
+# thorfinn round7 — 768d AdamW+RFF+compile (width scaling on stable base)
+
+## Hypothesis
+
+Scale width to 768d using the stable AdamW+RFF+compile base.
+PR #69 (768d Lion uncompiled) was budget-limited to 5 epochs.
+With compile, ~9-10 epochs of 768d should fit in 270 min.
+Orthogonal to frieren PR #73 (6L depth).
+
+## Reproduce Command
+
+```bash
+torchrun --standalone --nproc_per_node=8 train.py \
+  --agent thorfinn \
+  --wandb-name "thorfinn/round7-adamw-rff-768d-compile-rank0" \
+  --wandb-group "thorfinn-round7-768d-adamw-compile" \
+  --optimizer adamw \
+  --lr 1e-4 --weight-decay 1e-4 \
+  --rff-num-features 32 --rff-sigma 1.0 \
+  --compile-model \
+  --volume-loss-weight 2.0 --batch-size 4 --validation-every 1 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 4 --model-hidden-dim 768 --model-heads 12 --model-slices 128 \
+  --ema-decay 0.9995 \
+  --gradient-log-every 100 --weight-log-every 100 \
+  --no-log-gradient-histograms
+```
+
+## OOM Fallback
+
+If OOM, reduce points to 32768+32768.


### PR DESCRIPTION
## Hypothesis

**Single lever: scale width to 768d using the stable AdamW+RFF+compile base.**

PR #69 (thorfinn, 768d Lion uncompiled) achieved test_abupt=12.351 but was severely budget-limited — only 5 epochs completed in 270 min. The root issue was throughput: uncompiled 768d is too slow.

**This experiment** uses `--compile-model` (stable with AdamW) to unlock ~9-10 epochs of 768d within the 270 min budget (vs. 16 epochs for 512d compiled in PR #46). The hypothesis is that 768d capacity at 9-10 epochs beats both:
- 768d uncompiled at 5 epochs (test 12.351, PR #69)
- 512d AdamW+RFF+compile at 16 epochs (test 14.55, PR #46)

This is **orthogonal to frieren PR #73**, which tests depth scaling (6L) on the same AdamW+RFF+compile base. Together they probe the width vs. depth frontier.

Note: Lion+compile always diverges within budget on this task — we use AdamW which is stable with compile.

---

## Current SOTA Baseline

| PR | Student | Config | test_abupt | val_abupt |
|----|---------|--------|-----------|-----------|
| #50 | nezuko | Lion uncompiled, lr=5e-5/wd=5e-4, no RFF, 4L/512d/8h/128sl | **11.208** | — |
| #69 | thorfinn | Lion uncompiled, 768d, 4L/12h/128sl | 12.351 (ep5, budget) | — |
| #46 | thorfinn | AdamW+RFF+compile, 512d | 14.55 (ep16) | — |

**Target to beat:** test_abupt < 11.208

---

## Reproduce Command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --wandb-name "thorfinn/round7-adamw-rff-768d-compile-rank0" \
  --wandb-group "thorfinn-round7-768d-adamw-compile" \
  --optimizer adamw \
  --lr 1e-4 --weight-decay 1e-4 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --compile-model \
  --volume-loss-weight 2.0 --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 768 --model-heads 12 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

**Head dim:** `--model-heads 12` gives head_dim=64 (768/12=64), matching nezuko's 512d/8h=64. If 12 heads cause issues, fall back to `--model-heads 8` (head_dim=96).

---

## OOM Fallback (IMPORTANT — read before starting)

PR #69 OOM'd at 65536+65536 surface+volume points with 768d. If you hit OOM with the primary command, immediately retry with halved point counts:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --wandb-name "thorfinn/round7-adamw-rff-768d-compile-32k-rank0" \
  --wandb-group "thorfinn-round7-768d-adamw-compile" \
  --optimizer adamw \
  --lr 1e-4 --weight-decay 1e-4 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --compile-model \
  --volume-loss-weight 2.0 --batch-size 4 --validation-every 1 \
  --train-surface-points 32768 --eval-surface-points 32768 \
  --train-volume-points 32768 --eval-volume-points 32768 \
  --model-layers 4 --model-hidden-dim 768 --model-heads 12 --model-slices 128 \
  --ema-decay 0.9995 \
  --gradient-log-every 100 --weight-log-every 100 \
  --no-log-gradient-histograms
```

Log both W&B run IDs in your results comment if you had to switch.

---

## Expected Outcome

- With compile, 768d should complete ~9-10 epochs in 270 min (vs. 5 uncompiled in PR #69).
- More epochs + larger capacity should substantially beat test 12.351 (PR #69).
- If 768d+compile beats 512d+compile (test 14.55), width scaling is confirmed as a strong lever alongside frieren's depth test.
- Beating nezuko SOTA (11.208) would be a major result.

---

## Success Criteria

| Scenario | test_abupt | Conclusion |
|----------|-----------|------------|
| Beats SOTA | < 11.208 | Merge — width scaling is the new direction |
| Beats 512d+compile | 11.208–14.55 | Strong signal — explore 1024d or 6L+768d combo |
| Matches 768d uncompiled | ~12.35 | Compile didn't help enough — revisit |
| Worse | > 14.55 | Width scaling not the lever — close |

---

## Notes

- Keep `--ema-decay 0.9995` (same as nezuko SOTA).
- Keep `--volume-loss-weight 2.0` (validated across recent experiments).
- `--rff-sigma 1.0` default (same as PR #46 base).
- In your results comment, report: best val_abupt checkpoint epoch, its test_abupt, final epoch test_abupt, W&B run ID, and total epochs completed within budget.