### PR TITLE
frieren: bilateral-symmetry test-time augmentation for tau_y/z gap

### DIFF
--- a/analyze_tta.py
+++ b/analyze_tta.py
@@ -1,0 +1,151 @@
+"""Analyze TTA experiment results from W&B runs.
+
+Usage:
+    python analyze_tta.py <run_id1> [<run_id2> ...]
+"""
+from __future__ import annotations
+
+import sys
+import wandb
+
+
+PRIMARY_KEYS = [
+    "abupt_axis_mean_rel_l2_pct",
+    "surface_pressure_rel_l2_pct",
+    "wall_shear_rel_l2_pct",
+    "wall_shear_x_rel_l2_pct",
+    "wall_shear_y_rel_l2_pct",
+    "wall_shear_z_rel_l2_pct",
+    "volume_pressure_rel_l2_pct",
+]
+
+
+def fmt(v):
+    if v is None:
+        return "—"
+    return f"{v:.4f}"
+
+
+def fmt_delta(t, n):
+    if t is None or n is None:
+        return "—"
+    return f"{t - n:+.4f}"
+
+
+def fmt_rel(t, n):
+    if t is None or n is None or abs(n) < 1e-9:
+        return "—"
+    return f"{(t - n) / n * 100:+.2f}%"
+
+
+def per_epoch_table(history):
+    """Build per-epoch table of TTA-on vs TTA-off val_primary."""
+    rows = []
+    for entry in history:
+        if "val_tta/val_surface/abupt_axis_mean_rel_l2_pct" not in entry:
+            continue
+        if "val_no_tta/val_surface/abupt_axis_mean_rel_l2_pct" not in entry:
+            continue
+        gs = entry.get("global_step")
+        tta = entry["val_tta/val_surface/abupt_axis_mean_rel_l2_pct"]
+        ctrl = entry["val_no_tta/val_surface/abupt_axis_mean_rel_l2_pct"]
+        rows.append((gs, ctrl, tta))
+    return rows
+
+
+def summary_dict(summary, prefix):
+    out = {}
+    for key in PRIMARY_KEYS:
+        full = f"{prefix}/{key}"
+        if full in summary:
+            out[key] = summary[full]
+    return out
+
+
+def analyze(run_id, project="wandb-applied-ai-team/senpai-v1-drivaerml"):
+    api = wandb.Api()
+    run = api.run(f"{project}/{run_id}")
+    print(f"\n{'=' * 80}")
+    print(f"Run: {run.name}  ({run.id})  state={run.state}")
+    print(f"  group: {run.group}")
+    print(f"  config: max_train_cases={run.config.get('max_train_cases')} "
+          f"batch_size={run.config.get('batch_size')} "
+          f"epochs={run.config.get('epochs')} "
+          f"lr={run.config.get('lr')}")
+    print('=' * 80)
+
+    # Per-epoch comparison
+    history = list(run.scan_history(
+        keys=[
+            "global_step",
+            "val_tta/val_surface/abupt_axis_mean_rel_l2_pct",
+            "val_no_tta/val_surface/abupt_axis_mean_rel_l2_pct",
+            "val_tta/val_surface/surface_pressure_rel_l2_pct",
+            "val_no_tta/val_surface/surface_pressure_rel_l2_pct",
+            "val_tta/val_surface/wall_shear_rel_l2_pct",
+            "val_no_tta/val_surface/wall_shear_rel_l2_pct",
+            "val_tta/val_surface/wall_shear_x_rel_l2_pct",
+            "val_no_tta/val_surface/wall_shear_x_rel_l2_pct",
+            "val_tta/val_surface/wall_shear_y_rel_l2_pct",
+            "val_no_tta/val_surface/wall_shear_y_rel_l2_pct",
+            "val_tta/val_surface/wall_shear_z_rel_l2_pct",
+            "val_no_tta/val_surface/wall_shear_z_rel_l2_pct",
+            "val_tta/val_surface/volume_pressure_rel_l2_pct",
+            "val_no_tta/val_surface/volume_pressure_rel_l2_pct",
+        ],
+    ))
+    print("\n## Per-epoch table: val abupt_axis_mean_rel_l2_pct")
+    print(f"| Epoch | step | val_no_tta | val_tta | Δ(TTA−ctrl) | Δ% |")
+    print(f"|-------|------|------------|---------|-------------|-----|")
+    for i, entry in enumerate(history):
+        gs = entry.get("global_step", "?")
+        tta = entry.get("val_tta/val_surface/abupt_axis_mean_rel_l2_pct")
+        ctrl = entry.get("val_no_tta/val_surface/abupt_axis_mean_rel_l2_pct")
+        if tta is None or ctrl is None:
+            continue
+        delta = tta - ctrl
+        rel = (delta / ctrl) * 100 if abs(ctrl) > 1e-9 else 0
+        print(f"| {i+1} | {gs} | {ctrl:.4f}% | {tta:.4f}% | {delta:+.4f} | {rel:+.2f}% |")
+
+    print("\n## Per-component breakdown (last logged epoch)")
+    if history:
+        last = history[-1]
+        print(f"| Component | val_no_tta | val_tta | Δ(TTA−ctrl) | Δ% |")
+        print(f"|-----------|------------|---------|-------------|-----|")
+        for key in PRIMARY_KEYS:
+            ctrl = last.get(f"val_no_tta/val_surface/{key}")
+            tta = last.get(f"val_tta/val_surface/{key}")
+            print(f"| {key} | {fmt(ctrl)} | {fmt(tta)} | {fmt_delta(tta, ctrl)} | {fmt_rel(tta, ctrl)} |")
+
+    summary = run.summary
+    print("\n## Final full_val (best checkpoint)")
+    full_val_tta = summary_dict(summary, "full_val_tta/val_surface")
+    full_val_no = summary_dict(summary, "full_val_no_tta/val_surface")
+    print(f"| Component | full_val_no_tta | full_val_tta | Δ | Δ% |")
+    print(f"|-----------|-----------------|--------------|---|-----|")
+    for key in PRIMARY_KEYS:
+        ctrl = full_val_no.get(key)
+        tta = full_val_tta.get(key)
+        print(f"| {key} | {fmt(ctrl)} | {fmt(tta)} | {fmt_delta(tta, ctrl)} | {fmt_rel(tta, ctrl)} |")
+
+    print("\n## Final test (best checkpoint)")
+    test_tta = summary_dict(summary, "test_tta/test_surface")
+    test_no = summary_dict(summary, "test_no_tta/test_surface")
+    print(f"| Component | test_no_tta | test_tta | Δ | Δ% |")
+    print(f"|-----------|-------------|----------|---|-----|")
+    for key in PRIMARY_KEYS:
+        ctrl = test_no.get(key)
+        tta = test_tta.get(key)
+        print(f"| {key} | {fmt(ctrl)} | {fmt(tta)} | {fmt_delta(tta, ctrl)} | {fmt_rel(tta, ctrl)} |")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    for run_id in sys.argv[1:]:
+        analyze(run_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/smoke_test_tta.py
+++ b/smoke_test_tta.py
@@ -1,0 +1,173 @@
+"""Smoke tests for symmetry-TTA in train.py.
+
+Exits with non-zero status on any failure. Run on a single GPU.
+"""
+from __future__ import annotations
+
+import sys
+import torch
+
+import train as T
+from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM, SurfaceBatch
+
+
+def _make_dummy_batch(device: torch.device, *, batch_size: int = 1, n_surface: int = 8, n_volume: int = 8) -> SurfaceBatch:
+    g = torch.Generator(device="cpu").manual_seed(0)
+    surface_x = torch.randn(batch_size, n_surface, SURFACE_X_DIM, generator=g)
+    surface_y = torch.randn(batch_size, n_surface, SURFACE_Y_DIM, generator=g)
+    surface_mask = torch.ones(batch_size, n_surface, dtype=torch.bool)
+    volume_x = torch.randn(batch_size, n_volume, VOLUME_X_DIM, generator=g)
+    volume_y = torch.randn(batch_size, n_volume, VOLUME_Y_DIM, generator=g)
+    volume_mask = torch.ones(batch_size, n_volume, dtype=torch.bool)
+    return SurfaceBatch(
+        case_ids=["synthetic_case_0"],
+        surface_x=surface_x.to(device),
+        surface_y=surface_y.to(device),
+        surface_mask=surface_mask.to(device),
+        volume_x=volume_x.to(device),
+        volume_y=volume_y.to(device),
+        volume_mask=volume_mask.to(device),
+        metadata=[{}],
+    )
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    cfg = T.Config(
+        model_layers=2,
+        model_hidden_dim=64,
+        model_heads=4,
+        model_slices=8,
+        compile_model=False,
+        amp_mode="none",
+        use_film=False,
+    )
+    model = T.build_model(cfg).to(device).eval()
+    batch = _make_dummy_batch(device)
+
+    # ---- Smoke test 2 — input transformation correctness -----------------------
+    surf_x_refl = batch.surface_x.clone()
+    surf_x_refl[..., 1] = -surf_x_refl[..., 1]
+    surf_x_refl[..., 4] = -surf_x_refl[..., 4]
+    vol_x_refl = batch.volume_x.clone()
+    vol_x_refl[..., 1] = -vol_x_refl[..., 1]
+
+    # Surface: y (idx 1) and ny (idx 4) negated; others unchanged
+    invariant_surface_idxs = [0, 2, 3, 5, 6]  # x, z, nx, nz, area
+    for i in invariant_surface_idxs:
+        if not torch.allclose(batch.surface_x[..., i], surf_x_refl[..., i]):
+            print(f"FAIL: surface_x channel {i} should be invariant under y-reflection")
+            sys.exit(1)
+    if not torch.allclose(batch.surface_x[..., 1], -surf_x_refl[..., 1]):
+        print("FAIL: surface_x y-coord (idx 1) not properly negated")
+        sys.exit(1)
+    if not torch.allclose(batch.surface_x[..., 4], -surf_x_refl[..., 4]):
+        print("FAIL: surface_x ny-normal (idx 4) not properly negated")
+        sys.exit(1)
+
+    # Volume: y (idx 1) negated; sdf (idx 3) invariant
+    if not torch.allclose(batch.volume_x[..., 0], vol_x_refl[..., 0]):
+        print("FAIL: volume_x x-coord should be invariant")
+        sys.exit(1)
+    if not torch.allclose(batch.volume_x[..., 2], vol_x_refl[..., 2]):
+        print("FAIL: volume_x z-coord should be invariant")
+        sys.exit(1)
+    if not torch.allclose(batch.volume_x[..., 3], vol_x_refl[..., 3]):
+        print("FAIL: volume_x sdf should be invariant")
+        sys.exit(1)
+    if not torch.allclose(batch.volume_x[..., 1], -vol_x_refl[..., 1]):
+        print("FAIL: volume_x y-coord (idx 1) not properly negated")
+        sys.exit(1)
+    print("PASS: smoke test 2 — input y-coord and y-normal negation correct")
+
+    # ---- Smoke test 3 — output correction correctness --------------------------
+    with torch.no_grad():
+        out_orig = model(
+            surface_x=batch.surface_x,
+            surface_mask=batch.surface_mask,
+            volume_x=batch.volume_x,
+            volume_mask=batch.volume_mask,
+        )
+        out_refl = model(
+            surface_x=surf_x_refl,
+            surface_mask=batch.surface_mask,
+            volume_x=vol_x_refl,
+            volume_mask=batch.volume_mask,
+        )
+    surface_preds_refl_pre = out_refl["surface_preds"].clone()
+    surface_preds_refl_corrected = surface_preds_refl_pre.clone()
+    surface_preds_refl_corrected[..., 2] = -surface_preds_refl_corrected[..., 2]
+
+    # Channels 0 (cp), 1 (tau_x), 3 (tau_z) should be unchanged by the correction
+    if not torch.allclose(surface_preds_refl_pre[..., 0], surface_preds_refl_corrected[..., 0]):
+        print("FAIL: cp channel modified by correction (should be invariant)")
+        sys.exit(1)
+    if not torch.allclose(surface_preds_refl_pre[..., 1], surface_preds_refl_corrected[..., 1]):
+        print("FAIL: tau_x channel modified by correction (should be invariant)")
+        sys.exit(1)
+    if not torch.allclose(surface_preds_refl_pre[..., 3], surface_preds_refl_corrected[..., 3]):
+        print("FAIL: tau_z channel modified by correction (should be invariant)")
+        sys.exit(1)
+    # Channel 2 (tau_y) should be sign-flipped
+    if not torch.allclose(surface_preds_refl_pre[..., 2], -surface_preds_refl_corrected[..., 2]):
+        print("FAIL: tau_y not properly sign-flipped")
+        sys.exit(1)
+    print("PASS: smoke test 3 — output tau_y sign flip applied; tau_x/tau_z/cp unchanged")
+
+    # Also: print sample values for visual inspection
+    print("\nSample predictions (first batch, first 3 surface points):")
+    print(f"  pred_orig  (cp, tau_x, tau_y, tau_z): {out_orig['surface_preds'][0, :3].detach().cpu().tolist()}")
+    print(f"  pred_refl  (cp, tau_x, tau_y, tau_z): {surface_preds_refl_pre[0, :3].detach().cpu().tolist()}")
+    print(f"  pred_refl* (cp, tau_x, tau_y, tau_z): {surface_preds_refl_corrected[0, :3].detach().cpu().tolist()}  # tau_y sign-flipped")
+    pred_tta = 0.5 * (out_orig["surface_preds"].float() + surface_preds_refl_corrected.float())
+    print(f"  pred_tta = 0.5*(orig + refl*): {pred_tta[0, :3].detach().cpu().tolist()}")
+
+    # ---- Smoke test 1 — evaluate_split runs and produces finite metrics -------
+    # Build a tiny one-batch loader for evaluate_split.
+    class _OneBatchLoader:
+        def __init__(self, batch):
+            self._batch = batch
+        def __iter__(self):
+            return iter([self._batch])
+
+    loader = _OneBatchLoader(batch)
+    surf_y_mean = torch.zeros(SURFACE_Y_DIM)
+    surf_y_std = torch.ones(SURFACE_Y_DIM)
+    vol_y_mean = torch.zeros(VOLUME_Y_DIM)
+    vol_y_std = torch.ones(VOLUME_Y_DIM)
+    transform = T.TargetTransform(
+        surface_y_mean=surf_y_mean,
+        surface_y_std=surf_y_std,
+        volume_y_mean=vol_y_mean,
+        volume_y_std=vol_y_std,
+    )
+    metrics_no_tta = T.evaluate_split(model, loader, transform, device, use_symmetry_tta=False)
+    metrics_tta = T.evaluate_split(model, loader, transform, device, use_symmetry_tta=True)
+    for k, v in metrics_no_tta.items():
+        if isinstance(v, float) and (v != v or abs(v) == float("inf")):  # NaN/Inf check
+            print(f"FAIL: no-TTA metric {k} = {v}")
+            sys.exit(1)
+    for k, v in metrics_tta.items():
+        if isinstance(v, float) and (v != v or abs(v) == float("inf")):
+            print(f"FAIL: TTA metric {k} = {v}")
+            sys.exit(1)
+    print("PASS: smoke test 1 — evaluate_split produces finite metrics for both arms")
+
+    # Sanity: TTA should produce numerically different metrics from no-TTA on a random model
+    abupt_diff = abs(metrics_tta["abupt_axis_mean_rel_l2_pct"] - metrics_no_tta["abupt_axis_mean_rel_l2_pct"])
+    print(f"\nMetrics on random-init model (small dummy batch):")
+    print(f"  no-TTA abupt_axis_mean_rel_l2_pct: {metrics_no_tta['abupt_axis_mean_rel_l2_pct']:.4f}")
+    print(f"  TTA    abupt_axis_mean_rel_l2_pct: {metrics_tta['abupt_axis_mean_rel_l2_pct']:.4f}")
+    print(f"  delta abs: {abupt_diff:.6f}")
+    print(f"  no-TTA tau_y_rel_l2_pct: {metrics_no_tta['wall_shear_y_rel_l2_pct']:.4f}")
+    print(f"  TTA    tau_y_rel_l2_pct: {metrics_tta['wall_shear_y_rel_l2_pct']:.4f}")
+    if abupt_diff < 1e-6:
+        print("WARN: TTA and no-TTA metrics are essentially identical — verify reflection is doing something")
+    print("\nAll smoke tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import wandb
 import yaml
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
 
 from data import (
@@ -601,6 +601,8 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    eval_symmetry_tta: bool = False
+    max_train_cases: int = 0  # 0 = use all; >0 = subsample first N training cases
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -707,6 +709,10 @@ def make_loaders(
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
     )
+    # Optionally restrict to the first N training cases (for fast diagnostic runs).
+    if config.max_train_cases > 0 and config.max_train_cases < len(train_ds):
+        train_ds = Subset(train_ds, list(range(config.max_train_cases)))
+        print(f"max_train_cases={config.max_train_cases}: training set limited to {len(train_ds)} views")
     num_workers = resolve_num_workers(config)
     loader_kwargs = {
         "collate_fn": pad_collate,
@@ -1441,6 +1447,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    use_symmetry_tta: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -1472,14 +1479,35 @@ def evaluate_split(
         surface_target_norm = transform.apply_surface(batch.surface_y)
         volume_target_norm = transform.apply_volume(batch.volume_y)
         with autocast_context(device, amp_mode):
-            out = model(
+            out_orig = model(
                 surface_x=batch.surface_x,
                 surface_mask=batch.surface_mask,
                 volume_x=batch.volume_x,
                 volume_mask=batch.volume_mask,
             )
-        surface_pred_norm = out["surface_preds"].float()
-        volume_pred_norm = out["volume_preds"].float()
+            if use_symmetry_tta:
+                # Build y-reflected inputs: negate y-coord (index 1) and y-normal (index 4)
+                # for surface points; negate y-coord (index 1) for volume points.
+                surface_x_refl = batch.surface_x.clone()
+                surface_x_refl[..., 1] = -surface_x_refl[..., 1]   # y coord
+                surface_x_refl[..., 4] = -surface_x_refl[..., 4]   # ny normal
+                volume_x_refl = batch.volume_x.clone()
+                volume_x_refl[..., 1] = -volume_x_refl[..., 1]     # y coord
+                out_refl = model(
+                    surface_x=surface_x_refl,
+                    surface_mask=batch.surface_mask,
+                    volume_x=volume_x_refl,
+                    volume_mask=batch.volume_mask,
+                )
+                # Undo reflection on predictions: tau_y (channel 2) is anti-symmetric
+                surface_preds_refl = out_refl["surface_preds"].clone()
+                surface_preds_refl[..., 2] = -surface_preds_refl[..., 2]
+                # Average original and reflection-corrected predictions
+                surface_pred_norm = 0.5 * (out_orig["surface_preds"].float() + surface_preds_refl.float())
+                volume_pred_norm = 0.5 * (out_orig["volume_preds"].float() + out_refl["volume_preds"].float())
+            else:
+                surface_pred_norm = out_orig["surface_preds"].float()
+                volume_pred_norm = out_orig["volume_preds"].float()
         surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
         volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
         surface_loss_sse += surface_sse
@@ -2001,9 +2029,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=config.eval_symmetry_tta)
             for name, loader in val_loaders.items()
         }
+        # Dual-eval: when symmetry TTA is enabled, also evaluate without TTA so both
+        # arms are logged at every epoch under distinct W&B prefixes.
+        if config.eval_symmetry_tta:
+            val_metrics_no_tta = {
+                name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=False)
+                for name, loader in val_loaders.items()
+            }
+        else:
+            val_metrics_no_tta = None
         if ema is not None:
             ema.restore(model)
 
@@ -2026,6 +2063,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         for split_name, metrics in val_metrics.items():
             for key, value in metrics.items():
                 log_metrics[f"val/{split_name}/{key}"] = value
+        # Log both TTA arms under distinct prefixes when dual-eval is active.
+        if config.eval_symmetry_tta:
+            for split_name, metrics in val_metrics.items():
+                for key, value in metrics.items():
+                    log_metrics[f"val_tta/{split_name}/{key}"] = value
+            assert val_metrics_no_tta is not None
+            for split_name, metrics in val_metrics_no_tta.items():
+                for key, value in metrics.items():
+                    log_metrics[f"val_no_tta/{split_name}/{key}"] = value
         log_metrics.update(
             val_slope_tracker.update(
                 global_step=global_step,
@@ -2116,9 +2162,18 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=config.eval_symmetry_tta)
         for name, loader in val_loaders.items()
     }
+    # When TTA is on, also evaluate the same checkpoint without TTA so both arms
+    # are logged at the final-val/test stage on the same model state.
+    if config.eval_symmetry_tta:
+        full_val_metrics_no_tta = {
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=False)
+            for name, loader in val_loaders.items()
+        }
+    else:
+        full_val_metrics_no_tta = None
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
     full_val_log: dict[str, object] = {
         "full_val_primary/abupt_axis_mean_rel_l2_pct": full_val_primary,
@@ -2137,6 +2192,14 @@ def main(argv: Iterable[str] | None = None) -> None:
     for split_name, metrics in full_val_metrics.items():
         for key, value in metrics.items():
             full_val_log[f"full_val/{split_name}/{key}"] = value
+    if config.eval_symmetry_tta:
+        for split_name, metrics in full_val_metrics.items():
+            for key, value in metrics.items():
+                full_val_log[f"full_val_tta/{split_name}/{key}"] = value
+        assert full_val_metrics_no_tta is not None
+        for split_name, metrics in full_val_metrics_no_tta.items():
+            for key, value in metrics.items():
+                full_val_log[f"full_val_no_tta/{split_name}/{key}"] = value
     full_val_log.update(
         full_val_slope_tracker.update(
             global_step=global_step,
@@ -2148,11 +2211,20 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.log(full_val_log)
     wandb.summary.update(_numeric_metric_items(full_val_log))
     print_metrics("full_val", full_val_metrics["val_surface"])
+    if full_val_metrics_no_tta is not None:
+        print_metrics("full_val_no_tta", full_val_metrics_no_tta["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=config.eval_symmetry_tta)
         for name, loader in test_loaders.items()
     }
+    if config.eval_symmetry_tta:
+        test_metrics_no_tta = {
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_symmetry_tta=False)
+            for name, loader in test_loaders.items()
+        }
+    else:
+        test_metrics_no_tta = None
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]
     test_log: dict[str, object] = {
         "test_primary/abupt_axis_mean_rel_l2_pct": test_primary,
@@ -2171,6 +2243,14 @@ def main(argv: Iterable[str] | None = None) -> None:
     for split_name, metrics in test_metrics.items():
         for key, value in metrics.items():
             test_log[f"test/{split_name}/{key}"] = value
+    if config.eval_symmetry_tta:
+        for split_name, metrics in test_metrics.items():
+            for key, value in metrics.items():
+                test_log[f"test_tta/{split_name}/{key}"] = value
+        assert test_metrics_no_tta is not None
+        for split_name, metrics in test_metrics_no_tta.items():
+            for key, value in metrics.items():
+                test_log[f"test_no_tta/{split_name}/{key}"] = value
     test_log.update(
         test_slope_tracker.update(
             global_step=global_step,
@@ -2182,6 +2262,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.log(test_log)
     wandb.summary.update(_numeric_metric_items(test_log))
     print_metrics("test_surface", test_metrics["test_surface"])
+    if test_metrics_no_tta is not None:
+        print_metrics("test_no_tta", test_metrics_no_tta["test_surface"])
 
     log_model_artifact(
         run=run,


### PR DESCRIPTION
## Hypothesis

**Test-time augmentation (TTA) via bilateral symmetry will produce a free 1–3% relative reduction in `val_primary/abupt_axis_mean_rel_l2_pct` — concentrated on the dominant `wall_shear_y/z` gap — without retraining.**

DrivAerML vehicles are bilaterally symmetric about the y=0 plane (longitudinal axis x, vertical z, lateral y). Under the y → −y reflection of the input geometry:
- Surface pressure `p_s`, volume pressure `p_v`, `tau_x`, `tau_z`: **invariant** (same scalar/component at the reflected point)
- `tau_y`: **anti-symmetric** (negated at the reflected point)

A model trained without this prior produces predictions whose symmetric component carries useful signal but whose anti-symmetric component carries noise. **Symmetrization at inference** (predict on x and on y-reflected x, undo the reflection on the second prediction, average) should:

1. Reduce variance on `tau_y` predictions by exploiting the anti-symmetry constraint exactly. Currently `tau_y` is ~3.7× the AB-UPT reference target — it is the dominant remaining error component.
2. Slightly reduce variance on `tau_x/z`, `p_s`, `p_v` (free averaging gain on already-noisy predictions).
3. Cost: **2× inference compute, zero extra training**. Inference is a small fraction of a 9-epoch run, so wall-clock impact is minor.

This experiment is **orthogonal to and compatible with** every in-flight PR (#225 training-time symmetry aug, #224 fern Fourier embeddings, #273 edward focal loss, #261 norman Muon, etc.). If TTA wins on the current AdamW yi-baseline, it stacks on top of any winner from those PRs. The hypothesis is also independent of the unmerged Lion+DDP infrastructure gap (PR #222 lives on `tay`, not `yi`).

**Why now:** the y/z gap has been characterized as a "feature-resolution" problem (CURRENT_RESEARCH_STATE insight #3). TTA is a complementary intervention — it doesn't try to fix the model's resolution, it averages out the residual asymmetric noise. Different mechanism than every active PR.

## Instructions

You are testing a 2-arm matched comparison on a single fixed model: same training run, two evaluation paths (no-TTA control vs. symmetry-TTA arm). Use 4 GPUs in parallel — one full 3-epoch training, plus the eval matrix described below.

### Step 1 — Implement TTA evaluation in `target/train.py`

Add a new CLI flag `--eval-symmetry-tta` (default `False`). When the flag is set, modify the validation loop so that for every validation step:

1. Compute the model's predictions on the original input batch as today: `pred_orig = model(batch)`.
2. Construct a y-reflected copy of the batch: negate the `y` coordinate of every point (surface points, volume points, mesh sample points — every coordinate channel where y is the lateral axis). Important: **only negate the y-coordinate of geometry, not the y-component of `tau` targets**. Targets stay as-is — TTA is purely on the prediction side.
3. Run the model on the reflected batch: `pred_refl = model(batch_with_y_negated)`.
4. Undo the reflection on `pred_refl`: negate the y-component of the predicted wall-shear (`tau_y`). Leave `tau_x`, `tau_z`, surface pressure, volume pressure unchanged. **`tau_y` is the only output channel that flips sign** under the y→−y geometric reflection.
5. Average: `pred_tta = 0.5 * (pred_orig + reflected_pred_refl)`.
6. Compute all val/* metrics (including `val_primary/abupt_axis_mean_rel_l2_pct`, `surface_pressure_rel_l2_pct`, `wall_shear_y_rel_l2_pct`, etc.) using `pred_tta` instead of `pred_orig`.

When `--eval-symmetry-tta` is OFF, validation behavior is unchanged. When ON, the only change is in evaluation; **training is identical**.

**Verify the implementation is correct before launching the full sweep**:
- Smoke test 1: load any prior checkpoint (or freshly initialized model), run validation with `--eval-symmetry-tta` ON; confirm val metrics are produced and finite.
- Smoke test 2: with a deterministic input, manually verify that `pred_orig.tau_x` ≈ `reflected_pred_refl.tau_x` at the matching point pairs (within float tolerance). If they don't match, the y-coordinate negation isn't being applied where you think it is, or the model has y-asymmetric internal state that the reflection isn't undoing.
- Smoke test 3: confirm that `tau_y` is sign-flipped and the rest aren't. Print a few values.

If any smoke test fails, debug before launching long runs.

### Step 2 — Train a single 3-epoch baseline model on yi

Use the highest-quality yi-monolithic-compatible config (yi train.py is AdamW-only, single-process, `--lr-warmup-steps` form):

```bash
cd target/
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent frieren \
  --lr 5e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --epochs 3 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --use-ema \
  --ema-decay 0.999 \
  --lr-warmup-steps 500 \
  --wallshear-y-weight 2 \
  --wallshear-z-weight 2 \
  --seed -1 \
  --kill-thresholds "3000:train/grad/global_norm<300" \
  --wandb-group frieren-symmetry-tta-r15 \
  --wandb-name frieren-tta-train
```

3 epochs is sufficient for the experiment because the test is **arm-relative on the same trained model**: TTA-on vs TTA-off both evaluate the same checkpoint. We don't need the full 9 epochs to test the TTA hypothesis. (If results are conclusive at 3 epochs, we'll consider extending.)

### Step 3 — Evaluate the trained model both ways

After training completes, evaluate the **same final checkpoint** twice, varying only `--eval-symmetry-tta`:

The cleanest way to do this without re-architecting eval: at the end of training, run the validation loop twice — once with TTA off (Arm A control), once with TTA on (Arm B treatment). Implement this as either:
- (option 1) A `--final-eval-both-modes` post-training switch that runs val twice and logs both sets of metrics with distinct W&B prefixes (e.g. `val/no_tta/...` and `val/tta/...`), OR
- (option 2) Run training to completion and persist the final checkpoint; then run two short eval-only invocations of `train.py` that load the checkpoint and run validation. (Cleaner but requires checkpoint-load eval mode that yi may not have.)

Choose whichever is easier given the existing yi train.py structure. If neither is straightforward, the simplest path is: log val metrics for both TTA-on and TTA-off **at every epoch** during training (no extra training cost — just one extra forward pass per val batch). That gives you a per-epoch comparison and is the most rigorous design.

### Step 4 — Report

Post results in a comment on this PR with:

1. Per-epoch table of `val_primary/abupt_axis_mean_rel_l2_pct` for both arms (control vs TTA), Δ(TTA − control), and Δ relative %.
2. Per-component breakdown at the final epoch: `surface_pressure_rel_l2_pct`, `wall_shear_rel_l2_pct`, `wall_shear_y_rel_l2_pct`, `wall_shear_z_rel_l2_pct`, `volume_pressure_rel_l2_pct` for both arms. We expect tau_y to show the largest relative improvement.
3. The two W&B run IDs (or one run with two metric prefixes).
4. The smoke-test outputs you produced in Step 1.

### Notes & gotchas

- **Preserve normal-vectors / orientation features**: if the surface input includes per-point normals, the y-component of normals must also be negated when y is reflected (a normal is a covector — same transform as a position vector under reflection). Same for any directional input feature.
- **Volume sample point coordinates** must also be y-reflected, not just surface points.
- **Freestream/inflow conditions**: if the model has any global feature that encodes flow direction with a y-component, that needs reflecting too. Check the dataset loader — DrivAerML inflow is typically along x, so this should be a no-op, but verify.
- **EMA model is the one that gets evaluated** when `--use-ema` is on. Make sure TTA wraps the EMA forward pass, not the live-weights forward.
- This is a single-GPU experiment — you have 3 spare GPUs. Use them for the smoke tests / a second seed if you finish early. Do NOT run the same configuration in parallel on multiple GPUs without distinct W&B run names.

## Baseline

**Current best on yi (PR #222 fern, Lion + DDP, lives on `tay` codebase — yi monolithic train.py cannot reproduce):**
- `val_primary/abupt_axis_mean_rel_l2_pct` = **9.2910%** (W&B run `ut1qmc3i`, group `tay-round12-lr-warmup-1ep`)
- This is the **merge bar**.

**yi-monolithic AdamW reference** (what your control arm will look like) — comparable historical AdamW@lr=5e-4 / 4L/512d / warmup=500 runs land in the **10.2–11.0%** range at 3 epochs (per recent fleet observations). Your TTA arm should beat your control arm at every epoch — that's the test of the hypothesis. If TTA reduces the val_abupt by a meaningful margin (≥ 1% relative) on yi-AdamW, the same recipe is overwhelmingly likely to also land on tay-Lion when ported.

**Per-component AB-UPT reference targets** (from `target/program.md` / `BASELINE.md`):
- `surface_pressure_rel_l2_pct`: 3.82
- `wall_shear_rel_l2_pct`: 7.29
- `wall_shear_y_rel_l2_pct`: **3.65** (current ~3.7× over)
- `wall_shear_z_rel_l2_pct`: **3.63** (current ~4.0× over)
- `volume_pressure_rel_l2_pct`: 6.08 (already solved, 0.97×)

The y/z gap is the dominant remaining error. TTA is the most direct intervention: anti-symmetry-aware averaging on `tau_y` exploits a known physical invariance of the dataset.
