### PR TITLE
norman: EMA decay warmup schedule on PR #99 base

### DIFF
--- a/train.py
+++ b/train.py
@@ -581,6 +581,7 @@ class Config:
     ema_start_step: int = 50
     ema_decay_start: float = 0.0
     ema_decay_end: float = 0.9999
+    ema_decay_schedule_epochs: int = 0
     gradient_log_every: int = 1
     log_gradient_histograms: bool = True
     weight_log_every: int = 1
@@ -1689,6 +1690,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    ema_schedule_epochs = (
+        config.ema_decay_schedule_epochs if config.ema_decay_schedule_epochs > 0 else max_epochs
+    )
+    ema_schedule_total_steps = max(1, ema_schedule_epochs * max(len(train_loader), 1))
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1812,7 +1817,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
-                    progress = min(global_step / max(total_estimated_steps, 1), 1.0)
+                    progress = min(global_step / ema_schedule_total_steps, 1.0)
                     cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
                     ema_decay_now = config.ema_decay_start + cos_val * (
                         config.ema_decay_end - config.ema_decay_start


### PR DESCRIPTION
# norman — EMA decay warmup schedule on PR #99 6L/256d base

## Hypothesis

Current PR #99 uses fixed EMA decay = 0.9995 throughout training. With lr=5e-4 driving rapid early progress, a constant decay 0.9995 means the EMA tracks ~2000-step running average — too slow for the first epoch (you're still learning fast), too fast at the end (you want to lock in the converged weights). The `--ema-decay-start` and `--ema-decay-end` flags exist in `train.py` but have not been tested on PR #99. A schedule that starts loose (0.99 — fast tracking) and ramps to tight (0.9999 — heavy averaging at convergence) is standard practice for EMA in modern training (e.g. EDM, Karras et al.) and tends to help especially when epoch budget is tight.

## Baseline to beat (PR #99, fern, W&B run `3hljb0mg`)

| Metric | yi best | AB-UPT |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | — |

## Experiment plan — 3-arm EMA schedule sweep

Use `--wandb-group norman-ema-warmup-r5`:

| Arm | start | end |
|---|---:|---:|
| A | 0.99 | 0.9995 |
| B | 0.99 | 0.9999 |
| C | 0.999 | 0.9999 |

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay-start <START> --ema-decay-end <END> \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group norman-ema-warmup-r5
```

(Note: omit `--ema-decay 0.9995` — schedule flags should override the static value. If they conflict, please report it.)

## Diagnostics

- Final val_primary metrics for all 3 arms
- Compare EMA model val metrics vs raw model val metrics — if the gap is small, EMA is too slow; if EMA is much better, EMA is helping
- Loss slope at cutoff for each arm

## Reporting

Comment with a 3-arm table; flag the best arm; note whether EMA scheduling matters more than the final decay value.

