### PR TITLE
alphonse: QK-norm on SOTA stack (Lion+heads=4, never tested)

### DIFF
--- a/model.py
+++ b/model.py
@@ -124,7 +124,14 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        dropout: float = 0.0,
+        qk_norm: bool = False,
+    ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -133,12 +140,19 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.qk_norm = qk_norm
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+        if qk_norm:
+            self.q_norm: nn.Module = nn.RMSNorm(self.dim_head)
+            self.k_norm: nn.Module = nn.RMSNorm(self.dim_head)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
 
@@ -161,6 +175,8 @@ class TransolverAttention(nn.Module):
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -182,6 +198,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        qk_norm: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -191,6 +208,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            qk_norm=qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -213,6 +231,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        qk_norm: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -223,6 +242,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    qk_norm=qk_norm,
                 )
                 for _ in range(depth)
             ]
@@ -253,6 +273,7 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        qk_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -262,6 +283,7 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
+        self.qk_norm = qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -299,6 +321,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            qk_norm=qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -117,6 +117,7 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    qk_norm: bool = False
     debug: bool = False
 
 
@@ -176,6 +177,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        qk_norm=config.qk_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**QK-norm (per-head L2 normalization of Query and Key vectors) stabilizes Transolver slot attention, improving convergence rate and final quality.**

In transformers, unbounded growth of Q/K dot-product magnitudes causes attention entropy collapse ("attention sink"), where the softmax saturates to near-one-hot distributions. QK-norm — normalizing Q and K to unit L2 norm before scaled dot-product attention — is now standard in modern vision (ViT-22B, 2022), language (Gemma-2, 2024), and diffusion (Stable Diffusion 3.5, 2024) transformers. The mechanism was also used in the Llama-style QK-norm applied via RMSNorm.

For our 4-head Transolver with dim_head=128: with Lion optimizer and sharp gradient updates, Q/K norms can grow unchecked. QK-norm:
1. Keeps attention distributions from collapsing during the sharp Lion updates
2. Decouples the scale of attention (now purely learned via a separate learnable scale) from the direction
3. Has been shown to matter more at smaller head counts (4 heads, each dim_head=128) where diversity is already limited

This is a ~10-line code change in `model.py` with no CLI flags required. It either works or it doesn't — a clean binary outcome.

**Reference:** Wortsman et al., "Replacing Softmax with ReLU in Vision Transformers" (2023); Zhai et al., "Scaling Vision Transformers to 22 Billion Parameters" (2022, Sec 2.2); Henry et al., "Query-Key Normalization for Transformers" (EMNLP 2020).

## Instructions

**Step 1: Add QK-norm to `TransolverAttention.forward()` in `model.py`**

In the `forward` method of `TransolverAttention` (around line 160-174), after computing `q, k, v = qkv.chunk(3, dim=-1)`, add per-head L2 normalization to Q and K:

```python
# Add QK-norm: normalize Q and K to unit L2 norm per head
# Shape: [batch, heads, slices, dim_head]
q = F.normalize(q, p=2, dim=-1)
k = F.normalize(k, p=2, dim=-1)
```

The `F.normalize` call requires `import torch.nn.functional as F` which is already imported.

After adding QK-norm, the full forward method should look like:

```python
def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
    slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
    qkv = self.qkv(slice_tokens)
    q, k, v = qkv.chunk(3, dim=-1)
    # QK-norm: per-head L2 normalization (decouples magnitude from attention pattern)
    q = F.normalize(q, p=2, dim=-1)
    k = F.normalize(k, p=2, dim=-1)
    out_slice = F.scaled_dot_product_attention(
        q,
        k,
        v,
        dropout_p=self.dropout if self.training else 0.0,
    )
    out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
    out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
    out_x = _apply_token_mask(out_x, attn_mask)
    out_x = self.proj_dropout(self.proj(out_x))
    return _apply_token_mask(out_x, attn_mask)
```

Note: when QK-norm is active, the `self.temperature` parameter (used in slice routing, not in Q/K attention) is unaffected — only the per-head Q/K vectors going into `scaled_dot_product_attention` are normalized. The existing `1/sqrt(dim_head)` scaling inside `F.scaled_dot_product_attention` still applies.

**Step 2: Run with the SOTA stack (no other changes)**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --wandb-group tay-round16-qk-norm
```

The only change vs SOTA is `F.normalize(q)` + `F.normalize(k)` in `model.py`. No new CLI flags, no new dependencies.

**Step 3: Post your results**

Post a comment on this PR with:
- Your W&B run ID (rank0 run)
- Full validation trajectory table (epoch | val_abupt | gap to SOTA 9.0650%)
- Best val result and whether it beats 9.0650%
- Test metrics (from best-val checkpoint reload): `test_primary/abupt_axis_mean_rel_l2_pct` and all per-axis metrics

## Baseline (current SOTA — must beat)

**PR #232 (askeladd), W&B run `r8s2dtnq`, group `tay-round12-heads-4`**

| Metric | SOTA value |
|--------|-----------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.0650%** (ep11) |
| `test_primary/abupt_axis_mean_rel_l2_pct` | **10.190%** |
| `test_primary/surface_pressure_rel_l2_pct` | 5.461% |
| `test_primary/wall_shear_rel_l2_pct` | 9.910% |
| `test_primary/volume_pressure_rel_l2_pct` | 12.656% |
| `test_primary/wall_shear_y_rel_l2_pct` | 11.952% |
| `test_primary/wall_shear_z_rel_l2_pct` | 12.447% |

**SOTA config:**
- `--model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128`
- `--optimizer lion --lr 1e-4 --weight-decay 5e-4`
- `--ema-decay 0.999 --lr-warmup-epochs 1`
- `--no-compile-model --batch-size 4`
