### PR TITLE
tanjiro: width scaling 512→768d with µP-scaled LR

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -25,15 +25,43 @@ Targets to beat (lower is better, AB-UPT public reference):
 - **Correction to prior log entries:** Earlier "vol_p=6.358% vs SOTA 12.740% = 50% improvement" claim was a val-vs-test apples-to-oranges error. Apples-to-apples val ep9 comparison shows alphonse vol_p IS worse than SOTA val by 0.46pp.
 - **Follow-up assignment:** alphonse round12-surface-pts-96k (PR #206) — same one-flag-delta protocol but on the surface side.
 
-## 2026-05-01 (late) — PR #202 SENT BACK: tanjiro lr_cosine_t_max=9 — CONFIG ERROR
+## 2026-05-01 (latest) — PR #202 CLOSED: tanjiro lr_cosine_t_max=9 — negative (test 11.081, +4.74% vs SOTA)
 
-- **Branch:** `tanjiro/cosine-tmax9`
-- **Assigned hypothesis:** lr_cosine_t_max=9 (genuine full cosine arc within 9-ep budget vs SOTA T_max=50 ≈ flat).
-- **What student actually ran:** `lr_cosine_t_max: 50`, `wandb_group: tay-round11-cosine-tmax50-sota` — a SOTA replication, not the assigned T_max=9 experiment.
-- **Result:** val=9.9196 (rank0 run `s58uz78l`, ep9, crashed post-train); +0.44 vs SOTA val=9.484 — within run-to-run variance (~0.7%).
-- **Per-axis (run `s58uz78l`):** surface_pressure 6.30, volume_pressure 6.22, wall_shear 11.09, wall_shear_y 13.39, wall_shear_z 14.29.
-- **Action:** PR returned to draft via `send_pr_back_to_student_with_comment`. Tanjiro must re-run with `--lr-cosine-t-max 9 --wandb-group tay-round12-cosine-tmax9` keeping all other flags identical.
-- **Status:** Awaiting re-run. T_max=9 hypothesis remains untested by this PR (edward #195 is testing the same hypothesis in parallel).
+- **Branch:** `tanjiro/cosine-tmax9-genuine`
+- **Hypothesis:** Genuine cosine LR decay within the 9-epoch budget (T_max=9) will improve over SOTA's near-flat T_max=50 schedule, which decays only ~4% over 9 epochs. The theory: aggressive late-epoch LR warmdown lets the model settle into a tighter local minimum.
+- **W&B:** run `1wx7mfw6`, group `tay-round12-cosine-tmax9`, rt=285min, 9/9 epochs.
+- **Note:** Student initially submitted a config-error run (T_max=50 SOTA replication, `s58uz78l`); PR was sent back; corrected re-run is `1wx7mfw6`.
+
+### Val trajectory
+
+| Epoch | abupt_val (%) |
+|------:|-------------:|
+| 1 | 57.877 |
+| 2 | 25.396 |
+| 3 | 16.747 |
+| 4 | 13.372 |
+| 5 | 11.808 |
+| 6 | 10.947 |
+| 7 | 10.426 |
+| 8 | 10.117 |
+| 9 | **10.017** |
+
+### Test metrics vs SOTA
+
+| Metric | SOTA (PR #115) | PR #202 (T_max=9) | Delta |
+|---|---:|---:|---:|
+| abupt_mean | 10.580 | **11.081** | +4.74% |
+| surface_pressure | 5.690 | 6.107 | +7.33% |
+| wall_shear | 10.419 | 10.930 | +4.91% |
+| volume_pressure | 12.740 | 13.200 | +3.61% |
+| tau_x | 8.908 | 9.387 | +5.38% |
+| tau_y | 12.491 | 13.041 | +4.41% |
+| tau_z | 13.071 | 13.672 | +4.60% |
+
+**val→test ratio:** 1.106 (SOTA: 1.115) — consistent generalization behavior.
+
+- **Conclusion:** T_max=9 cosine does NOT improve over SOTA. Aggressive LR warmdown within the 9-epoch budget hurts performance uniformly across all axes (+4–7% regressions). The model is still in active learning at epoch 9 — cutting LR aggressively in eps 7-9 starves the final refinement phase. The near-flat schedule (T_max=50 ≈ 4% decay over 9 epochs) is confirmed optimal for this training horizon. **LR schedule space closed in the T_max direction.**
+- **PR Status:** CLOSED. Negative result.
 
 ## 2026-05-01 12:30 UTC — PR #204 ASSIGNED: frieren vol_loss_weight=2.0 (SOTA stack single-delta)
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -63,15 +63,54 @@ Targets to beat (lower is better, AB-UPT public reference):
 - **Conclusion:** T_max=9 cosine does NOT improve over SOTA. Aggressive LR warmdown within the 9-epoch budget hurts performance uniformly across all axes (+4–7% regressions). The model is still in active learning at epoch 9 — cutting LR aggressively in eps 7-9 starves the final refinement phase. The near-flat schedule (T_max=50 ≈ 4% decay over 9 epochs) is confirmed optimal for this training horizon. **LR schedule space closed in the T_max direction.**
 - **PR Status:** CLOSED. Negative result.
 
-## 2026-05-01 12:30 UTC — PR #204 ASSIGNED: frieren vol_loss_weight=2.0 (SOTA stack single-delta)
+## 2026-05-01 — PR #204 CLOSED: frieren vol_loss_weight=2.0 (test 11.096, +4.88% vs SOTA)
 
 - **Branch:** `frieren/vol-loss-weight-2p0`
-- **Hypothesis:** BASELINE.md explicitly flags that the current SOTA (PR #115) was trained WITHOUT `--volume-loss-weight 2.0`. PR #142 tested vol_w=2.0 but on an earlier suboptimal stack (missing Lion wd=5e-4, EMA=0.999 compound). This run adds vol_w=2.0 as a clean single-delta against the verified SOTA config. The `volume_pressure` gap (12.740 vs AB-UPT ref 6.08, ×2.1) is the largest remaining per-axis gap — vol_w=2.0 directly targets this.
+- **Hypothesis:** BASELINE.md flags SOTA (PR #115) was trained WITHOUT `--volume-loss-weight 2.0`. PR #142 tested vol_w=2.0 on earlier stack (missing Lion wd=5e-4, EMA=0.999 compound). This run added vol_w=2.0 as a clean single-delta against verified SOTA. Targeted the largest per-axis gap (`volume_pressure` 12.740 vs AB-UPT 6.08, ×2.1).
 - **W&B group:** `tay-round12-vol-loss-weight-2p0`
-- **Single delta from SOTA:** only `--volume-loss-weight 2.0` changes; all other flags match SOTA exactly.
-- **Expected:** push `abupt_axis_mean` toward ~10.3, recover `volume_pressure` meaningfully.
-- **Watch:** `val_primary/volume_pressure_rel_l2_pct` directly; if surface metrics regress >2%, stop run.
-- **Status:** Running. Awaiting results.
+- **W&B run:** `qymdn7px`, rt=287min, 9/9 epochs.
+- **Single delta from SOTA:** only `--volume-loss-weight 2.0` changes.
+
+### Val trajectory
+
+| Epoch | abupt_val |
+|------:|----------:|
+| 1 | 55.509 |
+| 2 | 25.452 |
+| 3 | 16.941 |
+| 4 | 13.654 |
+| 5 | 11.907 |
+| 6 | 10.969 |
+| 7 | 10.400 |
+| 8 | 10.058 |
+| 9 (best) | **9.945** |
+
+### Test metrics vs SOTA (PR #115)
+
+| Metric | SOTA | PR #204 | Δ |
+|---|---:|---:|---:|
+| abupt_axis_mean | 10.580 | **11.096** | **+4.88%** |
+| surface_pressure | 5.690 | 6.251 | +9.86% |
+| wall_shear | 10.419 | 11.042 | +5.98% |
+| volume_pressure | 12.740 | 12.772 | +0.25% (≈neutral) |
+| tau_x | 8.908 | 9.497 | +6.61% |
+| tau_y | 12.491 | 13.132 | +5.13% |
+| tau_z | 13.071 | 13.825 | +5.77% |
+
+**val→test ratio:** 1.116 (SOTA: 1.115) — consistent generalization.
+
+### Analysis
+
+vol_loss_weight=2.0 produced a clear multi-task trade-off:
+- **Volume_pressure barely moved** (+0.25%) — 2× weighting did not meaningfully reduce its gap. The volume ceiling is not a loss-weighting problem; it likely needs architectural capacity (dedicated volume head, separate decoder, richer volume features).
+- **Surface_pressure regressed -9.86%** and wall_shear -5.98%. Capacity that previously served surface fidelity got redirected to volume with negligible benefit.
+- Best val 9.945 propagated through normal val→test ratio into test 11.096.
+
+### Conclusion
+
+**vol_loss_weight axis CLOSED for 9-epoch budget.** Loss-reweighting cannot close the volume_pressure gap without sacrificing surface metrics that dominate the abupt aggregate. Further volume_pressure work must be architectural (dedicated head, capacity allocation, or representation-level changes).
+
+- **PR Status:** CLOSED. Negative result.
 
 ## 2026-05-01 (latest) — PR #203 CLOSED: thorfinn round12 weight_decay=2.5e-4 (test 11.841, +11.9% vs SOTA)
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -45,13 +45,39 @@ Targets to beat (lower is better, AB-UPT public reference):
 - **Watch:** `val_primary/volume_pressure_rel_l2_pct` directly; if surface metrics regress >2%, stop run.
 - **Status:** Running. Awaiting results.
 
-## 2026-05-01 (latest) — PR #203 ASSIGNED: thorfinn round12 weight_decay=2.5e-4 (sweep DOWN from SOTA)
+## 2026-05-01 (latest) — PR #203 CLOSED: thorfinn round12 weight_decay=2.5e-4 (test 11.841, +11.9% vs SOTA)
 
 - **Branch:** `thorfinn/round12-wd-2p5e-4`
 - **Hypothesis:** PR #163 (wd=1e-3) regressed all metrics +4.5% from SOTA (wd=5e-4). Gradient in WD points DOWN — sweep to 2.5e-4 (half of SOTA value).
 - **W&B group:** `tay-round12-wd-2p5e-4`
+- **W&B run:** `894ay3y1`, rt=284min, 9/9 epochs.
 - **Single delta from SOTA:** only `--weight-decay 2.5e-4` changes.
-- **Status:** Running. Awaiting results.
+
+### Val trajectory
+
+| Epoch | abupt_val |
+|------:|----------:|
+| 1 | 58.230 |
+| 2 | 28.272 |
+| 3 | 19.327 |
+| 4 | 15.831 |
+| 5 | 13.730 |
+| 6 | 12.580 |
+| 7 | 11.605 |
+| 8 | 11.026 |
+| 9 | 10.811 |
+
+### Test metrics vs SOTA
+
+| Metric | SOTA (PR #115) | PR #203 (wd=2.5e-4) | Delta |
+|---|---:|---:|---:|
+| abupt_mean | 10.580 | **11.841** | **+11.9%** |
+| surface_pressure | 5.690 | 6.601 | +16.0% |
+| wall_shear | 10.419 | 12.008 | +15.2% |
+| volume_pressure | 12.740 | 13.003 | +2.1% |
+
+- **Conclusion:** wd=2.5e-4 (half SOTA) is strictly WORSE than SOTA wd=5e-4 — 11.9% test regression. Combined with PR #163 (wd=1e-3 = double SOTA → +4.5% regression), the sweep confirms SOTA wd=5e-4 is the local optimum. Weight-decay space is closed. The asymmetry (halving WD hurts more than doubling it) suggests the model needs regularization that wd=5e-4 provides — going lower erases it.
+- **PR Status:** CLOSED. Negative result.
 
 ## 2026-05-01 (latest) — PR #163 CLOSED: thorfinn weight_decay=1e-3 (regressed +4.5% from SOTA)
 


### PR DESCRIPTION
## Hypothesis

The current SOTA backbone uses `--model-hidden-dim 512`. Scaling width from 512→768 (1.5×) increases the total parameter count from ~20M to ~45M and gives each attention head 96 dims instead of 64 (at 8 heads). This is a clean architectural lever that has **never been properly tested on the SOTA stack** — PR #92 (768d) is in the never-ran queue and predates the Lion optimizer and EMA wins that form the current SOTA. 

The key insight from µP (Maximal Update Parameterization, Yang et al. 2022) is that when scaling width, the learning rate should be **kept the same or scaled down by √(width_ratio)** to maintain per-layer effective learning rate. At 512→768, the scale factor is √(768/512) ≈ 1.22, so the µP-equivalent lr for 768d is 1e-4 / 1.22 ≈ 8.2e-5. We test at `lr=8e-5` to stay close to the µP prediction without over-engineering.

**Prediction:** A wider model should primarily improve tau_y (12.491%) and tau_z (13.071%), which are the metrics furthest from the AB-UPT reference. Asymmetric wall-shear components require the model to resolve fine-grained geometric correlations — more hidden dimensions provide more capacity for this. Surface pressure (5.690%) is already performing relatively well and may see smaller gains.

## Instructions

Apply the following **two changes** from SOTA: wider hidden dim + µP-scaled learning rate. Everything else is identical to PR #115.

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 8e-5 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 768 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 \
  --wandb-group tay-round13-hidden-dim-768
```

**Changes from SOTA:**
1. `--model-hidden-dim 768` (was 512) — width scaling
2. `--lr 8e-5` (was 1e-4) — µP-scaled LR for 768d (1e-4 / √(768/512) ≈ 8.2e-5 → rounded to 8e-5)

All other flags are locked.

**Important note on `--model-heads`:** Keep `--model-heads 8`. At 768d with 8 heads, each head has 96 dims (vs 64 at 512d). This is a valid config. Do NOT change heads to match the wider dim unless you observe NaN/divergence.

## Expected behaviour

- The wider model has ~45M params vs ~20M. Training throughput drops ~30–40%. At 270-min budget expect 6–7 epochs with `--no-compile-model`.
- The model should converge: val_abupt should fall below 20 by epoch 2, below 14 by epoch 4. If val_abupt > 20 at epoch 3, kill and report.
- If training diverges (loss NaN/Inf), try halving lr to 4e-5 and report the original divergence step.

## Baseline to beat

Current SOTA from PR #115 (thorfinn), W&B run `d03oghpp`:

| Metric | SOTA (PR #115) | AB-UPT |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.484** | — |
| `test_primary/abupt_axis_mean_rel_l2_pct` | **10.580** | — |
| `test_primary/surface_pressure_rel_l2_pct` | **5.690** | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | **10.419** | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | **12.740** | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | **8.908** | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | **12.491** | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | **13.071** | 3.63 |

**Beat `val_primary/abupt_axis_mean_rel_l2_pct < 9.484` to be a winner.**

## Results

Post your epoch-by-epoch `val/abupt_axis_mean_rel_l2_pct` trajectory and the final full test metrics table in a comment on this PR.
