### PR TITLE
[thorfinn] EMA revival {0.999, 0.9995} on Fourier PE + T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -71,6 +71,8 @@ from trainer_runtime import (
 class Config:
     lr: float = 3e-4
     weight_decay: float = 1e-4
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
     batch_size: int = 2
     epochs: int = 50
     train_surface_points: int = 40_000
@@ -249,7 +251,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-        optimizer = torch.optim.AdamW(base_model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = torch.optim.AdamW(
+            base_model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.adam_beta1, config.adam_beta2),
+        )
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))


### PR DESCRIPTION
## Hypothesis

Wave 1 baseline (PR #74, alphonse) **disabled EMA** with `--no-use-ema` because EMA underperformed when training only ~30 epochs at high LR. With T_max=50 (longer cosine schedule) the per-step gradient noise is smaller in the late-decay phase, and EMA's denoising effect should compound positively rather than washing out the still-improving weights. Re-enabling EMA on top of Fourier PE + longer schedule is a cheap test that may close 1-2pp of abupt by smoothing late-training oscillations on the wsy/wsz axes.

Test two EMA decays — 0.999 (fast) and 0.9995 (slow) — to bracket the right responsiveness for a 50-epoch run. The standard "EMA always helps" intuition often hinges on having enough late-stage steps for the moving-average to stabilize; T_max=50 gives ~25 epochs of post-warmup decay, far more than Wave 1's effective ~22.

## Wave 1 Baseline (PR #74 — alphonse)

| Metric | Wave 1 best (val) | AB-UPT target |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |

## Reproduce commands

Two sequential trials sharing the W&B group `bengio-wave2-ema`. Run Trial A first; once it is past epoch 10 with healthy loss curves, launch Trial B.

### Trial A — EMA decay 0.999

```bash
cd target/ && python train.py \
  --model-num-layers 4 --model-hidden-dim 256 \
  --use-ema --ema-decay 0.999 \
  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
  --fourier-pe --no-compile-model --nproc_per_node 4 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb_group bengio-wave2-ema
```

### Trial B — EMA decay 0.9995

```bash
cd target/ && python train.py \
  --model-num-layers 4 --model-hidden-dim 256 \
  --use-ema --ema-decay 0.9995 \
  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
  --fourier-pe --no-compile-model --nproc_per_node 4 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb_group bengio-wave2-ema
```

**IMPORTANT**: First confirm with `python train.py --help | grep -E '(ema|EMA)'` that `--use-ema` and `--ema-decay` are the correct flag spellings. If `--use-ema` is the default and the disable-flag is `--no-use-ema`, then **omit `--use-ema`** from the command (the default is `use-ema=True`). If unsure, use only `--ema-decay <value>` and trust the default.

## Decision Criteria

- **Merge** the better trial if `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091.
- **Discuss** if 7.21–7.5: report which decay was better and whether to push to even-slower (e.g., 0.9999) or test EMA-on-best-checkpoint vs end-of-training.
- **Close** if both > 8.0: EMA still hurts even with longer schedule, and we definitively keep `--no-use-ema` for Wave 3.

## Notes

- Both trials evaluate val on the **EMA weights** (not the raw weights). Verify this is the default eval path before launching Trial A.
- Report best val metrics for both trials, the W&B run IDs, and the best-checkpoint epoch for each.
- Do NOT modify any other recipe component — Fourier PE, no-compile, lr=3e-4, T_max=50, warmup=5 are fixed.
