### PR TITLE
emma: multi-scale point hierarchy for tau_y/z gap (2/3 scales)

### DIFF
--- a/train.py
+++ b/train.py
@@ -274,6 +274,120 @@ class FiLMLayer(nn.Module):
         return h * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
 
 
+class CrossAttention(nn.Module):
+    """Cross-attention via SDPA. Zero-init out_proj so initial output is exactly zero."""
+
+    def __init__(self, hidden_dim: int, num_heads: int):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.dim_head = hidden_dim // num_heads
+        self.q_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.k_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.v_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        kv_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, _ = q.shape
+        M = kv.shape[1]
+        Q = self.q_proj(q).view(B, N, self.num_heads, self.dim_head).transpose(1, 2)
+        K = self.k_proj(kv).view(B, M, self.num_heads, self.dim_head).transpose(1, 2)
+        V = self.v_proj(kv).view(B, M, self.num_heads, self.dim_head).transpose(1, 2)
+        if kv_mask is not None:
+            # Zero K and V at padded positions (post-projection cancels k/v_proj bias).
+            # softmax(Q*K_padded^T) * V_padded contributes 0 to output. We avoid passing
+            # an attn_mask so SDPA can dispatch to FlashAttention.
+            kv_mask_b = kv_mask[:, None, :, None].to(K.dtype)
+            K = K * kv_mask_b
+            V = V * kv_mask_b
+        out = F.scaled_dot_product_attention(Q, K, V)
+        out = out.transpose(1, 2).contiguous().view(B, N, self.hidden_dim)
+        return self.out_proj(out)
+
+
+class CrossAttentionBlock(nn.Module):
+    """Pre-norm cross-attention with residual; supports stop-gradient on the kv path."""
+
+    def __init__(self, hidden_dim: int, num_heads: int, stop_gradient: bool = False):
+        super().__init__()
+        self.norm_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.attn = CrossAttention(hidden_dim, num_heads)
+        self.stop_gradient = stop_gradient
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        kv_mask: torch.Tensor | None = None,
+        q_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.stop_gradient:
+            kv = kv.detach()
+        normed_q = self.norm_q(q)
+        normed_kv = self.norm_kv(kv)
+        attn_out = self.attn(normed_q, normed_kv, kv_mask=kv_mask)
+        if q_mask is not None:
+            attn_out = attn_out * q_mask.unsqueeze(-1).to(attn_out.dtype)
+        return q + attn_out
+
+
+class MultiScaleHierarchy(nn.Module):
+    """Cross-scale enrichment of surface features.
+
+    Builds num_scales-1 coarse levels by progressive strided downsampling
+    (factor 4x per level: 65536 -> 16384 -> 4096) and applies fine -> coarse
+    cross-attention at each level. Output of each cross-attention is
+    zero-initialized so the model starts identically to the no-hierarchy baseline.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int,
+        num_heads: int = 4,
+        num_scales: int = 3,
+        stop_gradient: bool = False,
+        coarse_factor: int = 4,
+    ):
+        super().__init__()
+        if num_scales < 2:
+            raise ValueError("num_scales must be at least 2 for a hierarchy")
+        self.num_scales = num_scales
+        self.coarse_factor = coarse_factor
+        n_levels = num_scales - 1
+        self.cross_blocks = nn.ModuleList(
+            [
+                CrossAttentionBlock(hidden_dim, num_heads, stop_gradient=stop_gradient)
+                for _ in range(n_levels)
+            ]
+        )
+
+    def forward(
+        self,
+        fine_feats: torch.Tensor,
+        fine_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        out = fine_feats
+        coarse_feats = fine_feats
+        coarse_mask = fine_mask
+        s = self.coarse_factor
+        for block in self.cross_blocks:
+            coarse_feats = coarse_feats[:, ::s].contiguous()
+            coarse_mask = coarse_mask[:, ::s].contiguous()
+            out = block(out, coarse_feats, kv_mask=coarse_mask, q_mask=fine_mask)
+        return out
+
+
 class Transformer(nn.Module):
     def __init__(
         self,
@@ -348,6 +462,9 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        use_multiscale_hierarchy: bool = False,
+        num_scales: int = 3,
+        multiscale_stop_gradient: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,6 +476,7 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.use_multiscale_hierarchy = use_multiscale_hierarchy
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -387,6 +505,16 @@ class SurfaceTransolver(nn.Module):
             film_geom_dim=film_encoder_dim if use_film else 0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        self.hierarchy = (
+            MultiScaleHierarchy(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                num_scales=num_scales,
+                stop_gradient=multiscale_stop_gradient,
+            )
+            if use_multiscale_hierarchy
+            else None
+        )
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
@@ -461,6 +589,10 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.hierarchy is not None and surface_x is not None:
+            surface_hidden = self.hierarchy(surface_hidden, surface_mask)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
@@ -571,6 +703,9 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    use_multiscale_hierarchy: bool = False
+    num_scales: int = 3
+    multiscale_stop_gradient: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -730,6 +865,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        use_multiscale_hierarchy=config.use_multiscale_hierarchy,
+        num_scales=config.num_scales,
+        multiscale_stop_gradient=config.multiscale_stop_gradient,
     )
 
 
@@ -1739,6 +1877,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("train/hierarchy/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"


### PR DESCRIPTION
## Hypothesis

The current Transolver processes all 65 536 surface points at a single spatial resolution. Boundary-layer features driving `tau_y` and `tau_z` require simultaneous access to **fine local geometry** (sub-millimetre surface curvature) and **broad geometric context** (wheel arches, A-pillars, underbody channels that span metres). A multi-scale point hierarchy — coarsening 65 536 → 16 384 → 4 096 surface points with cross-scale attention — lets the model resolve both regimes independently and fuse them. This is the PointNet++ SetAbstraction intuition applied to the Transolver backbone.

**Why the y/z axes specifically?** The tau_x dominant axis is driven by streamwise pressure gradient — a long-range, low-frequency signal. tau_y and tau_z are driven by local surface geometry (curvature normals, wing tips, wheel-arch lips) — a short-range, high-frequency signal that a single-resolution slice-attention model cannot separate from background streamwise flow. A two- or three-scale hierarchy creates explicit receptive-field widths that match both signal types.

## Instructions

Add a `--use-multiscale-hierarchy` boolean flag and `--num-scales N` (int, default 3) to `Config` and the argparser. No changes to the existing single-scale path (flag defaults to `False` so existing runs are unaffected).

**Implementation sketch:**

```python
class MultiScaleHierarchy(nn.Module):
    """Wrap Transolver with coarse-to-fine attention between 3 point scales."""
    def __init__(self, base_model, scales=(65536, 16384, 4096), hidden_dim=256):
        super().__init__()
        self.base = base_model          # existing Transolver encoder
        self.scale_ratios = scales
        # Lightweight cross-scale attention (Q=fine keys, K/V=coarse features)
        self.coarse_proj = nn.ModuleList([
            nn.Linear(hidden_dim, hidden_dim) for _ in range(len(scales)-1)
        ])
        self.cross_attn = nn.ModuleList([
            nn.MultiheadAttention(hidden_dim, num_heads=4, batch_first=True)
            for _ in range(len(scales)-1)
        ])

    def downsample(self, pts, feats, target_n):
        """Strided indexing: take every k-th point to reach target_n."""
        B, N, C = feats.shape
        step = N // target_n
        idx = torch.arange(0, N, step, device=feats.device)[:target_n]
        return pts[:, idx], feats[:, idx]

    def forward(self, surf_pts, surf_feats, vol_pts, vol_feats, geom):
        # 1. Full-resolution Transolver encoding
        fine_out = self.base.encode(surf_pts, surf_feats)  # (B, 65536, D)
        
        # 2. Build coarse levels and cross-attend fine←coarse
        coarse_pts, coarse_feats = surf_pts, fine_out
        for i, target_n in enumerate(self.scale_ratios[1:]):
            coarse_pts, coarse_feats = self.downsample(coarse_pts, coarse_feats, target_n)
            # Fine queries attend to coarse keys/values
            fine_out, _ = self.cross_attn[i](
                query=fine_out,
                key=self.coarse_proj[i](coarse_feats),
                value=coarse_feats
            )
        
        # 3. Decode with enriched features
        return self.base.decode(fine_out, vol_pts, vol_feats, geom)
```

Wrap the model construction in `train.py` under `if config.use_multiscale_hierarchy:` immediately after the base model is instantiated. Keep the same output heads.

**3-arm sweep:**

| Arm | Config | Run name |
|---|---|---|
| A | 2 scales: 65536→16384 | `emma-ms-2scale` |
| B | 3 scales: 65536→16384→4096 | `emma-ms-3scale` |
| C | 3 scales + stop-gradient on cross-attn (ablate whether gradient flow through hierarchy helps) | `emma-ms-3scale-stopgrad` |

**All arms use lr=3e-4** (CRITICAL — modifying gradient landscape requires dropping below the lr=5e-4 stability ceiling; see fleet-wide discovery in PR #117 and #126). Base command for each arm:

```bash
cd target/
python train.py \
  --use-multiscale-hierarchy \
  --num-scales <2|3> \
  --lr 3e-4 --weight-decay 5e-4 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group emma-multiscale-hierarchy-r10 \
  --wandb-run-name <arm-name>
```

**What to log:** In addition to standard metrics, log `train/cross_attn_weight_mean` per cross-attn level (mean absolute attention weight) to verify the coarse context is actually being used. If these stay near 0 throughout training, the hierarchy is learning to ignore coarse context — that's diagnostic.

## Baseline (PR #99, W&B run `3hljb0mg`)

| Metric | yi best (val) | yi best (test) | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | **11.73** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 6.64 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 11.48 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 14.42 | 6.08 |
| `wall_shear_x_rel_l2_pct` | 10.17 | 10.06 | 5.35 |
| `wall_shear_y_rel_l2_pct` | **13.73** | **13.53** | **3.65** ← 3.8× gap |
| `wall_shear_z_rel_l2_pct` | **14.73** | **13.98** | **3.63** ← 4.1× gap |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
