### PR TITLE
tanjiro: curriculum tau_y/z weighting schedule

### DIFF
--- a/train.py
+++ b/train.py
@@ -556,6 +556,12 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    wallshear_y_weight_start: float = -1.0
+    wallshear_y_weight_end: float = -1.0
+    wallshear_z_weight_start: float = -1.0
+    wallshear_z_weight_end: float = -1.0
+    wallshear_weight_warmup_frac: float = 0.5
+    wallshear_weight_warmup_steps: int = 0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1285,6 +1291,42 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def curriculum_wallshear_weight(
+    step: int,
+    total_steps: int,
+    *,
+    static_value: float,
+    start_value: float,
+    end_value: float,
+    warmup_frac: float,
+    warmup_steps_override: int = 0,
+) -> float:
+    """Linear curriculum schedule for a wallshear axis weight.
+
+    A negative ``start_value``/``end_value`` falls back to ``static_value``,
+    preserving backward compatibility with the static ``--wallshear-{y,z}-weight``
+    flags. Ramps linearly from start->end over the first ``warmup_frac`` of
+    ``total_steps`` and holds at end thereafter. ``warmup_steps_override>0``
+    bypasses ``warmup_frac * total_steps`` so the schedule horizon can be set
+    in actual-training step units (useful when timeout cuts training short of
+    the configured ``--epochs`` budget).
+    """
+    s = static_value if start_value < 0 else start_value
+    e = static_value if end_value < 0 else end_value
+    if s == e:
+        return s
+    if warmup_steps_override > 0:
+        warmup_steps = float(warmup_steps_override)
+    elif warmup_frac <= 0.0:
+        return e
+    else:
+        warmup_steps = max(1.0, warmup_frac * float(total_steps))
+    if warmup_steps <= 0.0:
+        return e
+    progress = min(1.0, float(step) / warmup_steps)
+    return s + (e - s) * progress
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1770,6 +1812,24 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            current_wallshear_y_weight = curriculum_wallshear_weight(
+                global_step,
+                total_estimated_steps,
+                static_value=config.wallshear_y_weight,
+                start_value=config.wallshear_y_weight_start,
+                end_value=config.wallshear_y_weight_end,
+                warmup_frac=config.wallshear_weight_warmup_frac,
+                warmup_steps_override=config.wallshear_weight_warmup_steps,
+            )
+            current_wallshear_z_weight = curriculum_wallshear_weight(
+                global_step,
+                total_estimated_steps,
+                static_value=config.wallshear_z_weight,
+                start_value=config.wallshear_z_weight_start,
+                end_value=config.wallshear_z_weight_end,
+                warmup_frac=config.wallshear_weight_warmup_frac,
+                warmup_steps_override=config.wallshear_weight_warmup_steps,
+            )
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1780,8 +1840,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 volume_loss_weight=config.volume_loss_weight,
                 aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
-                wallshear_y_weight=config.wallshear_y_weight,
-                wallshear_z_weight=config.wallshear_z_weight,
+                wallshear_y_weight=current_wallshear_y_weight,
+                wallshear_z_weight=current_wallshear_z_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1838,6 +1898,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/wallshear_y_weight": current_wallshear_y_weight,
+                "train/wallshear_z_weight": current_wallshear_z_weight,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,


### PR DESCRIPTION
# tanjiro — Curriculum tau_y/z weighting (Round-5 from CURRENT_RESEARCH_STATE)

## Hypothesis

PR #66 thorfinn established W_y=2, W_z=2 as a static gain. PR #116 (fern, in flight) is sweeping higher static weights. Both are static. A complementary Round-5 idea: **curriculum the tau_y/z weighting** — start with W_y=W_z=1.0 (let the model learn the dominant tau_x axis cleanly first) and ramp to 3.0 by mid-training. This avoids early-training gradient interference where a still-untrained model is asked to upweight axes it can barely predict.

This will need a small code change to `train.py`. Add a linear-schedule mechanism for the wallshear axis weights, controlled by two new flags:

- `--wallshear-y-weight-start` / `--wallshear-y-weight-end` (default to current `--wallshear-y-weight`)
- `--wallshear-z-weight-start` / `--wallshear-z-weight-end`
- `--wallshear-weight-warmup-frac` (fraction of total training to ramp linearly; default 0.5)

Ramp linearly from start to end over the first `warmup_frac` of total training steps; hold at end thereafter.

## Baseline to beat (PR #99, fern, W&B run `3hljb0mg`)

| Metric | yi best | AB-UPT |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | — |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 |

## Experiment plan — 3-arm curriculum sweep

Use `--wandb-group tanjiro-curriculum-tau-yz-r5`:

| Arm | start (Wy=Wz) | end (Wy=Wz) | warmup_frac |
|---|---:|---:|---:|
| A | 1.0 | 3.0 | 0.5 |
| B | 1.0 | 4.0 | 0.5 |
| C | 1.0 | 3.0 | 0.3 |

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight-start <S> --wallshear-y-weight-end <E> \
  --wallshear-z-weight-start <S> --wallshear-z-weight-end <E> \
  --wallshear-weight-warmup-frac <F> \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group tanjiro-curriculum-tau-yz-r5
```

## Implementation notes

- Compute current weight as `start + (end - start) * min(1.0, step / (warmup_frac * total_steps))`
- Log the current y/z weights to W&B as `train/wallshear_y_weight` and `train/wallshear_z_weight` so we can visualize the schedule
- Maintain backward compatibility: if neither `-start` nor `-end` is set, fall back to the static `--wallshear-y-weight` value

## Diagnostics

- 3-arm metrics table; per-axis wall-shear deltas
- W&B chart of the y/z weights over training (sanity check that the schedule is firing)
- Loss-slope at end of warmup phase vs. PR #99 — does the curriculum delay or accelerate convergence?

## Reporting

Comment with the 3-arm table, weight schedule plot, and recommendation. If a curriculum arm clearly beats baseline, propose extending to W_x as well in a follow-up.

