### PR TITLE
tanjiro: round10 — per-axis tau_y/tau_z weights W=1.5 (conservative, attack ×3.4-3.6 binding gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,6 +79,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    wallshear_y_weight: float = 1.0
+    wallshear_z_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -179,6 +181,24 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def _per_channel_masked_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    """Per-channel masked MSE. Returns a [C] tensor, one scalar per channel."""
+    diff_sq = (pred - target).square()
+    expanded_mask = mask
+    while expanded_mask.ndim < diff_sq.ndim:
+        expanded_mask = expanded_mask.unsqueeze(-1)
+    expanded_mask = expanded_mask.to(device=diff_sq.device, dtype=diff_sq.dtype)
+    weighted = diff_sq * expanded_mask
+    reduce_dims = tuple(range(diff_sq.ndim - 1))  # all but the last (channel) dim
+    numer = weighted.sum(dim=reduce_dims)
+    denom = expanded_mask.expand_as(diff_sq).sum(dim=reduce_dims).clamp_min(1.0)
+    return numer / denom
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -188,6 +208,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    wallshear_y_weight: float = 1.0,
+    wallshear_z_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -199,19 +221,40 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        # Per-channel MSE for surface: [cp, tau_x, tau_y, tau_z]
+        per_ch_mse = _per_channel_masked_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )
+        ch_weights = torch.ones_like(per_ch_mse)
+        # Surface channel layout: 0=cp, 1=tau_x, 2=tau_y, 3=tau_z
+        if per_ch_mse.shape[0] >= 4:
+            ch_weights[2] = wallshear_y_weight
+            ch_weights[3] = wallshear_z_weight
+        surface_loss = (per_ch_mse * ch_weights).mean()
+        surface_loss_unweighted = per_ch_mse.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        base_mse_loss = surface_loss_unweighted + volume_loss
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
-        "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_loss": float(surface_loss_unweighted.detach().cpu().item()),
+        "surface_loss_axis_weighted": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    per_ch_cpu = per_ch_mse.detach().float().cpu()
+    if per_ch_cpu.shape[0] >= 1:
+        metrics["surface_loss_cp"] = float(per_ch_cpu[0].item())
+    if per_ch_cpu.shape[0] >= 2:
+        metrics["surface_loss_tau_x"] = float(per_ch_cpu[1].item())
+    if per_ch_cpu.shape[0] >= 3:
+        metrics["surface_loss_tau_y"] = float(per_ch_cpu[2].item())
+    if per_ch_cpu.shape[0] >= 4:
+        metrics["surface_loss_tau_z"] = float(per_ch_cpu[3].item())
+    return loss, metrics
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -324,6 +367,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    wallshear_y_weight=config.wallshear_y_weight,
+                    wallshear_z_weight=config.wallshear_z_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -361,6 +406,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if "surface_loss_axis_weighted" in batch_loss_metrics:
+                        train_log["train/surface_loss_axis_weighted"] = batch_loss_metrics[
+                            "surface_loss_axis_weighted"
+                        ]
+                    for ch_key, log_key in (
+                        ("surface_loss_cp", "train/loss_cp"),
+                        ("surface_loss_tau_x", "train/loss_tau_x"),
+                        ("surface_loss_tau_y", "train/loss_tau_y"),
+                        ("surface_loss_tau_z", "train/loss_tau_z"),
+                    ):
+                        if ch_key in batch_loss_metrics:
+                            train_log[log_key] = batch_loss_metrics[ch_key]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

**The biggest remaining tay performance gap is in tau_y (12.491, 3.4× ref) and tau_z (13.071, 3.6× ref).** All other components are 1.4-1.7× from AB-UPT reference. Yi PR #66 (thorfinn) demonstrated that **per-axis upweighting of tau_y and tau_z** gave a single-shot −3.1% improvement on yi's stack.

Tay's prior attempt (PR #54 fern, AdamW + per-axis weights including very aggressive scaling) **diverged** because the weights were too aggressive and combined with multiple confounders (AdamW, RFF, axis weights all together). 

**Conservative single-delta test:** add per-axis weights `W_y=1.5, W_z=1.5` (smaller than yi's W_y=W_z=2.0) on top of the new SOTA stack (PR #115). This isolates the tau-axis effect on the modern Lion+EMA base.

If this works, follow-up will test W_y=W_z=2.0 (yi's exact value) and W_y=W_z=2.5 to find the sweet spot.

Projected outcomes:
- **Best:** captures yi's −3.1% gain → test ~10.25 (−3% vs SOTA)
- **Likely:** partial transfer due to different optimizer/EMA regime → test ~10.4-10.5 (−1 to −2%)
- **Worst:** marginal regression if Lion's sign-based updates already balance the axis losses → test ~10.6-10.7

## Instructions

Add per-axis wall_shear weighting on top of the PR #115 SOTA stack. The relevant flags need verification — please run `python train.py --help | grep -i 'wall.shear\|axis\|tau'` to confirm the exact CLI flag spelling. Likely flags:
- `--wallshear-y-weight 1.5` and `--wallshear-z-weight 1.5` (or similar)
- OR `--axis-weights "1.0,1.0,1.5,1.0,1.5,1.0"` (component vector format)
- OR a config file flag

If multiple flag styles exist, prefer the most explicit per-axis form. If no such flag exists in current train.py (it may have been removed since yi's port), report back immediately and I will reassign.

```bash
# After verifying flag spelling, run:
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 \
  <ADD CORRECT PER-AXIS WEIGHT FLAGS HERE: W_y=1.5, W_z=1.5> \
  --wandb-group tay-round10-tau-axis-weights
```

**Single conceptual delta vs PR #115 SOTA:** add per-axis tau_y/tau_z upweighting (W_y=W_z=1.5). Everything else identical.

Hard timeout 270 min. Hard cap 9 epochs.

Post results: best val_primary/abupt_axis_mean_rel_l2_pct, final test_primary/abupt_axis_mean_rel_l2_pct, per-component test breakdown (especially tau_y and tau_z), W&B run URL.

Key observations:
- Did tau_y and tau_z improve? By how much?
- Did surface_pressure or volume_pressure regress as a side-effect?
- The previous attempt diverged — does it train smoothly with conservative weights?

## Baseline (PR #115 thorfinn — current SOTA, test_abupt 10.580)

| Metric | PR #115 SOTA | AB-UPT | Gap |
|---|---:|---:|---:|
| `abupt` mean | **10.580** | — | — |
| `surface_pressure` | 5.690 | 3.82 | ×1.5 |
| `wall_shear` | 10.419 | 7.29 | ×1.4 |
| `volume_pressure` | 12.740 | 6.08 | ×2.1 |
| `tau_x` | 8.908 | 5.35 | ×1.7 |
| **tau_y** | **12.491** | 3.65 | **×3.4** ← target |
| **tau_z** | **13.071** | 3.63 | **×3.6** ← target |

Reference: yi PR #66 thorfinn (per-axis W_y=W_z=2.0): −3.1% single-shot. Tay PR #54 (W_y=W_z=2.0+ AdamW): diverged.
