### PR TITLE
frieren: step-decay LR drop after epoch 1 (ep1→ep2 divergence fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -593,6 +593,8 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    lr_step_epochs: str = ""
+    lr_step_factor: float = 0.2
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1776,10 +1778,32 @@ def main(argv: Iterable[str] | None = None) -> None:
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
 
+    lr_step_epochs = (
+        [int(e) for e in config.lr_step_epochs.split(",") if e.strip()]
+        if config.lr_step_epochs
+        else []
+    )
+
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
             print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
             break
+
+        if epoch in lr_step_epochs:
+            for param_group in optimizer.param_groups:
+                param_group["lr"] *= config.lr_step_factor
+            current_lr = optimizer.param_groups[0]["lr"]
+            print(
+                f"Epoch {epoch}: LR step decay applied "
+                f"(factor={config.lr_step_factor}), new lr={current_lr:.2e}"
+            )
+            wandb.log(
+                {
+                    "train/lr_step_decay": current_lr,
+                    "train/epoch": epoch,
+                    "global_step": global_step,
+                }
+            )
 
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()


### PR DESCRIPTION
## Hypothesis

Every arm in PR #123 showed the same failure: ep1 validation OK (17–46%), then ep2 collapses dramatically higher. This happened with 4 different target normalizations (control, asinh-1.0, log1p, asinh-0.5), ruling out the normalization as the sole cause.

**Root cause hypothesis:** At the end of epoch 1 (~step 10,800), the learning rate is still at 5e-4. The model has learned bulk structure in epoch 1, but the optimizer continues taking large exploratory steps into epoch 2 that overshoot the finer-grained surface structure needed to reduce rel_L2. A sharp LR drop at the epoch 1→2 boundary (step decay from 5e-4 → 1e-4) transitions the optimizer from exploration to exploitation exactly when the model is ready for fine-tuning.

This is the classic ResNet/VGG step-decay pattern: train at high LR until loss plateau, then drop sharply. The hypothesis is that the epoch boundary is precisely the right drop point for our training regime.

This differs from cosine annealing (1cycle PR #164/#191): cosine starts decaying from step 0. Step decay keeps full LR for all of ep1, giving more exploration budget, then drops decisively.

## Instructions

### Step 1 — Add `--lr-step-epochs` and `--lr-step-factor` flags to `train.py`

```python
parser.add_argument("--lr-step-epochs", type=str, default="",
    help="Comma-separated epoch numbers at which to multiply LR by --lr-step-factor. "
         "E.g. '1' drops after epoch 1; '1,2' drops after epoch 1 and again after epoch 2.")
parser.add_argument("--lr-step-factor", type=float, default=0.2,
    help="Multiplicative factor applied to LR at each --lr-step-epoch boundary.")
```

### Step 2 — Apply the step at the start of each new epoch

In the training loop, at the beginning of each epoch (before iterating batches):

```python
lr_step_epochs = [int(e) for e in args.lr_step_epochs.split(",") if e.strip()] if args.lr_step_epochs else []

for epoch in range(args.epochs):
    # Apply LR step decay at epoch boundary
    if epoch in lr_step_epochs:
        for param_group in optimizer.param_groups:
            param_group["lr"] *= args.lr_step_factor
        current_lr = optimizer.param_groups[0]["lr"]
        print(f"Epoch {epoch}: LR step decay applied, new lr={current_lr:.2e}")
        wandb.log({"train/lr_step_decay": current_lr, "train/epoch": epoch})
    # ... rest of training epoch
```

Note: this should fire at the START of epoch `e` (so "epoch 1" means the second epoch, i.e. after completing ep0). If epochs are 0-indexed, "epoch 1" = second training epoch.

### Step 3 — Run 4-arm sweep, 1 GPU each, 3 epochs

```bash
# Arm A — control (no step decay, baseline PR #99 config)
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --lr-warmup-steps 500 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group frieren-lr-drop-r6 --seed 42 --epochs 3

# Arm B — drop after ep1, factor=0.2 (5e-4 → 1e-4)
python train.py [same as above] --lr-step-epochs 1 --lr-step-factor 0.2 \
  --wandb-group frieren-lr-drop-r6

# Arm C — drop after ep1, factor=0.1 (5e-4 → 5e-5, more aggressive)
python train.py [same as above] --lr-step-epochs 1 --lr-step-factor 0.1 \
  --wandb-group frieren-lr-drop-r6

# Arm D — two drops: after ep1 factor=0.3 (→1.5e-4), after ep2 factor=0.3 (→4.5e-5)
python train.py [same as above] --lr-step-epochs 1,2 --lr-step-factor 0.3 \
  --wandb-group frieren-lr-drop-r6
```

W&B group: `frieren-lr-drop-r6`

### Key metrics to report

For each arm at each epoch:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary — must beat 10.69)
- `val_primary/wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` (secondary focus)
- Whether ep1→ep2 train/val divergence is present or absent

The KEY question: does Arm B or C show ep2 val LOWER than ep1 val? If yes, this is the unlock.

If Arm B wins on val but ep3 val regresses (lr too low for continued improvement), try a 3-drop schedule in a follow-up: 5e-4 → 2e-4 → 1e-4 → 5e-5.

## Baseline

Current best: **PR #99 (fern)** · W&B run `3hljb0mg`

| Metric | Baseline (PR #99) | AB-UPT Reference |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 |

To reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
