### PR TITLE
fern: U-net skip connections in Transformer backbone (geometric feature preservation)

### DIFF
--- a/model.py
+++ b/model.py
@@ -213,8 +213,10 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        unet_skip: bool = False,
     ):
         super().__init__()
+        self.unet_skip = unet_skip
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -227,11 +229,29 @@ class Transformer(nn.Module):
                 for _ in range(depth)
             ]
         )
+        if unet_skip:
+            # Learnable scalar gates for U-Net skip connections (initialized to 0
+            # so they start as identity and gradually open).
+            # With depth=4: skip_gate_2 gates block[0]->block[2], skip_gate_3 gates block[1]->block[3]
+            self.skip_gate_2 = nn.Parameter(torch.zeros(1))
+            self.skip_gate_3 = nn.Parameter(torch.zeros(1))
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
-        return x
+        if not self.unet_skip:
+            for block in self.blocks:
+                x = block(x, attn_mask=attn_mask)
+            return x
+
+        # 4-layer U-Net skip connections:
+        # x0 = blocks[0](x_in)
+        # x1 = blocks[1](x0)
+        # x2 = blocks[2](x1 + skip_gate_2 * x0)   <- skip from block-0 output
+        # x3 = blocks[3](x2 + skip_gate_3 * x1)   <- skip from block-1 output
+        x0 = self.blocks[0](x, attn_mask=attn_mask)
+        x1 = self.blocks[1](x0, attn_mask=attn_mask)
+        x2 = self.blocks[2](x1 + self.skip_gate_2 * x0, attn_mask=attn_mask)
+        x3 = self.blocks[3](x2 + self.skip_gate_3 * x1, attn_mask=attn_mask)
+        return x3
 
 
 class SurfaceTransolver(nn.Module):
@@ -253,6 +273,7 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        unet_skip: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -299,6 +320,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            unet_skip=unet_skip,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -91,6 +91,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    model_unet_skip: bool = False
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     amp_mode: str = "bf16"
@@ -176,6 +177,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        unet_skip=config.model_unet_skip,
     )
 
 
@@ -471,6 +473,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }
+            if config.model_unet_skip and getattr(base_model.backbone, "unet_skip", False):
+                backbone = base_model.backbone
+                for gate_name in ("skip_gate_2", "skip_gate_3"):
+                    gate = getattr(backbone, gate_name, None)
+                    if gate is not None:
+                        log_metrics[f"train/unet_skip/{gate_name}"] = float(gate.detach().cpu().item())
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
                 wandb.log(log_metrics)


### PR DESCRIPTION
# U-Net Skip Connections in Transformer Backbone

## Hypothesis

The current `Transformer` backbone is a plain sequential chain of `TransformerBlock`s with no
cross-layer information flow beyond the residual connections within each block. U-Net-style skip
connections (pairing early and late layers) are a well-established technique in encoder-decoder
architectures that allow low-level geometric features to bypass the deepest processing stages and
be directly combined with high-level semantic representations. In a 4-layer Transformer, this
means layer-0 output is added to layer-2 input, and layer-1 output is added to layer-3 input —
cutting the effective depth for feature propagation in half and providing two skip paths. Our
validation errors are largest on shear-stress components (tau_y, tau_z) which depend on fine
near-wall geometry; skip connections may help preserve this geometric detail across layers.

**Prediction**: U-net skip connections will reduce val_abupt, with the largest gains on tau_y and
tau_z (currently 3–3.5× above the AB-UPT reference line).

## Current SOTA Baseline (PR #232, askeladd, run `r8s2dtnq`)

| Metric                 | val       | test      |
|------------------------|-----------|-----------|
| abupt_axis_mean_rel_l2 | **9.065%** | 10.190%  |
| tau_y                  | 11.952%   | —         |
| tau_z                  | 12.447%   | —         |
| vol_pressure           | 12.656%   | —         |

SOTA recipe: `--optimizer lion --lr 1e-4 --weight-decay 5e-4 --no-compile --batch-size 4 --ema-decay 0.999 --lr-warmup-epochs 1 --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4`

Beat target: val_abupt < **9.065%**.

## Code Changes Required

You must modify **`target/model.py`** and **`target/train.py`**. No other files.

### 1. Add `model_unet_skip` to `Config` in `train.py`

In the `Config` dataclass (around line 88), add after `model_dropout`:

```python
model_unet_skip: bool = False
```

This auto-registers as `--model-unet-skip` / `--no-model-unet-skip` CLI flags.

### 2. Pass `unet_skip` to `SurfaceTransolver` in `train.py`

In `build_model()` (around line 170), add the kwarg:

```python
def build_model(config: Config) -> SurfaceTransolver:
    return SurfaceTransolver(
        n_layers=config.model_layers,
        n_hidden=config.model_hidden_dim,
        dropout=config.model_dropout,
        n_head=config.model_heads,
        mlp_ratio=config.model_mlp_ratio,
        slice_num=config.model_slices,
        rff_num_features=config.rff_num_features,
        rff_sigma=config.rff_sigma,
        unet_skip=config.model_unet_skip,     # <-- add this
    )
```

### 3. Add `unet_skip` to `Transformer` in `model.py`

Modify the `Transformer` class (lines 207–233) to support skip connections:

```python
class Transformer(nn.Module):
    def __init__(
        self,
        depth: int,
        hidden_dim: int,
        num_heads: int,
        mlp_expansion_factor: int | float,
        num_slices: int,
        dropout: float = 0.0,
        unet_skip: bool = False,
    ):
        super().__init__()
        self.unet_skip = unet_skip
        self.blocks = nn.ModuleList(
            [
                TransformerBlock(
                    hidden_dim=hidden_dim,
                    num_heads=num_heads,
                    mlp_expansion_factor=mlp_expansion_factor,
                    num_slices=num_slices,
                    dropout=dropout,
                )
                for _ in range(depth)
            ]
        )
        # Learnable per-layer scale for skip injection (init near 0 so training is stable)
        if unet_skip:
            half = depth // 2
            self.skip_scales = nn.ParameterList(
                [nn.Parameter(torch.zeros(1)) for _ in range(half)]
            )

    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
        if not self.unet_skip:
            for block in self.blocks:
                x = block(x, attn_mask=attn_mask)
            return x

        depth = len(self.blocks)
        half = depth // 2
        skip_cache: list[torch.Tensor] = []

        # Encoder half — cache outputs
        for i in range(half):
            x = self.blocks[i](x, attn_mask=attn_mask)
            skip_cache.append(x)

        # Decoder half — inject cached encoder outputs scaled by learned gate
        for i in range(half, depth):
            skip_idx = depth - 1 - i          # pairs (half→0, half+1→1, …)
            if skip_idx < len(skip_cache):
                x = x + self.skip_scales[skip_idx] * skip_cache[skip_idx]
            x = self.blocks[i](x, attn_mask=attn_mask)

        return x
```

### 4. Add `unet_skip` to `SurfaceTransolver.__init__` in `model.py`

Pass through to `Transformer`:

```python
self.backbone = Transformer(
    depth=n_layers,
    hidden_dim=n_hidden,
    num_heads=n_head,
    mlp_expansion_factor=mlp_ratio,
    num_slices=slice_num,
    dropout=dropout,
    unet_skip=unet_skip,     # <-- add this
)
```

And add `unet_skip: bool = False` to `SurfaceTransolver.__init__`'s signature.

## Experiment: Single DDP8 run

Run **one arm** — SOTA config + `--model-unet-skip`:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --wandb-group fern-unet-skip \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile \
  --batch-size 4 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --model-mlp-ratio 4 \
  --model-unet-skip
```

## Reporting

Post results as a PR comment with this table:

| Run | val_abupt | tau_y | tau_z | vol_pressure | W&B run |
|-----|-----------|-------|-------|--------------|---------|
| unet-skip | … | … | … | … | … |
| SOTA baseline | 9.065% | 11.952% | 12.447% | 12.656% | r8s2dtnq |

Also note whether the skip_scales learned non-zero values (check W&B weight histograms or
log `model.backbone.skip_scales` norms). If skip_scales all stayed near zero the architecture
may be ignoring the skip paths — worth reporting.
