### PR TITLE
nezuko: SAM optimizer for flat-minima generalization (tau_y/z gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -593,6 +593,8 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    use_sam: bool = False
+    sam_rho: float = 0.05
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1754,6 +1756,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("train/sam/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
@@ -1821,6 +1824,79 @@ def main(argv: Iterable[str] | None = None) -> None:
                 global_step += 1
                 continue
             loss.backward()
+            sam_first_grad_norm_value: float | None = None
+            sam_loss_perturbed_value: float | None = None
+            if config.use_sam:
+                first_grad_sq = torch.zeros((), device=device, dtype=torch.float32)
+                for p in model.parameters():
+                    if p.grad is not None:
+                        first_grad_sq = first_grad_sq + p.grad.detach().float().pow(2).sum()
+                first_grad_norm = first_grad_sq.sqrt()
+                first_grad_norm_f = float(first_grad_norm.detach().cpu().item())
+                sam_first_grad_norm_value = first_grad_norm_f
+                if not math.isfinite(first_grad_norm_f) or first_grad_norm_f <= 0.0:
+                    optimizer.zero_grad(set_to_none=True)
+                    nonfinite_skip_count += 1
+                    wandb.log(
+                        {
+                            "train/nonfinite_skip_count": nonfinite_skip_count,
+                            "train/nonfinite_skip_kind": 3,
+                            "global_step": global_step,
+                        }
+                    )
+                    if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                        raise RuntimeError(
+                            f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                            f"loss/grad steps; training is structurally broken."
+                        )
+                    global_step += 1
+                    continue
+                eps_w: dict[torch.nn.Parameter, torch.Tensor] = {}
+                scale = config.sam_rho / (first_grad_norm_f + 1e-12)
+                with torch.no_grad():
+                    for p in model.parameters():
+                        if p.grad is not None:
+                            eps = (scale * p.grad).detach().clone().to(p.dtype)
+                            eps_w[p] = eps
+                            p.data.add_(eps)
+                optimizer.zero_grad(set_to_none=True)
+                loss_perturbed, _ = train_loss(
+                    model,
+                    batch,
+                    transform,
+                    device,
+                    config.amp_mode,
+                    surface_loss_weight=config.surface_loss_weight,
+                    volume_loss_weight=config.volume_loss_weight,
+                    aux_rel_l2_weight=config.aux_rel_l2_weight,
+                    use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                    wallshear_y_weight=config.wallshear_y_weight,
+                    wallshear_z_weight=config.wallshear_z_weight,
+                )
+                loss_perturbed_finite = bool(torch.isfinite(loss_perturbed).item())
+                if loss_perturbed_finite:
+                    loss_perturbed.backward()
+                    sam_loss_perturbed_value = float(loss_perturbed.detach().cpu().item())
+                with torch.no_grad():
+                    for p, eps in eps_w.items():
+                        p.data.sub_(eps)
+                if not loss_perturbed_finite:
+                    optimizer.zero_grad(set_to_none=True)
+                    nonfinite_skip_count += 1
+                    wandb.log(
+                        {
+                            "train/nonfinite_skip_count": nonfinite_skip_count,
+                            "train/nonfinite_skip_kind": 4,
+                            "global_step": global_step,
+                        }
+                    )
+                    if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                        raise RuntimeError(
+                            f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                            f"loss/grad steps; training is structurally broken."
+                        )
+                    global_step += 1
+                    continue
             should_log_gradients = (
                 config.gradient_log_every > 0
                 and (global_step + 1) % config.gradient_log_every == 0
@@ -1919,6 +1995,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
+            if config.use_sam:
+                if sam_first_grad_norm_value is not None:
+                    train_log["train/sam/grad_norm_first"] = sam_first_grad_norm_value
+                if sam_loss_perturbed_value is not None:
+                    train_log["train/sam/loss_perturbed"] = sam_loss_perturbed_value
+                    train_log["train/sam/loss_gap"] = (
+                        sam_loss_perturbed_value - float(loss.detach().cpu().item())
+                    )
             for key, value in batch_loss_metrics.items():
                 if key.startswith("film/"):
                     train_log[f"train/{key}"] = value


### PR DESCRIPTION
## Hypothesis

The current best model (val 10.69, PR #99) likely sits in a sharp loss minimum — it
has been trained at a high learning rate (5e-4) with AdamW's momentum pulling toward
the flattest direction in the curvature landscape, which may not coincide with flat
minima in weight space. Sharp minima overfit to the specific 500 training geometries
and generalize poorly to the 50 validation geometries.

**Sharpness-Aware Minimization (SAM, Foret et al. 2021)** explicitly penalizes
sharpness by seeking weights in flat loss neighborhoods:

    min_{w} max_{||ε||≤ρ} L(w + ε)  ≈ min_{w} L(w + ρ · ∇L/||∇L||)

For each step, SAM: (1) computes gradient, (2) perturbs weights to the steepest
nearby point, (3) computes gradient at the perturbed point, (4) restores weights,
(5) applies the perturbed gradient via optimizer. The result is a gradient that
minimizes the worst-case loss in a ρ-ball around the current weights.

For DrivAerML specifically:
- 500 train vs 50 val geometries — small dataset, sharp minima expected
- tau_y/z channels are the most shape-dependent — SAM's flat-minima bias should
  particularly help generalization from seen to unseen geometries
- Zero VRAM overhead; ~2× compute per step (two forward+backward passes)

Reference: Foret et al. "Sharpness-Aware Minimization for Efficiently Improving
Generalization" ICLR 2021 (https://arxiv.org/abs/2010.01412)

## Instructions

### Step 1 — Add `--use-sam` and `--sam-rho` flags to `train.py`

```python
parser.add_argument("--use-sam", action="store_true", default=False,
    help="Use Sharpness-Aware Minimization (SAM) optimizer wrapper")
parser.add_argument("--sam-rho", type=float, default=0.05,
    help="SAM perturbation radius ρ (rho). Paper recommends 0.05-0.1 for AdamW.")
```

### Step 2 — Implement SAM in the training loop

Replace (or wrap) the existing training step with:

```python
if args.use_sam:
    # === SAM First Pass: compute gradient and find perturbation direction ===
    # (loss already computed, don't backward twice if you can help it)
    loss.backward()
    # Compute gradient norm for normalizing perturbation
    grad_norm = torch.sqrt(sum(
        p.grad.data.norm(2) ** 2
        for p in model.parameters() if p.grad is not None
    )).clamp(min=1e-12)
    # Save and apply perturbation: w_perturb = w + rho * grad / ||grad||
    eps_w = {}
    for p in model.parameters():
        if p.grad is not None:
            eps = (args.sam_rho / grad_norm) * p.grad.data
            eps_w[p] = eps
            p.data.add_(eps)
    optimizer.zero_grad()

    # === SAM Second Pass: compute gradient at perturbed weights ===
    # Re-forward at perturbed weights (same batch)
    outputs_perturbed = model(surface_x, surface_pos, volume_x, volume_pos, ...)  # match your call signature
    loss_perturbed = compute_total_loss(outputs_perturbed, targets, ...)
    loss_perturbed.backward()

    # Restore original weights
    for p in model.parameters():
        if p in eps_w:
            p.data.sub_(eps_w[p])

    # Apply clip and optimizer step using the perturbed-point gradient
    if args.clip_grad_norm:
        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
    optimizer.step()
    optimizer.zero_grad()

else:
    # Standard path (unchanged)
    loss.backward()
    if args.clip_grad_norm:
        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
    optimizer.step()
    optimizer.zero_grad()
```

**Important implementation notes:**
- The EMA update (`ema.update(model.parameters())`) should happen AFTER `optimizer.step()`, same as in the standard path. The restored weights are what the EMA should track.
- LR warmup, scheduler step, and W&B gradient logging should all happen on the `optimizer.step()` call count, not the `loss.backward()` call count.
- The `eps_w` dict stores the perturbation per-parameter — don't store gradients here (they change at the second pass).
- If you use AMP (`scaler`), apply `scaler.unscale_()` before computing `grad_norm` in the first pass, and call `scaler.step(optimizer)` + `scaler.update()` in the second pass.

### Step 3 — Run 4-arm sweep, 1 GPU each

SAM takes ~2× wall clock per epoch. Use `--epochs 2` for SAM arms (Arm B/C/D) to fit
in the ~270 min training budget:

```bash
# Arm A — control (no SAM, baseline PR #99 config, 3 epochs)
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --lr-warmup-steps 500 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group nezuko-sam-r6 --seed 42 --epochs 3

# Arm B — SAM rho=0.05 (paper default for AdamW), 2 epochs
python train.py [same flags] --use-sam --sam-rho 0.05 \
  --epochs 2 --wandb-group nezuko-sam-r6

# Arm C — SAM rho=0.10 (stronger sharpness penalty), 2 epochs
python train.py [same flags] --use-sam --sam-rho 0.10 \
  --epochs 2 --wandb-group nezuko-sam-r6

# Arm D — SAM rho=0.02 (gentle perturbation), 2 epochs
python train.py [same flags] --use-sam --sam-rho 0.02 \
  --epochs 2 --wandb-group nezuko-sam-r6
```

W&B group: `nezuko-sam-r6`

### Key metrics to report

For each arm:
- `val_primary/abupt_axis_mean_rel_l2_pct` at each epoch (primary — must beat 10.69)
- `val_primary/wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` (secondary focus)
- Wall-clock time per epoch (confirm ~2× slowdown vs control arm A)
- `train/grad/pre_clip_norm` — SAM should produce smoother gradients overall

**If SAM ep2 val is < control ep3 val (10.69):** that is a win. The test is whether
2 SAM epochs of high-quality flat-minima training beat 3 epochs of sharp-minima training.

**If SAM is stable but val is still > 10.69 at ep2:** try rho=0.15 or 0.20 in a
follow-up, or SAM + gradient accumulation (eff_bs=32) to give SAM richer
gradient signals.

## Baseline

Current best: **PR #99 (fern)** · W&B run `3hljb0mg`

| Metric | Baseline (PR #99) | AB-UPT Reference |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | — |
| `surface_pressure_rel_l2_pct` | 6.97 | 3.82 |
| `wall_shear_rel_l2_pct` | 11.69 | 7.29 |
| `volume_pressure_rel_l2_pct` | 7.85 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 13.73 | 3.65 |
| `wall_shear_z_rel_l2_pct` | 14.73 | 3.63 |

To reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```
