### PR TITLE
[edward] Per-channel wall-shear loss multipliers (wsy/wsz upweight sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -117,6 +117,8 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    wsy_loss_weight: float = 1.0
+    wsz_loss_weight: float = 1.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -157,6 +159,17 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def _surface_per_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    expanded_mask = mask.unsqueeze(-1).to(device=pred.device, dtype=pred.dtype)
+    diff_sq = (pred - target).square() * expanded_mask
+    n_valid = expanded_mask.sum().clamp_min(1.0)
+    return diff_sq.sum(dim=tuple(range(diff_sq.ndim - 1))) / n_valid
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -167,6 +180,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     raw_rel_l2_weight: float = 0.0,
+    surface_channel_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -178,7 +192,17 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_per_channel_mse = _surface_per_channel_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )
+        if surface_channel_weights is None:
+            surface_loss = surface_per_channel_mse.mean()
+        else:
+            weights = surface_channel_weights.to(
+                device=surface_per_channel_mse.device,
+                dtype=surface_per_channel_mse.dtype,
+            )
+            surface_loss = (surface_per_channel_mse * weights).sum() / weights.sum().clamp_min(1e-12)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -204,12 +228,21 @@ def train_loss(
             aux_loss = aux_loss + vol_rel_l2
             loss = loss + raw_rel_l2_weight * aux_loss
 
+    surface_channel_names = ("surface_pressure", "wsx", "wsy", "wsz")
+    per_channel_log: dict[str, float] = {}
+    detached_per_channel = surface_per_channel_mse.detach().cpu()
+    for ch_idx, ch_name in enumerate(surface_channel_names):
+        if ch_idx < detached_per_channel.numel():
+            per_channel_log[f"surface_per_channel_mse/{ch_name}"] = float(
+                detached_per_channel[ch_idx].item()
+            )
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **per_channel_log,
         **aux_metrics,
     }
 
@@ -239,6 +272,24 @@ def main(argv: Iterable[str] | None = None) -> None:
             volume_y_mean=stats["volume_y_mean"].to(device),
             volume_y_std=stats["volume_y_std"].to(device),
         )
+        surface_channel_weights_cfg = (
+            1.0,
+            1.0,
+            float(config.wsy_loss_weight),
+            float(config.wsz_loss_weight),
+        )
+        surface_channel_weights = torch.tensor(
+            surface_channel_weights_cfg, device=device, dtype=torch.float32
+        )
+        surface_channel_weights_active = any(
+            abs(w - 1.0) > 1e-12 for w in surface_channel_weights_cfg
+        )
+        if state.is_main:
+            print(
+                "Surface channel loss weights "
+                "[surface_pressure, wsx, wsy, wsz] = "
+                f"{surface_channel_weights_cfg}"
+            )
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())
@@ -325,6 +376,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     raw_rel_l2_weight=config.raw_rel_l2_weight,
+                    surface_channel_weights=(
+                        surface_channel_weights
+                        if surface_channel_weights_active
+                        else None
+                    ),
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -368,6 +424,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                                      "raw_rel_l2/vol_pressure"):
                         if _aux_key in batch_loss_metrics:
                             train_log[f"train/{_aux_key}"] = batch_loss_metrics[_aux_key]
+                    for _per_channel_key in (
+                        "surface_per_channel_mse/surface_pressure",
+                        "surface_per_channel_mse/wsx",
+                        "surface_per_channel_mse/wsy",
+                        "surface_per_channel_mse/wsz",
+                    ):
+                        if _per_channel_key in batch_loss_metrics:
+                            train_log[f"train/{_per_channel_key}"] = batch_loss_metrics[_per_channel_key]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

The bengio baseline's binding constraints are **wall_shear_y (wsy=9.10% vs 3.65% target)** and **wall_shear_z (wsz=10.87% vs 3.63% target)** — both are ~3x worse than AB-UPT. The current loss treats all wall-shear channels equally. Hypothesis: **fixed per-channel multipliers** that explicitly upweight wsy and wsz in the wall-shear loss term will redirect optimization pressure toward the binding axes.

This is a direct, low-risk attack on the two specific axes that gate our overall abupt_axis_mean. Edward's earlier uncertainty-weighting approach underperformed in Wave 1 (rank 12 / 16) — fixed multipliers are a simpler, more controllable alternative.

## Instructions

This requires a **small `train.py` edit** to add per-channel wall-shear multipliers, then a 3-trial sweep.

**Code change**: Find the wall-shear loss computation in `train.py` (it computes MSE/L2 over the 3-channel WSS vector). Replace the unweighted mean with a weighted mean using a fixed per-channel weight tensor:

```python
# At top of training step or as a constant in the loss helper:
WSS_CHANNEL_WEIGHTS = torch.tensor([1.0, args.wsy_loss_weight, args.wsz_loss_weight], device=device)
# In wall_shear loss:
ws_per_channel = (pred_ws - target_ws).pow(2).mean(dim=tuple_excluding_channel_dim)  # shape (3,)
ws_loss = (ws_per_channel * WSS_CHANNEL_WEIGHTS).sum() / WSS_CHANNEL_WEIGHTS.sum()
```

Add CLI flags:
- `--wsy-loss-weight` (default 1.0)
- `--wsz-loss-weight` (default 1.0)

Defaults of 1.0 preserve current baseline behavior (no regression on no-flag runs).

**Trials** — sweep three weight pairs on the alphonse Wave 1 base + Fourier PE:

```bash
# Trial A: mild upweight (wsy=2.0, wsz=3.0)
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --fourier-pe --no-use-ema --lr 3e-4 --lr-cosine-t-max 30 --epochs 50 \
  --wsy-loss-weight 2.0 --wsz-loss-weight 3.0 \
  --no-compile-model \
  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
  --wandb-group bengio-wave6-wss-channel-weights \
  --wandb-name edward-wss-w2-3

# Trial B: aggressive upweight (wsy=3.0, wsz=5.0)
... --wsy-loss-weight 3.0 --wsz-loss-weight 5.0 \
... --wandb-name edward-wss-w3-5

# Trial C: very aggressive (wsy=5.0, wsz=8.0) — only if A or B shows signal
... --wsy-loss-weight 5.0 --wsz-loss-weight 8.0 \
... --wandb-name edward-wss-w5-8
```

Run Trial A and B in parallel if you have spare DDP4 capacity; otherwise sequential.

**What to report:**
- Best `val_primary/abupt_axis_mean_rel_l2_pct` for each trial
- Per-axis val metrics — particularly **wsy and wsz** at best checkpoint (these should improve)
- Watch for unintended degradation on wsx, sp, vp (the cost of redirecting optimization)
- W&B run ids and links

## Baseline

Current best on bengio (`/target/BASELINE.md`):
- W&B run: `m9775k1v` (alphonse PR #74), ep30, 4L/256d
- `val_primary/abupt_axis_mean_rel_l2_pct` = **7.2091%**
- wsy = 9.10%, wsz = 10.87% (binding constraints)
- AB-UPT targets: wsy = 3.65%, wsz = 3.63%
