### PR TITLE
[norman] Fourier PE num_freqs sweep {16, 32, 64, 128} on Wave 1 recipe

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,6 +72,29 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression."""
+
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_freqs = num_freqs
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+        if isinstance(self.proj, nn.Linear):
+            _init_linear(self.proj)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -226,6 +249,8 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        fourier_pe: bool = False,
+        fourier_pe_num_freqs: int = 8,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -236,7 +261,12 @@ class SurfaceTransolver(nn.Module):
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if fourier_pe:
+            self.pos_embed = FourierEmbed(
+                hidden_dim=n_hidden, input_dim=space_dim, num_freqs=fourier_pe_num_freqs
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (

--- a/train.py
+++ b/train.py
@@ -115,6 +115,8 @@ class Config:
     compile_model: bool = True
     debug: bool = False
     raw_rel_l2_weight: float = 0.0
+    fourier_pe: bool = False
+    fourier_pe_num_freqs: int = 8
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -150,6 +152,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        fourier_pe=config.fourier_pe,
+        fourier_pe_num_freqs=config.fourier_pe_num_freqs,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**The number of Fourier PE frequency bands is an untuned hyperparameter on bengio. Sweeping `num_freqs` may unlock additional resolution for the wsy/wsz binding axes.**

Chihiro's PR #176 introduced the canonical `FourierEmbed` to bengio. The `--fourier-pe-num-freqs` flag was added with a default value (likely 32 or 64). But the optimal band count is **dataset-dependent** and we have not done any sweep.

Higher `num_freqs` → finer spatial frequencies represented → potentially better resolution of small-scale BL structure that drives wall-shear y/z. Lower `num_freqs` → smoother features → less overfitting to noisy local geometry.

For DrivAerML at ~40k surface points × car length ~5m, the Nyquist frequency for surface point spacing (~5cm) corresponds to ~10/m wavenumber. A Fourier PE with 32 bands log-spaced from 1/m to 100/m covers this well; 64 bands oversample. But 16 bands undersample. The optimal value is somewhere in `{16, 32, 64, 128}` — unknown until we sweep.

This is a low-complexity, high-EV experiment — orthogonal to all other Wave 3 PRs.

## Instructions

**No code changes required.** Use the existing `--fourier-pe` and `--fourier-pe-num-freqs` flags from chihiro's PR #176. **Cherry-pick the chihiro FourierEmbed commit** onto your branch first if it isn't already in bengio main:

```bash
git fetch origin chihiro/lr-sweep-fourier-pe-baseline
git cherry-pick <chihiro fourier-pe-implementation commit>  # find it via gh pr view 176 --json commits
```

(If chihiro PR #176 has already been merged into bengio by the time you pick this up, just rebase onto bengio and skip the cherry-pick.)

**Run a sweep of `--fourier-pe-num-freqs ∈ {16, 32, 64, 128}`** in W&B group `bengio-wave3-norman-pe-bands`:

```bash
for NF in 16 32 64 128; do
  cd target/ && python train.py \
    --model-num-layers 4 \
    --model-hidden-dim 256 \
    --no-use-ema \
    --lr-cosine-t-max 30 \
    --fourier-pe \
    --fourier-pe-num-freqs $NF \
    --no-compile-model \
    --nproc_per_node 4 \
    --wandb_group bengio-wave3-norman-pe-bands \
    --run-name norman/fourier-pe-nf$NF
done
```

Run sequentially. Use the launcher pattern (one run, wait for SIGTERM, next run) to avoid GPU contention.

**Kill threshold (CRITICAL — do NOT use the dead default)**: `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`

**Gates per run**:
- ep5 abupt < 13% → continue (early divergence may indicate `num_freqs` is too high → killing weights with high-freq noise — kill that run)
- ep10 abupt < 11% → continue
- ep15 abupt < 9.5% → run to T_max
- If a value of `num_freqs` shows ep10 > 12%, kill it early — that's a clear miss.

**Comparison protocol**: After all 4 runs complete (~80 GPU-hours total at 30 epochs each), report a single comparison table with the best-val-checkpoint metrics for all 4 sweep points. The expected curve is U-shaped — a clear minimum at one value of `num_freqs`. Report which won and by how much.

## Baseline

Current best (PR #74 alphonse, val, run `m9775k1v`):
- `val_primary/abupt_axis_mean_rel_l2_pct` = **7.2091** (target: 4.51)
- `val_primary/wall_shear_y_rel_l2_pct` = 9.100 (target: 3.65)
- `val_primary/wall_shear_z_rel_l2_pct` = 10.869 (target: 3.63)

The Wave 1 baseline used `ContinuousSincosEmbed`, not `FourierEmbed` — so the comparison here is to ALL Wave 2 chihiro/fern/etc. fourier-PE runs which used the chihiro default `num_freqs`. Establish the default's number first if it's already known from chihiro PR #176, and call out the additional sweep points.

**Reproduce baseline command**:
```bash
cd target/ && python train.py --model-num-layers 4 --model-hidden-dim 256 --no-use-ema --lr-cosine-t-max 30 --no-compile-model --nproc_per_node 4 --wandb_group bengio-wave1-alphonse-repro
```

## Notes from advisor

- Norman, your PR #180 close commentary above was excellent — keep that disciplined gate-check + decision-request format on this PR too.
- Acknowledge this assignment within 30 minutes of pickup with W&B run ID for the first sweep point. Two missed acknowledgments = closure (per the same protocol that just closed PRs #215-220).
- This is a multi-trial sweep so use `--wandb_group bengio-wave3-norman-pe-bands` for grouping.
