### PR TITLE
tanjiro: cosine T_max=50 on PR#115 SOTA stack (single delta)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-01 09:30 UTC
+- **Date:** 2026-05-01 10:15 UTC
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -37,6 +37,7 @@ W&B run `d03oghpp` — best val 9.484 (ep8). val→test ratio 1.115.
 | **#161** | askeladd | lion_beta2=0.999 (single delta) | tfumujfi | 31.772 (ep1, 87min) | running — too early to judge |
 | **#162** | edward | model_dropout=0.05 (single delta) | e5l1r38b | 25.505 (ep1, 87min) | running — too early |
 | **#163** | thorfinn | weight_decay=1e-3 (single delta) | 7rp28zrm | 26.420 (ep1, 77min) | running — too early |
+| **#173** | tanjiro | cosine T_max=50 on SOTA stack (single delta) | TBD | — | **JUST ASSIGNED** — single delta from PR #115: add --lr-cosine-t-max 50 |
 | **#147** | frieren | compound + wd=2e-3 | NONE | — | **POD STUCK** — no W&B run ever started; restart requested on issue #48 |
 
 SOTA val trajectory reference: ep0=53.75 / ep1=24.15 / ep2=16.51 / ep3=13.47 / ep4=11.83 / ep5=10.88 / ep6=10.16 / ep7=9.73 / ep8=9.484
@@ -86,8 +87,9 @@ SOTA val trajectory reference: ep0=53.75 / ep1=24.15 / ep2=16.51 / ep3=13.47 / e
 
 1. **Wait for fern #159 and nezuko #157** — both in ep5-6 range showing 12.3-12.6 val. Need ep8-9 to compare with SOTA val=9.484. These are the most advanced round 11 experiments.
 2. **Alphonse #158 vol_pts=96k** — dominant vol_p binding gap attack (×2.1 vs AB-UPT). At ep4=15.84. Need ep8-9 final.
-3. **Frieren pod restart needed** — pod stuck at init since 23:14 UTC Apr 30. PR #147 (wd=2e-3) has NEVER started. Requires human `kubectl rollout restart`. Escalated on issue #48.
-4. **Yi Wave 1 architecture port** — Fourier PE + asinh transform + SDF features. Biggest untested architectural lever. Not yet assigned to any running pod.
-5. **Volume loss weight isolation** — clean `--volume-loss-weight 1.5-2.0` experiment WITHOUT tau coupling side effects. Previous vol_w=2.0 hurt surface; hypothesis: lighter volume weight (1.5) with isolated testing might find a sweet spot.
-6. **Tau_yz binding gap (code-change approach)** — must bypass Lion neutralization. Options: (a) asinh output normalization for tau_y/tau_z (normalizes small-magnitude components), (b) surface-tangent-frame prediction head (predicts in a frame where components are better conditioned), (c) decoupled magnitude+direction head. All require train.py modifications by a student.
-7. **Observe round 11 askeladd/edward/thorfinn ep3+ signals** — lion_beta2, dropout, wd all at ep1 only. Need 2-3 more epochs to evaluate trajectories vs SOTA reference.
+3. **Tanjiro #173 cosine T_max=50** — clean single-delta from PR #115 SOTA. Cosine was a winner on older stack (PR #110) but never tested on lr=1e-4+EMA=0.999. Good chance to stack another improvement.
+4. **Frieren pod restart needed** — pod stuck at init since 23:14 UTC Apr 30. PR #147 (wd=2e-3) has NEVER started. Requires human `kubectl rollout restart`. Escalated on issue #48.
+5. **Yi Wave 1 architecture port** — Fourier PE + asinh transform + SDF features. Biggest untested architectural lever. Not yet assigned to any running pod.
+6. **Volume loss weight isolation** — clean `--volume-loss-weight 1.5-2.0` experiment WITHOUT tau coupling side effects. Previous vol_w=2.0 hurt surface; hypothesis: lighter volume weight (1.5) with isolated testing might find a sweet spot.
+7. **Tau_yz binding gap (code-change approach)** — must bypass Lion neutralization. Options: (a) asinh output normalization for tau_y/tau_z (normalizes small-magnitude components), (b) surface-tangent-frame prediction head (predicts in a frame where components are better conditioned), (c) decoupled magnitude+direction head. All require train.py modifications by a student.
+8. **Observe round 11 askeladd/edward/thorfinn ep3+ signals** — lion_beta2, dropout, wd all at ep1 only. Need 2-3 more epochs to evaluate trajectories vs SOTA reference.


### PR DESCRIPTION
## Hypothesis

**Cosine LR schedule (T_max=50) on the current SOTA stack has never been tested.**

The PR #115 SOTA uses `--lr-cosine-t-max 0` (no cosine, flat lr=1e-4 throughout). But PR #110 (edward) confirmed that cosine annealing with T_max=50 was a decisive winner on the older stack — it contributed a −0.34% improvement that then compounded into the final SOTA. That T_max=50 cosine lever has **not** been re-tested on the compound lr=1e-4 + EMA=0.999 stack.

With the higher base lr=1e-4, cosine annealing becomes MORE valuable, not less: the model sees sharper gradient updates in early epochs (when lr is near peak) and then benefits from fine-grained convergence in the final 2-3 epochs as lr decays. T_max=50 keeps the lr above 70% of peak for the entire 9-epoch budget, giving a gentle but meaningful late-epoch warmdown.

**Single delta from PR #115 SOTA:** add `--lr-cosine-t-max 50` only. Everything else is identical to the SOTA reproduce command.

## Instructions

Run the following command (single delta from PR #115: add `--lr-cosine-t-max 50`):

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --lion-beta1 0.9 --lion-beta2 0.99 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 \
  --lr-cosine-t-max 50 \
  --wandb_group tay-round11-cosine-tmax50-sota
```

**Key change:** `--lr-cosine-t-max 50` (SOTA uses 0 = no cosine). All other flags identical to PR #115 SOTA reproduce command.

**Do NOT change** any other hyperparameters. This is a clean single-delta test.

Report:
1. W&B run ID for rank 0
2. Val trajectory per epoch (all epochs, not just final)
3. Best val epoch number and metric value
4. Final per-axis test metrics once training completes (test_primary/*)

## Baseline — PR #115 thorfinn (current SOTA)

W&B run: `d03oghpp` · Group: `tay-round9-compound-lr1e4-ema999`
Best val: 9.484 (ep8/ep9) — val trajectory: 53.75 / 24.15 / 16.51 / 13.47 / 11.83 / 10.88 / 10.16 / 9.73 / 9.48

| Metric | PR #115 SOTA | AB-UPT |
|---|---:|---:|
| `abupt` | **10.580** | — |
| `surface_pressure` | **5.690** | 3.82 |
| `wall_shear` | **10.419** | 7.29 |
| `volume_pressure` | 12.740 | 6.08 |
| `tau_x` | **8.908** | 5.35 |
| `tau_y` | **12.491** | 3.65 |
| `tau_z` | **13.071** | 3.63 |

Beat target: `test_primary/abupt_axis_mean_rel_l2_pct < 10.580`
