### PR TITLE
chihiro: mlp_ratio=8 hardened (3-seed, 1k warmup, lr=3e-4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import math
 import os
+import random
 import re
 import subprocess
 import time
@@ -24,6 +25,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -661,6 +663,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         value = getattr(defaults, field.name)
         arg_name = f"--{field.name.replace('_', '-')}"
         help_value = help_text.get(field.name)
+        if field.name == "model_mlp_ratio":
+            parser.add_argument(
+                arg_name,
+                "--mlp-ratio",
+                type=int,
+                default=value,
+                dest="model_mlp_ratio",
+                help=help_value,
+            )
+            continue
         if isinstance(value, bool):
             parser.add_argument(arg_name, action="store_true", default=value, help=help_value)
             parser.add_argument(f"--no-{field.name.replace('_', '-')}", action="store_false", dest=field.name)
@@ -668,6 +680,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def _warmup_lr(global_step: int, base_lr: float, warmup_steps: int, warmup_start_lr: float) -> float:
+    if warmup_steps <= 0 or global_step >= warmup_steps:
+        return base_lr
+    progress = global_step / float(warmup_steps)
+    return warmup_start_lr + progress * (base_lr - warmup_start_lr)
 
 
 def autocast_context(device: torch.device, amp_mode: str):
@@ -1672,14 +1698,7 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
     if config.seed >= 0:
-        import random
-
-        import numpy as np
-
-        random.seed(config.seed)
-        np.random.seed(config.seed)
-        torch.manual_seed(config.seed)
-        torch.cuda.manual_seed_all(config.seed)
+        _seed_everything(config.seed)
     kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
     max_epochs = min(config.epochs, 3) if config.debug else config.epochs
     timeout_minutes = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30"))
@@ -1754,8 +1773,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
-    wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
+    wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
@@ -1789,6 +1808,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if config.lr_warmup_steps > 0:
+                lr_now = _warmup_lr(
+                    global_step,
+                    config.lr,
+                    config.lr_warmup_steps,
+                    config.lr_warmup_start_lr,
+                )
+                for pg in optimizer.param_groups:
+                    pg["lr"] = lr_now
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1863,16 +1891,6 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 global_step += 1
                 continue
-            if config.lr_warmup_steps > 0:
-                if global_step < config.lr_warmup_steps:
-                    warmup_lr = config.lr_warmup_start_lr + (
-                        config.lr - config.lr_warmup_start_lr
-                    ) * (global_step / config.lr_warmup_steps)
-                    for pg in optimizer.param_groups:
-                        pg["lr"] = warmup_lr
-                elif global_step == config.lr_warmup_steps:
-                    for pg in optimizer.param_groups:
-                        pg["lr"] = config.lr
             optimizer.step()
             ema_decay_now: float | None = None
             if ema is not None:
@@ -1948,7 +1966,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if config.lr_warmup_steps == 0:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0
@@ -1961,7 +1980,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         log_metrics = {
             "train/epoch_loss": epoch_train_loss,
-            "lr": scheduler.get_last_lr()[0],
+            "lr": float(optimizer.param_groups[0]["lr"]),
             "epoch_time_s": dt,
             "global_step": global_step,
         }


### PR DESCRIPTION
## Hypothesis

Your previous PR #118 (mlp-ratio-sweep-r4) was closed AMBIGUOUS: 12/16 runs diverged due to seed-dependent gradient instability, but the 4 valid epoch-1 values trended better for mlp_ratio=8 than the default mlp_ratio=4. The instability pattern is the same as alphonse's 384d width experiment — wider FFN layers have higher early-step gradient variance from the larger out-projection matrix.

**Hypothesis:** `mlp_ratio=8` (FFN intermediate: 256→2048 instead of 256→1024) gives +3M effective parameters with no depth or attention overhead. Under a stability-hardened recipe (lower peak LR + 1k-step warmup + fixed seed for reproducibility), it should converge cleanly and beat baseline 10.69.

The wider FFN captures more high-frequency spatial variation per attention step, which is the bottleneck for wall-shear prediction on complex car body geometry.

## Instructions

Start from the PR #99 winning base config. Make the following changes:

**1. mlp_ratio flag:** Add a `--mlp-ratio` CLI argument that scales the FFN intermediate dimension as `mlp_ratio * model_hidden_dim`. Default remains 4. Set to `--mlp-ratio 8` for this experiment (256 × 8 = 2048 intermediate dim per layer).

**2. Lower peak LR:** Use `--lr 3e-4` (down from fern's 5e-4). Wider FFN has more parameter mass — it needs a slower warm-in to avoid early instability. This is the primary stability fix.

**3. Linear LR warmup:** Add `--lr-warmup-steps 1000` and `--lr-warmup-start-lr 1e-5`. Implement as: for the first 1000 training steps, linearly interpolate lr from `1e-5` to `3e-4`. After step 1000, keep lr constant at `3e-4` (no decay in this experiment). Log current lr to W&B as `train/lr` every step.

**4. Seed reproducibility:** Add a `--seed` CLI flag. In the training script, call:
```python
import random, numpy as np, torch
random.seed(args.seed)
np.random.seed(args.seed)
torch.manual_seed(args.seed)
torch.cuda.manual_seed_all(args.seed)
```
immediately after argument parsing.

**5. 3-arm seed sweep:** Run arms with seeds 42, 1337, and 7 — all identical except the seed. Use `--wandb_group chihiro-mlpratio8-seeds`. Report all 3 results; take best of 3 as the final result.

**6. Keep unchanged:** `--clip-grad-norm 1.0`, `--batch-size 8`, `--model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128`, `--ema-decay 0.9995`, `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`, `--volume-loss-weight 2.0`, all point counts (65536).

**Reproduce command (arm seed=42):**
```bash
cd target/
python train.py \
  --mlp-ratio 8 \
  --lr 3e-4 --weight-decay 5e-4 \
  --lr-warmup-steps 1000 --lr-warmup-start-lr 1e-5 \
  --seed 42 \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group chihiro-mlpratio8-seeds
```

## Baseline

Current best: **PR #99 fern**, W&B run `3hljb0mg`

| Metric | Current Best |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 |
| `val_primary/wall_shear_x_rel_l2_pct` | 10.17 |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 |

## Report back

Please report:
1. All 3 seeds: val_primary/* at each completed epoch, noting which seed produced best results
2. Whether any arm diverged (pre_clip_norm spike > 5.0 after warmup phase)
3. Final test_primary/* metrics from best-val checkpoint of best seed
4. W&B run IDs for all 3 arms
