### PR TITLE
askeladd: sandwich-LN to unlock 8L/256d depth (stability fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -622,6 +622,7 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    lr_warmup_epochs: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1723,6 +1724,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Device: {device}" + (" [DEBUG]" if config.debug else ""))
 
     train_loader, val_loaders, test_loaders, stats = make_loaders(config)
+    if config.lr_warmup_epochs > 0:
+        steps_per_epoch = max(len(train_loader), 1)
+        config.lr_warmup_steps = config.lr_warmup_epochs * steps_per_epoch
+        print(
+            f"LR warmup: {config.lr_warmup_epochs} epoch(s) = "
+            f"{config.lr_warmup_steps} steps (steps_per_epoch={steps_per_epoch})"
+        )
     transform = TargetTransform(
         surface_y_mean=stats["surface_y_mean"].to(device),
         surface_y_std=stats["surface_y_std"].to(device),

--- a/train.py
+++ b/train.py
@@ -210,8 +210,12 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         drop_path_prob: float = 0.0,
+        norm_style: str = "pre-ln",
     ):
         super().__init__()
+        if norm_style not in {"pre-ln", "sandwich-ln"}:
+            raise ValueError(f"norm_style must be 'pre-ln' or 'sandwich-ln', got {norm_style!r}")
+        self.norm_style = norm_style
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
         self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.attention = TransolverAttention(
@@ -222,13 +226,25 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if norm_style == "sandwich-ln":
+            self.norm1_post = nn.LayerNorm(hidden_dim, eps=1e-6)
+            self.norm2_post = nn.LayerNorm(hidden_dim, eps=1e-6)
+        else:
+            self.norm1_post = None
+            self.norm2_post = None
         self.drop_path = DropPath(drop_path_prob)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
+        attn_out = self.attention(self.norm1(x), attn_mask=attn_mask)
+        if self.norm1_post is not None:
+            attn_out = self.norm1_post(attn_out)
+        x = x + self.drop_path(attn_out)
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.drop_path(self.mlp(self.norm2(x)))
+        mlp_out = self.mlp(self.norm2(x))
+        if self.norm2_post is not None:
+            mlp_out = self.norm2_post(mlp_out)
+        x = x + self.drop_path(mlp_out)
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -286,6 +302,7 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
         film_geom_dim: int = 0,
+        norm_style: str = "pre-ln",
     ):
         super().__init__()
         if depth <= 1:
@@ -303,6 +320,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     drop_path_prob=drop_path_rates[i],
+                    norm_style=norm_style,
                 )
                 for i in range(depth)
             ]
@@ -350,6 +368,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        norm_style: str = "pre-ln",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -392,6 +411,7 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
             film_geom_dim=film_encoder_dim if use_film else 0,
+            norm_style=norm_style,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -579,6 +599,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    norm_style: str = "pre-ln"
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -675,7 +696,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    if config.norm_style not in {"pre-ln", "sandwich-ln"}:
+        parser.error(
+            f"--norm-style must be 'pre-ln' or 'sandwich-ln', got {config.norm_style!r}"
+        )
+    return config
 
 
 def autocast_context(device: torch.device, amp_mode: str):
@@ -745,6 +771,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        norm_style=config.norm_style,
     )
 
 


### PR DESCRIPTION
## Hypothesis

8L/256d depth scaling has been tried twice:
- PR #144 (constant lr=5e-4): val_abupt=12.69 — negative
- PR #164 (1cycle lr up to 8e-4): all arms diverged — negative

The failure mode is consistent: pre_clip_norm cascades from O(1) → O(1e9) within
~10k steps at any LR ≥ 5e-4. This suggests the default Transolver block's
post-LN placement allows residual-amplified gradients to compound across depth.

**Sandwich-LN** (also called NormFormer or Double-LN) places a LayerNorm BOTH
before and after each sublayer inside the residual branch:

    h = x + drop( LN_post( sublayer( LN_pre(x) ) ) )

The post-LN inside the residual dampens gradient magnitude before it is added back
to the residual stream, preventing the O(depth) gradient growth that destabilizes
deep transformers. This has been shown to make 16L+ transformers stable without
learning-rate warmup tricks (Shleifer et al. NormFormer 2021, Ding et al. CogView).

**Round 6 result (committed):** 8L/256d sandwich-LN with lr=5e-4, lr_warmup_steps=500,
clip=1.0, bs=4 achieved val_abupt = **9.892%** (W&B `sc24mpqh`), beating the previous 10.69
baseline. Uniformly improved 7/7 test_primary metrics over PR #99. 

**Round 7 (this submission):** New baseline merged on yi (PR #222 fern, lr_warmup_epochs=1
gives val_abupt 9.291% on 4L/512d Lion). New merge bar = **9.291%**. The advisor
recommends pushing to 10L/256d with the new 1-epoch LR warmup schedule.

References:
- Shleifer, Press, Smith "NormFormer: Improved Transformer Pretraining with Extra Normalization" 2021 (https://arxiv.org/abs/2110.09456)
- Ding et al. "CogView" 2021 §3.2 (https://arxiv.org/abs/2105.13290)

## Round-7 instructions (post-rebase, post-PR#222)

### Code changes (already pushed to this branch)

- `--norm-style {pre-ln, sandwich-ln}` — adds the post-sublayer LN inside the residual.
- `--lr-warmup-epochs N` — new flag matching the PR #222 baseline; converts to
  `lr_warmup_steps = N * len(train_loader)` once the data loader is built and
  overrides any explicit `--lr-warmup-steps`.

### Round-7 experiment matrix (single GPU each; 4 GPUs total)

All 4 arms use:
`--norm-style sandwich-ln --pos-max-wavelength 1000 --lr-warmup-epochs 1 --clip-grad-norm 1.0 --ema-decay 0.9995 --batch-size 4 --lr 5e-4 --weight-decay 5e-4 --train-surface-points 65536 --train-volume-points 65536 --eval-surface-points 65536 --eval-volume-points 65536 --validation-every 1 --volume-loss-weight 2.0 --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --epochs 3`

| Arm | depth | seed | role |
|----:|------:|-----:|------|
| 10L-A | 10 | 42 | **Primary** (advisor's preferred path) |
| 10L-B | 10 | 43 | Replicate |
| 8L-A  | 8  | 42 | Control: sandwich-LN + lr_warmup_epochs=1 at 8L |
| 8L-B  | 8  | 43 | Control replicate |

Memory: 10L bs=4 ≈ 64 GB / 96 GB (verified via 200-step smoke). Step rate ≈ 2.5 it/s sustained. Within the 4.5h training timeout the runs reach ~1.7 epochs of 10L training (warmup + partial decay).

W&B group: `askeladd-sandwich-ln-r8`

### Key signals to report

- Per-arm pre_clip_norm median and max over training (cascade detection)
- Epoch-by-epoch val_primary/abupt_axis_mean_rel_l2_pct
- 10L vs 8L delta with the new warmup schedule
- All seven test_primary metrics for the best-val arm

## Baseline

Current best on `yi`: **PR #222 (fern)** · W&B run `ut1qmc3i`
- val_primary/abupt_axis_mean_rel_l2_pct: **9.2910%** (4L/512d, Lion, lr_warmup_epochs=1, 8-GPU torchrun)

Merge bar: **9.291%**. Anything higher does not merge but may unlock the depth-scaling path for follow-up rounds.

Round-6 reference (this PR's prior round, pre-rebase): 8L/256d sandwich-LN val=9.892% (`sc24mpqh`).

## Round-6 history (kept for posterity)

- 4-arm matrix at lr=5e-4, lr_warmup_steps=500: A=8L pre-LN diverged (loss-bounce, max pcn=491), B=8L sandwich-LN bs=4 won at 9.892%, C=6L sandwich-LN regressed vs 6L pre-LN baseline (sandwich-LN is depth-conditional — only beneficial at 8L+), D=8L sandwich-LN+clip=0.5+wu=1000 cascaded systematically across both seeds.
- W&B runs: A=`2ziqqs4w`, **B=`sc24mpqh` (Round-6 winner)**, C=`slu3mfe9`, D_orig=`rqjlhmlr`, D2=`y1lcj70t`.