### PR TITLE
alphonse: Adaptive Gradient Clipping (AGC) for per-param stability

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,6 +588,9 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
+    use_agc: bool = False
+    agc_lambda: float = 0.01
+    agc_eps: float = 1e-3
     compile_model: bool = True
     debug: bool = False
     seed: int = -1
@@ -898,6 +901,71 @@ def _parameter_display_type(
             continue
         return type(parent).__name__
     return type(module).__name__
+
+
+def _unitwise_norm(x: torch.Tensor, norm_type: float = 2.0) -> torch.Tensor:
+    """Per-output-unit Frobenius norm following Brock et al. 2021 (NFNets, App. B).
+
+    For ndim<=1 tensors returns a scalar tensor. For ndim>=2 tensors returns
+    a tensor of shape [out_dim, 1, 1, ...] containing the norm of each output
+    unit (row of a Linear weight, output channel of a Conv weight).
+    """
+    if x.ndim <= 1:
+        return x.norm(norm_type)
+    return x.norm(norm_type, dim=tuple(range(1, x.ndim)), keepdim=True)
+
+
+def adaptive_gradient_clipping(
+    parameters,
+    agc_lambda: float,
+    eps: float = 1e-3,
+) -> dict[str, float]:
+    """Unit-wise Adaptive Gradient Clipping (Brock et al. 2021, Appendix B).
+
+    Clips each output unit's gradient so that its norm is at most
+    ``agc_lambda * ||W_unit||``. Skips parameters with ndim<2 (biases,
+    LayerNorm gamma/beta) per the paper. Returns diagnostics computed before
+    the gradient is modified so the clipped fraction is meaningful.
+
+    Must be called after ``loss.backward()`` and before ``optimizer.step()``.
+    With bf16 AMP we operate directly on fp32 ``.grad`` (no scaler unscale).
+    """
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    parameters = [p for p in parameters if p.grad is not None]
+
+    eligible = 0
+    clipped_units = 0
+    total_units = 0
+    max_ratio = 0.0
+
+    for p in parameters:
+        if p.ndim < 2:
+            continue
+        eligible += 1
+        p_norm = _unitwise_norm(p.detach()).clamp_(min=eps)
+        g_norm = _unitwise_norm(p.grad.detach())
+        max_norm = p_norm * agc_lambda
+        ratio = (g_norm / p_norm).max().item()
+        if ratio > max_ratio:
+            max_ratio = ratio
+        trigger = g_norm > max_norm
+        n_units = trigger.numel()
+        total_units += n_units
+        n_clipped = int(trigger.sum().item())
+        clipped_units += n_clipped
+        if n_clipped > 0:
+            scale = max_norm / g_norm.clamp(min=1e-6)
+            clipped_grad = p.grad * scale
+            p.grad.detach().copy_(torch.where(trigger, clipped_grad, p.grad))
+
+    return {
+        "eligible_params": float(eligible),
+        "clipped_units": float(clipped_units),
+        "total_units": float(total_units),
+        "clipped_fraction": clipped_units / max(total_units, 1),
+        "max_ratio_to_lambda": max_ratio / max(agc_lambda, 1e-12),
+    }
 
 
 def collect_gradient_metrics(
@@ -1838,6 +1906,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                 else {}
             )
             grad_is_finite = True
+            if config.use_agc:
+                agc_diag = adaptive_gradient_clipping(
+                    model.parameters(),
+                    agc_lambda=config.agc_lambda,
+                    eps=config.agc_eps,
+                )
+                if should_log_gradients:
+                    gradient_metrics["train/agc/clipped_fraction"] = agc_diag["clipped_fraction"]
+                    gradient_metrics["train/agc/clipped_units"] = agc_diag["clipped_units"]
+                    gradient_metrics["train/agc/total_units"] = agc_diag["total_units"]
+                    gradient_metrics["train/agc/eligible_params"] = agc_diag["eligible_params"]
+                    gradient_metrics["train/agc/max_ratio_to_lambda"] = agc_diag["max_ratio_to_lambda"]
+                    gradient_metrics["train/agc/lambda"] = config.agc_lambda
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), max_norm=config.clip_grad_norm


### PR DESCRIPTION
## Hypothesis

Adaptive Gradient Clipping (AGC, Brock et al. 2021 NFNets) replaces the brittle
absolute-threshold gradient clipping with a per-parameter, scale-invariant ratio
clamp. Instead of `clip_grad_norm`, AGC clips each parameter's gradient to:

    clip_threshold_p = λ × ||W_p||_F / ||grad_p||_F

This adapts automatically to layer scale and directly prevents the Adam m/v
corruption mechanism we've observed across the fleet (PRs #123, #168, #165,
#164) where large-but-finite gradient spikes bypass NaN-skip, get normalized by
clip_grad_norm, and then corrupt Adam's second moment estimate.

**Why this addresses the root cause:** AGC's unit is unitless (gradient-to-weight
ratio), so a layer that has been trained into a small weight regime (early layers,
residual projections) gets a tighter clip automatically. clip_grad_norm=1.0 treats
all parameters the same and normalizes the direction of a poisoned gradient
without reducing its damage to m/v.

Paper: Brock, De, Smith, Simonyan "High-Performance Large-Scale Image Recognition
Without Normalization" 2021, Appendix B (https://arxiv.org/abs/2102.06171).

## Instructions

### Step 1 — Add `--use-agc` and `--agc-lambda` flags to `train.py`

Add these arguments to the `argparse` section:

```python
parser.add_argument("--use-agc", action="store_true", default=False,
                    help="Use Adaptive Gradient Clipping (AGC) per-parameter before clip_grad_norm")
parser.add_argument("--agc-lambda", type=float, default=0.01,
                    help="AGC clipping factor λ (gradient-to-weight norm ratio threshold)")
```

### Step 2 — Implement the AGC function

Add to `train.py` (or import from a small util):

```python
def adaptive_gradient_clipping(parameters, agc_lambda: float, eps: float = 1e-3):
    """Per-parameter gradient clipping scaled to weight norm.
    Reference: Brock et al. 2021 NFNets, Appendix B.
    """
    for param in parameters:
        if param.grad is None:
            continue
        p_norm = param.data.norm(2).clamp(min=eps)
        g_norm = param.grad.data.norm(2).clamp(min=eps)
        max_g_norm = agc_lambda * p_norm
        if g_norm > max_g_norm:
            param.grad.data.mul_(max_g_norm / g_norm)
```

### Step 3 — Call AGC before clip_grad_norm in the training loop

Find the gradient clipping section (called after `scaler.unscale_` or loss.backward)
and insert AGC before the existing clip:

```python
if args.use_agc:
    adaptive_gradient_clipping(model.parameters(), agc_lambda=args.agc_lambda)
# then existing global clip follows as a safety net:
if args.clip_grad_norm:
    torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
```

### Step 4 — Add W&B logging for AGC events

After the AGC call, log the fraction of parameters that were clipped this step:

```python
if args.use_agc and step % args.gradient_log_every == 0:
    params = list(model.parameters())
    clipped = sum(1 for p in params if p.grad is not None and
                  p.grad.data.norm(2) > agc_lambda * p.data.norm(2).clamp(min=1e-3))
    total = sum(1 for p in params if p.grad is not None)
    wandb.log({"train/agc/clipped_fraction": clipped / max(total, 1),
               "train/agc/lambda": args.agc_lambda}, step=step)
```

### Step 5 — Run 4-arm sweep, 1 GPU each

Each arm uses the PR #99 baseline config, 3 epochs:

```bash
# Arm A — control (no AGC, baseline config)
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --lr-warmup-steps 500 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group alphonse-agc-r6 --seed 42 --epochs 3

# Arm B — AGC λ=0.005
python train.py [same as above] --use-agc --agc-lambda 0.005 \
  --wandb-group alphonse-agc-r6

# Arm C — AGC λ=0.01 (NFNets paper default)
python train.py [same as above] --use-agc --agc-lambda 0.01 \
  --wandb-group alphonse-agc-r6

# Arm D — AGC λ=0.02
python train.py [same as above] --use-agc --agc-lambda 0.02 \
  --wandb-group alphonse-agc-r6
```

W&B group: `alphonse-agc-r6`

### Interpret the results

Key signals to report:
- `train/agc/clipped_fraction` over training — should be low (< 0.05) at steady state
- `train/grad/pre_clip_norm` — expect it to stop spiking above ~50 when AGC is active
- ep3 `val_primary/abupt_axis_mean_rel_l2_pct` — primary metric

If Arm C (λ=0.01) stabilizes training but val metric is still above 10.69, try:
- Combine with 8L/256d depth (askeladd's sandwich-LN PR) to test if the real win
  is unblocking depth rather than changing the 6L baseline
- Try AGC + drop clip_grad_norm entirely (remove the global 1.0 safety net) to
  test pure per-param clipping

## Baseline

Current best: **PR #99 (fern)** · W&B run `3hljb0mg`

| Metric | Baseline (PR #99) | AB-UPT Reference |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 |

To reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
