### PR TITLE
tanjiro: relative grad-skip EMA to fix fleet-wide Adam m/v corruption

### DIFF
--- a/train.py
+++ b/train.py
@@ -593,6 +593,8 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    grad_skip_relative_threshold: float = 0.0
+    grad_skip_ema_beta: float = 0.95
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1770,6 +1772,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_metrics: dict[str, float] = {}
     global_step = 0
     nonfinite_skip_count = 0
+    running_grad_norm_ema: float | None = None
+    relative_skip_count = 0
     early_stop_reason: str | None = None
     timeout_hit = False
     train_start = time.time()
@@ -1838,11 +1842,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                 else {}
             )
             grad_is_finite = True
-            if config.clip_grad_norm > 0:
+            pre_clip_norm_val: float | None = None
+            need_pre_clip_norm = (
+                config.clip_grad_norm > 0
+                or config.grad_skip_relative_threshold > 0
+            )
+            if need_pre_clip_norm:
+                max_n = (
+                    config.clip_grad_norm
+                    if config.clip_grad_norm > 0
+                    else float("inf")
+                )
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
-                    model.parameters(), max_norm=config.clip_grad_norm
+                    model.parameters(), max_norm=max_n
                 )
                 grad_is_finite = bool(torch.isfinite(pre_clip_norm).item())
+                if grad_is_finite:
+                    pre_clip_norm_val = float(pre_clip_norm)
                 if should_log_gradients:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
@@ -1861,6 +1877,43 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
                         f"loss/grad steps; training is structurally broken."
                     )
+                global_step += 1
+                continue
+            relative_skip = False
+            relative_skip_ratio_now: float | None = None
+            if (
+                config.grad_skip_relative_threshold > 0
+                and pre_clip_norm_val is not None
+            ):
+                if running_grad_norm_ema is None:
+                    running_grad_norm_ema = pre_clip_norm_val
+                else:
+                    running_grad_norm_ema = (
+                        config.grad_skip_ema_beta * running_grad_norm_ema
+                        + (1.0 - config.grad_skip_ema_beta) * pre_clip_norm_val
+                    )
+                if (
+                    running_grad_norm_ema > 0
+                    and pre_clip_norm_val
+                    > config.grad_skip_relative_threshold * running_grad_norm_ema
+                ):
+                    relative_skip = True
+                    relative_skip_count += 1
+                    relative_skip_ratio_now = (
+                        pre_clip_norm_val / running_grad_norm_ema
+                    )
+            if relative_skip:
+                optimizer.zero_grad(set_to_none=True)
+                wandb.log(
+                    {
+                        "train/grad/relative_skip": 1,
+                        "train/grad/relative_skip_ratio": relative_skip_ratio_now,
+                        "train/grad/relative_skip_total": relative_skip_count,
+                        "train/grad/relative_skip_pre_clip_norm": pre_clip_norm_val,
+                        "train/grad/running_ema_norm": running_grad_norm_ema,
+                        "global_step": global_step,
+                    }
+                )
                 global_step += 1
                 continue
             if config.lr_warmup_steps > 0:
@@ -1905,10 +1958,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "train/lr": float(optimizer.param_groups[0]["lr"]),
                 "train/nonfinite_skip_count": nonfinite_skip_count,
+                "train/grad/relative_skip": 0,
+                "train/grad/relative_skip_total": relative_skip_count,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
             }
+            if pre_clip_norm_val is not None:
+                train_log.setdefault(
+                    "train/grad/pre_clip_norm", pre_clip_norm_val
+                )
+            if running_grad_norm_ema is not None:
+                train_log["train/grad/running_ema_norm"] = running_grad_norm_ema
+                if pre_clip_norm_val is not None and running_grad_norm_ema > 0:
+                    train_log["train/grad/relative_skip_ratio"] = (
+                        pre_clip_norm_val / running_grad_norm_ema
+                    )
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"


### PR DESCRIPTION
## Hypothesis

PR #169 (thorfinn) added NaN/Inf gradient skip, but **large-but-finite gradient spikes bypass it**. We have confirmed from 4 independent experiments (PRs #123, #168, #165, #164) that:

- pre_clip_norm regularly reaches 165, 252, 2200, 254611 — all finite numbers
- clip_grad_norm=1.0 normalizes the direction but leaves the poison vector intact
- Adam's second moment m₂ (β₂=0.999 ≈ 1000-step half-life) accumulates the wrong-direction estimate and cannot recover quickly
- The fleet has a structural gradient explosion issue that NaN-skip alone does not solve

**The fix:** A relative magnitude-based gradient skip that adapts to each model's training phase automatically. Instead of a fixed absolute threshold (frieren's PR #123 --grad-skip-threshold=1000 was too aggressive at step 0, too permissive at step 2800), we compare the current pre_clip_norm to an exponential moving average of recent norms. If it exceeds N× the EMA, skip the optimizer step entirely.

This is adaptive, unitless, and works across all training phases without manual tuning.

## Instructions

### Step 1 — Add `--grad-skip-relative-threshold` and `--grad-skip-ema-beta` flags to `train.py`

```python
parser.add_argument("--grad-skip-relative-threshold", type=float, default=0.0,
    help="Skip optimizer step if pre_clip_norm > threshold * running_grad_norm_ema. "
         "0.0 = disabled. Recommended: 10.0")
parser.add_argument("--grad-skip-ema-beta", type=float, default=0.95,
    help="EMA beta for the running gradient norm estimate used by relative skip. Default 0.95.")
```

### Step 2 — Implement in the training loop

Add these variables before the training loop:
```python
running_grad_norm_ema = None
relative_skip_count = 0
```

Inside the training loop, after `loss.backward()` and `scaler.unscale_()` (if using AMP), before `clip_grad_norm`:

```python
# Compute pre-clip norm
pre_clip_norm = sum(
    p.grad.data.norm(2).item() ** 2
    for p in model.parameters() if p.grad is not None
) ** 0.5

# Update EMA
if running_grad_norm_ema is None:
    running_grad_norm_ema = pre_clip_norm
else:
    running_grad_norm_ema = (args.grad_skip_ema_beta * running_grad_norm_ema
                             + (1 - args.grad_skip_ema_beta) * pre_clip_norm)

# Relative skip check
skip_step = False
if (args.grad_skip_relative_threshold > 0
        and running_grad_norm_ema > 0
        and pre_clip_norm > args.grad_skip_relative_threshold * running_grad_norm_ema):
    skip_step = True
    relative_skip_count += 1
    optimizer.zero_grad()
    wandb.log({
        "train/grad/relative_skip": 1,
        "train/grad/relative_skip_ratio": pre_clip_norm / running_grad_norm_ema,
        "train/grad/relative_skip_total": relative_skip_count,
    }, step=global_step)
    continue  # skip optimizer.step, scheduler.step, ema.update

# (existing NaN/Inf absolute skip and clip_grad_norm continue here if skip_step is False)
wandb.log({
    "train/grad/running_ema_norm": running_grad_norm_ema,
    "train/grad/pre_clip_norm": pre_clip_norm,
    "train/grad/relative_skip": 0,
}, step=global_step)
```

### Step 3 — Run 4-arm sweep, 1 GPU each, 3 epochs

```bash
# Arm A — control (no relative skip, baseline PR #99 config exactly)
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --lr-warmup-steps 500 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group tanjiro-grad-skip-infra-r6 --seed 42 --epochs 3

# Arm B — relative skip at 5×
python train.py [same as above] --grad-skip-relative-threshold 5.0 \
  --wandb-group tanjiro-grad-skip-infra-r6

# Arm C — relative skip at 10× (recommended starting point)
python train.py [same as above] --grad-skip-relative-threshold 10.0 \
  --wandb-group tanjiro-grad-skip-infra-r6

# Arm D — relative skip at 20×
python train.py [same as above] --grad-skip-relative-threshold 20.0 \
  --wandb-group tanjiro-grad-skip-infra-r6
```

W&B group: `tanjiro-grad-skip-infra-r6`

### Key metrics to report

For each arm at each epoch:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary)
- `train/grad/pre_clip_norm` max value (should be suppressed in arms B-D)
- `train/grad/relative_skip` total count and fraction of steps
- `train/grad/running_ema_norm` trajectory (expect smooth in arms B-D)

**Win condition:** An arm where `train/grad/relative_skip_total` is < 1% of steps AND `pre_clip_norm` never exceeds 100 AND `val_primary/abupt_axis_mean_rel_l2_pct` ≤ 10.69. That threshold becomes the fleet default.

**Note:** This is complementary to frieren's PR #123 --grad-skip-threshold (absolute threshold). The relative version here adapts to training phase; the absolute version is a hard safety ceiling. Both should ideally be used together.

## Baseline

Current best: **PR #99 (fern)** · W&B run `3hljb0mg`

| Metric | Baseline (PR #99) | AB-UPT Reference |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 |

To reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
