### PR TITLE
haku: 1cycle LR max=1e-3 (super-convergence in epoch-limited regime)

### DIFF
--- a/train.py
+++ b/train.py
@@ -590,6 +590,12 @@ class Config:
     clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
+    use_onecycle_lr: bool = False
+    onecycle_max_lr: float = 1e-3
+    onecycle_pct_start: float = 0.3
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
+    onecycle_total_steps: int = 0
 
 
 class TargetTransform:
@@ -1692,9 +1698,33 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    if config.use_onecycle_lr:
+        onecycle_total_steps = (
+            int(config.onecycle_total_steps)
+            if config.onecycle_total_steps > 0
+            else total_estimated_steps
+        )
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.onecycle_max_lr,
+            total_steps=onecycle_total_steps,
+            pct_start=config.onecycle_pct_start,
+            anneal_strategy="cos",
+            div_factor=config.onecycle_div_factor,
+            final_div_factor=config.onecycle_final_div_factor,
+            cycle_momentum=False,
+        )
+        print(
+            f"OneCycleLR: max_lr={config.onecycle_max_lr:.2e} "
+            f"pct_start={config.onecycle_pct_start} "
+            f"total_steps={onecycle_total_steps} "
+            f"initial_lr={config.onecycle_max_lr / config.onecycle_div_factor:.2e} "
+            f"final_lr={config.onecycle_max_lr / config.onecycle_div_factor / config.onecycle_final_div_factor:.2e}"
+        )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1815,6 +1845,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
+            if config.use_onecycle_lr and scheduler.last_epoch < scheduler.total_steps:
+                scheduler.step()
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -1844,6 +1876,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/lr": scheduler.get_last_lr()[0],
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
@@ -1887,7 +1920,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not config.use_onecycle_lr:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0

--- a/train.py
+++ b/train.py
@@ -1056,20 +1056,26 @@ def collect_weight_metrics(
     return metrics
 
 
-def _numeric_metric_items(metrics: dict[str, object]) -> dict[str, float]:
-    numeric: dict[str, float] = {}
+def _coerce_metric_floats(metrics: dict[str, object]) -> dict[str, float]:
+    """Coerce metric values to floats, keeping NaN/Inf so callers can detect them."""
+
+    coerced: dict[str, float] = {}
     for key, value in metrics.items():
         if isinstance(value, bool):
             continue
         if isinstance(value, (int, float)):
-            number = float(value)
+            coerced[key] = float(value)
         elif isinstance(value, torch.Tensor) and value.numel() == 1:
-            number = float(value.detach().cpu().item())
-        else:
-            continue
-        if math.isfinite(number):
-            numeric[key] = number
-    return numeric
+            coerced[key] = float(value.detach().cpu().item())
+    return coerced
+
+
+def _numeric_metric_items(metrics: dict[str, object]) -> dict[str, float]:
+    return {
+        key: value
+        for key, value in _coerce_metric_floats(metrics).items()
+        if math.isfinite(value)
+    }
 
 
 def slope_source_metrics(metrics: dict[str, object]) -> dict[str, float]:
@@ -1225,11 +1231,11 @@ def check_kill_thresholds(
     metrics: dict[str, object],
     thresholds: list[KillThreshold],
 ) -> str | None:
-    numeric = _numeric_metric_items(metrics)
+    raw = _coerce_metric_floats(metrics)
     for threshold in thresholds:
-        if global_step < threshold.step or threshold.metric not in numeric:
+        if global_step < threshold.step or threshold.metric not in raw:
             continue
-        observed = numeric[threshold.metric]
+        observed = raw[threshold.metric]
         if not math.isfinite(observed) or not threshold.passes(observed):
             return (
                 f"kill threshold failed at step {global_step}: "


### PR DESCRIPTION
## Hypothesis

Current baseline uses `lr=5e-4` (flat warmup then decay). W&B gradient analysis showed gradient norms 0.3-0.8 throughout training with still-negative loss slope at epoch cutoff — the model is **epoch-limited, not capacity-limited**. We cannot add more epochs. But we can squeeze more convergence from the same iteration budget by using a **1cycle learning rate schedule**.

The 1cycle LR policy (Smith & Topin 2019, https://arxiv.org/abs/1708.07120):
- Linearly warms from `lr_min` to `lr_max` over the first 30% of training
- Cosine-anneals from `lr_max` back to `lr_min` over the remaining 70%
- Much more aggressive warmup → faster initial convergence
- Cosine annealing in final phase → smooth, stable convergence without oscillation
- Works exceptionally well in epoch-limited regimes (classic "super-convergence")

**Key change:** Push `lr_max=1e-3` (2× current peak of 5e-4). With 1cycle, the higher peak is safe because the schedule is structured — it warms gradually, spends brief time at peak, then anneals smoothly. The current flat lr=5e-4 stays at its peak the entire time, which is more aggressive overall than a 1cycle that peaks at 1e-3.

## Instructions

Add 1cycle LR scheduling to `target/train.py`. PyTorch has a built-in implementation: `torch.optim.lr_scheduler.OneCycleLR`.

### Step 1 — Add OneCycleLR scheduler

```python
from torch.optim.lr_scheduler import OneCycleLR

# After creating optimizer, add scheduler:
if args.use_onecycle_lr:
    scheduler = OneCycleLR(
        optimizer,
        max_lr=args.onecycle_max_lr,           # e.g. 1e-3
        total_steps=total_training_steps,       # total optimizer steps = epochs * steps_per_epoch
        pct_start=args.onecycle_pct_start,     # fraction of training for warmup, e.g. 0.3
        anneal_strategy='cos',
        div_factor=args.onecycle_div_factor,   # lr_start = max_lr / div_factor, e.g. 25 → lr_start=4e-5
        final_div_factor=args.onecycle_final_div_factor,  # lr_end = lr_start / final_div_factor, e.g. 1e4
        cycle_momentum=False,   # no momentum cycling (Adam optimizer)
    )
```

Call `scheduler.step()` **after each optimizer step** (not after each epoch — OneCycleLR is step-based).

**Remove or bypass the existing LR warmup/cosine code** when `--use-onecycle-lr` is set.

### Step 2 — Add CLI flags

```
--use-onecycle-lr              # enable 1cycle schedule (flag)
--onecycle-max-lr FLOAT        # peak LR (default: 1e-3)
--onecycle-pct-start FLOAT     # warmup fraction (default: 0.3)
--onecycle-div-factor FLOAT    # initial LR = max_lr/div_factor (default: 25.0)
--onecycle-final-div-factor FLOAT  # final LR = initial_lr/final_div_factor (default: 1e4)
```

### Step 3 — Log the LR schedule to W&B

Log `train/lr` at every gradient step so we can see the schedule shape in W&B.

### Arms to run (use `--wandb-group onecycle-lr-r5`)

**Arm A — Control (flat lr=5e-4, baseline config):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group onecycle-lr-r5 --wandb-name arm-A-flat-lr5e4-control
```

**Arm B — 1cycle, max_lr=1e-3, pct_start=0.3 (primary hypothesis):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --use-onecycle-lr --onecycle-max-lr 1e-3 --onecycle-pct-start 0.3 \
  --wandb-group onecycle-lr-r5 --wandb-name arm-B-1cycle-1e3-pct0.3
```

**Arm C — 1cycle, max_lr=2e-3 (bolder):**
```bash
cd target/
python train.py \
  [same as B but] --onecycle-max-lr 2e-3 \
  --wandb-name arm-C-1cycle-2e3-pct0.3
```

**Arm D — 1cycle, max_lr=1e-3, pct_start=0.1 (shorter warmup, faster ramp):**
```bash
cd target/
python train.py \
  [same as B but] --onecycle-pct-start 0.1 \
  --wandb-name arm-D-1cycle-1e3-pct0.1
```

You have 4 GPUs — run all 4 arms concurrently.

**Instability handling:** If Arm C (2e-3) diverges (loss NaN or gradient norm spikes), close it early and focus on B and D. The `--clip-grad-norm 1.0` is already set and provides a safety net.

### Key metrics to report

- `val_primary/abupt_axis_mean_rel_l2_pct` at best epoch (primary — beat 10.69)
- All 6 sub-metrics for each arm
- `train/lr` schedule shape (confirm from W&B plot it looks like the expected triangular shape)
- Gradient norm at epochs 1, mid, final for each arm
- **Convergence speed**: which arm reaches 12.0 first? 11.0? 10.69? (check W&B per-epoch val curve)
- Best validation epoch number for each arm (tells us if we're hitting the cap)

## Baseline (PR #99, W&B run `3hljb0mg`)

| Metric | Current Best (PR #99) | AB-UPT Target | Ratio |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 | 1.8× |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 | 1.6× |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 | 1.3× |
| `wall_shear_x_rel_l2_pct` | 10.17 | 5.35 | 1.9× |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 | 3.8× |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 | 4.1× |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
