### PR TITLE
fern: omega-bank frequency sweep (per-axis sincos for tau_y/z gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,44 +124,6 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
-class AxisSincosEmbed(nn.Module):
-    """Per-axis continuous sincos embedding with independent max_wavelength per axis.
-
-    Splits hidden_dim into input_dim equal chunks (rounded down to even), runs an
-    independent ContinuousSincosEmbed (input_dim=1) on each coordinate axis with
-    its own max_wavelength, concatenates outputs, and zero-pads to hidden_dim.
-    """
-
-    def __init__(self, hidden_dim: int, input_dim: int, max_wavelengths: tuple[int, ...]):
-        super().__init__()
-        if len(max_wavelengths) != input_dim:
-            raise ValueError(
-                f"max_wavelengths must have length {input_dim}, got {len(max_wavelengths)}"
-            )
-        self.hidden_dim = hidden_dim
-        self.input_dim = input_dim
-        per_axis = (hidden_dim // input_dim) // 2 * 2
-        if per_axis <= 0:
-            raise ValueError("hidden_dim must be large enough for per-axis sincos")
-        self.per_axis = per_axis
-        self.padding = hidden_dim - per_axis * input_dim
-        self.max_wavelengths = tuple(int(mw) for mw in max_wavelengths)
-        self.embeds = nn.ModuleList(
-            [
-                ContinuousSincosEmbed(hidden_dim=per_axis, input_dim=1, max_wavelength=mw)
-                for mw in self.max_wavelengths
-            ]
-        )
-
-    def forward(self, coords: torch.Tensor) -> torch.Tensor:
-        outputs = [self.embeds[i](coords[..., i : i + 1]) for i in range(self.input_dim)]
-        emb = torch.cat(outputs, dim=-1)
-        if self.padding > 0:
-            pad = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
-            emb = torch.cat([emb, pad], dim=-1)
-        return emb
-
-
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -387,8 +349,7 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
-        pos_max_wavelength: int = 10_000,
-        pos_axis_wavelengths: tuple[int, ...] | None = None,
+        pos_max_wavelength: int = 1000,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -401,22 +362,12 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
-        self.pos_axis_wavelengths = (
-            tuple(int(mw) for mw in pos_axis_wavelengths) if pos_axis_wavelengths else None
-        )
 
-        if self.pos_axis_wavelengths is not None:
-            self.pos_embed = AxisSincosEmbed(
-                hidden_dim=n_hidden,
-                input_dim=space_dim,
-                max_wavelengths=self.pos_axis_wavelengths,
-            )
-        else:
-            self.pos_embed = ContinuousSincosEmbed(
-                hidden_dim=n_hidden,
-                input_dim=space_dim,
-                max_wavelength=pos_max_wavelength,
-            )
+        self.pos_embed = ContinuousSincosEmbed(
+            hidden_dim=n_hidden,
+            input_dim=space_dim,
+            max_wavelength=pos_max_wavelength,
+        )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -627,8 +578,7 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
-    pos_max_wavelength: int = 10_000
-    pos_axis_wavelengths: str = ""
+    pos_max_wavelength: int = 1000
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -783,24 +733,6 @@ def make_loaders(
     return train_loader, val_loaders, test_loaders, stats
 
 
-def _parse_axis_wavelengths(spec: str) -> tuple[int, ...] | None:
-    spec = (spec or "").strip()
-    if not spec:
-        return None
-    parts = [p.strip() for p in spec.split(",") if p.strip()]
-    if len(parts) != 3:
-        raise ValueError(
-            f"--pos-axis-wavelengths must be a comma-separated triple of ints, got '{spec}'"
-        )
-    try:
-        values = tuple(int(p) for p in parts)
-    except ValueError as exc:
-        raise ValueError(f"--pos-axis-wavelengths must be ints, got '{spec}'") from exc
-    if any(v <= 0 for v in values):
-        raise ValueError(f"--pos-axis-wavelengths entries must be positive, got '{spec}'")
-    return values
-
-
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -813,7 +745,6 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
-        pos_axis_wavelengths=_parse_axis_wavelengths(config.pos_axis_wavelengths),
     )
 
 

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class ContinuousSincosEmbed(nn.Module):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
+        self.max_wavelength = max_wavelength
         padding = hidden_dim % input_dim
         dim_per_axis = (hidden_dim - padding) // input_dim
         sincos_padding = dim_per_axis % 2
@@ -120,6 +121,44 @@ class ContinuousSincosEmbed(nn.Module):
         if self.padding > 0:
             padding = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
             emb = torch.cat([emb, padding], dim=-1)
+        return emb
+
+
+class AxisSincosEmbed(nn.Module):
+    """Per-axis continuous sincos embedding with independent max_wavelength per axis.
+
+    Splits hidden_dim into input_dim equal chunks (rounded down to even), runs an
+    independent ContinuousSincosEmbed (input_dim=1) on each coordinate axis with
+    its own max_wavelength, concatenates outputs, and zero-pads to hidden_dim.
+    """
+
+    def __init__(self, hidden_dim: int, input_dim: int, max_wavelengths: tuple[int, ...]):
+        super().__init__()
+        if len(max_wavelengths) != input_dim:
+            raise ValueError(
+                f"max_wavelengths must have length {input_dim}, got {len(max_wavelengths)}"
+            )
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        per_axis = (hidden_dim // input_dim) // 2 * 2
+        if per_axis <= 0:
+            raise ValueError("hidden_dim must be large enough for per-axis sincos")
+        self.per_axis = per_axis
+        self.padding = hidden_dim - per_axis * input_dim
+        self.max_wavelengths = tuple(int(mw) for mw in max_wavelengths)
+        self.embeds = nn.ModuleList(
+            [
+                ContinuousSincosEmbed(hidden_dim=per_axis, input_dim=1, max_wavelength=mw)
+                for mw in self.max_wavelengths
+            ]
+        )
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        outputs = [self.embeds[i](coords[..., i : i + 1]) for i in range(self.input_dim)]
+        emb = torch.cat(outputs, dim=-1)
+        if self.padding > 0:
+            pad = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
+            emb = torch.cat([emb, pad], dim=-1)
         return emb
 
 
@@ -348,6 +387,8 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        pos_max_wavelength: int = 10_000,
+        pos_axis_wavelengths: tuple[int, ...] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,8 +400,23 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.pos_max_wavelength = pos_max_wavelength
+        self.pos_axis_wavelengths = (
+            tuple(int(mw) for mw in pos_axis_wavelengths) if pos_axis_wavelengths else None
+        )
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if self.pos_axis_wavelengths is not None:
+            self.pos_embed = AxisSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelengths=self.pos_axis_wavelengths,
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -571,6 +627,8 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    pos_max_wavelength: int = 10_000
+    pos_axis_wavelengths: str = ""
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -725,6 +783,24 @@ def make_loaders(
     return train_loader, val_loaders, test_loaders, stats
 
 
+def _parse_axis_wavelengths(spec: str) -> tuple[int, ...] | None:
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if len(parts) != 3:
+        raise ValueError(
+            f"--pos-axis-wavelengths must be a comma-separated triple of ints, got '{spec}'"
+        )
+    try:
+        values = tuple(int(p) for p in parts)
+    except ValueError as exc:
+        raise ValueError(f"--pos-axis-wavelengths must be ints, got '{spec}'") from exc
+    if any(v <= 0 for v in values):
+        raise ValueError(f"--pos-axis-wavelengths entries must be positive, got '{spec}'")
+    return values
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -736,6 +812,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        pos_max_wavelength=config.pos_max_wavelength,
+        pos_axis_wavelengths=_parse_axis_wavelengths(config.pos_axis_wavelengths),
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #143 (your coord-normalization sweep) decisively falsified the **coordinate-normalization** form of the sincos-anisotropy hypothesis: normalizing y/z to match x destroys the meter-calibrated `omega` bank and either tanks accuracy (`global-scale`: e1 abupt=24.85 vs control 16.20) or causes volume-token explosions (`per-axis`: all diverged).

**But the underlying observation still stands** — DrivAerML raw bbox is ~8m × 2.5m × 2m, so the *physical wavelengths* `omega` covers are well-suited for x-direction features but undersample y/z high-frequency surface detail (mirrors, wheel arches, A-pillar, rear spoiler). The fix is to **change the omega bank, not the coordinates.** Two concrete forms:

1. **Wider/denser `max_wavelength` sweep** — current `max_wavelength=10_000` (default in `ContinuousSincosEmbed.__init__`). Lowering it (e.g. 1000, 100) shifts the bank toward higher frequencies; raising it stretches it lower. Kaggle-style sweep finds the sweet spot for vehicle-scale geometry.
2. **Per-axis omega banks** — give y and z their own (denser, higher-frequency) omega arrays while keeping x at the current calibration. This restores the *frequency* isotropy the coord-normalization attempt was after, without touching the coordinates that the volume-bias and slice-attention paths rely on.

This is a pure encoder-frontend change — no new module, no instability surface, no FiLM-style amplification path. Should run cleanly at lr=5e-4 with the protected (commit `6e8b674`) grad-skip guard already on `yi`.

## Instructions

Modify `target/train.py`:

1. **Add a `max_wavelength` argument to `ContinuousSincosEmbed.__init__`** (already exists as a default — just plumb it through from a CLI flag).

2. **Add `--pos-max-wavelength` CLI flag** (default 10_000 = current behavior) and pass it to both calls of `ContinuousSincosEmbed(...)` (the global `pos_embed` and any per-block usage).

3. **Add `--pos-axis-wavelengths` optional CLI flag** that takes a comma-separated triple, e.g. `10000,2500,2000`, allowing per-axis `max_wavelength`. When set, build *three* `ContinuousSincosEmbed` modules (one per axis with `input_dim=1`) and concatenate their outputs to match the original `hidden_dim`. The split should be 1/3 of `hidden_dim` per axis (round to even), with any remainder padded with zeros (mirror the existing `padding` logic). Keep the default code path identical when the flag is unset.

4. **Sweep grid (4 GPUs, 4 arms, single seed each, `--wandb-group fern-omega-bank-sweep`):**

   | Arm | flags | rationale |
   |---|---|---|
   | A | `--pos-max-wavelength 1000` | shift whole bank ~10× higher freq |
   | B | `--pos-max-wavelength 100` | shift whole bank ~100× higher freq (Fourier-features territory) |
   | C | `--pos-axis-wavelengths 10000,2500,2000` | match physical bbox aspect ratio (x=8m → keep, y=2.5m → 4× denser, z=2m → 5× denser) |
   | D | `--pos-axis-wavelengths 5000,1000,1000` | aggressive y/z densification |

   Run all 4 against the PR #99 base config (lr=5e-4, 6L/256d/4h/128s, `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 --batch-size 8 --validation-every 1`).

5. **Win criterion:** any arm with `val_primary/abupt_axis_mean_rel_l2_pct < 10.69`. **Soft-win signal to call out:** improvement in `tau_y` or `tau_z` even without total-abupt win (these are the 4× AB-UPT gap axes that motivated the experiment).

6. **Stability note:** the haku grad-skip guard (commit `6e8b674` on `yi`) protects against silent NaN cascades — but you should still log `train/grad/pre_clip_norm` (already wired) and call out divergence steps in your results.

## Baseline

Current best on `yi` — PR #99 (fern), W&B run `3hljb0mg`, val abupt=10.69, test abupt=11.73:

| metric | val | test | AB-UPT | ratio |
|---|---:|---:|---:|---:|
| abupt_axis_mean | **10.69** | **11.73** | — | — |
| surface_pressure | 6.97 | 6.64 | 3.82 | 1.8× |
| wall_shear | 11.69 | 11.48 | 7.29 | 1.6× |
| volume_pressure | 7.85 | 14.42 | 6.08 | 1.3× |
| wall_shear_x | 10.17 | 10.06 | 5.35 | 1.9× |
| wall_shear_y | **13.73** | **13.53** | **3.65** | **3.8×** ← target |
| wall_shear_z | **14.73** | **13.98** | **3.63** | **4.1×** ← target |

Reproduce command (per arm — replace `<arm-flags>` with the row from the grid):

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group fern-omega-bank-sweep \
  <arm-flags>
```
