### PR TITLE
haku: left-right symmetry augmentation for tau_y/z gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,9 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    use_symmetry_augmentation: bool = False
+    symmetry_flip_prob: float = 0.5
+    symmetry_include_both: bool = False
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1300,6 +1303,65 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def _flip_y_inplace(batch: SurfaceBatch) -> SurfaceBatch:
+    """Reflect a batch through the y=0 plane.
+
+    surface_x layout: [x, y, z, nx, ny, nz, area] — flip y (idx 1) and ny (idx 4).
+    volume_x layout:  [x, y, z, sdf]              — flip y (idx 1).
+    surface_y layout: [cp, tau_x, tau_y, tau_z]   — flip tau_y (idx 2).
+    volume_y layout:  [p_v]                       — unchanged (scalar).
+    """
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = -surface_x[..., 1]
+    surface_x[..., 4] = -surface_x[..., 4]
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = -volume_x[..., 1]
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = -surface_y[..., 2]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
+def maybe_apply_symmetry_augmentation(
+    batch: SurfaceBatch,
+    *,
+    use_augmentation: bool,
+    flip_prob: float,
+    include_both: bool,
+) -> tuple[SurfaceBatch, str]:
+    """Optionally apply y-axis reflection augmentation to a training batch.
+
+    Returns the (possibly augmented) batch and a string label describing what
+    was applied this step ('off' / 'orig' / 'flip' / 'both').
+    """
+    if not use_augmentation:
+        return batch, "off"
+    if include_both:
+        flipped = _flip_y_inplace(batch)
+        combined = SurfaceBatch(
+            case_ids=list(batch.case_ids) + list(flipped.case_ids),
+            surface_x=torch.cat([batch.surface_x, flipped.surface_x], dim=0),
+            surface_y=torch.cat([batch.surface_y, flipped.surface_y], dim=0),
+            surface_mask=torch.cat([batch.surface_mask, flipped.surface_mask], dim=0),
+            volume_x=torch.cat([batch.volume_x, flipped.volume_x], dim=0),
+            volume_y=torch.cat([batch.volume_y, flipped.volume_y], dim=0),
+            volume_mask=torch.cat([batch.volume_mask, flipped.volume_mask], dim=0),
+            metadata=list(batch.metadata) + list(flipped.metadata),
+        )
+        return combined, "both"
+    if torch.rand(1).item() < flip_prob:
+        return _flip_y_inplace(batch), "flip"
+    return batch, "orig"
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1798,6 +1860,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            batch, symm_label = maybe_apply_symmetry_augmentation(
+                batch,
+                use_augmentation=config.use_symmetry_augmentation,
+                flip_prob=config.symmetry_flip_prob,
+                include_both=config.symmetry_include_both,
+            )
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1810,6 +1878,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+            )
+            batch_loss_metrics["symmetry_aug_applied"] = (
+                1.0 if symm_label == "flip" else (2.0 if symm_label == "both" else 0.0)
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())


### PR DESCRIPTION
## Hypothesis

**Left-right (y-axis) symmetry augmentation will reduce tau_y/z errors by providing more consistent cross-flow training signal and effectively doubling training data coverage.**

DrivAerML vehicles have approximate bilateral symmetry about the x-z plane (y=0). However, the dataset contains both left-hand and right-hand examples of the same configuration, meaning the model currently learns tau_y and tau_z from a sample-limited distribution. By reflecting each training sample through the y=0 plane (negating all y-coordinates, flipping the sign of tau_y and all y-component quantities) and presenting the reflected version as an additional training example, we:

1. **Double effective training examples** with no extra GPU memory cost (augment on-the-fly)
2. **Force the model to learn symmetric physical laws** — which are exactly correct for tau_y/z (cross-flow shear is antisymmetric under left-right reflection)
3. **Reduce sampling variance for rare geometric configurations** (asymmetric features like exhaust pipes, side vents) that currently bias tau_y training

**Physical grounding:** Under reflection y → −y:
- Surface point coordinates: `(x, y, z) → (x, -y, z)`
- Surface normals: `(nx, ny, nz) → (nx, -ny, nz)`
- Pressure `p_s`, volume pressure `p_v`: **unchanged** (scalar, symmetric)
- Wall shear: `(tau_x, tau_y, tau_z) → (tau_x, -tau_y, tau_z)` — only tau_y flips sign

This is an exact physical symmetry, not an approximation. Using it as augmentation cannot hurt the model's physics — it can only help by providing more consistent gradient signal for the anti-symmetric tau_y component.

**Reference:** Symmetry augmentation is standard in point-cloud learning (PointNet, DGCNN) and CFD surrogate literature. For vector field prediction specifically, equivariant augmentation is known to accelerate convergence on directional outputs — which is exactly what tau_y/z are.

## Instructions

In `target/train.py`, add left-right (y-axis) symmetry augmentation to the **training** data pipeline only (NOT eval/test):

1. Add a CLI flag `--use-symmetry-augmentation` (boolean, default False).

2. In the training loop (after loading each batch but before the forward pass), with probability 0.5 flip the batch through the y=0 plane:

```python
if args.use_symmetry_augmentation and torch.rand(1).item() < 0.5:
    # Flip y coordinates of surface and volume points
    # surface_x shape: [B, N_surf, 3+] where dim 1 = y coord
    surface_x = surface_x.clone()
    surface_x[..., 1] = -surface_x[..., 1]  # negate y coordinate
    
    # If surface normals are present as additional features, negate their y component too
    # (check where normals are stored in the feature vector and negate normal_y)
    
    volume_x = volume_x.clone()
    volume_x[..., 1] = -volume_x[..., 1]  # negate y coordinate
    
    # Flip targets: tau_y (surface_y index 1) changes sign, others unchanged
    # surface targets shape: [B, N, 4] = [p_s, tau_x, tau_y, tau_z]
    surface_targets = surface_targets.clone()
    surface_targets[..., 2] = -surface_targets[..., 2]  # negate tau_y (index 2)
    # volume targets (p_v) are unchanged — pressure is symmetric
```

3. **IMPORTANT:** Look at the actual feature/target tensor layouts in `train.py` before implementing — verify which indices correspond to y-coordinates, y-normals, and tau_y. The indices above are approximate; match them to the actual code.

4. **Eval sampling remains UNAUGMENTED** — eval must be on real data for fair metric comparison.

**Sweep plan — 4 arms, one per GPU:**

| Arm | Flag | flip_prob | Notes |
|-----|------|-----------|-------|
| A (control) | no augmentation | 0.0 | Baseline replication with warmup=500 |
| B | `--use-symmetry-augmentation` | 0.5 (default) | Standard random flip |
| C | `--use-symmetry-augmentation` (always flip) | 1.0 | Use reflected version of every sample AND original (double batch cost, halve batch size to 4) |
| D | `--use-symmetry-augmentation` | 0.5 + higher y/z weights W_y=3, W_z=3 | Combined augmentation + loss weight |

All arms use the full PR #183 base config with `--lr-warmup-steps 500` and `--wandb-group haku-symm-aug-r13`.

**Full reproduce command (Arm B — primary recommendation):**

```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 \
  --batch-size 8 \
  --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --lr-warmup-steps 500 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 \
  --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --pos-max-wavelength 1000 \
  --use-symmetry-augmentation \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
  --wandb-group haku-symm-aug-r13
```

**Implementation note for Arm C:** If running always-flip (p=1.0), present each sample twice per optimizer step — original and reflected — by doubling the dataset with augmented copies and halving batch size to keep GPU memory constant: `--batch-size 4`.

## Baseline (PR #183, W&B run `bplngfyo`)

| Metric | Current best (val) | AB-UPT target | Ratio |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **10.21** | — | — |
| `surface_pressure_rel_l2_pct` | 6.85 | 3.82 | 1.8× |
| `wall_shear_rel_l2_pct` | 11.43 | 7.29 | 1.6× |
| `volume_pressure_rel_l2_pct` | 6.32 | 6.08 | 1.0× |
| `wall_shear_x_rel_l2_pct` | 9.89 | 5.35 | 1.8× |
| `wall_shear_y_rel_l2_pct` | **13.47** | **3.65** | **3.7×** |
| `wall_shear_z_rel_l2_pct` | **14.52** | **3.63** | **4.0×** |

**Win criterion:** Best arm beats val `abupt_axis_mean_rel_l2_pct` < 10.21 AND shows disproportionate tau_y improvement (since the flip targets tau_y directly). Even a 5% improvement on tau_y would be significant. Report all 7 val metrics for each arm.

**Note:** If you discover the DrivAerML dataset already provides paired left/right samples, report this — it would mean augmentation is redundant but the finding is still valuable for understanding dataset structure.
