### PR TITLE
askeladd: surface-tangent-frame wall-shear head (fix 4× y/z gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -348,6 +348,9 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        use_tangent_frame_wallshear: bool = False,
+        wallshear_mean: torch.Tensor | None = None,
+        wallshear_std: torch.Tensor | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,6 +362,19 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.use_tangent_frame_wallshear = use_tangent_frame_wallshear
+        if use_tangent_frame_wallshear:
+            if wallshear_mean is None or wallshear_std is None:
+                raise ValueError(
+                    "use_tangent_frame_wallshear requires wallshear_mean and wallshear_std"
+                )
+            ws_mean = wallshear_mean.detach().to(torch.float32).reshape(3)
+            ws_std = wallshear_std.detach().to(torch.float32).reshape(3).clamp(min=1e-6)
+        else:
+            ws_mean = torch.zeros(3, dtype=torch.float32)
+            ws_std = torch.ones(3, dtype=torch.float32)
+        self.register_buffer("wallshear_mean", ws_mean, persistent=False)
+        self.register_buffer("wallshear_std", ws_std, persistent=False)
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -464,6 +480,17 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_tangent_frame_wallshear:
+                normals = surface_x[..., 3:6]
+                ws_global_norm = rotate_to_tangent_frame_global(
+                    surface_preds[..., 1:4],
+                    normals,
+                    wallshear_mean=self.wallshear_mean,
+                    wallshear_std=self.wallshear_std,
+                )
+                surface_preds = torch.cat(
+                    [surface_preds[..., 0:1], ws_global_norm], dim=-1
+                ) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -554,6 +581,7 @@ class Config:
     volume_loss_weight: float = 1.0
     aux_rel_l2_weight: float = 0.0
     use_tangential_wallshear_loss: bool = False
+    use_tangent_frame_wallshear: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
@@ -719,7 +747,18 @@ def make_loaders(
     return train_loader, val_loaders, test_loaders, stats
 
 
-def build_model(config: Config) -> SurfaceTransolver:
+def build_model(
+    config: Config, stats: dict[str, torch.Tensor] | None = None
+) -> SurfaceTransolver:
+    wallshear_mean: torch.Tensor | None = None
+    wallshear_std: torch.Tensor | None = None
+    if config.use_tangent_frame_wallshear:
+        if stats is None:
+            raise ValueError(
+                "build_model requires stats when use_tangent_frame_wallshear is True"
+            )
+        wallshear_mean = stats["surface_y_mean"][1:4].detach().clone()
+        wallshear_std = stats["surface_y_std"][1:4].detach().clone()
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -730,6 +769,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        use_tangent_frame_wallshear=config.use_tangent_frame_wallshear,
+        wallshear_mean=wallshear_mean,
+        wallshear_std=wallshear_std,
     )
 
 
@@ -1285,6 +1327,69 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def build_tangent_frame_duff(normals: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Branchless orthonormal tangent frame from unit normals (Duff et al. 2017, JCGT).
+
+    normals: [..., 3] expected to be unit-length (will be re-normalized for safety).
+    Returns t1, t2 each [..., 3], orthonormal to each other and to ``normals``.
+    Continuous w.r.t. the normal field (no reference-axis discontinuity), avoiding
+    the gauge-flip artifacts of the simpler |n_x|>0.9 fallback construction.
+    """
+    n = F.normalize(normals.float(), dim=-1, eps=1e-8)
+    nx = n[..., 0]
+    ny = n[..., 1]
+    nz = n[..., 2]
+    sign = torch.where(nz >= 0.0, torch.ones_like(nz), -torch.ones_like(nz))
+    a = -1.0 / (sign + nz)
+    b = nx * ny * a
+    t1 = torch.stack(
+        [1.0 + sign * nx * nx * a, sign * b, -sign * nx],
+        dim=-1,
+    )
+    t2 = torch.stack(
+        [b, sign + ny * ny * a, -ny],
+        dim=-1,
+    )
+    return t1, t2
+
+
+def rotate_to_tangent_frame_global(
+    wallshear_norm: torch.Tensor,
+    normals: torch.Tensor,
+    *,
+    wallshear_mean: torch.Tensor,
+    wallshear_std: torch.Tensor,
+) -> torch.Tensor:
+    """Reinterpret normalized wall-shear channels [a, b, _] as physical tangent-frame
+    scalars and rotate to global Cartesian, returning normalized global wall shear.
+
+    The first two raw output channels are treated as (a, b) tangent-frame scalars
+    along the local basis (t1, t2) built from ``normals`` via Duff branchless ONB.
+    The third raw channel is dropped — by construction the normal component of the
+    rotated vector is zero (no-slip enforcement at inference and training time).
+
+    Tangent scalars use an isotropic scale (RMS of the per-axis stds) and zero
+    mean: per-Cartesian-axis stats describe projections onto fixed axes, but
+    (a, b) live in a spatially-varying tangent frame whose orientation has no
+    fixed-axis identity. Re-normalization to global Cartesian after rotation
+    uses the per-axis stats so the loss matches the existing target-normalized
+    Cartesian frame.
+
+    wallshear_norm: [B, N, 3] model output (normalized space).
+    normals: [B, N, 3] unit surface normals from the input features.
+    wallshear_mean, wallshear_std: [3] tensors for the global Cartesian frame.
+    """
+    std_f = wallshear_std.float()
+    sigma_iso = std_f.square().mean().sqrt()
+    ws_norm_f = wallshear_norm.float()
+    t1, t2 = build_tangent_frame_duff(normals)
+    a = ws_norm_f[..., 0:1] * sigma_iso
+    b = ws_norm_f[..., 1:2] * sigma_iso
+    ws_global_phys = a * t1 + b * t2
+    ws_global_norm = (ws_global_phys - wallshear_mean) / std_f
+    return ws_global_norm.to(wallshear_norm.dtype)
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1298,6 +1403,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    log_wallshear_normal_rms: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1367,6 +1473,15 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    elif log_wallshear_normal_rms and bool(batch.surface_mask.any()):
+        ws_std = transform.surface_y_std[1:4].to(surface_pred_norm.device)
+        ws_mean = transform.surface_y_mean[1:4].to(surface_pred_norm.device)
+        ws_pred_phys = surface_pred_norm[..., 1:4].detach().float() * ws_std + ws_mean
+        n_hat = F.normalize(batch.surface_x[..., 3:6].float(), dim=-1, eps=1e-8)
+        normal_dot = (ws_pred_phys * n_hat).sum(dim=-1)
+        metrics["wallshear_pred_normal_rms"] = float(
+            normal_dot[batch.surface_mask].square().mean().sqrt().cpu().item()
+        )
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -1679,7 +1794,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         volume_y_std=stats["volume_y_std"].to(device),
     )
 
-    model = build_model(config).to(device)
+    model = build_model(config, stats=stats).to(device)
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
@@ -1782,6 +1897,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                log_wallshear_normal_rms=config.use_tangent_frame_wallshear,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()


### PR DESCRIPTION
## Hypothesis

Wall shear components tau_y and tau_z are currently 3.8-4.1× worse than AB-UPT (tau_y: 13.73% vs 3.65%; tau_z: 14.73% vs 3.63%). We believe this gap is a **coordinate frame problem**: the model predicts tau in global Cartesian coordinates, but the physically meaningful constraint is that wall shear lies *in the surface tangent plane* (zero normal component by no-slip condition). AB-UPT likely exploits this geometric structure.

**Proposed fix:** Modify the wall shear prediction head to output shear components in the local surface-tangent frame (tau_tangent1, tau_tangent2), then rotate back to global Cartesian for loss computation. This regularizes the prediction space: tau_normal ≈ 0 by construction, which eliminates the largest source of error in the y/z components.

Concretely, at each surface point the mesh provides a unit normal vector n̂. We can compute an orthonormal tangent frame {t̂₁, t̂₂} via Gram-Schmidt from n̂ and a canonical up-vector (or any fixed reference). The model predicts (a, b) scalars; the global shear is recovered as τ = a·t̂₁ + b·t̂₂. This ensures τ·n̂ = 0 exactly at inference time. The loss is still computed in global coordinates after rotation (so existing loss code, weighting flags, etc. remain unchanged).

Reference: This is the approach used in surface-normal-conditioned prediction heads in mesh neural networks (e.g., NeuralLBO, GeomNet). The surface normals are already available in the DrivAerML dataset per point.

## Instructions

You will need to modify `target/train.py` to add a surface-tangent-frame prediction head for wall shear. Here is exactly what to implement:

### Step 1 — Add tangent frame rotation utility

Add a function (e.g., `build_tangent_frame(normals)`) that accepts surface point normals `(N, 3)` and returns an orthonormal tangent frame `(t1, t2)` of shape `(N, 3)` each, using Gram-Schmidt:

```python
def build_tangent_frame(normals):
    # normals: (N, 3), unit normals at each surface point
    # Returns t1, t2: (N, 3) each, orthonormal to normals and each other
    ref = torch.zeros_like(normals)
    ref[:, 0] = 1.0  # X-axis reference
    # where normal is ~parallel to X-axis, use Z-axis instead
    parallel = (normals[:, 0].abs() > 0.9)
    ref[parallel, 0] = 0.0
    ref[parallel, 2] = 1.0
    t1 = ref - (ref * normals).sum(-1, keepdim=True) * normals
    t1 = F.normalize(t1, dim=-1)
    t2 = torch.cross(normals, t1, dim=-1)
    return t1, t2
```

### Step 2 — Rotate predicted wall shear into global coordinates

After the model outputs `wall_shear_pred` of shape `(N, 3)` (currently in global coords), instead interpret the first two components as tangent-frame scalars `(a, b)` and rotate:

```python
# In the loss/prediction step where wall_shear_pred is produced:
t1, t2 = build_tangent_frame(surface_normals)  # surface_normals from batch
# wall_shear_pred[:, :2] = (a, b) in tangent frame
a = wall_shear_pred[:, 0:1]
b = wall_shear_pred[:, 1:2]
wall_shear_pred_global = a * t1 + b * t2
# Use wall_shear_pred_global for loss computation (drop the 3rd component)
```

The model still outputs a 3-component vector, but only the first two are used as tangent-frame scalars. This forces tau · n̂ = 0 at inference.

### Step 3 — Add CLI flag `--use-tangent-frame-wallshear`

Add a boolean flag (default: False) so we can A/B compare. Set it to `True` for this experiment run.

### Step 4 — Ensure surface normals are in the batch

Check whether surface point normals are already passed through the data pipeline. If not, add them to the surface point feature tensor (they should be in the dataset as per DrivAerML specs — each surface mesh vertex has an outward-facing normal). If they are already included as input features to the model, extract them from the batch for use in `build_tangent_frame`.

### Step 5 — Run both arms for comparison

Run two arms using `--wandb-group wallshear-tangent-frame-r5`:

**Arm A (control — baseline config, no tangent frame):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group wallshear-tangent-frame-r5 --wandb-name arm-A-control
```

**Arm B (tangent-frame head enabled):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --use-tangent-frame-wallshear \
  --wandb-group wallshear-tangent-frame-r5 --wandb-name arm-B-tangent-frame
```

You have 4 GPUs — run arms A and B concurrently (one per GPU) to save time.

### Key metrics to report

For each arm, report:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary — lower is better)
- `val_primary/wall_shear_y_rel_l2_pct` (target: reduce 13.73 → closer to 3.65)
- `val_primary/wall_shear_z_rel_l2_pct` (target: reduce 14.73 → closer to 3.63)
- `val_primary/wall_shear_rel_l2_pct`
- `val_primary/surface_pressure_rel_l2_pct`
- gradient norms for wall_shear head at epochs 1 and final

**Also check:** If surface normals are NOT in the dataset, report this and describe what you found — this would be an important negative result.

## Baseline (PR #99, W&B run `3hljb0mg`)

| Metric | Current Best (PR #99) | AB-UPT Target | Ratio |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 | 1.8× |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 | 1.6× |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 | 1.3× |
| `wall_shear_x_rel_l2_pct` | 10.17 | 5.35 | 1.9× |
| `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | **3.8×** |
| `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | **4.1×** |

The wall_shear_y and wall_shear_z gaps (3.8-4.1× AB-UPT) are the highest priority to close. This experiment directly targets that structural problem.

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
