### PR TITLE
edward: OHEM hard surface-point weighting for tau_y/z gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    ohem_fraction: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1288,6 +1289,56 @@ def weighted_masked_mse_per_channel(
     return weighted_loss, per_axis_mean
 
 
+def ohem_wall_shear_loss(
+    ws_pred: torch.Tensor,      # [B, N, 3] wall-shear prediction (normalized)
+    ws_true: torch.Tensor,      # [B, N, 3] wall-shear target (normalized)
+    mask: torch.Tensor,         # [B, N] bool
+    ohem_fraction: float = 0.5,
+    channel_weights: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> torch.Tensor:
+    """OHEM (Online Hard Example Mining) loss for wall-shear channels.
+
+    Selects the top `ohem_fraction` of surface points per batch element by
+    *unweighted* per-point mean squared error across the 3 ws channels (so
+    per-channel upweighting in the loss does not bias selection — see
+    S-OHEM, Li et al. 2017, arXiv:1705.02233). Hard-point contributions are
+    upweighted by 1/ohem_fraction. The loss scale matches
+    weighted_masked_mse_per_channel on the same 3 channels exactly when
+    ohem_fraction == 1.0; for ohem_fraction < 1.0 the loss equals the
+    standard ws MSE multiplied by the hard-set concentration factor
+    (typically 1.5-2x), giving a clean knob to focus gradient on hard
+    regions without inflating surface-vs-volume balance.
+
+    ws_pred, ws_true: [B, N, 3]. mask: [B, N] bool. Returns a scalar tensor.
+    """
+    sq_err = (ws_pred.float() - ws_true.float()).square()  # [B, N, 3]
+    w = torch.tensor(channel_weights, device=sq_err.device, dtype=sq_err.dtype)
+    sq_err_weighted = sq_err * w  # [B, N, 3]
+    N = ws_pred.shape[1]
+    if N == 0 or not bool(mask.any()):
+        return ws_pred.sum() * 0.0
+    n_channels = sq_err.shape[-1]
+    # Selection by unweighted priority (no channel bias)
+    priority = sq_err.mean(dim=-1)  # [B, N]
+    priority_masked = priority.masked_fill(~mask, float('-inf'))
+    N_valid = mask.float().sum(dim=-1).long()  # [B]
+    k = (N_valid.float() * ohem_fraction).long().clamp(min=1)  # [B]
+    # Per-element threshold via sort+gather avoids the variable-k topk issue
+    # across batch items (with a uniform topk over k.max(), batch elements
+    # with smaller N_valid would have -inf in their topk window and end up
+    # selecting all of their valid points).
+    sorted_priority, _ = priority_masked.sort(dim=-1, descending=True)  # [B, N]
+    k_idx = (k - 1).clamp(min=0, max=N - 1)  # [B]
+    topk_val = sorted_priority.gather(1, k_idx.unsqueeze(1))  # [B, 1]
+    hard_mask = mask & (priority_masked >= topk_val)  # [B, N]
+    # Hard-point upweight by 1/ohem_fraction; divide by total valid points * n_channels
+    # to keep the same scale as weighted_masked_mse_per_channel at f=1.
+    hard_weight = hard_mask.float() / ohem_fraction  # [B, N]
+    weighted_sum = (sq_err_weighted * hard_weight.unsqueeze(-1)).sum()  # scalar
+    n_valid_total = mask.float().sum().clamp_min(1)
+    return weighted_sum / (n_valid_total * n_channels)
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1313,6 +1364,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    ohem_fraction: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1352,12 +1404,52 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
-            surface_pred_used,
-            surface_target_used,
-            batch.surface_mask,
-            channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
-        )
+        if ohem_fraction < 1.0:
+            # OHEM on the wall-shear channels (1:4) only; cp (channel 0) keeps its
+            # standard contribution. The cp and ws sub-losses are rescaled so that
+            # at ohem_fraction=1.0 the sum exactly equals the standard 4-channel
+            # weighted_masked_mse_per_channel (clean numerical control vs. Arm D),
+            # and at ohem_fraction<1.0 only the ws portion is amplified by the
+            # hard-set concentration factor (~1.5-2x for top-50%). This keeps the
+            # surface-vs-volume balance intact and isolates the OHEM effect.
+            #
+            # Standard 4ch weighted MSE = (cp_term + ws_term) / (N * 4) where each
+            # `*_term` is the unnormalized weighted SSE. So:
+            #   cp_term/(4N) = (1/4) * masked_mse(cp_pred, cp_true, mask)
+            #   ws_term/(4N) = (3/4) * weighted_masked_mse_per_channel(ws_pred,
+            #                          ws_true, mask, w_ws) on 3 channels
+            # which at f=1 sums to the standard 4ch loss. ohem_wall_shear_loss
+            # has the 3-channel weighted_masked_mse_per_channel scale at f=1
+            # (and `concentration` x that at f<1).
+            cp_unscaled = masked_mse(
+                surface_pred_used[..., :1],
+                surface_target_used[..., :1],
+                batch.surface_mask,
+            )
+            ws_unscaled = ohem_wall_shear_loss(
+                surface_pred_used[..., 1:4],
+                surface_target_used[..., 1:4],
+                batch.surface_mask,
+                ohem_fraction=ohem_fraction,
+                channel_weights=(1.0, wallshear_y_weight, wallshear_z_weight),
+            )
+            cp_loss = cp_unscaled * 0.25  # 1/n_total_channels (cp share in 4ch)
+            ws_ohem_loss = ws_unscaled * 0.75  # n_ws_channels/n_total_channels
+            surface_loss = cp_loss + ws_ohem_loss
+            # Compute unweighted per-axis diagnostics over all points (no OHEM applied)
+            _, per_axis_unweighted = weighted_masked_mse_per_channel(
+                surface_pred_used,
+                surface_target_used,
+                batch.surface_mask,
+                channel_weights=(1.0, 1.0, 1.0, 1.0),
+            )
+        else:
+            surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
+                surface_pred_used,
+                surface_target_used,
+                batch.surface_mask,
+                channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+            )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
         aux_rel_l2_value: float | None = None
@@ -1380,6 +1472,8 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if ohem_fraction < 1.0:
+        metrics["ohem_fraction"] = ohem_fraction
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1810,6 +1904,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                ohem_fraction=config.ohem_fraction,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())


### PR DESCRIPTION
## Hypothesis

The wall-shear y/z gap (tau_y: 13.47 vs AB-UPT 3.65, tau_z: 14.52 vs 3.63) suggests the model consistently struggles with specific surface regions — the lateral/vertical panels where tau_y and tau_z are high-frequency and high-magnitude. With uniform random sampling of 65k/~350k points (~18% coverage), there is no guarantee that the model sees adequate coverage of the hardest surface regions each step.

**Hypothesis:** Online Hard Example Mining (OHEM) at the surface-point level can force the model to concentrate gradient on the highest-error points without changing the total number of surface points or any architecture parameters. Concretely: after the forward pass, select the `top_k_fraction` of surface points with the highest per-point squared wall-shear error and upweight their contribution to the loss. This is a free per-step focus mechanism that requires no change to the data loader.

OHEM is well-established in object detection (Shrivastava et al., 2016 — "Training Region-based Object Detectors with Online Hard Example Mining") and has been applied to point cloud segmentation (PointNet++, Tang et al., 2020). The mechanism is directly applicable here: the per-point loss is already computed before aggregation, so selecting hard points is a minimal surgery.

**Key distinction from thorfinn PR #193 (curvature-biased sampling):** Curvature sampling changes *which* points are loaded from disk. OHEM changes *which* loaded points dominate the gradient. They are orthogonal mechanisms — curvature sampling ensures high-curvature regions are represented; OHEM ensures the hardest points (wherever they are) drive training.

## Instructions

**Overview:** Add a `--ohem-fraction` flag. When set, compute per-point wall-shear squared errors after the forward pass, select the top fraction of hardest points per-batch, and upweight their loss contribution by inverse-fraction (so total loss scale is preserved).

**Step 1: Modify `weighted_masked_mse_per_channel` or add a new OHEM helper.**

Add a new function after the existing loss utilities:

```python
def ohem_wall_shear_loss(
    ws_pred: torch.Tensor,      # [B, N, 3] wall-shear prediction (normalized)
    ws_true: torch.Tensor,      # [B, N, 3] wall-shear target (normalized)
    mask: torch.Tensor,         # [B, N] bool
    ohem_fraction: float = 0.5, # fraction of hard points to select (0 < f <= 1)
    channel_weights: tuple[float, float, float] = (1.0, 1.0, 1.0),
) -> torch.Tensor:
    """OHEM wall-shear loss: select top-ohem_fraction hardest surface points and
    upweight their contribution so total loss scale is preserved.

    Hard = highest per-point mean squared error across tau_x, tau_y, tau_z channels.
    """
    # Per-point squared error [B, N, 3]
    sq_err = (ws_pred.float() - ws_true.float()).square()
    # Per-channel weighted version for loss computation [B, N, 3]
    w = torch.tensor(channel_weights, device=sq_err.device, dtype=sq_err.dtype)
    sq_err_weighted = sq_err * w
    # Per-point scalar priority = unweighted mean sq error [B, N]
    priority = sq_err.mean(dim=-1)  # use raw error for selection (no channel bias)
    priority = priority.masked_fill(~mask, float('-inf'))
    # Select top-k indices per batch element
    N_valid = mask.float().sum(dim=-1).long()  # [B] number of valid points
    k = (N_valid.float() * ohem_fraction).long().clamp(min=1)  # [B] points to select
    # Build hard-point mask: for each batch element, keep top-k priority points
    topk_val = torch.topk(priority, k=k.max().item(), dim=-1, sorted=False).values.min(dim=-1, keepdim=True).values
    hard_mask = mask & (priority >= topk_val)  # [B, N]
    # Scale: upweight by 1/ohem_fraction so total loss magnitude is preserved
    hard_weight = hard_mask.float() / ohem_fraction
    # Weighted MSE over hard points
    hard_weighted_sq = (sq_err_weighted * hard_weight.unsqueeze(-1)).sum(dim=(1, 2))
    denom = hard_mask.float().sum(dim=-1).clamp(min=1) * w.mean()
    loss_per_batch = hard_weighted_sq / denom
    return loss_per_batch.mean()
```

**Step 2: Add config flag and modify `train_loss()`.**

In `TrainConfig`:
```python
ohem_fraction: float = 1.0  # 1.0 = no OHEM; <1.0 = select hardest fraction
```

In `train_loss()` signature: add `ohem_fraction: float = 1.0`.

In the loss computation, after computing `surface_pred_used` and `surface_target_used`, replace the surface loss call with:

```python
if ohem_fraction < 1.0:
    # Apply OHEM only to wall-shear channels (1:4); use standard MSE for cp (channel 0)
    cp_pred = surface_pred_used[..., :1]
    cp_true = surface_target_used[..., :1]
    ws_pred = surface_pred_used[..., 1:4]
    ws_true = surface_target_used[..., 1:4]
    cp_loss = masked_mse(cp_pred, cp_true, batch.surface_mask)
    ws_loss = ohem_wall_shear_loss(
        ws_pred, ws_true, batch.surface_mask,
        ohem_fraction=ohem_fraction,
        channel_weights=(1.0, wallshear_y_weight, wallshear_z_weight),
    )
    surface_loss = cp_loss + ws_loss
    per_axis_unweighted = torch.zeros(4, device=cp_loss.device)  # approx for logging
else:
    surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
        surface_pred_used, surface_target_used, batch.surface_mask,
        channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
    )
```

**Step 3: Add CLI flag.**

```python
parser.add_argument("--ohem-fraction", type=float, default=1.0,
    help="OHEM hard-point fraction for wall-shear loss (0<f<=1; 1.0=disabled)")
```

**Step 4: Wire it through to `train_loss()` call sites.**

Pass `ohem_fraction=config.ohem_fraction` to all `train_loss()` call sites in the training loop.

**Step 5: Run a 4-arm sweep using `--wandb_group edward-ohem`.**

**Arm A (ohem_fraction=0.5 — hardest 50% of points):**
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --pos-max-wavelength 1000 --lr-warmup-steps 500 \
  --ohem-fraction 0.5 --seed 42 \
  --wandb_group edward-ohem \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

**Arm B (ohem_fraction=0.25 — hardest 25% of points):**
Same as Arm A, but `--ohem-fraction 0.25` on `CUDA_VISIBLE_DEVICES=1`.

**Arm C (ohem_fraction=0.75 — harder 75% of points, mild):**
Same as Arm A, but `--ohem-fraction 0.75` on `CUDA_VISIBLE_DEVICES=2`.

**Arm D (ohem_fraction=1.0 — baseline/control, no OHEM):**
Same as Arm A, but `--ohem-fraction 1.0` on `CUDA_VISIBLE_DEVICES=3`. This is the matched control for this exact config+seed.

The key comparison is Arm A/B/C vs Arm D. If any OHEM fraction beats Arm D, the hard-point selection mechanism is helping.

## Baseline

Current best — PR #183 (fern), W&B run `bplngfyo`:
```
val_primary/abupt_axis_mean_rel_l2_pct: 10.21   ← merge bar (must beat)
val_primary/surface_pressure_rel_l2_pct: 6.85
val_primary/wall_shear_rel_l2_pct: 11.43
val_primary/volume_pressure_rel_l2_pct: 6.32
val_primary/wall_shear_x_rel_l2_pct: 9.89
val_primary/wall_shear_y_rel_l2_pct: 13.47      ← primary target (~4× AB-UPT)
val_primary/wall_shear_z_rel_l2_pct: 14.52      ← primary target (~4× AB-UPT)
```

Reproduce baseline:
```bash
cd target/
python train.py \
  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
  --lr 5e-4 --weight-decay 5e-4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9995 --clip-grad-norm 1.0 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --pos-max-wavelength 1000 \
  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
```

## Key Diagnostics to Report

Per epoch, per arm:
1. `val_primary/wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` — primary target
2. `val_primary/abupt_axis_mean_rel_l2_pct` — merge metric
3. `val_primary/surface_pressure_rel_l2_pct` — watch for regression (cp uses standard MSE, but OHEM indirect effects)
4. `train/grad_pre` median+max — OHEM changes gradient distribution; watch for spikes

**Stability note:** OHEM concentrates gradient on high-error points, which may increase gradient variance. If `grad_pre` median > 30 sustained or spikes > 300, kill the aggressive arms (B=0.25 first) and report. Arm A (0.5) and Arm C (0.75) are more conservative.

**Merge bar:** val_abupt < 10.21 from best-val checkpoint.
