### PR TITLE
nezuko: linear-warmdown LR schedule (modded-NanoGPT WSD-style) on 4L/512d SOTA

### DIFF
--- a/train.py
+++ b/train.py
@@ -2324,9 +2324,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             or (timeout_hit and n_batches > 0)
         )
 
+        if scheduler is not None:
+            current_lr = scheduler.get_last_lr()[0]
+        else:
+            current_lr = optimizer.param_groups[0]["lr"]
         log_metrics = {
             "train/epoch_loss": epoch_train_loss,
-            "lr": scheduler.get_last_lr()[0],
+            "lr": current_lr,
             "epoch_time_s": dt,
             "global_step": global_step,
         }

--- a/train.py
+++ b/train.py
@@ -738,6 +738,8 @@ class Config:
     lr_warmup_steps: int = 0
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    lr_schedule: str = "cosine"
+    lr_warmdown_start_epoch: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1992,16 +1994,36 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"lr={config.lr} wd={config.weight_decay}"
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    if config.lr_schedule == "cosine":
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    elif config.lr_schedule == "linear-warmdown":
+        scheduler = None
+    else:
+        raise ValueError(
+            f"Unknown lr_schedule '{config.lr_schedule}'. Supported: 'cosine', 'linear-warmdown'."
+        )
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
-    total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    steps_per_epoch = max(len(train_loader), 1)
+    total_estimated_steps = max(1, max_epochs * steps_per_epoch)
     effective_warmup_steps = config.lr_warmup_steps
     if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
-        effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+        effective_warmup_steps = config.lr_warmup_epochs * steps_per_epoch
+    if config.lr_warmdown_start_epoch > 0.0:
+        lr_warmdown_start_step = int(round(config.lr_warmdown_start_epoch * steps_per_epoch))
+    else:
+        lr_warmdown_start_step = int(round(0.7 * total_estimated_steps))
+    lr_warmdown_start_step = max(int(effective_warmup_steps), lr_warmdown_start_step)
+    lr_warmdown_total_steps = max(1, total_estimated_steps - lr_warmdown_start_step)
     if is_main and effective_warmup_steps > 0:
         print(
             f"LR warmup: {effective_warmup_steps} steps "
             f"(start_lr={config.lr_warmup_start_lr} -> peak_lr={config.lr})"
+        )
+    if is_main:
+        print(
+            f"LR schedule: {config.lr_schedule} | warmup_steps={int(effective_warmup_steps)} | "
+            f"warmdown_start_step={lr_warmdown_start_step} (epoch={config.lr_warmdown_start_epoch}) | "
+            f"total_steps={total_estimated_steps} | steps_per_epoch={steps_per_epoch}"
         )
     if is_main and kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
@@ -2186,7 +2208,24 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 global_step += 1
                 continue
-            if effective_warmup_steps > 0:
+            if config.lr_schedule == "linear-warmdown":
+                if effective_warmup_steps > 0 and global_step < effective_warmup_steps:
+                    progress = global_step / effective_warmup_steps
+                    start_ratio = (
+                        config.lr_warmup_start_lr / max(config.lr, 1e-12)
+                    )
+                    lr_ratio = start_ratio + (1.0 - start_ratio) * progress
+                elif global_step < lr_warmdown_start_step:
+                    lr_ratio = 1.0
+                else:
+                    progress = min(
+                        1.0,
+                        (global_step - lr_warmdown_start_step) / lr_warmdown_total_steps,
+                    )
+                    lr_ratio = max(0.0, 1.0 - progress)
+                for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
+                    pg["lr"] = base_lr * lr_ratio
+            elif effective_warmup_steps > 0:
                 if global_step < effective_warmup_steps:
                     progress = global_step / effective_warmup_steps
                     start_ratio = (
@@ -2273,7 +2312,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if scheduler is not None:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

Replace cosine LR decay (current SOTA, PR #222) with a **trapezoidal "warmup → constant → linear-warmdown" schedule**. Tests whether the cosine knee is suboptimally early in our 9-epoch budget — modded-NanoGPT (https://github.com/kellerjordan/modded-nanogpt) found that linear warmdown over the last 25-40% of training matches or beats cosine at matched compute, while the constant-LR phase covers more diverse loss-landscape regions.

**Mechanism.** Cosine LR spends most of its budget at LR << peak (the bottom half of the cosine). Linear warmdown is a sharper, later decay: stay at peak LR for the first ~60-75% of training (the "constant" phase explores the loss landscape with full step size), then linearly drop to ~0 over the last 25-40%. In modded-NanoGPT this is empirically the world-record schedule.

**Why for our setting.** Our 9-epoch budget is short. Cosine decays the lr to ~5% of peak by ep5 (we currently train at warmup + cosine T_max=9, peak=1e-4 dropping to ~5e-6 by ep9). At that point the model is barely moving. A constant-then-warmdown schedule would keep the lr at the full 1e-4 through ep5-6, then drop linearly to 0 over ep6-9. More effective steps at peak lr → more capacity used.

**Risk.** If the lr=1e-4 + 4L/512d + Lion configuration is operating at a stability margin, an extra 3-4 epochs at peak lr may push it into the divergence regime that we've been carefully avoiding. The `--lr-warmup-epochs 1` start is essential and must be preserved.

## Instructions

**Code change to `target/train.py`:**

1. Add a new LR schedule option: `--lr-schedule {cosine,linear-warmdown}` (default cosine to preserve current SOTA behavior).

2. When `linear-warmdown` is selected:
   - Phase 1 (0 → `lr_warmup_epochs`): linear warmup 0 → peak lr (same as current)
   - Phase 2 (`lr_warmup_epochs` → `lr_warmdown_start`): constant at peak lr
   - Phase 3 (`lr_warmdown_start` → `total_epochs`): linear decay peak lr → 0

   Add CLI flags:
   - `--lr-warmdown-start-epoch` (when warmdown begins; default = total_epochs * 0.7)

3. **Run a 4-arm sweep on 4 GPUs (single-process per GPU):**

   Total epochs = 9 (matching SOTA). Warmup = 1 epoch.

   | Arm | warmdown-start | constant phase length | warmdown phase length |
   |---|---:|---:|---:|
   | A (control) | (cosine — n/a) | — | — |
   | B | 5 | 4 epochs (ep1-5) | 4 epochs (ep5-9) |
   | C | 6 | 5 epochs (ep1-6) | 3 epochs (ep6-9) |
   | D | 7 | 6 epochs (ep1-7) | 2 epochs (ep7-9) |

   All arms otherwise identical to PR #222 SOTA: Lion, lr=1e-4, weight-decay=5e-4, 4L/512d/8h/128 slices, ema=0.999, batch=4.

   **W&B group:** `nezuko-linear-warmdown-sweep`.

4. **Per-arm command (Arm B example):**

```bash
cd target/
CUDA_VISIBLE_DEVICES=1 torchrun --standalone --nproc-per-node=1 train.py \
  --agent nezuko --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --lr-schedule linear-warmdown --lr-warmdown-start-epoch 5 \
  --wandb-name nezuko/warmdown-start5 --wandb-group nezuko-linear-warmdown-sweep
```

## Gates

- **ep5:** kill any arm if val_abupt > 14% (SOTA ep5 = 11.60%)
- **ep7:** kill any arm if val_abupt > 11% (SOTA ep7 = 9.88%)
- **ep9:** beat 9.291% on any arm = win

## Win criterion

**Best linear-warmdown arm reaches val_abupt < 9.291% at ep9 → merge.** Direction-of-improvement matters: if Arm D (warmdown-start=7) beats Arm B (warmdown-start=5), it confirms more constant-LR exploration helps; if Arm B wins, more warmdown smoothing helps.

## Stability watch

If any arm shows train-loss spike or grad/global_norm > 100× running median during the constant-LR phase, kill that arm immediately. The risk profile is: more time at peak lr → more chances to hit a bad batch. The stability ceiling for Lion at 1e-4 is the 4L/512d configuration's known sweet spot; we are not pushing higher lr.

## Baseline (current SOTA on yi)

| Metric | yi best | PR | W&B run |
|---|---:|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910** | #222 (fern) | `ut1qmc3i` |
| `val_primary/surface_pressure_rel_l2_pct` | **5.8707** | #222 | `ut1qmc3i` |
| `val_primary/wall_shear_rel_l2_pct` | **10.3423** | #222 | `ut1qmc3i` |
| `val_primary/volume_pressure_rel_l2_pct` | **5.8789** | #222 | `ut1qmc3i` |

**SOTA epoch trajectory (cosine schedule, for comparison):**

| Epoch | val_abupt | surf_p | vol_p | wall_shear |
|---|---:|---:|---:|---:|
| 5 | 11.60 | 7.62 | 6.86 | 13.02 |
| 6 | 10.50 | 6.78 | 6.26 | 11.80 |
| 7 | 9.88 | 6.31 | 6.01 | 11.06 |
| 8 | 9.45 | 6.00 | 5.76 | 10.58 |
| 9 | 9.29 | 5.87 | 5.88 | 10.34 |

The slope ep5→ep9 is -0.58/ep — if linear-warmdown sustains a steeper slope (more effective LR through ep5-7), we'd expect ep7-8 vals 0.3-0.5pp ahead of cosine at the same epoch.

## Context

This experiment is one of the issue #252 (Modded-NanoGPT inspiration) directions. The cosine schedule has been the fleet default; this is the first test of its alternative.
