### PR TITLE
nezuko: left/right symmetry augmentation (tau_y gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -556,6 +556,8 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    symmetry_augmentation: bool = False
+    symmetry_aug_prob: float = 0.5
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1285,6 +1287,49 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def apply_symmetry_augmentation(
+    batch: SurfaceBatch, aug_prob: float
+) -> tuple[SurfaceBatch, float]:
+    """Reflect a fraction of batch elements about the xz-plane (y -> -y).
+
+    DrivAerML cars are bilaterally symmetric. Under y-reflection:
+      - surface positions: y (idx 1) negated
+      - surface normals (vectors): ny (idx 4) negated
+      - volume positions: y (idx 1) negated; sdf (idx 3) invariant (scalar distance)
+      - surface targets: tau_y (idx 2) negated (antisymmetric); cp, tau_x, tau_z invariant
+      - volume targets: volume_pressure (scalar) invariant
+    """
+    if aug_prob <= 0.0:
+        return batch, 0.0
+    B = batch.surface_x.shape[0]
+    n_aug = min(B, int(round(B * aug_prob)))
+    if n_aug <= 0:
+        return batch, 0.0
+
+    aug_idx = torch.randperm(B, device=batch.surface_x.device)[:n_aug]
+
+    surface_x = batch.surface_x.clone()
+    surface_y = batch.surface_y.clone()
+    volume_x = batch.volume_x.clone()
+
+    surface_x[aug_idx, :, 1] = -surface_x[aug_idx, :, 1]
+    surface_x[aug_idx, :, 4] = -surface_x[aug_idx, :, 4]
+    volume_x[aug_idx, :, 1] = -volume_x[aug_idx, :, 1]
+    surface_y[aug_idx, :, 2] = -surface_y[aug_idx, :, 2]
+
+    aug_batch = SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+    return aug_batch, float(n_aug) / float(B)
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1770,6 +1815,11 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            aug_frac = 0.0
+            if config.symmetry_augmentation:
+                batch, aug_frac = apply_symmetry_augmentation(
+                    batch, config.symmetry_aug_prob
+                )
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1838,6 +1888,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/aug_frac": aug_frac,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,


### PR DESCRIPTION
## Hypothesis

DrivAerML cars have **bilateral (left/right) symmetry** in geometry — yet the model is trained without exploiting this. Reflecting a car geometry about the xz-plane (y → -y) gives a physically valid new training example with analytically known label transformations:

- `p_surface` → unchanged (scalar, symmetric)
- `tau_x` → unchanged (streamwise, symmetric)
- `tau_y` → **negated** (span-wise, antisymmetric under y-flip)
- `tau_z` → unchanged (vertical, symmetric)
- `p_volume` → unchanged

This doubles the effective training set for **free** — no new data needed, no additional GPU cost beyond the computation of the mirrored batch.

**Why this specifically targets tau_y:** tau_y is currently 3.8× above AB-UPT (worst remaining gap). tau_y measures spanwise wall shear — a quantity that is statistically balanced around zero across the symmetric geometry. By training on both the original and mirror-flipped view in each batch, the model sees double the examples of spanwise shear at opposite signs, which forces it to learn the true antisymmetric structure of the tau_y field rather than relying on statistical biases in the training split.

**Prior attempt:** PR #16 (thorfinn) applied TTA bilateral symmetry at test-time on the epoch-1 model (baseline abupt ~35%) and found no improvement — the model was too poorly trained for TTA to help. Training-time augmentation is fundamentally different: it regularizes the learned representation directly, not just the prediction averaging.

## Instructions

Add a `--symmetry-augmentation` boolean flag (default `False`) and `--symmetry-aug-prob` float (default `0.5`) to `Config` and the argparser.

**Implementation — in the training loop, after loading each batch:**

```python
if config.symmetry_augmentation and torch.rand(1).item() < config.symmetry_aug_prob:
    # Mirror all points about the xz-plane: y → -y
    surf_pts_aug = surf_pts.clone()
    surf_pts_aug[..., 1] = -surf_pts_aug[..., 1]   # flip y coordinate
    
    vol_pts_aug = vol_pts.clone()
    vol_pts_aug[..., 1] = -vol_pts_aug[..., 1]
    
    # Surface targets: negate tau_y only
    surf_targets_aug = surf_targets.clone()
    # surf_targets layout: [p_s, tau_x, tau_y, tau_z]
    # Find the tau_y column index from config (check how train.py orders surface targets)
    surf_targets_aug[..., TAU_Y_IDX] = -surf_targets_aug[..., TAU_Y_IDX]
    
    # Volume targets: p_volume is scalar, unchanged
    vol_targets_aug = vol_targets.clone()
    
    # Concatenate original + augmented into a doubled batch
    surf_pts = torch.cat([surf_pts, surf_pts_aug], dim=0)
    surf_targets = torch.cat([surf_targets, surf_targets_aug], dim=0)
    vol_pts = torch.cat([vol_pts, vol_pts_aug], dim=0)
    vol_targets = torch.cat([vol_targets, vol_targets_aug], dim=0)
    # Note: if geom conditioning is present (FiLM), also cat geom features
```

Check `train.py` to confirm the column ordering of wall-shear targets (tau_x, tau_y, tau_z column indices). If the implementation doubles effective batch size on augmented steps, confirm VRAM is sufficient at bs=8 (standard 6L/256d uses ~75GB at bs=8; the doubled batch at aug_prob=0.5 will hit ~150GB which is over budget — instead, use **half batch size (bs=4) as the base** when augmentation is active so augmented steps stay within 96GB, OR apply augmentation to the *existing* batch only without doubling — by replacing half the batch with flipped copies).

**Recommended approach:** Replace `aug_prob` fraction of each batch with mirrored copies (no batch size increase, no VRAM concern):

```python
if config.symmetry_augmentation:
    B = surf_pts.shape[0]
    n_aug = int(B * config.symmetry_aug_prob)
    aug_idx = torch.randperm(B)[:n_aug]
    surf_pts[aug_idx, :, 1] = -surf_pts[aug_idx, :, 1]
    vol_pts[aug_idx, :, 1] = -vol_pts[aug_idx, :, 1]
    surf_targets[aug_idx, :, TAU_Y_IDX] = -surf_targets[aug_idx, :, TAU_Y_IDX]
    # vol_targets unchanged (p_volume is symmetric)
```

Log `train/aug_frac` each step so we can verify augmentation is active.

**2-arm sweep:**

| Arm | aug_prob | Run name |
|---|---|---|
| A | 0.5 (50% of each batch flipped) | `nezuko-symm-p50` |
| B | 1.0 (100% of each batch flipped — full symmetric training) | `nezuko-symm-p100` |

Both arms use full PR #99 base config at lr=5e-4 (symmetry augmentation does **not** change the gradient landscape — it is a data transform only, so the standard lr applies):

```bash
cd target/
python train.py \
  --symmetry-augmentation \
  --symmetry-aug-prob <0.5|1.0> \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group nezuko-symmetry-augmentation-r10 \
  --wandb-run-name <arm-name>
```

**Important:** During evaluation and test, do NOT apply augmentation — eval/test should use the original geometry only, with the standard validation code path unchanged.

## Baseline (PR #99, W&B run `3hljb0mg`)

| Metric | yi best (val) | yi best (test) | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** | **11.73** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 6.64 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 11.48 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 14.42 | 6.08 |
| `wall_shear_x_rel_l2_pct` | 10.17 | 10.06 | 5.35 |
| `wall_shear_y_rel_l2_pct` | **13.73** | **13.53** | **3.65** ← 3.8× gap — primary target |
| `wall_shear_z_rel_l2_pct` | **14.73** | **13.98** | **3.63** ← 4.1× gap |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
