### PR TITLE
Round12: model-slices=64 — halve attention slices (SOTA=128, 256 regressed)

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -6,6 +6,14 @@ Targets to beat (lower is better, AB-UPT public reference):
 `surface_pressure 3.82`, `wall_shear 7.29`, `volume_pressure 6.08`,
 `tau_x 5.35`, `tau_y 3.65`, `tau_z 3.63`.
 
+## 2026-05-01 18:00 — ASSIGNED: nezuko round12-model-slices-64 (halve attention slices)
+
+- **Branch:** `nezuko/round12-model-slices-64`
+- **Hypothesis:** SOTA uses `--model-slices 128`. PR #139 tested `--model-slices 256` (double, regressed). The opposite direction — `--model-slices 64` (half) — has never been tested. Reducing slices may reduce overfitting by shrinking attention capacity or improve training signal concentration.
+- **W&B group:** `tay-round12-model-slices-64`
+- **Single delta from SOTA:** only `--model-slices 64` changes (SOTA=128)
+- **Status:** Assigned. Awaiting results.
+
 ## 2026-05-01 15:30 — PR #186 CLOSED: alphonse vol_pts=96k clean re-run — does not beat SOTA
 
 - **Branch:** `alphonse/round11-vol-pts-96k-clean`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -6,6 +6,20 @@ Targets to beat (lower is better, AB-UPT public reference):
 `surface_pressure 3.82`, `wall_shear 7.29`, `volume_pressure 6.08`,
 `tau_x 5.35`, `tau_y 3.65`, `tau_z 3.63`.
 
+## 2026-05-01 18:30 — PR #194 CLOSED: askeladd EMA=0.9995 — negative result, EMA space retired
+
+- **Branch:** `askeladd/ema-decay-0p9995`
+- **Hypothesis:** EMA decay of 0.9995 (between SOTA 0.999 and previously-tested 0.9999) may improve generalization.
+- **Result:** test_abupt=11.619% (+9.8% vs SOTA test=10.580%) — clear regression.
+- **EMA sweep summary (all four values tested):**
+  | EMA | val_abupt | test_abupt | Outcome |
+  |---|---|---|---|
+  | 0.998 | ~10.5% | — | Negative |
+  | **0.999** | **9.484%** | **10.580%** | **SOTA** |
+  | 0.9995 | — | 11.619% | Negative |
+  | 0.9999 | — | ~11%+ | Negative |
+- **Conclusion:** EMA decay space fully closed. 0.999 is the clear optimum. Branch deleted.
+
 ## 2026-05-01 18:00 — ASSIGNED: nezuko round12-model-slices-64 (halve attention slices)
 
 - **Branch:** `nezuko/round12-model-slices-64`


### PR DESCRIPTION
## Hypothesis

SOTA uses \`--model-slices 128\`. PR #139 tested \`--model-slices 256\` (double) and regressed — adding more attention slices hurt. The opposite direction — \`--model-slices 64\` (half the SOTA value) — has **never been tested**.

Halving the slice count reduces attention capacity per head but may:
- Reduce overfitting by constraining the model's capacity
- Improve training efficiency / gradient concentration within each slice
- Find a sweet spot between too coarse (64→32 would be extreme) and current SOTA (128)

This is the last untested point in the model-slices sweep: 64 → **128 (SOTA)** → 256 (regressed).

## Current Baseline to Beat

| Metric | Value |
|--------|-------|
| val_abupt | **9.484%** |
| test_abupt | 10.580% |
| val_surface_p | 6.305% |
| val_wall_shear | 10.499% |
| val_volume_p | 7.265% |

W&B run: `d03oghpp`, group: `tay-round9-compound-lr1e4-ema999` (PR #115, thorfinn)

## Single Delta

Only one change from SOTA: `--model-slices 64` (SOTA=128).

All other hyperparameters are identical to SOTA PR #115.

## Experiment Instructions

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --lion-beta1 0.9 --lion-beta2 0.99 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 64 \
  --ema-decay 0.999 \
  --wandb-group tay-round12-model-slices-64
```

## Results

<!-- Fill in after training completes -->

| Metric | This Run | SOTA (#115) | Delta |
|--------|----------|-------------|-------|
| val_abupt | | 9.484% | |
| test_abupt | | 10.580% | |
| val_surface_p | | 6.305% | |
| val_wall_shear | | 10.499% | |
| val_volume_p | | 7.265% | |

W&B run id:
W&B group: `tay-round12-model-slices-64`

## Suggested Follow-ups

- If model-slices=64 beats SOTA: try model-slices=32 to continue the sweep downward
- If model-slices=64 regresses: slices sweep is closed; 128 is optimal