### PR TITLE
alphonse: 8L/256d depth + 1cycle LR (time-limited recovery)

### DIFF
--- a/train.py
+++ b/train.py
@@ -590,6 +590,13 @@ class Config:
     clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
+    use_1cycle_lr: bool = False
+    onecycle_max_lr: float = 8e-4
+    onecycle_pct_start: float = 0.30
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
+    onecycle_warmup_steps: int = 500
+    onecycle_warmup_start_lr: float = 1e-5
 
 
 class TargetTransform:
@@ -1686,9 +1693,39 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    onecycle_start_lr: float = 0.0
+    if config.use_1cycle_lr:
+        onecycle_start_lr = config.onecycle_max_lr / config.onecycle_div_factor
+        onecycle_total_steps = max(1, total_estimated_steps - config.onecycle_warmup_steps)
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.onecycle_max_lr,
+            total_steps=onecycle_total_steps,
+            pct_start=config.onecycle_pct_start,
+            div_factor=config.onecycle_div_factor,
+            final_div_factor=config.onecycle_final_div_factor,
+            anneal_strategy="cos",
+        )
+        for pg in optimizer.param_groups:
+            pg["lr"] = config.onecycle_warmup_start_lr
+        peak_step_after_warmup = int(onecycle_total_steps * config.onecycle_pct_start)
+        print(
+            f"OneCycleLR: max_lr={config.onecycle_max_lr:.2e} "
+            f"pct_start={config.onecycle_pct_start} "
+            f"div_factor={config.onecycle_div_factor} "
+            f"final_div_factor={config.onecycle_final_div_factor:.0e} "
+            f"start_lr={onecycle_start_lr:.3e} "
+            f"total_steps={onecycle_total_steps} (estimated peak @ global_step "
+            f"{peak_step_after_warmup + config.onecycle_warmup_steps})"
+        )
+        print(
+            f"Linear warmup guard: lr {config.onecycle_warmup_start_lr:.0e} -> "
+            f"{onecycle_start_lr:.3e} over {config.onecycle_warmup_steps} steps"
+        )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1770,6 +1807,16 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if config.use_1cycle_lr:
+                if global_step < config.onecycle_warmup_steps:
+                    warmup_lr = config.onecycle_warmup_start_lr + (
+                        onecycle_start_lr - config.onecycle_warmup_start_lr
+                    ) * (global_step / float(max(1, config.onecycle_warmup_steps)))
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = warmup_lr
+                elif global_step == config.onecycle_warmup_steps:
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = onecycle_start_lr
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1830,6 +1877,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_loss_sum += float(loss.detach().cpu().item())
             n_batches += 1
             global_step += 1
+            if config.use_1cycle_lr and global_step > config.onecycle_warmup_steps:
+                try:
+                    scheduler.step()
+                except ValueError:
+                    pass
+            current_lr = float(optimizer.param_groups[0]["lr"])
             train_log: dict[str, object] = {
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
@@ -1838,6 +1891,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "lr": current_lr,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
@@ -1881,7 +1935,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not config.use_1cycle_lr:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0
@@ -1894,7 +1949,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         log_metrics = {
             "train/epoch_loss": epoch_train_loss,
-            "lr": scheduler.get_last_lr()[0],
+            "lr": float(optimizer.param_groups[0]["lr"]),
             "epoch_time_s": dt,
             "global_step": global_step,
         }


### PR DESCRIPTION
## Hypothesis

Your previous PR #117 (width-384d-sweep) found a critical signal: **8L/256d depth scale-up was time-limited, not architecture-limited**. The 8L/256d arm (W&B `xl92i3f5`, lr=3e-4) reached val abupt=11.33 at partial epoch 3, with slope -0.59 abupt-pct/1k steps. Extrapolated baseline crossing of 10.69 was at ~step 26,500, but the 270-min train_timeout fired at step ~25,400 — roughly 11 minutes short.

**Hypothesis:** Pair 8L/256d with 1cycle LR (super-convergence) to compress convergence into the available step budget. OneCycleLR with peak 8e-4 provides a warm, aggressive ramp that pushes the model faster early, then anneals smoothly — allowing baseline crossing well within the time window. 8L also had better volume_pressure (13.84 partial vs 14.42 baseline), suggesting the extra depth helps volumetric generalization.

Reference: [Smith & Touvron, 2019 super-convergence](https://arxiv.org/abs/1708.07120) — 1cycle LR achieves faster convergence than cosine annealing in the same epoch budget by using a higher peak LR with structured warm-up and cool-down.

## Instructions

Start from the PR #99 winning base config. Make **only** the following changes:

**1. Model depth:** Change `--model-layers 6` → `--model-layers 8` (keep 256d/4h/128 slices unchanged)

**2. 1cycle LR scheduler:** Replace the default constant LR with `torch.optim.lr_scheduler.OneCycleLR`:
```python
scheduler = OneCycleLR(
    optimizer,
    max_lr=8e-4,               # peak — higher than fern's 5e-4 to compensate more layers
    total_steps=total_train_steps,  # epochs * steps_per_epoch
    pct_start=0.30,            # 30% of steps on the warm-up ramp
    div_factor=25.0,           # start_lr = max_lr / 25 = 3.2e-5
    final_div_factor=1e4,      # end_lr = start_lr / 1e4 ≈ 3.2e-9
    anneal_strategy='cos',
)
```
Call `scheduler.step()` **every training step** (not every epoch). Add `--use-1cycle-lr` flag to enable this.

**3. Short linear warmup guard:** For the first 500 steps, linearly ramp lr from 1e-5 to the OneCycleLR start_lr before handing off to the scheduler. This absorbs any early gradient spike from the extra depth. Implement as: if `global_step < 500`: `lr = 1e-5 + (start_lr - 1e-5) * (global_step / 500)`, set on optimizer param groups directly. From step 500 onward, let OneCycleLR drive.

**4. Keep unchanged:**
- `--clip-grad-norm 1.0`
- `--batch-size 8`
- `--ema-decay 0.9995`
- `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`
- `--volume-loss-weight 2.0`
- All surface/volume point counts (65536 each)

**5. Single-arm only** — no sweep. Focus all 4 GPUs on this one config via DDP.

**6. W&B:** Use `--wandb_group alphonse-depth-8L-1cycle`

**Reproduce command:**
```bash
cd target/
python train.py \
  --model-layers 8 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --use-1cycle-lr \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group alphonse-depth-8L-1cycle
```

## Baseline

Current best: **PR #99 fern**, W&B run `3hljb0mg`

| Metric | Current Best |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 |
| `val_primary/wall_shear_x_rel_l2_pct` | 10.17 |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 |

**AB-UPT reference targets (lower = better):**

| Metric | AB-UPT |
|---|---:|
| wall_shear_y | 3.65 |
| wall_shear_z | 3.63 |
| volume_pressure | 6.08 |

## Expected outcome

- val abupt < 10.69 by epoch 3 (1cycle LR concentrates gains early)
- volume_pressure sub-metric improvement (depth helps volumetric generalization)
- Wall-shear training logs: watch pre_clip_norm in W&B — if it spikes above 5.0 in steps 0–500, the warmup guard is working; if it never exceeds 2.0, depth is stable and the 1cycle peak can be raised in a follow-up

## Report back

Please report:
1. All val_primary/* metrics at each completed epoch
2. Final test_primary/* metrics (evaluated from best val checkpoint)
3. W&B run ID
4. Whether the 500-step warmup guard was triggered (pre_clip_norm behaviour in steps 0–500)
