### PR TITLE
edward: AdamW beta2 sweep (0.95 vs 0.999) at lr 3e-4 and 5e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -543,6 +543,10 @@ class EMA:
 class Config:
     lr: float = 3e-4
     weight_decay: float = 1e-4
+    beta1: float = 0.9
+    beta2: float = 0.999
+    lr_warmup_steps: int = 0
+    lr_warmup_start_factor: float = 0.01
     batch_size: int = 2
     epochs: int = 50
     train_surface_points: int = 40_000
@@ -1685,8 +1689,26 @@ def main(argv: Iterable[str] | None = None) -> None:
     n_params = sum(param.numel() for param in model.parameters())
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.lr,
+        weight_decay=config.weight_decay,
+        betas=(config.beta1, config.beta2),
+    )
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    if config.lr_warmup_steps > 0:
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=config.lr_warmup_start_factor,
+            end_factor=1.0,
+            total_iters=config.lr_warmup_steps,
+        )
+        print(
+            f"LR warmup: linear ramp from {config.lr * config.lr_warmup_start_factor:.2e} to "
+            f"{config.lr:.2e} over {config.lr_warmup_steps} steps"
+        )
+    else:
+        warmup_scheduler = None
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
     if kill_thresholds:
@@ -1809,6 +1831,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
+            if warmup_scheduler is not None and global_step < config.lr_warmup_steps:
+                warmup_scheduler.step()
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -1838,6 +1862,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/lr": float(optimizer.param_groups[0]["lr"]),
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
@@ -1881,7 +1906,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if config.lr_warmup_steps == 0 or global_step >= config.lr_warmup_steps:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

The entire yi fleet has been running AdamW with default betas (beta1=0.9, beta2=0.999). The fleet-wide training instability pattern (lr=5e-4, gradient explosion in epochs 1–2) suggests the second-moment EMA is not adapting fast enough to the actual gradient distribution of this CFD problem.

Why lower beta2 helps on CFD:
- DrivAerML gradients are **non-stationary and bursty**: high-|tau| boundary-layer surface points generate large gradient spikes that are rare relative to total sample count. With beta2=0.999, the running second-moment estimate requires ~1000 steps to "forget" the last gradient spike. In a 10,883-step epoch, this means the second-moment estimate lags real gradient variance by nearly the full epoch.
- **Lower beta2 (0.95–0.99) adapts faster**: The denominator `sqrt(v_t + eps)` tracks current gradient scale more accurately, giving a more robust per-parameter learning rate.
- **Well-known empirical result** from Karpathy's nanoGPT and the original Chinchilla / GPT-3 papers: beta2=0.95 works better than 0.999 on tasks with noisy/bursty gradients. Also supported by the "depth-wise varying betas" literature.

Additionally, the fleet has confirmed that lr=5e-4 is at the stability ceiling. A targeted sweep at lr=3e-4 with beta2=0.95 would (a) establish the correct stability baseline for all subsequent experiments and (b) test whether lower beta2 allows lr to be safely raised back toward 5e-4.

**Proposed 4-arm sweep** (flags-only, no code changes needed):

| Arm | lr | beta2 | warmup | Run name |
|---|---|---|---|---|
| A | 5e-4 | 0.999 (current default) | 500 steps | `edward-adamw-ctrl` |
| B | 5e-4 | 0.95 | 500 steps | `edward-adamw-b95` |
| C | 3e-4 | 0.95 | 500 steps | `edward-adamw-lr3e4-b95` |
| D | 3e-4 | 0.999 (current default) | 500 steps | `edward-adamw-lr3e4-ctrl` |

This 2×2 design isolates the lr effect (A vs D; B vs C) and the beta2 effect (A vs B; C vs D).

## Instructions

**Code change:** Add `--beta1`, `--beta2`, and `--lr-warmup-steps` flags to `Config` and the argparser:
```python
beta1: float = 0.9      # AdamW default
beta2: float = 0.999    # AdamW default
lr_warmup_steps: int = 0
```

In the optimizer initialization section, pass the betas:
```python
optimizer = torch.optim.AdamW(
    model.parameters(),
    lr=config.lr,
    weight_decay=config.weight_decay,
    betas=(config.beta1, config.beta2),
)
```

For the linear LR warmup (if `lr_warmup_steps > 0`), add a `LambdaLR` scheduler applied for the first `lr_warmup_steps` steps:
```python
if config.lr_warmup_steps > 0:
    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
        optimizer,
        start_factor=0.01,   # start at 1% of lr
        end_factor=1.0,
        total_iters=config.lr_warmup_steps
    )
    # step warmup_scheduler at each optimizer.step() for the first lr_warmup_steps steps
```

Log `train/beta2` as a hyperparameter in W&B init and log `train/lr` every `gradient_log_every` steps so the warmup ramp is visible.

**All 4 arms share this base config:**
```bash
cd target/
python train.py \
  --beta2 <0.999|0.95> \
  --lr <5e-4|3e-4> \
  --lr-warmup-steps 500 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group edward-adamw-beta2-sweep \
  --wandb-name edward-adamw-<ctrl|b95|lr3e4-b95|lr3e4-ctrl>
```

Per-arm flags:
- Arm A: `--lr 5e-4 --beta2 0.999`
- Arm B: `--lr 5e-4 --beta2 0.95`
- Arm C: `--lr 3e-4 --beta2 0.95`
- Arm D: `--lr 3e-4 --beta2 0.999`

**Stability monitoring:** Log `grad/pre_clip_norm` every 100 steps. If Arm A (control) diverges again with NaN in epoch 2, that's expected given fleet history. If Arm B (same lr, lower beta2) stays stable where A diverged, that's a direct proof of the hypothesis.

**Kill thresholds:** Use `--kill-thresholds "5000:train/loss>=3.0"` for all arms — if loss exceeds 3.0 after step 5000, the run has diverged.

## Baseline

Current best — PR #99 (fern), W&B run `3hljb0mg`:

| Metric | val | test |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | 11.73 |
| `surface_pressure_rel_l2_pct` | 6.97 | 6.64 |
| `wall_shear_rel_l2_pct` | 11.69 | 11.48 |
| `volume_pressure_rel_l2_pct` | 7.85 | 14.42 |
| `wall_shear_x_rel_l2_pct` | 10.17 | 10.06 |
| `wall_shear_y_rel_l2_pct` | 13.73 | 13.53 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 13.98 |

Fleet context: lr=5e-4/clip=1.0/bf16 has been the stability ceiling. Edward (RFF), kohaku (FiLM), senku (surface upweighting), violet (decoupled wallshear), and alphonse (width/depth scale-up) have ALL diverged mid-epoch-2 at lr=5e-4. If beta2=0.95 stabilizes lr=5e-4 without metric regression, this is a fleet-wide unlocker for all subsequent experiments.

Success criteria:
1. Any arm with `val_primary/abupt_axis_mean_rel_l2_pct < 10.69` is a merge.
2. If Arm B (lr=5e-4, beta2=0.95) is stable (no NaN through epoch 2) and matches/beats A, this is strong evidence for a fleet-wide config update.

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
