### PR TITLE
thorfinn: GradNorm dynamic per-task loss weighting for tau_y/z

### DIFF
--- a/train.py
+++ b/train.py
@@ -568,6 +568,8 @@ class Config:
     dynamic_warmup_steps: int = 500
     dynamic_weight_clip_min: float = 0.1
     dynamic_weight_clip_max: float = 10.0
+    dynamic_shared_probe: str = "norm"
+    dynamic_static_floor: bool = False
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1339,6 +1341,7 @@ def _apply_dynamic_loss_weighting(
     ema_decay: float,
     weight_clip_min: float,
     weight_clip_max: float,
+    static_floor: dict[str, float] | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     """GradNorm-lite: w_i = clamp(median_j(EMA(g_j)) / EMA(g_i), [w_min, w_max]).
 
@@ -1347,6 +1350,12 @@ def _apply_dynamic_loss_weighting(
     sum(w_i) = N_tasks, then clamped. During the first `warmup_steps` we hold
     all weights at 1.0 so the model has time to leave random init before we
     react to its gradients.
+
+    If ``static_floor`` is provided, the final weight for each task is
+    ``max(dynamic_weight, static_floor[name])``. Tasks not in the dict default
+    to a floor of 1.0. This implements the hybrid weighting variant where a
+    PR #66 prior (e.g. tau_y/z = 2) is enforced as a lower bound while still
+    allowing the optimizer to upweight any task whose gradient becomes weak.
     """
     n_tasks = len(per_task_losses)
     log: dict[str, float] = {}
@@ -1394,6 +1403,18 @@ def _apply_dynamic_loss_weighting(
             }
         log["train/dynamic_weight/median_grad_ema"] = median_g
         log["train/dynamic_weight/sum_after_clip"] = float(sum(weights.values()))
+
+    if static_floor is not None:
+        floored: dict[str, float] = {}
+        for name in per_task_losses:
+            floor = float(static_floor.get(name, 1.0))
+            dyn_w = float(weights[name])
+            final_w = max(dyn_w, floor)
+            floored[name] = final_w
+            log[f"train/dynamic_weight/dynamic_only/{name}"] = dyn_w
+            log[f"train/dynamic_weight/static_floor/{name}"] = floor
+        weights = floored
+        log["train/dynamic_weight/sum_after_floor"] = float(sum(weights.values()))
 
     total = None
     for name, loss_i in per_task_losses.items():
@@ -1913,19 +1934,57 @@ def main(argv: Iterable[str] | None = None) -> None:
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
 
-    # GradNorm-lite state. EMA-smoothed per-task gradient norms; shared params
-    # are the last LayerNorm before the surface/volume head split. Cheap to
-    # autograd to (one head matmul) and a stable signal across all 5 tasks.
+    # GradNorm-lite state. EMA-smoothed per-task gradient norms measured on
+    # parameters at one of three depths in the shared trunk:
+    #   * "norm"                  -- last shared LayerNorm before the head split (default)
+    #   * "first_block" / "embed" -- first transformer block (earliest fully-shared layer)
+    #   * "last_block"            -- last transformer block (deepest shared point upstream
+    #                                of the LayerNorm)
+    # The probe choice changes which task gets surfaced as "under-attended"
+    # because gradient magnitudes at different depths reflect different
+    # things: shallow probes see input-side feature competition; deep probes
+    # see decoder-side capacity allocation.
     dynamic_grad_ema: dict[str, float] = {name: 1.0 for name in PER_TASK_LOSS_NAMES}
     dynamic_shared_params: list[torch.nn.Parameter] = []
+    dynamic_static_floor_map: dict[str, float] | None = None
     if config.dynamic_loss_weighting:
         unwrapped = getattr(model, "_orig_mod", model)
-        dynamic_shared_params = [p for p in unwrapped.norm.parameters() if p.requires_grad]
+        probe = config.dynamic_shared_probe
+        if probe == "norm":
+            probe_module = unwrapped.norm
+        elif probe in ("first_block", "embed"):
+            # First transformer block is the first layer where surface and
+            # volume tokens are concatenated and share a single set of
+            # parameters; the upstream input projections (surface_bias,
+            # volume_bias, project_*_features) are per-task and therefore
+            # not useful for measuring relative gradient pressure across all
+            # five tasks.
+            probe_module = unwrapped.backbone.blocks[0]
+        elif probe == "last_block":
+            probe_module = unwrapped.backbone.blocks[-1]
+        else:
+            raise ValueError(
+                f"dynamic_shared_probe must be one of 'norm', 'first_block' "
+                f"(alias 'embed'), 'last_block'; got {probe!r}"
+            )
+        dynamic_shared_params = [p for p in probe_module.parameters() if p.requires_grad]
         if not dynamic_shared_params:
             raise RuntimeError(
-                "dynamic_loss_weighting requires trainable parameters in model.norm; "
-                "found none."
+                f"dynamic_loss_weighting probe={probe!r} requires trainable "
+                "parameters at the chosen depth; found none."
             )
+        if config.dynamic_static_floor:
+            # Hybrid: enforce static W_y/W_z (from --wallshear-y-weight,
+            # --wallshear-z-weight) as a floor on the dynamic weights so PR
+            # #66's tau_y/z=2 prior is preserved. Other tasks default to a
+            # floor of 1.0 (no-op vs the dynamic weight when sum(w)=N).
+            dynamic_static_floor_map = {
+                "surface_pressure": 1.0,
+                "wall_shear_x": 1.0,
+                "wall_shear_y": float(config.wallshear_y_weight),
+                "wall_shear_z": float(config.wallshear_z_weight),
+                "volume_pressure": 1.0,
+            }
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
@@ -1964,6 +2023,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     ema_decay=config.dynamic_grad_ema_decay,
                     weight_clip_min=config.dynamic_weight_clip_min,
                     weight_clip_max=config.dynamic_weight_clip_max,
+                    static_floor=dynamic_static_floor_map,
                 )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())

--- a/train.py
+++ b/train.py
@@ -563,6 +563,11 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    dynamic_loss_weighting: bool = False
+    dynamic_grad_ema_decay: float = 0.9
+    dynamic_warmup_steps: int = 500
+    dynamic_weight_clip_min: float = 0.1
+    dynamic_weight_clip_max: float = 10.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1259,6 +1264,21 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def masked_mse_channel(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor, channel: int
+) -> torch.Tensor:
+    """Mean-of-squared-error over masked points for a single channel.
+
+    pred, target: [B, N, C]. mask: [B, N] bool. Used to expose per-task
+    losses (surface_pressure, wall_shear_x/y/z) for GradNorm-lite.
+    """
+    if not bool(mask.any()):
+        return pred.sum() * 0.0
+    diff_sq = (pred[..., channel] - target[..., channel]).pow(2)
+    mask_f = mask.to(pred.dtype)
+    return (diff_sq * mask_f).sum() / mask_f.sum().clamp_min(1)
+
+
 def weighted_masked_mse_per_channel(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -1300,6 +1320,91 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+PER_TASK_LOSS_NAMES = (
+    "surface_pressure",
+    "wall_shear_x",
+    "wall_shear_y",
+    "wall_shear_z",
+    "volume_pressure",
+)
+
+
+def _apply_dynamic_loss_weighting(
+    *,
+    per_task_losses: dict[str, torch.Tensor],
+    shared_params: list[torch.nn.Parameter],
+    grad_ema: dict[str, float],
+    global_step: int,
+    warmup_steps: int,
+    ema_decay: float,
+    weight_clip_min: float,
+    weight_clip_max: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """GradNorm-lite: w_i = clamp(median_j(EMA(g_j)) / EMA(g_i), [w_min, w_max]).
+
+    Per-task gradient norms are measured at the last shared LayerNorm (cheap:
+    one head matmul + LN). EMA-smoothed across steps, weights renormalized so
+    sum(w_i) = N_tasks, then clamped. During the first `warmup_steps` we hold
+    all weights at 1.0 so the model has time to leave random init before we
+    react to its gradients.
+    """
+    n_tasks = len(per_task_losses)
+    log: dict[str, float] = {}
+    if global_step < warmup_steps:
+        weights = {name: 1.0 for name in per_task_losses}
+        log["train/dynamic_weight/active"] = 0.0
+    else:
+        log["train/dynamic_weight/active"] = 1.0
+        last_idx = n_tasks - 1
+        for idx, (name, loss_i) in enumerate(per_task_losses.items()):
+            grads = torch.autograd.grad(
+                loss_i,
+                shared_params,
+                retain_graph=True,
+                create_graph=False,
+                allow_unused=True,
+            )
+            valid = [g for g in grads if g is not None]
+            if valid:
+                g_vec = torch.cat([g.detach().float().reshape(-1) for g in valid])
+                g_norm = float(g_vec.norm(2).item())
+                if not math.isfinite(g_norm):
+                    g_norm = grad_ema[name]
+            else:
+                g_norm = grad_ema[name]
+            grad_ema[name] = ema_decay * grad_ema[name] + (1.0 - ema_decay) * g_norm
+            log[f"train/dynamic_grad_norm/{name}"] = g_norm
+            log[f"train/dynamic_grad_ema/{name}"] = grad_ema[name]
+            del valid, grads
+            _ = idx == last_idx  # keep retain_graph=True everywhere; final backward consumes the graph
+
+        ema_values = sorted(grad_ema.values())
+        median_g = ema_values[len(ema_values) // 2]
+        raw_weights = {
+            name: median_g / max(grad_ema[name], 1e-6) for name in per_task_losses
+        }
+        w_sum = sum(raw_weights.values())
+        if w_sum <= 0.0:
+            weights = {name: 1.0 for name in per_task_losses}
+        else:
+            scale = n_tasks / w_sum
+            weights = {
+                name: max(weight_clip_min, min(weight_clip_max, raw_weights[name] * scale))
+                for name in per_task_losses
+            }
+        log["train/dynamic_weight/median_grad_ema"] = median_g
+        log["train/dynamic_weight/sum_after_clip"] = float(sum(weights.values()))
+
+    total = None
+    for name, loss_i in per_task_losses.items():
+        weight = float(weights[name])
+        log[f"train/dynamic_weight/{name}"] = weight
+        term = weight * loss_i
+        total = term if total is None else total + term
+    assert total is not None
+    return total, log
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1313,7 +1418,7 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
-) -> tuple[torch.Tensor, dict[str, float]]:
+) -> tuple[torch.Tensor, dict[str, float], dict[str, torch.Tensor]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -1359,6 +1464,26 @@ def train_loss(
             channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # Per-task losses (gradient-carrying tensors) for GradNorm-lite dynamic
+        # weighting. Channels 0..3 are cp, tau_x, tau_y, tau_z on the surface
+        # decoder; volume_pressure is the volume MSE. Use the same surface
+        # tensors that fed the static loss so tangential projection (when
+        # enabled) propagates to the per-task signal too.
+        per_task_losses: dict[str, torch.Tensor] = {
+            "surface_pressure": masked_mse_channel(
+                surface_pred_used, surface_target_used, batch.surface_mask, 0
+            ),
+            "wall_shear_x": masked_mse_channel(
+                surface_pred_used, surface_target_used, batch.surface_mask, 1
+            ),
+            "wall_shear_y": masked_mse_channel(
+                surface_pred_used, surface_target_used, batch.surface_mask, 2
+            ),
+            "wall_shear_z": masked_mse_channel(
+                surface_pred_used, surface_target_used, batch.surface_mask, 3
+            ),
+            "volume_pressure": volume_loss,
+        }
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
@@ -1390,7 +1515,7 @@ def train_loss(
         metrics["film/geom_token_abs_mean"] = float(
             geom_token.abs().mean().cpu().item()
         )
-    return loss, metrics
+    return loss, metrics, per_task_losses
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -1763,6 +1888,9 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("train/dynamic_weight/*", step_metric="global_step")
+    wandb.define_metric("train/dynamic_grad_norm/*", step_metric="global_step")
+    wandb.define_metric("train/dynamic_grad_ema/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
@@ -1785,6 +1913,20 @@ def main(argv: Iterable[str] | None = None) -> None:
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
 
+    # GradNorm-lite state. EMA-smoothed per-task gradient norms; shared params
+    # are the last LayerNorm before the surface/volume head split. Cheap to
+    # autograd to (one head matmul) and a stable signal across all 5 tasks.
+    dynamic_grad_ema: dict[str, float] = {name: 1.0 for name in PER_TASK_LOSS_NAMES}
+    dynamic_shared_params: list[torch.nn.Parameter] = []
+    if config.dynamic_loss_weighting:
+        unwrapped = getattr(model, "_orig_mod", model)
+        dynamic_shared_params = [p for p in unwrapped.norm.parameters() if p.requires_grad]
+        if not dynamic_shared_params:
+            raise RuntimeError(
+                "dynamic_loss_weighting requires trainable parameters in model.norm; "
+                "found none."
+            )
+
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
             print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
@@ -1798,7 +1940,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
-            loss, batch_loss_metrics = train_loss(
+            loss, batch_loss_metrics, per_task_losses = train_loss(
                 model,
                 batch,
                 transform,
@@ -1811,6 +1953,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
             )
+            dynamic_weight_log: dict[str, float] = {}
+            if config.dynamic_loss_weighting:
+                loss, dynamic_weight_log = _apply_dynamic_loss_weighting(
+                    per_task_losses=per_task_losses,
+                    shared_params=dynamic_shared_params,
+                    grad_ema=dynamic_grad_ema,
+                    global_step=global_step,
+                    warmup_steps=config.dynamic_warmup_steps,
+                    ema_decay=config.dynamic_grad_ema_decay,
+                    weight_clip_min=config.dynamic_weight_clip_min,
+                    weight_clip_max=config.dynamic_weight_clip_max,
+                )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
             if not loss_is_finite:
@@ -1931,6 +2085,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             for key, value in batch_loss_metrics.items():
                 if key.startswith("film/"):
                     train_log[f"train/{key}"] = value
+            if dynamic_weight_log:
+                train_log.update(dynamic_weight_log)
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Dynamic gradient-norm-based loss weighting (GradNorm-lite)** adjusts the static per-task loss weights inversely proportional to the current gradient magnitude of each task, forcing roughly equal gradient contributions from all tasks at each step. This directly addresses the documented tau_y/z 4× gap: because wall_shear_y/z losses are small in magnitude but poorly-predicted, their gradients are dominated by surface_pressure gradients, which are larger. Static weighting (W_y=W_z=2) partially corrects this, but the optimal static weight is epoch-dependent — dynamic weighting removes the epoch-dependence.

**Mechanism:**
At each training step, compute:
1. `g_i = ||∇_θ L_i||_2` — gradient norm of task `i`'s contribution to the shared backbone (measured on the final shared layer's gradient)
2. `w_i^t = (median_j(g_j^t) / g_i^t)` — weight inversely proportional to gradient magnitude
3. `L_total = Σ_i w_i^t · L_i`

This is a simplified version of **GradNorm** (Chen et al. 2018, "GradNorm: Gradient Normalization for Adaptive Loss Balancing in Deep Multitask Networks", ICML 2018). The key insight is that tasks with small gradient norms are being undertrained — boosting their weight forces the optimizer to pay more attention to them.

In our case, tau_y and tau_z have smaller gradient norms than surface_pressure and volume_pressure (the latter are more predictable, hence larger gradient magnitudes from the correct predictions). Dynamic weighting should automatically upweight tau_y/z without requiring hand-tuning W_y, W_z.

**References:**
- GradNorm (Chen et al. 2018): https://arxiv.org/abs/1711.02257
- Uncertainty-weighted MTL (Kendall et al.): https://arxiv.org/abs/1705.07115

## Instructions

### Code change — implement GradNorm-lite dynamic weighting

Add a new `--dynamic-loss-weighting` flag (BooleanOptionalAction, default False) that enables per-step gradient-norm-based task weight adjustment.

**Implementation in `target/train.py`:**

```python
# After computing per-task losses:
loss_terms = {
    'surface_pressure': loss_surf_pressure,
    'wall_shear_x': loss_wsx,
    'wall_shear_y': loss_wsy,
    'wall_shear_z': loss_wsz,
    'volume_pressure': loss_vol,
}

if args.dynamic_loss_weighting:
    # Compute gradient norm for each task via autograd
    grad_norms = {}
    for task, loss_i in loss_terms.items():
        grads = torch.autograd.grad(
            loss_i, shared_params,  # last shared layer params
            retain_graph=True, allow_unused=True
        )
        grad_norms[task] = sum(
            g.norm(2).item() for g in grads if g is not None
        ) + 1e-8

    median_norm = float(torch.tensor(list(grad_norms.values())).median())
    weights = {task: median_norm / grad_norms[task] for task in grad_norms}
    total_loss = sum(weights[task] * loss_terms[task] for task in loss_terms)
    
    # Log the dynamic weights to W&B for diagnostic purposes
    wandb.log({f'dynamic_weight/{task}': weights[task] for task in weights})
else:
    # Fall back to static weights (existing behaviour)
    total_loss = loss_surf_pressure + args.wallshear_y_weight * loss_wsy + ...
```

**Identify `shared_params`** as the last shared transformer layer's parameters (before the surface/volume decoder split). This is where gradient conflicts between tasks manifest.

**Important:** `retain_graph=True` on all but the last grad computation is required. Or alternatively, compute gradient norms on a detached forward pass (more memory-efficient).

**If per-task grad computation is too costly:** Fall back to a simpler approximation — compute a running EMA of each task's per-step loss, and set `w_i = 1 / (EMA_i + eps)`. This is a "loss-norm-balanced" weighting that approximates the GradNorm idea without the extra backward passes.

### Run — single arm with dynamic weighting

```bash
cd target/
python train.py \
  --agent thorfinn \
  --wandb-group thorfinn-pcgrad-r18 \
  --wandb-name dynamic-gradnorm \
  --dynamic-loss-weighting \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 1.0 \
  --no-compile-model \
  --batch-size 8 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999
```

Note: do NOT set `--wallshear-y-weight` / `--wallshear-z-weight` when using dynamic weighting — the dynamic weights replace the static ones.

Also run a static control arm at W_y=W_z=2.0 (baseline):
```bash
python train.py [same flags, no --dynamic-loss-weighting] \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --wandb-name static-wy2-wz2
```

### What to report

1. Dynamic vs static control: val_abupt, surface_pressure, wall_shear, vol_pressure, wall_shear_y/z
2. W&B run IDs for both arms
3. Plot or table of the dynamic weights `w_tau_y`, `w_tau_z` over training steps — was the dynamic upweighting of tau_y/z larger or smaller than the static W=2?
4. Any compute overhead from `retain_graph=True` gradient computations? (Steps/sec comparison)
5. Was the dynamic version numerically stable? (log any extreme weight values, e.g. w > 20)

## Baseline (PR #222, W&B run `ut1qmc3i`)

| Metric | Best (val) |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | **9.2910%** — merge bar |
| `surface_pressure_rel_l2_pct` | **5.8707%** |
| `wall_shear_rel_l2_pct` | **10.3423%** |
| `volume_pressure_rel_l2_pct` | **5.8789%** |

**To beat:** dynamic arm val_abupt < 9.291%, with specific tau_y/z improvement over the W_y=W_z=2.0 static baseline.

AB-UPT targets: surface_pressure 3.82%, wall_shear 7.29%, volume_pressure 6.08%, tau_y 3.65%, tau_z 3.63%.
