### PR TITLE
fern: coordinate normalization sweep (fix sincos anisotropy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -351,9 +351,10 @@ class SurfaceTransolver(nn.Module):
         coord_normalize: str = "none",
     ):
         super().__init__()
-        if coord_normalize not in {"none", "global-scale", "per-axis"}:
+        if coord_normalize not in {"none", "global-scale", "per-axis", "per-axis-clamped"}:
             raise ValueError(
-                f"coord_normalize must be 'none', 'global-scale', or 'per-axis'; got {coord_normalize!r}"
+                "coord_normalize must be 'none', 'global-scale', 'per-axis', "
+                f"or 'per-axis-clamped'; got {coord_normalize!r}"
             )
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
@@ -409,6 +410,8 @@ class SurfaceTransolver(nn.Module):
         pos = x[:, :, : self.space_dim]
         if self.coord_normalize != "none":
             pos = (pos - self.coord_shift) / self.coord_scale.clamp(min=1e-6)
+            if self.coord_normalize == "per-axis-clamped":
+                pos = pos.clamp(0.0, 1.0)
         hidden = self.pos_embed(pos)
         if project_features is not None and x.shape[-1] > self.space_dim:
             hidden = hidden + project_features(x[:, :, self.space_dim :])
@@ -798,7 +801,7 @@ def resolve_coord_normalization(
     if mode == "none":
         return torch.zeros_like(xmin), torch.ones_like(xmin)
     extent = xmax - xmin
-    if mode == "per-axis":
+    if mode in ("per-axis", "per-axis-clamped"):
         return xmin.clone(), extent.clone()
     if mode == "global-scale":
         diag = torch.norm(extent)

--- a/train.py
+++ b/train.py
@@ -1844,6 +1844,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
     global_step = 0
+    nonfinite_grad_skip_count = 0
     early_stop_reason: str | None = None
     timeout_hit = False
     train_start = time.time()
@@ -1894,16 +1895,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            grad_finite = True
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), max_norm=config.clip_grad_norm
                 )
+                grad_finite = bool(torch.isfinite(pre_clip_norm).item())
                 if should_log_gradients:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
-            optimizer.step()
+            if grad_finite:
+                optimizer.step()
+            else:
+                nonfinite_grad_skip_count += 1
+                optimizer.zero_grad(set_to_none=True)
             ema_decay_now: float | None = None
-            if ema is not None:
+            if ema is not None and grad_finite:
                 if config.ema_decay_start > 0.0:
                     progress = min(global_step / max(total_estimated_steps, 1), 1.0)
                     cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
@@ -1931,6 +1938,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/grad/step_skipped": 0.0 if grad_finite else 1.0,
+                "train/grad/nonfinite_skip_total": float(nonfinite_grad_skip_count),
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,

--- a/train.py
+++ b/train.py
@@ -348,8 +348,13 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        coord_normalize: str = "none",
     ):
         super().__init__()
+        if coord_normalize not in {"none", "global-scale", "per-axis"}:
+            raise ValueError(
+                f"coord_normalize must be 'none', 'global-scale', or 'per-axis'; got {coord_normalize!r}"
+            )
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
@@ -359,6 +364,9 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.coord_normalize = coord_normalize
+        self.register_buffer("coord_shift", torch.zeros(space_dim))
+        self.register_buffer("coord_scale", torch.ones(space_dim))
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -399,6 +407,8 @@ class SurfaceTransolver(nn.Module):
         placeholder: torch.Tensor,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
+        if self.coord_normalize != "none":
+            pos = (pos - self.coord_shift) / self.coord_scale.clamp(min=1e-6)
         hidden = self.pos_embed(pos)
         if project_features is not None and x.shape[-1] > self.space_dim:
             hidden = hidden + project_features(x[:, :, self.space_dim :])
@@ -589,6 +599,7 @@ class Config:
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
     compile_model: bool = True
+    coord_normalize: str = "none"
     debug: bool = False
 
 
@@ -730,7 +741,69 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        coord_normalize=config.coord_normalize,
     )
+
+
+def compute_coord_stats(
+    manifest_path: str,
+    root: str | None,
+    *,
+    debug: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-axis (min, max) of vehicle-surface xyz coords across the training split.
+
+    Scans surface_xyz.npy via mmap; reuses the loader's PVC mirror/symlink path
+    resolver so the scan works on either mount layout.
+
+    Surface-only by design: volume_xyz extends across the wind-tunnel CFD
+    domain (~120 x 43 x 21 m), 25x wider than the vehicle (~5 x 2 x 1.5 m).
+    Including volume bounds would shrink surface features to ~4% of the unit
+    cube — the opposite of what the PR hypothesis aims to fix. Volume points
+    are encoded by the same shifted/scaled embedding; they fall outside the
+    unit cube but sin/cos pos_embed handles that gracefully.
+    """
+
+    import numpy as np
+
+    from data import DrivAerMLCaseStore
+    from data.loader import _resolve_artifact_path
+
+    store = DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
+    train_ids = store.case_ids("train")
+    if debug:
+        train_ids = train_ids[:4]
+    xmin = np.full(3, np.inf, dtype=np.float64)
+    xmax = np.full(3, -np.inf, dtype=np.float64)
+    for case_id in train_ids:
+        case_dir = store.root / case_id
+        arr = np.load(_resolve_artifact_path(case_dir / "surface_xyz.npy"), mmap_mode="r")
+        xmin = np.minimum(xmin, arr.min(axis=0).astype(np.float64))
+        xmax = np.maximum(xmax, arr.max(axis=0).astype(np.float64))
+    if not np.isfinite(xmin).all() or not np.isfinite(xmax).all():
+        raise RuntimeError("compute_coord_stats produced non-finite bounds")
+    return (
+        torch.from_numpy(xmin.astype(np.float32)),
+        torch.from_numpy(xmax.astype(np.float32)),
+    )
+
+
+def resolve_coord_normalization(
+    mode: str,
+    xmin: torch.Tensor,
+    xmax: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return per-axis (shift, scale) buffers for the requested mode."""
+
+    if mode == "none":
+        return torch.zeros_like(xmin), torch.ones_like(xmin)
+    extent = xmax - xmin
+    if mode == "per-axis":
+        return xmin.clone(), extent.clone()
+    if mode == "global-scale":
+        diag = torch.norm(extent)
+        return xmin.clone(), diag.expand_as(extent).clone()
+    raise ValueError(f"unknown coord_normalize mode: {mode!r}")
 
 
 def _metric_path(name: str) -> str:
@@ -1680,6 +1753,25 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     model = build_model(config).to(device)
+    coord_bbox: dict[str, list[float]] = {}
+    if config.coord_normalize != "none":
+        xmin, xmax = compute_coord_stats(
+            config.manifest, config.data_root or None, debug=config.debug
+        )
+        shift, scale = resolve_coord_normalization(config.coord_normalize, xmin, xmax)
+        model.coord_shift.copy_(shift.to(device=device, dtype=model.coord_shift.dtype))
+        model.coord_scale.copy_(scale.to(device=device, dtype=model.coord_scale.dtype))
+        coord_bbox = {
+            "xmin": xmin.tolist(),
+            "xmax": xmax.tolist(),
+            "shift": shift.tolist(),
+            "scale": scale.tolist(),
+        }
+        print(
+            f"Coord normalize='{config.coord_normalize}' "
+            f"xmin={coord_bbox['xmin']} xmax={coord_bbox['xmax']} "
+            f"shift={coord_bbox['shift']} scale={coord_bbox['scale']}"
+        )
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
@@ -1711,6 +1803,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             "surface_targets": SURFACE_TARGET_NAMES,
             "volume_targets": VOLUME_TARGET_NAMES,
             "total_estimated_steps": total_estimated_steps,
+            "coord_bbox": coord_bbox,
         },
         mode=os.environ.get("WANDB_MODE", "online"),
     )

--- a/train.py
+++ b/train.py
@@ -351,10 +351,17 @@ class SurfaceTransolver(nn.Module):
         coord_normalize: str = "none",
     ):
         super().__init__()
-        if coord_normalize not in {"none", "global-scale", "per-axis", "per-axis-clamped"}:
+        if coord_normalize not in {
+            "none",
+            "global-scale",
+            "per-axis",
+            "per-axis-clamped",
+            "per-axis-surfonly",
+        }:
             raise ValueError(
                 "coord_normalize must be 'none', 'global-scale', 'per-axis', "
-                f"or 'per-axis-clamped'; got {coord_normalize!r}"
+                "'per-axis-clamped', or 'per-axis-surfonly'; "
+                f"got {coord_normalize!r}"
             )
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
@@ -406,12 +413,17 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        is_surface: bool,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         if self.coord_normalize != "none":
-            pos = (pos - self.coord_shift) / self.coord_scale.clamp(min=1e-6)
-            if self.coord_normalize == "per-axis-clamped":
-                pos = pos.clamp(0.0, 1.0)
+            apply_norm = True
+            if self.coord_normalize == "per-axis-surfonly" and not is_surface:
+                apply_norm = False
+            if apply_norm:
+                pos = (pos - self.coord_shift) / self.coord_scale.clamp(min=1e-6)
+                if self.coord_normalize == "per-axis-clamped":
+                    pos = pos.clamp(0.0, 1.0)
         hidden = self.pos_embed(pos)
         if project_features is not None and x.shape[-1] > self.space_dim:
             hidden = hidden + project_features(x[:, :, self.space_dim :])
@@ -445,6 +457,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    is_surface=True,
                 )
             )
             masks.append(surface_mask)
@@ -457,6 +470,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    is_surface=False,
                 )
             )
             masks.append(volume_mask)
@@ -801,7 +815,7 @@ def resolve_coord_normalization(
     if mode == "none":
         return torch.zeros_like(xmin), torch.ones_like(xmin)
     extent = xmax - xmin
-    if mode in ("per-axis", "per-axis-clamped"):
+    if mode in ("per-axis", "per-axis-clamped", "per-axis-surfonly"):
         return xmin.clone(), extent.clone()
     if mode == "global-scale":
         diag = torch.norm(extent)


### PR DESCRIPTION
## Hypothesis

DrivAerML point-cloud coordinates are raw meters with a strongly anisotropic bounding box: x-axis spans ~8m (vehicle length), y-axis ~2.5m (width), z-axis ~2m (height). `ContinuousSincosEmbed` multiplies raw coordinates by a fixed frequency bank `omega`, so each axis's sinusoidal frequencies are implicitly scaled by its physical extent. This means the x-axis gets ~3–4× more frequency resolution than y/z — the positional encoding "sees" more detail along the vehicle axis than across it.

This anisotropy is a likely contributor to the persistent 4× gap between our tau_y/tau_z and AB-UPT. Surface wall-shear in the y/z direction is predominantly driven by crossflow and spanwise gradients, which the model must resolve at ~2m scale while the embedding is calibrated for an 8m range. Normalizing coordinates to a unit cube (or unit sphere) before `pos_embed` gives equal per-axis frequency resolution.

Evidence: edward's RFF experiment (PR #119) found wall_shear_y/z were the worst per-axis components (21.3%, 23.2%), and he explicitly noted "isotropic σ produces uneven effective frequencies on the y/z axes." The same issue applies to `ContinuousSincosEmbed` with raw-meter coordinates.

**Proposed change:** Add a `--coord-normalize` flag with three modes to `train.py`:

- `none` (default, current behavior — raw meter coords)
- `global-scale` — divide all axes by the global bounding-box diagonal (single scalar, preserves isotropy of existing encoding)
- `per-axis` — divide each axis by its own range (x/8.0, y/2.5, z/2.0), giving equal frequency density per axis

The normalization is applied in `SurfaceTransolver._encode_group` before calling `self.pos_embed(pos)`. The normalization statistics should be pre-computed from the training set bounding box and stored as `register_buffer` tensors so they're consistent at val/test time.

## Instructions

**New flag:** Add `--coord-normalize` to the `Config` dataclass and argparser with choices `["none", "global-scale", "per-axis"]`, default `"none"`. This preserves backward compatibility.

**Implementation in `SurfaceTransolver.__init__`:**
```python
# In SurfaceTransolver.__init__, add:
self.coord_normalize = coord_normalize  # store the flag
# These will be set externally after construction with actual data stats:
self.register_buffer("coord_shift", torch.zeros(space_dim))   # per-axis min
self.register_buffer("coord_scale", torch.ones(space_dim))    # per-axis divisor
```

**Set the normalization statistics in `build_model` or before the training loop** by computing the min/max of all surface+volume xyz from the training dataset loader (first pass or from a pre-computed stats file). Example:
```python
# Compute from training data (do this once, before training loop starts):
x_min = torch.tensor([-1.0, -1.25, -0.05])   # approx DrivAerML bbox min (meters)
x_max = torch.tensor([7.0,  1.25,  1.95])    # approx DrivAerML bbox max (meters)
# For 'per-axis': divide by per-axis range
coord_scale_per_axis = x_max - x_min          # shape [3]
# For 'global-scale': divide by diagonal (single scalar broadcast)
coord_scale_global = torch.norm(x_max - x_min).expand(3)
```

The simplest correct approach is to compute these from the **actual training batches** using a one-pass scan before training, OR hardcode the known DrivAerML bounding box values. Either is fine — the key is that val/test coordinates are normalized with the SAME shift/scale.

**Apply normalization in `_encode_group`:**
```python
def _encode_group(self, x, *, project_features, bias, placeholder):
    pos = x[:, :, :self.space_dim]
    if self.coord_normalize != "none":
        pos = (pos - self.coord_shift) / self.coord_scale.clamp(min=1e-6)
    hidden = self.pos_embed(pos)
    ...
```

**Three arms to run:**
| Arm | `--coord-normalize` | Run name |
|---|---|---|
| A | `none` (control — exact PR #99 config, reproduced) | `fern-coord-none` |
| B | `global-scale` | `fern-coord-global` |
| C | `per-axis` | `fern-coord-peraxis` |

Use `--wandb-group fern-coord-normalization` for all arms.

All other flags identical to PR #99 baseline:
```bash
cd target/
python train.py \
  --coord-normalize <none|global-scale|per-axis> \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group fern-coord-normalization \
  --wandb-name fern-coord-<none|global|peraxis>
```

**Logging:** Log `coord/shift_{x,y,z}` and `coord/scale_{x,y,z}` as hyperparameters in W&B init so the actual normalization applied is visible.

**Watch for:** The per-axis arm should show lower val loss on tau_y and tau_z specifically. If both B and C beat A, the per-axis arm is the deeper insight. If only C beats A, that confirms the anisotropy hypothesis directly.

## Baseline

Current best — PR #99 (fern), W&B run `3hljb0mg`:

| Metric | val | test |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | 11.73 |
| `surface_pressure_rel_l2_pct` | 6.97 | 6.64 |
| `wall_shear_rel_l2_pct` | 11.69 | 11.48 |
| `volume_pressure_rel_l2_pct` | 7.85 | 14.42 |
| `wall_shear_x_rel_l2_pct` | 10.17 | 10.06 |
| `wall_shear_y_rel_l2_pct` | **13.73** | 13.53 |
| `wall_shear_z_rel_l2_pct` | **14.73** | 13.98 |

AB-UPT targets (to beat long-term): sp=3.82, wsx=5.35, wsy=3.65, wsz=3.63, vp=6.08.

Success criterion: any arm with `val_primary/abupt_axis_mean_rel_l2_pct < 10.69`.

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
