### PR TITLE
edward: RFF coordinate encoding (Tancik 2020) vs sincos

### DIFF
--- a/train.py
+++ b/train.py
@@ -123,6 +123,27 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class RFFEncoding(nn.Module):
+    """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
+    Projects 3D coordinates via N(0, sigma^2) random matrix before sincos encoding.
+    Captures high-frequency spatial patterns better than fixed sincos embedding.
+    """
+    def __init__(self, in_dim: int, num_features: int = 64, sigma: float = 1.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigma = sigma
+        self.register_buffer("B", torch.randn(in_dim, num_features) * sigma)
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        proj = 2.0 * math.pi * (x.float() @ self.B.to(dtype=torch.float32))
+        return torch.cat([proj.sin(), proj.cos()], dim=-1)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -348,6 +369,8 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        rff_num_features: int = 0,
+        rff_sigma: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,8 +382,16 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.rff_num_features = rff_num_features
+        self.rff_sigma = rff_sigma
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if rff_num_features > 0:
+            rff = RFFEncoding(in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma)
+            rff_proj = nn.Linear(rff.output_dim, n_hidden)
+            _init_linear(rff_proj)
+            self.pos_embed = nn.Sequential(rff, rff_proj)
+        else:
+            self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -571,6 +602,8 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    rff_num_features: int = 0
+    rff_sigma: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -730,6 +763,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        rff_num_features=config.rff_num_features,
+        rff_sigma=config.rff_sigma,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current codebase uses `ContinuousSincosEmbed` for 3D coordinate encoding — a deterministic sinusoidal Fourier encoding. Gaussian Random Fourier Features (RFF, Tancik et al. 2020, "Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains") project coordinates through a learnable random Gaussian matrix before sincos encoding, which can better capture high-frequency spatial patterns.

RFF encoding theory: given coordinates x ∈ R^d, encode as [sin(2π B x), cos(2π B x)] where B ∈ R^{d×m} is sampled from N(0, σ²). The σ hyperparameter controls the bandwidth — higher σ captures finer-grained spatial detail. For CFD with steep pressure gradients near surfaces, this may provide richer coordinate representations.

This code change requires **modifying `train.py`**. Add a `RFFEncoding` class and a `--rff-num-features` flag that, when non-zero, replaces `ContinuousSincosEmbed` with RFF encoding.

## Instructions

**Step 1: Add RFF encoding to `train.py`**

Find the `ContinuousSincosEmbed` class (around line 100) and add the following class immediately after it:

```python
class RFFEncoding(nn.Module):
    """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
    Projects 3D coordinates via N(0, sigma^2) random matrix before sincos encoding.
    Captures high-frequency spatial patterns better than fixed sincos embedding.
    """
    def __init__(self, in_dim: int, num_features: int = 64, sigma: float = 1.0):
        super().__init__()
        self.in_dim = in_dim
        self.num_features = num_features
        self.sigma = sigma
        self.register_buffer("B", torch.randn(in_dim, num_features) * sigma)

    @property
    def output_dim(self) -> int:
        return 2 * self.num_features

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        import math
        proj = 2.0 * math.pi * (x @ self.B.to(dtype=x.dtype))
        return torch.cat([proj.sin(), proj.cos()], dim=-1)
```

**Step 2: Add CLI flags**

In the argument parser, add:
```python
parser.add_argument("--rff-num-features", type=int, default=0,
    help="If >0, use RFF coordinate encoding with this many features (replaces sincos). Default: 0 (sincos).")
parser.add_argument("--rff-sigma", type=float, default=1.0,
    help="Bandwidth sigma for RFF encoding. Higher values capture finer spatial detail. Default: 1.0.")
```

**Step 3: Wire up the encoding**

In the model initialization code where `ContinuousSincosEmbed` is instantiated, add a branch:
```python
if config.rff_num_features > 0:
    coord_embed = RFFEncoding(in_dim=3, num_features=config.rff_num_features, sigma=config.rff_sigma)
else:
    coord_embed = ContinuousSincosEmbed(hidden_dim=config.model_hidden_dim, input_dim=3)
```

Make sure the output_dim of the chosen encoder matches what downstream layers expect.

**Step 4: Run a 3-arm sweep** using `--wandb_group edward-rff-sweep`:

**Arm 1 — RFF 64 features, sigma=1.0 (standard bandwidth):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --rff-num-features 64 --rff-sigma 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group edward-rff-sweep --wandb_name edward-rff64-s10
```

**Arm 2 — RFF 64 features, sigma=5.0 (higher frequency):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --rff-num-features 64 --rff-sigma 5.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group edward-rff-sweep --wandb_name edward-rff64-s50
```

**Arm 3 — RFF 128 features, sigma=2.0 (larger feature map):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --rff-num-features 128 --rff-sigma 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group edward-rff-sweep --wandb_name edward-rff128-s20
```

Note: RFF features must be compatible with the model's hidden dim. If the RFF encoder output dim (2×num_features) doesn't match what the model expects, add a learned linear projection: `nn.Linear(2*num_features, hidden_dim)`.

## Baseline (PR #99 fern, run 3hljb0mg)

| Metric | Current Best |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 |
| `val_primary/wall_shear_x_rel_l2_pct` | 10.17 |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 |

**Reference:** Tancik et al. 2020, "Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains": https://arxiv.org/abs/2006.10739

## Success Criterion

Report abupt and all sub-metrics. A win requires abupt < 10.69. Also report: which sigma value works best, and whether RFF helps more on surface_pressure (fine spatial detail) vs wall_shear (which involves near-wall gradients).
