### PR TITLE
senku: MLP expansion ratio sweep (mlp_ratio=2/4/8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,7 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    max_steps_per_epoch: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1797,7 +1798,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        epoch_step_limit = config.max_steps_per_epoch if config.max_steps_per_epoch > 0 else None
+        epoch_step_idx = 0
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if epoch_step_limit is not None and epoch_step_idx >= epoch_step_limit:
+                break
+            epoch_step_idx += 1
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,


### PR DESCRIPTION
## Hypothesis

The MLP feed-forward expansion ratio (`mlp_ratio`) in the Transolver blocks controls the ratio of the FFN hidden dimension to the attention hidden dimension. The current baseline uses `mlp_ratio=4` (i.e. the FFN is 4× wider than the attention dim), which is the standard ViT/GPT default. However, the optimal `mlp_ratio` for CFD surrogate regression tasks — where the output requires learning sharp, non-smooth physical gradients rather than semantic features — is unknown.

**Two competing effects:**
- **Higher mlp_ratio (e.g. 8):** More expressive per-layer FFN → can model sharper non-linearities in the pressure/shear distribution. May help especially for wall_shear_y/z which has high spatial frequency in the boundary layer. Cost: 2× more FFN parameters, proportionally more compute per step.
- **Lower mlp_ratio (e.g. 2):** Fewer FFN parameters → less capacity but forces the model to use attention layers more efficiently. Attention is the part of the Transolver that aggregates over surface slices; a lower FFN ratio forces it to do more heavy lifting. May help if the bottleneck is global context (pressure waves) rather than local non-linearity.

For reference, GPT-2 uses mlp_ratio=4, but MoE transformers and modern efficient architectures often reduce this to 2 or even 1 to save compute and increase depth. For our fixed 4L/512d architecture, mlp_ratio=8 adds ~12M → ~18M params — still fits comfortably in 96GB VRAM at bs=8.

**Expected gain:** 0.3–1.0pp on val_abupt from the winning arm. Best gain likely at mlp_ratio=8 if the FFN is currently capacity-limited on the tau_y/z spatial frequencies.

## Instructions

### Confirmed existing flag

`--model-mlp-ratio` already exists in `target/train.py`. Confirm with `python train.py --help | grep mlp-ratio`.

### Sweep plan — 3 arms (1 GPU per arm, run in parallel)

```bash
# Arm A — mlp_ratio=2 (reduced FFN, more attention-driven)
cd target/
python train.py \
  --agent senku \
  --wandb-group senku-mlp-ratio-r18 \
  --wandb-name mlp-ratio-2 \
  --model-mlp-ratio 2 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 1.0 \
  --no-compile-model \
  --batch-size 8 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0

# Arm B — mlp_ratio=4 (baseline / control)
python train.py [same flags] --model-mlp-ratio 4 --wandb-name mlp-ratio-4

# Arm C — mlp_ratio=8 (expanded FFN, higher non-linearity capacity)
python train.py [same flags] --model-mlp-ratio 8 --wandb-name mlp-ratio-8
```

All other flags are identical across all 3 arms. The only difference is `--model-mlp-ratio`.

### What to report

1. 3-arm table: mlp_ratio, param_count (if logged), val_abupt (final best epoch), surface_pressure, wall_shear, vol_pressure, wall_shear_y/z
2. W&B run IDs for all 3 arms
3. Were all arms stable? (Any NaN/kill?)
4. Which arm had the best tau_y improvement specifically?
5. Training speed comparison: steps/sec for mlp_ratio=2 vs 4 vs 8 (to verify compute tradeoff)

## Baseline (PR #222, W&B run `ut1qmc3i`)

| Metric | Best (val) |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **9.2910%** — merge bar |
| `surface_pressure_rel_l2_pct` | **5.8707%** |
| `wall_shear_rel_l2_pct` | **10.3423%** |
| `volume_pressure_rel_l2_pct` | **5.8789%** |

**To beat:** val_abupt < 9.291% at the best-performing mlp_ratio arm.

AB-UPT targets: surface_pressure 3.82%, wall_shear 7.29%, volume_pressure 6.08%, tau_y 3.65%, tau_z 3.63%.

Arm B (mlp_ratio=4) is the within-experiment control — it should approximately match the baseline 9.291%. The arm A and C deltas relative to arm B quantify the FFN capacity effect.
