### PR TITLE
[senku] DrivAerML Metric-Aware Loss: MSE + Raw Rel-L2 Auxiliary (w=0.05)

### DIFF
--- a/train.py
+++ b/train.py
@@ -51,6 +51,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    squared_relative_l2_loss,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -113,6 +114,7 @@ class Config:
     kill_thresholds: str = ""
     compile_model: bool = True
     debug: bool = False
+    raw_rel_l2_weight: float = 0.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -160,6 +162,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    raw_rel_l2_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -177,12 +180,33 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+        aux_metrics: dict[str, float] = {}
+        if raw_rel_l2_weight > 0.0:
+            # Un-normalize predictions back to physical space for relative L2 loss.
+            # Surface channels: 0=surface_pressure, 1=wsx, 2=wsy, 3=wsz
+            surface_preds_phys = transform.invert_surface(out["surface_preds"])
+            volume_preds_phys = transform.invert_volume(out["volume_preds"])
+            _surface_channel_names = ["surface_pressure", "wsx", "wsy", "wsz"]
+            aux_loss = torch.zeros(1, device=device, dtype=loss.dtype).squeeze()
+            for ch_idx, ch_name in enumerate(_surface_channel_names):
+                ch_pred = surface_preds_phys[..., ch_idx : ch_idx + 1]
+                ch_tgt = batch.surface_y[..., ch_idx : ch_idx + 1]
+                ch_rel_l2 = squared_relative_l2_loss(ch_pred, ch_tgt, batch.surface_mask)
+                aux_metrics[f"raw_rel_l2/{ch_name}"] = float(ch_rel_l2.detach().cpu().item())
+                aux_loss = aux_loss + ch_rel_l2
+            vol_rel_l2 = squared_relative_l2_loss(volume_preds_phys, batch.volume_y, batch.volume_mask)
+            aux_metrics["raw_rel_l2/vol_pressure"] = float(vol_rel_l2.detach().cpu().item())
+            aux_loss = aux_loss + vol_rel_l2
+            loss = loss + raw_rel_l2_weight * aux_loss
+
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **aux_metrics,
     }
 
 
@@ -296,6 +320,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    raw_rel_l2_weight=config.raw_rel_l2_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -333,6 +358,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    # Log per-channel raw relative L2 auxiliary metrics when enabled.
+                    for _aux_key in ("raw_rel_l2/surface_pressure", "raw_rel_l2/wsx",
+                                     "raw_rel_l2/wsy", "raw_rel_l2/wsz",
+                                     "raw_rel_l2/vol_pressure"):
+                        if _aux_key in batch_loss_metrics:
+                            train_log[f"train/{_aux_key}"] = batch_loss_metrics[_aux_key]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

The DrivAerML training objective uses per-task MSE losses in normalized (zero-mean, unit-variance) space. The test metric that determines success is `abupt_axis_mean_rel_l2_pct` — a **relative L2 error** computed on un-normalized, physical-scale predictions. These two objectives are structurally misaligned: a model minimizing normalized MSE is not directly minimizing the relative L2 error that determines the final ranking.

This misalignment is especially damaging for `wall_shear_y` and `wall_shear_z`, which have heavy-tailed distributions and where the relative L2 penalty can diverge sharply in physical space even when normalized MSE appears small.

**Hypothesis**: Adding a small auxiliary `raw_rel_l2` (relative L2, un-normalized) penalty term directly to the training loss will orient gradient updates toward the actual evaluation metric, improving `abupt_axis_mean_rel_l2_pct` — particularly the wall-shear axes which are the binding constraint.

This idea is validated by radford PR #3302, which used `mse_plus_raw_rel_l2` with w=0.05 on the best DDP8 recipe and achieved `val_abupt = 3.700%` — decisively below the AB-UPT target of 4.51%. This experiment ports that approach to the alphonse Wave 1 base recipe (4L/256d/4H + Fourier PE + T_max=30 + no-EMA) running on DDP4.

The weight w=0.05 is small enough that the auxiliary term doesn't destabilize MSE training (which provides the dense gradient signal), but large enough to communicate the relative-scale objective clearly.

## Instructions

**Base recipe**: alphonse Wave 1 winner — 4L/256d/4H + Fourier PE + T_max=30 + no-EMA, DDP4.

**What to implement**: Add a `raw_rel_l2` auxiliary loss to `train.py`. After computing each per-task MSE in normalized space, compute an additional per-task relative L2 loss in un-normalized (physical) space and add it with weight w=0.05.

### Concrete implementation

In `target/train.py`, in the per-task loss computation section, after you have `preds` and `targets` in **un-normalized** physical space, add:

```python
# Relative L2 auxiliary loss (in physical/un-normalized space)
def raw_rel_l2(pred, target, eps=1e-8):
    """Relative L2 error: ||pred - target||_2 / (||target||_2 + eps)"""
    num = torch.sum((pred - target) ** 2, dim=-1)   # [B, N]
    den = torch.sum(target ** 2, dim=-1) + eps       # [B, N]
    return torch.mean(num / den)

RAW_REL_L2_WEIGHT = 0.05

# For each task (surface_pressure, wall_shear_x/y/z, volume_pressure):
loss = mse_loss + RAW_REL_L2_WEIGHT * raw_rel_l2(pred_phys, target_phys)
```

Key implementation details:
- Compute `raw_rel_l2` on un-normalized predictions and targets (after applying the stored mean/std back out), NOT on the normalized tensors.
- Apply the auxiliary term independently to each output head (surface_pressure, wsx, wsy, wsz, vol_pressure) using the same relative weight w=0.05 for all.
- The MSE loss in normalized space is the primary training signal — do not remove or reduce it.
- Keep the existing task-weight schedule (surface weight, volume weight) unchanged.
- Log the raw_rel_l2 contributions per-task to W&B: `train/raw_rel_l2/surface_pressure`, `train/raw_rel_l2/wsx`, `train/raw_rel_l2/wsy`, `train/raw_rel_l2/wsz`, `train/raw_rel_l2/vol_pressure`.

### Training command

```bash
cd target/ && python train.py \
  --wandb_project DrivAerML \
  --wandb_group senku-metric-aware-loss \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --model-slices 96 \
  --model-mlp-ratio 4 \
  --use-fourier-pos-enc \
  --no-ema \
  --lr 3e-4 \
  --scheduler cosine \
  --T-max 30 \
  --epochs 50 \
  --no-compile-model \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25"
```

Note: `--no-compile-model` is mandatory — torch.compile crashes at first validation on this cluster.

### What to report

In your PR comment, include:
- W&B run ID and link
- `full_val_primary/abupt_axis_mean_rel_l2_pct` (best epoch)
- `full_val_primary/surface_pressure_rel_l2_pct`
- `full_val_primary/wall_shear_y_rel_l2_pct`
- `full_val_primary/wall_shear_z_rel_l2_pct`
- `full_val_primary/volume_pressure_rel_l2_pct`
- `test_primary/abupt_axis_mean_rel_l2_pct` (from best checkpoint)
- W&B plots of `train/raw_rel_l2/wsy` and `train/raw_rel_l2/wsz` over training steps

If the run diverges early (abupt > 25 at step 2000), reduce w to 0.01 and re-run.

## Baseline

Current Wave 1 mid-training leader: **alphonse** (4L/256d/4H + Fourier PE + T_max=30 + no-EMA)
- `val/abupt_axis_mean_rel_l2_pct` ≈ 7.33 (step 421k, mid-training — NOT final)
- `val/surface_pressure_rel_l2_pct` ≈ 4.87
- `val/volume_pressure_rel_l2_pct` ≈ 4.23
- Wall-shear y/z: universally 9–12% across all Wave 1 runs (AB-UPT targets: wsy < 3.65, wsz < 3.63)

**AB-UPT targets to beat** (test_primary):
| Metric | Target |
|--------|--------|
| `surface_pressure_rel_l2_pct` | < 3.82 |
| `volume_pressure_rel_l2_pct` | < 6.08 |
| `wall_shear_x_rel_l2_pct` | < 5.35 |
| `wall_shear_y_rel_l2_pct` | < 3.65 |
| `wall_shear_z_rel_l2_pct` | < 3.63 |
| `abupt_axis_mean_rel_l2_pct` | < 4.51 |

**Radford PR #3302 validation** (DDP8 recipe): `mse_plus_raw_rel_l2` w=0.05 achieved val_abupt = **3.700%** — below all AB-UPT targets simultaneously.

## Expected outcome

Convergence to a lower `abupt_axis_mean_rel_l2_pct` than the alphonse base recipe, with the largest relative improvement on `wall_shear_y` and `wall_shear_z` (current binding constraints). The training loss may appear slightly higher due to the auxiliary term, but validation metrics should improve.
