### PR TITLE
fern: learned Fourier embeddings for tau_y/z gap (per-axis freq learning)

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,6 +124,33 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class LearnedFourierEmbed(nn.Module):
+    """Learned Fourier positional embedding: replaces fixed sincos grid with a
+    learned linear projection W: R^{coord_dim} -> R^{hidden_dim//2}, output
+    is [sin(W x), cos(W x)] concatenated along the feature dim.
+
+    W is initialized from N(0, std) where std = init_scale / sqrt(hidden_dim).
+    For hidden_dim=256 and meter-scale coords (vehicle bbox ~8m), init_scale
+    in [10, 32] gives phase angles of order 2-8 rad at edges (Tancik 2020).
+    """
+
+    def __init__(self, hidden_dim: int, coord_dim: int = 3, init_scale: float = 10.0):
+        super().__init__()
+        if hidden_dim % 2 != 0:
+            raise ValueError("LearnedFourierEmbed requires an even hidden_dim")
+        self.hidden_dim = hidden_dim
+        self.coord_dim = coord_dim
+        self.init_scale = float(init_scale)
+        self.W = nn.Linear(coord_dim, hidden_dim // 2, bias=False)
+        std = self.init_scale / (hidden_dim ** 0.5)
+        nn.init.normal_(self.W.weight, mean=0.0, std=std)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        proj = self.W(coords)
+        return torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -350,6 +377,8 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        use_learned_fourier_embed: bool = False,
+        learned_fourier_init_scale: float = 10.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,12 +391,21 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.use_learned_fourier_embed = use_learned_fourier_embed
+        self.learned_fourier_init_scale = float(learned_fourier_init_scale)
 
-        self.pos_embed = ContinuousSincosEmbed(
-            hidden_dim=n_hidden,
-            input_dim=space_dim,
-            max_wavelength=pos_max_wavelength,
-        )
+        if use_learned_fourier_embed:
+            self.pos_embed = LearnedFourierEmbed(
+                hidden_dim=n_hidden,
+                coord_dim=space_dim,
+                init_scale=learned_fourier_init_scale,
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -579,6 +617,8 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    use_learned_fourier_embed: bool = False
+    learned_fourier_init_scale: float = 10.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -745,6 +785,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        use_learned_fourier_embed=config.use_learned_fourier_embed,
+        learned_fourier_init_scale=config.learned_fourier_init_scale,
     )
 
 
@@ -1068,6 +1110,49 @@ def collect_weight_metrics(
     if log_histograms and finite_weight_chunks:
         metrics["train/weight_hist/all"] = wandb.Histogram(torch.cat(finite_weight_chunks).numpy())
 
+    return metrics
+
+
+def collect_learned_fourier_metrics(model: nn.Module) -> dict[str, float | wandb.Histogram]:
+    """Per-axis frequency statistics of any LearnedFourierEmbed in the model.
+
+    Reports mean magnitude of W per axis (to see if the model emphasizes
+    one coordinate axis over another), the std of W (frequency spread),
+    and effective rank of W.
+    """
+
+    base_model = getattr(model, "_orig_mod", model)
+    metrics: dict[str, float | wandb.Histogram] = {}
+    for name, module in base_model.named_modules():
+        if not isinstance(module, LearnedFourierEmbed):
+            continue
+        with torch.no_grad():
+            W = module.W.weight.detach().float()  # [d_model//2, coord_dim]
+            prefix = f"train/learned_fourier/{name or 'pos_embed'}"
+            metrics[f"{prefix}/W_std"] = float(W.std().item())
+            metrics[f"{prefix}/W_abs_mean"] = float(W.abs().mean().item())
+            metrics[f"{prefix}/W_abs_max"] = float(W.abs().max().item())
+            for axis_idx in range(W.shape[1]):
+                axis_name = ["x", "y", "z"][axis_idx] if W.shape[1] <= 3 else f"a{axis_idx}"
+                col = W[:, axis_idx]
+                metrics[f"{prefix}/W_axis_{axis_name}_abs_mean"] = float(col.abs().mean().item())
+                metrics[f"{prefix}/W_axis_{axis_name}_std"] = float(col.std().item())
+                metrics[f"{prefix}/W_axis_{axis_name}_norm"] = float(col.norm().item())
+            try:
+                S = torch.linalg.svdvals(W)
+                S2 = (S ** 2)
+                p = S2 / (S2.sum() + 1e-12)
+                eff_rank = float(torch.exp(-(p * (p.clamp_min(1e-12)).log()).sum()).item())
+                metrics[f"{prefix}/W_effective_rank"] = eff_rank
+                metrics[f"{prefix}/W_singular_max"] = float(S[0].item())
+                metrics[f"{prefix}/W_singular_min"] = float(S[-1].item())
+            except Exception:
+                pass
+            metrics[f"{prefix}/W_hist"] = wandb.Histogram(W.cpu().numpy())
+            row_norms = W.norm(dim=1)
+            metrics[f"{prefix}/W_row_norm_mean"] = float(row_norms.mean().item())
+            metrics[f"{prefix}/W_row_norm_std"] = float(row_norms.std().item())
+            metrics[f"{prefix}/W_row_norm_hist"] = wandb.Histogram(row_norms.cpu().numpy())
     return metrics
 
 
@@ -1762,6 +1847,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_type/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
+    wandb.define_metric("train/learned_fourier/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
@@ -2026,6 +2112,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         for split_name, metrics in val_metrics.items():
             for key, value in metrics.items():
                 log_metrics[f"val/{split_name}/{key}"] = value
+        log_metrics.update(collect_learned_fourier_metrics(model))
         log_metrics.update(
             val_slope_tracker.update(
                 global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Learned per-axis Fourier features will close the wall_shear_y/z gap** by replacing the fixed `ContinuousSincosEmbed` with a learned linear projection that maps (x, y, z) coordinates into a high-dimensional frequency space — allowing the network to discover the optimal per-axis frequency bands rather than using the fixed sinusoidal grid.

**Core motivation:** The coordinate anisotropy problem (x~8m, y/z~2m in DrivAerML) means the current fixed `pos_max_wavelength=1000` encoding is still frequency-resolution-limited on y and z relative to x. The PR #183 omega-bank sweep proved that per-axis frequency tuning matters — but it still used a fixed grid. A learned linear Fourier projection lets the model find the right frequency distribution _automatically_, with zero hand-tuning.

**Technical mechanism:**  
Replace `ContinuousSincosEmbed` (which computes `sin(x/λ_k)`, `cos(x/λ_k)` for a fixed bank of λ) with a `LearnedFourierEmbed` that:
1. Applies a learned `Linear(3, d_model//2)` projection: `B = W @ [x, y, z]^T` where W is learned
2. Outputs `[sin(B), cos(B)]` concatenated → same `d_model`-dim output shape
3. Initializes W from `N(0, 1.0 / (2π * pos_max_wavelength / sqrt(d_model)))` to match the scale of the existing fixed encoding at the start of training

This is the "Random Fourier Features" concept (Rahimi & Recht 2007) but with W **learned** rather than fixed-random. Benbarka et al. 2022 ("Seeing Far in the Dark with Patterned Flash Illumination") and Tancik et al. 2020 ("Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains") both show learned FF significantly beats fixed FF for spatial regression tasks — which is exactly what CFD surface prediction is.

**Why this won't break the existing baseline:** W is initialized to mimic the current encoding's frequency scale (so epoch 0 performance ≈ current baseline), then the network learns to redistribute frequencies over training. This is lower risk than a completely new architecture.

## Instructions

In `target/train.py`, find the `ContinuousSincosEmbed` class (or wherever the positional embedding is defined) and add a `LearnedFourierEmbed` alternative:

```python
class LearnedFourierEmbed(nn.Module):
    """Learned Fourier positional embedding: replaces fixed sincos grid with a
    learned linear projection W: R^3 -> R^{d//2}, output = [sin(Wx), cos(Wx)]."""
    def __init__(self, d_model: int, coord_dim: int = 3, init_scale: float = 1.0):
        super().__init__()
        # W maps coordinates to d//2 frequencies
        self.W = nn.Linear(coord_dim, d_model // 2, bias=False)
        # Init to mimic existing fixed encoding at scale ~1/pos_max_wavelength
        nn.init.normal_(self.W.weight, std=init_scale / (d_model ** 0.5))

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: [..., coord_dim]  →  output: [..., d_model]
        proj = self.W(x)   # [..., d//2]
        return torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)
```

Add a CLI flag `--use-learned-fourier-embed` (boolean, default False). When set, replace the `ContinuousSincosEmbed` with `LearnedFourierEmbed(d_model=args.model_hidden_dim, init_scale=args.learned_fourier_init_scale)`. Also add `--learned-fourier-init-scale` (float, default 1.0).

**Sweep plan — 4 arms, one per GPU:**

| Arm | Flag | init_scale | Notes |
|-----|------|-----------|-------|
| A (control) | `--pos-max-wavelength 1000` (no learned FF) | — | Baseline replication |
| B | `--use-learned-fourier-embed --learned-fourier-init-scale 1.0` | 1.0 | Neutral init |
| C | `--use-learned-fourier-embed --learned-fourier-init-scale 0.1` | 0.1 | Tighter init (higher initial freqs) |
| D | `--use-learned-fourier-embed --learned-fourier-init-scale 10.0` | 10.0 | Wider init (lower initial freqs) |

All arms use the full PR #183 base config with `--lr-warmup-steps 500` and `--wandb-group fern-learned-ff-r13`.

**Full reproduce command (arm B — recommended primary):**

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --lr-warmup-steps 500 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --use-learned-fourier-embed \
  --learned-fourier-init-scale 1.0 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group fern-learned-ff-r13
```

## Baseline (PR #183, W&B run `bplngfyo`)

| Metric | Current best (val) |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.21** |
| `surface_pressure_rel_l2_pct` | 6.85 |
| `wall_shear_rel_l2_pct` | 11.43 |
| `volume_pressure_rel_l2_pct` | 6.32 |
| `wall_shear_x_rel_l2_pct` | 9.89 |
| `wall_shear_y_rel_l2_pct` | 13.47 |
| `wall_shear_z_rel_l2_pct` | 14.52 |

AB-UPT targets: surface_pressure 3.82 | wall_shear 7.29 | vol_pressure 6.08 | ws_x 5.35 | ws_y 3.65 | ws_z 3.63

**Win criterion:** Best arm beats val `abupt_axis_mean_rel_l2_pct` < 10.21 AND shows disproportionate tau_y/z improvement (>10% relative gain on ws_y/ws_z vs <5% on surface_pressure). The init_scale sweep will reveal whether the model prefers high-frequency or low-frequency initial features.

## Expected outcome

The frequency-learning hypothesis predicts that W converges to emphasize y and z axes more than x (since they have finer shear gradients), effectively performing per-axis coordinate normalization that the fixed encoding cannot do. If successful, this is a low-complexity, permanent improvement: the learned W adds only 3×(d//2) = 384 parameters.
