### PR TITLE
[violet] Round-3: vol_w decay schedule (4→1.5, 3→1.5) on 6L base

### DIFF
--- a/train.py
+++ b/train.py
@@ -552,6 +552,9 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    volume_loss_weight_start: float = 0.0
+    volume_loss_weight_end: float = 0.0
+    volume_loss_weight_schedule_epochs: int = 0
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
@@ -1755,6 +1758,20 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        if config.volume_loss_weight_start > 0 and config.volume_loss_weight_end > 0:
+            schedule_epochs = (
+                config.volume_loss_weight_schedule_epochs
+                if config.volume_loss_weight_schedule_epochs > 0
+                else max_epochs
+            )
+            t = min(epoch / max(schedule_epochs - 1, 1), 1.0)
+            effective_vol_w = (
+                config.volume_loss_weight_start * (1 - t)
+                + config.volume_loss_weight_end * t
+            )
+        else:
+            effective_vol_w = config.volume_loss_weight
+
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
             loss, batch_loss_metrics = train_loss(
                 model,
@@ -1763,7 +1780,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 device,
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
-                volume_loss_weight=config.volume_loss_weight,
+                volume_loss_weight=effective_vol_w,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
@@ -1819,6 +1836,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
                 "train/volume_loss": batch_loss_metrics["volume_loss"],
+                "train/volume_loss_weight": float(effective_vol_w),
                 "train/loss_cp": batch_loss_metrics["loss_cp"],
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],


### PR DESCRIPTION
## Hypothesis

Your PR #65 found that `vol_w=2.0` is the correct static operating point — `vol_w=4.0` improved volume_pressure (13.30 vs 13.58) but hurt wall-shear (net-negative). The fundamental tension is that volume_pressure and wall-shear are competing for gradient budget: a high vol_w gives too much budget to volume at the cost of surface.

**New approach:** Instead of a fixed vol_w throughout training, use a **decaying volume loss schedule**. Start with `vol_w_start=4.0` (high emphasis on volume early when the model is learning coarse structure) and decay to `vol_w_end=1.5` by the final epoch (shifting emphasis toward surface refinement in later epochs). This mirrors curriculum learning: teach the model coarse physics first, then fine-tune the surface boundary layer.

**Physics motivation:** Volume pressure is dominated by large-scale flow patterns (stagnation zones, wake structure) that the model should learn first. Surface shear requires fine-grained local feature learning that benefits from later-epoch refinement. A decaying vol_w schedule follows the natural learning order.

**Alternative schedule:** Also test a `vol_w_start=3.0` → `vol_w_end=1.5` schedule as a milder version.

## Instructions

**1. Add config fields to `Config`:**

```python
volume_loss_weight_start: float = 0.0   # if > 0, override volume_loss_weight with linear decay from start to end
volume_loss_weight_end: float = 0.0     # final vol_w at last epoch (0 = disabled, use volume_loss_weight)
```

Add these after `volume_loss_weight` in `Config`.

**2. Add CLI wiring:**

```python
parser.add_argument("--volume-loss-weight-start", type=float, default=0.0)
parser.add_argument("--volume-loss-weight-end", type=float, default=0.0)
```

**3. Compute the effective vol_w per epoch** in the training loop, just before calling `train_loss`. Add this computation at the start of each epoch (or per-batch for step-level scheduling):

```python
# Per-epoch vol_w schedule (linear decay)
if config.volume_loss_weight_start > 0 and config.volume_loss_weight_end > 0:
    # Linear interpolation: epoch 1 → start, epoch max_epochs → end
    t = (epoch - 1) / max(max_epochs - 1, 1)  # 0 at epoch 1, 1 at final epoch
    effective_vol_w = config.volume_loss_weight_start * (1 - t) + config.volume_loss_weight_end * t
else:
    effective_vol_w = config.volume_loss_weight
```

Then pass `volume_loss_weight=effective_vol_w` to every `train_loss` call inside the epoch loop. Also log it: `wandb.log({"train/volume_loss_weight": effective_vol_w}, step=global_step)`.

**4. Run 3 arms on 3 GPUs:**

| GPU | `--volume-loss-weight-start` | `--volume-loss-weight-end` | Notes | `--wandb-name` |
|---|---|---|---|---|
| 0 | — | — | control (static vol_w=2.0) | `violet-vw-static-ctrl` |
| 1 | 4.0 | 1.5 | aggressive decay | `violet-vw-decay-4to15` |
| 2 | 3.0 | 1.5 | mild decay | `violet-vw-decay-3to15` |

```bash
cd target/
python train.py \
  [--volume-loss-weight-start <VW_START> --volume-loss-weight-end <VW_END>] \
  --volume-loss-weight 2.0 \    # used only if start/end are not set (arm 0)
  --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group violet-vol-loss-decay-schedule \
  --wandb-name violet-vw-<SLUG>
```

**Beat target: abupt=12.74** (PR #66, W&B `gvigs86q`).

Key diagnostics:
- `train/volume_loss_weight` curve — confirm the linear decay schedule is applied.
- `test_primary/volume_pressure_rel_l2_pct` — should improve vs static vol_w=2.0 (currently 13.14).
- `test_primary/wall_shear_*` — should not regress vs static vol_w=2.0.
- Per-epoch val trajectory — does the decay schedule change the convergence profile?

## Baseline (current yi best — PR #66 thorfinn, 6L/256d + W_y=2, W_z=2, vol_w=2.0)

| Metric | Current best (`gvigs86q`) | AB-UPT |
|---|---:|---:|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | — |
| `test_primary/surface_pressure_rel_l2_pct` | 7.86 | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 12.86 | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 13.14 | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 11.29 | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 15.15 | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 15.05 | 3.63 |

From your PR #65 vol_w sweep:
- vol_w=4.0 (static): abupt=13.71, vol_pressure=13.30 (better), wall_shear worse → net negative
- vol_w=2.0 (static): abupt=13.61 (control on different base — now baseline is 12.74)

**Reproduce (current base):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 2e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Results

Post results as a PR comment with:
1. All `test_primary/*_rel_l2_pct` and `full_val_primary/*` for each arm.
2. `train/volume_loss_weight` schedule per arm (confirm the decay is applied).
3. Per-epoch val abupt trajectory for all 3 arms.
4. W&B run IDs and URLs.

## Constraints
- Do **not** modify `data/*`, `pyproject.toml`, or `instructions/*`.
- Do **not** override `SENPAI_MAX_EPOCHS` or `SENPAI_TIMEOUT_MINUTES`.
- `test_primary/*` must **not** be NaN.
