### PR TITLE
[chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,6 +72,29 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression."""
+
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_freqs = num_freqs
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+        if isinstance(self.proj, nn.Linear):
+            _init_linear(self.proj)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -226,6 +249,8 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        fourier_pe: bool = False,
+        fourier_pe_num_freqs: int = 8,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -236,7 +261,12 @@ class SurfaceTransolver(nn.Module):
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if fourier_pe:
+            self.pos_embed = FourierEmbed(
+                hidden_dim=n_hidden, input_dim=space_dim, num_freqs=fourier_pe_num_freqs
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (

--- a/train.py
+++ b/train.py
@@ -115,6 +115,8 @@ class Config:
     compile_model: bool = True
     debug: bool = False
     raw_rel_l2_weight: float = 0.0
+    fourier_pe: bool = False
+    fourier_pe_num_freqs: int = 8
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -150,6 +152,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        fourier_pe=config.fourier_pe,
+        fourier_pe_num_freqs=config.fourier_pe_num_freqs,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Wave 1 winner used lr=3e-4 (default). However, 3e-4 may be suboptimal for the Fourier PE baseline — the Fourier features expand the input space significantly and a slightly higher or lower lr may train more efficiently. This experiment sweeps two lr values (1e-4 and 5e-4) on the exact Wave 1 winner config to find the optimal lr for the Fourier PE regime. Run both as sequential trials.

**Target gap:** val_abupt from 7.21% → below 6.8%.

## Instructions

Run two sequential trials (Trial A then Trial B), same config except lr:

**Trial A (lr=1e-4):**
```bash
cd target/ && python train.py \
  --model-num-layers 4 \
  --model-hidden-dim 256 \
  --no-use-ema \
  --lr 1e-4 \
  --lr-cosine-t-max 50 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 3 \
  --fourier-pe \
  --no-compile-model \
  --nproc_per_node 4 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb_group bengio-wave2-lr-sweep
```

**Trial B (lr=5e-4):**
```bash
cd target/ && python train.py \
  --model-num-layers 4 \
  --model-hidden-dim 256 \
  --no-use-ema \
  --lr 5e-4 \
  --lr-cosine-t-max 50 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 3 \
  --fourier-pe \
  --no-compile-model \
  --nproc_per_node 4 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb_group bengio-wave2-lr-sweep
```

Key changes vs Wave 1 baseline:
- `--lr` swept over {1e-4, 5e-4} (baseline was 3e-4)
- `--lr-cosine-t-max 50` (was 30) — longer schedule gives lr differences more time to manifest
- `--fourier-pe` — mandatory (Wave 1 lesson)
- All other config identical to Wave 1 winner

Report val_primary metrics at the best checkpoint for each trial. Compare against the 3e-4 baseline.

## Baseline

Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`, lr=3e-4):

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
