### PR TITLE
[askeladd] 4L/384d + Fourier PE + T_max=50 width scaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,6 +72,35 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression.
+
+    Multi-scale sinusoidal encoding for 3D coordinates: produces
+    [sin(2^k * pi * x), cos(2^k * pi * x)] for k in 0..num_freqs-1, then
+    projects to hidden_dim. Used as the Wave 1 winning replacement for
+    ContinuousSincosEmbed (PR #74).
+    """
+
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_freqs = num_freqs
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+        if isinstance(self.proj, nn.Linear):
+            _init_linear(self.proj)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -226,6 +255,8 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        use_fourier_pe: bool = False,
+        fourier_num_freqs: int = 8,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,10 +264,16 @@ class SurfaceTransolver(nn.Module):
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
+        self.use_fourier_pe = use_fourier_pe
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if use_fourier_pe:
+            self.pos_embed = FourierEmbed(
+                hidden_dim=n_hidden, input_dim=space_dim, num_freqs=fourier_num_freqs
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (

--- a/train.py
+++ b/train.py
@@ -115,6 +115,8 @@ class Config:
     compile_model: bool = True
     debug: bool = False
     raw_rel_l2_weight: float = 0.0
+    fourier_pe: bool = False
+    fourier_num_freqs: int = 8
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -150,6 +152,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        use_fourier_pe=config.fourier_pe,
+        fourier_num_freqs=config.fourier_num_freqs,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Wave 1 best (PR #74): 4L/256d + Fourier PE → val_abupt=7.2091%. Wave 1 haku (#77) tested 4L/384d WITHOUT Fourier PE and plateaued around 8.5% at ep11. Since Fourier PE was the dominant Wave 1 perf driver, the question is: does 384d hidden dim provide additional capacity over 256d when PE is present? The extra 128 channels may better represent the spatial frequency content from the Fourier encoding.

**Target gap:** val_abupt from 7.21% → below 6.8% (stretch: below 6.5%).

## Instructions

Run exactly one training job with the following config:

```bash
cd target/ && python train.py \
  --model-num-layers 4 \
  --model-hidden-dim 384 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 50 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 5 \
  --fourier-pe \
  --no-compile-model \
  --nproc_per_node 4 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb_group bengio-wave2
```

Key changes vs Wave 1 baseline:
- `--model-hidden-dim 384` (was 256) — 50% more hidden channels
- `--lr-cosine-t-max 50` (was 30) — longer schedule to exploit wider model
- `--lr-warmup-epochs 5` — gentle warmup for wider model
- `--fourier-pe` — mandatory (Wave 1 lesson)
- `--no-use-ema` — same as baseline winner

Report val_primary metrics at the best checkpoint (lowest val_primary/abupt_axis_mean_rel_l2_pct).

## Baseline

Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`):

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
