### PR TITLE
[tanjiro] DomainLayerNorm: domain-specific affine LayerNorm for surface vs volume tokens

### DIFF
--- a/model.py
+++ b/model.py
@@ -121,6 +121,38 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class DomainLayerNorm(nn.Module):
+    """LayerNorm with shared per-token statistics and separate affine params for surface vs volume tokens."""
+
+    def __init__(self, hidden_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.eps = eps
+        self.norm = nn.LayerNorm(hidden_dim, elementwise_affine=False, eps=eps)
+        self.surface_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.surface_bias = nn.Parameter(torch.zeros(hidden_dim))
+        self.volume_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.volume_bias = nn.Parameter(torch.zeros(hidden_dim))
+
+    def forward(self, x: torch.Tensor, surface_tokens: int = 0) -> torch.Tensor:
+        normed = self.norm(x)
+        total = x.shape[1]
+        surface_tokens = max(0, min(surface_tokens, total))
+        # Always compute both branches so both sets of affine params are in the
+        # autograd graph (DDP find_unused_parameters=False otherwise hangs when
+        # ranks see different empty-slice patterns, e.g. surface_tokens=0 batches).
+        surf = normed[:, :surface_tokens] * self.surface_weight + self.surface_bias
+        vol = normed[:, surface_tokens:] * self.volume_weight + self.volume_bias
+        out = torch.cat([surf, vol], dim=1)
+        # Ghost connection: zero-valued contribution that guarantees all 4 affine
+        # params are touched even when one slice is empty across the entire batch.
+        ghost = (
+            self.surface_weight.sum() + self.surface_bias.sum()
+            + self.volume_weight.sum() + self.volume_bias.sum()
+        ) * 0.0
+        return out + ghost
+
+
 class TransolverAttention(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
         super().__init__()
@@ -180,24 +212,40 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_domain_ln: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
-        self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.use_domain_ln = use_domain_ln
+        if use_domain_ln:
+            self.norm1 = DomainLayerNorm(hidden_dim)
+            self.norm2 = DomainLayerNorm(hidden_dim)
+        else:
+            self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+            self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.attention = TransolverAttention(
             hidden_dim=hidden_dim,
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
         )
-        self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        surface_tokens: int = 0,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
-        x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        if self.use_domain_ln:
+            x = x + self.attention(self.norm1(x, surface_tokens), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x, surface_tokens))
+        else:
+            x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -211,6 +259,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_domain_ln: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -221,14 +270,20 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    use_domain_ln=use_domain_ln,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        surface_tokens: int = 0,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, surface_tokens=surface_tokens)
         return x
 
 
@@ -251,8 +306,10 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         fourier_pe: bool = False,
         fourier_pe_num_freqs: int = 8,
+        domain_ln: bool = False,
     ):
         super().__init__()
+        self.domain_ln = domain_ln
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
@@ -284,6 +341,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            use_domain_ln=domain_ln,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -349,7 +407,7 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, surface_tokens=surface_tokens)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,21 +1,18 @@
 # SENPAI Research State
 
-- **2026-05-01 17:40Z (Wave 3 reassignment round)** — After two escalations with zero student response on PRs #215 senku, #216 askeladd, #217 edward, #219 haku, #220 kohaku — all five closed per non-response protocol, branches deleted. Five fresh Wave 3 hypotheses assigned, all targeting the wsy/wsz binding constraint via different levers: PR #234 senku (mirror-symmetry TTA — free wsy gain via y-flip averaging at inference), PR #235 askeladd (4L/512d/8H radford champion port — width frontier untried on bengio), PR #236 edward (fixed wsy×3/wsz×5 channel multipliers — simplest possible wsy/wsz attack after UW #84 and GradNorm #137 both closed), PR #237 haku (squared rel-L2 aux loss — focal-loss-equivalent for hard-sample focusing), PR #238 kohaku (high-shear curriculum oversampling with linear anneal — orthogonal data-axis lever). All five include the corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and a 30-minute acknowledgment requirement. 11 active Wave 2/Wave 3 PRs continue; 16 bengio WIP total after reassignment.
-
-
-- **2026-05-01 ~17:00Z** — Comprehensive PR audit complete. 16 WIP, 0 review-ready, 0 idle. Key update: tanjiro SW=2.0 T_max=30 full test results in (test abupt=9.697% — lost to alphonse 8.480%). First confirmed alphonse test baseline: **8.480%**. val/test gap confirmed at ~2.5× on vol_p (val=5.19% → test=12.90%). Wave 3 PRs #214 (gilbert) and #218 (frieren) launched with results incoming. Stale PRs: #215 (senku), #216 (askeladd), #217 (edward), #219 (haku), #220 (kohaku) — no student responses to advisor check-ins.
+- **2026-04-30 ~21:00Z (Wave 4 mid-flight + Wave 2/3 closure round)** — PR #218 (frieren TangentFrameHead) closed as clean negative result at ep11 abupt=13.195% with 5 follow-ups archived for Wave 5+. PR #176 (chihiro FourierEmbed lr sweep) merged to bengio. PR #80 (tanjiro SW=2.0/T_max=50) PASSED ep16 gate at 8.963%. Both fern PR #75 Trial B and emma PR #79 Trial B v2 are descending strongly (fern ep19=8.342%, emma ep19=8.662%) and on track to compete with the alphonse 7.21% baseline. PR #174 (alphonse 5L/256d + T_max=50) is the surprise leader: `vu4jsiic` at ep12 abupt=8.111% — already beating the original ep15<9% gate by ~0.9pp; on track for terminal <7.0%.
 
 ## Most Recent Human Researcher Direction
 
 - **Issue #48 (tay/morganmcg1)**: "Hows it going? we making progress?" — Responded.
-- **Issue #18 (yi)**: "Ensure you're really pushing hard on new ideas" — Wave 3 prioritizes bold architectural moves.
+- **Issue #18 (yi)**: "Ensure you're really pushing hard on new ideas" — Wave 3+4 prioritize bold architectural moves.
 - Mission: crush DrivAerML AB-UPT public reference metrics across all 6 axis metrics simultaneously on **test** set.
 
 ## AB-UPT Targets (all must be beaten simultaneously on test)
 
 | Metric | AB-UPT Target | Best Val | Best Test | Status |
 |--------|:---:|:---:|:---:|----|
-| abupt_axis_mean_rel_l2_pct | 4.51% | **7.209%** (`m9775k1v`) | **8.480%** (alphonse, confirmed by tanjiro) | gap −3.97pp (test) |
+| abupt_axis_mean_rel_l2_pct | 4.51% | **7.209%** (`m9775k1v`) | **8.480%** (alphonse, confirmed) | gap −3.97pp (test) |
 | surface_pressure_rel_l2_pct | 3.82% | 4.802% | 5.078% (tanjiro SW2) | gap −1.26pp (test) |
 | volume_pressure_rel_l2_pct | 6.08% | **4.166%** (val only) | 12.897% (tanjiro SW2, 2.5× val/test gap) | **val WON but test fails badly** |
 | wall_shear_x_rel_l2_pct | 5.35% | 7.109% | 7.953% (tanjiro SW2) | gap −2.60pp (test) |
@@ -24,124 +21,110 @@
 
 **CRITICAL**: The val/test gap on vol_p is ~2.5×. Surface-loss reweighting (SW=2.0) did NOT help on test — it was worse than alphonse on all 5 axes. Do not chase val vol_p wins without test confirmation.
 
-**Alphonse test baseline confirmed**: abupt=8.480% (5 axis mean, tanjiro PR #80 reported on 2026-05-01). Previously only val=7.209% was known.
-
-## Baseline Correction (2026-05-01, frieren PR #218 audit)
-
-- alphonse Wave 1 winner `m9775k1v` used **`ContinuousSincosEmbed`** NOT FourierEmbed
-- PR #74 was a squash merge of assignment commit only — no model code landed
-- FourierEmbed added to bengio later by chihiro PR #176 (not yet merged)
-- All students using `--fourier-pe` are cherry-picking askeladd commit `d97c19d` from PR #175
-
-## Universal ep31 Peak Pattern
-
-All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max. This is a dataset/architecture property. Experiments with T_max=50+ may benefit from continued cosine decay but the primary valley is always near ep31.
-
 ## Active Experiments — Live Tracking
 
-### Legacy Wave 2 (still running)
+### Wave 2/3 leftovers (still running, descending)
 
-| PR | Student | Run ID | Experiment | Best abupt | Epoch | Gate | ETA |
-|----|---------|--------|-----------|:----------:|-------|------|-----|
-| #75 | fern | `uz4em31o` | lr=5e-4 Trial B | ~9.40% | ep9 | ep15 <9% | ep31 ~10:30Z May 2 |
-| #79 | emma | `3evzgru1` | 60k pts + Fourier PE + T_max=50 Trial B v2 | 9.214% | ep12 | ep15 <9% (projected ~8.82% PASS) | ep31 ~TBD |
-| #80 | tanjiro | `0qjbutkd` | SW=2.0 + T_max=50 (Trial B1) | 9.562% | ep10 | ep15 <9%, ep25 <8%, ep50 <7% | ep50 ~May 2 10:30Z |
-| #174 | alphonse | `vu4jsiic` | 5L/256d + T_max=50 Trial B v2 | 9.917% | ep10 | ep15 <9% | TBD |
-| #176 | chihiro | `ld3ff1gs` | lr=5e-4 Trial B (FourierEmbed) | ~11% | ep5+ | ep15 <9% | TBD |
-| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | 10.51% | ep5 | ep5 gate PASSED | ep31 ~May 2 11:00Z |
-| #180 | norman | `1rieq278` | raw rel-L2 aux loss w=0.1 Trial A | 10.85% | ep5 | ep10 <9% (may fail) | TBD |
-| #181 | thorfinn | `scefipy4` | no-EMA + b1=0.95 + T_max=50 | ? | ep1+ | ep10-15 report pending | TBD |
+| PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
+|----|---------|--------|-----------|:----------:|------:|---------|
+| #75 | fern | `uz4em31o` | T_max=30 + lr=5e-4 + Fourier PE Trial B | **8.342%** | 19 | descending; ep30 valley projected ~7.2-7.4% |
+| #79 | emma | `3evzgru1` | 60k pts + Fourier PE + T_max=50 Trial B v2 | **8.662%** | 19 | descending; ep50 valley projected ~6.9-7.1%; PR has merge conflict |
+| #80 | tanjiro | `0qjbutkd` | SW=2.0 + T_max=50 (Trial B1) | **8.963%** | 16 | PASSED ep16 gate; next ep20<8.5% |
+| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **8.111%** | 12 | LEADER OF SECOND ROUND; ep30 projected <7.4%; ep50 stretch <7.0% |
+| #221 | violet | ? | Per-channel adaptive loss reweighting | stale at ep1-2 | 2 | needs check-in |
+| #214 | gilbert | `2rnm99yl` | k-NN local attention | merge conflict | early | needs rebase |
+| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | merge conflict | TBD | needs rebase |
+| #239 | norman | TBD | Fourier PE num_freqs sweep {16,32,64,128} | launch pending | — | Wave 3 second round |
 
-**Tanjiro Trial B matrix auto-launch**: B2 (SW=3.0/T_max=30) and B3 (SW=3.0/T_max=50) queued via PID 188667 script, fire after B1 ep31.
+### Wave 4 (launched 2026-04-30) — wsy/wsz binding-constraint attack
 
-**Fern Trial C**: `auto_kc_trialC.sh` queued to fire after Trial B ep31 (~May 2 01:30Z). Trial C = T_max=50 + lr=5e-4.
+| PR | Student | Hypothesis | Tier |
+|----|---------|------------|------|
+| #253 | askeladd | FourierEmbed vs ContinuousSincosEmbed standalone A/B | Embedding family disambiguation |
+| #254 | chihiro | Raw rel-L2 auxiliary loss sweep w in {0.05, 0.1} | Loss aux term |
+| #255 | edward | Fixed per-channel wsy/wsz loss multipliers | Simplest loss rebalance |
+| #256 | frieren | Mirror-symmetry TTA for wsy reduction (REASSIGNED from #218) | Inference-time / free gain |
+| #257 | haku | High-shear curriculum oversampling with linear anneal | Data sampling reweight |
+| #258 | kohaku | Squared rel-L2 aux loss on wall-shear (focal-loss-equivalent) | Loss formulation |
+| #259 | senku | grad-clip-norm sweep {0.5, 2.0} on baseline | Optimization stability |
+| #260 | thorfinn | model-slices sweep {64, 128, 192} on baseline | Architecture scaling |
 
-### Wave 3 (launched 2026-05-01)
+All Wave 4 PRs include corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and 30-min ack requirement.
 
-| PR | Student | Run ID | Experiment | Last Known | Kill Threshold Fixed? | Notes |
-|----|---------|--------|-----------|:----------:|-----------------------|-------|
-| #214 | gilbert | `2rnm99yl` | k-NN local attention (PointTransformer-style rel PE, zero-init out_proj) | launched 16:42Z | YES → `35000:<20` | k=16, chunk=4096, ~8.4 it/s; ~21.5h ETA for ep1; no ep val yet |
-| #215 | senku | ? | SWA last-5-epoch averaging | no response | NO | Stale — only advisor check-in |
-| #216 | askeladd | ? | Per-axis EMA variance autoweighting | no response | NO | Stale — only advisor check-in |
-| #217 | edward | ? | Lion optimizer sweep (lr=1e-4, 3e-4) | no response | NO | Stale — only advisor check-in |
-| #218 | frieren | ? (no ID posted) | TangentFrameHead w/ Frisvad-Duff basis (τ = α·e_t1 + β·e_t2) | launched, no W&B ID in thread | YES → `35000:<20` | Physically motivated; `max|τ·n|<1e-6` by construction; stats buffered before torch.compile |
-| #219 | haku | ? | 5L depth + Fourier PE + GradNorm α=1.5 stack | no response | NO | Stale — depends on PR #176 landing |
-| #220 | kohaku | ? | Asinh surf pressure + 96k pts | no response | NO | Stale — only advisor check-in |
-| #221 | violet | ? | Adaptive loss reweighting (gap-ratio softmax, τ=1.0, weights every 5 ep) | ep1-2 launched | YES | Run A (ContinuousSincosEmbed) — no recent update |
+### Recently closed
 
-**Dead RANS experiments** (nezuko): `pe2ryffk` (λ=0.1) crashed step 12K; `8u7jc8kt` (control) crashed step 13K. Direction closed.
+- **PR #218 frieren TangentFrameHead** — closed at ep11=13.195%; clean negative result; 5 follow-ups archived for Wave 5+. Reassigned to PR #256.
+- **PR #176 chihiro FourierEmbed lr sweep** — MERGED. lr=3e-4 confirmed optimal among {1e-4, 3e-4, 5e-4} on bengio.
+- **PR #75 fern** Trial A `pxty4knv` finished ep50=9.0433% (non-competitive); Trial B `uz4em31o` is the productive replacement.
 
-**Symmetry augmentation** (nezuko Wave 2): symm-p50=16.564%, symm-p100=54.686%. Direction closed — breaks coordinate encoding.
+## Critical Findings
 
-## Stale PR Watch List (need follow-up)
+### val/test gap on vol_p is ~2.5× (tanjiro SW2 evidence)
+- val=4.17% → test=12.90%
+- Surface-loss reweighting moves error around between train channels but does not reduce test error
+- Implication: regularization or test-time generalization of volume head is the gap, not architecture or loss weight
 
-PRs with only advisor check-in, no student response — may need escalation or reassignment:
-- **#215 (senku)**: SWA
-- **#216 (askeladd)**: Per-axis EMA variance autoweighting
-- **#217 (edward)**: Lion optimizer
-- **#219 (haku)**: GradNorm stack
-- **#220 (kohaku)**: Asinh surf pressure
+### wsy/wsz binding constraint (Wave 4 entire focus)
+- Best wsy = 9.10% (alphonse val) / 10.895% (tanjiro test) vs target 3.65%. Gap 2.5–3× on test.
+- Best wsz = 10.87% (alphonse val) / 11.664% (tanjiro test) vs target 3.63%. Gap 3.2× on test.
+- TangentFrameHead failed (PR #218) — pure inductive bias did not work
+- Wave 4 attacks via 8 different orthogonal levers: loss multipliers (#255), focal loss (#258), data oversampling (#257), TTA (#256), embedding family (#253), aux loss (#254), grad clip (#259), slice scaling (#260)
 
-All share the dead kill threshold bug (`3000:val_primary/abupt_axis_mean_rel_l2_pct<=25`). Fix communicated in advisor check-in comments: use `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`.
+### Universal ep31 valley pattern
+All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max. T_max=50 schedules are showing this pattern is the dominant force — the cosine knee aligns with this valley. Runs with T_max=50 may extract more after ep31 but the primary descent is always near ep31.
 
-## Critical Research Finding: Surface-Loss Reweighting Does Not Help on Test
+### lr=5e-4 unlocks vol_p capacity at 60k pts (fern Trial B)
+fern Trial B at ep18 hit vol_p=6.07% — at AB-UPT target — while still 12 epochs from cosine knee. Confirms 60k pts + Fourier PE + lr=5e-4 is a valid recipe ingredient. Need to test on test set.
 
-tanjiro PR #80 provides the definitive result:
-- SW=2.0 T_max=30 (`846uciam`): test abupt=9.697% vs alphonse test=8.480% — **lost on all 5 axes**
-- The "vol_p beats AB-UPT" result (val=4.17%) is a **val artifact** — test vol_p=12.897% (2.5× degradation)
-- Surface loss reweighting moves error around between train channels but does not reduce test error
-- SW=2.0 T_max=50 (B1 `0qjbutkd`) currently testing whether longer schedule recovers SW benefits
+## Potential Next Research Directions (Wave 5 prep)
 
-## Critical Gap — wsy/wsz Binding Constraint
+**If Wave 4 wsy/wsz attacks succeed (one or more land <8.0% with healthy wsy/wsz)**:
+- Stack winners: best loss formulation + best embedding + 5L/256d + T_max=50 + EMA off (i.e. extend the alphonse `vu4jsiic` recipe with the wsy/wsz winner)
+- Test-set re-evaluation campaign on all val-winners
 
-Best wsy = 9.10% (alphonse val) / 10.895% (tanjiro test) vs target 3.65%. Gap is 2.5–3× on test.  
-Best wsz = 10.87% (alphonse val) / 11.664% (tanjiro test) vs target 3.63%. Gap is 3.2× on test.
-
-Wave 3 bets targeting this:
-- **#218 frieren** (TangentFrameHead): theoretically motivated — shear lives in tangent plane, predict α/β scalars → reconstruct τ. Strongest inductive bias bet.
-- **#214 gilbert** (k-NN local attention): local surface geometry may explain shear underperformance
-- **#216 askeladd** (EMA variance autoweighting): upweights harder axes dynamically
-- **#221 violet** (gap-ratio softmax): explicitly targets axes furthest from AB-UPT target
-
-Empirical signal: fern Trial B wsy delta = −2.2pp at ep5 vs Trial A — strongest wsy/wsz improvement yet from lr=5e-4.
-
-## Potential Next Research Directions (Wave 4)
-
-**Bold architectural moves**:
-- SO(3)-equivariant representations (Wave 3 PR #218 testing first flavor)
-- Spectral-graph convolution as parallel branch alongside Transolver attention
-- Latent diffusion prior for surface field reconstruction
-- Boundary-layer-aware attention with explicit `y+` distance feature
+**If Wave 4 wsy/wsz attacks plateau at ~9% (no gain on the binding axes)**:
+- Architecture pivot: spectral graph convolution branch parallel to Transolver attention
+- Boundary-layer-aware attention with explicit y+ distance feature
 - Graph neural network on surface mesh (explicit topology vs point cloud)
+- Boundary-layer physics loss (eddy-viscosity-aware, log-law inspired)
+- Stronger regularization specific to volume decoder (target 2.5× val/test gap)
+- TangentFrameHead followups: PCA-of-kNN-normals basis, soft loss term, warm start from Cartesian
 
-**Empirical compounders** (ready once Wave 3 data returns):
-- Stack all winning ingredients: 5L depth + Fourier PE + GradNorm α=1.5 + T_max=50 + SWA
-- Asinh on volume fields too (not just surface pressure)
-- Per-axis loss weights from senku metric-aware coefficients (transfer optimal weights)
-- Trial C for fern: lr=5e-4 + T_max=50 if Trial B lands 7.5–8.5%
-
-**Test-focused strategy**:
-- The val/test vol_p gap (2.5×) is the biggest blocker. Hypothesis: overfitting to training distribution on volume pressure. Try stronger regularization (higher dropout, weight decay) specifically for volume decoder.
-- Consider test_primary eval of all completed val-winners before claiming any axis beat.
-
-**Plateau protocol**: 5+ consecutive experiments with no test improvement → escalate to architecture-level changes. We are at ~2 rounds of improvements post-Wave-1 with no test beat. Wave 3 results are the next decision point.
+**Already merged ingredients to compose**:
+- FourierEmbed (PR #176, lr=3e-4 optimal)
+- 60k points (emma confirmed lr=5e-4 unlocks vol_p)
+- T_max=50 cosine schedule
+- EMA off (alphonse `vu4jsiic` is leading without EMA)
+- 5L depth (alphonse `vu4jsiic` 5L/256d)
 
 ## Upcoming Gates and Checkpoints
 
 | Time (approx) | Event |
 |---|---|
-| ~May 1 18:00Z | Emma `3evzgru1` ep15 (projected 8.82%, PASS) |
-| ~May 1 19:00Z | Chihiro `ld3ff1gs` ep15 gate (<9%) |
-| ~May 1 20:00Z | Gilbert `2rnm99yl` ep1 val (first wsy/wsz vs baseline) |
-| ~May 2 01:30Z | Fern Trial B ep31 → auto-fire Trial C |
-| ~May 2 10:30Z | Tanjiro B1 `0qjbutkd` ep50 → auto-fire B2 (SW=3.0/T_max=30) |
-| ~May 2 11:00Z | Nezuko `ud5iddlc` ep31 (5L/384d valley) |
-| ~May 2 11:00Z | Alphonse `vu4jsiic` ep31 (5L/256d + T_max=50) |
-| ~May 2 TBD | Frieren first ep1-5 results (TangentFrameHead) |
+| ~May 1 02:00Z | fern `uz4em31o` ep20 (gate <8.0%, projected 8.25%) |
+| ~May 1 04:00Z | emma `3evzgru1` ep20 |
+| ~May 1 ~12Z | alphonse `vu4jsiic` ep20 (current trajectory <8.0% gate) |
+| ~May 1 ~21Z | tanjiro `0qjbutkd` ep20 (gate <8.5%) |
+| ~May 1+ | Wave 4 PRs #253-260 first ep5/ep10 reports |
+| ~May 2 ~13Z | fern Trial B ep30 valley (terminal) |
+| ~May 2 ~22Z | emma `3evzgru1` ep30 |
+| ~May 2 ~23Z | alphonse `vu4jsiic` ep30 (projected <7.4%) |
+
+## Plateau Protocol Status
+
+We are not on a plateau. Two productive surprises in this session:
+1. alphonse `vu4jsiic` is the leader of round 2 — 5L/256d + Fourier PE + T_max=50 + EMA off recipe stack
+2. fern Trial B Trial B 60k pts + lr=5e-4 unlocks vol_p
+
+Both are worth investing in; if either lands <7.5% on test, that becomes the new baseline and Wave 4 results stack on top.
+
+## Discipline Note (this session)
+
+- alphonse: Two unanswered escalations on PR #174. Run is healthy and beating gates so PR was NOT closed, but a final acknowledgment was demanded with a 1-hour deadline. Unauthorized `alphonse-agc-r6` sweep flagged (3 still running outside any PR — must kill or move to dedicated PR).
+- Several PRs need rebase: #214 gilbert, #179 nezuko, #79 emma — all post-#176 chihiro merge.
 
 ## Research Log Pointers
 
 - All experiments: `/research/EXPERIMENTS_LOG.md`
 - Current baseline: `/BASELINE.md` — alphonse Wave 1 val=7.209%, test=8.480%
 - Research ideas: `/research/RESEARCH_IDEAS_2026-04-30_15:34.md`
-- Wave 3 check-ins: posted 2026-05-01 on PRs #214-221

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -505,3 +505,39 @@ All five students immediately reassigned with fresh Wave 3 hypotheses targeting 
 | #238 | kohaku | High-shear curriculum oversampling + linear anneal | Data axis — sampling reweight |
 
 All five new PRs include the corrected kill threshold `35000:val_primary/abupt_axis_mean_rel_l2_pct<20`, explicit ep5/ep10/ep15/ep20 gates, and a 30-minute acknowledgment requirement. Two missed acknowledgments = closure (consistent with the protocol that produced this round's reassignments).
+
+## 2026-04-30 21:00 — PR #218: [frieren] SO(3)-equivariant TangentFrameHead (CLOSED)
+
+- **Branch:** `frieren/tangent-frame-wallshear-head`
+- **Run IDs:** `lpnr8zhi` (primary), `dwl5oi97`, `d4cvbt1p`, `i3lx54ou` (siblings, all killed)
+- **Hypothesis:** Predict wall shear in the local tangent plane (Frisvad-Duff orthonormal basis built from surface normals) instead of Cartesian xyz, restoring SO(3)-equivariance and providing inductive bias toward physical wall-tangent flow direction.
+
+### Results table (kill at ep11)
+
+| Metric | TangentFrame (lpnr8zhi) | Cartesian baseline | Δ |
+|---|---:|---:|---:|
+| val_abupt | 13.195% | ~9.0% | +4.2pp WORSE |
+| val_surf_p | 6.288% | ~5.5% | +0.8pp |
+| val_vol_p | 5.868% | ~5.6% | +0.3pp |
+| val_wsx | 13.057% | ~8.5% | +4.6pp |
+| val_wsy | 19.379% | ~11.0% | +8.4pp |
+| val_wsz | 21.380% | ~13.0% | +8.4pp |
+
+Validation trajectory: ep1=18.7%, ep5=14.9%, ep11=13.2% — converging too slowly; slope analysis projected ep30 ≈ 11–12%, never reaching <9.0%.
+
+### Diagnosis (student writeup)
+
+The Frisvad-Duff basis introduces anisotropic gradient flow: small variations in the surface normal cause large discontinuous changes in the tangent frame, which the optimizer must compensate for. The wall-shear-y/z components (the binding constraint) ended up 2× WORSE than the dense MLP Cartesian baseline despite the equivariance prior — the geometric inductive bias is correct in theory but the optimization landscape is hostile in practice.
+
+### Conclusion
+
+**Rejected. Closed as dead end.** Clean negative result: SO(3)-equivariance via tangent frame reparametrization does not help on DrivAerML when the binding constraint is wsy/wsz absolute magnitude. Archived 5 follow-ups for Wave 5+:
+
+1. PCA-of-k-NN-normals tangent basis (smoother than Frisvad-Duff)
+2. Hybrid Cartesian + tangent prediction with learnable gate
+3. Tangent constraint as soft loss term, not hard reparametrization
+4. Warm-start tangent head from Cartesian baseline checkpoint
+5. Pair tangent head with Wave 4 wsy/wsz loss multipliers
+
+Frieren reassigned to PR #256 (Mirror-symmetry TTA for wsy reduction) in the Wave 4 launch.
+

--- a/train.py
+++ b/train.py
@@ -117,6 +117,7 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    domain_ln: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -154,6 +155,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         fourier_pe=config.fourier_pe,
         fourier_pe_num_freqs=config.fourier_pe_num_freqs,
+        domain_ln=config.domain_ln,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Different geometric domains (surface vs volume) in this CFD surrogate have fundamentally different physical characteristics — surface tokens encode boundary layer physics while volume tokens encode free-stream flow. Using **shared** LayerNorm affine parameters (weight/bias) forces the model to normalize both domains identically, which may suppress domain-specific signal. 

**DomainLayerNorm** replaces each `norm1` and `norm2` in every `TransformerBlock` with a module that keeps **separate** affine parameters for surface tokens vs volume tokens, while using the same running statistics. This is a parameter-cheap architectural improvement: just `2 × 2 × n_layers` extra (weight, bias) pairs of size `hidden_dim`. For 4L/256d, that's 4 × 2 × 256 = ~2048 extra parameters on a ~4M param model (<0.05%).

This approach is inspired by domain-conditioned normalization in multi-domain transformers (e.g., DomainLayerNorm in AB-UPT, cross-domain ViTs). The intuition: surface tokens need to capture steep pressure gradients and wall shear boundary conditions, while volume tokens represent smoother field values — letting them have separate affine scales and biases gives the model a free channel to express this.

## Instructions

This experiment requires **modifying `model.py`** only. `train.py` should NOT be modified.

### Step 1: Add `DomainLayerNorm` class to `model.py`

Insert this class after the `UpActDownMlp` class (around line 122, before `TransolverAttention`):

```python
class DomainLayerNorm(nn.Module):
    """LayerNorm with separate affine params for surface vs volume tokens.

    Args:
        hidden_dim: Feature dimension.
        eps: Epsilon for numerical stability.
    """

    def __init__(self, hidden_dim: int, eps: float = 1e-6):
        super().__init__()
        self.eps = eps
        # Shared norm (no affine) for computing statistics
        self.norm = nn.LayerNorm(hidden_dim, elementwise_affine=False, eps=eps)
        # Separate affine params per domain
        self.surface_weight = nn.Parameter(torch.ones(hidden_dim))
        self.surface_bias = nn.Parameter(torch.zeros(hidden_dim))
        self.volume_weight = nn.Parameter(torch.ones(hidden_dim))
        self.volume_bias = nn.Parameter(torch.zeros(hidden_dim))

    def forward(self, x: torch.Tensor, surface_tokens: int) -> torch.Tensor:
        """
        x: [B, T, D] where T = surface_tokens + volume_tokens
        surface_tokens: number of leading surface tokens
        """
        normed = self.norm(x)
        if surface_tokens > 0 and surface_tokens < x.shape[1]:
            # Mixed batch: apply domain-specific affine
            surf = normed[:, :surface_tokens] * self.surface_weight + self.surface_bias
            vol = normed[:, surface_tokens:] * self.volume_weight + self.volume_bias
            return torch.cat([surf, vol], dim=1)
        elif surface_tokens == x.shape[1]:
            # Surface-only batch
            return normed * self.surface_weight + self.surface_bias
        else:
            # Volume-only batch
            return normed * self.volume_weight + self.volume_bias
```

### Step 2: Modify `TransformerBlock` to accept and use `DomainLayerNorm`

Replace the `TransformerBlock.__init__` to accept a `use_domain_ln` flag:

```python
class TransformerBlock(nn.Module):
    def __init__(
        self,
        hidden_dim: int,
        num_heads: int,
        mlp_expansion_factor: int | float,
        num_slices: int,
        dropout: float = 0.0,
        use_domain_ln: bool = False,
    ):
        super().__init__()
        mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
        self.use_domain_ln = use_domain_ln
        if use_domain_ln:
            self.norm1 = DomainLayerNorm(hidden_dim)
            self.norm2 = DomainLayerNorm(hidden_dim)
        else:
            self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
            self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
        self.attention = TransolverAttention(
            hidden_dim=hidden_dim,
            num_heads=num_heads,
            num_slices=num_slices,
            dropout=dropout,
        )
        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
```

Update `TransformerBlock.forward` to pass `surface_tokens` through:

```python
    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
        x = _apply_token_mask(x, attn_mask)
        if self.use_domain_ln:
            x = x + self.attention(self.norm1(x, surface_tokens), attn_mask=attn_mask)
            x = _apply_token_mask(x, attn_mask)
            x = x + self.mlp(self.norm2(x, surface_tokens))
        else:
            x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
            x = _apply_token_mask(x, attn_mask)
            x = x + self.mlp(self.norm2(x))
        x = _apply_token_mask(x, attn_mask)
        return x
```

### Step 3: Modify `Transformer` to propagate `surface_tokens`

Update `Transformer.__init__` to pass `use_domain_ln` to each block:

```python
class Transformer(nn.Module):
    def __init__(
        self,
        depth: int,
        hidden_dim: int,
        num_heads: int,
        mlp_expansion_factor: int | float,
        num_slices: int,
        dropout: float = 0.0,
        use_domain_ln: bool = False,
    ):
        super().__init__()
        self.blocks = nn.ModuleList(
            [
                TransformerBlock(
                    hidden_dim=hidden_dim,
                    num_heads=num_heads,
                    mlp_expansion_factor=mlp_expansion_factor,
                    num_slices=num_slices,
                    dropout=dropout,
                    use_domain_ln=use_domain_ln,
                )
                for _ in range(depth)
            ]
        )

    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
        for block in self.blocks:
            x = block(x, attn_mask=attn_mask, surface_tokens=surface_tokens)
        return x
```

### Step 4: Thread `use_domain_ln` and `surface_tokens` through `SurfaceTransolver`

In `SurfaceTransolver.__init__`, add the new parameter and pass it to `Transformer`:

```python
def __init__(
    self,
    *,
    space_dim: int = 3,
    surface_input_dim: int = SURFACE_X_DIM,
    surface_output_dim: int = SURFACE_Y_DIM,
    volume_input_dim: int = VOLUME_X_DIM,
    volume_output_dim: int = VOLUME_Y_DIM,
    n_layers: int = 3,
    n_hidden: int = 192,
    dropout: float = 0.0,
    n_head: int = 3,
    mlp_ratio: int = 4,
    slice_num: int = 96,
    fourier_pe: bool = False,
    fourier_pe_num_freqs: int = 8,
    domain_ln: bool = False,     # <-- add this
):
    ...
    self.backbone = Transformer(
        depth=n_layers,
        hidden_dim=n_hidden,
        num_heads=n_head,
        mlp_expansion_factor=mlp_ratio,
        num_slices=slice_num,
        dropout=dropout,
        use_domain_ln=domain_ln,   # <-- pass through
    )
```

In `SurfaceTransolver.forward`, capture `surface_tokens` and pass it to `self.backbone`:

```python
    # existing code already sets:
    # surface_tokens = surface_x.shape[1]   (or 0 if surface_x is None)
    
    # Replace:
    hidden = self.backbone(hidden, attn_mask=attn_mask)
    # With:
    hidden = self.backbone(hidden, attn_mask=attn_mask, surface_tokens=surface_tokens)
```

### Step 5: Wire the CLI flag in `train.py`

Find the model instantiation in `train.py` (search for `SurfaceTransolver(`) and:

1. Add a config field (or just use a flag) to toggle `domain_ln=True`.
2. Add `--domain-ln` flag to the argument parser (search for `add_argument` calls near other model flags like `--fourier-pe`).
3. Pass `domain_ln=config.domain_ln` to `SurfaceTransolver(...)`.

The pattern to follow is the existing `--fourier-pe` / `fourier_pe` flag wiring.

### Step 6: Run command

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --domain-ln \
  --no-compile-model \
  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
  --wandb-group bengio-wave5-tanjiro
```

## Baseline (current best — PR #74, W&B run `m9775k1v`, ep30)

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
| `val_primary/volume_pressure_rel_l2_pct` | 4.166 ✓ | 6.08 |
| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |

**Win condition**: `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091%

## Kill Gates

- ep5: abupt > 13% → kill
- ep10: abupt > 9.5% → kill
- ep20: abupt > 8.0% → kill

## What to Report

Report `val_primary/abupt_axis_mean_rel_l2_pct` at the best checkpoint, plus all 6 axis metrics. Note whether domain_ln helps or hurts wsy/wsz specifically — those are the hardest targets (wsy target=3.65%, wsz target=3.63%). Include the W&B run ID in the PR comment.
