### PR TITLE
Physics-informed RANS divergence-free penalty on volume velocity

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-05-01 12:00 — PR #151: [nezuko] Left/right symmetry augmentation (tau_y gap)
+- Branch: `nezuko/symmetry-augmentation`
+- Hypothesis: DrivAerML cars have bilateral (left/right) symmetry — reflecting geometry about the xz-plane (y→-y) gives a physically valid new training example, potentially doubling effective training data and regularizing tau_y predictions.
+- Results: W&B runs `agns4wt7` (Arm A p=0.5), `9xsrl7pp` (Arm B p=1.0)
+
+| Metric | Arm A (p=0.5) val | Arm A test | Arm B (p=1.0) val | Arm B test | Baseline val | AB-UPT |
+|---|---:|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | 17.63 | 18.46 | 45.92 | 45.62 | **10.69** | — |
+| `surface_pressure_rel_l2_pct` | 12.68 | 12.49 | 36.45 | 35.37 | 6.97 | 3.82 |
+| `wall_shear_rel_l2_pct` | 19.42 | 19.28 | 50.90 | 49.66 | 11.69 | 7.29 |
+| `volume_pressure_rel_l2_pct` | 11.18 | 16.59 | 23.80 | 28.30 | 7.85 | 6.08 |
+| `wall_shear_y_rel_l2_pct` | 22.85 | 22.60 | 65.14 | 63.59 | **13.73** | **3.65** |
+| `wall_shear_z_rel_l2_pct` | 24.56 | 23.75 | 61.55 | 59.43 | **14.73** | **3.63** |
+
+- Commentary: **NEGATIVE RESULT. CLOSED.** Both arms diverged. Arm A (p=0.5) crashed with NaN at epoch 2 step ~19400 (grad norm spiked from ~1 to 1537+ over ~900 steps). Arm B (p=1.0) collapsed in ep1 (val=45.9%) and went NaN at step ~11185.
+  
+  Root cause: DrivAerML cars have real Y-asymmetries (drivetrain, suspension, mirrors, fuel filler). At 65536 surface points, the mirrored geometry is a *new* car with labels that don't satisfy the symmetry assumption. The augmentation creates an inconsistent gradient signal — once the model has fit the asymmetric ground truth, augmented batches push conflicting constraints, eventually destabilizing the optimizer. Arm B (always-mirror) prevents the model from ever seeing the original geometry orientation and diverges even faster.
+  
+  Key finding: **The symmetry assumption needs empirical verification before any symmetry-based method can be applied.** For a few held-out cars, one should check that tau_y(flip(x)) ≈ -tau_y(x) actually holds in the data — if geometry asymmetries cause a ~5-15% residual, that is a noise floor for any symmetry-based method.
+  
+  Suggested follow-ups from student: (1) Anti-symmetric soft loss penalty L_sym = ||y_pred(x) + flip(y_pred(flip(x)))||² as a regularizer (not data augmentation). (2) Lower lr or warmup-then-augment approach. (3) Tighter grad clipping (clip=0.25-0.5) when augmentation is active.
+
+---
+
 ## 2026-04-29 03:00 — PR #11: [kohaku] Tangential wall-shear projection loss
 - Branch: `kohaku/round1-tangential-wallshear-loss`
 - Hypothesis: Project wall-shear predictions onto the tangential plane at each surface point to enforce the no-slip boundary condition physically.

--- a/train.py
+++ b/train.py
@@ -556,6 +556,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    rans_divergence_weight: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1304,6 +1305,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    rans_divergence_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1317,16 +1319,26 @@ def train_loss(
         )
         surface_pred_norm = out["surface_preds"]
         normal_rms = float("nan")
-        if use_tangential_wallshear_loss:
-            # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
-            # in normalized space does not equal physical-space tangent projection.
-            # Denormalize -> project in physical space -> renormalize.
+        rans_penalty_value: float | None = None
+        # Compute normal-component dot product when needed by either tangential
+        # loss or the RANS soft no-slip-wall penalty (tau . n = 0).
+        need_normal_dot = use_tangential_wallshear_loss or rans_divergence_weight > 0.0
+        if need_normal_dot:
+            # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]); we work in
+            # physical space so the constraint matches the physical identity.
             normals = batch.surface_x[..., 3:6]
             ws_std = transform.surface_y_std[1:4]
             ws_mean = transform.surface_y_mean[1:4]
-            ws_pred_norm = surface_pred_norm[..., 1:4]
+            ws_pred_norm_chan = surface_pred_norm[..., 1:4]
+            ws_pred_phys = ws_pred_norm_chan * ws_std + ws_mean
+            n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+            normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
+            if bool(batch.surface_mask.any()):
+                normal_rms = float(
+                    normal_dot[batch.surface_mask].square().mean().sqrt().detach().cpu().item()
+                )
+        if use_tangential_wallshear_loss:
             ws_true_norm = surface_target[..., 1:4]
-            ws_pred_phys = ws_pred_norm * ws_std + ws_mean
             ws_true_phys = ws_true_norm * ws_std + ws_mean
             ws_pred_tan = project_tangential(ws_pred_phys, normals)
             ws_true_tan = project_tangential(ws_true_phys, normals)
@@ -1334,12 +1346,6 @@ def train_loss(
             ws_true_tan_norm = (ws_true_tan - ws_mean) / ws_std
             surface_pred_used = torch.cat([surface_pred_norm[..., :1], ws_pred_tan_norm], dim=-1)
             surface_target_used = torch.cat([surface_target[..., :1], ws_true_tan_norm], dim=-1)
-            if bool(batch.surface_mask.any()):
-                n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
-                normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
-                normal_rms = float(
-                    normal_dot[batch.surface_mask].square().mean().sqrt().detach().cpu().item()
-                )
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
@@ -1351,6 +1357,15 @@ def train_loss(
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        if rans_divergence_weight > 0.0:
+            if bool(batch.surface_mask.any()):
+                mask_f = batch.surface_mask.float()
+                normal_dot_clamped = normal_dot.float().clamp(-10.0, 10.0)
+                rans_penalty = ((normal_dot_clamped ** 2) * mask_f).sum() / mask_f.sum().clamp_min(1.0)
+            else:
+                rans_penalty = torch.zeros((), device=loss.device, dtype=torch.float32)
+            loss = loss + rans_divergence_weight * rans_penalty.to(loss.dtype)
+            rans_penalty_value = float(rans_penalty.detach().cpu().item())
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
             surf_pred_f = surface_pred_norm.float()
@@ -1371,8 +1386,10 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
-    if use_tangential_wallshear_loss:
+    if need_normal_dot:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if rans_penalty_value is not None:
+        metrics["rans_divergence_loss"] = rans_penalty_value
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -1801,6 +1818,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                rans_divergence_weight=config.rans_divergence_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -1912,6 +1930,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "rans_divergence_loss" in batch_loss_metrics:
+                train_log["train/rans_divergence_loss"] = batch_loss_metrics[
+                    "rans_divergence_loss"
                 ]
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[


### PR DESCRIPTION
## Hypothesis

The 4× gap in `wall_shear_y` and `wall_shear_z` vs AB-UPT (our 13.73/14.73 vs AB-UPT 3.65/3.63) may partly stem from the model learning unphysical velocity and shear fields that violate RANS continuity. AB-UPT likely benefits from physics-aware training signals. We hypothesize that adding a **soft divergence-free penalty on volume velocity predictions** will improve gradient quality and improve wall shear accuracy by pushing the learned velocity field toward physically plausible solutions.

The incompressible RANS continuity equation requires ∇·u = 0 (div(u) = 0). The DrivAerML volume points include 3-component velocity (u_x, u_y, u_z). We can compute a finite-difference approximation of ∇·u at each volume point neighborhood and penalize large divergences during training.

**Why this might help tau_y/z specifically:** The tangential wall shear stress is the viscous gradient of velocity normal to the surface. If the bulk velocity field is divergence-free, the near-wall velocity gradients are more physically consistent, which should reduce error in the tangential shear components — particularly y and z which are most sensitive to flow coherence.

Reference: Physics-informed neural networks (Raissi et al. 2019, J. Comput. Phys.) show RANS constraints improve accuracy in turbulent flow prediction. This is a soft constraint version (regularization penalty) that doesn't require architectural changes.

## Instructions

Add a **soft divergence-free penalty** to the volume loss in `target/train.py`.

### Step 1: Implement the penalty in `train.py`

In the training loss computation for volume points, after computing the velocity predictions, add a soft penalty term:

```python
# In the volume loss section, extract predicted u_x, u_y, u_z from volume predictions
# volume_pred shape: (B, N_vol, C) where C includes [p, u_x, u_y, u_z] at appropriate indices
# Compute pairwise finite-difference divergence approximation using nearest-neighbor pairs

# Penalty: for each point i, find its k=4 nearest neighbors, 
# estimate ∂u_x/∂x + ∂u_y/∂y + ∂u_z/∂z using least-squares local gradient,
# penalize squared divergence: lambda_rans * mean(div_u ** 2)
```

**Simpler alternative (preferred for first experiment — avoid extra kNN computation):**
Use the existing structure of volume point batches. If volume points have coordinates `x_vol` (shape B×N×3), compute divergence across the batch using coordinate differences:

For adjacent volume points (index i vs i+1 within a batch), estimate:
```
div_approx = (u_x[i+1] - u_x[i]) / (x[i+1] - x[i] + 1e-8) 
           + (u_y[i+1] - u_y[i]) / (y[i+1] - y[i] + 1e-8) 
           + (u_z[i+1] - u_z[i]) / (z[i+1] - z[i] + 1e-8)
rans_loss = lambda_rans * torch.mean(div_approx ** 2)
total_loss = total_loss + rans_loss
```

Note: You need to identify the correct output channel indices for u_x, u_y, u_z in the volume prediction tensor — inspect `train.py` to find how volume targets are structured (likely `vol_target = [p, u_x, u_y, u_z]` or similar).

### Step 2: Add CLI flags

Add `--rans-divergence-weight` flag (default: 0.0) so the penalty can be enabled/disabled and swept:

```python
parser.add_argument('--rans-divergence-weight', type=float, default=0.0,
                    help='Weight for RANS divergence-free soft constraint on volume velocity predictions')
```

### Step 3: Log the RANS penalty separately in W&B

```python
wandb.log({"train/rans_divergence_loss": rans_loss.item(), ...})
```

### Step 4: Run a 3-arm sweep on 3 GPUs using `--wandb_group rans_divergence_sweep`

| Arm | GPU | lambda_rans | Command suffix |
|-----|-----|-------------|----------------|
| A | 0 | 0.001 | `--rans-divergence-weight 0.001` |
| B | 1 | 0.01 | `--rans-divergence-weight 0.01` |
| C | 2 | 0.1 | `--rans-divergence-weight 0.1` |

Use standard base config on all arms:

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --lr-warmup-steps 500 \
  --seed 42 \
  --rans-divergence-weight <LAMBDA> \
  --wandb_group rans_divergence_sweep
```

Use GPU 3 as a **no-penalty control** (same as baseline, to confirm reproducibility):
```bash
--rans-divergence-weight 0.0 --seed 42  # arm D, control
```

### Implementation notes

- If the volume prediction tensor doesn't contain velocity (check target variable names in `train.py`), fall back to computing divergence on the **surface** normal-component residual instead: penalize `(tau · n)^2` summed over surface points (tau should be tangential, not normal). This is the "normal consistency" approach — but applied as a direct loss penalty rather than a separate term.
- Check W&B early (ep1) for rans_divergence_loss convergence. If it's NaN or exploding, cap with `torch.clamp(div_approx, -10, 10)` before squaring.
- Report `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` separately — these are the primary target metrics.

## Baseline to beat

Current best (PR #99, fern, W&B run `3hljb0mg`):

| Metric | Baseline (PR #99) | AB-UPT | Gap |
|--------|:-----------------:|:------:|:---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
| `val_primary/surface_pressure_rel_l2_pct` | 6.97 | 3.82 | 1.8× |
| `val_primary/wall_shear_rel_l2_pct` | 11.69 | 7.29 | 1.6× |
| `val_primary/volume_pressure_rel_l2_pct` | 7.85 | 6.08 | 1.3× |
| `val_primary/wall_shear_x_rel_l2_pct` | 10.17 | 5.35 | 1.9× |
| `val_primary/wall_shear_y_rel_l2_pct` | 13.73 | 3.65 | **3.8×** |
| `val_primary/wall_shear_z_rel_l2_pct` | 14.73 | 3.63 | **4.1×** |

**Primary target:** `val_primary/abupt_axis_mean_rel_l2_pct < 10.69`. Focus especially on reducing `wall_shear_y` and `wall_shear_z` — these are our biggest gaps vs AB-UPT.

## Success criteria

- Any arm with `val_primary/abupt_axis_mean_rel_l2_pct < 10.69` wins.
- Also watch for `wall_shear_y_rel_l2_pct` or `wall_shear_z_rel_l2_pct` reductions even if the composite metric doesn't beat baseline — that's scientifically valuable.
- If the `rans_divergence_loss` W&B log shows it consistently dropping (even if slowly), the physical constraint is doing something. Report even null results with the loss curves.
