### PR TITLE
haku: symm-aug Arm C (include-both bs=4) on stable lr=1e-4/wu=1ep base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch>=0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -601,6 +601,13 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    lr_warmup_epochs: int = 0
+    optimizer: str = "adamw"
+    lion_beta1: float = 0.9
+    lion_beta2: float = 0.99
+    use_symmetry_augmentation: bool = False
+    symmetry_flip_prob: float = 0.5
+    symmetry_include_both: bool = False
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1300,6 +1307,93 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def _flip_batch_y(batch: SurfaceBatch) -> SurfaceBatch:
+    """Reflect a batch through the y=0 plane.
+
+    surface_x: [..., 7] = [x, y, z, nx, ny, nz, area]  -> flip y (idx 1) and ny (idx 4)
+    surface_y: [..., 4] = [Cp, tau_x, tau_y, tau_z]    -> flip tau_y (idx 2)
+    volume_x:  [..., 4] = [x, y, z, sdf]               -> flip y (idx 1); sdf invariant
+    volume_y:  [..., 1] = [pressure]                   -> invariant scalar field
+    """
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = -surface_x[..., 1]
+    surface_x[..., 4] = -surface_x[..., 4]
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = -volume_x[..., 1]
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = -surface_y[..., 2]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
+def maybe_apply_symmetry_augmentation(
+    batch: SurfaceBatch,
+    *,
+    use_augmentation: bool,
+    flip_prob: float,
+    include_both: bool,
+    rng: torch.Generator | None = None,
+) -> tuple[SurfaceBatch, str]:
+    """Optionally apply y-axis reflection augmentation to a training batch.
+
+    Returns (possibly augmented batch, label) where label is one of
+    'off' / 'orig' / 'flip' / 'both'. With include_both=True we always
+    concatenate orig+flip along batch dim, doubling effective batch.
+    """
+    if not use_augmentation:
+        return batch, "off"
+    if include_both:
+        flipped = _flip_batch_y(batch)
+        combined = SurfaceBatch(
+            case_ids=list(batch.case_ids) + list(flipped.case_ids),
+            surface_x=torch.cat([batch.surface_x, flipped.surface_x], dim=0),
+            surface_y=torch.cat([batch.surface_y, flipped.surface_y], dim=0),
+            surface_mask=torch.cat([batch.surface_mask, flipped.surface_mask], dim=0),
+            volume_x=torch.cat([batch.volume_x, flipped.volume_x], dim=0),
+            volume_y=torch.cat([batch.volume_y, flipped.volume_y], dim=0),
+            volume_mask=torch.cat([batch.volume_mask, flipped.volume_mask], dim=0),
+            metadata=list(batch.metadata) + list(flipped.metadata),
+        )
+        return combined, "both"
+    if rng is not None:
+        draw = torch.rand(1, generator=rng).item()
+    else:
+        draw = torch.rand(1).item()
+    if draw < flip_prob:
+        return _flip_batch_y(batch), "flip"
+    return batch, "orig"
+
+
+def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
+    """Build optimizer based on config.optimizer ('adamw' or 'lion')."""
+    name = config.optimizer.lower()
+    if name == "adamw":
+        return torch.optim.AdamW(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+    if name == "lion":
+        from lion_pytorch import Lion
+
+        return Lion(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1709,8 +1803,16 @@ def main(argv: Iterable[str] | None = None) -> None:
     n_params = sum(param.numel() for param in model.parameters())
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+    optimizer = build_optimizer(model, config)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    if config.lr_warmup_epochs > 0:
+        steps_per_epoch = max(len(train_loader), 1)
+        config.lr_warmup_steps = int(config.lr_warmup_epochs * steps_per_epoch)
+        print(
+            f"Using {config.lr_warmup_epochs}-epoch LR warmup -> "
+            f"{config.lr_warmup_steps} steps "
+            f"(steps_per_epoch={steps_per_epoch})"
+        )
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
     if kill_thresholds:
@@ -1798,6 +1900,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            batch, symm_label = maybe_apply_symmetry_augmentation(
+                batch,
+                use_augmentation=config.use_symmetry_augmentation,
+                flip_prob=config.symmetry_flip_prob,
+                include_both=config.symmetry_include_both,
+            )
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1811,6 +1919,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
             )
+            symm_aug_code = {"off": 0.0, "orig": 0.0, "flip": 1.0, "both": 2.0}[symm_label]
+            batch_loss_metrics["symmetry_aug_applied"] = symm_aug_code
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
             if not loss_is_finite:
@@ -1925,6 +2035,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
+                ]
+            if "symmetry_aug_applied" in batch_loss_metrics:
+                train_log["train/symmetry_aug_applied"] = batch_loss_metrics[
+                    "symmetry_aug_applied"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now


### PR DESCRIPTION
## Hypothesis

Symmetry augmentation (left-right y-axis reflection) improved the tau_y/z wall-shear gap by −28% at epoch 1 in PR #225, but fleet-wide lr=5e-4 + warmup=500 instability prevented convergence — 10/11 runs hit NONFINITE_SKIP_ABORT before epoch 2. Critically, the control arm crashed just as often as the augmented arms, so the instability was structural, not augmentation-induced.

The yi SOTA baseline now uses `--lr-warmup-epochs 1` (PR #222), which produces stable Lion training on the 4L/512d architecture. This PR retests Arm C (symm-both, bs=4 — the strongest augmentation variant: effective bs×2 by concatenating orig+flip per step) on that stable base config. The hypothesis: symmetry augmentation at the stable lr=1e-4/warmup=1ep recipe will converge past the 9.291% merge bar, and the tau_y/z components will fall disproportionately.

**Physical motivation.** DrivAerML geometries are left-right symmetric around the y=0 plane. The current model has no inductive bias enforcing this — it must learn Cp and wall-shear symmetry from the 500 training cases alone. Flipping each sample and concatenating orig+flipped per step gives the model paired evidence that τ_y must negate and τ_z must negate-and-mirror, without adding any computational complexity beyond an effective 2× data augmentation.

## Context from PR #225

**Best ep1 result (Arm C `d03gq4om`, seed=101, lr=5e-4):**

| Metric | Baseline ep1 (bplngfyo) | Arm C (d03gq4om) | Δ |
|---|---:|---:|---:|
| abupt_axis_mean | 17.72% | 12.75% | −28.0% |
| surface_pressure | 12.85% | 9.00% | −30.0% |
| wall_shear (vec) | 19.74% | 14.06% | −28.8% |
| wall_shear_y | 23.07% | 16.29% | −29.4% |
| wall_shear_z | 25.35% | 17.89% | −29.4% |

This is a very strong ep1 signal. The −29.4% on tau_y and tau_z is 1.05× the overall improvement — mild disproportionality, but the overall −28% is large enough that even 50% of this gain surviving to convergence would comfortably beat 9.291%.

## Your task

### Step 1 — Re-apply symmetry augmentation implementation

The code from PR #225 (`haku/symmetry-augmentation`) implemented symmetry augmentation cleanly. The remote branch was deleted on close but you have the implementation. Re-apply to the yi base:

**Reflection helper** (re-implement or port from your prior work):
```python
def flip_sample_y_axis(surface_x, surface_y, volume_x):
    """Reflect a CFD sample around the y=0 plane.
    
    surface_x: [..., 7] = [x, y, z, nx, ny, nz, area]
    surface_y: [..., 4] = [Cp, tau_x, tau_y, tau_z]
    volume_x:  [..., 4] = [x, y, z, p]   (volume_y is unchanged Cp)
    """
    s = surface_x.clone()
    s[..., 1] = -s[..., 1]   # y → -y
    s[..., 4] = -s[..., 4]   # ny → -ny
    
    sv = surface_y.clone()
    sv[..., 2] = -sv[..., 2] # tau_y → -tau_y
    
    vx = volume_x.clone()
    vx[..., 1] = -vx[..., 1] # y → -y
    
    # tau_x, tau_z, Cp, p_v unchanged under y-flip
    return s, sv, vx
```

**Three CLI flags** (add to `train.py` argparse):
- `--use-symmetry-augmentation` (bool, default False)
- `--symmetry-flip-prob FLOAT` (default 0.5, only used for stochastic-flip mode)
- `--symmetry-include-both` (bool, default False; when True concatenates orig+flip in the same batch, making effective batch_size×2)

**Train loop wiring** (inside the per-step train loop, after loading a batch):
```python
if cfg.use_symmetry_augmentation and cfg.symmetry_include_both:
    # concatenate orig + flipped → effective bs×2
    s_flip, sy_flip, vx_flip = flip_sample_y_axis(surface_x, surface_y, volume_x)
    surface_x  = torch.cat([surface_x, s_flip], dim=0)
    surface_y  = torch.cat([surface_y, sy_flip], dim=0)
    volume_x   = torch.cat([volume_x, vx_flip], dim=0)
    # volume_y (pressure) is unchanged under y-flip — concat zeros or orig
```

Log `symmetry_aug_applied` (0/1/2) per step for traceability.

### Step 2 — Run the experiment

**Single-arm target.** Run 1 primary arm + 1 backup seed:

| Arm | Config | Purpose |
|---|---|---|
| Primary (seed=42) | symm-include-both, bs=4, lr=1e-4, warmup=1ep | Main result |
| Backup (seed=7) | symm-include-both, bs=4, lr=1e-4, warmup=1ep | Seed robustness check |

**Training command (primary):**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent haku \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --use-symmetry-augmentation \
  --symmetry-include-both \
  --wandb-group haku-symm-c-lr3e4 \
  --wandb-name "haku/symm-both-bs4-lr1e4-wu1ep-seed42" \
  --seed 42
```

**Backup arm (seed=7):** same but `--seed 7` and `--wandb-name "haku/symm-both-bs4-lr1e4-wu1ep-seed7"`.

Notes:
- `--lr-warmup-epochs 1` is the PR #222 stability fix — use this, not `--lr-warmup-steps 500`
- With `--symmetry-include-both` at bs=4, effective batch = bs×2 = 8 per GPU × 8 GPUs = 64 global. This is 2× the baseline. To match effective bs=32 exactly, use `--batch-size 2` with `--symmetry-include-both`. **Prefer bs=2** for the main arm if OOM is not a concern.

**Memory check.** PR #225 Arm C ran at bs=4/single-GPU with 65k pts → 75.5 GB. On 8-GPU DDP at bs=4, each rank sees 4 samples, then doubles to 8 with include-both → 8×65k pts per rank. Check OOM before committing to bs=4; drop to bs=2 if needed and report peak VRAM.

### Step 3 — Report results

Include:
1. Full val table (abupt/sp/ws/vp/wsy/wsz) from best-val checkpoint for each arm
2. Compare against PR #222 baseline ep-by-ep curve to confirm convergence direction
3. Note peak VRAM per GPU
4. Note whether tau_y/z fell faster than headline abupt (disproportionality ratio)

**Win criterion:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.291%` from best-val checkpoint.

## Baseline

**Current best (PR #222, W&B run `ut1qmc3i`):**

| Metric | Value |
|---|---:|
| val_abupt_axis_mean | **9.2910%** |
| val_surface_pressure | 5.8707% |
| val_wall_shear | 10.3423% |
| val_volume_pressure | 5.8789% |

Best epoch: 9 (step 23544). See BASELINE.md for full epoch-by-epoch curve.

**Reproduce baseline:**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1
```

**AB-UPT targets:** surface_pressure 3.82 | wall_shear 7.29 | volume_pressure 6.08 | tau_y 3.65 | tau_z 3.63

**Volume pressure already beats AB-UPT** (5.88 vs 6.08, 0.97×). Surface pressure and wall_shear are the remaining gaps.
