### PR TITLE
[alphonse] Round-3: area-weighted surface MSE loss (phys-motivated)

### DIFF
--- a/train.py
+++ b/train.py
@@ -555,6 +555,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    use_area_weighted_surface_loss: bool = False
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1249,13 +1250,17 @@ def weighted_masked_mse_per_channel(
     mask: torch.Tensor,
     *,
     channel_weights: Iterable[float],
+    point_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, list[float]]:
     """Per-channel weighted masked MSE for surface predictions.
 
     pred, target: [B, N, C]. mask: [B, N] bool.
-    Returns the weighted scalar loss plus an unweighted per-channel mean for
-    diagnostic logging. With all weights == 1 this is numerically equivalent
-    to F.mse_loss(pred[mask], target[mask]).
+    point_weights: optional [B, N, 1] non-negative tensor normalized so that the
+    mean over each case's valid points is 1; allows physically motivated
+    re-weighting (e.g. by surface patch area) without changing the global scale
+    of the loss. Returns the weighted scalar loss plus an unweighted per-channel
+    mean for diagnostic logging. With all weights == 1 this is numerically
+    equivalent to F.mse_loss(pred[mask], target[mask]).
     """
     weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
     if not bool(mask.any()):
@@ -1266,6 +1271,8 @@ def weighted_masked_mse_per_channel(
     valid = mask_f.sum().clamp_min(1)
     n_channels = diff_sq.shape[-1]
     weighted_diff = diff_sq * weights.view(1, 1, -1)
+    if point_weights is not None:
+        weighted_diff = weighted_diff * point_weights.to(pred.dtype)
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
     per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
@@ -1296,6 +1303,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    use_area_weighted_surface_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1335,11 +1343,35 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
+        area_weights: torch.Tensor | None = None
+        area_weight_max = float("nan")
+        area_weight_min = float("nan")
+        area_weight_mean = float("nan")
+        if use_area_weighted_surface_loss:
+            # surface_x channels: [x, y, z, nx, ny, nz, area]; channel 6 is the
+            # per-point patch area. Normalize per case so the mean of the
+            # weight over each case's valid points is 1: this preserves the
+            # global magnitude of the surface loss (so other axis weights and
+            # surface_loss_weight stay calibrated) while reshaping the
+            # gradient toward physically larger surface patches.
+            mask_f = batch.surface_mask.unsqueeze(-1).to(batch.surface_x.dtype)
+            area_raw = batch.surface_x[..., 6:7].clamp(min=0.0) * mask_f
+            area_sum = area_raw.sum(dim=1, keepdim=True).clamp_min(1e-8)
+            valid_per_case = batch.surface_mask.sum(dim=1, keepdim=True).unsqueeze(-1).to(area_raw.dtype)
+            # area_weights: per-case mean over valid points ≈ 1, padding rows are 0.
+            area_weights = area_raw / area_sum * valid_per_case
+            if bool(batch.surface_mask.any()):
+                valid_area_weights = area_weights[batch.surface_mask.unsqueeze(-1).expand_as(area_weights)].detach().float()
+                if valid_area_weights.numel() > 0:
+                    area_weight_max = float(valid_area_weights.max().cpu().item())
+                    area_weight_min = float(valid_area_weights.min().cpu().item())
+                    area_weight_mean = float(valid_area_weights.mean().cpu().item())
         surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
             surface_pred_used,
             surface_target_used,
             batch.surface_mask,
             channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+            point_weights=area_weights,
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -1353,6 +1385,10 @@ def train_loss(
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if use_area_weighted_surface_loss:
+        metrics["area_weight_max"] = area_weight_max
+        metrics["area_weight_min"] = area_weight_min
+        metrics["area_weight_mean"] = area_weight_mean
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -1767,6 +1803,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                use_area_weighted_surface_loss=config.use_area_weighted_surface_loss,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1831,6 +1868,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            if "area_weight_max" in batch_loss_metrics:
+                train_log["train/area_weight_max"] = batch_loss_metrics["area_weight_max"]
+                train_log["train/area_weight_min"] = batch_loss_metrics["area_weight_min"]
+                train_log["train/area_weight_mean"] = batch_loss_metrics["area_weight_mean"]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():


### PR DESCRIPTION
## Hypothesis

Each surface point has an associated area (`surface_area.npy`) that represents the physical patch of car surface it covers. Currently the surface MSE loss treats all surface points equally — a tiny near-stagnation-point patch contributes the same gradient as a large flat-panel patch. This is physically wrong: large-area patches integrate more total force on the vehicle, so getting them right matters more for drag/lift prediction.

**Hypothesis:** Weighting each surface point's loss contribution by its normalized area will steer the gradient toward physically important surface regions, improving `surface_pressure_rel_l2_pct` (and potentially all surface axes) without any architectural change.

**Why this hasn't been tried:** `surface_area` is already available in the input features (`surface_x` channel 6 = area). The loader reads `surface_area.npy` and includes it. We just need to weight the MSE by it.

**Expected effect:** Surface pressure is currently 7.64 vs AB-UPT target 3.82 (2.0× gap) — the largest remaining single-axis gap in absolute terms. Area weighting should reduce the contribution of isolated small patches (near stagnation point, trailing edge tips) that are hard to predict but physically less important.

## Instructions

**1. Add a config field to `Config`:**

```python
use_area_weighted_surface_loss: bool = False   # weight surface MSE by normalized point area
```

Add this immediately after `wallshear_z_weight` in the `Config` dataclass.

**2. Add CLI wiring** (in the argparse block):

```python
parser.add_argument("--use-area-weighted-surface-loss", action="store_true", default=False)
parser.add_argument("--no-use-area-weighted-surface-loss", dest="use_area_weighted_surface_loss", action="store_false")
```

**3. Thread `use_area_weighted_surface_loss` and the area tensor through `train_loss`.**

The `train_loss` function currently receives `batch` which has `batch.surface_x` — channel 6 of `surface_x` is area (in the loader concatenation: `[x, y, z, nx, ny, nz, area]`). Extract it:

```python
# Inside train_loss, after computing surface_loss_weight and surface_target:
if config.use_area_weighted_surface_loss:
    # Extract area from surface_x channel 6: [B, N, 1]
    area_raw = batch.surface_x[..., 6:7].clamp(min=0.0)
    # Normalize per case so weights sum to 1 over valid surface points
    mask_f = batch.surface_mask.unsqueeze(-1).float()  # [B, N, 1]
    area_sum = (area_raw * mask_f).sum(dim=1, keepdim=True).clamp(min=1e-8)  # [B, 1, 1]
    area_weights = area_raw / area_sum * mask_f  # [B, N, 1] — sums to ~1 per case
    area_weights = area_weights * batch.surface_mask.sum(dim=1, keepdim=True).unsqueeze(-1).float()
    # area_weights now is normalized so mean over valid pts ≈ 1.0
```

Then modify the loss computation. The `weighted_masked_mse_per_channel` function computes:
`(surface_diff_weighted * mask.unsqueeze(-1).float()).sum() / mask.float().sum().clamp_min(1) / 4.0`

You need to also multiply by `area_weights` before summing. Here is the modification to make in `weighted_masked_mse_per_channel` — add an optional `point_weights` parameter:

```python
def weighted_masked_mse_per_channel(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    channel_weights: tuple[float, ...],
    point_weights: torch.Tensor | None = None,   # [B, N, 1] normalized per-point weights
) -> tuple[torch.Tensor, list[float]]:
    """
    Returns the weighted scalar loss plus an unweighted per-channel mean for
    diagnostic logging. With all weights == 1 this is numerically equivalent
    to F.mse_loss(pred[mask], target[mask]).
    """
    weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
    diff = (pred - target) ** 2  # [B, N, C]
    diff_weighted = diff * weights.unsqueeze(0).unsqueeze(0)  # [B, N, C]
    mask_f = mask.unsqueeze(-1).float()  # [B, N, 1]
    if point_weights is not None:
        # point_weights: [B, N, 1], normalized so valid mean ≈ 1
        loss = (diff_weighted * mask_f * point_weights).sum() / max(mask.float().sum().item() * len(channel_weights), 1)
    else:
        loss = (diff_weighted * mask_f).sum() / mask.float().sum().clamp_min(1) / len(channel_weights)
    # Per-channel unweighted (for logging)
    per_ch = []
    for c in range(diff.shape[-1]):
        ch_val = (diff[..., c] * mask.float()).sum() / mask.float().sum().clamp_min(1)
        per_ch.append(float(ch_val.detach().cpu().item()))
    return loss, per_ch
```

Then pass `point_weights=area_weights if config.use_area_weighted_surface_loss else None` to the `weighted_masked_mse_per_channel` call inside `train_loss`.

Log `area_weights.max()` and `area_weights.min()` for the first batch each epoch for diagnostics.

**4. Run 2 arms** on 2 GPUs:

| GPU | Flag | `--wandb-name` |
|---|---|---|
| 0 | `--use-area-weighted-surface-loss` | `alphonse-area-wt-on` |
| 1 | (control — no flag) | `alphonse-area-wt-ctrl` |

```bash
cd target/
python train.py \
  --use-area-weighted-surface-loss \     # ARM 0 only
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group alphonse-area-weighted-loss \
  --wandb-name alphonse-area-wt-<SLUG>
```

**Beat target: abupt=12.74** (PR #66 thorfinn, W&B `gvigs86q`).

Watch especially: `test_primary/surface_pressure_rel_l2_pct` (target: 7.86→lower) and `test_primary/wall_shear_*` axes.

## Baseline (current yi best — PR #66 thorfinn, 6L/256d + W_y=2, W_z=2)

| Metric | Current best (`gvigs86q`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | — |
| `test_primary/surface_pressure_rel_l2_pct` | 7.86 | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 12.86 | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 13.14 | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 11.29 | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 15.15 | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 15.05 | 3.63 |

**Reproduce (new base):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Results

Post results as a PR comment with:
1. All `test_primary/*_rel_l2_pct` and `full_val_primary/*` for both arms.
2. `area_weights` diagnostics (max/min area weight per case) — confirm the weights are non-trivial.
3. Per-epoch val trajectory for both arms.
4. W&B run IDs and URLs.

## Constraints
- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
