### PR TITLE
thorfinn: NaN-skip + seed + LR warmup utility flags (stability infra)

### DIFF
--- a/train.py
+++ b/train.py
@@ -590,6 +590,12 @@ class Config:
     clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
+    seed: int = -1
+    lr_warmup_steps: int = 0
+    lr_warmup_start_lr: float = 1e-5
+
+
+NONFINITE_SKIP_ABORT = 200
 
 
 class TargetTransform:
@@ -1665,6 +1671,15 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    if config.seed >= 0:
+        import random
+
+        import numpy as np
+
+        random.seed(config.seed)
+        np.random.seed(config.seed)
+        torch.manual_seed(config.seed)
+        torch.cuda.manual_seed_all(config.seed)
     kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
     max_epochs = min(config.epochs, 3) if config.debug else config.epochs
     timeout_minutes = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30"))
@@ -1740,6 +1755,9 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
+    wandb.define_metric("train/lr", step_metric="global_step")
+    wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
+    wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1751,6 +1769,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
     global_step = 0
+    nonfinite_skip_count = 0
     early_stop_reason: str | None = None
     timeout_hit = False
     train_start = time.time()
@@ -1784,6 +1803,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
             )
             optimizer.zero_grad(set_to_none=True)
+            loss_is_finite = bool(torch.isfinite(loss).item())
+            if not loss_is_finite:
+                nonfinite_skip_count += 1
+                wandb.log(
+                    {
+                        "train/nonfinite_skip_count": nonfinite_skip_count,
+                        "train/nonfinite_skip_kind": 1,
+                        "global_step": global_step,
+                    }
+                )
+                if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                    raise RuntimeError(
+                        f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                        f"loss/grad steps; training is structurally broken."
+                    )
+                global_step += 1
+                continue
             loss.backward()
             should_log_gradients = (
                 config.gradient_log_every > 0
@@ -1801,13 +1837,42 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            grad_is_finite = True
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), max_norm=config.clip_grad_norm
                 )
+                grad_is_finite = bool(torch.isfinite(pre_clip_norm).item())
                 if should_log_gradients:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
+            if not grad_is_finite:
+                optimizer.zero_grad(set_to_none=True)
+                nonfinite_skip_count += 1
+                wandb.log(
+                    {
+                        "train/nonfinite_skip_count": nonfinite_skip_count,
+                        "train/nonfinite_skip_kind": 2,
+                        "global_step": global_step,
+                    }
+                )
+                if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                    raise RuntimeError(
+                        f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                        f"loss/grad steps; training is structurally broken."
+                    )
+                global_step += 1
+                continue
+            if config.lr_warmup_steps > 0:
+                if global_step < config.lr_warmup_steps:
+                    warmup_lr = config.lr_warmup_start_lr + (
+                        config.lr - config.lr_warmup_start_lr
+                    ) * (global_step / config.lr_warmup_steps)
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = warmup_lr
+                elif global_step == config.lr_warmup_steps:
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = config.lr
             optimizer.step()
             ema_decay_now: float | None = None
             if ema is not None:
@@ -1838,6 +1903,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/lr": float(optimizer.param_groups[0]["lr"]),
+                "train/nonfinite_skip_count": nonfinite_skip_count,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,


### PR DESCRIPTION
## Hypothesis

Your PR #131 (log-magnitude wall-shear targets) was closed NEGATIVE on the transform itself, but contained a structurally valuable code contribution: the **NaN/Inf-skip safeguard** (commit `2a8f7e4`). Round-5 saw at least 5 experiments crash due to gradient explosions (alphonse 384d arms, tanjiro curriculum, senku surface weight sweep). Many of these divergences might have been recoverable with this safeguard.

This is a code infrastructure PR. The goal is to cherry-pick three stability utilities into `yi`'s `train.py` as standalone features that all future experiments can use:

1. **NaN/Inf-skip safeguard** — prevents irreversible weight corruption from gradient explosions
2. **`--seed` flag** — enables reproducible experiments across students
3. **`--lr-warmup-steps` flag** — enables soft LR warm-in for experiments with high initial gradient variance

**Hypothesis:** With these three utilities in the base config, future experiments will have significantly lower divergence rates. The validation run (2 epochs at PR #99 config + seed=42 + no warmup) confirms zero regression from the additions.

## Instructions

**1. Cherry-pick NaN/Inf-skip safeguard from commit `2a8f7e4`:**

In the training step, after computing loss:
```python
if not torch.isfinite(loss):
    nonfinite_skip_count += 1
    wandb.log({"train/nonfinite_skip_count": nonfinite_skip_count, 
               "train/nonfinite_skip_kind": "loss"}, step=global_step)
    optimizer.zero_grad()
    if nonfinite_skip_count > 200:
        raise RuntimeError(f"Aborted: {nonfinite_skip_count} non-finite skips")
    continue  # skip backward, step, ema.update
loss.backward()
```

After `torch.nn.utils.clip_grad_norm_()`:
```python
pre_clip_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
if not torch.isfinite(pre_clip_norm):
    nonfinite_skip_count += 1
    wandb.log({"train/nonfinite_skip_count": nonfinite_skip_count,
               "train/nonfinite_skip_kind": "grad"}, step=global_step)
    optimizer.zero_grad()
    if nonfinite_skip_count > 200:
        raise RuntimeError(f"Aborted: {nonfinite_skip_count} non-finite skips")
    continue  # skip step, ema.update
optimizer.step()
ema.update()
```

**2. Add `--seed` flag (int, default -1):**
```python
if args.seed >= 0:
    import random, numpy as np
    random.seed(args.seed)
    np.random.seed(args.seed)
    torch.manual_seed(args.seed)
    torch.cuda.manual_seed_all(args.seed)
```
Call immediately after argument parsing.

**3. Add `--lr-warmup-steps` (int, default 0) and `--lr-warmup-start-lr` (float, default 1e-5):**
In the training loop, before each optimizer step:
```python
if global_step < args.lr_warmup_steps:
    warmup_lr = args.lr_warmup_start_lr + (args.lr - args.lr_warmup_start_lr) * (global_step / args.lr_warmup_steps)
    for pg in optimizer.param_groups:
        pg['lr'] = warmup_lr
elif global_step == args.lr_warmup_steps:
    for pg in optimizer.param_groups:
        pg['lr'] = args.lr  # snap to main lr
```
Log `train/lr` to W&B each step.

**4. Validation run (required):**
Run 2 epochs with **exactly PR #99 base config** + `--seed 42` (no warmup, `--lr-warmup-steps 0`). Val abupt should track within ~5% of the PR #99 epoch-1/epoch-2 trajectory (expected ~12.0-13.0 at epoch 1, ~11.0-11.5 at epoch 2). This confirms no regression from the additions.

Use `--wandb_group thorfinn-nanskim-seed-warmup`.

**Reproduce command:**
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --seed 42 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb_group thorfinn-nanskim-seed-warmup
```

## Baseline

Current best: **PR #99 fern**, W&B run `3hljb0mg`

| Metric | Current Best |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 |

## Merge criteria

This PR will be merged if:
- The three features are correctly implemented
- Validation run shows no regression vs PR #99 trajectory (epoch 1 and 2 val abupt within 5% of expected ~12.0-13.0 and ~11.0-11.5 respectively)

This is a **code contribution PR** — it will be merged to `yi` regardless of metric improvement so that all subsequent experiments benefit from the utilities.

## Report back

1. Val_primary/* at epochs 1 and 2 from the validation run (seed=42, no warmup)
2. W&B run ID
3. Confirm: does `train/nonfinite_skip_count` appear in W&B even if it stays at 0?
4. Confirm: does `train/lr` log correctly (should be constant at 5e-4 since warmup-steps=0)?
