### PR TITLE
askeladd: normal-consistency penalty (soft tangential constraint)

### DIFF
--- a/train.py
+++ b/train.py
@@ -556,6 +556,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    normal_penalty_weight: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1298,6 +1299,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    normal_penalty_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1345,6 +1347,32 @@ def train_loss(
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        normal_penalty_value: float | None = None
+        normal_penalty_raw_value: float | None = None
+        normal_penalty_phys_value: float | None = None
+        if normal_penalty_weight > 0.0:
+            # Normalized-space tangentiality penalty per advisor spec: dot the
+            # raw model prediction with the unit surface normal. This treats
+            # the three wall-shear axes uniformly, matching the surface_loss
+            # space and keeping the calibrated lambda meaningful.
+            normals_pen = batch.surface_x[..., 3:6]
+            n_hat_pen = F.normalize(normals_pen.float(), dim=-1, eps=1e-8)
+            tau_pred_norm = surface_pred_norm[..., 1:4].float()
+            mask_pen = batch.surface_mask
+            if bool(mask_pen.any()):
+                dot_norm = (tau_pred_norm * n_hat_pen).sum(dim=-1)
+                nc_loss = dot_norm[mask_pen].square().mean()
+                with torch.no_grad():
+                    ws_std_pen = transform.surface_y_std[1:4].to(surface_pred_norm.device)
+                    ws_mean_pen = transform.surface_y_mean[1:4].to(surface_pred_norm.device)
+                    tau_pred_phys = tau_pred_norm * ws_std_pen + ws_mean_pen
+                    dot_phys = (tau_pred_phys * n_hat_pen).sum(dim=-1)
+                    normal_penalty_phys_value = float(dot_phys[mask_pen].square().mean().item())
+            else:
+                nc_loss = torch.zeros((), device=surface_pred_norm.device, dtype=torch.float32)
+            loss = loss + normal_penalty_weight * nc_loss
+            normal_penalty_raw_value = float(nc_loss.detach().cpu().item())
+            normal_penalty_value = normal_penalty_weight * normal_penalty_raw_value
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
             surf_pred_f = surface_pred_norm.float()
@@ -1365,6 +1393,12 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if normal_penalty_value is not None:
+        metrics["normal_penalty_loss"] = normal_penalty_value
+    if normal_penalty_raw_value is not None:
+        metrics["normal_penalty_raw"] = normal_penalty_raw_value
+    if normal_penalty_phys_value is not None:
+        metrics["normal_penalty_phys"] = normal_penalty_phys_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1782,6 +1816,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                normal_penalty_weight=config.normal_penalty_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1849,6 +1884,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
+                ]
+            if "normal_penalty_loss" in batch_loss_metrics:
+                train_log["train/normal_penalty_loss"] = batch_loss_metrics[
+                    "normal_penalty_loss"
+                ]
+            if "normal_penalty_raw" in batch_loss_metrics:
+                train_log["train/normal_penalty_raw"] = batch_loss_metrics[
+                    "normal_penalty_raw"
+                ]
+            if "normal_penalty_phys" in batch_loss_metrics:
+                train_log["train/normal_penalty_phys"] = batch_loss_metrics[
+                    "normal_penalty_phys"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

Your previous PR #121 (surface-tangent-frame-wallshear) was closed NEGATIVE due to two structural problems with the Duff branchless ONB approach:
1. **Frame discontinuity:** Duff's t1 flips sign on adjacent patches with similar normals — non-gauge-equivariant Transolver can't learn discontinuous frame mappings from data
2. **Adam channel coupling:** τ_y/τ_z shared (a,b) coordinates caused correlated gradient spikes that Adam's per-parameter second moment couldn't smooth

**The underlying physics is still correct:** wall-shear vectors must be tangential to the surface — their dot product with the surface normal should be zero. The problem was reparametrizing the prediction space. A softer approach achieves the same goal: add a penalty on the normal component of the predicted shear vector, regularizing against out-of-plane drift without any frame change.

**Hypothesis:** Add `L_nc = λ * mean(|dot(τ_pred, n̂)|²)` over surface points as an auxiliary loss. This encourages predicted shear to lie in the tangential plane without requiring frame discontinuities, channel coupling, or new output dimensions. With λ small (0.01–0.10), it acts as a soft regularizer that doesn't destabilize Adam.

## Instructions

Start from the PR #99 winning base config. Make **only** the following addition:

**1. Normal-consistency penalty loss:**
Add a `--normal-penalty-weight` flag (default 0.0, float). When > 0:
```python
# surface_pred: (N, 4) — channels [0]=p_s, [1]=tau_x, [2]=tau_y, [3]=tau_z
# surface_normals: (N, 3) — unit normals from data loader (check what field name is used)
tau_pred = surface_pred[:, 1:4]  # (N, 3) predicted wall shear vector
dot_with_normal = (tau_pred * surface_normals).sum(dim=-1)  # (N,)
nc_loss = (dot_with_normal ** 2).mean()
total_loss = total_loss + args.normal_penalty_weight * nc_loss
```
Log `nc_loss * args.normal_penalty_weight` to W&B as `train/normal_penalty_loss`.

**Check data loader first:** Confirm surface normals are exposed. Look in `train.py` for how surface point features are loaded — the normal vector field may be named `normals`, `surface_normals`, or similar. If not exposed, add it (it should be a 3-vector per surface point, pre-normalized).

**2. Three-arm sweep** over lambda values: `--normal-penalty-weight 0.01`, `0.05`, `0.10`.
Use `--wandb_group askeladd-normal-penalty`. All other flags: PR #99 base config unchanged.

**3. Keep unchanged:** `--lr 5e-4`, `--clip-grad-norm 1.0`, `--batch-size 8`, `--model-layers 6 --model-hidden-dim 256 --model-heads 4`, `--ema-decay 0.9995`, `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`, `--volume-loss-weight 2.0`.

**Reproduce command (lambda=0.01 arm):**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --normal-penalty-weight 0.01 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group askeladd-normal-penalty
```

## Baseline

Current best: **PR #99 fern**, W&B run `3hljb0mg`

| Metric | Current Best | AB-UPT Target | Gap |
|---|---:|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 | 3.65 | **3.8×** |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 | 3.63 | **4.1×** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 | 3.82 | — |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 | 7.29 | — |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 | 6.08 | — |

## Success criteria

- val_primary/abupt_axis_mean_rel_l2_pct < 10.69 (beat baseline)
- OR: wall_shear_y and wall_shear_z both improve meaningfully (>5% reduction) without regressing abupt

## Report back

1. All 3 lambda arms: val_primary/* at epoch 1 and 2
2. Which lambda produced best results?
3. Final test_primary/* from best-val checkpoint of best lambda
4. W&B run IDs for all 3 arms
5. What field name were surface normals exposed under in the data loader?
