### PR TITLE
norman: coordinate jitter augmentation sweep (σ=0.002/0.005/0.01)

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,7 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    coord_noise_std: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1313,15 +1314,29 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    coord_noise_std: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    surface_x_in = batch.surface_x
+    volume_x_in = batch.volume_x
+    if coord_noise_std > 0.0 and model.training:
+        # Jitter the xyz coordinates only (channels 0:3); leave normals, area, sdf
+        # untouched so the model still receives accurate non-positional features.
+        surface_x_in = surface_x_in.clone()
+        surface_x_in[..., :3] = surface_x_in[..., :3] + (
+            torch.randn_like(surface_x_in[..., :3]) * coord_noise_std
+        )
+        volume_x_in = volume_x_in.clone()
+        volume_x_in[..., :3] = volume_x_in[..., :3] + (
+            torch.randn_like(volume_x_in[..., :3]) * coord_noise_std
+        )
     with autocast_context(device, amp_mode):
         out = model(
-            surface_x=batch.surface_x,
+            surface_x=surface_x_in,
             surface_mask=batch.surface_mask,
-            volume_x=batch.volume_x,
+            volume_x=volume_x_in,
             volume_mask=batch.volume_mask,
         )
         surface_pred_norm = out["surface_preds"]
@@ -1810,6 +1825,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                coord_noise_std=config.coord_noise_std,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())


### PR DESCRIPTION
## Hypothesis

**Coordinate jitter augmentation** — adding small Gaussian noise to surface/volume point coordinates during training — is a standard point-cloud regularization technique that prevents the model from memorizing exact coordinate positions and forces it to learn geometry-invariant representations.

**Physical motivation:** In DrivAerML, the training set consists of 500 vehicle geometries with fixed surface tessellations. The model can overfit to exact nodal positions from the training split. Adding small Gaussian noise (σ ≈ 0.002–0.01 in normalized coordinates, roughly 2–10mm on a ~4m car) during training forces the model to predict wall-shear and pressure from smooth geometric features rather than memorized exact positions.

This is directly analogous to:
- PointNet++ (Qi et al. 2017): random jitter σ=0.02 is standard practice for point cloud classification
- Dropout regularization in space (spatially corrupting coordinates forces positional generalization)
- Neural SDF/NeRF jitter: "perturbing query points improves interpolation quality in learned function spaces"

**Expected gain:** 0.3–1.5pp on val_abupt, especially on tau_y/z which are the hardest components (most sensitive to local geometry — jitter forces learning of smoother local features). Surface pressure should improve by a smaller margin (it is smoother and less position-sensitive).

**Why this hasn't been tried yet:** All augmentation work so far has focused on the y-reflection bilateral symmetry (PRs #225, #286, #297). Coordinate noise is orthogonal to reflection and can stack on top.

## Instructions

### Code change — add coordinate noise in the training batch loop

In `target/train.py`, locate where `surface_x` and `volume_x` batches are prepared in the training loop (before they are passed to the model). Add Gaussian noise **only during training**, not validation/test.

```python
# Add after loading surface_x, volume_x tensors, before model forward pass
# Only during training, not validation:
if model.training and args.coord_noise_std > 0:
    surface_x = surface_x + torch.randn_like(surface_x) * args.coord_noise_std
    volume_x = volume_x + torch.randn_like(volume_x) * args.coord_noise_std
```

Add a new flag: `--coord-noise-std FLOAT` (default `0.0`, BooleanOptionalAction not needed — 0.0 disables it cleanly).

**Important:** Apply noise to coordinates only, not to target values (`surface_y`, `volume_y`). The targets should remain exact.

### Sweep plan — 3 arms + control (1 GPU per arm, 4 arms in parallel)

All arms use identical base config. Only `--coord-noise-std` varies:

```bash
# Control (no noise)
python train.py --agent norman --wandb-group norman-coord-noise-r18 --wandb-name noise-0 \
  --coord-noise-std 0.0 \
  --lr 5e-4 --weight-decay 1e-4 --lr-warmup-steps 500 --clip-grad-norm 1.0 \
  --no-compile-model --batch-size 8 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --wallshear-y-weight 2.0 --wallshear-z-weight 2.0

# Arm 1 — σ=0.002 (fine noise, ~2mm on 4m car)
python train.py --agent norman --wandb-group norman-coord-noise-r18 --wandb-name noise-002 \
  --coord-noise-std 0.002 [other flags same as above]

# Arm 2 — σ=0.005 (medium noise, ~5mm)
python train.py --agent norman --wandb-group norman-coord-noise-r18 --wandb-name noise-005 \
  --coord-noise-std 0.005 [other flags same as above]

# Arm 3 — σ=0.01 (coarse noise, ~10mm)
python train.py --agent norman --wandb-group norman-coord-noise-r18 --wandb-name noise-01 \
  --coord-noise-std 0.01 [other flags same as above]
```

**Note:** Coordinates in DrivAerML are normalized — check the data loader to confirm the coordinate scale before running. The values 0.002/0.005/0.01 assume coordinates are in the range ~[-2, 2] (normalized to vehicle bbox). If coordinates are in raw metres (~[-4, 4]), multiply σ values by 2.

### What to report

1. 4-arm table: noise_std, val_abupt (final), surface_pressure, wall_shear, vol_pressure, wall_shear_y/z
2. W&B run IDs for all 4 arms
3. Were noisy-coord arms stable? Any NaN or gnorm spike?
4. Did any arm show worse vol_pressure? (A regression there is a red flag — volume coordinates should not be heavily jittered)

## Baseline (PR #222, W&B run `ut1qmc3i`)

| Metric | Best (val) |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **9.2910%** — merge bar |
| `surface_pressure_rel_l2_pct` | **5.8707%** |
| `wall_shear_rel_l2_pct` | **10.3423%** |
| `volume_pressure_rel_l2_pct` | **5.8789%** |

**To beat:** val_abupt < 9.291%. Watch for tau_y/z improvement specifically.

AB-UPT targets: surface_pressure 3.82%, wall_shear 7.29%, volume_pressure 6.08%, tau_y 3.65%, tau_z 3.63%.
