### PR TITLE
kohaku: FiLM with identity/zero-init (DiT-style stable conditioning)

### DIFF
--- a/train.py
+++ b/train.py
@@ -254,18 +254,36 @@ class GeomEncoder(nn.Module):
 
 
 class FiLMLayer(nn.Module):
-    """FiLM with AdaLN-zero init: gamma=0, beta=0 at start so output equals input.
+    """FiLM with configurable init for stability.
 
-    Applies h' = h * (1 + gamma) + beta where (gamma, beta) come from a linear
-    projection of the per-case geometry token. Final linear is zero-initialized
-    so the layer is identity at training start (residual modulation).
+    Parameterization: h' = h * (1 + gamma) + beta where (gamma, beta) come from
+    a linear projection of the per-case geometry token.
+
+    - zero_init=True (default, AdaLN-Zero style): weight=0, bias=0 → gamma=0,
+      beta=0 → exact identity at init. The modulation ramps in via gradient.
+    - zero_init=False, init_scale<1: keep default Linear init for bias and scale
+      the projection weight by init_scale. Soft-init that starts near identity
+      but with non-trivial bias-driven perturbation (faster ramp-in than full
+      zero-init).
+    - zero_init=False, init_scale=1.0: full default Linear init (vanilla).
     """
 
-    def __init__(self, geom_dim: int, hidden_dim: int):
+    def __init__(
+        self,
+        geom_dim: int,
+        hidden_dim: int,
+        *,
+        zero_init: bool = True,
+        init_scale: float = 1.0,
+    ):
         super().__init__()
         self.to_gamma_beta = nn.Linear(geom_dim, 2 * hidden_dim)
-        nn.init.zeros_(self.to_gamma_beta.weight)
-        nn.init.zeros_(self.to_gamma_beta.bias)
+        if zero_init:
+            nn.init.zeros_(self.to_gamma_beta.weight)
+            nn.init.zeros_(self.to_gamma_beta.bias)
+        elif init_scale != 1.0:
+            with torch.no_grad():
+                self.to_gamma_beta.weight.mul_(init_scale)
 
     def forward(self, h: torch.Tensor, geom: torch.Tensor) -> torch.Tensor:
         # h: [B, N, hidden_dim], geom: [B, geom_dim]
@@ -285,6 +303,8 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
         film_geom_dim: int = 0,
+        film_zero_init: bool = True,
+        film_init_scale: float = 1.0,
     ):
         super().__init__()
         if depth <= 1:
@@ -308,7 +328,15 @@ class Transformer(nn.Module):
         )
         self.film_layers = (
             nn.ModuleList(
-                [FiLMLayer(film_geom_dim, hidden_dim) for _ in range(depth)]
+                [
+                    FiLMLayer(
+                        film_geom_dim,
+                        hidden_dim,
+                        zero_init=film_zero_init,
+                        init_scale=film_init_scale,
+                    )
+                    for _ in range(depth)
+                ]
             )
             if film_geom_dim > 0
             else None
@@ -348,6 +376,8 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        film_zero_init: bool = True,
+        film_init_scale: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,6 +389,8 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.film_zero_init = film_zero_init
+        self.film_init_scale = film_init_scale
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -385,6 +417,8 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
             film_geom_dim=film_encoder_dim if use_film else 0,
+            film_zero_init=film_zero_init,
+            film_init_scale=film_init_scale,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -571,6 +605,8 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    film_zero_init: bool = True
+    film_init_scale: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -730,6 +766,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        film_zero_init=config.film_zero_init,
+        film_init_scale=config.film_init_scale,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Your PR #126 falsified the **vanilla-init FiLM × lr ≥ 3e-4** hypothesis but produced one extremely valuable signal: Arm 3 (lr=4e-4, clip=0.5) at epoch 2 hit `val_primary/volume_pressure_rel_l2_pct=7.05` vs baseline 7.85 — a real improvement on the metric closest to AB-UPT (1.3× away). The **direction** is right; the failure mode is **dynamics, not capability**.

Mechanistic root cause from your divergence forensics:
- `train/film/geom_token_norm_mean` was steady (~0.73-0.81) at all 4 divergence points → the *geometry token itself* is fine.
- Layer-0 `to_gamma_beta/bias grad_to_param_norm=0.567` was the smoking gun → the **FiLM linear projection layers** are the gradient amplification path, not the geometry encoder.

This points to a classic deep-residual-init problem: at default Linear-init, FiLM gamma/beta projections start with nontrivial output (random gamma deviating from 1, random beta deviating from 0), so the very first forward pass already perturbs every block's features by O(1). The solution is **identity-initialization**: gamma=1, beta=0 at start, ramping in via gradient — standard practice in modern diffusion/conditioning architectures (DiT, MM-DiT, AdaLN-Zero, FiT).

## Instructions

Modify `target/train.py` to add an identity-init mode for FiLM:

1. **In the FiLM module's `__init__`** (the `to_gamma_beta` Linear layer), add a `--film-zero-init` flag. When set:
   - `nn.init.zeros_(self.to_gamma_beta.weight)` — output is zero regardless of input
   - `nn.init.zeros_(self.to_gamma_beta.bias[:hidden_dim])` — gamma bias = 0 → gamma = 1+0 = 1 (assumes the existing code parameterizes as `gamma = 1 + delta_gamma`; if it's parameterized as raw gamma, set bias[:hidden_dim] = 1.0 instead)
   - `nn.init.zeros_(self.to_gamma_beta.bias[hidden_dim:])` — beta bias = 0
   - Verify in code review that the FiLM module starts as exactly identity (residual feature == input feature for the first forward pass). If the existing parameterization is `feat * gamma + beta` (raw), bias[:hidden_dim] must be 1.0; if it's `feat * (1+gamma) + beta` (delta), bias must be all zeros. **Read the existing FiLM code before deciding.**

2. **Add `--film-init-scale` flag** (default 1.0 = current behavior, `--film-zero-init` overrides to 0). When set to e.g. 0.01, scale `to_gamma_beta.weight` by that factor — soft-init that ramps in faster than full zero-init but keeps initial perturbation small.

3. **Sweep grid (4 arms, single seed, `--wandb-group kohaku-film-smallinit-sweep`):**

   | Arm | flags | rationale |
   |---|---|---|
   | A | `--use-film --film-zero-init --lr 5e-4` | full zero-init at PR #99 lr |
   | B | `--use-film --film-zero-init --lr 4e-4 --clip-grad-norm 0.5` | zero-init at your Arm-3 settings (best partial last time) |
   | C | `--use-film --film-init-scale 0.01 --lr 5e-4` | soft-init at full lr |
   | D | `--use-film --film-zero-init --lr 5e-4 --film-only-bottleneck` *(if feasible)* OR `--use-film --film-zero-init --lr 5e-4 --weight-decay 1e-3` | bottleneck-only OR stronger WD as a structural variant |

   Pick whichever Arm D is easier to implement cleanly. If `--film-only-bottleneck` requires a non-trivial refactor, use the WD variant.

4. **Run the PR #99 base config** (6L/256d/4h/128s, bs=8, validation-every=1, vol_w=2, wallshear y/z weight=2, ema=0.9995, surface/volume points=65536). **Do NOT change** `--ema-decay` from baseline; FiLM should ride on the same ramp.

5. **Stability protection:** the haku grad-skip guard (commit `6e8b674`) is on `yi` — if a step hits non-finite or large pre-clip grad, it will be skipped instead of corrupting weights. Keep `--clip-grad-norm 1.0` for arms A/C/D and 0.5 for arm B.

6. **Win criterion:** ANY arm with `val_primary/abupt_axis_mean_rel_l2_pct < 10.69`. **Soft-win to call out separately:** any arm with `val_primary/volume_pressure_rel_l2_pct < 7.85` even if total abupt doesn't beat baseline (your previous run already showed FiLM helps volume — confirming this in a stable regime is itself a useful research result).

7. **Logging:** keep `train/film/geom_token_norm_mean` and per-layer `to_gamma_beta` weight/grad norms — we want to see how identity-init behaves over training and whether gamma/beta drift gradually away from identity.

## Baseline

Current best on `yi` — PR #99 (fern), W&B run `3hljb0mg`, val abupt=10.69:

| metric | val | test | AB-UPT | ratio |
|---|---:|---:|---:|---:|
| abupt_axis_mean | **10.69** | **11.73** | — | — |
| surface_pressure | 6.97 | 6.64 | 3.82 | 1.8× |
| wall_shear | 11.69 | 11.48 | 7.29 | 1.6× |
| volume_pressure | **7.85** | 14.42 | **6.08** | **1.3×** ← FiLM target |
| wall_shear_x | 10.17 | 10.06 | 5.35 | 1.9× |
| wall_shear_y | 13.73 | 13.53 | 3.65 | 3.8× |
| wall_shear_z | 14.73 | 13.98 | 3.63 | 4.1× |

Your previous best partial (PR #126 Arm 3 e2): abupt=11.67, vp=7.05 — confirming FiLM's volume signal. Now make it stable.

Reproduce command (per arm — replace `<arm-flags>`):

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group kohaku-film-smallinit-sweep \
  <arm-flags>
```
