### PR TITLE
tanjiro: static W_y=W_z=3.5 + 1k LR warmup (per-component y/z boost)

### DIFF
--- a/train.py
+++ b/train.py
@@ -542,6 +542,8 @@ class EMA:
 @dataclass
 class Config:
     lr: float = 3e-4
+    lr_warmup_steps: int = 0
+    lr_warmup_start_lr: float = 0.0
     weight_decay: float = 1e-4
     batch_size: int = 2
     epochs: int = 50
@@ -671,6 +673,15 @@ def autocast_context(device: torch.device, amp_mode: str):
     if not supports_bf16():
         return nullcontext()
     return torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+
+
+def compute_warmup_lr(
+    step: int, base_lr: float, warmup_steps: int, warmup_start_lr: float
+) -> float:
+    if warmup_steps <= 0 or step >= warmup_steps:
+        return base_lr
+    progress = step / max(warmup_steps, 1)
+    return warmup_start_lr + progress * (base_lr - warmup_start_lr)
 
 
 def resolve_num_workers(config: Config) -> int:
@@ -1770,6 +1781,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if config.lr_warmup_steps > 0:
+                current_lr = compute_warmup_lr(
+                    global_step,
+                    config.lr,
+                    config.lr_warmup_steps,
+                    config.lr_warmup_start_lr,
+                )
+                for pg in optimizer.param_groups:
+                    pg["lr"] = current_lr
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1838,6 +1858,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/lr": float(optimizer.param_groups[0]["lr"]),
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
@@ -1881,7 +1902,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if config.lr_warmup_steps == 0:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0
@@ -1894,7 +1916,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         log_metrics = {
             "train/epoch_loss": epoch_train_loss,
-            "lr": scheduler.get_last_lr()[0],
+            "lr": float(optimizer.param_groups[0]["lr"]),
             "epoch_time_s": dt,
             "global_step": global_step,
         }


### PR DESCRIPTION
## Hypothesis

Your previous PR #130 (curriculum tau_y/z weighting) was closed NEGATIVE — all 6 arms diverged. The curriculum schedule caused Adam second-moment desynchronization around W_y≈2.7, because the ramping weight changed the loss gradient magnitudes mid-training, after Adam's m/v statistics had already calibrated to lower W_y values.

**Key lesson:** The direction is right (wall_shear_y=13.73 and wall_shear_z=14.73 are 3.8-4.1× above AB-UPT targets of 3.65/3.63), but the mechanism was wrong. Static per-component weights at training start ensure Adam's m/v initialize correctly for each channel from step 0 — no mid-run desync possible.

**Hypothesis:** Setting `--wallshear-y-weight 3.5 --wallshear-z-weight 3.5` (75% boost from current 2.0, vs your prior 3.0 in senku's PR) with a 1000-step LR warmup gives Adam's second moments time to calibrate before full-lr updates hit the higher-weighted channels. This is the same direction as senku's Round-6 experiment (#166, W_y=W_z=3.0) but slightly more aggressive — we need two data points to find the per-component stability ceiling.

## Instructions

Start from the PR #99 winning base config. Make **only** the following changes:

**1. Static per-component weights:**
Change `--wallshear-y-weight 2.0` → `--wallshear-y-weight 3.5`
Change `--wallshear-z-weight 2.0` → `--wallshear-z-weight 3.5`

Do **NOT** change `--surface-loss-weight` — leave it at default (1.0). Do NOT implement any schedule — these are static from step 0.

**2. 1000-step linear LR warmup:**
Add `--lr-warmup-steps 1000` and `--lr-warmup-start-lr 1e-5` flags. For the first 1000 training steps, linearly interpolate lr from 1e-5 to 5e-4. After step 1000, hold at 5e-4 (no decay). Log `train/lr` to W&B each step.

**3. Keep unchanged:**
- `--lr 5e-4`, `--weight-decay 5e-4`, `--clip-grad-norm 1.0`
- `--batch-size 8`, `--validation-every 1`
- `--model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128`
- `--ema-decay 0.9995`, `--volume-loss-weight 2.0`
- All point counts (65536 surface and volume)

**4. Single-arm experiment.** Use `--wandb_group tanjiro-static-wyz35`.

**Reproduce command:**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --lr-warmup-steps 1000 --lr-warmup-start-lr 1e-5 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 3.5 \
  --wallshear-z-weight 3.5 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group tanjiro-static-wyz35
```

## Baseline

Current best: **PR #99 fern**, W&B run `3hljb0mg`

| Metric | Current Best | AB-UPT Target | Gap |
|---|---:|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 | 3.65 | **3.8×** |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 | 3.63 | **4.1×** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 | 3.82 | 1.8× |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 | 7.29 | 1.6× |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 | 6.08 | 1.3× |

## Stability checkpoint

In W&B, monitor `train/pre_clip_norm` during the first 1000 steps. If it stays below 5.0 during warmup and loss trends normally, the config is stable. If pre_clip_norm spikes above 10.0, increase warmup to 2000 steps.

Note: senku is running the same hypothesis with W_y=W_z=3.0 (#166). Your result at 3.5 combined with his result at 3.0 will map the per-component stability ceiling.

## Report back

1. All val_primary/* at each completed epoch (especially wall_shear_y/z vs 13.73/14.73)
2. Stability: pre_clip_norm behaviour during warmup steps 0-1000
3. Final test_primary/* from best-val checkpoint
4. W&B run ID
