### PR TITLE
gilbert: RANS divergence constraint (physics-informed ∇·u=0 penalty)

### DIFF
--- a/train.py
+++ b/train.py
@@ -556,6 +556,10 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    div_constraint_weight: float = 0.0
+    div_constraint_k: int = 8
+    div_constraint_sdf_threshold: float = 0.05
+    div_constraint_anchor_count: int = 4096
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1285,6 +1289,77 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def divergence_constraint_loss(
+    p_pred: torch.Tensor,
+    coords: torch.Tensor,
+    sdf: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    k: int,
+    sdf_threshold: float,
+    anchor_count: int,
+) -> torch.Tensor:
+    """Discrete-Laplacian smoothness penalty on predicted volume pressure.
+
+    DrivAerML exposes only volume pressure (no velocity), so the strongest
+    physics prior we can apply is the homogeneous pressure-Poisson form
+    `nabla^2 p approx 0` away from the body surface. We approximate it
+    with a kNN inverse-distance-weighted Laplacian computed on a random
+    subsample of valid far-field volume points (sdf magnitude above
+    `sdf_threshold`). All math is in fp32 for bf16 stability.
+
+    Inputs are in normalized space (the same space the data loss uses).
+
+    Args:
+        p_pred: [B, N, 1] predicted volume pressure (normalized).
+        coords: [B, N, 3] raw volume xyz from `batch.volume_x[..., :3]`.
+        sdf: [B, N, 1] raw SDF channel from `batch.volume_x[..., 3:4]`.
+        mask: [B, N] bool, True for non-padded volume tokens.
+        k: number of nearest neighbours per anchor.
+        sdf_threshold: anchors with `|sdf|` below this are filtered out.
+        anchor_count: random subsample size per batch element.
+
+    Returns:
+        Scalar loss with gradient flow back through `p_pred`. Returns a
+        graph-preserving zero when no batch element contains enough
+        far-field anchors (e.g. tiny debug batches).
+    """
+    if anchor_count <= 0 or k <= 0:
+        return p_pred.sum() * 0.0
+    batch_size = p_pred.shape[0]
+    if batch_size == 0 or p_pred.shape[1] == 0:
+        return p_pred.sum() * 0.0
+    p_flat = p_pred.squeeze(-1).float()
+    coords_f = coords.float()
+    sdf_abs = sdf.squeeze(-1).float().abs()
+    far = sdf_abs > sdf_threshold
+    valid = mask & far
+    losses: list[torch.Tensor] = []
+    for b in range(batch_size):
+        valid_idx = valid[b].nonzero(as_tuple=False).squeeze(-1)
+        if int(valid_idx.numel()) < k + 2:
+            continue
+        n_sub = min(int(anchor_count), int(valid_idx.numel()))
+        perm = torch.randperm(int(valid_idx.numel()), device=coords_f.device)[:n_sub]
+        sub = valid_idx[perm]
+        c_sub = coords_f[b, sub]
+        p_sub = p_flat[b, sub]
+        with torch.no_grad():
+            dists = torch.cdist(c_sub, c_sub)
+            topk = dists.topk(k + 1, dim=-1, largest=False).indices
+            nbr_idx = topk[:, 1:].contiguous()
+        nbr_xyz = c_sub[nbr_idx]
+        d = (nbr_xyz - c_sub.unsqueeze(1)).norm(dim=-1).clamp_min(1e-6)
+        w = 1.0 / d
+        w = w / w.sum(dim=-1, keepdim=True)
+        nbr_p = p_sub[nbr_idx]
+        lap = (w * (nbr_p - p_sub.unsqueeze(-1))).sum(dim=-1)
+        losses.append(lap.pow(2).mean())
+    if not losses:
+        return p_pred.sum() * 0.0
+    return torch.stack(losses).mean()
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1298,6 +1373,10 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    div_constraint_weight: float = 0.0,
+    div_constraint_k: int = 8,
+    div_constraint_sdf_threshold: float = 0.05,
+    div_constraint_anchor_count: int = 4096,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1355,6 +1434,19 @@ def train_loss(
             aux_rel_l2 = num / den
             loss = loss + aux_rel_l2_weight * aux_rel_l2
             aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
+        div_constraint_value: float | None = None
+        if div_constraint_weight > 0.0:
+            div_loss = divergence_constraint_loss(
+                p_pred=out["volume_preds"],
+                coords=batch.volume_x[:, :, :3],
+                sdf=batch.volume_x[:, :, 3:4],
+                mask=batch.volume_mask,
+                k=div_constraint_k,
+                sdf_threshold=div_constraint_sdf_threshold,
+                anchor_count=div_constraint_anchor_count,
+            )
+            loss = loss + div_constraint_weight * div_loss
+            div_constraint_value = float(div_loss.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1365,6 +1457,8 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if div_constraint_value is not None:
+        metrics["div_constraint_loss"] = div_constraint_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1782,6 +1876,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                div_constraint_weight=config.div_constraint_weight,
+                div_constraint_k=config.div_constraint_k,
+                div_constraint_sdf_threshold=config.div_constraint_sdf_threshold,
+                div_constraint_anchor_count=config.div_constraint_anchor_count,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1849,6 +1947,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
+                ]
+            if "div_constraint_loss" in batch_loss_metrics:
+                train_log["train/div_constraint_loss"] = batch_loss_metrics[
+                    "div_constraint_loss"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

The model currently knows nothing about fluid mechanics — it treats CFD fields as arbitrary functions to regress. AB-UPT likely encodes physical priors. One of the most fundamental constraints in incompressible RANS: **continuity (∇·u = 0, divergence-free velocity)**. In steady-state CFD, the velocity field satisfies this everywhere in the volume domain.

**Proposed fix:** Add a physics-informed soft penalty to the training loss that penalizes divergence of the predicted volume pressure field. While we predict pressure (not velocity), the pressure Poisson equation links them: ∇²p = -ρ·(∇u:∇u), so pressure gradients implicitly encode divergence information.

**More directly actionable:** The DrivAerML dataset likely includes velocity components (u, v, w) as volume features. If so, we can directly enforce ∇·u ≈ 0 as a soft constraint. If only pressure is predicted, we enforce smoothness of pressure gradients as a proxy.

**Implementation strategy:** Use finite differences between neighboring volume point predictions to approximate ∇·u. Add this as a regularization term weighted by λ_div (start small: 0.01).

Reference: Physics-Informed Neural Networks (PINNs, Raissi et al. 2019); FlowDNN (Chen et al. 2021) applied similar RANS residual penalties to automotive CFD surrogate models.

## Instructions

Add a physics-informed divergence constraint to `target/train.py`.

### Step 1 — Understand the volume field structure

First, examine what volume fields are in the DrivAerML dataset (`target/data/` or `target/train.py` data loading code). Identify whether velocity components (u, v, w) are available as targets or only pressure (p_v). Log your findings in the PR comment — this determines the exact constraint to implement.

### Step 2a — If velocity components are available as targets

Compute discrete divergence using the k-nearest neighbors of each volume point:

```python
def divergence_loss(coords, vel_pred, k=8):
    """
    Approximate ∇·u ≈ 0 using finite differences over k nearest neighbors.
    coords: (N, 3) volume point coordinates
    vel_pred: (N, 3) predicted velocity (u, v, w)
    Returns scalar divergence penalty.
    """
    # For each point, find k nearest neighbors (use torch_geometric or brute-force for small batches)
    # Approximate d(u)/dx + d(v)/dy + d(w)/dz using linear regression on local neighborhood
    # Penalize squared divergence: loss = mean(div_u^2)
    ...
```

### Step 2b — If only pressure is predicted

Apply a Laplacian smoothness regularizer on the volume pressure predictions (encourages solutions consistent with pressure Poisson):

```python
def pressure_smoothness_loss(coords, p_pred, k=8):
    """
    Approximate Laplacian smoothness: penalize large |∇²p|.
    This is a weaker constraint but still encodes physical regularity.
    """
    ...
```

### Step 3 — Add CLI flags

```
--div-constraint-weight FLOAT    # λ_div, default 0.0 (disabled)
--div-constraint-k INT           # neighborhood size, default 8
```

### Step 4 — Arms to run (use `--wandb-group rans-div-constraint-r5`)

**Arm A — Control (baseline, no physics constraint):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group rans-div-constraint-r5 --wandb-name arm-A-control
```

**Arm B — div constraint, λ=0.01:**
```bash
cd target/
python train.py \
  [same as A] \
  --div-constraint-weight 0.01 \
  --wandb-name arm-B-div-0.01
```

**Arm C — div constraint, λ=0.1:**
```bash
cd target/
python train.py \
  [same as A] \
  --div-constraint-weight 0.1 \
  --wandb-name arm-C-div-0.1
```

**If velocity targets are NOT available:** Implement the pressure smoothness version and run Arm B and C with it (same λ values). Note in your results what constraint was used.

You have 4 GPUs — run all arms concurrently.

### Key metrics to report

- Whether velocity (u, v, w) targets are available in DrivAerML (critical finding)
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary — beat 10.69)
- `val_primary/volume_pressure_rel_l2_pct` (expected improvement if divergence constraint helps)
- `val_primary/wall_shear_y_rel_l2_pct`, `wall_shear_z_rel_l2_pct`
- All other sub-metrics
- Log `train/div_loss` or `train/smoothness_loss` separately for analysis

## Baseline (PR #99, W&B run `3hljb0mg`)

| Metric | Current Best (PR #99) | AB-UPT Target | Ratio |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 | 1.8× |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 | 1.6× |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 | 1.3× |
| `wall_shear_x_rel_l2_pct` | 10.17 | 5.35 | 1.9× |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 | 3.8× |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 | 4.1× |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
