### PR TITLE
edward: learned spectral encoding — STRING separable + GRAPE-M vs RFF control (3-arm)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-02 ~01:00 UTC
+- **Date:** 2026-05-02 ~02:00 UTC
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -37,62 +37,60 @@ torchrun --standalone --nproc_per_node=8 train.py \
   --ema-decay 0.999 --lr-warmup-epochs 1
 ```
 
-## In-flight — Rounds 13–16 (2026-05-02 ~01:00 UTC)
+## In-flight — Rounds 13–17 (2026-05-02 ~02:00 UTC)
 
-**Active DrivAerML students (ddp8):** alphonse, askeladd, edward, fern, frieren, nezuko, tanjiro, thorfinn.
-
-**NOTE:** Round 15 PRs (#263-272) assigned to non-existent students were closed 2026-05-02. Deferred hypotheses listed under Key Learnings.
+**Active DrivAerML students (ddp8):** alphonse, askeladd, chihiro, edward, emma, fern, frieren, gilbert, haku, kohaku, nezuko, norman, senku, tanjiro, thorfinn, violet.
 
 | PR | Student | Hypothesis | Status |
 |---|---|---|---|
 | #232 | askeladd | model_heads=4 | **MERGED — CURRENT SOTA** |
 | #240 | frieren | mlp_ratio=8 | **CLOSED NEGATIVE** — best val=9.5498% at ep7.52 (+0.485pp). |
-| #241 | tanjiro | hidden_dim=768 (lr=1e-4) | Running; **tracking NEGATIVE** (~10.5% likely final). |
-| #247 | thorfinn | lr-cosine-t-max=14 | Running; ep7=9.9253%, **tracking NEGATIVE** (+0.860pp). |
-| #251 | fern | T_max=8+warmup+lr-min=5e-6 | Running; ep5=11.835%, **tracking NEGATIVE** (behind frieren at every epoch). |
-| #280 | frieren | MLP activation ablation (SwiGLU/ReLU²) | WIP — pod waiting for #240 cleanup. |
-| #281 | askeladd | --compile-model on SOTA stack | Running; ep2=45.04% (**anomalous — 2x worse than SOTA ep2=22%**). Monitor. |
-| #282 | edward | --lion-beta1 0.95 | Running; ep1=63.7% (normal). Monitor ep2. |
-| #283 | nezuko | --model-layers 5 depth sweep | Running; ep1=64.78% (normal). Monitor ep2. |
-| **#287** | **alphonse** | **QK-norm on SOTA stack** | **NEW Round 16 — pod pickup pending.** |
+| #251 | fern | T_max=8+warmup+lr-min=5e-6 | Running; ep5=11.835%, **NEGATIVE** (behind frieren at every epoch). Let finish; close when done. |
+| #280 | frieren | MLP activation ablation (SwiGLU/ReLU²/GELU) | 4-arm sequential DDP8 sweep; started ~22:59 UTC 2026-05-01; ~18h total; results due ~17:00 UTC 2026-05-02. Branch has merge conflict — rebase reminder posted. |
+| #282 | edward | lion-beta1=0.95 | Running; ep3=26.10% (gap narrowing, down from ep2=53.3%). Monitor for convergence. |
+| #283 | nezuko | model-layers=5 depth sweep | Running; ep1=64.78% (warmup normal). Monitor ep2+. |
+| #287 | alphonse | QK-norm on SOTA stack (per-head L2 norm) | Round 16 — pod starting; 0 comments. |
+| #289 | chihiro | lr-warmup-epochs=2 (1ep→2ep) | Round 17 — pod starting; 0 comments. |
+| #290 | emma | RFF retest on current SOTA stack (heads=4+warmup=1ep) | Round 17 — pod starting; 0 comments. |
+| #291 | gilbert | ema-decay=0.9995 with lr-warmup-epochs=1 | Round 17 — pod starting; 0 comments. |
+| #292 | haku | grad-clip-norm=0.5 (Lion stabilization) | Round 17 — pod starting; 0 comments. |
+| #293 | kohaku | lr-cosine-t-max=12 (fill T_max=9 neg / T_max=14 neg gap) | Round 17 — pod starting; 0 comments. |
+| #294 | norman | warmup=1ep + lr-cosine-t-max=9 (warmup+anneal compound) | Round 17 — pod starting; 0 comments. |
+| #295 | senku | model-hidden-dim=768 + muP lr=8.2e-5 (rescue tanjiro w/ correct LR scaling) | Round 17 — pod starting; 0 comments. |
+| #296 | violet | lr-min=1e-5 on SOTA stack (cosine LR floor) | Round 17 — pod starting; 0 comments. |
+| #299 | askeladd | Muon optimizer (Newton-Schulz orthogonalized momentum) | Round 17 — pod starting; 0 comments. |
+| #300 | tanjiro | Post-attention + post-MLP RMSNorm (sandwich-norm) | Round 17 — pod starting; 0 comments. |
+| #309 | thorfinn | grad-clip-norm=0.5 (Lion+EMA+warmup+heads=4) | Round 17 — pod starting; 0 comments. |
 
 ## Active Human Research Directives
 
 **Issue #252 (Modded-NanoGPT):** Mine the Modded-NanoGPT world-record training history for applicable improvements. Techniques ranked by transfer plausibility:
-1. Muon optimizer (Newton-Schulz orthogonalized momentum) — would require code change; high priority next free slot
-2. Post-attention RMSNorm / QK-norm — stabilizes Transolver slot attention
-3. Linear warmdown LR (being approximated by norman #269 + fern #251)
-4. U-net skip connections — cheap residual across layers
-5. Sequence packing / FlexAttention — throughput lever (more epochs/budget)
+1. Muon optimizer (Newton-Schulz orthogonalized momentum) — **in-flight** askeladd #299
+2. Post-attention RMSNorm / QK-norm — **in-flight** tanjiro #300 (RMSNorm) + alphonse #287 (QK-norm)
+3. Linear warmdown LR (approximated by norman #294 + fern #251)
+4. U-net skip connections — cheap residual across layers (deferred)
+5. Sequence packing / FlexAttention — throughput lever (deferred)
+
+**Issue #285 (GRAPE/Representational Position Encoding):** 3-arm sweep (RFF control / 3D STRING separable / full GRAPE-M learned non-axis-aligned planes) — **unassigned; deferred to next free slot.**
 
 ## Current Research Focus
 
-**Primary focus:** Architecture and attention normalization (Round 16).
-- QK-norm on SOTA stack (alphonse #287) — per-head L2 normalization, never tested
-- MLP activation ablation SwiGLU/ReLU² vs GELU (frieren #280) — activation function sweep
+**Primary focus — Round 17 (architecture + optimizer):**
+- Muon optimizer (askeladd #299) — highest-variance bet; Newton-Schulz orthogonalization replaces Adam/Lion
+- Sandwich-norm RMSNorm (tanjiro #300) — post-attn + post-MLP normalization; stabilizes Transolver attention
+- QK-norm (alphonse #287) — per-head L2 normalization; never tested
 
-**Secondary focus (closing out active runs):**
-- compile_model efficiency (askeladd #281) — anomalous ep2 val; monitor for recovery
-- model-layers=5 depth sweep (nezuko #283) — closing the depth axis
-- lion-beta1=0.95 (edward #282) — closing the lion_beta1 sweep axis
-- LR anneal T_max=8 (fern #251) — tracking NEGATIVE; close when done
-- LR cosine T_max=14 (thorfinn #247) — tracking NEGATIVE; close when done
-- Width 768d (tanjiro #241) — tracking NEGATIVE; close when done
+**Secondary focus — Round 17 (hyperparameter closure):**
+- MLP activation ablation (frieren #280) — SwiGLU/ReLU²/GELU 4-arm sweep; results due ~17:00 UTC 2026-05-02
+- lion-beta1=0.95 (edward #282) — closing lion_beta1 axis
+- model-layers=5 (nezuko #283) — closing depth axis
 
-**Deferred (hypotheses from closed Round 15 orphans — assign to ddp8 students):**
-- lr-warmup-epochs=2 (was chihiro #263)
-- RFF retest on current SOTA stack (was emma #264)
-- ema-decay=0.9995 WITH warmup=1ep (was gilbert #265)
-- grad-clip-norm=0.5 (was haku #267)
-- lr-cosine-t-max=12 (was kohaku #268)
-- warmup=1ep + cosine T_max=9 (was norman #269)
-- model-hidden-dim=768 + muP lr=8.2e-5 (was senku #271)
-- lr-min=1e-5 (was violet #272)
-
-**Next priority (after Round 16):** Modded-NanoGPT code-change ideas
-- Muon optimizer (Newton-Schulz orthogonalized gradient) — highest expected gain
-- Post-attention RMSNorm (stabilize Transolver attention, ~4-line change)
-- U-net skip connections (cross-layer residuals)
+**Deferred (assign when next student frees up):**
+- GRAPE/Group Representational Position Encoding (Issue #285) — 3-arm: RFF ctrl / 3D STRING / GRAPE-M
+- U-net skip connections (Modded-NanoGPT inspired)
+- Sequence packing / FlexAttention (throughput lever)
+- Dedicated volume decoder head (volume_pressure ×2.08 gap)
+- Surface-tangent-frame projection for tau_y/tau_z (×3.27/×3.43 gaps)
 
 ## Key Learnings (cumulative)
 
@@ -106,36 +104,41 @@ torchrun --standalone --nproc_per_node=8 train.py \
 | Vol loss weight | CLOSED | 1.0 SOTA; 1.5 and 2.0 both negative |
 | Vol points | CLOSED | 65536 SOTA; 96k regressed |
 | Surface points | CLOSED | 65536 SOTA; 96k (PR #206) negative |
-| mlp_ratio | **CLOSED NEGATIVE** | 4 SOTA; 6 regressed (+6.4%); 8 NEGATIVE (PR#240, +0.485pp, timeout-bounded) |
-| Dropout | CLOSED | 0.0 SOTA; 0.05 regressed (+4.24%); model underfits |
+| mlp_ratio | CLOSED NEGATIVE | 4 SOTA; 6 regressed (+6.4%); 8 negative (PR#240, +0.485pp) |
+| Dropout | CLOSED | 0.0 SOTA; 0.05 regressed (+4.24%) |
 | Tau axis weights | CLOSED | 1.0 SOTA; Lion sign neutralizes per-channel weighting |
 | model_layers | Closing | 4 SOTA; 3L regression (PR #233); 5L in-flight (#283) |
-| model_heads | **CLOSED — NEW SOTA** | 4H beats 8H (PR #232 merged; −0.226pp val) |
-| model_slices | Closing | 128 SOTA; 64 tracking regression (PR #231) |
+| model_heads | CLOSED — NEW SOTA | 4H beats 8H (PR #232 merged; −0.226pp val) |
+| model_slices | CLOSED NEGATIVE | 128 SOTA; 64 regression (PR #231) |
+| model_hidden_dim | CLOSED NEGATIVE | 512 SOTA; 768 tanjiro #241 negative; 768+muP in-flight (#295) |
 | lr_cosine T_max=9 | CLOSED NEGATIVE | Confirmed ×2 (edward #195, tanjiro #202) |
-| lr_cosine T_max=14 | NEGATIVE (in-flight) | thorfinn #247: ep7=9.925%, tracking +0.86pp above SOTA |
+| lr_cosine T_max=14 | CLOSED NEGATIVE | thorfinn #247: ep7=9.925%, +0.86pp above SOTA |
 | lr_cosine T_max=8 + anneal | NEGATIVE (in-flight) | fern #251: ep5=11.83%, behind frieren at every epoch |
+| lr_cosine T_max=12 | In-flight | kohaku #293: fills T_max gap; pod starting |
 | lr_warmup_epochs=1 | WIN (compound) | PR #222 fern — +2.03% val, +1.51% test |
-| lr-min | DEFERRED | 1e-5 was violet #272 (no pod — orphan closed) |
-| grad-clip-norm | DEFERRED | 0.5 was haku #267 (no pod — orphan closed) |
-| RFF features | DEFERRED | Emma #264 retest on SOTA (no pod — orphan closed) |
-| model_hidden_dim | NEGATIVE (in-flight) | 512 SOTA; 768 tanjiro #241 tracking plateau |
-| Warmup 2ep | DEFERRED | chihiro #263 (no pod — orphan closed) |
+| lr_warmup_epochs=2 | In-flight | chihiro #289: pod starting |
+| lr-min=1e-5 | In-flight | violet #296: pod starting |
+| warmup+T_max=9 compound | In-flight | norman #294: pod starting |
+| grad-clip-norm=0.5 | In-flight | haku #292 + thorfinn #309: pods starting |
+| RFF features | In-flight | emma #290: SOTA-stack retest (heads=4+warmup); pod starting |
+| ema-decay=0.9995 | In-flight | gilbert #291: with warmup=1ep; pod starting |
 | batch_size | CLOSED NEGATIVE | batch=5 OOM'd; batch-size lever closed; 4=SOTA |
-| compile_model | Anomalous (in-flight) | askeladd #281: ep2=45% vs SOTA 22% — monitoring for recovery |
-| lion_beta1 | Closing | 0.9 SOTA; 0.8 negative; 0.95 in-flight (edward #282) |
-| MLP activation | In-flight | SwiGLU/ReLU²/GELU ablation (frieren #280) |
-| QK-norm | In-flight | Per-head L2 norm (alphonse #287) — new Round 16 |
+| compile_model | CLOSED ANOMALOUS | askeladd #281: ep2=45% anomalous; closed |
+| MLP activation | In-flight (long run) | SwiGLU/ReLU²/GELU ablation (frieren #280); ~18h sweep |
+| QK-norm | In-flight | Per-head L2 norm (alphonse #287); pod starting |
+| Sandwich-norm (RMSNorm) | In-flight | Post-attn+post-MLP (tanjiro #300); pod starting |
+| Muon optimizer | In-flight | Newton-Schulz orthogonalization (askeladd #299); pod starting |
 
 ## Largest Remaining Gaps to AB-UPT
 
 1. **volume_pressure** ×2.08 — Not a loss-weighting problem (closed). Likely architectural: dedicated volume decoder, richer SDF features, hierarchical multi-scale volume heads.
 2. **tau_y** ×3.27, **tau_z** ×3.43 — Shear stress direction prediction. Needs geometry-informed head (surface tangent frame) or output transformation (asinh normalization).
 
-## Next Priorities (after Rounds 15/16 close)
+## Next Priorities (after Rounds 16/17 close)
 
-1. **Muon optimizer** — Newton-Schulz orthogonalized gradient, highest-variance Modded-NanoGPT bet
-2. **Post-attention RMSNorm** — stabilize Transolver slot attention, cheap code change
-3. **Volume architecture** — dedicated volume decoder head; potentially copy from AB-UPT paper's design
+1. **GRAPE/Representational Position Encoding** (Issue #285) — 3-arm sweep once a student frees up
+2. **U-net skip connections** — cross-layer residuals (Modded-NanoGPT inspired)
+3. **Volume architecture** — dedicated volume decoder head; copy from AB-UPT paper's design
 4. **Tau head reform** — surface-tangent-frame projection to close tau_y/tau_z gap
-5. **Compound winners** — stack Round 15/16 winners once identified
+5. **Compound winners** — stack Round 16/17 winners once identified
+6. **Sequence packing / FlexAttention** — throughput lever (more epochs/budget)


### PR DESCRIPTION
## Hypothesis

Random Fourier Features (RFF) use **isotropic** Gaussian sampling of spectral frequencies, which treats all spatial directions identically. For CFD surface meshes, the geometry is fundamentally anisotropic — the streamwise direction (x-axis) matters very differently from wall-normal or spanwise directions, and wall shear stress (tau_y, tau_z) is dominated by near-surface directional gradients. 

**Group Representational Position Encoding (GRAPE)** [Knigge et al., 2024, ICLR] replaces the isotropic Gaussian basis with learned non-axis-aligned projection planes whose orientations are optimized end-to-end. The learned planes can align to the dominant frequency directions in the flow field — e.g., the boundary-layer normal direction and streamwise pressure gradient — rather than sampling uniformly. This is directly motivated by the large tau_y/tau_z gap (×3.27, ×3.43 vs AB-UPT) which suggests the model lacks sensitivity to the geometric orientation of the surface.

A simpler approximation, **STRING (Separable Tensor Representation for Implicit Neural Geometry)**, uses axis-aligned frequencies with per-axis independent learnable amplitude and phase — no learned plane orientations, but separable axis sensitivity.

This is a **3-arm ablation** to isolate the encoding contribution on the current SOTA stack:
1. **Arm A — RFF control (current best):** Isotropic Gaussian RFF, sigma=1.0, 32 features — confirms the SOTA stack hasn't drifted.
2. **Arm B — 3D STRING separable:** Axis-aligned sincos with learnable per-axis amplitude and phase (no random projection), num_features=32. Simple to implement: replace the fixed Gaussian `B` matrix with separate per-axis learnable frequency/phase parameters.
3. **Arm C — GRAPE-M learned planes:** Replace fixed Gaussian `B` with a learnable `(in_dim, num_features)` projection matrix initialized from a Gaussian, trainable end-to-end. This is the minimal GRAPE implementation: just make `B` a `nn.Parameter` instead of a buffer.

All three arms run on the full SOTA stack. Same budget (270 min wall, up to 11 epochs). Run arms sequentially on the DDP8 pod.

**Expected impact:** Arm C (GRAPE-M) directly reduces the spectral mismatch between isotropic RFF and flow-field anisotropy. If learned planes align to streamwise/spanwise directions, we expect tau_y/tau_z improvement. Even partial alignment on the ×3.27/×3.43 gap would be significant. Arm B tests whether the improvement is from axis-separation alone (simpler explanation) or truly from learned plane orientations.

References:
- Knigge et al. "GRAPE: Group Representational Position Encoding" ICLR 2024 — https://openreview.net/forum?id=Sf1gXpTKkS
- Tancik et al. "Fourier Features Let Networks Learn High-Frequency Functions in Low Dimensional Domains" NeurIPS 2020

## Instructions

This requires three sequential training runs using the current SOTA stack. Modify **`model.py`** only — no changes to `train.py`, `trainer_runtime.py`, or `data/`.

### Arm A — RFF control (baseline recheck)

No model changes. Run with `--rff-num-features 32 --rff-sigma 1.0` on the SOTA stack:

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --wandb-group tay-round18-grape-ablation
```

### Arm B — 3D STRING separable encoding

In `model.py`, add a new class `StringEncoding` that replaces the fixed Gaussian `B` matrix with per-axis learnable log-amplitude and phase:

```python
class StringEncoding(nn.Module):
    """Separable axis-aligned learnable frequency encoding (STRING-inspired).
    
    Each of the `in_dim` axes gets `num_features_per_axis` independent learnable
    frequencies (log-amplitude + phase). Output dim = in_dim * num_features_per_axis * 2.
    """
    def __init__(self, in_dim: int, num_features_per_axis: int = 11, sigma: float = 1.0):
        super().__init__()
        self.in_dim = in_dim
        self.num_features_per_axis = num_features_per_axis
        # Initialize log-freq around log(sigma) with small spread
        self.log_freq = nn.Parameter(
            torch.randn(in_dim, num_features_per_axis) * 0.1 + math.log(sigma)
        )
        self.phase = nn.Parameter(torch.zeros(in_dim, num_features_per_axis))
    
    @property
    def output_dim(self) -> int:
        return self.in_dim * self.num_features_per_axis * 2
    
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: [..., in_dim]
        freq = self.log_freq.exp()  # [in_dim, F]
        # axis-wise: proj[..., d, f] = x[..., d] * freq[d, f] + phase[d, f]
        proj = x.unsqueeze(-1) * freq + self.phase  # [..., in_dim, F]
        proj = 2.0 * math.pi * proj
        return torch.cat([proj.sin(), proj.cos()], dim=-1).flatten(start_dim=-2)
```

Use `num_features_per_axis=11` so output dim = 3 × 11 × 2 = 66, slightly larger than RFF (64) to keep capacity comparable.

Wire it in by replacing `RFFEncoding` with `StringEncoding` in the `Transolver.__init__` when a new flag `--rff-mode string` (or just hardcode the class swap for this experiment — use a new CLI flag `--pos-encoding-mode` with values `rff` / `string` / `grape`). 

Alternatively: just add a `pos_encoding_mode` parameter to the `Transolver` class and branch there. Pass it through from `train.py`'s config. The simplest approach: add `--pos-encoding-mode` to `train.py` argparse with default `rff`, values `rff/string/grape`.

Run Arm B:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --pos-encoding-mode string \
  --wandb-group tay-round18-grape-ablation
```

### Arm C — GRAPE-M (learned projection planes)

In `model.py`, add a `GrapeEncoding` class that converts the fixed buffer `B` in `RFFEncoding` into a trainable `nn.Parameter`:

```python
class GrapeEncoding(nn.Module):
    """Minimal GRAPE-M: learnable spectral projection planes (Knigge et al. 2024).
    
    Identical to RFFEncoding but B is an nn.Parameter trained end-to-end.
    Output dim = 2 * num_features.
    """
    def __init__(self, in_dim: int, num_features: int = 32, sigma: float = 1.0):
        super().__init__()
        self.in_dim = in_dim
        self.num_features = num_features
        self.B = nn.Parameter(torch.randn(in_dim, num_features) * sigma)
    
    @property
    def output_dim(self) -> int:
        return 2 * self.num_features
    
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        proj = 2.0 * math.pi * (x @ self.B.to(dtype=x.dtype))
        return torch.cat([proj.sin(), proj.cos()], dim=-1)
```

Use `--pos-encoding-mode grape`. Run Arm C:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --rff-num-features 32 --rff-sigma 1.0 \
  --pos-encoding-mode grape \
  --wandb-group tay-round18-grape-ablation
```

### Implementation notes

- Add `--pos-encoding-mode` to `train.py` config with `default="rff"`, choices `["rff", "string", "grape"]`
- Pass through to `Transolver.__init__` and use to select `RFFEncoding` / `StringEncoding` / `GrapeEncoding`
- For STRING: `--rff-num-features` is repurposed as `num_features_per_axis` (so output is 3× larger — this is intentional)
- Keep `--rff-num-features 32 --rff-sigma 1.0` in all arms for consistent CLI; ignore `rff-sigma` in STRING mode
- All three encoding classes should share the same `output_dim` property interface

### Reporting

Report per-arm val_abupt curves and best-epoch metrics in a table:

| Arm | Encoding | Best val_abupt | Best epoch | tau_y | tau_z | surface_pressure |
|-----|----------|---------------|------------|-------|-------|-----------------|
| A | RFF (σ=1.0, fixed) | ? | ? | ? | ? | ? |
| B | STRING (learnable axis-freq) | ? | ? | ? | ? | ? |
| C | GRAPE-M (learnable planes) | ? | ? | ? | ? | ? |

Focus reporting on tau_y and tau_z (the ×3.27/×3.43 gaps vs AB-UPT). Report W&B run IDs for all arms.

## Baseline

Current SOTA — PR #232 (askeladd, model-heads=4), W&B run `r8s2dtnq`:

| Metric | SOTA | AB-UPT | Gap |
|--------|------|--------|-----|
| `val_abupt` (best, ep11) | **9.0650%** | — | — |
| `test_abupt` | **10.190%** | — | — |
| `surface_pressure` | **5.461%** | 3.82% | ×1.43 |
| `wall_shear` | **9.910%** | 7.29% | ×1.36 |
| `volume_pressure` | **12.656%** | 6.08% | ×2.08 |
| `tau_x` | **8.432%** | 5.35% | ×1.58 |
| `tau_y` | **11.952%** | 3.65% | **×3.27** |
| `tau_z` | **12.447%** | 3.63% | **×3.43** |

Target: beat val_abupt 9.0650% (any arm). Bonus: reduce tau_y/tau_z gap.

Reproduce SOTA:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1
```
