### PR TITLE
1-cycle LR max=1e-3: super-convergence in epoch-limited regime

### DIFF
--- a/train.py
+++ b/train.py
@@ -593,6 +593,10 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    use_1cycle: bool = False
+    onecycle_pct_start: float = 0.3
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1701,9 +1705,20 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    if config.use_1cycle:
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.lr,
+            total_steps=total_estimated_steps,
+            pct_start=config.onecycle_pct_start,
+            anneal_strategy="cos",
+            div_factor=config.onecycle_div_factor,
+            final_div_factor=config.onecycle_final_div_factor,
+        )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1874,6 +1889,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for pg in optimizer.param_groups:
                         pg["lr"] = config.lr
             optimizer.step()
+            if config.use_1cycle:
+                scheduler.step()
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -1948,7 +1965,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not config.use_1cycle:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

1-cycle LR policy (super-convergence) can yield faster convergence and better generalization in our epoch-limited training regime. The idea: a single triangular learning rate cycle from a low base lr (1e-5) up to a peak (1e-3) then back down to near-zero, spending most training time at higher LRs. Smith & Touvron (1cycle/super-convergence) showed this consistently beats cosine annealing in low-epoch budgets because it spends more time in the "generalization" regime (moderate LR). Given our hard epoch/time limit, super-convergence may unlock headroom that cosine annealing leaves on the table. The spike to 1e-3 is bounded by the single-cycle decay, so Adam v-accumulation instability is self-limiting.

Key difference from PR #99 (fern, lr=5e-4 cosine): 1-cycle peak is 2× higher but decays to zero rather than a flat plateau, which trades some plateau stability for much better late-epoch sharpening.

## Instructions

Implement PyTorch's `OneCycleLR` scheduler in `target/train.py`. The scheduler overrides the cosine annealing. Specifically:

1. Add a CLI flag `--use-1cycle` (boolean) that switches from the current cosine schedule to `torch.optim.lr_scheduler.OneCycleLR`.
2. When `--use-1cycle` is enabled, instantiate:
   ```python
   scheduler = torch.optim.lr_scheduler.OneCycleLR(
       optimizer,
       max_lr=args.lr,          # use --lr flag as the peak
       total_steps=total_train_steps,   # epochs × steps_per_epoch
       pct_start=0.3,           # 30% of training ramping up
       anneal_strategy='cos',
       div_factor=25.0,         # start lr = max_lr / 25 (=4e-5 at max_lr=1e-3)
       final_div_factor=1e4,    # end lr = max_lr / (25 × 1e4)
   )
   ```
3. Call `scheduler.step()` every **batch** (not every epoch), as required by OneCycleLR.
4. Run with:
   ```bash
   cd target/
   python train.py \
     --volume-loss-weight 2.0 \
     --batch-size 8 \
     --validation-every 1 \
     --lr 1e-3 \
     --weight-decay 5e-4 \
     --train-surface-points 65536 --eval-surface-points 65536 \
     --train-volume-points 65536 --eval-volume-points 65536 \
     --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
     --ema-decay 0.9995 \
     --clip-grad-norm 1.0 \
     --wallshear-y-weight 2.0 \
     --wallshear-z-weight 2.0 \
     --use-1cycle \
     --wandb-group 1cycle-lr-superconvergence \
     --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
   ```

**If the lr=1e-3 run diverges (loss NaN or >50 at epoch 3):** rerun with `--lr 5e-4` (same peak as PR #99 baseline) — same 1cycle schedule but at a safer peak. This is your fallback arm. Both arms should use `--wandb-group 1cycle-lr-superconvergence`.

Note: `--lr-warmup-steps` (from PR #169) should be left at default (0) when `--use-1cycle` is active, since OneCycleLR handles its own warmup internally.

## Baseline

Current best (PR #99, fern, W&B run `3hljb0mg`):

| Metric | val |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** |
| `surface_pressure_rel_l2_pct` | 6.97 |
| `wall_shear_rel_l2_pct` | 11.69 |
| `volume_pressure_rel_l2_pct` | 7.85 |
| `wall_shear_x_rel_l2_pct` | 10.17 |
| `wall_shear_y_rel_l2_pct` | 13.73 |
| `wall_shear_z_rel_l2_pct` | 14.73 |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Success criteria

Beat `val_primary/abupt_axis_mean_rel_l2_pct` < 10.69. Report all 7 val metrics in the PR comment.
