### PR TITLE
asinh target normalization for tau_y/z (log-mag heavy-tail fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -556,6 +556,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    asinh_wallshear_yz: bool = False
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1304,6 +1305,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    asinh_wallshear_yz: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1343,6 +1345,17 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
+        if asinh_wallshear_yz:
+            # Compress heavy-tailed wall-shear y (idx 2) and z (idx 3) targets
+            # via asinh. The model output is trained to live in asinh-normalized
+            # space for these channels and is inverted with sinh at metric time.
+            surface_target_used = torch.cat(
+                [
+                    surface_target_used[..., :2],
+                    torch.asinh(surface_target_used[..., 2:4]),
+                ],
+                dim=-1,
+            )
         surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
             surface_pred_used,
             surface_target_used,
@@ -1432,6 +1445,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    asinh_wallshear_yz: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -1471,13 +1485,38 @@ def evaluate_split(
             )
         surface_pred_norm = out["surface_preds"].float()
         volume_pred_norm = out["volume_preds"].float()
-        surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
+        if asinh_wallshear_yz:
+            # Mirror the training-time target transform for val SSE so it stays
+            # comparable to train loss (model output is in asinh-normalized space
+            # for y/z, targets are asinh-transformed before MSE).
+            surface_target_norm_for_loss = torch.cat(
+                [
+                    surface_target_norm[..., :2],
+                    torch.asinh(surface_target_norm[..., 2:4]),
+                ],
+                dim=-1,
+            )
+        else:
+            surface_target_norm_for_loss = surface_target_norm
+        surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm_for_loss, batch.surface_mask)
         volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
         surface_loss_sse += surface_sse
         surface_loss_count += surface_count
         volume_loss_sse += volume_sse
         volume_loss_count += volume_count
-        surface_pred = transform.invert_surface(surface_pred_norm)
+        if asinh_wallshear_yz:
+            # Invert asinh on y/z predictions (sinh) before standard denorm so
+            # all rel-L2/MAE metrics are computed in physical units.
+            surface_pred_norm_for_metrics = torch.cat(
+                [
+                    surface_pred_norm[..., :2],
+                    torch.sinh(surface_pred_norm[..., 2:4]),
+                ],
+                dim=-1,
+            )
+        else:
+            surface_pred_norm_for_metrics = surface_pred_norm
+        surface_pred = transform.invert_surface(surface_pred_norm_for_metrics)
         volume_pred = transform.invert_volume(volume_pred_norm)
 
         if bool(batch.surface_mask.any()):
@@ -1801,6 +1840,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                asinh_wallshear_yz=config.asinh_wallshear_yz,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -1992,7 +2032,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, asinh_wallshear_yz=config.asinh_wallshear_yz)
             for name, loader in val_loaders.items()
         }
         if ema is not None:
@@ -2107,7 +2147,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, asinh_wallshear_yz=config.asinh_wallshear_yz)
         for name, loader in val_loaders.items()
     }
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -2141,7 +2181,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, asinh_wallshear_yz=config.asinh_wallshear_yz)
         for name, loader in test_loaders.items()
     }
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]


### PR DESCRIPTION
## Hypothesis

The tau_y and tau_z components have a ~4× gap vs AB-UPT targets. One likely cause: their magnitude distributions have heavy tails — a few points near wheel arches and mirrors have very large tau_y/z values, while most surface points have near-zero values. The L2 loss treats all points equally, so the model learns the mean well but fails at the extreme values where the AB-UPT reference is strongest.

**Hypothesis:** Applying a log-magnitude transform `sign(x) * log(1 + |x|)` (soft-sign log, equivalent to `asinh(x)`) to the wall-shear targets before computing loss normalizes this distribution. The model then predicts in log-magnitude space, which collapses the heavy tail and forces it to learn the fine-grained structure of small-magnitude regions — exactly where tau_y/z errors are largest relative to AB-UPT.

This is frieren's PR #123 direction (asinh normalization) but applied **only to wall-shear y and z** (not x, not pressure), since tau_y/z are the components with the largest gap. The per-component application isolates the effect cleanly.

The asinh transform `asinh(x) = log(x + sqrt(x² + 1))` is numerically stable and invertible — predictions can be inverted back to physical units for metric computation.

## Instructions

Modify `target/train.py` to apply asinh normalization to wall-shear y and z targets only:

1. Add a CLI flag `--asinh-wallshear-yz` (boolean, default False).

2. When `--asinh-wallshear-yz` is enabled, before computing the wall-shear loss:
   - Apply `target_yz = torch.asinh(target_yz)` to the y and z components of the wall-shear target tensor.
   - Apply the same transform to the **predictions** for y and z before computing the loss.
   - For metric computation (the `abupt_axis_mean_rel_l2_pct` etc.), invert the transform: `torch.sinh(pred_yz)` before computing relative L2.
   - Leave tau_x, surface_pressure, and volume_pressure untransformed.

3. The wall-shear target is a 3-vector (tau_x, tau_y, tau_z). In `train.py`, identify where the wall-shear loss is computed and apply the transform to indices 1 and 2 (y, z) of the target and prediction tensors.

4. Run with:
   ```bash
   cd target/
   python train.py \
     --volume-loss-weight 2.0 \
     --batch-size 8 \
     --validation-every 1 \
     --lr 5e-4 --weight-decay 5e-4 \
     --train-surface-points 65536 --eval-surface-points 65536 \
     --train-volume-points 65536 --eval-volume-points 65536 \
     --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
     --ema-decay 0.9995 \
     --clip-grad-norm 1.0 \
     --wallshear-y-weight 2.0 \
     --wallshear-z-weight 2.0 \
     --asinh-wallshear-yz \
     --wandb-group asinh-wallshear-yz \
     --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
   ```

**IMPORTANT — metric correctness:** The val/test metrics must be computed in the **original physical units** (not in log space). Ensure you invert the asinh transform on predictions before calling any metric function. If the metric function is called from a separate validation pass that doesn't go through the loss, make sure the inversion happens there too.

**Fallback:** If val abupt at epoch 3 is > 15 (significantly worse), check whether the inversion is being applied correctly. The most common bug is forgetting to invert at metric time.

## Baseline

Current best (PR #99, fern, W&B run `3hljb0mg`):

| Metric | val |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.69** |
| `surface_pressure_rel_l2_pct` | 6.97 |
| `wall_shear_rel_l2_pct` | 11.69 |
| `volume_pressure_rel_l2_pct` | 7.85 |
| `wall_shear_x_rel_l2_pct` | 10.17 |
| `wall_shear_y_rel_l2_pct` | **13.73** (3.8× AB-UPT target 3.65) |
| `wall_shear_z_rel_l2_pct` | **14.73** (4.1× AB-UPT target 3.63) |

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Success criteria

Primarily: reduce `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` vs baseline. Secondary: do not regress `surface_pressure` or `volume_pressure` more than 5%. Report all 7 val metrics.
