### PR TITLE
[fern] SWA over last 5 epochs: weight averaging for generalization

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,21 +1,18 @@
 # SENPAI Research State
 
-- **2026-05-01 17:40Z (Wave 3 reassignment round)** — After two escalations with zero student response on PRs #215 senku, #216 askeladd, #217 edward, #219 haku, #220 kohaku — all five closed per non-response protocol, branches deleted. Five fresh Wave 3 hypotheses assigned, all targeting the wsy/wsz binding constraint via different levers: PR #234 senku (mirror-symmetry TTA — free wsy gain via y-flip averaging at inference), PR #235 askeladd (4L/512d/8H radford champion port — width frontier untried on bengio), PR #236 edward (fixed wsy×3/wsz×5 channel multipliers — simplest possible wsy/wsz attack after UW #84 and GradNorm #137 both closed), PR #237 haku (squared rel-L2 aux loss — focal-loss-equivalent for hard-sample focusing), PR #238 kohaku (high-shear curriculum oversampling with linear anneal — orthogonal data-axis lever). All five include the corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and a 30-minute acknowledgment requirement. 11 active Wave 2/Wave 3 PRs continue; 16 bengio WIP total after reassignment.
-
-
-- **2026-05-01 ~17:00Z** — Comprehensive PR audit complete. 16 WIP, 0 review-ready, 0 idle. Key update: tanjiro SW=2.0 T_max=30 full test results in (test abupt=9.697% — lost to alphonse 8.480%). First confirmed alphonse test baseline: **8.480%**. val/test gap confirmed at ~2.5× on vol_p (val=5.19% → test=12.90%). Wave 3 PRs #214 (gilbert) and #218 (frieren) launched with results incoming. Stale PRs: #215 (senku), #216 (askeladd), #217 (edward), #219 (haku), #220 (kohaku) — no student responses to advisor check-ins.
+- **2026-04-30 ~21:00Z (Wave 4 mid-flight + Wave 2/3 closure round)** — PR #218 (frieren TangentFrameHead) closed as clean negative result at ep11 abupt=13.195% with 5 follow-ups archived for Wave 5+. PR #176 (chihiro FourierEmbed lr sweep) merged to bengio. PR #80 (tanjiro SW=2.0/T_max=50) PASSED ep16 gate at 8.963%. Both fern PR #75 Trial B and emma PR #79 Trial B v2 are descending strongly (fern ep19=8.342%, emma ep19=8.662%) and on track to compete with the alphonse 7.21% baseline. PR #174 (alphonse 5L/256d + T_max=50) is the surprise leader: `vu4jsiic` at ep12 abupt=8.111% — already beating the original ep15<9% gate by ~0.9pp; on track for terminal <7.0%.
 
 ## Most Recent Human Researcher Direction
 
 - **Issue #48 (tay/morganmcg1)**: "Hows it going? we making progress?" — Responded.
-- **Issue #18 (yi)**: "Ensure you're really pushing hard on new ideas" — Wave 3 prioritizes bold architectural moves.
+- **Issue #18 (yi)**: "Ensure you're really pushing hard on new ideas" — Wave 3+4 prioritize bold architectural moves.
 - Mission: crush DrivAerML AB-UPT public reference metrics across all 6 axis metrics simultaneously on **test** set.
 
 ## AB-UPT Targets (all must be beaten simultaneously on test)
 
 | Metric | AB-UPT Target | Best Val | Best Test | Status |
 |--------|:---:|:---:|:---:|----|
-| abupt_axis_mean_rel_l2_pct | 4.51% | **7.209%** (`m9775k1v`) | **8.480%** (alphonse, confirmed by tanjiro) | gap −3.97pp (test) |
+| abupt_axis_mean_rel_l2_pct | 4.51% | **7.209%** (`m9775k1v`) | **8.480%** (alphonse, confirmed) | gap −3.97pp (test) |
 | surface_pressure_rel_l2_pct | 3.82% | 4.802% | 5.078% (tanjiro SW2) | gap −1.26pp (test) |
 | volume_pressure_rel_l2_pct | 6.08% | **4.166%** (val only) | 12.897% (tanjiro SW2, 2.5× val/test gap) | **val WON but test fails badly** |
 | wall_shear_x_rel_l2_pct | 5.35% | 7.109% | 7.953% (tanjiro SW2) | gap −2.60pp (test) |
@@ -24,124 +21,110 @@
 
 **CRITICAL**: The val/test gap on vol_p is ~2.5×. Surface-loss reweighting (SW=2.0) did NOT help on test — it was worse than alphonse on all 5 axes. Do not chase val vol_p wins without test confirmation.
 
-**Alphonse test baseline confirmed**: abupt=8.480% (5 axis mean, tanjiro PR #80 reported on 2026-05-01). Previously only val=7.209% was known.
-
-## Baseline Correction (2026-05-01, frieren PR #218 audit)
-
-- alphonse Wave 1 winner `m9775k1v` used **`ContinuousSincosEmbed`** NOT FourierEmbed
-- PR #74 was a squash merge of assignment commit only — no model code landed
-- FourierEmbed added to bengio later by chihiro PR #176 (not yet merged)
-- All students using `--fourier-pe` are cherry-picking askeladd commit `d97c19d` from PR #175
-
-## Universal ep31 Peak Pattern
-
-All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max. This is a dataset/architecture property. Experiments with T_max=50+ may benefit from continued cosine decay but the primary valley is always near ep31.
-
 ## Active Experiments — Live Tracking
 
-### Legacy Wave 2 (still running)
+### Wave 2/3 leftovers (still running, descending)
 
-| PR | Student | Run ID | Experiment | Best abupt | Epoch | Gate | ETA |
-|----|---------|--------|-----------|:----------:|-------|------|-----|
-| #75 | fern | `uz4em31o` | lr=5e-4 Trial B | ~9.40% | ep9 | ep15 <9% | ep31 ~10:30Z May 2 |
-| #79 | emma | `3evzgru1` | 60k pts + Fourier PE + T_max=50 Trial B v2 | 9.214% | ep12 | ep15 <9% (projected ~8.82% PASS) | ep31 ~TBD |
-| #80 | tanjiro | `0qjbutkd` | SW=2.0 + T_max=50 (Trial B1) | 9.562% | ep10 | ep15 <9%, ep25 <8%, ep50 <7% | ep50 ~May 2 10:30Z |
-| #174 | alphonse | `vu4jsiic` | 5L/256d + T_max=50 Trial B v2 | 9.917% | ep10 | ep15 <9% | TBD |
-| #176 | chihiro | `ld3ff1gs` | lr=5e-4 Trial B (FourierEmbed) | ~11% | ep5+ | ep15 <9% | TBD |
-| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | 10.51% | ep5 | ep5 gate PASSED | ep31 ~May 2 11:00Z |
-| #180 | norman | `1rieq278` | raw rel-L2 aux loss w=0.1 Trial A | 10.85% | ep5 | ep10 <9% (may fail) | TBD |
-| #181 | thorfinn | `scefipy4` | no-EMA + b1=0.95 + T_max=50 | ? | ep1+ | ep10-15 report pending | TBD |
+| PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
+|----|---------|--------|-----------|:----------:|------:|---------|
+| #75 | fern | `uz4em31o` | T_max=30 + lr=5e-4 + Fourier PE Trial B | **8.342%** | 19 | descending; ep30 valley projected ~7.2-7.4% |
+| #79 | emma | `3evzgru1` | 60k pts + Fourier PE + T_max=50 Trial B v2 | **8.662%** | 19 | descending; ep50 valley projected ~6.9-7.1%; PR has merge conflict |
+| #80 | tanjiro | `0qjbutkd` | SW=2.0 + T_max=50 (Trial B1) | **8.963%** | 16 | PASSED ep16 gate; next ep20<8.5% |
+| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **8.111%** | 12 | LEADER OF SECOND ROUND; ep30 projected <7.4%; ep50 stretch <7.0% |
+| #221 | violet | ? | Per-channel adaptive loss reweighting | stale at ep1-2 | 2 | needs check-in |
+| #214 | gilbert | `2rnm99yl` | k-NN local attention | merge conflict | early | needs rebase |
+| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | merge conflict | TBD | needs rebase |
+| #239 | norman | TBD | Fourier PE num_freqs sweep {16,32,64,128} | launch pending | — | Wave 3 second round |
 
-**Tanjiro Trial B matrix auto-launch**: B2 (SW=3.0/T_max=30) and B3 (SW=3.0/T_max=50) queued via PID 188667 script, fire after B1 ep31.
+### Wave 4 (launched 2026-04-30) — wsy/wsz binding-constraint attack
 
-**Fern Trial C**: `auto_kc_trialC.sh` queued to fire after Trial B ep31 (~May 2 01:30Z). Trial C = T_max=50 + lr=5e-4.
+| PR | Student | Hypothesis | Tier |
+|----|---------|------------|------|
+| #253 | askeladd | FourierEmbed vs ContinuousSincosEmbed standalone A/B | Embedding family disambiguation |
+| #254 | chihiro | Raw rel-L2 auxiliary loss sweep w in {0.05, 0.1} | Loss aux term |
+| #255 | edward | Fixed per-channel wsy/wsz loss multipliers | Simplest loss rebalance |
+| #256 | frieren | Mirror-symmetry TTA for wsy reduction (REASSIGNED from #218) | Inference-time / free gain |
+| #257 | haku | High-shear curriculum oversampling with linear anneal | Data sampling reweight |
+| #258 | kohaku | Squared rel-L2 aux loss on wall-shear (focal-loss-equivalent) | Loss formulation |
+| #259 | senku | grad-clip-norm sweep {0.5, 2.0} on baseline | Optimization stability |
+| #260 | thorfinn | model-slices sweep {64, 128, 192} on baseline | Architecture scaling |
 
-### Wave 3 (launched 2026-05-01)
+All Wave 4 PRs include corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and 30-min ack requirement.
 
-| PR | Student | Run ID | Experiment | Last Known | Kill Threshold Fixed? | Notes |
-|----|---------|--------|-----------|:----------:|-----------------------|-------|
-| #214 | gilbert | `2rnm99yl` | k-NN local attention (PointTransformer-style rel PE, zero-init out_proj) | launched 16:42Z | YES → `35000:<20` | k=16, chunk=4096, ~8.4 it/s; ~21.5h ETA for ep1; no ep val yet |
-| #215 | senku | ? | SWA last-5-epoch averaging | no response | NO | Stale — only advisor check-in |
-| #216 | askeladd | ? | Per-axis EMA variance autoweighting | no response | NO | Stale — only advisor check-in |
-| #217 | edward | ? | Lion optimizer sweep (lr=1e-4, 3e-4) | no response | NO | Stale — only advisor check-in |
-| #218 | frieren | ? (no ID posted) | TangentFrameHead w/ Frisvad-Duff basis (τ = α·e_t1 + β·e_t2) | launched, no W&B ID in thread | YES → `35000:<20` | Physically motivated; `max|τ·n|<1e-6` by construction; stats buffered before torch.compile |
-| #219 | haku | ? | 5L depth + Fourier PE + GradNorm α=1.5 stack | no response | NO | Stale — depends on PR #176 landing |
-| #220 | kohaku | ? | Asinh surf pressure + 96k pts | no response | NO | Stale — only advisor check-in |
-| #221 | violet | ? | Adaptive loss reweighting (gap-ratio softmax, τ=1.0, weights every 5 ep) | ep1-2 launched | YES | Run A (ContinuousSincosEmbed) — no recent update |
+### Recently closed
 
-**Dead RANS experiments** (nezuko): `pe2ryffk` (λ=0.1) crashed step 12K; `8u7jc8kt` (control) crashed step 13K. Direction closed.
+- **PR #218 frieren TangentFrameHead** — closed at ep11=13.195%; clean negative result; 5 follow-ups archived for Wave 5+. Reassigned to PR #256.
+- **PR #176 chihiro FourierEmbed lr sweep** — MERGED. lr=3e-4 confirmed optimal among {1e-4, 3e-4, 5e-4} on bengio.
+- **PR #75 fern** Trial A `pxty4knv` finished ep50=9.0433% (non-competitive); Trial B `uz4em31o` is the productive replacement.
 
-**Symmetry augmentation** (nezuko Wave 2): symm-p50=16.564%, symm-p100=54.686%. Direction closed — breaks coordinate encoding.
+## Critical Findings
 
-## Stale PR Watch List (need follow-up)
+### val/test gap on vol_p is ~2.5× (tanjiro SW2 evidence)
+- val=4.17% → test=12.90%
+- Surface-loss reweighting moves error around between train channels but does not reduce test error
+- Implication: regularization or test-time generalization of volume head is the gap, not architecture or loss weight
 
-PRs with only advisor check-in, no student response — may need escalation or reassignment:
-- **#215 (senku)**: SWA
-- **#216 (askeladd)**: Per-axis EMA variance autoweighting
-- **#217 (edward)**: Lion optimizer
-- **#219 (haku)**: GradNorm stack
-- **#220 (kohaku)**: Asinh surf pressure
+### wsy/wsz binding constraint (Wave 4 entire focus)
+- Best wsy = 9.10% (alphonse val) / 10.895% (tanjiro test) vs target 3.65%. Gap 2.5–3× on test.
+- Best wsz = 10.87% (alphonse val) / 11.664% (tanjiro test) vs target 3.63%. Gap 3.2× on test.
+- TangentFrameHead failed (PR #218) — pure inductive bias did not work
+- Wave 4 attacks via 8 different orthogonal levers: loss multipliers (#255), focal loss (#258), data oversampling (#257), TTA (#256), embedding family (#253), aux loss (#254), grad clip (#259), slice scaling (#260)
 
-All share the dead kill threshold bug (`3000:val_primary/abupt_axis_mean_rel_l2_pct<=25`). Fix communicated in advisor check-in comments: use `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`.
+### Universal ep31 valley pattern
+All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max. T_max=50 schedules are showing this pattern is the dominant force — the cosine knee aligns with this valley. Runs with T_max=50 may extract more after ep31 but the primary descent is always near ep31.
 
-## Critical Research Finding: Surface-Loss Reweighting Does Not Help on Test
+### lr=5e-4 unlocks vol_p capacity at 60k pts (fern Trial B)
+fern Trial B at ep18 hit vol_p=6.07% — at AB-UPT target — while still 12 epochs from cosine knee. Confirms 60k pts + Fourier PE + lr=5e-4 is a valid recipe ingredient. Need to test on test set.
 
-tanjiro PR #80 provides the definitive result:
-- SW=2.0 T_max=30 (`846uciam`): test abupt=9.697% vs alphonse test=8.480% — **lost on all 5 axes**
-- The "vol_p beats AB-UPT" result (val=4.17%) is a **val artifact** — test vol_p=12.897% (2.5× degradation)
-- Surface loss reweighting moves error around between train channels but does not reduce test error
-- SW=2.0 T_max=50 (B1 `0qjbutkd`) currently testing whether longer schedule recovers SW benefits
+## Potential Next Research Directions (Wave 5 prep)
 
-## Critical Gap — wsy/wsz Binding Constraint
+**If Wave 4 wsy/wsz attacks succeed (one or more land <8.0% with healthy wsy/wsz)**:
+- Stack winners: best loss formulation + best embedding + 5L/256d + T_max=50 + EMA off (i.e. extend the alphonse `vu4jsiic` recipe with the wsy/wsz winner)
+- Test-set re-evaluation campaign on all val-winners
 
-Best wsy = 9.10% (alphonse val) / 10.895% (tanjiro test) vs target 3.65%. Gap is 2.5–3× on test.  
-Best wsz = 10.87% (alphonse val) / 11.664% (tanjiro test) vs target 3.63%. Gap is 3.2× on test.
-
-Wave 3 bets targeting this:
-- **#218 frieren** (TangentFrameHead): theoretically motivated — shear lives in tangent plane, predict α/β scalars → reconstruct τ. Strongest inductive bias bet.
-- **#214 gilbert** (k-NN local attention): local surface geometry may explain shear underperformance
-- **#216 askeladd** (EMA variance autoweighting): upweights harder axes dynamically
-- **#221 violet** (gap-ratio softmax): explicitly targets axes furthest from AB-UPT target
-
-Empirical signal: fern Trial B wsy delta = −2.2pp at ep5 vs Trial A — strongest wsy/wsz improvement yet from lr=5e-4.
-
-## Potential Next Research Directions (Wave 4)
-
-**Bold architectural moves**:
-- SO(3)-equivariant representations (Wave 3 PR #218 testing first flavor)
-- Spectral-graph convolution as parallel branch alongside Transolver attention
-- Latent diffusion prior for surface field reconstruction
-- Boundary-layer-aware attention with explicit `y+` distance feature
+**If Wave 4 wsy/wsz attacks plateau at ~9% (no gain on the binding axes)**:
+- Architecture pivot: spectral graph convolution branch parallel to Transolver attention
+- Boundary-layer-aware attention with explicit y+ distance feature
 - Graph neural network on surface mesh (explicit topology vs point cloud)
+- Boundary-layer physics loss (eddy-viscosity-aware, log-law inspired)
+- Stronger regularization specific to volume decoder (target 2.5× val/test gap)
+- TangentFrameHead followups: PCA-of-kNN-normals basis, soft loss term, warm start from Cartesian
 
-**Empirical compounders** (ready once Wave 3 data returns):
-- Stack all winning ingredients: 5L depth + Fourier PE + GradNorm α=1.5 + T_max=50 + SWA
-- Asinh on volume fields too (not just surface pressure)
-- Per-axis loss weights from senku metric-aware coefficients (transfer optimal weights)
-- Trial C for fern: lr=5e-4 + T_max=50 if Trial B lands 7.5–8.5%
-
-**Test-focused strategy**:
-- The val/test vol_p gap (2.5×) is the biggest blocker. Hypothesis: overfitting to training distribution on volume pressure. Try stronger regularization (higher dropout, weight decay) specifically for volume decoder.
-- Consider test_primary eval of all completed val-winners before claiming any axis beat.
-
-**Plateau protocol**: 5+ consecutive experiments with no test improvement → escalate to architecture-level changes. We are at ~2 rounds of improvements post-Wave-1 with no test beat. Wave 3 results are the next decision point.
+**Already merged ingredients to compose**:
+- FourierEmbed (PR #176, lr=3e-4 optimal)
+- 60k points (emma confirmed lr=5e-4 unlocks vol_p)
+- T_max=50 cosine schedule
+- EMA off (alphonse `vu4jsiic` is leading without EMA)
+- 5L depth (alphonse `vu4jsiic` 5L/256d)
 
 ## Upcoming Gates and Checkpoints
 
 | Time (approx) | Event |
 |---|---|
-| ~May 1 18:00Z | Emma `3evzgru1` ep15 (projected 8.82%, PASS) |
-| ~May 1 19:00Z | Chihiro `ld3ff1gs` ep15 gate (<9%) |
-| ~May 1 20:00Z | Gilbert `2rnm99yl` ep1 val (first wsy/wsz vs baseline) |
-| ~May 2 01:30Z | Fern Trial B ep31 → auto-fire Trial C |
-| ~May 2 10:30Z | Tanjiro B1 `0qjbutkd` ep50 → auto-fire B2 (SW=3.0/T_max=30) |
-| ~May 2 11:00Z | Nezuko `ud5iddlc` ep31 (5L/384d valley) |
-| ~May 2 11:00Z | Alphonse `vu4jsiic` ep31 (5L/256d + T_max=50) |
-| ~May 2 TBD | Frieren first ep1-5 results (TangentFrameHead) |
+| ~May 1 02:00Z | fern `uz4em31o` ep20 (gate <8.0%, projected 8.25%) |
+| ~May 1 04:00Z | emma `3evzgru1` ep20 |
+| ~May 1 ~12Z | alphonse `vu4jsiic` ep20 (current trajectory <8.0% gate) |
+| ~May 1 ~21Z | tanjiro `0qjbutkd` ep20 (gate <8.5%) |
+| ~May 1+ | Wave 4 PRs #253-260 first ep5/ep10 reports |
+| ~May 2 ~13Z | fern Trial B ep30 valley (terminal) |
+| ~May 2 ~22Z | emma `3evzgru1` ep30 |
+| ~May 2 ~23Z | alphonse `vu4jsiic` ep30 (projected <7.4%) |
+
+## Plateau Protocol Status
+
+We are not on a plateau. Two productive surprises in this session:
+1. alphonse `vu4jsiic` is the leader of round 2 — 5L/256d + Fourier PE + T_max=50 + EMA off recipe stack
+2. fern Trial B Trial B 60k pts + lr=5e-4 unlocks vol_p
+
+Both are worth investing in; if either lands <7.5% on test, that becomes the new baseline and Wave 4 results stack on top.
+
+## Discipline Note (this session)
+
+- alphonse: Two unanswered escalations on PR #174. Run is healthy and beating gates so PR was NOT closed, but a final acknowledgment was demanded with a 1-hour deadline. Unauthorized `alphonse-agc-r6` sweep flagged (3 still running outside any PR — must kill or move to dedicated PR).
+- Several PRs need rebase: #214 gilbert, #179 nezuko, #79 emma — all post-#176 chihiro merge.
 
 ## Research Log Pointers
 
 - All experiments: `/research/EXPERIMENTS_LOG.md`
 - Current baseline: `/BASELINE.md` — alphonse Wave 1 val=7.209%, test=8.480%
 - Research ideas: `/research/RESEARCH_IDEAS_2026-04-30_15:34.md`
-- Wave 3 check-ins: posted 2026-05-01 on PRs #214-221

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -505,3 +505,39 @@ All five students immediately reassigned with fresh Wave 3 hypotheses targeting 
 | #238 | kohaku | High-shear curriculum oversampling + linear anneal | Data axis — sampling reweight |
 
 All five new PRs include the corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and a 30-minute acknowledgment requirement. Two missed acknowledgments = closure (consistent with the protocol that produced this round's reassignments).
+
+## 2026-04-30 21:00 — PR #218: [frieren] SO(3)-equivariant TangentFrameHead (CLOSED)
+
+- **Branch:** `frieren/tangent-frame-wallshear-head`
+- **Run IDs:** `lpnr8zhi` (primary), `dwl5oi97`, `d4cvbt1p`, `i3lx54ou` (siblings, all killed)
+- **Hypothesis:** Predict wall shear in the local tangent plane (Frisvad-Duff orthonormal basis built from surface normals) instead of Cartesian xyz, restoring SO(3)-equivariance and providing inductive bias toward physical wall-tangent flow direction.
+
+### Results table (kill at ep11)
+
+| Metric | TangentFrame (lpnr8zhi) | Cartesian baseline | Δ |
+|---|---:|---:|---:|
+| val_abupt | 13.195% | ~9.0% | +4.2pp WORSE |
+| val_surf_p | 6.288% | ~5.5% | +0.8pp |
+| val_vol_p | 5.868% | ~5.6% | +0.3pp |
+| val_wsx | 13.057% | ~8.5% | +4.6pp |
+| val_wsy | 19.379% | ~11.0% | +8.4pp |
+| val_wsz | 21.380% | ~13.0% | +8.4pp |
+
+Validation trajectory: ep1=18.7%, ep5=14.9%, ep11=13.2% — converging too slowly; slope analysis projected ep30 ≈ 11–12%, never reaching <9.0%.
+
+### Diagnosis (student writeup)
+
+The Frisvad-Duff basis introduces anisotropic gradient flow: small variations in the surface normal cause large discontinuous changes in the tangent frame, which the optimizer must compensate for. The wall-shear-y/z components (the binding constraint) ended up 2× WORSE than the dense MLP Cartesian baseline despite the equivariance prior — the geometric inductive bias is correct in theory but the optimization landscape is hostile in practice.
+
+### Conclusion
+
+**Rejected. Closed as dead end.** Clean negative result: SO(3)-equivariance via tangent frame reparametrization does not help on DrivAerML when the binding constraint is wsy/wsz absolute magnitude. Archived 5 follow-ups for Wave 5+:
+
+1. PCA-of-k-NN-normals tangent basis (smoother than Frisvad-Duff)
+2. Hybrid Cartesian + tangent prediction with learnable gate
+3. Tangent constraint as soft loss term, not hard reparametrization
+4. Warm-start tangent head from Cartesian baseline checkpoint
+5. Pair tangent head with Wave 4 wsy/wsz loss multipliers
+
+Frieren reassigned to PR #256 (Mirror-symmetry TTA for wsy reduction) in the Wave 4 launch.
+

--- a/train.py
+++ b/train.py
@@ -26,6 +26,7 @@ import torch.nn as nn
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
+from torch.optim.swa_utils import AveragedModel, update_bn
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
@@ -117,6 +118,7 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    swa_last_k_epochs: int = 5
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -290,6 +292,16 @@ def main(argv: Iterable[str] | None = None) -> None:
         timeout_hit = False
         train_start = time.time()
 
+        swa_enabled = config.swa_last_k_epochs > 0 and max_epochs > config.swa_last_k_epochs
+        swa_start_epoch = max_epochs - config.swa_last_k_epochs if swa_enabled else max_epochs
+        swa_model = AveragedModel(base_model) if swa_enabled else None
+        swa_snapshots = 0
+        if swa_enabled and state.is_main:
+            print(
+                f"SWA: averaging last {config.swa_last_k_epochs} epochs "
+                f"(epochs {swa_start_epoch + 1}..{max_epochs})"
+            )
+
         for epoch in range(max_epochs):
             if isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
@@ -461,6 +473,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     break
 
             scheduler.step()
+            if swa_enabled and epoch >= swa_start_epoch:
+                swa_model.update_parameters(base_model)
+                swa_snapshots += 1
             epoch_train_loss = train_loss_sum / max(n_batches, 1)
             dt = time.time() - t0
             peak_gb = torch.cuda.max_memory_allocated(device) / 1e9 if torch.cuda.is_available() else 0.0
@@ -623,6 +638,59 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary.update({"total_train_minutes": total_minutes})
             wandb.finish()
             return
+
+        if swa_enabled and swa_snapshots > 0:
+            swa_model = swa_model.to(device)
+            with torch.no_grad():
+                update_bn(train_loader, swa_model)
+            swa_model.eval()
+            swa_val_metrics = {
+                name: evaluate_split(swa_model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in val_loaders.items()
+            }
+            swa_primary_val = swa_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
+            swa_log: dict[str, object] = {
+                "global_step": global_step,
+                "swa/snapshots": swa_snapshots,
+                "swa/start_epoch": swa_start_epoch + 1,
+            }
+            swa_log.update(primary_metric_log("swa", swa_val_metrics["val_surface"]))
+            for split_name, metrics in swa_val_metrics.items():
+                swa_log.update(metric_namespace("swa", split_name, metrics))
+            wandb.log(swa_log)
+            print(f"SWA model val_abupt={swa_primary_val:.4f} (snapshots={swa_snapshots})")
+            print_metrics("swa_val_surface", swa_val_metrics["val_surface"])
+            swa_improved = should_update_best_checkpoint(swa_primary_val, best_val)
+            wandb.summary.update(
+                {
+                    "swa/best_primary_abupt": swa_primary_val,
+                    "swa/snapshots": swa_snapshots,
+                    "swa/start_epoch": swa_start_epoch + 1,
+                    "swa/improved_over_per_epoch": 1.0 if swa_improved else 0.0,
+                    "swa/per_epoch_best_primary_abupt": best_val,
+                }
+            )
+            if swa_improved:
+                best_val = swa_primary_val
+                best_metrics = {
+                    "epoch": float(max_epochs),
+                    **swa_val_metrics["val_surface"],
+                }
+                best_checkpoint_source = "swa"
+                torch.save(
+                    {
+                        "model": swa_model.module.state_dict(),
+                        "config": asdict(config),
+                        "epoch": max_epochs,
+                        "val_metrics": swa_val_metrics,
+                        "checkpoint_source": "swa",
+                        "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
+                        "swa_snapshots": swa_snapshots,
+                        "swa_start_epoch": swa_start_epoch + 1,
+                    },
+                    model_path,
+                )
+                print(f"SWA checkpoint saved (improved over best per-epoch val={best_val:.4f})")
 
         if not best_metrics:
             wandb.summary.update(


### PR DESCRIPTION
## Hypothesis

Stochastic Weight Averaging (SWA) averages model weights from the last K epochs of training to produce a final model that generalizes better than any single checkpoint. Unlike EMA (which tracks a running average throughout training), SWA averages a small window of final checkpoints after the cosine LR has annealed to its minimum. This is a cheap ensemble-like technique compatible with cosine scheduling that can reduce val_abupt without additional training cost.

The idea: after the LR cosine cycle ends (after T_max epochs), instead of taking the final checkpoint, average the weights from the last 5 epoch snapshots. The averaged model is then evaluated. Reference: Izmailov et al. 2018, "Averaging Weights Leads to Wider Optima and Better Generalization".

This was previously archived from Wave 3 (PR #215, senku) where the student did not respond. Now assigned to you with full implementation instructions.

## Instructions

This requires a **code modification to `target/train.py`**. No other files need to change.

**Add SWA over the last 5 epochs of training using PyTorch's built-in `torch.optim.swa_utils.AveragedModel`.**

Here is the exact implementation:

**Step 1: Import at the top of `train.py`** (add after the existing torch imports):
```python
from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
```

**Step 2: Before the training loop**, create the SWA model and decide the SWA start epoch:
```python
# SWA: start averaging in the last 5 epochs
swa_start_epoch = max_epochs - 5
swa_model = AveragedModel(base_model)
swa_enabled = swa_start_epoch > 0
```

**Step 3: At the END of each epoch** (after `scheduler.step()` on line ~463), add:
```python
# SWA: collect weight snapshots for final averaging
if swa_enabled and epoch >= swa_start_epoch:
    swa_model.update_parameters(base_model)
```

**Step 4: After the training loop ends** (before `distributed_barrier` on line ~621), add SWA evaluation:
```python
# SWA: evaluate averaged model if we collected any snapshots
if swa_enabled and state.is_main:
    # Update batch norm statistics with train data
    with torch.no_grad():
        update_bn(train_loader, swa_model.to(device))
    # Evaluate SWA model
    swa_model.eval()
    swa_val_metrics = evaluate(swa_model, val_loader, transform, device, config.amp_mode)
    swa_primary_val = swa_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
    swa_log = {"swa/abupt_axis_mean_rel_l2_pct": swa_primary_val}
    swa_log.update({f"swa/{k}": v for k, v in swa_val_metrics["val_surface"].items()})
    wandb.log(swa_log)
    print(f"SWA model val_abupt={swa_primary_val:.4f}")
    # If SWA beats the best regular checkpoint, use SWA weights
    if swa_primary_val < best_val:
        best_val = swa_primary_val
        best_metrics = {"epoch": float(max_epochs), "swa": True, **swa_val_metrics["val_surface"]}
        torch.save(
            {
                "model": swa_model.module.state_dict(),
                "config": asdict(config),
                "epoch": max_epochs,
                "val_metrics": swa_val_metrics,
                "checkpoint_source": "swa",
                "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
            },
            model_path,
        )
        print(f"SWA checkpoint saved (improved over best_val)")
```

**Base recipe** (no code changes beyond the SWA addition above):
```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --no-compile-model \
  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
  --wandb-group bengio-wave5-fern
```

**Notes**:
- Run for 30 epochs (matching the baseline T_max=30). The SWA window covers epochs 26–30.
- The `update_bn` call iterates over the train loader once — expected to take ~2-3 minutes extra.
- `swa_model.module` gives you the underlying model state_dict (AveragedModel wraps the model).
- If `evaluate` is not the correct function name for running validation, find the equivalent in train.py and adapt.

**Win condition**: SWA val_abupt < 7.2091% at best checkpoint.

## Baseline (Current Best)

From PR #74 (alphonse), W&B run `m9775k1v`, ep30, 4L/256d/4H:

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
| `val_primary/volume_pressure_rel_l2_pct` | 4.166 ✓ | 6.08 |
| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |

## What to Report

Post your best-checkpoint metrics (all 7 metrics above) plus the SWA-specific val_abupt with W&B run ID in a PR comment. Note whether the best checkpoint came from regular training or SWA averaging.
