### PR TITLE
[gilbert] Spectral Fourier loss on wall-shear tau_y/z channels

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    spectral_loss_weight: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1288,6 +1289,42 @@ def weighted_masked_mse_per_channel(
     return weighted_loss, per_axis_mean
 
 
+def spectral_relative_l2_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    min_valid_points: int = 16,
+) -> torch.Tensor:
+    """Relative-L2 in the 1-D rFFT magnitude domain along the point axis.
+
+    pred, target: [B, N, C] surface predictions in normalized space.
+    mask: [B, N] bool — True for non-padding points.
+
+    Per-sample loop avoids padding contaminating the spectrum (each sample has
+    a different N_valid). FFT runs in fp32 for numeric stability. norm="ortho"
+    keeps the spectral energy comparable to the spatial energy (Parseval).
+    """
+    pred_f = pred.float()
+    target_f = target.float()
+    losses: list[torch.Tensor] = []
+    for b in range(pred_f.shape[0]):
+        m = mask[b]
+        valid_count = int(m.sum().item())
+        if valid_count < min_valid_points:
+            continue
+        p = pred_f[b][m]
+        t = target_f[b][m]
+        p_freq = torch.fft.rfft(p, dim=0, norm="ortho")
+        t_freq = torch.fft.rfft(t, dim=0, norm="ortho")
+        diff_mag_sq = (p_freq.abs() - t_freq.abs()).pow(2).sum()
+        denom = t_freq.abs().pow(2).sum().clamp(min=1e-8)
+        losses.append(diff_mag_sq / denom)
+    if not losses:
+        return pred_f.new_zeros(())
+    return torch.stack(losses).mean()
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1313,6 +1350,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    spectral_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1370,6 +1408,15 @@ def train_loss(
             aux_rel_l2 = num / den
             loss = loss + aux_rel_l2_weight * aux_rel_l2
             aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
+        spectral_loss_value: float | None = None
+        if spectral_loss_weight > 0.0:
+            spec_loss = spectral_relative_l2_loss(
+                surface_pred_norm[..., 1:4],
+                surface_target[..., 1:4],
+                batch.surface_mask,
+            )
+            loss = loss + spectral_loss_weight * spec_loss
+            spectral_loss_value = float(spec_loss.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1380,6 +1427,8 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if spectral_loss_value is not None:
+        metrics["spectral_loss"] = spectral_loss_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1810,6 +1859,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                spectral_loss_weight=config.spectral_loss_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -1925,6 +1975,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
+                ]
+            if "spectral_loss" in batch_loss_metrics:
+                train_log["train/spectral_loss"] = batch_loss_metrics[
+                    "spectral_loss"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

Wall-shear tau_y and tau_z remain ~3.7–4× above the AB-UPT reference. The dominant failure mode is likely the heavy-tail distribution of tau_y/z: a few high-curvature surface regions (wheel arches, A-pillars, mirror bases) drive the relative-L2 error while the model optimises for the dense low-shear flat surfaces. Standard MSE in the spatial domain is blind to this; it cannot distinguish a spatially-correlated structured error from scattered random noise.

We propose adding a **spectral (Fourier) loss component** on the surface field predictions. By computing the FFT of predicted and target wall-shear along the point-ordering dimension, we can directly penalise the mismatch in the frequency content of the error signal. High-frequency components encode sharp spatial gradients — exactly the regions where tau_y/z is hardest to predict. A small spectral weight (λ_spec = 0.05–0.2) on top of the existing spatial MSE acts as a structured regulariser that forces the model to capture spatial patterns, not just pointwise means.

Theoretical motivation: spectral losses are widely used in image synthesis (see STFT loss in audio WaveNet, frequency domain losses in super-resolution) and have shown consistent improvement when the target field has strong spatial correlations. DrivAerML surface point clouds are pseudo-regular (fixed DrivAer topology, ~65k points), so a per-sample FFT over a 1-D ordering of points is well-conditioned.

## Instructions

Implement a spectral auxiliary loss in `target/train.py`. Here is the precise plan:

### Step 1: Add a CLI flag

Add `spectral_loss_weight: float = 0.0` to the `TrainConfig` dataclass (around line 560–570 where other loss weights live). This flag controls how strongly the spectral loss is blended with the existing spatial loss.

### Step 2: Implement the spectral loss helper

After the existing loss utilities, add a function:

```python
def spectral_relative_l2_loss(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
    """
    Compute relative-L2 loss in the 1-D FFT magnitude domain.
    pred, target: [B, N, C] — surface predictions in normalized space
    mask: [B, N] — True for valid (non-padding) points
    Returns: scalar loss
    """
    # Work per-sample to avoid padding contaminating the spectrum
    losses = []
    for b in range(pred.shape[0]):
        m = mask[b]  # [N]
        p = pred[b][m]   # [N_valid, C]
        t = target[b][m]  # [N_valid, C]
        if p.shape[0] < 16:
            continue  # skip degenerate views
        # FFT over the point dimension for each output channel
        p_freq = torch.fft.rfft(p, dim=0, norm="ortho")  # [N//2+1, C]
        t_freq = torch.fft.rfft(t, dim=0, norm="ortho")
        # Relative L2 in magnitude spectrum
        diff_mag = (p_freq.abs() - t_freq.abs()).pow(2).sum()
        denom = t_freq.abs().pow(2).sum().clamp(min=1e-8)
        losses.append(diff_mag / denom)
    if not losses:
        return pred.new_zeros(1).squeeze()
    return torch.stack(losses).mean()
```

### Step 3: Integrate into the training loss

In the `compute_loss` function (around line 1310), after the existing `surface_loss` / `volume_loss` computation, add:

```python
if spectral_loss_weight > 0.0:
    # Surface channels 1-3 are wall-shear (x, y, z)
    spec_loss = spectral_relative_l2_loss(
        surface_pred_norm[:, :, 1:4],   # wall-shear channels only
        surface_target_norm[:, :, 1:4],
        surface_mask,
    )
    loss = loss + spectral_loss_weight * spec_loss
    metrics["spectral_loss"] = float(spec_loss.detach().cpu().item())
```

Make sure `spectral_loss_weight` is threaded through as an argument to `compute_loss` alongside the existing loss-weight arguments.

### Step 4: Sweep three arms

Run three arms in parallel — all on the PR #222 base config with `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`:

**Arm A — λ_spec = 0.05**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent gilbert \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --spectral-loss-weight 0.05 \
  --wandb_group gilbert-spectral-loss-sweep
```

**Arm B — λ_spec = 0.10**
Same as Arm A but `--spectral-loss-weight 0.10`.

**Arm C — λ_spec = 0.20**
Same as Arm A but `--spectral-loss-weight 0.20`.

Use GPUs 0–7 for Arm A, 8–15 for Arm B, 16–23 for Arm C if available, or run sequentially.

If any arm diverges (gnorm > 300 in epoch 1), kill immediately, relaunch at `--lr 5e-5` — do NOT relaunch at the same LR.

## Baseline

Current best — PR #222 fern, W&B run `ut1qmc3i`:

| Metric | yi best (val) | AB-UPT target | Ratio |
|---|---:|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910** | — | — |
| `val_primary/surface_pressure_rel_l2_pct` | **5.8707** | 3.82 | 1.54× |
| `val_primary/wall_shear_rel_l2_pct` | **10.3423** | 7.29 | 1.42× |
| `val_primary/volume_pressure_rel_l2_pct` | **5.8789** | 6.08 | **0.97× (SOLVED)** |
| `val_primary/wall_shear_y_rel_l2_pct` | ~13.5 | 3.65 | ~3.7× |
| `val_primary/wall_shear_z_rel_l2_pct` | ~13.9 | 3.63 | ~4.0× |

**Merge bar: 9.291% — beat this `val_primary/abupt_axis_mean_rel_l2_pct` to merge.**

Reproduce baseline:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent gilbert \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1
```

## Success Criteria

- Any arm beats 9.291% on `val_primary/abupt_axis_mean_rel_l2_pct` → winner candidate
- Watch specifically for improvement in `val_primary/wall_shear_y_rel_l2_pct` and `val_primary/wall_shear_z_rel_l2_pct` — these are the primary gap vs AB-UPT
- If `volume_pressure_rel_l2_pct` increases above 6.50%, the spectral loss is over-regularising — try a lower λ_spec
