### PR TITLE
emma: surface-loss-weight=2.0 on SOTA Lion 4L/512d stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wandb/
 *.pth
 *.ckpt
 data/point_counts.json
+logs/

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -22,6 +22,7 @@ and volume_pressure (7.85 vs 13.14). 4.6h runtime, lr=5e-4, wd=5e-4.
 5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
 6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2
 7. PR #99 fern — LR peak 5e-4 (5× base) (this PR)
+8. PR #169 thorfinn — NaN/Inf-skip safeguard, --seed, --lr-warmup-steps (infra utilities, no metric regression)
 
 **New recommended base config (PR #99 winning arm):**
 
@@ -131,6 +132,7 @@ Note: Additional code wins pending merge (all superseded on headline metric by
 PR #99 but contain orthogonal code contributions) — PRs #98 (emma weight-decay),
 #106 (thorfinn yw2.5-zw2.5), #97 (edward slices192), #63 (askeladd sq-rel),
 #104 (senku ema9997), #102 (haku dropout). PRs #8 (frieren FiLM) merged 2026-04-29.
+PR #169 (thorfinn, infra utilities) merged 2026-04-29 — adds NaN/Inf-skip, --seed, --lr-warmup-steps to train.py.
 
 **Distance from AB-UPT targets (multiple of target):**
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,17 +2,17 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: fern PR #183 wins — new baseline 2026-04-29
+## Status: fern PR #222 wins — new baseline 2026-05-01
 
-PR #183 (fern, omega-bank sweep: pos_max_wavelength=1000) reduced
-`val_primary/abupt_axis_mean_rel_l2_pct` from 10.69 (fern PR #99) to
-**10.21** — a 4.5% improvement on the headline metric. W&B run: `bplngfyo`.
+PR #222 (fern, 1-epoch LR warmup before cosine decay) reduced
+`val_primary/abupt_axis_mean_rel_l2_pct` from 9.484% (fern PR #208 / prior best) to
+**9.2910%** — a 2.0% improvement on the headline metric. W&B run: `ut1qmc3i`, group: `tay-round12-lr-warmup-1ep`.
 
-Key finding: compressing `pos_max_wavelength` from 10,000 → 1,000 in
-`ContinuousSincosEmbed` significantly improves all metrics. The vehicle bbox
-is ~8m × 2.5m × 2m, so 1,000 gives much denser frequency sampling across all
-axes. Best-ever volume_pressure (6.32 vs 7.85) and consistent improvements on
-surface_pressure (6.85 vs 6.97), wall_shear (11.43 vs 11.69). 4.6h runtime.
+Key finding: adding a single epoch of linear LR warm-up before cosine annealing stabilises
+Lion training on the 4L/512d architecture (lr=1e-4, batch=4, torchrun 8-GPU DDP).
+Smooth loss descent across all 9 epochs with no instability. Best-epoch=9.
+Operates on the **4L/512d** architecture (not 6L/256d), which had been the
+previous SoTA architecture.
 
 **Compounding wins so far (all landed on `yi`):**
 1. PR #11 kohaku — tangential wall-shear projection loss code
@@ -24,26 +24,45 @@ surface_pressure (6.85 vs 6.97), wall_shear (11.43 vs 11.69). 4.6h runtime.
 7. PR #99 fern — LR peak 5e-4 (5× base)
 8. PR #169 thorfinn — NaN/Inf-skip safeguard, --seed, --lr-warmup-steps (infra utilities, no metric regression)
 9. PR #183 fern — pos_max_wavelength=1000 (omega-bank sincos positional encoding)
+10. PR #222 fern — lr_warmup_epochs=1 (Lion stability, 4L/512d architecture)
 
-**New recommended base config (PR #183 winning arm):**
+**New recommended base config (PR #222 winning arm):**
 
 ```bash
 cd target/
-python train.py \
-  --volume-loss-weight 2.0 \
-  --batch-size 8 \
+torchrun --standalone --nproc_per_node=8 train.py \
+  --agent fern \
+  --optimizer lion \
+  --lr 1e-4 \
+  --weight-decay 5e-4 \
+  --no-compile-model \
+  --batch-size 4 \
   --validation-every 1 \
-  --lr 5e-4 --weight-decay 5e-4 \
-  --train-surface-points 65536 --eval-surface-points 65536 \
-  --train-volume-points 65536 --eval-volume-points 65536 \
-  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
-  --ema-decay 0.9995 \
-  --clip-grad-norm 1.0 \
-  --wallshear-y-weight 2.0 \
-  --wallshear-z-weight 2.0 \
-  --pos-max-wavelength 1000 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
+  --train-surface-points 65536 \
+  --eval-surface-points 65536 \
+  --train-volume-points 65536 \
+  --eval-volume-points 65536 \
+  --model-layers 4 \
+  --model-hidden-dim 512 \
+  --model-heads 8 \
+  --model-slices 128 \
+  --ema-decay 0.999 \
+  --lr-warmup-epochs 1
 ```
+
+**PR #222 epoch-by-epoch metrics (W&B run `ut1qmc3i`):**
+
+| Epoch | Step  | val_abupt  | surf_pres | vol_pres  | wall_shear |
+|-------|-------|-----------|-----------|-----------|------------|
+| 1     | 2720  | 67.7263%  | 52.1452%  | 59.6851%  | 68.9568%   |
+| 2     | 5441  | 41.9288%  | 31.5194%  | 25.0452%  | 46.0780%   |
+| 3     | 8162  | 19.3033%  | 13.3635%  | 11.4773%  | 21.4948%   |
+| 4     | 10883 | 13.7327%  | 9.2451%   | 8.0774%   | 15.3581%   |
+| 5     | 13604 | 11.6016%  | 7.6196%   | 6.8622%   | 13.0241%   |
+| 6     | 16325 | 10.5020%  | 6.7791%   | 6.2569%   | 11.7950%   |
+| 7     | 19046 | 9.8759%   | 6.3077%   | 6.0145%   | 11.0603%   |
+| 8     | 21767 | 9.4516%   | 6.0019%   | 5.7614%   | 10.5847%   |
+| **9** | **23544** | **9.2910%** | **5.8707%** | **5.8789%** | **10.3423%** |
 
 ---
 
@@ -122,36 +141,34 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.21** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/surface_pressure_rel_l2_pct` | **6.85** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/wall_shear_rel_l2_pct` | **11.43** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/volume_pressure_rel_l2_pct` | **6.32** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/wall_shear_x_rel_l2_pct` | **9.89** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/wall_shear_y_rel_l2_pct` | **13.47** | #183 | bplngfyo | 2026-04-29 |
-| `val_primary/wall_shear_z_rel_l2_pct` | **14.52** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910** | #222 | ut1qmc3i | 2026-05-01 |
+| `val_primary/surface_pressure_rel_l2_pct` | **5.8707** | #222 | ut1qmc3i | 2026-05-01 |
+| `val_primary/wall_shear_rel_l2_pct` | **10.3423** | #222 | ut1qmc3i | 2026-05-01 |
+| `val_primary/volume_pressure_rel_l2_pct` | **5.8789** | #222 | ut1qmc3i | 2026-05-01 |
+| `val_primary/wall_shear_x_rel_l2_pct` | — | — | — | — |
+| `val_primary/wall_shear_y_rel_l2_pct` | — | — | — | — |
+| `val_primary/wall_shear_z_rel_l2_pct` | — | — | — | — |
 
-Note: Additional code wins pending merge (all superseded on headline metric by
-PR #183 but contain orthogonal code contributions) — PRs #98 (emma weight-decay),
-#106 (thorfinn yw2.5-zw2.5), #97 (edward slices192), #63 (askeladd sq-rel),
-#104 (senku ema9997), #102 (haku dropout). PRs #8 (frieren FiLM) merged 2026-04-29.
+Note: PR #222 (fern, lr_warmup_epochs=1) merged 2026-05-01. Additional code wins in history:
+PRs #98 (emma weight-decay), #106 (thorfinn yw2.5-zw2.5), #97 (edward slices192),
+#63 (askeladd sq-rel), #104 (senku ema9997), #102 (haku dropout). PR #8 (frieren FiLM) merged 2026-04-29.
 PR #169 (thorfinn, infra utilities) merged 2026-04-29 — adds NaN/Inf-skip, --seed, --lr-warmup-steps to train.py.
-PR #183 (fern, omega-bank sweep) merged 2026-04-29 — pos_max_wavelength=1000 now default in train.py.
+PR #183 (fern, omega-bank sweep) merged 2026-04-29 — pos_max_wavelength=1000.
+**Merge bar: 9.291% — any PR must beat this to merge.**
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best (PR #183) | AB-UPT | Ratio |
+| Metric | yi best (PR #222) | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 6.85 | 3.82 | 1.8× |
-| wall_shear | 11.43 | 7.29 | 1.6× |
-| volume_pressure | 6.32 | 6.08 | 1.0× |
-| wall_shear_x | 9.89 | 5.35 | 1.8× |
-| wall_shear_y | 13.47 | 3.65 | 3.7× |
-| wall_shear_z | 14.52 | 3.63 | 4.0× |
+| surface_pressure | 5.8707 | 3.82 | 1.54× |
+| wall_shear | 10.3423 | 7.29 | 1.42× |
+| volume_pressure | 5.8789 | 6.08 | 0.97× |
+| abupt_axis_mean | 9.2910 | — | — |
 
-Wall_shear_y and wall_shear_z remain the largest gap at ~4× AB-UPT.
-Volume pressure has now matched AB-UPT (1.0×, 6.32 vs 6.08), suggesting
-strong capacity for scalar fields. Wall-shear axis precision remains the
-key challenge and the primary target for future experiments.
+Volume pressure has now beaten AB-UPT (0.97×, 5.88 vs 6.08) — our architecture
+is competitive on scalar fields. Surface pressure and wall_shear remain the key
+gap. Per-axis wall_shear_y/z breakdown not available for PR #222 at time of
+writing — check W&B run `ut1qmc3i` for latest.
 
 ## Reference config (`train.py` defaults on `yi`)
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,23 +2,27 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: senku PR #14 wins — new baseline 2026-04-29
+## Status: thorfinn PR #66 wins — new baseline 2026-04-30
 
-PR #14 (senku, 6L/256d/4h/128sl depth scale-up) reduced
-`test_primary/abupt_axis_mean_rel_l2_pct` from 16.64 (chihiro PR #4) to
-**13.15** — a 21.0% improvement on the headline metric. Both 5L (13.52, −18.7%)
-and 6L (13.15, −21.0%) beat all pending PRs. W&B runs: `t5tv01ch` (5L) and
-`et4ajeqj` (6L). Config: bs=8, vol_w=2.0, lr=2e-4, clip=1.0, 65536 pts,
-validation-every=1. Key finding: depth is more parameter-efficient than width —
-6L/256d (4.73M params) crushes 4L/512d (12.7M params).
+PR #66 (thorfinn, per-axis tau_y/z loss upweighting W_y=2, W_z=2 on 6L/256d base) reduced
+`test_primary/abupt_axis_mean_rel_l2_pct` from 13.15 (senku PR #14) to
+**12.74** — a 3.1% improvement on the headline metric. Tau_y dropped from 16.23→15.15
+(−6.7%) and tau_z from 16.75→15.05 (−10.2%). W&B run: `gvigs86q`.
+
+Key finding: upweighting the two hardest wall-shear axes (tau_y and tau_z) by 2×
+improves the composite metric without hurting surface_pressure or volume_pressure.
+W_y=2, W_z=2 beats W_y=1.5, W_z=1.5 and the equal-weight arms. Thorfinn's code
+adds `--wallshear-y-weight` and `--wallshear-z-weight` flags to `train.py`.
 
 **Compounding wins so far (all landed on `yi`):**
-1. PR #11 kohaku — tangential wall-shear projection loss
+1. PR #11 kohaku — tangential wall-shear projection loss code
 2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
 3. PR #4 chihiro — width scale-up to 512d/8h
-4. PR #14 senku — depth scale-up to 6L/256d (this PR)
+4. PR #14 senku — depth scale-up to 6L/256d
+5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
+6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2 (this PR)
 
-**6L winning config (new recommended base):**
+**New recommended base config (PR #66 winning arm):**
 
 ```bash
 cd target/
@@ -32,13 +36,21 @@ python train.py \
   --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
   --ema-decay 0.9995 \
   --clip-grad-norm 1.0 \
+  --wallshear-y-weight 2.0 \
+  --wallshear-z-weight 2.0 \
   --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
 ```
 
-**Note:** Grad clipping (clip=1.0) was active on 6L (pre-clip norm ~2.53 at end).
-5L did not need clipping (pre-clip norm ~0.79). Use clip=1.0 as default for deeper
-configs. Both runs were still descending at timeout — more epochs would improve further.
-Volume pressure shows val→test gap (6.93→13.6) — orthogonal to depth, needs SDF gating.
+---
+
+## Previous: senku PR #14 — baseline 2026-04-29
+
+PR #14 (senku, 6L/256d depth scale-up) reduced
+`test_primary/abupt_axis_mean_rel_l2_pct` from 16.64 (chihiro PR #4) to
+**13.15** — a 21.0% improvement on the headline metric. Both 5L (13.52, −18.7%)
+and 6L (13.15, −21.0%) beat all pending PRs. W&B runs: `t5tv01ch` (5L) and
+`et4ajeqj` (6L). Key finding: depth is more parameter-efficient than width —
+6L/256d (4.73M params) crushes 4L/512d (12.7M params).
 
 ---
 
@@ -100,13 +112,13 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | #66 | gvigs86q | 2026-04-30 |
 | `test_primary/surface_pressure_rel_l2_pct` | **7.64** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/wall_shear_rel_l2_pct` | **13.47** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/wall_shear_rel_l2_pct` | **12.86** | #66 | gvigs86q | 2026-04-30 |
+| `test_primary/volume_pressure_rel_l2_pct` | **13.14** | #66 | gvigs86q | 2026-04-30 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **11.29** | #66 | gvigs86q | 2026-04-30 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **15.15** | #66 | gvigs86q | 2026-04-30 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **15.05** | #66 | gvigs86q | 2026-04-30 |
 
 Note: Additional code wins pending merge (all superseded on headline metric by
 PR #14 but contain orthogonal code contributions) — PRs #22 (gilbert clip=1.0,
@@ -160,18 +172,18 @@ experiments should layer on top of the gilbert config and add
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best (PR #14) | AB-UPT | Ratio |
+| Metric | yi best (PR #66) | AB-UPT | Ratio |
 |---|---:|---:|---:|
 | surface_pressure | 7.64 | 3.82 | 2.0× |
-| wall_shear | 13.47 | 7.29 | 1.8× |
-| volume_pressure | 13.58 | 6.08 | 2.2× |
-| wall_shear_x | 11.53 | 5.35 | 2.2× |
-| wall_shear_y | 16.23 | 3.65 | 4.4× |
-| wall_shear_z | 16.75 | 3.63 | 4.6× |
+| wall_shear | 12.86 | 7.29 | 1.8× |
+| volume_pressure | 13.14 | 6.08 | 2.2× |
+| wall_shear_x | 11.29 | 5.35 | 2.1× |
+| wall_shear_y | 15.15 | 3.65 | 4.2× |
+| wall_shear_z | 15.05 | 3.63 | 4.1× |
 
-All axes have improved substantially. Wall_shear_y and wall_shear_z remain the
-largest gap at ~4-5× AB-UPT. Volume pressure shows a known val→test gap
-(val 6.93 ≈ AB-UPT level, test 13.58 = 2×) — test generalization is the
+Wall_shear_y and wall_shear_z remain the largest gap at ~4× AB-UPT despite
+thorfinn's W_y=W_z=2 win. Volume pressure shows a known val→test gap (val
+~6.9 ≈ AB-UPT level, test 13.14 = 2.2×) — test generalization is the
 remaining challenge, not model capacity per se.
 
 **Known training-stability bug (gilbert flagged in PR #9):** `train.py` has

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,7 +2,27 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: gilbert PR #9 wins — new baseline 2026-04-29 03:57 UTC
+## Status: chihiro PR #4 wins — new baseline 2026-04-29
+
+PR #4 (chihiro, 4L/512d/8h large-model scale-up) reduced
+`test_primary/abupt_axis_mean_rel_l2_pct` from 17.39 (gilbert PR #9) to
+**16.64** — a 4.3% improvement on the headline metric. Run `pejudvyd`,
+state=finished, 3 best epochs, params ~12.7M. Width upgrade used `lr=5e-5`
+(3 prior runs at 2e-4 diverged) and `bs=4` (largest power-of-2 fitting 96GB).
+Standout gain: `volume_pressure` 14.37 vs 15.21 — orthogonal to FiLM and
+cosine-EMA wins still pending merge (PRs #8, #13).
+
+**Compounding wins so far (all landed on `yi`):**
+1. PR #11 kohaku — tangential wall-shear projection loss
+2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
+3. PR #4 chihiro — width scale-up to 512d/8h (this PR)
+
+PRs #8 (frieren FiLM, 16.53) and #13 (norman cosine EMA, 15.82) are pending
+rebase+merge and should push the composite lower still.
+
+---
+
+## Previous: gilbert PR #9 — baseline 2026-04-29 03:57 UTC
 
 PR #9 (gilbert, vol_w=2.0 + protocol fixes) reduced
 `test_primary/abupt_axis_mean_rel_l2_pct` from 35.12 (kohaku PR #11) to
@@ -40,20 +60,43 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **17.3933** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/surface_pressure_rel_l2_pct` | **11.0733** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/wall_shear_rel_l2_pct` | **18.3180** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/volume_pressure_rel_l2_pct` | **15.2059** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/wall_shear_x_rel_l2_pct` | **15.6465** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/wall_shear_y_rel_l2_pct` | **21.8605** | #9 | y2gigs61 | 2026-04-29 |
-| `test_primary/wall_shear_z_rel_l2_pct` | **23.1803** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **16.64** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/surface_pressure_rel_l2_pct` | **10.65** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/wall_shear_rel_l2_pct` | **17.66** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/volume_pressure_rel_l2_pct` | **14.37** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **14.87** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **19.89** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **21.73** | #4 | pejudvyd | 2026-04-29 |
+
+Note: PRs #8 (frieren FiLM, abupt=16.53) and #13 (norman cosine EMA, abupt=15.82)
+are verified wins currently pending rebase — once merged the headline metric
+will drop further, with #13 as projected new best.
 
 (`p_s = 10.07` from PR #11 is a marginally better single-axis number, but the
 abupt_axis_mean win is decisive and `tau_*` improvements dominate the
 composite metric.)
 
-**Reproduce (PR #9 winning config — recommended for all future PRs):**
+**Reproduce (PR #4 winning config — new recommended base for 512d experiments):**
 
+```bash
+cd target/
+python train.py \
+  --volume-loss-weight 2.0 \
+  --batch-size 4 \
+  --validation-every 1 \
+  --lr 5e-5 --weight-decay 5e-4 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
+  --ema-decay 0.9995 \
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
+```
+
+**Note:** `lr=5e-5` is necessary for 512d — three runs at 2e-4 diverged.
+`bs=4` is the largest batch fitting 96GB VRAM at 512d. For 256d experiments
+still use `bs=8 lr=2e-4` (gilbert PR #9 config).
+
+**Previous 256d baseline reproduce (PR #9):**
 ```bash
 cd target/
 python train.py \
@@ -75,14 +118,14 @@ experiments should layer on top of the gilbert config and add
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best | AB-UPT | Ratio |
+| Metric | yi best (PR #4) | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 11.07 | 3.82 | 2.9× |
-| wall_shear | 18.32 | 7.29 | 2.5× |
-| volume_pressure | 15.21 | 6.08 | 2.5× |
-| wall_shear_x | 15.65 | 5.35 | 2.9× |
-| wall_shear_y | 21.86 | 3.65 | 6.0× |
-| wall_shear_z | 23.18 | 3.63 | 6.4× |
+| surface_pressure | 10.65 | 3.82 | 2.8× |
+| wall_shear | 17.66 | 7.29 | 2.4× |
+| volume_pressure | 14.37 | 6.08 | 2.4× |
+| wall_shear_x | 14.87 | 5.35 | 2.8× |
+| wall_shear_y | 19.89 | 3.65 | 5.5× |
+| wall_shear_z | 21.73 | 3.63 | 6.0× |
 
 The wall-shear axes (esp. `tau_y`, `tau_z`) remain the largest gap to AB-UPT
 but have collapsed by ~60–70% from where we started. Volume pressure and

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,11 +2,25 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: first baseline merged 2026-04-29 — PR #11 (kohaku, tangential wall-shear projection)
+## Status: gilbert PR #9 wins — new baseline 2026-04-29 03:57 UTC
 
-Tangential wall-shear projection loss merged from PR #11. Run `uy0ds6iz`
-(state=finished, 1 epoch reached before pre-fix timeout). All `test_primary/*`
-metrics non-NaN. Subsequent PRs must beat these numbers.
+PR #9 (gilbert, vol_w=2.0 + protocol fixes) reduced
+`test_primary/abupt_axis_mean_rel_l2_pct` from 35.12 (kohaku PR #11) to
+**17.39** — a 50.5% improvement on the headline metric. Wall-shear axes saw
+~50–70% reductions. Surface pressure regressed slightly (+1 pp). Run
+`y2gigs61`, state=finished, 6 epochs reached, best_epoch=3.
+
+PR #9 was a CLI-flag-only change (no code diff). The win compounds the
+existing PR #11 projection-loss code on `yi` with: `--volume-loss-weight 2.0`,
+`--batch-size 8`, `--validation-every 1`, `--gradient-log-every 100
+--weight-log-every 100`. **Future PRs should adopt this base config.**
+
+**Important caveat** — gilbert's run did **not** include
+`--use-tangential-wallshear-loss`, yet still beat kohaku's projection-loss
+run by 50%. This means the bulk of the win came from the protocol fixes
+(bs=8 + validation-every=1 + log cadence), not the loss form. A follow-up
+combining all three (projection + vol_w=2.0 + protocol) should be even
+better.
 
 ## Reference baseline targets (must beat — AB-UPT public reference)
 
@@ -26,44 +40,60 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **35.1239** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/surface_pressure_rel_l2_pct` | **10.0667** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/wall_shear_rel_l2_pct` | **43.0515** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/volume_pressure_rel_l2_pct` | **14.9879** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/wall_shear_x_rel_l2_pct` | **30.8498** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/wall_shear_y_rel_l2_pct` | **42.0609** | #11 | uy0ds6iz | 2026-04-29 |
-| `test_primary/wall_shear_z_rel_l2_pct` | **77.6541** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **17.3933** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/surface_pressure_rel_l2_pct` | **11.0733** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/wall_shear_rel_l2_pct` | **18.3180** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/volume_pressure_rel_l2_pct` | **15.2059** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **15.6465** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **21.8605** | #9 | y2gigs61 | 2026-04-29 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **23.1803** | #9 | y2gigs61 | 2026-04-29 |
 
-**Reproduce (PR #11 merged config):**
+(`p_s = 10.07` from PR #11 is a marginally better single-axis number, but the
+abupt_axis_mean win is decisive and `tau_*` improvements dominate the
+composite metric.)
+
+**Reproduce (PR #9 winning config — recommended for all future PRs):**
 
 ```bash
 cd target/
 python train.py \
-  --use-tangential-wallshear-loss \
+  --volume-loss-weight 2.0 \
+  --batch-size 8 \
+  --validation-every 1 \
   --lr 2e-4 --weight-decay 5e-4 \
   --train-surface-points 65536 --eval-surface-points 65536 \
   --train-volume-points 65536 --eval-volume-points 65536 \
   --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
   --ema-decay 0.9995 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
-  --validation-every 1
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
 ```
+
+**Note:** PR #9 did **not** include `--use-tangential-wallshear-loss`. PR #11
+showed the projection helps; combining both should compose. Future Round-2
+experiments should layer on top of the gilbert config and add
+`--use-tangential-wallshear-loss` if the hypothesis is wall-shear-related.
 
 **Distance from AB-UPT targets (multiple of target):**
 
 | Metric | yi best | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 10.07 | 3.82 | 2.6× |
-| wall_shear | 43.05 | 7.29 | 5.9× |
-| volume_pressure | 14.99 | 6.08 | 2.5× |
-| wall_shear_x | 30.85 | 5.35 | 5.8× |
-| wall_shear_y | 42.06 | 3.65 | 11.5× |
-| wall_shear_z | 77.65 | 3.63 | 21.4× |
+| surface_pressure | 11.07 | 3.82 | 2.9× |
+| wall_shear | 18.32 | 7.29 | 2.5× |
+| volume_pressure | 15.21 | 6.08 | 2.5× |
+| wall_shear_x | 15.65 | 5.35 | 2.9× |
+| wall_shear_y | 21.86 | 3.65 | 6.0× |
+| wall_shear_z | 23.18 | 3.63 | 6.4× |
 
-The wall-shear axes (especially `tau_z`) are the largest gap to close. PR #11
-ran only 1 epoch — the per-step timeout fix on `yi` (commit `af92e9a`) plus
-`--validation-every 1` should let subsequent runs reach 4–5 epochs and likely
-crush these numbers further.
+The wall-shear axes (esp. `tau_y`, `tau_z`) remain the largest gap to AB-UPT
+but have collapsed by ~60–70% from where we started. Volume pressure and
+surface pressure are now the rate-limiting axes by absolute ratio.
+
+**Known training-stability bug (gilbert flagged in PR #9):** `train.py` has
+**no gradient clipping**. Run B (vol_w=3.0) and several other Round-1 PRs
+diverged on this exact mechanism. Follow-up PR #22 (gilbert) is opened to
+add `torch.nn.utils.clip_grad_norm_` between `loss.backward()` and
+`optimizer.step()`. Once landed, larger LR / vol_w / batch sweeps become
+safe.
 
 ## Reference config (`train.py` defaults on `yi`)
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,11 +2,11 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: clean slate — no completed runs yet
+## Status: first baseline merged 2026-04-29 — PR #11 (kohaku, tangential wall-shear projection)
 
-We have no `test_primary/*` numbers on this project. The first wave will calibrate
-both the reference defaults and a stronger known-good config, then layer single-delta
-experiments on top.
+Tangential wall-shear projection loss merged from PR #11. Run `uy0ds6iz`
+(state=finished, 1 epoch reached before pre-fix timeout). All `test_primary/*`
+metrics non-NaN. Subsequent PRs must beat these numbers.
 
 ## Reference baseline targets (must beat — AB-UPT public reference)
 
@@ -24,14 +24,46 @@ checkpoint reload.
 
 ## Current best on `yi`
 
-_Nothing merged yet. All metrics N/A._
-
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | — | — | — | — |
-| `test_primary/surface_pressure_rel_l2_pct` | — | — | — | — |
-| `test_primary/wall_shear_rel_l2_pct` | — | — | — | — |
-| `test_primary/volume_pressure_rel_l2_pct` | — | — | — | — |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **35.1239** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/surface_pressure_rel_l2_pct` | **10.0667** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/wall_shear_rel_l2_pct` | **43.0515** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/volume_pressure_rel_l2_pct` | **14.9879** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **30.8498** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **42.0609** | #11 | uy0ds6iz | 2026-04-29 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **77.6541** | #11 | uy0ds6iz | 2026-04-29 |
+
+**Reproduce (PR #11 merged config):**
+
+```bash
+cd target/
+python train.py \
+  --use-tangential-wallshear-loss \
+  --lr 2e-4 --weight-decay 5e-4 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
+  --ema-decay 0.9995 \
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms \
+  --validation-every 1
+```
+
+**Distance from AB-UPT targets (multiple of target):**
+
+| Metric | yi best | AB-UPT | Ratio |
+|---|---:|---:|---:|
+| surface_pressure | 10.07 | 3.82 | 2.6× |
+| wall_shear | 43.05 | 7.29 | 5.9× |
+| volume_pressure | 14.99 | 6.08 | 2.5× |
+| wall_shear_x | 30.85 | 5.35 | 5.8× |
+| wall_shear_y | 42.06 | 3.65 | 11.5× |
+| wall_shear_z | 77.65 | 3.63 | 21.4× |
+
+The wall-shear axes (especially `tau_z`) are the largest gap to close. PR #11
+ran only 1 epoch — the per-step timeout fix on `yi` (commit `af92e9a`) plus
+`--validation-every 1` should let subsequent runs reach 4–5 epochs and likely
+crush these numbers further.
 
 ## Reference config (`train.py` defaults on `yi`)
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,7 +2,47 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: chihiro PR #4 wins — new baseline 2026-04-29
+## Status: senku PR #14 wins — new baseline 2026-04-29
+
+PR #14 (senku, 6L/256d/4h/128sl depth scale-up) reduced
+`test_primary/abupt_axis_mean_rel_l2_pct` from 16.64 (chihiro PR #4) to
+**13.15** — a 21.0% improvement on the headline metric. Both 5L (13.52, −18.7%)
+and 6L (13.15, −21.0%) beat all pending PRs. W&B runs: `t5tv01ch` (5L) and
+`et4ajeqj` (6L). Config: bs=8, vol_w=2.0, lr=2e-4, clip=1.0, 65536 pts,
+validation-every=1. Key finding: depth is more parameter-efficient than width —
+6L/256d (4.73M params) crushes 4L/512d (12.7M params).
+
+**Compounding wins so far (all landed on `yi`):**
+1. PR #11 kohaku — tangential wall-shear projection loss
+2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
+3. PR #4 chihiro — width scale-up to 512d/8h
+4. PR #14 senku — depth scale-up to 6L/256d (this PR)
+
+**6L winning config (new recommended base):**
+
+```bash
+cd target/
+python train.py \
+  --volume-loss-weight 2.0 \
+  --batch-size 8 \
+  --validation-every 1 \
+  --lr 2e-4 --weight-decay 5e-4 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
+  --ema-decay 0.9995 \
+  --clip-grad-norm 1.0 \
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
+```
+
+**Note:** Grad clipping (clip=1.0) was active on 6L (pre-clip norm ~2.53 at end).
+5L did not need clipping (pre-clip norm ~0.79). Use clip=1.0 as default for deeper
+configs. Both runs were still descending at timeout — more epochs would improve further.
+Volume pressure shows val→test gap (6.93→13.6) — orthogonal to depth, needs SDF gating.
+
+---
+
+## Previous: chihiro PR #4 — baseline 2026-04-29
 
 PR #4 (chihiro, 4L/512d/8h large-model scale-up) reduced
 `test_primary/abupt_axis_mean_rel_l2_pct` from 17.39 (gilbert PR #9) to
@@ -60,17 +100,19 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **16.64** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/surface_pressure_rel_l2_pct` | **10.65** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/wall_shear_rel_l2_pct` | **17.66** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/volume_pressure_rel_l2_pct` | **14.37** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/wall_shear_x_rel_l2_pct` | **14.87** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/wall_shear_y_rel_l2_pct` | **19.89** | #4 | pejudvyd | 2026-04-29 |
-| `test_primary/wall_shear_z_rel_l2_pct` | **21.73** | #4 | pejudvyd | 2026-04-29 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/wall_shear_rel_l2_pct` | **13.47** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/volume_pressure_rel_l2_pct` | **13.58** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **11.53** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | #14 | et4ajeqj | 2026-04-29 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | #14 | et4ajeqj | 2026-04-29 |
 
-Note: PRs #8 (frieren FiLM, abupt=16.53) and #13 (norman cosine EMA, abupt=15.82)
-are verified wins currently pending rebase — once merged the headline metric
-will drop further, with #13 as projected new best.
+Note: Additional wins pending merge — PRs #22 (gilbert clip=1.0, 14.80),
+#24 (emma sq-rel-L2, 14.81), #3 (askeladd codex-lineage, 15.27),
+#13 (norman cosine EMA, 15.82), #8 (frieren FiLM, 16.53). All are now
+superseded on headline metric by PR #14 but may contain orthogonal code
+contributions worth extracting.
 
 (`p_s = 10.07` from PR #11 is a marginally better single-axis number, but the
 abupt_axis_mean win is decisive and `tau_*` improvements dominate the
@@ -118,18 +160,19 @@ experiments should layer on top of the gilbert config and add
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best (PR #4) | AB-UPT | Ratio |
+| Metric | yi best (PR #14) | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 10.65 | 3.82 | 2.8× |
-| wall_shear | 17.66 | 7.29 | 2.4× |
-| volume_pressure | 14.37 | 6.08 | 2.4× |
-| wall_shear_x | 14.87 | 5.35 | 2.8× |
-| wall_shear_y | 19.89 | 3.65 | 5.5× |
-| wall_shear_z | 21.73 | 3.63 | 6.0× |
+| surface_pressure | 7.64 | 3.82 | 2.0× |
+| wall_shear | 13.47 | 7.29 | 1.8× |
+| volume_pressure | 13.58 | 6.08 | 2.2× |
+| wall_shear_x | 11.53 | 5.35 | 2.2× |
+| wall_shear_y | 16.23 | 3.65 | 4.4× |
+| wall_shear_z | 16.75 | 3.63 | 4.6× |
 
-The wall-shear axes (esp. `tau_y`, `tau_z`) remain the largest gap to AB-UPT
-but have collapsed by ~60–70% from where we started. Volume pressure and
-surface pressure are now the rate-limiting axes by absolute ratio.
+All axes have improved substantially. Wall_shear_y and wall_shear_z remain the
+largest gap at ~4-5× AB-UPT. Volume pressure shows a known val→test gap
+(val 6.93 ≈ AB-UPT level, test 13.58 = 2×) — test generalization is the
+remaining challenge, not model capacity per se.
 
 **Known training-stability bug (gilbert flagged in PR #9):** `train.py` has
 **no gradient clipping**. Run B (vol_w=3.0) and several other Round-1 PRs

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -108,11 +108,11 @@ checkpoint reload.
 | `test_primary/wall_shear_y_rel_l2_pct` | **16.23** | #14 | et4ajeqj | 2026-04-29 |
 | `test_primary/wall_shear_z_rel_l2_pct` | **16.75** | #14 | et4ajeqj | 2026-04-29 |
 
-Note: Additional wins pending merge — PRs #22 (gilbert clip=1.0, 14.80),
-#24 (emma sq-rel-L2, 14.81), #3 (askeladd codex-lineage, 15.27),
-#13 (norman cosine EMA, 15.82), #8 (frieren FiLM, 16.53). All are now
-superseded on headline metric by PR #14 but may contain orthogonal code
-contributions worth extracting.
+Note: Additional code wins pending merge (all superseded on headline metric by
+PR #14 but contain orthogonal code contributions) — PRs #22 (gilbert clip=1.0,
+14.80), #24 (emma sq-rel-L2, 14.81), #3 (askeladd codex-lineage, 15.27),
+#13 (norman cosine EMA, 15.82). PR #8 (frieren FiLM, 16.53) merged 2026-04-29 —
+FiLM geometry conditioning code now on `yi`.
 
 (`p_s = 10.07` from PR #11 is a marginally better single-axis number, but the
 abupt_axis_mean win is decisive and `tau_*` improvements dominate the

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,17 +2,17 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: fern PR #99 wins — new baseline 2026-04-29
+## Status: fern PR #183 wins — new baseline 2026-04-29
 
-PR #99 (fern, lr=5e-4 peak LR, 5× base lr=1e-4) reduced
-`val_primary/abupt_axis_mean_rel_l2_pct` from 12.74 (thorfinn PR #66) to
-**10.69** — a 16.1% improvement on the headline metric. W&B run: `3hljb0mg`.
+PR #183 (fern, omega-bank sweep: pos_max_wavelength=1000) reduced
+`val_primary/abupt_axis_mean_rel_l2_pct` from 10.69 (fern PR #99) to
+**10.21** — a 4.5% improvement on the headline metric. W&B run: `bplngfyo`.
 
-Key finding: raising the peak learning rate from 2e-4 (thorfinn base) to 5e-4
-significantly improves convergence without instability. The 5× LR boost applied
-on top of the thorfinn base config (6L/256d, W_y=2, W_z=2) yields best-ever
-metrics across surface_pressure (6.97 vs 7.64), wall_shear (11.69 vs 12.86),
-and volume_pressure (7.85 vs 13.14). 4.6h runtime, lr=5e-4, wd=5e-4.
+Key finding: compressing `pos_max_wavelength` from 10,000 → 1,000 in
+`ContinuousSincosEmbed` significantly improves all metrics. The vehicle bbox
+is ~8m × 2.5m × 2m, so 1,000 gives much denser frequency sampling across all
+axes. Best-ever volume_pressure (6.32 vs 7.85) and consistent improvements on
+surface_pressure (6.85 vs 6.97), wall_shear (11.43 vs 11.69). 4.6h runtime.
 
 **Compounding wins so far (all landed on `yi`):**
 1. PR #11 kohaku — tangential wall-shear projection loss code
@@ -21,10 +21,11 @@ and volume_pressure (7.85 vs 13.14). 4.6h runtime, lr=5e-4, wd=5e-4.
 4. PR #14 senku — depth scale-up to 6L/256d
 5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
 6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2
-7. PR #99 fern — LR peak 5e-4 (5× base) (this PR)
+7. PR #99 fern — LR peak 5e-4 (5× base)
 8. PR #169 thorfinn — NaN/Inf-skip safeguard, --seed, --lr-warmup-steps (infra utilities, no metric regression)
+9. PR #183 fern — pos_max_wavelength=1000 (omega-bank sincos positional encoding)
 
-**New recommended base config (PR #99 winning arm):**
+**New recommended base config (PR #183 winning arm):**
 
 ```bash
 cd target/
@@ -40,6 +41,7 @@ python train.py \
   --clip-grad-norm 1.0 \
   --wallshear-y-weight 2.0 \
   --wallshear-z-weight 2.0 \
+  --pos-max-wavelength 1000 \
   --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
 ```
 
@@ -120,34 +122,36 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/surface_pressure_rel_l2_pct` | **6.97** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/wall_shear_rel_l2_pct` | **11.69** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/volume_pressure_rel_l2_pct` | **7.85** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/wall_shear_x_rel_l2_pct` | **10.17** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/wall_shear_y_rel_l2_pct` | **13.73** | #99 | 3hljb0mg | 2026-04-29 |
-| `val_primary/wall_shear_z_rel_l2_pct` | **14.73** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.21** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/surface_pressure_rel_l2_pct` | **6.85** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/wall_shear_rel_l2_pct` | **11.43** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **6.32** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/wall_shear_x_rel_l2_pct` | **9.89** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/wall_shear_y_rel_l2_pct` | **13.47** | #183 | bplngfyo | 2026-04-29 |
+| `val_primary/wall_shear_z_rel_l2_pct` | **14.52** | #183 | bplngfyo | 2026-04-29 |
 
 Note: Additional code wins pending merge (all superseded on headline metric by
-PR #99 but contain orthogonal code contributions) — PRs #98 (emma weight-decay),
+PR #183 but contain orthogonal code contributions) — PRs #98 (emma weight-decay),
 #106 (thorfinn yw2.5-zw2.5), #97 (edward slices192), #63 (askeladd sq-rel),
 #104 (senku ema9997), #102 (haku dropout). PRs #8 (frieren FiLM) merged 2026-04-29.
 PR #169 (thorfinn, infra utilities) merged 2026-04-29 — adds NaN/Inf-skip, --seed, --lr-warmup-steps to train.py.
+PR #183 (fern, omega-bank sweep) merged 2026-04-29 — pos_max_wavelength=1000 now default in train.py.
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best (PR #99) | AB-UPT | Ratio |
+| Metric | yi best (PR #183) | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 6.97 | 3.82 | 1.8× |
-| wall_shear | 11.69 | 7.29 | 1.6× |
-| volume_pressure | 7.85 | 6.08 | 1.3× |
-| wall_shear_x | 10.17 | 5.35 | 1.9× |
-| wall_shear_y | 13.73 | 3.65 | 3.8× |
-| wall_shear_z | 14.73 | 3.63 | 4.1× |
+| surface_pressure | 6.85 | 3.82 | 1.8× |
+| wall_shear | 11.43 | 7.29 | 1.6× |
+| volume_pressure | 6.32 | 6.08 | 1.0× |
+| wall_shear_x | 9.89 | 5.35 | 1.8× |
+| wall_shear_y | 13.47 | 3.65 | 3.7× |
+| wall_shear_z | 14.52 | 3.63 | 4.0× |
 
 Wall_shear_y and wall_shear_z remain the largest gap at ~4× AB-UPT.
-Volume pressure is now very close to AB-UPT (1.3×), suggesting the model
-has good capacity but wall-shear axis precision remains the key challenge.
+Volume pressure has now matched AB-UPT (1.0×, 6.32 vs 6.08), suggesting
+strong capacity for scalar fields. Wall-shear axis precision remains the
+key challenge and the primary target for future experiments.
 
 ## Reference config (`train.py` defaults on `yi`)
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -1,0 +1,43 @@
+# DrivAerML Baseline
+
+**Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
+
+## Status: clean slate — no completed runs yet
+
+We have no `test_primary/*` numbers on this project. The first wave will calibrate
+both the reference defaults and a stronger known-good config, then layer single-delta
+experiments on top.
+
+## Reference baseline targets (must beat — AB-UPT public reference)
+
+| Target | This-repo metric | AB-UPT |
+|---|---|---:|
+| Surface pressure `p_s` | `test_primary/surface_pressure_rel_l2_pct` | **3.82** |
+| Vector wall shear `tau` | `test_primary/wall_shear_rel_l2_pct` | **7.29** |
+| Volume pressure `p_v` | `test_primary/volume_pressure_rel_l2_pct` | **6.08** |
+| Wall shear `tau_x` | `test_primary/wall_shear_x_rel_l2_pct` | **5.35** |
+| Wall shear `tau_y` | `test_primary/wall_shear_y_rel_l2_pct` | **3.65** |
+| Wall shear `tau_z` | `test_primary/wall_shear_z_rel_l2_pct` | **3.63** |
+
+Lower is better. Final claims must come from `test_primary/*` after best-validation
+checkpoint reload.
+
+## Current best on `yi`
+
+_Nothing merged yet. All metrics N/A._
+
+| Metric | Best | PR | W&B run | Date |
+|---|---:|---|---|---|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | — | — | — | — |
+| `test_primary/surface_pressure_rel_l2_pct` | — | — | — | — |
+| `test_primary/wall_shear_rel_l2_pct` | — | — | — | — |
+| `test_primary/volume_pressure_rel_l2_pct` | — | — | — | — |
+
+## Reference config (`train.py` defaults on `yi`)
+
+```
+lr=3e-4  weight_decay=1e-4  batch_size=2  epochs=50
+train_/eval_ surface_points=40_000  train_/eval_ volume_points=40_000
+model: 3 layers · 192 hidden · 3 heads · 96 slices · mlp_ratio=4
+amp=bf16  ema_decay=0.999  validation_every=10
+```

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -2,7 +2,49 @@
 
 **Branch:** `yi` · **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`
 
-## Status: thorfinn PR #66 wins — new baseline 2026-04-30
+## Status: fern PR #99 wins — new baseline 2026-04-29
+
+PR #99 (fern, lr=5e-4 peak LR, 5× base lr=1e-4) reduced
+`val_primary/abupt_axis_mean_rel_l2_pct` from 12.74 (thorfinn PR #66) to
+**10.69** — a 16.1% improvement on the headline metric. W&B run: `3hljb0mg`.
+
+Key finding: raising the peak learning rate from 2e-4 (thorfinn base) to 5e-4
+significantly improves convergence without instability. The 5× LR boost applied
+on top of the thorfinn base config (6L/256d, W_y=2, W_z=2) yields best-ever
+metrics across surface_pressure (6.97 vs 7.64), wall_shear (11.69 vs 12.86),
+and volume_pressure (7.85 vs 13.14). 4.6h runtime, lr=5e-4, wd=5e-4.
+
+**Compounding wins so far (all landed on `yi`):**
+1. PR #11 kohaku — tangential wall-shear projection loss code
+2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
+3. PR #4 chihiro — width scale-up to 512d/8h
+4. PR #14 senku — depth scale-up to 6L/256d
+5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
+6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2
+7. PR #99 fern — LR peak 5e-4 (5× base) (this PR)
+
+**New recommended base config (PR #99 winning arm):**
+
+```bash
+cd target/
+python train.py \
+  --volume-loss-weight 2.0 \
+  --batch-size 8 \
+  --validation-every 1 \
+  --lr 5e-4 --weight-decay 5e-4 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
+  --ema-decay 0.9995 \
+  --clip-grad-norm 1.0 \
+  --wallshear-y-weight 2.0 \
+  --wallshear-z-weight 2.0 \
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
+```
+
+---
+
+## Previous: thorfinn PR #66 — baseline 2026-04-30
 
 PR #66 (thorfinn, per-axis tau_y/z loss upweighting W_y=2, W_z=2 on 6L/256d base) reduced
 `test_primary/abupt_axis_mean_rel_l2_pct` from 13.15 (senku PR #14) to
@@ -13,33 +55,6 @@ Key finding: upweighting the two hardest wall-shear axes (tau_y and tau_z) by 2�
 improves the composite metric without hurting surface_pressure or volume_pressure.
 W_y=2, W_z=2 beats W_y=1.5, W_z=1.5 and the equal-weight arms. Thorfinn's code
 adds `--wallshear-y-weight` and `--wallshear-z-weight` flags to `train.py`.
-
-**Compounding wins so far (all landed on `yi`):**
-1. PR #11 kohaku — tangential wall-shear projection loss code
-2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
-3. PR #4 chihiro — width scale-up to 512d/8h
-4. PR #14 senku — depth scale-up to 6L/256d
-5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
-6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2 (this PR)
-
-**New recommended base config (PR #66 winning arm):**
-
-```bash
-cd target/
-python train.py \
-  --volume-loss-weight 2.0 \
-  --batch-size 8 \
-  --validation-every 1 \
-  --lr 2e-4 --weight-decay 5e-4 \
-  --train-surface-points 65536 --eval-surface-points 65536 \
-  --train-volume-points 65536 --eval-volume-points 65536 \
-  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
-  --ema-decay 0.9995 \
-  --clip-grad-norm 1.0 \
-  --wallshear-y-weight 2.0 \
-  --wallshear-z-weight 2.0 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
-```
 
 ---
 
@@ -64,14 +79,6 @@ state=finished, 3 best epochs, params ~12.7M. Width upgrade used `lr=5e-5`
 Standout gain: `volume_pressure` 14.37 vs 15.21 — orthogonal to FiLM and
 cosine-EMA wins still pending merge (PRs #8, #13).
 
-**Compounding wins so far (all landed on `yi`):**
-1. PR #11 kohaku — tangential wall-shear projection loss
-2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
-3. PR #4 chihiro — width scale-up to 512d/8h (this PR)
-
-PRs #8 (frieren FiLM, 16.53) and #13 (norman cosine EMA, 15.82) are pending
-rebase+merge and should push the composite lower still.
-
 ---
 
 ## Previous: gilbert PR #9 — baseline 2026-04-29 03:57 UTC
@@ -84,7 +91,7 @@ PR #9 (gilbert, vol_w=2.0 + protocol fixes) reduced
 
 PR #9 was a CLI-flag-only change (no code diff). The win compounds the
 existing PR #11 projection-loss code on `yi` with: `--volume-loss-weight 2.0`,
-`--batch-size 8`, `--validation-every 1`, `--gradient-log-every 100
+`--batch-size 8`, `--validation-every=1`, `--gradient-log-every 100
 --weight-log-every 100`. **Future PRs should adopt this base config.**
 
 **Important caveat** — gilbert's run did **not** include
@@ -112,86 +119,33 @@ checkpoint reload.
 
 | Metric | Best | PR | W&B run | Date |
 |---|---:|---|---|---|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | #66 | gvigs86q | 2026-04-30 |
-| `test_primary/surface_pressure_rel_l2_pct` | **7.64** | #14 | et4ajeqj | 2026-04-29 |
-| `test_primary/wall_shear_rel_l2_pct` | **12.86** | #66 | gvigs86q | 2026-04-30 |
-| `test_primary/volume_pressure_rel_l2_pct` | **13.14** | #66 | gvigs86q | 2026-04-30 |
-| `test_primary/wall_shear_x_rel_l2_pct` | **11.29** | #66 | gvigs86q | 2026-04-30 |
-| `test_primary/wall_shear_y_rel_l2_pct` | **15.15** | #66 | gvigs86q | 2026-04-30 |
-| `test_primary/wall_shear_z_rel_l2_pct` | **15.05** | #66 | gvigs86q | 2026-04-30 |
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **10.69** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/surface_pressure_rel_l2_pct` | **6.97** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/wall_shear_rel_l2_pct` | **11.69** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **7.85** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/wall_shear_x_rel_l2_pct` | **10.17** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/wall_shear_y_rel_l2_pct` | **13.73** | #99 | 3hljb0mg | 2026-04-29 |
+| `val_primary/wall_shear_z_rel_l2_pct` | **14.73** | #99 | 3hljb0mg | 2026-04-29 |
 
 Note: Additional code wins pending merge (all superseded on headline metric by
-PR #14 but contain orthogonal code contributions) — PRs #22 (gilbert clip=1.0,
-14.80), #24 (emma sq-rel-L2, 14.81), #3 (askeladd codex-lineage, 15.27),
-#13 (norman cosine EMA, 15.82). PR #8 (frieren FiLM, 16.53) merged 2026-04-29 —
-FiLM geometry conditioning code now on `yi`.
-
-(`p_s = 10.07` from PR #11 is a marginally better single-axis number, but the
-abupt_axis_mean win is decisive and `tau_*` improvements dominate the
-composite metric.)
-
-**Reproduce (PR #4 winning config — new recommended base for 512d experiments):**
-
-```bash
-cd target/
-python train.py \
-  --volume-loss-weight 2.0 \
-  --batch-size 4 \
-  --validation-every 1 \
-  --lr 5e-5 --weight-decay 5e-4 \
-  --train-surface-points 65536 --eval-surface-points 65536 \
-  --train-volume-points 65536 --eval-volume-points 65536 \
-  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
-  --ema-decay 0.9995 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
-```
-
-**Note:** `lr=5e-5` is necessary for 512d — three runs at 2e-4 diverged.
-`bs=4` is the largest batch fitting 96GB VRAM at 512d. For 256d experiments
-still use `bs=8 lr=2e-4` (gilbert PR #9 config).
-
-**Previous 256d baseline reproduce (PR #9):**
-```bash
-cd target/
-python train.py \
-  --volume-loss-weight 2.0 \
-  --batch-size 8 \
-  --validation-every 1 \
-  --lr 2e-4 --weight-decay 5e-4 \
-  --train-surface-points 65536 --eval-surface-points 65536 \
-  --train-volume-points 65536 --eval-volume-points 65536 \
-  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
-  --ema-decay 0.9995 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
-```
-
-**Note:** PR #9 did **not** include `--use-tangential-wallshear-loss`. PR #11
-showed the projection helps; combining both should compose. Future Round-2
-experiments should layer on top of the gilbert config and add
-`--use-tangential-wallshear-loss` if the hypothesis is wall-shear-related.
+PR #99 but contain orthogonal code contributions) — PRs #98 (emma weight-decay),
+#106 (thorfinn yw2.5-zw2.5), #97 (edward slices192), #63 (askeladd sq-rel),
+#104 (senku ema9997), #102 (haku dropout). PRs #8 (frieren FiLM) merged 2026-04-29.
 
 **Distance from AB-UPT targets (multiple of target):**
 
-| Metric | yi best (PR #66) | AB-UPT | Ratio |
+| Metric | yi best (PR #99) | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 7.64 | 3.82 | 2.0× |
-| wall_shear | 12.86 | 7.29 | 1.8× |
-| volume_pressure | 13.14 | 6.08 | 2.2× |
-| wall_shear_x | 11.29 | 5.35 | 2.1× |
-| wall_shear_y | 15.15 | 3.65 | 4.2× |
-| wall_shear_z | 15.05 | 3.63 | 4.1× |
+| surface_pressure | 6.97 | 3.82 | 1.8× |
+| wall_shear | 11.69 | 7.29 | 1.6× |
+| volume_pressure | 7.85 | 6.08 | 1.3× |
+| wall_shear_x | 10.17 | 5.35 | 1.9× |
+| wall_shear_y | 13.73 | 3.65 | 3.8× |
+| wall_shear_z | 14.73 | 3.63 | 4.1× |
 
-Wall_shear_y and wall_shear_z remain the largest gap at ~4× AB-UPT despite
-thorfinn's W_y=W_z=2 win. Volume pressure shows a known val→test gap (val
-~6.9 ≈ AB-UPT level, test 13.14 = 2.2×) — test generalization is the
-remaining challenge, not model capacity per se.
-
-**Known training-stability bug (gilbert flagged in PR #9):** `train.py` has
-**no gradient clipping**. Run B (vol_w=3.0) and several other Round-1 PRs
-diverged on this exact mechanism. Follow-up PR #22 (gilbert) is opened to
-add `torch.nn.utils.clip_grad_norm_` between `loss.backward()` and
-`optimizer.step()`. Once landed, larger LR / vol_w / batch sweeps become
-safe.
+Wall_shear_y and wall_shear_z remain the largest gap at ~4× AB-UPT.
+Volume pressure is now very close to AB-UPT (1.3×), suggesting the model
+has good capacity but wall-shear axis precision remains the key challenge.
 
 ## Reference config (`train.py` defaults on `yi`)
 

--- a/program.md
+++ b/program.md
@@ -196,6 +196,8 @@ Use a mix of shorter and longer experiments:
 
 Do not run only short experiments; they can discard ideas before the model has started learning. Do not run only long experiments; they burn the time budget before enough hypotheses are screened. Use the metrics' slope, gradient, and weight logs etc to decide which short runs deserve a longer confirmation run.
 
+The launch wall-clock limit is a hard cutoff, not a target duration; choose `--epochs` and any step limits according to the evidence needed for the experiment.
+
 ## Research Workflow
 
 For substantial architecture or training-strategy changes, preserve main context by using research subagents before implementation. The advisor should deliberately run two complementary streams instead of only local hill-climbing.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -58,7 +58,7 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 | #14 | senku | Deeper model 5L/256d/4h (depth ablation) | all |
 | #15 | tanjiro | SDF-gated volume attention bias (near-wall emphasis) | p_v (6.08%) |
 | #16 | thorfinn | Test-time bilateral symmetry TTA (xz-plane) | tau_y esp. |
-| #17 | violet | Surface-area-weighted MSE loss (physics-consistent) | p_s / tau |
+| ~~#17~~ | ~~violet~~ | ~~Surface-area-weighted MSE loss~~ — CLOSED 2026-04-29 (heavy-tail variance non-viable) |
 
 ## Round 2 plan — bold architecture replacements
 
@@ -105,6 +105,7 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 | #28 | norman | A02 — SE(3) equivariant local-frame coord features |
 | #29 | chihiro | B06 — width × FiLM × cosine EMA composition at 512d |
+| #38 | violet | C02 — Deep Evidential Regression (NIG head, lambda sweep 0.01 / 0.1) |
 
 **Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
 SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,155 +1,145 @@
 # SENPAI Research State
-- 2026-05-01 07:45 UTC — closed PR #143 (fern coord-norm) and PR #126 (kohaku FiLM); reassigned to PR #183 (fern omega-bank) and PR #184 (kohaku FiLM zero-init)
+- **Updated:** 2026-05-01 11:45 UTC
+- **Branch:** `yi`
+- **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
+
+---
 
 ## Most Recent Research Direction from Human Researcher Team
 
-From Issue #18 (open, Morgan — latest message 2026-04-30T20:29:19Z):
+**Issue #18 (Morgan, 2026-04-30T20:29:19Z — overarching directive):**
+> Stop incremental tuning. Rip out the model architecture and try completely new approaches. Students can handle radical departures from the reference train.py as long as logging/validation/checkpointing are maintained.
 
-**Overarching directive:** Stop incremental tuning. Rip out the model architecture and try completely new approaches. Students can handle radical departures from the reference train.py as long as logging/validation/checkpointing are maintained.
+**Morgan's ordered priority list:**
+1. Surface-tangent frame wall-shear prediction — 4× wall shear y/z error is a coordinate frame mismatch
+2. Perceiver-IO backbone replacement — ~3× faster per epoch = more epochs within budget
+3. asinh/log target normalization — wall shear spans 4 decades (tested, **NEGATIVE — tail suppression problem**)
+4. Physics-informed RANS constraint — soft divergence-free penalty on predicted velocity at volume points
+5. 1-cycle LR schedule with higher peak (tested, **NEGATIVE — budget starvation + stability ceiling at ~6.5e-4**)
 
-**Round-5 bold experiment priorities (Morgan's ordered list by impact):**
-1. **Surface-tangent frame wall-shear prediction** — 4× wall shear y/z error is a coordinate frame mismatch, not a hyperparameter problem
-2. **Perceiver-IO backbone replacement** — Replace Transolver entirely; ~3× faster per epoch = more epochs within budget
-3. **asinh/log target normalization** — Wall shear spans 4 decades; predict asinh(tau) to fix MSE over-weighting
-4. **Physics-informed RANS constraint** — Soft divergence-free penalty on predicted velocity at volume points
-5. **1-cycle LR schedule with higher peak** — Warmup to 1e-3, cosine decay to 1e-6
+---
 
-**Advisor status:** Issue #18 acknowledged and responded. No new messages since 2026-04-30T20:42Z.
+## Current Baseline
 
-## Current Baseline: PR #99 (fern) — abupt 10.69 — 2026-04-29
-
-Baseline unchanged — all 7 Round-5 PRs were NEGATIVE.
-
-**Compounded wins on `yi` so far:**
-1. PR #11 kohaku — tangential wall-shear projection loss code
-2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
-3. PR #4 chihiro — width scale-up to 512d/8h
-4. PR #14 senku — depth scale-up to 6L/256d (21% improvement: 16.64 → 13.15)
-5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
-6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2 (3.1%: 13.15 → 12.74)
-7. PR #99 fern — LR peak 5e-4 (16.1%: 12.74 → 10.69)
-
-**Current best metrics (PR #99, W&B run `3hljb0mg`):**
-
-| Metric | yi best | AB-UPT | Ratio |
+| Metric | yi best | AB-UPT | Gap |
 |---|---:|---:|---:|
 | `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
 | `surface_pressure_rel_l2_pct` | **6.97** | 3.82 | 1.8× |
 | `wall_shear_rel_l2_pct` | **11.69** | 7.29 | 1.6× |
 | `volume_pressure_rel_l2_pct` | **7.85** | 6.08 | 1.3× |
 | `wall_shear_x_rel_l2_pct` | **10.17** | 5.35 | 1.9× |
-| `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | 3.8× |
-| `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | 4.1× |
+| `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | **3.8×** |
+| `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | **4.1×** |
 
-**Standard base config (PR #99 winning arm):**
-```bash
-python train.py \
-  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
-  --lr 5e-4 --weight-decay 5e-4 \
-  --train-surface-points 65536 --eval-surface-points 65536 \
-  --train-volume-points 65536 --eval-volume-points 65536 \
-  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
-  --ema-decay 0.9995 --clip-grad-norm 1.0 \
-  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
-  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
-```
+**The wall_shear_y/z gap at 3.8-4.1× AB-UPT is the primary research target.**
 
-## Round-5 Closed Results (all NEGATIVE — 2026-05-01)
+---
 
-Critical lessons learned from 7 failed experiments:
+## Active WIP PRs (as of 2026-05-01 11:45 UTC)
 
-| PR | Student | Hypothesis | Outcome | Key Finding |
-|---|---|---|---|---|
-| #131 | thorfinn | logmag transform (eps=0.01-1.0) | NEGATIVE abupt=11.03 | Gradient of log1p near 0 is ~1/eps; eps≤0.10 caused 2M+ pre_clip_norm spikes. NaN-skip safeguard (commit 2a8f7e4) is a keeper. |
-| #130 | tanjiro | Curriculum W_y 1→3 ramp | NEGATIVE 6/6 diverged | Adam m/v desync around W_y≈2.7; static weights needed, not curriculum |
-| #124 | gilbert | Laplacian pressure constraint | NEGATIVE wrong physics | ∇²p≈0 is creeping flow; real RANS has advective terms. kNN Laplacian implementation reusable. |
-| #121 | askeladd | Tangent-frame wall-shear | NEGATIVE worse than Cartesian | Duff ONB discontinuous at t1.x sign-flip; non-gauge-equivariant model can't learn it. Channel coupling in Adam. |
-| #118 | chihiro | mlp_ratio sweep 6/8 | AMBIGUOUS 12/16 diverged | Trend toward mlp_ratio=8 but seed-dependent instability prevented convergent comparison. Needs warmup + seed flags. |
-| #129 | senku | Uniform surface_sw sweep | NEGATIVE 7/8 diverged | Uniform sw amplifies all surface incl. already-upweighted W_y=W_z=2. Monotone instability with sw. Per-component is right knob. |
-| #117 | alphonse | 6L/384d + 8L/256d depth | NEGATIVE no merger | 8L/256d time-limited (extrapolated to cross baseline 11 min after timeout). 384d unstable in bf16 at all LRs. Depth (not width) is viable scale-up. |
-
-## Active WIP PRs (in flight)
-
-### Still-running from Round-5 launch batch
-| PR | Student | Branch | Hypothesis |
+| PR | Student | Hypothesis | Status |
 |---|---|---|---|
-| #156 | levi | `levi/ohem-hard-case-mining` | OHEM top-25% hard case mining |
-| #155 | armin | `armin/checkpoint-ensemble` | Top-3 checkpoint ensemble |
-| #154 | mikasa | `mikasa/gradient-accumulation` | Grad accum eff-bs=32 |
-| #153 | mob | `mob/lookahead-optimizer` | Lookahead optimizer k=5/10 |
-| #152 | violet | `violet/geom-moment-conditioning` | 14-dim analytic geometry conditioning |
-| #151 | nezuko | `nezuko/symmetry-augmentation` | L/R symmetry augmentation for tau_y gap |
-| #185 | emma | `emma/sam-sharpness-aware-min` | SAM optimizer ρ=0.05/0.10 (val→test gap) |
-| #144 | edward | `edward/adamw-beta2-sweep` | AdamW beta2 sweep (0.95 vs 0.999) |
-| #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR max=1e-3 |
-| #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
+| **#199** | stark | Smooth tangent-frame wall-shear prediction (continuous e_x-projection frame, 2D output) | JUST ASSIGNED |
+| **#200** | emma | Wall-shear magnitude/direction decomposition loss (log-mag + cosine direction) | JUST ASSIGNED |
+| **#198** | senku | Stochastic Weight Averaging (SWA) free gain (r12) | WIP, no data yet |
+| **#197** | gilbert | k-NN local surface attention for tau_y/z gap (r12) | WIP, no data yet |
+| **#196** | edward | Lion optimizer sweep vs AdamW (r12) | WIP, no data yet |
+| **#193** | thorfinn | Curvature-biased surface point sampling | WIP, 1 comment only |
+| **#192** | tanjiro | asinh target normalization for tau_y/z (separate from frieren's approach) | WIP, 4-seed relaunch w/ warmup-500 |
+| **#191** | haku | 1-cycle LR max=1e-3 (corrected epoch-limited schedule) | WIP, A_tuned running |
+| **#184** | kohaku | FiLM with identity/zero-init (DiT-style) | **arm B (lr=4e-4) sole survivor, ep2≈99%, ETA ~14:25 UTC** |
+| **#183** | fern | Omega-bank frequency sweep | **3 arms healthy (A2/C3/D3); mw=100 FALSIFIED; ep2 results ~12:00-12:20 UTC** |
+| **#171** | norman | Snapshot ensemble with cyclic LR | **V2 running (okm6uoea, eta_min=5e-5 + clip=0.5); ETA ~17:30 UTC** |
+| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | **λ=0.10 (gawdh7ah) ep1=17.103; clip=0.5 relaunches for λ=0.01/0.05 in flight** |
+| **#165** | chihiro | mlp_ratio=8 hardened (3-seed) | **seed1337 ep3=11.92 (NOT beating 10.69); clip=0.5 go/no-go at 12:20/13:30 UTC** |
+| **#164** | alphonse | 8L/256d + 1cycle LR recovery | WIP |
+| **#152** | violet | 14-dim analytic geometry moment conditioning | WIP |
+| **#151** | nezuko | L/R symmetry augmentation (tau_y gap) | WIP |
+| **#123** | frieren | asinh/log wall-shear target normalization | **Critical finding: asinh-1.0 trades metric for stability; arms A/D/B(v3p1) final results ~12:10-13:51 UTC** |
 
-### Round-6 newly assigned (2026-05-01)
-| PR | Student | Branch | Hypothesis |
-|---|---|---|---|
-| #164 | alphonse | `alphonse/depth-8L-1cycle-recovery` | 8L/256d depth + OneCycleLR (time-limited recovery) |
-| #165 | chihiro | `chihiro/mlp-ratio-8-hardened` | mlp_ratio=8 + 1k warmup + seed=42/1337/7 (3-arm) |
-| #166 | senku | `senku/per-component-wallshear-yz-3` | Static W_y=W_z=3.0 + 500-step LR warmup |
-| #167 | tanjiro | `tanjiro/static-wyz-35-warmup` | Static W_y=W_z=3.5 + 1k LR warmup |
-| #168 | askeladd | `askeladd/normal-penalty-wallshear-yz` | Normal-consistency soft penalty λ∈{0.01,0.05,0.10} |
-| #169 | thorfinn | `thorfinn/nan-skip-utility-cherry-pick` | NaN-skip + seed + LR warmup utility infra |
-| #170 | gilbert | `gilbert/width-384d-qknorm-fp32attn` | 384d + QK-norm + fp32-attention (stability fix) |
-| #171 | norman | `norman/snapshot-ensemble-cyclic-lr` | Snapshot ensemble via cyclic LR (3 ckpts avg) |
-| #172 | stark | `stark/adamw-eps-sweep` | AdamW eps sweep 1e-8/7/6/5 (gradient stability) |
-| #183 | fern | `fern/omega-bank-sweep` | Omega-bank frequency sweep (per-axis sincos for tau_y/z gap) — replaces #143 |
-| #184 | kohaku | `kohaku/film-zero-init` | FiLM with identity/zero-init (DiT-style stable conditioning) — replaces #126 |
+---
 
 ## Current Research Themes
 
-### Theme 1: Closing wall_shear_y/z gap (4× AB-UPT — HIGHEST PRIORITY)
-The single biggest lever: **why do y/z shear components fail 4× harder than AB-UPT?**
-- #166 senku — per-component W_y=W_z=3.0, static (correct knob vs #129's failed uniform sw)
-- #167 tanjiro — per-component W_y=W_z=3.5, static (complement to senku's 3.0, maps stability ceiling)
-- #168 askeladd — soft normal-consistency penalty λ∈{0.01,0.05,0.10} (physics without frame discontinuity)
-- #123 frieren (in flight) — asinh target normalization (heavy-tail hypothesis)
-- #151 nezuko (in flight) — L/R symmetry augmentation for tau_y gap
+### Theme 1: Coordinate-Frame Hypothesis for tau_y/z Gap (HIGHEST PRIORITY)
+**Root question:** Is the 4× tau_y/z error a coordinate-frame problem? AB-UPT achieves equal error on tau_x/y/z (~3.6) while we have 10/14/15. The asymmetry exists in our model but not in AB-UPT.
 
-### Theme 2: Convergence / Architecture scaling
-Epoch budget is tight (~3-4 epochs). Depth beats width. 8L/256d was time-limited.
-- #164 alphonse — 8L/256d + 1cycle LR (super-convergence to beat 10.69 within budget)
-- #165 chihiro — mlp_ratio=8 + stability hardening (seed + warmup)
-- #170 gilbert — 384d width + QK-norm + fp32 attention (stability for width scale-up)
-- #125 haku (in flight) — 1cycle LR max=1e-3
+- **#199 stark (NEW):** Full tangent-frame prediction (smooth e_x-projection frame). Addresses Morgan's #1 directive. Different from PR #121 (Duff ONB discontinuity) — uses continuous frame with fallback at poles.
+- **#168 askeladd:** Normal-consistency penalty (soft tangentiality constraint from the other direction)
+- **#200 emma (NEW):** Magnitude/direction decomposition loss — separate log-mag and cosine-direction losses to decouple scale from alignment learning
+- **#192 tanjiro:** asinh normalization applied specifically to y/z channels
 
-### Theme 3: Optimizer stability
-Pervasive Round-5 divergences motivate systematic optimizer investigation.
-- #172 stark — AdamW eps sweep (1e-8/7/6/5, maps denominator floor effect)
-- #169 thorfinn — NaN-skip + seed + LR warmup utility PR (infra for all future experiments)
-- #144 edward (in flight) — AdamW beta2 sweep (0.95 vs 0.999)
+### Theme 2: Target Representation for Heavy-Tail Distributions
+- **#123 frieren (near completion):** PARTIAL RESULT — asinh-1.0 is NEGATIVE (suppresses tail learning signal). log1p (arm D) and asinh-0.5 (arm B) still viable; final results ~12:10-13:51 UTC.
+- **Key finding:** Cannot suppress tail to gain stability — the gap lives in the tail. Need a way to handle heavy-tailed targets WITHOUT compression.
 
-### Theme 4: Post-training / test-time gain + generalization
-- #171 norman — snapshot ensemble with cyclic LR (free gain from averaging 3 cycle ckpts)
-- #155 armin (in flight) — top-3 checkpoint ensemble
-- #185 emma — **SAM optimizer ρ=0.05/0.10** (Sharpness-Aware Minimization; targets val→test gap of 1.04pp; wraps AdamW with perturbation step)
+### Theme 3: Optimizer Stability Infrastructure (CONFIRMED FLEET-WIDE GAP)
+**Four independent confirmations (frieren #123, fern #183, askeladd #168, chihiro #165):** PR #169's NaN-skip only catches non-finite gradients. Large-but-finite spikes (165, 252, 2.2M) bypass it, corrupt Adam m/v after clipping.
+- Needed: magnitude-based grad-skip (pre_clip_norm > N × running_median, or abs threshold)
+- Also needed: finite-but-pathological loss guard (abort if train_loss > 5× running_median for sustained steps)
+- **This should be an infrastructure PR** — candidate to assign to the next available thorfinn/infra-capable student
 
-### Theme 5: Data representation and augmentation
-- #183 fern (newly assigned) — **omega-bank frequency sweep** (max_wavelength sweep + per-axis omega banks); follow-up to falsified #143 coord-normalization
-- #184 kohaku (newly assigned) — **FiLM with identity/zero-init** (DiT-style); follow-up to falsified #126 vanilla-init FiLM, preserving the volume-pressure signal Arm 3 found
-- #151 nezuko (in flight) — L/R symmetry augmentation
-- #152 violet (in flight) — analytic geometry moment conditioning (14-dim)
+### Theme 4: FiLM Geometry Conditioning (Near Complete)
+- **#184 kohaku:** FiLM stability characterized. 5/5 at lr=5e-4 dead regardless of init_scale. Stability axis is lr alone. Arm B (lr=4e-4) sole survivor, completing ~14:25 UTC.
+- **Key finding:** FiLM requires lr ≤ 4e-4, which may conflict with the lr=5e-4 optimum. The volume_pressure signal from PR #126 Arm-3 (vp=7.05 vs 7.85 baseline) is real — FiLM may still help volume even if it can't close the tau_y/z gap.
+
+### Theme 5: Training Budget Efficiency
+- **#171 norman:** Snapshot ensemble with cyclic LR. V1 diverged at epoch 3 (50× LR jump); V2 has 10× ratio + clip=0.5, running cleanly, ETA ~17:30 UTC.
+- **#196 edward:** Lion optimizer (round 12) — Lion typically needs ~3× lower LR than AdamW
+- **#198 senku:** SWA — free post-train gain from averaging model weights across last epochs
+- **#197 gilbert:** k-NN local attention — addresses spatial locality for tau_y/z
+
+### Theme 6: Architecture Exploration (Round 12)
+- **#191 haku:** 1cycle LR (corrected — calibrated to actual epoch budget)
+- **#164 alphonse:** 8L/256d depth with 1cycle (time-limited recovery — must beat PR #144 ep4 val=12.69)
+
+---
 
 ## Key Structural Findings Accumulated
 
-- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M) in param efficiency. 8L/256d promising but time-limited.
-- **Adam m/v coupling:** Mid-run weight schedule changes (curriculum, EMA warmup) cause second-moment desynchronization. Always initialize Adam with the training-time weights.
-- **Uniform surface_sw is the wrong knob:** Amplifies already-upweighted W_y/W_z. Per-component --wallshear-y/z-weight is correct.
-- **384d in bf16 is unstable:** d_head=96 causes pre-softmax logit variance overflow. QK-norm or fp32 attention required.
-- **logmag transform gradient:** gradient of sign(x)*log1p(|x|/eps) is ~1/eps near 0; eps≤0.10 caused 2M+ pre_clip_norm.
-- **Duff ONB discontinuity:** Branchless ONB has sign-flip discontinuity incompatible with non-gauge-equivariant Transolver.
-- **Δp≈0 is wrong RANS physics:** Laplacian pressure constraint only valid for Stokes (creeping) flow.
-- **Volume pressure nearly converged:** 1.3× AB-UPT at baseline — wall_shear_y/z is the main gap.
-- **LR warmup guards:** 500-1000 step linear warmup from 1e-5 is now standard practice for experiments with elevated initial gradients.
-- **Multi-scale hierarchy failed (PR #150, closed 2026-05-01):** 2-scale arm stable but all primary metrics worse than baseline; 3-scale both diverged. Volume_pressure ~12% better on val but not the primary metric. Multi-scale spatial receptive field is not the lever for tau_y/z gap.
-- **Coord-norm is the wrong lever (PR #143):** The 4× tau_y/z gap is NOT primarily a sincos-anisotropy problem. `global-scale` normalization breaks the meter-calibrated `omega` bank (e1 abupt 24.85 vs control 16.20); `per-axis` causes volume-token explosions through the bias→attention path. Right next attack is the omega bank itself, in physical-meter coords (PR #183).
-- **FiLM at default-init × LR ≥ 3e-4 is unstable (PR #126):** Geom token is fine (norm steady ~0.75), but `to_gamma_beta` linear projections are the gradient amplification path (layer-0 grad/param ratio 0.567 at divergence). Volume-pressure signal real (Arm 3 vp=7.05 vs baseline 7.85) → identity-init follow-up justified (PR #184).
+### Stability
+- **Fleet-wide instability mechanism (CONFIRMED):** Large-but-finite grad spikes bypass PR #169's NaN-skip. clip_grad_norm=1.0 normalizes direction but preserves poison vector → Adam m/v corruption. Fix needed: magnitude-based skip.
+- **FiLM stability axis is LR, not init_scale:** scale=0.001 delays divergence 6× vs scale=1.0 but cannot prevent it at lr=5e-4. lr=4e-4 is the stability boundary.
+- **mw=100 (omega-bank) structurally untenable:** 3 independent attempts all diverged. Low max_wavelength → highly compressed Fourier features → fragile at lr=5e-4.
+- **LR ceiling at ~6.5e-4:** OneCycleLR peaks ≥ 6.5e-4 diverge regardless of warmup schedule.
+- **W_y=W_z > 2.0 overfits tau_y/z:** W=3 (PR #66) scores 13.18 vs 12.74 for W=2. Static W=2 is the sweet spot.
+
+### Target Representation
+- **asinh-1.0 trades metric for stability (frieren #123):** Suppresses gradient explosions by compressing the tail, but the gap to AB-UPT lives in the tail. Stability ≠ metric improvement.
+- **Heavy-tail is real:** Wall shear spans 4 decades. The tail (high-|τ| separation regions) dominates the rel_L2 numerator AND denominator. Compression hurts.
+
+### Architecture
+- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M). 8L/256d time-limited but promising.
+- **Multi-scale hierarchy failed (PR #150):** Receptive field is not the lever for tau_y/z gap.
+- **384d in bf16 is unstable:** QK-norm + fp32 attention required (PR #170 gilbert testing).
+
+### Loss/Data Representation
+- **Per-axis wallshear upweighting:** W_y=W_z=2 is optimal (PR #66). W=3+ overfits, W=1.5- underdirects.
+- **Normal-consistency λ ranking inversion:** λ=0.10 most stable, λ=0.01 most unstable — larger constraint enforces stronger out-of-plane avoidance, bounding the squared-dot spike.
+- **Tangent-frame prediction (Duff ONB):** Discontinuous at t1.x sign-flip → incompatible with non-gauge-equivariant Transolver. Use smooth e_x-projection frame instead.
+- **Coord-normalization wrong lever (PR #143):** global-scale breaks meter-calibrated omega bank; per-axis causes volume-token explosions.
+
+### Optimizer
+- **EMA m/v desynchronization:** Mid-run schedule changes → second-moment coupling issues. Start Adam with training-time weights.
+- **Uniform surface_sw amplifies already-upweighted channels.** Per-component weight is the right knob.
+
+---
+
+## Near-Term Priority Queue
+
+1. **Await and merge #184 (kohaku FiLM, arm B) ~14:25 UTC** — if val_abupt < 10.69
+2. **Review #123 (frieren) final results ~12:10-13:51 UTC** — close based on best arm
+3. **Monitor #165 (chihiro)** — seed42 go/no-go at step 6783 (~12:20 UTC)
+4. **Review #183 (fern)** — cross-arm ep2 table at ~12:30 UTC
+5. **Infrastructure PR** — magnitude-based grad-skip (assign to thorfinn when free)
+6. **Perceiver-IO backbone** (Morgan's #2 directive) — not yet assigned; needs careful scoping
+7. **Physics-informed RANS** (Morgan's #4 directive) — not yet assigned
+
+---
 
 ## Key Constraints
 - Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)
-- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses ~75 GB; 384d requires bs=4
-- Gradient clipping: clip_grad_norm=1.0 is standard
-- Students have 4 GPUs each (DDP available for large architectures)
+- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses ~75 GB
+- Gradient clipping: clip_grad_norm=1.0 standard; clip=0.5 used for stability-sensitive experiments
+- LR warmup: 500 steps (1e-5 start) now standard for experiments with elevated initial gradients
+- Students have 4 GPUs each

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -94,20 +94,26 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 ## Round 1 — reviewed results (2026-04-29)
 
-### MERGED — first yi baseline established
+### MERGED — yi baseline progression
 
-- **PR #11 (kohaku, tangential wall-shear projection) MERGED.**
-  `test_primary/abupt_axis_mean = 35.12` — ~46% better than nearest
-  comparator (norman 64.66). Run `uy0ds6iz`, 1 epoch only (pre-fix), state=finished.
-  All future PRs measured against this baseline.
-  - kohaku correctly deviated from the PR pseudocode (denormalize → project →
-    renormalize), since per-axis stds are non-uniform.
-  - Diagnostic `train/wallshear_pred_normal_rms` exposed predicted normal
-    component growing 2.4× during 1 epoch — the regularization gap.
+- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED 03:57 UTC — new yi best.**
+  `abupt_axis_mean = 17.39` (vs prior 35.12 = 50.5% reduction). Wall-shear
+  axes -50% to -70%. Surface pressure +1pp. Run A `y2gigs61`, state=finished,
+  6 epochs reached, best_epoch=3. PR was CLI-flag-only (no code diff).
+  Win came primarily from **protocol fixes** (bs=8, validation-every=1,
+  gradient-log-every=100), not from vol_w (which is at worst neutral).
+  - **Infrastructure bug flagged:** `train.py` has no gradient clipping.
+    Multiple Round-1 PRs diverged on this mechanism (chihiro, emma, fern,
+    haku, gilbert run B). Follow-up PR #22 (gilbert) adds it.
+- **PR #11 (kohaku, tangential wall-shear projection) — MERGED earlier,
+  superseded as baseline by PR #9.** Code remains on yi (default off);
+  expected to compose with gilbert's config for further gains.
 - **Follow-up PR #21 (kohaku, normal-component suppression sweep)** —
   λ ∈ {0.0, 0.01, 0.1, 1.0} of `λ * mean((ws_pred · n_hat)^2)` on top of
-  projection. λ=0 arm is the first multi-epoch projection run (with timeout
-  fix + validation-every 1).
+  projection.
+- **Follow-up PR #22 (gilbert, gradient clipping)** — adds
+  `torch.nn.utils.clip_grad_norm_` + 4-arm sweep. Infrastructure win
+  blocking high-LR / high-weight / high-batch sweeps.
 
 ### CLOSED
 
@@ -125,12 +131,15 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 ### Cross-cutting directives broadcast to all active PRs
 
 1. Rebase onto `yi` to pick up `af92e9a` + projection code (default off).
-2. `--validation-every 1` (or 2) — `validation_every=10` only gives one usable
-   checkpoint inside the 6 h budget.
-3. `--gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms` (Issue #19).
-4. Wall-shear targeted PRs (haku #10, tanjiro #15, thorfinn #16) should
+2. **New recommended base config (PR #9 winner):**
+   `--volume-loss-weight 2.0 --batch-size 8 --validation-every 1
+    --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms`
+3. Wall-shear targeted PRs (haku #10, tanjiro #15, thorfinn #16) should
    compose with `--use-tangential-wallshear-loss` so their delta stacks on
    the merged baseline.
+4. **Training-stability bug flagged:** until PR #22 lands gradient clipping,
+   sudden train-loss spikes followed by best_epoch lock-in are the bug, not
+   the hypothesis.
 5. Report any train→val divergence observed.
 
 ### Open question

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,119 +1,148 @@
 # SENPAI Research State
-- 2026-04-30 15:25 UTC (Round-3 running, Round-4 first assignment)
+- 2026-04-30 (Round-5 bold experiments fanning out — all 14 yi students running)
 
 ## Most Recent Research Direction from Human Researcher Team
 
-From Issue #18 (open):
-- Use ALL W&B logged metrics — gradient norms, weight histograms, loss slope — not just final val loss
-- Flag epoch-limited runs (still on a downward trajectory at the epoch cap) as promising, not closed
-- Differentiate failure modes: flat/diverging gradients early = fundamental; healthy slope at cutoff = epoch-limited
-- Prioritize convergence speed in new hypotheses (warmup schedules, better init, fast-converging architectures)
-- Bold architecture changes permitted — students may completely replace the model backbone as long as logging/validation/checkpointing are preserved
-- Scan noam and radford branches for prior techniques and inspiration
-- Use gradient norms, weight histograms, loss slopes to identify epoch-limited runs for follow-up
+From Issue #18 (open, Morgan — latest message 2026-04-30T20:29:19Z):
 
-## Current Research Focus and Themes
+**Overarching directive:** Stop incremental tuning. Rip out the model architecture and try completely new approaches. Students can handle radical departures from the reference train.py as long as logging/validation/checkpointing are maintained.
 
-### Yi Best: 12.74 abupt (PR #66, thorfinn per-axis tau_y/z W_y=W_z=2, 2026-04-30)
+**Round-5 bold experiment priorities (Morgan's ordered list by impact):**
+1. **Surface-tangent frame wall-shear prediction** — The 4× wall shear y/z error is a coordinate frame mismatch, not a hyperparameter problem. Predict tau in local surface-tangent frame (tau_normal=0, tau_t1, tau_t2), rotate back to global. Requires per-point surface normal computation + rotation head.
+2. **Perceiver-IO backbone replacement** — Replace Transolver entirely. Perceiver-IO uses learned latent queries for unstructured CFD meshes, ~3× faster per epoch = more epochs within budget.
+3. **asinh/log target normalization** — Wall shear spans 4 decades. Predict asinh(tau) to fix MSE over-weighting high-magnitude patches. 10-line change but changes the loss landscape entirely.
+4. **Physics-informed RANS constraint** — Add soft divergence-free penalty (∇·u=0) on predicted velocity at volume points. Pure loss change, no architecture touch.
+5. **1-cycle LR schedule with higher peak** — Warmup to 1e-3, cosine decay to 1e-6, ~20% warmup of total steps. Fern's lr=5e-4 was still converging at epoch cutoff.
 
-**Baseline config (PR #66 winning arm, W&B run gvigs86q):**
-```
-6L/256d/4h, lr=2e-4, ema-decay-start=0.99/end=0.9999, vol_w=2.0, bs=8, clip=1.0,
-wallshear-y-weight=2.0, wallshear-z-weight=2.0
-```
+**Additional guidance from Morgan:**
+- Use W&B gradient norms, weight histograms, and loss slopes to identify epoch-limited runs (healthy slope at cutoff = still converging, worth follow-up)
+- Before finalizing hypotheses, scan PRs from `noam` and `radford` branches for prior art inspiration
+- Gradient metric failure flags: spikes >10 or flat <0.01 = fundamental failure; healthy slope at cutoff = epoch-limited
 
-**Compounding wins on yi:**
+**Advisor status:** All 5 Morgan directives are actively running (PRs #121–125). Additional complementary Round-5 experiments also in flight (#126–132).
+
+## Current Baseline: PR #99 (fern) — abupt 10.69 — 2026-04-29
+
+**Compounded wins on `yi` so far:**
 1. PR #11 kohaku — tangential wall-shear projection loss code
 2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
 3. PR #4 chihiro — width scale-up to 512d/8h
-4. PR #14 senku — depth scale-up to 6L/256d (21% gain)
+4. PR #14 senku — depth scale-up to 6L/256d (21% improvement: 16.64 → 13.15)
 5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
-6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=W_z=2 (3.1% gain)
+6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=2, W_z=2 (3.1%: 13.15 → 12.74)
+7. PR #99 fern — LR peak 5e-4 (16.1%: 12.74 → 10.69)
 
-**Distance to AB-UPT (current best, PR #66):**
+**Current best metrics (PR #99, W&B run `3hljb0mg`):**
 
 | Metric | yi best | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 7.64 | 3.82 | 2.0x |
-| wall_shear | 12.86 | 7.29 | 1.8x |
-| volume_pressure | 13.14 | 6.08 | 2.2x |
-| wall_shear_x | 11.29 | 5.35 | 2.1x |
-| wall_shear_y | 15.15 | 3.65 | 4.2x |
-| wall_shear_z | 15.05 | 3.63 | 4.1x |
+| `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
+| `surface_pressure_rel_l2_pct` | **6.97** | 3.82 | 1.8× |
+| `wall_shear_rel_l2_pct` | **11.69** | 7.29 | 1.6× |
+| `volume_pressure_rel_l2_pct` | **7.85** | 6.08 | 1.3× |
+| `wall_shear_x_rel_l2_pct` | **10.17** | 5.35 | 1.9× |
+| `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | 3.8× |
+| `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | 4.1× |
 
-**Key diagnostic findings:**
-- Volume pressure val→test gap: val ~6.9 (≈AB-UPT) vs test 13.14 — overfitting not capacity
-- Wall-shear y/z (~4x AB-UPT) remain the largest gap; per-axis upweighting helps but not enough
-- Epoch-limited: baseline trajectory 22.78→15.89→13.30→12.36 still descending at epoch 4
-- FiLM on 6L: 12.905 abupt (norman PR #62 run phfo03pc) — beat old baseline but not new 12.74
+**Key structural observations:**
+- Depth (6L/256d, 4.73M params) is far more parameter-efficient than width (4L/512d, 12.7M params)
+- Wall_shear_y and wall_shear_z remain the largest gaps (~4× AB-UPT) despite thorfinn's 2× upweighting + fern's lr boost
+- Volume pressure gap almost closed (1.3× AB-UPT) — sp and ws_x are next priority
+- LR=5e-4 at 5× base dramatically accelerated convergence within epoch budget
+- Both 5L and 6L runs were still descending at timeout — epoch budget is tight
 
-## Active WIP PRs (Round-3 — running)
+**Standard base config (PR #99 winning arm):**
+```bash
+python train.py \
+  --volume-loss-weight 2.0 --batch-size 8 --validation-every 1 \
+  --lr 5e-4 --weight-decay 5e-4 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --model-layers 6 --model-hidden-dim 256 --model-heads 4 --model-slices 128 \
+  --ema-decay 0.9995 --clip-grad-norm 1.0 \
+  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
+  --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
+```
 
-| PR | Student | Hypothesis |
-|---|---|---|
-| #107 | violet | vol_w decay schedule (4→1.5, 3→1.5) |
-| #106 | thorfinn | Finer tau_y/z weight sweep (2.0/2.5/3.0 + asym) |
-| #105 | tanjiro | Huber surface loss (delta=0.05/0.10) |
-| #104 | senku | EMA decay sweep (0.999/0.9995/0.9997/0.9999) |
-| #103 | kohaku | vol→surf cross-attention for volume pressure |
-| #102 | haku | Attention dropout sweep (0/0.05/0.10/0.20) |
-| #101 | gilbert | Larger point budget 131072 vs 65536 |
-| #100 | frieren | cp-channel upweight (1.5/2.0/3.0) + tau_y/z=2 |
-| #99 | fern | LR peak sweep (1e-4/2e-4/3e-4/5e-4) on thorfinn base |
-| #98 | emma | Weight-decay sweep (1e-4/5e-4/2e-3/5e-3) |
-| #97 | edward | Slice-count sweep 128→192→256 |
-| #96 | chihiro | MLP-ratio sweep (4 vs 6 vs 8) |
-| #95 | alphonse | Area-weighted surface MSE loss |
+## Active WIP PRs (experiments in flight on PR #99 baseline)
 
-## Active WIP PRs (Older — action needed)
-
-| PR | Student | Hypothesis | Status |
+### Round-4 incremental PRs
+| PR | Student | Branch | Hypothesis |
 |---|---|---|---|
-| #62 | norman | FiLM conditioning on 6L | Needs rebase; advisor gave feedback to rebase + compose with tau_y/z=2 base |
-| #63 | askeladd | Squared rel-L2 aux loss on 6L | WIP, Round-2 |
+| #116 | fern | `fern/wallshear-axis-upweight-sweep` | Higher tau_y/z weights on lr=5e-4 base |
+| #117 | alphonse | `alphonse/width-384d-sweep` | 6L/384d width expansion test |
+| #118 | chihiro | `chihiro/mlp-ratio-sweep-r4` | MLP-ratio sweep on PR #99 base |
+| #119 | edward | `edward/rff-coordinate-encoding` | Random Fourier Feature coordinate encoding |
 
-## Round-4 Assignments
+### Round-5 bold PRs (Morgan Issue #18 directives + complementary explorations)
+| PR | Student | Branch | Hypothesis |
+|---|---|---|---|
+| #121 | askeladd | `askeladd/surface-tangent-frame-wallshear` | Predict tau in local {t1, t2, n} frame, rotate back |
+| #122 | emma | `emma/perceiver-io-backbone` | Perceiver-IO backbone replacing Transolver |
+| #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
+| #124 | gilbert | `gilbert/rans-divergence-constraint` | Soft div(u)=0 RANS penalty on volume points |
+| #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR with max=1e-3 peak |
+| #126 | kohaku | `kohaku/film-conditioning-6l-256d` | FiLM geometry conditioning on PR #99 base |
+| #127 | nezuko | `nezuko/stochastic-depth-regularization` | Stochastic-depth sweep (0.05/0.1/0.2) |
+| #128 | norman | `norman/ema-decay-warmup-schedule` | EMA decay warmup schedule (0.99 -> 0.9999) |
+| #129 | senku | `senku/surface-loss-upweight-sweep` | Surface loss weight sweep (1.5/2.0/3.0) |
+| #130 | tanjiro | `tanjiro/curriculum-tau-yz-weighting` | Curriculum tau_y/z weighting (start=1, ramp to 3-4) |
+| #131 | thorfinn | `thorfinn/log-magnitude-wallshear-targets` | Log-magnitude wall-shear target normalization |
+| #132 | violet | `violet/wallshear-magnitude-direction-decoupled` | Decoupled |tau| + direction (cosine loss) heads |
 
-| PR | Student | Hypothesis |
-|---|---|---|
-| #108 | nezuko | Point-cloud xyz jitter augmentation sigma sweep (0/0.001/0.003/0.005) |
+## Current Research Themes
 
-## Closed / Resolved This Session
+### Theme 1: Closing wall_shear_y/z gap (4× AB-UPT — HIGHEST PRIORITY)
+The single biggest lever still not pulled: **why do y/z shear components fail 4× harder than AB-UPT?**
+- #116 fern — higher tau_y/z weights on new lr=5e-4 base
+- #121 askeladd — surface-tangent frame prediction (Morgan #1 priority — coord frame mismatch hypothesis)
+- #130 tanjiro — curriculum tau_y/z weighting (start=1, ramp to 3-4)
+- #132 violet — decoupled |tau| + direction (cosine loss) heads
 
-| PR | Reason |
-|---|---|
-| #67 | kafka LR warmup — stale orphan, no kafka pod, superseded by PR #99 (fern LR sweep) |
+### Theme 2: Convergence speed within epoch budget
+Epoch budget is tight (~3-4 epochs). Every schedule/LR decision matters hugely.
+- #99 fern (merged) — lr=5e-4 gave 16.1% win; 5× acceleration effect
+- #125 haku — 1cycle LR max=1e-3 (Morgan #5 priority — warmup to 1e-3, cosine anneal to 1e-6)
+- #128 norman — EMA decay warmup schedule (0.99 → 0.9999 over training)
 
-## Potential Next Research Directions
+### Theme 3: Architecture — Backbone replacement and variants
+Currently on 6L/256d Transolver. Bold replacement being tested.
+- #117 alphonse — 6L/384d width expansion
+- #118 chihiro — MLP ratio sweep (6/8)
+- #119 edward — RFF coordinate encoding
+- #122 emma — Perceiver-IO backbone replacing Transolver (Morgan #2 priority — 3× faster per epoch)
+- #126 kohaku — FiLM geometry conditioning on PR #99 6L/256d base
 
-### Priority 1: Generalization — close the val→test gap (biggest leverage remaining)
-- Point cloud jitter augmentation (nezuko PR #108, just assigned) — sigma sweep on 6L base
-- FiLM on 6L with thorfinn base — norman PR #62 needs rebase; FiLM showed 12.905 vs old baseline 13.15; if it beats new 12.74 it merges
-- Surface-volume consistency aux loss (enforce p_s = p_v at SDF~0) — not yet assigned
-- SAM optimizer (Sharpness-Aware Minimization) — explicitly targets flat minima / generalization
+### Theme 4: Target normalization
+Wall shear spans 4 decades of magnitude. MSE on raw values over-weights large signals.
+- #123 frieren — asinh/log wall-shear target normalization (Morgan #3 priority)
+- #131 thorfinn — log-magnitude wall-shear target normalization (complementary approach)
 
-### Priority 2: Bold architecture changes (human team directive)
-- Separate surface/volume backbone branches — specialized per modality
-- Multi-scale point cloud attention (PointTransformer-style setabstraction)
-- Mixture-of-Experts routing per surface region (wheel arch vs roof vs underbody)
+### Theme 5: Physics-informed constraints and loss engineering
+- #124 gilbert — RANS div(u)=0 penalty on volume points (Morgan #4 priority)
+- #129 senku — surface loss weight sweep (1.5/2.0/3.0)
+- #127 nezuko — stochastic depth regularization sweep
 
-### Priority 3: Wall-shear y/z targeted attacks (4x AB-UPT gap)
-- Finer tau_y/z sweep (thorfinn PR #106 running)
-- Asymmetric tau weights (harder axes upweighted more aggressively)
-- Physics-aware: divergence-free constraint on wall-shear (not yet tried)
-- Bernoulli-consistency loss in potential flow regions
-
-### Priority 4: Composition after Round-3 resolves
-- Best loss weights + best EMA decay + best LR + jitter on 6L (wait for winners first)
-- FiLM + tau_y/z + best lr/ema composition
-
-### Priority 5: Epoch-limited revisits (from human team issue #18 directive)
-- Flag any Round-3 run with downward slope at epoch limit as a candidate for longer run
-- Currently: baseline 6L was still descending at epoch 4 (12.36 partial) — 6L with more time is high-value
+## Closed Dead Ends (prior architecture experiments)
+- SE(3) equivariant coordinates (#25, #28) — CLOSED: didn't converge, gradient collapse
+- ANP cross-attention decoder (#26, #35) — CLOSED: unstable, no improvement
+- Mamba-2 SSM decoder (#45) — CLOSED: unstable, diverged
+- SDF-gated volume attention (#15, #36) — CLOSED: no improvement vs vanilla
+- AdaLN FiLM (#34) — CLOSED: marginal, superseded by FiLM on 6L (#62 pending)
+- Area-weighted loss v1 (#7, #17) — CLOSED: area-weighted non-viable on prior baselines; retesting on PR #99 base (#95)
 
 ## Key Constraints
-- Training budget: ~270 min training + ~90 min val/test = 360 min total
+- Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)
 - VRAM: 96 GB per GPU; 6L/256d at bs=8 uses 75.5 GB
 - Epoch budget: ~3-4 epochs at 6L/256d throughput (~2.1 it/s)
-- Gradient clipping: clip_grad_norm=1.0 is standard
-- Single-delta principle: one change per PR; bundle only when compound effect is the hypothesis
+- Gradient clipping: clip_grad_norm=1.0 is standard (anything without it is unstable)
+- Students have 4 GPUs each (but run single-GPU experiments; DDP available for bold architecture tests)
+
+## Next Research Directions (Round-5 Priorities)
+
+1. **Surface-tangent frame wall-shear prediction** — predict tau in local geometric frame, rotate back; directly targets 4× wsy/wsz gap
+2. **Perceiver-IO backbone** — replace Transolver; faster per-epoch enables more epochs within budget
+3. **asinh/log target normalization** — normalize wall shear before loss; heavy-tail problem hypothesis
+4. **1cycle LR with higher peak** (1e-3 max) — squeeze more convergence from limited epochs
+5. **Physics-informed RANS constraint** — div-free volume pressure soft penalty
+6. **Curriculum tau_y/z weighting** — start at W_y=W_z=1, ramp to 3-4 over training

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -4,13 +4,24 @@
 - **Branch:** `yi`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B:** `wandb-applied-ai-team/senpai-v1-drivaerml`
-- **Most recent direction from human team:** none received
+- **Most recent direction from human team:** 2026-04-28 — morganmcg1 (Issue #18)
+
+## Key directives from human research team (Issue #18, 2026-04-28)
+
+1. **Be bolder with architecture changes.** Don't be afraid to completely replace the model backbone. Students can handle radical departures from the reference `train.py` as long as logging, validation, and checkpointing are maintained.
+2. **Cross-branch inspiration.** Before finalizing new hypothesis assignments, scan PRs from the `noam` and `radford` branches in wandb/senpai for prior art on similar techniques — useful for refinement ideas even if the dataset context differs. Similar work on a different dataset is *not* a reason to skip an idea.
+3. **Empower students.** Frame assignments to give students the latitude to make big changes rather than conservative tweaks. Trust students to make great leaps.
 
 ## Current research focus
 
 Round 1 calibration on a clean slate. The W&B project has zero prior runs and
 `yi` has no merged baseline; the first wave must both establish a strong baseline
 and surface the strongest single-delta improvements over it.
+
+Next wave will prioritize **bold architectural ideas**: completely new model
+backbones, transformer variants, neural operators, equivariant architectures —
+not incremental tuning. Reference `noam` and `radford` branches before
+finalizing hypotheses to avoid duplicating work and to draw inspiration.
 
 ## Known prior art (from outside the `yi` W&B project)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-04-29 (Round-2 assignments complete)
+- 2026-04-30 15:25 UTC (Round-3 running, Round-4 first assignment)
 
 ## Most Recent Research Direction from Human Researcher Team
 
@@ -8,94 +8,112 @@ From Issue #18 (open):
 - Flag epoch-limited runs (still on a downward trajectory at the epoch cap) as promising, not closed
 - Differentiate failure modes: flat/diverging gradients early = fundamental; healthy slope at cutoff = epoch-limited
 - Prioritize convergence speed in new hypotheses (warmup schedules, better init, fast-converging architectures)
+- Bold architecture changes permitted — students may completely replace the model backbone as long as logging/validation/checkpointing are preserved
+- Scan noam and radford branches for prior techniques and inspiration
+- Use gradient norms, weight histograms, loss slopes to identify epoch-limited runs for follow-up
 
 ## Current Research Focus and Themes
 
-### Yi Best: 13.15 abupt (PR #14, senku 6L/256d, 2026-04-29)
+### Yi Best: 12.74 abupt (PR #66, thorfinn per-axis tau_y/z W_y=W_z=2, 2026-04-30)
 
-**Breakthrough:** Depth is more parameter-efficient than width at this scale.
-6L/256d (4.73M params) crushed 4L/512d (12.7M params) by 21%. Both 5L and 6L
-were still descending at timeout — significant untapped improvement available with
-longer training.
+**Baseline config (PR #66 winning arm, W&B run gvigs86q):**
+```
+6L/256d/4h, lr=2e-4, ema-decay-start=0.99/end=0.9999, vol_w=2.0, bs=8, clip=1.0,
+wallshear-y-weight=2.0, wallshear-z-weight=2.0
+```
 
-**Key findings from Round-1/2 reviews:**
-1. Depth scaling law: 4L→5L = −18.7%, 5L→6L = −2.7% (diminishing returns, but 7L/8L not yet tested)
-2. Cosine EMA (PR #13) adds 9% orthogonally — now standard on yi
-3. Gradient clipping clip=1.0 is now standard and essential for stability at 6L
-4. FiLM geometry conditioning: 46% relative improvement at 1 epoch on 4L (frieren PR #8 pending rebase)
-5. Volume pressure shows val→test gap (6.93 val ≈ AB-UPT, 13.58 test = 2×) — generalization problem
-6. Wall-shear y/z remain the largest gap (4.4-4.6× AB-UPT) despite 60-70% improvement from Round-1 start
+**Compounding wins on yi:**
+1. PR #11 kohaku — tangential wall-shear projection loss code
+2. PR #9 gilbert — protocol fixes (bs=8, vol_w=2.0, validation-every=1)
+3. PR #4 chihiro — width scale-up to 512d/8h
+4. PR #14 senku — depth scale-up to 6L/256d (21% gain)
+5. PR #58 alphonse — NaN-safe checkpoint guard (bugfix)
+6. PR #66 thorfinn — per-axis tau_y/z loss upweighting W_y=W_z=2 (3.1% gain)
 
-**Distance to AB-UPT (current best):**
+**Distance to AB-UPT (current best, PR #66):**
 
 | Metric | yi best | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| surface_pressure | 7.64 | 3.82 | 2.0× |
-| wall_shear | 13.47 | 7.29 | 1.8× |
-| volume_pressure | 13.58 | 6.08 | 2.2× |
-| wall_shear_x | 11.53 | 5.35 | 2.2× |
-| wall_shear_y | 16.23 | 3.65 | 4.4× |
-| wall_shear_z | 16.75 | 3.63 | 4.6× |
+| surface_pressure | 7.64 | 3.82 | 2.0x |
+| wall_shear | 12.86 | 7.29 | 1.8x |
+| volume_pressure | 13.14 | 6.08 | 2.2x |
+| wall_shear_x | 11.29 | 5.35 | 2.1x |
+| wall_shear_y | 15.15 | 3.65 | 4.2x |
+| wall_shear_z | 15.05 | 3.63 | 4.1x |
 
-## Active WIP PRs (Round-2)
+**Key diagnostic findings:**
+- Volume pressure val→test gap: val ~6.9 (≈AB-UPT) vs test 13.14 — overfitting not capacity
+- Wall-shear y/z (~4x AB-UPT) remain the largest gap; per-axis upweighting helps but not enough
+- Epoch-limited: baseline trajectory 22.78→15.89→13.30→12.36 still descending at epoch 4
+- FiLM on 6L: 12.905 abupt (norman PR #62 run phfo03pc) — beat old baseline but not new 12.74
+
+## Active WIP PRs (Round-3 — running)
 
 | PR | Student | Hypothesis |
 |---|---|---|
-| #58 | alphonse | NaN checkpoint guard bugfix (correctness) |
-| #59 | senku | 7L/8L depth sweep beyond 6L win |
-| #60 | chihiro | 6L/512d depth × width composition |
-| #61 | gilbert | Tangential wall-shear projection on 6L |
-| #62 | norman | FiLM geometry conditioning on 6L |
-| #63 | askeladd | Squared rel-L2 aux loss on 6L (w∈{0.1,0.5,1.0}) |
-| #64 | fern | Stochastic depth regularization (p∈{0.05,0.1,0.2}) |
-| #65 | violet | Volume loss weight sweep (1.5/2.0/3.0/4.0) |
-| #66 | thorfinn | Per-axis tau_y/z loss upweighting |
-| #67 | kafka | LR warmup + cosine decay schedule |
-| #21 | kohaku | Normal-suppression rerun on 6L (WIP — sent back) |
-| #15 | tanjiro | SDF-gated volume attention (sigma=0.005, sent back) |
+| #107 | violet | vol_w decay schedule (4→1.5, 3→1.5) |
+| #106 | thorfinn | Finer tau_y/z weight sweep (2.0/2.5/3.0 + asym) |
+| #105 | tanjiro | Huber surface loss (delta=0.05/0.10) |
+| #104 | senku | EMA decay sweep (0.999/0.9995/0.9997/0.9999) |
+| #103 | kohaku | vol→surf cross-attention for volume pressure |
+| #102 | haku | Attention dropout sweep (0/0.05/0.10/0.20) |
+| #101 | gilbert | Larger point budget 131072 vs 65536 |
+| #100 | frieren | cp-channel upweight (1.5/2.0/3.0) + tau_y/z=2 |
+| #99 | fern | LR peak sweep (1e-4/2e-4/3e-4/5e-4) on thorfinn base |
+| #98 | emma | Weight-decay sweep (1e-4/5e-4/2e-3/5e-3) |
+| #97 | edward | Slice-count sweep 128→192→256 |
+| #96 | chihiro | MLP-ratio sweep (4 vs 6 vs 8) |
+| #95 | alphonse | Area-weighted surface MSE loss |
 
-## Pending Code Merges
+## Active WIP PRs (Older — action needed)
 
-| PR | Student | Code | Status |
+| PR | Student | Hypothesis | Status |
 |---|---|---|---|
-| #8 | frieren | FiLM geometry conditioning code | Needs rebase |
-| #24 | emma | Squared rel-L2 aux loss code | Needs rebase |
-| #28 | norman | SE(3) local-frame features (A02) | Draft, no-status |
-| #23 | frieren | FiLM+projection+protocol composition | Draft, no-status |
+| #62 | norman | FiLM conditioning on 6L | Needs rebase; advisor gave feedback to rebase + compose with tau_y/z=2 base |
+| #63 | askeladd | Squared rel-L2 aux loss on 6L | WIP, Round-2 |
+
+## Round-4 Assignments
+
+| PR | Student | Hypothesis |
+|---|---|---|
+| #108 | nezuko | Point-cloud xyz jitter augmentation sigma sweep (0/0.001/0.003/0.005) |
+
+## Closed / Resolved This Session
+
+| PR | Reason |
+|---|---|
+| #67 | kafka LR warmup — stale orphan, no kafka pod, superseded by PR #99 (fern LR sweep) |
 
 ## Potential Next Research Directions
 
-### Priority 1: Compositional wins on 6L base (highest expected value)
-- FiLM + 6L (norman PR #62) — if FiLM's 46% gain at 1-epoch composes with depth, expect abupt < 11
-- Tangential projection + 6L (gilbert PR #61) — projection may finally work stably with clip=1.0
-- 7L/8L depth (senku PR #59) — depth scaling law may still hold; both 5L/6L descending at timeout
-- 6L/512d (chihiro PR #60) — test if width+depth is additive (hypothesis: abupt ~11-12)
+### Priority 1: Generalization — close the val→test gap (biggest leverage remaining)
+- Point cloud jitter augmentation (nezuko PR #108, just assigned) — sigma sweep on 6L base
+- FiLM on 6L with thorfinn base — norman PR #62 needs rebase; FiLM showed 12.905 vs old baseline 13.15; if it beats new 12.74 it merges
+- Surface-volume consistency aux loss (enforce p_s = p_v at SDF~0) — not yet assigned
+- SAM optimizer (Sharpness-Aware Minimization) — explicitly targets flat minima / generalization
 
-### Priority 2: Loss formulation and training dynamics
-- Squared rel-L2 aux loss on 6L (askeladd PR #63) — emma's w=0.5 showed +11% on 4L
-- Per-axis tau_y/z loss weighting (thorfinn PR #66) — direct attack on largest remaining gap
-- Volume loss weight sweep (violet PR #65) — vw=3.0 now safe with clip=1.0
-- LR warmup + cosine decay (kafka PR #67) — convergence speed is rate-limiting
+### Priority 2: Bold architecture changes (human team directive)
+- Separate surface/volume backbone branches — specialized per modality
+- Multi-scale point cloud attention (PointTransformer-style setabstraction)
+- Mixture-of-Experts routing per surface region (wheel arch vs roof vs underbody)
 
-### Priority 3: Generalization (volume pressure val→test gap)
-- Stochastic depth regularization (fern PR #64) — drop path targets the generalization gap
-- SDF-gated volume attention with sigma=0.005 (tanjiro PR #15) — near-wall focus
-- Data augmentation: point cloud jitter, geometry reflection during training (not yet tested)
+### Priority 3: Wall-shear y/z targeted attacks (4x AB-UPT gap)
+- Finer tau_y/z sweep (thorfinn PR #106 running)
+- Asymmetric tau weights (harder axes upweighted more aggressively)
+- Physics-aware: divergence-free constraint on wall-shear (not yet tried)
+- Bernoulli-consistency loss in potential flow regions
 
-### Priority 4: Architecture exploration (longer horizon)
-- SE(3) local-frame coordinate features (norman PR #28 draft) — equivariant features
-- Longer training runs (10-12h) on 6L or 7L — both still descending at 4.5h timeout
-- 6L with all current wins composed (projection + FiLM + EMA + clip + aux_loss)
+### Priority 4: Composition after Round-3 resolves
+- Best loss weights + best EMA decay + best LR + jitter on 6L (wait for winners first)
+- FiLM + tau_y/z + best lr/ema composition
 
-## Known Correctness Issues
-1. **NaN checkpoint guard bug**: when EMA becomes NaN, `_finite_mean()` returns 0.0
-   which incorrectly passes the `< best_val` check and overwrites a valid checkpoint.
-   Fix: `improved = math.isfinite(primary_val) and primary_val > 0.0 and primary_val < best_val`.
-   Assigned to alphonse PR #58.
+### Priority 5: Epoch-limited revisits (from human team issue #18 directive)
+- Flag any Round-3 run with downward slope at epoch limit as a candidate for longer run
+- Currently: baseline 6L was still descending at epoch 4 (12.36 partial) — 6L with more time is high-value
 
 ## Key Constraints
 - Training budget: ~270 min training + ~90 min val/test = 360 min total
-- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses 75.5 GB; 6L/512d at bs=4 estimated ~80-90 GB
+- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses 75.5 GB
 - Epoch budget: ~3-4 epochs at 6L/256d throughput (~2.1 it/s)
-- Gradient clipping: clip_grad_norm=1.0 is now standard (anything without it is unstable)
-- Baseline: 6L/256d, lr=2e-4, ema-decay-start=0.99/end=0.9999, vol_w=2.0, bs=8, clip=1.0
+- Gradient clipping: clip_grad_norm=1.0 is standard
+- Single-delta principle: one change per PR; bundle only when compound effect is the hypothesis

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -42,7 +42,7 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 | #3 | askeladd | codex/optimized-lineage config (4L/256d/4h, 65k pts, lr=2e-4) |
 | #4 | chihiro | Large model 4L/512d/8h — radford champion scale-up |
 | #5 | edward | Cosine LR + 5% warmup (proven radford winner family) |
-| #6 | emma | Metric-aware MSE + rel-L2 aux loss (proven 2nd radford winner) |
+| ~~#6~~ | ~~emma~~ | ~~Metric-aware MSE + rel-L2 aux loss~~ — CLOSED (sqrt instability) |
 
 ### Stream 2 — fresh targeted ideas
 
@@ -91,6 +91,13 @@ Full hypothesis pool: `research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.m
 
 Round 2 will assign these once Round 1 results come in (so we know which
 loss/optim/EMA/data-weighting wins to compose with the new backbone).
+
+## Round 2 — active assignments (2026-04-29)
+
+| PR | Student | Hypothesis |
+|---|---|---|
+| #24 | emma | Squared rel-L2 aux loss (drop sqrt, smooth backward) |
+| #25 | stark | SE(3) local-frame coordinate features (equivariant input augmentation) |
 
 ## Round 1 — reviewed results (2026-04-29)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -21,20 +21,33 @@ and surface the strongest single-delta improvements over it.
   rel-L2 auxiliary loss, and DomainLayerNorm. Best surface val ≈ 3.6%.
   The hardest known levers were `wall_shear` and `volume_pressure`.
 
-## Round 1 — two parallel streams
+## Round 1 — active PRs (all 16 students assigned 2026-04-28)
 
-### Stream 1 — exploit existing evidence (5 students)
+### Stream 1 — exploit existing evidence
 
-Pin the floor with multiple known-good baselines and proven-additive deltas
-(LR schedule, metric-aware aux loss, scale-up). Provides reliable comparison
-points for everything else.
+| PR | Student | Hypothesis |
+|---|---|---|
+| #2 | alphonse | Stock defaults baseline — calibration floor |
+| #3 | askeladd | codex/optimized-lineage config (4L/256d/4h, 65k pts, lr=2e-4) |
+| #4 | chihiro | Large model 4L/512d/8h — radford champion scale-up |
+| #5 | edward | Cosine LR + 5% warmup (proven radford winner family) |
+| #6 | emma | Metric-aware MSE + rel-L2 aux loss (proven 2nd radford winner) |
 
-### Stream 2 — fresh high-variance ideas (11 students)
+### Stream 2 — fresh targeted ideas
 
-Bias toward `wall_shear` (7.29%) and `volume_pressure` (6.08%) — the two
-hardest AB-UPT targets. Researcher-agent generates a ranked hypothesis pool;
-each student tests a single mechanistically distinct delta against the same
-strong base config.
+| PR | Student | Hypothesis | Primary target |
+|---|---|---|---|
+| #7 | fern | Gaussian random Fourier features for coordinates | p_s / tau |
+| #8 | frieren | Per-case geometry FiLM conditioning | all |
+| #9 | gilbert | Volume loss weight sweep 2.0x vs 3.0x | p_v (6.08%) |
+| #10 | haku | Per-axis wall-shear channel loss weights (2x vs 3x) | tau (7.29%) |
+| #11 | kohaku | Tangential wall-shear projection loss (physics-aware) | tau axes |
+| #12 | nezuko | Stochastic depth / DropPath regularization | generalization |
+| #13 | norman | Progressive EMA decay anneal 0.99→0.9999 | test checkpoint |
+| #14 | senku | Deeper model 5L/256d/4h (depth ablation) | all |
+| #15 | tanjiro | SDF-gated volume attention bias (near-wall emphasis) | p_v (6.08%) |
+| #16 | thorfinn | Test-time bilateral symmetry TTA (xz-plane) | tau_y esp. |
+| #17 | violet | Surface-area-weighted MSE loss (physics-consistent) | p_s / tau |
 
 ## Candidate next directions (post round 1)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-01 (Round-6 launched — 9 new student assignments after Round-5 all-negative batch)
+- 2026-05-01 07:45 UTC — closed PR #143 (fern coord-norm) and PR #126 (kohaku FiLM); reassigned to PR #183 (fern omega-bank) and PR #184 (kohaku FiLM zero-init)
 
 ## Most Recent Research Direction from Human Researcher Team
 
@@ -81,8 +81,6 @@ Critical lessons learned from 7 failed experiments:
 | #151 | nezuko | `nezuko/symmetry-augmentation` | L/R symmetry augmentation for tau_y gap |
 | #150 | emma | `emma/multi-scale-hierarchy` | Multi-scale point hierarchy (2/3 scales) |
 | #144 | edward | `edward/adamw-beta2-sweep` | AdamW beta2 sweep (0.95 vs 0.999) |
-| #143 | fern | `fern/coord-normalization-sweep` | Coordinate normalization fix for sincos anisotropy |
-| #126 | kohaku | `kohaku/film-conditioning-6l-256d` | FiLM geometry conditioning on PR #99 base |
 | #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR max=1e-3 |
 | #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
 
@@ -98,6 +96,8 @@ Critical lessons learned from 7 failed experiments:
 | #170 | gilbert | `gilbert/width-384d-qknorm-fp32attn` | 384d + QK-norm + fp32-attention (stability fix) |
 | #171 | norman | `norman/snapshot-ensemble-cyclic-lr` | Snapshot ensemble via cyclic LR (3 ckpts avg) |
 | #172 | stark | `stark/adamw-eps-sweep` | AdamW eps sweep 1e-8/7/6/5 (gradient stability) |
+| #183 | fern | `fern/omega-bank-sweep` | Omega-bank frequency sweep (per-axis sincos for tau_y/z gap) — replaces #143 |
+| #184 | kohaku | `kohaku/film-zero-init` | FiLM with identity/zero-init (DiT-style stable conditioning) — replaces #126 |
 
 ## Current Research Themes
 
@@ -127,7 +127,8 @@ Pervasive Round-5 divergences motivate systematic optimizer investigation.
 - #155 armin (in flight) — top-3 checkpoint ensemble
 
 ### Theme 5: Data representation and augmentation
-- #143 fern (in flight) — coordinate normalization sweep (sincos anisotropy fix)
+- #183 fern (newly assigned) — **omega-bank frequency sweep** (max_wavelength sweep + per-axis omega banks); follow-up to falsified #143 coord-normalization
+- #184 kohaku (newly assigned) — **FiLM with identity/zero-init** (DiT-style); follow-up to falsified #126 vanilla-init FiLM, preserving the volume-pressure signal Arm 3 found
 - #151 nezuko (in flight) — L/R symmetry augmentation
 - #152 violet (in flight) — analytic geometry moment conditioning (14-dim)
 
@@ -142,6 +143,8 @@ Pervasive Round-5 divergences motivate systematic optimizer investigation.
 - **Δp≈0 is wrong RANS physics:** Laplacian pressure constraint only valid for Stokes (creeping) flow.
 - **Volume pressure nearly converged:** 1.3× AB-UPT at baseline — wall_shear_y/z is the main gap.
 - **LR warmup guards:** 500-1000 step linear warmup from 1e-5 is now standard practice for experiments with elevated initial gradients.
+- **Coord-norm is the wrong lever (PR #143):** The 4× tau_y/z gap is NOT primarily a sincos-anisotropy problem. `global-scale` normalization breaks the meter-calibrated `omega` bank (e1 abupt 24.85 vs control 16.20); `per-axis` causes volume-token explosions through the bias→attention path. Right next attack is the omega bank itself, in physical-meter coords (PR #183).
+- **FiLM at default-init × LR ≥ 3e-4 is unstable (PR #126):** Geom token is fine (norm steady ~0.75), but `to_gamma_beta` linear projections are the gradient amplification path (layer-0 grad/param ratio 0.567 at divergence). Volume-pressure signal real (Arm 3 vp=7.05 vs baseline 7.85) → identity-init follow-up justified (PR #184).
 
 ## Key Constraints
 - Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 20:25 UTC
+- **Updated:** 2026-05-01 21:40 UTC
 - **Branches:** `yi` (4L/512d Lion SOTA), `bengio` (4L/256d AdamW Wave 2/3)
 
 ---
@@ -39,10 +39,12 @@ Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain th
 
 | PR | Student | Hypothesis | Status |
 |---|---|---|---|
+| #280 | frieren | **MLP activation ablation** (SwiGLU / ReLU² vs GELU) | NEW (just assigned) |
+| ~~#279~~ | ~~frieren~~ | ~~no-slip BC penalty~~ | CLOSED 21:40Z — duplicates failed PR #201 (GT tau·n RMS=12% contradicts continuum BC) |
 | #270 | violet | **tanh output soft-cap** (modded-NanoGPT logit-cap analog) | NEW (just assigned) |
 | #262 | nezuko | **linear-warmdown LR schedule** (modded-NanoGPT WSD-style) | NEW (just assigned) |
 | #261 | norman | **Muon optimizer** (Newton-Schulz orthogonalized momentum) | NEW (just assigned) |
-| #249 | tanjiro | asinh wall-shear normalization | Both arms healthy ep1 |
+| #249 | tanjiro | asinh wall-shear normalization | TempCollapse bug found; advisor authorized `T.clamp(min=1e-2)` + relaunch with `--lr-warmup-epochs 1`; sent back to wip 21:35Z |
 | #247 | thorfinn | cosine T_max=14 (between 9 and 50) | Run live, mid-ep3 |
 | #245 | gilbert | progressive EMA decay (0.99→0.9999 etc.) | Arm A surviving; B/C retries running |
 | #244 | emma | surface-loss-weight {1.5, 2.0} | Arm A crashed lr=5e-4; Arm B healthy |
@@ -55,7 +57,7 @@ Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain th
 | #224 | fern | learned Fourier embeddings per-axis | K/L/N/O surviving; J finding: init=10 beats sincos by 6.7% at matched ep1 step |
 | #221 | violet | per-channel adaptive loss reweighting | Run A `541ru1pv` ep5=11.12; gate-check stalled (cross-listed, primary on bengio) |
 | #210 | kohaku | gradient accumulation eff_bs=32 | Running |
-| #209 | frieren | step-decay LR drop after ep1 | Running |
+| ~~#209~~ | ~~frieren~~ | ~~step-decay LR drop after ep1~~ | CLOSED 2026-05-01 21:22 — hypothesis rejected; control 10.08 vs bar 9.291 on legacy stack |
 | #208 | askeladd | sandwich-LN to unlock 8L/256d | Arm B running ~18866+ steps |
 | #207 | alphonse | Adaptive Gradient Clipping (AGC) | lr=3e-4 arms only surviving |
 | #193 | thorfinn | curvature-biased surface point sampling | 3 lr=3e-4 arms healthy past warmup |
@@ -130,6 +132,9 @@ Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain th
 - **#224 fern (yi):** learned Fourier embeddings per-axis (init=10 beats sincos at matched ep1)
 - **#239 norman (bengio):** Fourier PE num_freqs sweep {16, 32, 64, 128}
 - **#253 askeladd (bengio):** FourierEmbed vs ContinuousSincosEmbed standalone test
+
+### Theme 8: Core Building Blocks (MLP / Activation)
+- **#280 frieren (yi):** MLP activation ablation (SwiGLU / ReLU² vs GELU) — NEW, modded-NanoGPT-inspired
 
 ### Theme 7: Symmetry / TTA / Augmentation
 - **#225 haku (yi):** mirror symmetry training augmentation

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,7 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 12:30 UTC
+- **Updated:** 2026-05-01 14:30 UTC
 - **Branch:** `yi`
 - **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
-
-## CURRENT HOTTEST FINDING (2026-05-01 12:30 UTC)
-**PR #168 askeladd ep2 crossover:** gawdh7ah (λ=0.10) ep2 val_abupt = **12.285** vs PR #99 fern ep2 = **12.417**. First experiment in this round to beat baseline trajectory at a matched epoch. vol_p ep2 = 7.055 vs 10.531 confirms backbone regularization. Awaiting ep3 (~13:30 UTC) for go/no-go on merge bar (10.69). Counter-intuitive ranking confirmed: λ=0.10 most stable; λ=0.01 fails (insufficient anchor → out-of-plane drift → squared-dot spike). λ=0.05 (1buc9rh1) ep1 abupt=15.875 = best ep1 of any arm.
 
 ---
 
@@ -15,10 +12,10 @@
 
 **Morgan's ordered priority list:**
 1. Surface-tangent frame wall-shear prediction — 4× wall shear y/z error is a coordinate frame mismatch
-2. Perceiver-IO backbone replacement — ~3× faster per epoch = more epochs within budget
-3. asinh/log target normalization — wall shear spans 4 decades (tested, **NEGATIVE — tail suppression problem**)
-4. Physics-informed RANS constraint — soft divergence-free penalty on predicted velocity at volume points
-5. 1-cycle LR schedule with higher peak (tested, **NEGATIVE — budget starvation + stability ceiling at ~6.5e-4**)
+2. **Perceiver-IO backbone replacement** — ~3× faster per epoch = more epochs within budget (**ASSIGNED #212 noam**)
+3. asinh/log target normalization — tested, **NEGATIVE — tail suppression problem (PR #123)**
+4. Physics-informed RANS constraint — soft divergence-free penalty (**ASSIGNED #201 nezuko**)
+5. 1-cycle LR schedule with higher peak — tested, **NEGATIVE — budget starvation + stability ceiling (PRs #164, #191)**
 
 ---
 
@@ -38,121 +35,119 @@
 
 ---
 
-## Active WIP PRs (as of 2026-05-01 11:45 UTC)
+## Active WIP PRs (as of 2026-05-01 14:30 UTC)
 
-| PR | Student | Hypothesis | Status |
-|---|---|---|---|
-| **#199** | stark | Smooth tangent-frame wall-shear prediction (continuous e_x-projection frame, 2D output) | JUST ASSIGNED |
-| **#200** | emma | Wall-shear magnitude/direction decomposition loss (log-mag + cosine direction) | JUST ASSIGNED |
-| **#198** | senku | Stochastic Weight Averaging (SWA) free gain (r12) | WIP, no data yet |
-| **#197** | gilbert | k-NN local surface attention for tau_y/z gap (r12) | WIP, no data yet |
-| **#196** | edward | Lion optimizer sweep vs AdamW (r12) | WIP, no data yet |
-| **#193** | thorfinn | Curvature-biased surface point sampling | WIP, 1 comment only |
-| **#192** | tanjiro | asinh target normalization for tau_y/z (separate from frieren's approach) | WIP, 4-seed relaunch w/ warmup-500 |
-| **#191** | haku | 1-cycle LR max=1e-3 (corrected epoch-limited schedule) | WIP, A_tuned running |
-| **#184** | kohaku | FiLM with identity/zero-init (DiT-style) | **arm B (lr=4e-4) sole survivor, ep2≈99%, ETA ~14:25 UTC** |
-| **#183** | fern | Omega-bank frequency sweep | **3 arms healthy (A2/C3/D3); mw=100 FALSIFIED; ep2 results ~12:00-12:20 UTC** |
-| **#171** | norman | Snapshot ensemble with cyclic LR | **V2 running (okm6uoea, eta_min=5e-5 + clip=0.5); ETA ~17:30 UTC** |
-| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | **λ=0.10 (gawdh7ah) ep2=12.285 < fern ep2 12.417 — FIRST CROSSOVER; ep3 ETA ~13:30 UTC** |
-| **#165** | chihiro | mlp_ratio=8 hardened (3-seed) | **seed1337 ep3=11.92 (NOT beating 10.69); clip=0.5 go/no-go at 12:20/13:30 UTC** |
-| **#164** | alphonse | 8L/256d + 1cycle LR recovery | WIP |
-| **#152** | violet | 14-dim analytic geometry moment conditioning | WIP |
-| **#201** | nezuko | Physics-informed RANS divergence-free penalty on volume velocity | JUST ASSIGNED |
-| **#123** | frieren | asinh/log wall-shear target normalization | **Critical finding: asinh-1.0 trades metric for stability; arms A/D/B(v3p1) final results ~12:10-13:51 UTC** |
+### Round-6 Assignments (Just Assigned)
+
+| PR | Student | Hypothesis |
+|---|---|---|
+| **#207** | alphonse | Adaptive Gradient Clipping (AGC, NFNets) per-parameter stability |
+| **#208** | askeladd | Sandwich-LN normalization to unlock 8L/256d depth |
+| **#209** | frieren | Step-decay LR drop after ep1 (5e-4→1e-4, attacks ep1→ep2 divergence) |
+| **#210** | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads |
+| **#211** | tanjiro | Relative magnitude-based grad-skip (EMA-adaptive) fleet infra |
+| **#212** | noam | Perceiver-IO backbone replacement (2-4× speed → more epochs) |
+
+### Ongoing From Earlier Rounds
+
+| PR | Student | Hypothesis |
+|---|---|---|
+| **#201** | nezuko | Physics-informed RANS divergence-free penalty on volume velocity |
+| **#200** | emma | Wall-shear magnitude/direction decomposition loss (τ y/z gap) |
+| **#199** | stark | Smooth tangent-frame wall-shear prediction (continuous e_x-projection) |
+| **#198** | senku | Stochastic Weight Averaging (SWA) free gain |
+| **#197** | gilbert | k-NN local surface attention for tau_y/z gap |
+| **#196** | edward | Lion optimizer sweep vs AdamW |
+| **#193** | thorfinn | Curvature-biased surface point sampling |
+| **#191** | haku | 1-cycle LR max=1e-3 (corrected epoch-limited schedule) |
+| **#183** | fern | Omega-bank frequency sweep |
+| **#171** | norman | Snapshot ensemble with cyclic LR |
+| **#165** | chihiro | mlp_ratio=8 hardened (3-seed) |
+| **#152** | violet | 14-dim analytic geometric moment conditioning |
+
+---
+
+## Round-6 Closed PRs (Negatives)
+
+| PR | Student | Hypothesis | Best Val | Verdict |
+|---|---|---|---:|---|
+| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | 12.285 (ep2) | NEGATIVE — tangentiality enforcement provides no metric gain |
+| **#164** | alphonse | 8L/256d + 1cycle LR | DNF (all diverged) | NEGATIVE — 8L/256d has LR ceiling < 5e-4 |
+| **#123** | frieren | asinh/log wall-shear target normalization | 17.55 (ep1) | NEGATIVE — tail suppression kills the signal |
 
 ---
 
 ## Current Research Themes
 
 ### Theme 1: Coordinate-Frame Hypothesis for tau_y/z Gap (HIGHEST PRIORITY)
-**Root question:** Is the 4× tau_y/z error a coordinate-frame problem? AB-UPT achieves equal error on tau_x/y/z (~3.6) while we have 10/14/15. The asymmetry exists in our model but not in AB-UPT.
+**Root question:** Is the 4× tau_y/z error a coordinate-frame problem? AB-UPT achieves equal error on tau_x/y/z (~3.6) while we have 10/14/15.
 
-- **#199 stark (NEW):** Full tangent-frame prediction (smooth e_x-projection frame). Addresses Morgan's #1 directive. Different from PR #121 (Duff ONB discontinuity) — uses continuous frame with fallback at poles.
-- **#168 askeladd:** Normal-consistency penalty (soft tangentiality constraint from the other direction)
-- **#200 emma (NEW):** Magnitude/direction decomposition loss — separate log-mag and cosine-direction losses to decouple scale from alignment learning
-- **#192 tanjiro:** asinh normalization applied specifically to y/z channels
+- **#199 stark:** Full tangent-frame prediction (smooth e_x-projection frame). Morgan's #1 directive.
+- **#200 emma:** Magnitude/direction decomposition loss — decouple scale from alignment learning.
+- **CLOSED NEGATIVE #168 askeladd:** Normal-consistency penalty — model already near-tangential naturally.
+- **CLOSED NEGATIVE #121:** Hard Duff-ONB tangent-frame — discontinuous at t1.x sign-flip.
 
-### Theme 2: Target Representation for Heavy-Tail Distributions
-- **#123 frieren (near completion):** PARTIAL RESULT — asinh-1.0 is NEGATIVE (suppresses tail learning signal). log1p (arm D) and asinh-0.5 (arm B) still viable; final results ~12:10-13:51 UTC.
-- **Key finding:** Cannot suppress tail to gain stability — the gap lives in the tail. Need a way to handle heavy-tailed targets WITHOUT compression.
+### Theme 2: Architecture Replacement (BOLD SWINGS — Morgan's directive)
+- **#212 noam (NEW):** Perceiver-IO backbone — cross-attention bottleneck, 2-4× faster per epoch → 5+ epochs in budget. Morgan's #2 priority.
+- **#208 askeladd (NEW):** Sandwich-LN to unlock 8L/256d depth — prior 8L attempts all diverged; sandwich-LN dampens gradient growth across depth.
 
-### Theme 3: Optimizer Stability Infrastructure (CONFIRMED FLEET-WIDE GAP)
-**Four independent confirmations (frieren #123, fern #183, askeladd #168, chihiro #165):** PR #169's NaN-skip only catches non-finite gradients. Large-but-finite spikes (165, 252, 2.2M) bypass it, corrupt Adam m/v after clipping.
-- Needed: magnitude-based grad-skip (pre_clip_norm > N × running_median, or abs threshold)
-- Also needed: finite-but-pathological loss guard (abort if train_loss > 5× running_median for sustained steps)
-- **This should be an infrastructure PR** — candidate to assign to the next available thorfinn/infra-capable student
+### Theme 3: Optimizer Stability Infrastructure
+**Four independent confirmations (PRs #123, #168, #165, #164):** Large-but-finite grad spikes bypass PR #169's NaN-skip.
+- **#211 tanjiro (NEW):** Relative magnitude-based grad-skip (EMA-adaptive threshold).
+- **#207 alphonse (NEW):** AGC per-parameter clipping (NFNets). Addresses root cause by making clip threshold proportional to weight norm.
+- Together these form a complementary infra pair; combine if both show promise.
 
-### Theme 4: Physics-Informed Constraints
-- **#201 nezuko (NEW):** RANS divergence-free penalty — soft constraint λ·mean(∇·u²) on volume velocity predictions. 4-arm sweep: λ∈{0.001, 0.01, 0.1} + control (λ=0.0). Addresses Morgan's #4 directive. Hypothesis: enforcing ∇·u=0 improves near-wall velocity gradient accuracy → reduces tau_y/z errors.
-- **#168 askeladd:** Normal-consistency penalty — related physics-informed constraint from the surface tangentiality direction.
-- **KEY FINDING (PR #151, nezuko) — CLOSED NEGATIVE:** L/R symmetry augmentation — both arms crashed NaN in epoch 2 (val abupt 17.63 and 45.92 vs baseline 10.69). DrivAerML cars have real Y-asymmetries; symmetry label assumption is invalid.
+### Theme 4: LR Schedule Optimization
+- **#209 frieren (NEW):** Step-decay LR drop after ep1 (5e-4→1e-4). Attacks the universal ep1→ep2 train/val divergence observed across 4 normalization variants in PR #123.
+- **CLOSED NEGATIVE #164/#191:** OneCycleLR — 8L/256d and LR ceiling at ~6.5e-4 confirmed.
 
-### Theme 5: FiLM Geometry Conditioning (Near Complete)
-- **#184 kohaku:** FiLM stability characterized. 5/5 at lr=5e-4 dead regardless of init_scale. Stability axis is lr alone. Arm B (lr=4e-4) sole survivor, completing ~14:25 UTC.
-- **Key finding:** FiLM requires lr ≤ 4e-4, which may conflict with the lr=5e-4 optimum. The volume_pressure signal from PR #126 Arm-3 (vp=7.05 vs 7.85 baseline) is real — FiLM may still help volume even if it can't close the tau_y/z gap.
+### Theme 5: Batch Statistics and Gradient Quality
+- **#210 kohaku (NEW):** Gradient accumulation eff_bs=32. Zero VRAM cost; smoother gradient estimates for rare high-|τ| tail points.
+- **#183 fern:** Omega-bank frequency sweep. Three arms healthy.
 
-### Theme 6: Training Budget Efficiency
-- **#171 norman:** Snapshot ensemble with cyclic LR. V1 diverged at epoch 3 (50× LR jump); V2 has 10× ratio + clip=0.5, running cleanly, ETA ~17:30 UTC.
-- **#196 edward:** Lion optimizer (round 12) — Lion typically needs ~3× lower LR than AdamW
-- **#198 senku:** SWA — free post-train gain from averaging model weights across last epochs
-- **#197 gilbert:** k-NN local attention — addresses spatial locality for tau_y/z
+### Theme 6: Physics-Informed Constraints
+- **#201 nezuko:** RANS divergence-free penalty on volume velocity. Morgan's #4 directive.
+- **CLOSED NEGATIVE #168:** Normal-consistency (tangential) constraint.
 
-### Theme 7: Architecture Exploration (Round 12)
-- **#191 haku:** 1cycle LR (corrected — calibrated to actual epoch budget)
-- **#164 alphonse:** 8L/256d depth with 1cycle (time-limited recovery — must beat PR #144 ep4 val=12.69)
+### Theme 7: Ensemble and Budget Efficiency
+- **#171 norman:** Snapshot ensemble with cyclic LR (V2).
+- **#198 senku:** SWA — free post-train gain from weight averaging.
+- **#196 edward:** Lion optimizer sweep.
+
+### Theme 8: Data Representation and Sampling
+- **#197 gilbert:** k-NN local surface attention for tau_y/z spatial locality.
+- **#193 thorfinn:** Curvature-biased surface point sampling.
+- **#152 violet:** 14-dim analytic geometric moment conditioning.
 
 ---
 
 ## Key Structural Findings Accumulated
 
 ### Stability
-- **Fleet-wide instability mechanism (CONFIRMED):** Large-but-finite grad spikes bypass PR #169's NaN-skip. clip_grad_norm=1.0 normalizes direction but preserves poison vector → Adam m/v corruption. Fix needed: magnitude-based skip.
-- **FiLM stability axis is LR, not init_scale:** scale=0.001 delays divergence 6× vs scale=1.0 but cannot prevent it at lr=5e-4. lr=4e-4 is the stability boundary.
-- **mw=100 (omega-bank) structurally untenable:** 3 independent attempts all diverged. Low max_wavelength → highly compressed Fourier features → fragile at lr=5e-4.
-- **LR ceiling at ~6.5e-4:** OneCycleLR peaks ≥ 6.5e-4 diverge regardless of warmup schedule.
-- **W_y=W_z > 2.0 overfits tau_y/z:** W=3 (PR #66) scores 13.18 vs 12.74 for W=2. Static W=2 is the sweet spot.
+- **Fleet-wide instability mechanism (CONFIRMED):** Large-but-finite grad spikes bypass PR #169's NaN-skip. clip_grad_norm=1.0 normalizes direction but preserves poison vector → Adam m/v corruption.
+- **FiLM stability axis is LR** (PR #184 closed): lr=4e-4 is the stability boundary; lr=5e-4 kills FiLM regardless of init_scale.
+- **LR ceiling at ~6.5e-4** (PRs #164, #191): OneCycleLR peaks ≥ 6.5e-4 diverge regardless of warmup.
+- **W_y=W_z > 2.0 overfits tau_y/z** (PR #66): W=3 scores 13.18 vs 12.74 for W=2.
 
 ### Target Representation
-- **asinh-1.0 trades metric for stability (frieren #123):** Suppresses gradient explosions by compressing the tail, but the gap to AB-UPT lives in the tail. Stability ≠ metric improvement.
-- **Heavy-tail is real:** Wall shear spans 4 decades. The tail (high-|τ| separation regions) dominates the rel_L2 numerator AND denominator. Compression hurts.
+- **asinh normalization NEGATIVE** (PR #123): Compresses tail → suppresses gradient explosions but also suppresses learning signal where y/z gap lives.
+- **Heavy-tail is real:** Wall shear spans 4 decades. The tail dominates rel_L2 numerator AND denominator. Cannot compress it.
 
 ### Architecture
-- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M). 8L/256d time-limited but promising.
-- **Multi-scale hierarchy failed (PR #150):** Receptive field is not the lever for tau_y/z gap.
-- **384d in bf16 is unstable:** QK-norm + fp32 attention required (PR #170 gilbert testing).
+- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M).
+- **8L/256d is blocked by LR ceiling** (PRs #144, #164): Cannot train at lr ≥ 5e-4 with current norm structure. Sandwich-LN (PR #208) is the unlock attempt.
+- **Multi-scale hierarchy failed** (PR #150): Receptive field is not the lever for tau_y/z gap.
 
 ### Loss/Data Representation
-- **Per-axis wallshear upweighting:** W_y=W_z=2 is optimal (PR #66). W=3+ overfits, W=1.5- underdirects.
-- **Normal-consistency λ ranking inversion:** λ=0.10 most stable, λ=0.01 most unstable — larger constraint enforces stronger out-of-plane avoidance, bounding the squared-dot spike.
-- **Tangent-frame prediction (Duff ONB):** Discontinuous at t1.x sign-flip → incompatible with non-gauge-equivariant Transolver. Use smooth e_x-projection frame instead.
-- **Coord-normalization wrong lever (PR #143):** global-scale breaks meter-calibrated omega bank; per-axis causes volume-token explosions.
-
-### Optimizer
-- **EMA m/v desynchronization:** Mid-run schedule changes → second-moment coupling issues. Start Adam with training-time weights.
-- **Uniform surface_sw amplifies already-upweighted channels.** Per-component weight is the right knob.
-
----
-
-## Near-Term Priority Queue
-
-1. **Watch #168 (askeladd) gawdh7ah ep3 (~13:30 UTC)** — if abupt < 10.69 with healthy ws_y/z, this is the headline merge candidate of the round
-2. **Watch #168 (askeladd) 1buc9rh1 (λ=0.05, clip=0.5) ep2** — best ep1 (15.875) of any arm; tests whether sweet-spot is between 0.05 and 0.10
-3. **Await and merge #184 (kohaku FiLM, arm B) ~14:25 UTC** — if val_abupt < 10.69
-4. **Review #123 (frieren) final results ~12:10-13:51 UTC** — close based on best arm; v3 already negative
-5. **Monitor #196 (edward Lion)** — C2 (seed=42, lr=2e-4) approaching the step-3500 danger zone; F (seed=43) is the bad-batch test
-6. **Monitor #165 (chihiro)** — clip=0.5 seed42/seed7 go/no-go around 12:20-13:30 UTC
-7. **Monitor #193 (thorfinn curvature)** — Arm A (alpha=0.5) and B (alpha=1.0) running; ep1 vals due ~13:00 UTC
-8. **Monitor #200 (emma)** — pod stuck in watchdog state; advisor posted explicit pkill instruction
-9. **Track #199 (stark)** — no pod visible in cluster; flagged in advisor comment
-10. **Infrastructure PR** — magnitude-based grad-skip (assign to thorfinn when free)
-11. **Perceiver-IO backbone** (Morgan's #2 directive) — not yet assigned; needs careful scoping
-12. **Physics-informed RANS** (Morgan's #4 directive) — ASSIGNED to nezuko (#201)
+- **Per-axis wallshear upweighting:** W_y=W_z=2 is optimal (PR #66).
+- **Explicit tangentiality enforcement provides no gain** (PRs #121, #168): Model already learns near-tangential predictions naturally.
+- **Tangent-frame prediction (Duff ONB) discontinuous** at t1.x sign-flip → incompatible with Transolver. Use smooth e_x-projection frame (PR #199).
 
 ---
 
 ## Key Constraints
 - Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)
 - VRAM: 96 GB per GPU; 6L/256d at bs=8 uses ~75 GB
-- Gradient clipping: clip_grad_norm=1.0 standard; clip=0.5 used for stability-sensitive experiments
-- LR warmup: 500 steps (1e-5 start) now standard for experiments with elevated initial gradients
+- Gradient clipping: clip_grad_norm=1.0 standard; clip=0.5 for stability-sensitive experiments
+- LR warmup: 500 steps (1e-5 start) now standard
 - Students have 4 GPUs each

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -40,7 +40,7 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 |---|---|---|
 | #2 | alphonse | Stock defaults baseline — calibration floor |
 | #3 | askeladd | codex/optimized-lineage config (4L/256d/4h, 65k pts, lr=2e-4) |
-| #4 | chihiro | Large model 4L/512d/8h — radford champion scale-up |
+| ~~#4~~ | ~~chihiro~~ | ~~Large model 4L/512d/8h~~ — MERGED (new yi baseline 16.64) |
 | #5 | edward | Cosine LR + 5% warmup (proven radford winner family) |
 | ~~#6~~ | ~~emma~~ | ~~Metric-aware MSE + rel-L2 aux loss~~ — CLOSED (sqrt instability) |
 
@@ -104,6 +104,7 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 | #26 | nezuko | A01 — ANP cross-attention surface decoder (architecture swap) |
 
 | #28 | norman | A02 — SE(3) equivariant local-frame coord features |
+| #29 | chihiro | B06 — width × FiLM × cosine EMA composition at 512d |
 
 **Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
 SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.
@@ -125,20 +126,27 @@ SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.
   Superseded as standalone best by PR #13 (15.82), but FiLM composes orthogonally
   with cosine EMA — composition should push below 14. Frieren rebasing.
   - Follow-up PR #23 (frieren): full composition — FiLM + vol_w=2.0 + projection + bs=8 + cosine EMA.
-- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED — official yi baseline.**
+- **PR #4 (chihiro, 4L/512d/8h large model) — MERGED 2026-04-29. NEW yi OFFICIAL BASELINE.**
+  `abupt_axis_mean = 16.64` (vs 17.39 prev = −4.3%). Run `pejudvyd`, 3 best epochs.
+  Best per-axis: `volume_pressure = 14.37` (standout win, orthogonal to FiLM/EMA).
+  Key: `lr=5e-5` required (3 runs at 2e-4 diverged), `bs=4` (VRAM limit at 512d).
+  BASELINE.md updated. chihiro reassigned → Round-2 composition run.
+- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) — MERGED, now superseded by PR #4.**
   `abupt_axis_mean = 17.39`. Run `y2gigs61`, 6 epochs.
 - **PR #11 (kohaku, tangential wall-shear projection) — MERGED.**
   Code on yi (default off). Composable with any future PR.
 - **Follow-up PR #21 (kohaku, normal-component suppression sweep)** — λ ∈ {0.0, 0.01, 0.1, 1.0}.
 - **Follow-up PR #22 (gilbert, gradient clipping)** — `clip_grad_norm_` + 4-arm sweep.
 
-**Four independent wins compounding (next big leap from stacking all):**
+**Five independent wins compounding (next big leap from stacking all):**
 1. Tangential projection (PR #11, default off, `--use-tangential-wallshear-loss`)
 2. Protocol fixes: vol_w=2.0, bs=8, validation-every=1 (PR #9)
-3. Per-block FiLM conditioning (PR #8, pending merge)
-4. Cosine EMA 0.99→0.9999 (PR #13, pending merge, `--ema-decay-start 0.99 --ema-decay-end 0.9999`)
-→ PR #23 (frieren) will test all four together once both PRs #8 and #13 land.
-→ Composition prediction: ~12–13 abupt (−20% from current 15.82).
+3. **Width scale-up 512d/8h (PR #4, MERGED)**
+4. Per-block FiLM conditioning (PR #8, pending merge)
+5. Cosine EMA 0.99→0.9999 (PR #13, pending merge, `--ema-decay-start 0.99 --ema-decay-end 0.9999`)
+→ PR #23 (frieren) will test FiLM + projection + vol_w + cosine EMA once PRs #8 and #13 land.
+→ chihiro Round-2: 512d × FiLM × cosine EMA composition.
+→ Composition prediction: ~12–13 abupt (−20% from current best pending 15.82).
 
 ### CLOSED
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,7 +1,10 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 12:15 UTC
+- **Updated:** 2026-05-01 12:30 UTC
 - **Branch:** `yi`
 - **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
+
+## CURRENT HOTTEST FINDING (2026-05-01 12:30 UTC)
+**PR #168 askeladd ep2 crossover:** gawdh7ah (λ=0.10) ep2 val_abupt = **12.285** vs PR #99 fern ep2 = **12.417**. First experiment in this round to beat baseline trajectory at a matched epoch. vol_p ep2 = 7.055 vs 10.531 confirms backbone regularization. Awaiting ep3 (~13:30 UTC) for go/no-go on merge bar (10.69). Counter-intuitive ranking confirmed: λ=0.10 most stable; λ=0.01 fails (insufficient anchor → out-of-plane drift → squared-dot spike). λ=0.05 (1buc9rh1) ep1 abupt=15.875 = best ep1 of any arm.
 
 ---
 
@@ -50,7 +53,7 @@
 | **#184** | kohaku | FiLM with identity/zero-init (DiT-style) | **arm B (lr=4e-4) sole survivor, ep2≈99%, ETA ~14:25 UTC** |
 | **#183** | fern | Omega-bank frequency sweep | **3 arms healthy (A2/C3/D3); mw=100 FALSIFIED; ep2 results ~12:00-12:20 UTC** |
 | **#171** | norman | Snapshot ensemble with cyclic LR | **V2 running (okm6uoea, eta_min=5e-5 + clip=0.5); ETA ~17:30 UTC** |
-| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | **λ=0.10 (gawdh7ah) ep1=17.103; clip=0.5 relaunches for λ=0.01/0.05 in flight** |
+| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | **λ=0.10 (gawdh7ah) ep2=12.285 < fern ep2 12.417 — FIRST CROSSOVER; ep3 ETA ~13:30 UTC** |
 | **#165** | chihiro | mlp_ratio=8 hardened (3-seed) | **seed1337 ep3=11.92 (NOT beating 10.69); clip=0.5 go/no-go at 12:20/13:30 UTC** |
 | **#164** | alphonse | 8L/256d + 1cycle LR recovery | WIP |
 | **#152** | violet | 14-dim analytic geometry moment conditioning | WIP |
@@ -132,13 +135,18 @@
 
 ## Near-Term Priority Queue
 
-1. **Await and merge #184 (kohaku FiLM, arm B) ~14:25 UTC** — if val_abupt < 10.69
-2. **Review #123 (frieren) final results ~12:10-13:51 UTC** — close based on best arm
-3. **Monitor #165 (chihiro)** — seed42 go/no-go at step 6783 (~12:20 UTC)
-4. **Review #183 (fern)** — cross-arm ep2 table at ~12:30 UTC
-5. **Infrastructure PR** — magnitude-based grad-skip (assign to thorfinn when free)
-6. **Perceiver-IO backbone** (Morgan's #2 directive) — not yet assigned; needs careful scoping
-7. **Physics-informed RANS** (Morgan's #4 directive) — ASSIGNED to nezuko (#201)
+1. **Watch #168 (askeladd) gawdh7ah ep3 (~13:30 UTC)** — if abupt < 10.69 with healthy ws_y/z, this is the headline merge candidate of the round
+2. **Watch #168 (askeladd) 1buc9rh1 (λ=0.05, clip=0.5) ep2** — best ep1 (15.875) of any arm; tests whether sweet-spot is between 0.05 and 0.10
+3. **Await and merge #184 (kohaku FiLM, arm B) ~14:25 UTC** — if val_abupt < 10.69
+4. **Review #123 (frieren) final results ~12:10-13:51 UTC** — close based on best arm; v3 already negative
+5. **Monitor #196 (edward Lion)** — C2 (seed=42, lr=2e-4) approaching the step-3500 danger zone; F (seed=43) is the bad-batch test
+6. **Monitor #165 (chihiro)** — clip=0.5 seed42/seed7 go/no-go around 12:20-13:30 UTC
+7. **Monitor #193 (thorfinn curvature)** — Arm A (alpha=0.5) and B (alpha=1.0) running; ep1 vals due ~13:00 UTC
+8. **Monitor #200 (emma)** — pod stuck in watchdog state; advisor posted explicit pkill instruction
+9. **Track #199 (stark)** — no pod visible in cluster; flagged in advisor comment
+10. **Infrastructure PR** — magnitude-based grad-skip (assign to thorfinn when free)
+11. **Perceiver-IO backbone** (Morgan's #2 directive) — not yet assigned; needs careful scoping
+12. **Physics-informed RANS** (Morgan's #4 directive) — ASSIGNED to nezuko (#201)
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -92,25 +92,53 @@ Full hypothesis pool: `research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.m
 Round 2 will assign these once Round 1 results come in (so we know which
 loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
-## Round 1 — first reviewed result (2026-04-29)
+## Round 1 — reviewed results (2026-04-29)
 
-- **PR #12 (nezuko, DropPath p=0.1) closed.** Significantly worse than the closest
-  no-DropPath comparator (norman): 81.21 vs 64.66 abupt_axis_mean. Root cause:
-  runs are in the **underfitting regime** (best_epoch=1, train loss falling while
-  EMA-val degrades), so any regularizer hurts. Stochastic depth is the wrong tool
-  for the current bottleneck.
-- **Critical infrastructure win from PR #12.** nezuko shipped a per-step timeout
-  fix (`train.py`); cherry-picked onto `yi` as `af92e9a`. Reserves
-  `SENPAI_VAL_BUDGET_MINUTES` (default 90), checks wall-clock per step, forces
-  validation on partial epoch when timeout hits. Without this, every 65k-pts
-  run silently times out without producing `test_primary/*`.
-- **Cross-cutting Round-1 directives broadcast to all active PRs (2026-04-29):**
-  rebase onto `yi` to pick up `af92e9a`; set `--validation-every 1` (or 2) for
-  Round-1 sized runs since `validation_every=10` only yields one usable
-  checkpoint inside the budget; report on observed train→val divergence.
-- **Open question for the round:** train loss decreases while EMA-val
-  degrades after epoch 1 on at least two runs. EMA decay too aggressive for
-  the fast initial fit? LR-warmup interplay? Worth a focused diagnostic.
+### MERGED — first yi baseline established
+
+- **PR #11 (kohaku, tangential wall-shear projection) MERGED.**
+  `test_primary/abupt_axis_mean = 35.12` — ~46% better than nearest
+  comparator (norman 64.66). Run `uy0ds6iz`, 1 epoch only (pre-fix), state=finished.
+  All future PRs measured against this baseline.
+  - kohaku correctly deviated from the PR pseudocode (denormalize → project →
+    renormalize), since per-axis stds are non-uniform.
+  - Diagnostic `train/wallshear_pred_normal_rms` exposed predicted normal
+    component growing 2.4× during 1 epoch — the regularization gap.
+- **Follow-up PR #21 (kohaku, normal-component suppression sweep)** —
+  λ ∈ {0.0, 0.01, 0.1, 1.0} of `λ * mean((ws_pred · n_hat)^2)` on top of
+  projection. λ=0 arm is the first multi-epoch projection run (with timeout
+  fix + validation-every 1).
+
+### CLOSED
+
+- **PR #12 (nezuko, DropPath p=0.1) closed.** 81.21 vs 64.66 norman
+  comparator. Underfitting regime (best_epoch=1 on both runs); any
+  regularizer hurts. Wrong tool for the binding constraint.
+- **Critical infrastructure win from PR #12.** nezuko shipped a per-step
+  timeout fix (`train.py`); cherry-picked onto `yi` as `af92e9a`. Reserves
+  `SENPAI_VAL_BUDGET_MINUTES` (default 90). Without this, every 65k-pts run
+  silently times out without producing `test_primary/*`.
+- **Follow-up PR #20 (nezuko, EMA decay sweep)** — disambiguates "EMA too
+  slow for our step density" vs "genuine post-epoch-1 degradation". Uses
+  `--validation-every 1`.
+
+### Cross-cutting directives broadcast to all active PRs
+
+1. Rebase onto `yi` to pick up `af92e9a` + projection code (default off).
+2. `--validation-every 1` (or 2) — `validation_every=10` only gives one usable
+   checkpoint inside the 6 h budget.
+3. `--gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms` (Issue #19).
+4. Wall-shear targeted PRs (haku #10, tanjiro #15, thorfinn #16) should
+   compose with `--use-tangential-wallshear-loss` so their delta stacks on
+   the merged baseline.
+5. Report any train→val divergence observed.
+
+### Open question
+
+Train loss decreases while EMA-val degrades after epoch 1 on multiple runs.
+EMA decay too slow for fast initial fit? LR-warmup interplay? Genuine
+overfit? PR #20 (nezuko EMA sweep) and PR #21 (kohaku normsupp sweep, λ=0
+arm) will provide multi-epoch trajectories under different EMA settings.
 
 ## Constraints
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,7 +1,7 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 14:45 UTC
+- **Updated:** 2026-05-01 16:30 UTC
 - **Branch:** `yi`
-- **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
+- **Baseline:** PR #183 (fern, `pos_max_wavelength=1000`), `abupt_axis_mean_rel_l2_pct = 10.21`
 
 ---
 
@@ -23,7 +23,7 @@
 
 | Metric | yi best | AB-UPT | Gap |
 |---|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **10.69** | — | — |
+| `abupt_axis_mean_rel_l2_pct` | **10.21** | — | — |
 | `surface_pressure_rel_l2_pct` | **6.97** | 3.82 | 1.8× |
 | `wall_shear_rel_l2_pct` | **11.69** | 7.29 | 1.6× |
 | `volume_pressure_rel_l2_pct` | **7.85** | 6.08 | 1.3× |

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,15 @@
 # SENPAI Research State
 - 2026-05-02 23:10Z (Round 15/16/17 in flight — 16 WIP PRs, 0 idle students)
+- 2026-04-29 00:50Z (post-cleanup: 16 bengio WIP + 10 yi WIP, 0 idle students; 4 stale yi PRs closed)
+
+## 2026-04-29 Survey Pass Highlights
+- Closed 4 stale yi PRs (#273 edward focal-loss, #270 violet tanh-cap, #261 norman Muon, #210 kohaku grad-accum) — all four students have active bengio PRs (#304, #301, #239, #307) so the yi versions were dead duplicates.
+- PR #298 (fern learned Fourier embed): rebase merged, 4-arm sweep running healthy at ep0.4 (single-GPU per arm because yi has no DDP). Adaptations approved; ep1 is the call.
+- PR #297 (haku symm-aug Arm C): 4 runs healthy at very early training (~step 2.8-3.0k); waiting for ep1.
+- PR #308 (haku surface-loss-weight): sw=2.0 DDP4 recovery healthy at ep1=13.26%; advisor escalated for missing PR-thread acknowledgment despite urgent message.
+- PR #307 (kohaku ws-rel-l2): kohaku running off-script (asinh-96k 5L 8.69% at ep7, asinh-surfp-32k-4L at 9.07%, grad-accum-A 6L). Advisor demanded PR-thread acknowledgment + scope decision (close PR vs proceed).
+- Bengio cohort: 16 students all WIP, no idle slots.
+- yi cohort: 10 students all WIP after stale cleanup; primary actives are alphonse 6L/512d depth-scaling, askeladd 8L/10L sandwich-LN, gilbert spectral-loss screen, frieren TTA mini, nezuko 3-epoch warmdown, plus chihiro/emma legacy sweeps.
 
 ## Most Recent Research Direction from Human Researcher Team
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -103,41 +103,42 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 | #24 | emma | Squared rel-L2 aux loss (drop sqrt, smooth backward) |
 | #26 | nezuko | A01 — ANP cross-attention surface decoder (architecture swap) |
 
+| #28 | norman | A02 — SE(3) equivariant local-frame coord features |
+
 **Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
-SE(3) local-frame coordinate features. Hypothesis remains a top-priority Round-2
-candidate (A02) and will be reassigned to a real idle student.
+SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.
 
 ## Round 1 — reviewed results (2026-04-29)
 
-### VERIFIED WIN (pending merge) + MERGED — yi baseline progression
+### VERIFIED WINS (pending merge) + MERGED — yi baseline progression
 
-- **PR #8 (frieren, per-block FiLM conditioning) — VERIFIED WIN, pending merge.**
-  `abupt_axis_mean = 16.53` (vs 17.39 baseline = −4.9%). Run `hltti2ec`,
-  state=finished, 1 epoch, best_epoch=1, bs=2 only. Beats baseline in every
-  test_primary axis. Apples-to-apples vs PR #3 (no FiLM, same config): 30.47 → 16.53
-  = 46% reduction. FiLM mechanistically confirmed (token norm 70× growth, FiLM weights
-  1.8–3.6×). Merge blocked on rebase conflict — frieren rebasing now.
-  **Will be the new yi best once merged.**
-  - Follow-up PR #23 (frieren): full composition — FiLM + vol_w=2.0 + projection + bs=8.
-- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED 03:57 UTC — current yi best.**
-  `abupt_axis_mean = 17.39` (vs prior 35.12 = 50.5% reduction). Run `y2gigs61`,
-  state=finished, 6 epochs reached, best_epoch=3.
-  Win came primarily from **protocol fixes** (bs=8, validation-every=1, log-cadence).
-  - **Infrastructure bug flagged:** `train.py` has no gradient clipping.
-    Follow-up PR #22 (gilbert) adds it.
-- **PR #11 (kohaku, tangential wall-shear projection) — MERGED earlier.**
-  Code remains on yi (default off). Expected to compose for further gains.
-- **Follow-up PR #21 (kohaku, normal-component suppression sweep)** —
-  λ ∈ {0.0, 0.01, 0.1, 1.0} on top of projection.
-- **Follow-up PR #22 (gilbert, gradient clipping)** — adds
-  `torch.nn.utils.clip_grad_norm_` + 4-arm sweep. Infrastructure win
-  blocking high-LR / high-weight / high-batch sweeps.
+- **PR #13 (norman, cosine EMA 0.99→0.9999) — VERIFIED WIN, pending merge (rebase required). NEW yi BEST.**
+  `abupt_axis_mean = 15.82` (vs 17.39 merged baseline = −9.0%). Run `wio9pqw2`,
+  state=finished, 4 epochs, best_epoch=4. Wins on every test_primary axis. No
+  train→val divergence — val improved monotonically epoch 1→4. Zero new params.
+  Critical revision of (B) verdict: divergence is config-conditional (bs=2 config
+  diverges; bs=8 + vol_w=2.0 does not). EMA cosine code now on `yi` when merged;
+  all future PRs should use `--ema-decay-start 0.99 --ema-decay-end 0.9999`.
+  - Follow-up PR #27 (norman): A02 SE(3) equivariant local-frame coord features.
+- **PR #8 (frieren, per-block FiLM conditioning) — VERIFIED WIN, pending merge (rebase).**
+  `abupt_axis_mean = 16.53` (vs 17.39 baseline = −4.9%). Run `hltti2ec`, 1 epoch.
+  Superseded as standalone best by PR #13 (15.82), but FiLM composes orthogonally
+  with cosine EMA — composition should push below 14. Frieren rebasing.
+  - Follow-up PR #23 (frieren): full composition — FiLM + vol_w=2.0 + projection + bs=8 + cosine EMA.
+- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED — official yi baseline.**
+  `abupt_axis_mean = 17.39`. Run `y2gigs61`, 6 epochs.
+- **PR #11 (kohaku, tangential wall-shear projection) — MERGED.**
+  Code on yi (default off). Composable with any future PR.
+- **Follow-up PR #21 (kohaku, normal-component suppression sweep)** — λ ∈ {0.0, 0.01, 0.1, 1.0}.
+- **Follow-up PR #22 (gilbert, gradient clipping)** — `clip_grad_norm_` + 4-arm sweep.
 
-**Three independent wins now compounding (next big leap from stacking all):**
+**Four independent wins compounding (next big leap from stacking all):**
 1. Tangential projection (PR #11, default off, `--use-tangential-wallshear-loss`)
 2. Protocol fixes: vol_w=2.0, bs=8, validation-every=1 (PR #9)
 3. Per-block FiLM conditioning (PR #8, pending merge)
-→ PR #23 (frieren) will test all three together.
+4. Cosine EMA 0.99→0.9999 (PR #13, pending merge, `--ema-decay-start 0.99 --ema-decay-end 0.9999`)
+→ PR #23 (frieren) will test all four together once both PRs #8 and #13 land.
+→ Composition prediction: ~12–13 abupt (−20% from current 15.82).
 
 ### CLOSED
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,0 +1,56 @@
+# SENPAI Research State
+
+- **Date:** 2026-04-28
+- **Branch:** `yi`
+- **Target repo:** `morganmcg1/DrivAerML`
+- **W&B:** `wandb-applied-ai-team/senpai-v1-drivaerml`
+- **Most recent direction from human team:** none received
+
+## Current research focus
+
+Round 1 calibration on a clean slate. The W&B project has zero prior runs and
+`yi` has no merged baseline; the first wave must both establish a strong baseline
+and surface the strongest single-delta improvements over it.
+
+## Known prior art (from outside the `yi` W&B project)
+
+- `codex/optimized-lineage` branch ships a heavier baseline: 4L/256d/4h/128sl,
+  lr 2e-4, wd 5e-4, 65k points, EMA 0.9995. Treated as the proven floor.
+- `wandb/senpai` `radford` branch converged on a 4L/512d/8h champion with
+  fourier features, cosine-T_max=36 LR schedule, EMA 0.9995, metric-aware
+  rel-L2 auxiliary loss, and DomainLayerNorm. Best surface val ≈ 3.6%.
+  The hardest known levers were `wall_shear` and `volume_pressure`.
+
+## Round 1 — two parallel streams
+
+### Stream 1 — exploit existing evidence (5 students)
+
+Pin the floor with multiple known-good baselines and proven-additive deltas
+(LR schedule, metric-aware aux loss, scale-up). Provides reliable comparison
+points for everything else.
+
+### Stream 2 — fresh high-variance ideas (11 students)
+
+Bias toward `wall_shear` (7.29%) and `volume_pressure` (6.08%) — the two
+hardest AB-UPT targets. Researcher-agent generates a ranked hypothesis pool;
+each student tests a single mechanistically distinct delta against the same
+strong base config.
+
+## Candidate next directions (post round 1)
+
+- Geometry-aware conditioning (per-case mesh encoder + FiLM/AdaLN)
+- Equivariant / vector-neuron variants of slice attention for vector targets
+- Latent neural-operator decoders for full-resolution surface/volume queries
+- Physics-residual auxiliary losses (continuity, smoothness, log-magnitude
+  wall-shear targets)
+- Attention scaling: linear / Performer / grouped-query for full-resolution
+- Curriculum sampling and hard-example mining once a stable baseline exists
+- Pretraining via self-supervised denoising on volume/surface points
+
+## Constraints
+
+- `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` are fixed by harness — do
+  not override. Throughput improvements (compile, AMP, point-count tuning,
+  attention scaling) are the main lever for "more update budget".
+- Read-only files: `data/*`, `pyproject.toml`, `instructions/*`. All edits
+  go in `train.py`.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -79,7 +79,7 @@ Critical lessons learned from 7 failed experiments:
 | #153 | mob | `mob/lookahead-optimizer` | Lookahead optimizer k=5/10 |
 | #152 | violet | `violet/geom-moment-conditioning` | 14-dim analytic geometry conditioning |
 | #151 | nezuko | `nezuko/symmetry-augmentation` | L/R symmetry augmentation for tau_y gap |
-| #150 | emma | `emma/multi-scale-hierarchy` | Multi-scale point hierarchy (2/3 scales) |
+| #185 | emma | `emma/sam-sharpness-aware-min` | SAM optimizer ρ=0.05/0.10 (val→test gap) |
 | #144 | edward | `edward/adamw-beta2-sweep` | AdamW beta2 sweep (0.95 vs 0.999) |
 | #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR max=1e-3 |
 | #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
@@ -122,9 +122,10 @@ Pervasive Round-5 divergences motivate systematic optimizer investigation.
 - #169 thorfinn — NaN-skip + seed + LR warmup utility PR (infra for all future experiments)
 - #144 edward (in flight) — AdamW beta2 sweep (0.95 vs 0.999)
 
-### Theme 4: Post-training / test-time gain
+### Theme 4: Post-training / test-time gain + generalization
 - #171 norman — snapshot ensemble with cyclic LR (free gain from averaging 3 cycle ckpts)
 - #155 armin (in flight) — top-3 checkpoint ensemble
+- #185 emma — **SAM optimizer ρ=0.05/0.10** (Sharpness-Aware Minimization; targets val→test gap of 1.04pp; wraps AdamW with perturbation step)
 
 ### Theme 5: Data representation and augmentation
 - #183 fern (newly assigned) — **omega-bank frequency sweep** (max_wavelength sweep + per-axis omega banks); follow-up to falsified #143 coord-normalization
@@ -143,6 +144,7 @@ Pervasive Round-5 divergences motivate systematic optimizer investigation.
 - **Δp≈0 is wrong RANS physics:** Laplacian pressure constraint only valid for Stokes (creeping) flow.
 - **Volume pressure nearly converged:** 1.3× AB-UPT at baseline — wall_shear_y/z is the main gap.
 - **LR warmup guards:** 500-1000 step linear warmup from 1e-5 is now standard practice for experiments with elevated initial gradients.
+- **Multi-scale hierarchy failed (PR #150, closed 2026-05-01):** 2-scale arm stable but all primary metrics worse than baseline; 3-scale both diverged. Volume_pressure ~12% better on val but not the primary metric. Multi-scale spatial receptive field is not the lever for tau_y/z gap.
 - **Coord-norm is the wrong lever (PR #143):** The 4× tau_y/z gap is NOT primarily a sincos-anisotropy problem. `global-scale` normalization breaks the meter-calibrated `omega` bank (e1 abupt 24.85 vs control 16.20); `per-axis` causes volume-token explosions through the bias→attention path. Right next attack is the omega bank itself, in physical-meter coords (PR #183).
 - **FiLM at default-init × LR ≥ 3e-4 is unstable (PR #126):** Geom token is fine (norm steady ~0.75), but `to_gamma_beta` linear projections are the gradient amplification path (layer-0 grad/param ratio 0.567 at divergence). Volume-pressure signal real (Arm 3 vp=7.05 vs baseline 7.85) → identity-init follow-up justified (PR #184).
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -96,8 +96,15 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 | PR | Student | Hypothesis |
 |---|---|---|
+| #20 | nezuko | EMA decay sweep — diagnose train→val divergence |
+| #21 | kohaku | Normal-component suppression on top of tangential projection |
+| #22 | gilbert | Add gradient clipping to train.py + 4-arm sweep |
+| #23 | frieren | Full composition: FiLM + projection + vol_w=2.0 + bs=8 |
 | #24 | emma | Squared rel-L2 aux loss (drop sqrt, smooth backward) |
-| #25 | stark | SE(3) local-frame coordinate features (equivariant input augmentation) |
+
+**Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
+SE(3) local-frame coordinate features. Hypothesis remains a top-priority Round-2
+candidate (A02) and will be reassigned to a real idle student.
 
 ## Round 1 — reviewed results (2026-04-29)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 16:30 UTC
+- **Updated:** 2026-05-01 19:00 UTC
 - **Branch:** `yi`
 - **Baseline:** PR #183 (fern, `pos_max_wavelength=1000`), `abupt_axis_mean_rel_l2_pct = 10.21`
 
@@ -35,93 +35,93 @@
 
 ---
 
-## Active WIP PRs (as of 2026-05-01 14:30 UTC)
+## Active WIP PRs (as of 2026-05-01 19:00 UTC)
 
-### Round-6 Assignments (Just Assigned)
+### Round 14 Baseline Sweep (Just Assigned — ~Round 14)
 
-| PR | Student | Hypothesis |
-|---|---|---|
-| **#207** | alphonse | Adaptive Gradient Clipping (AGC, NFNets) per-parameter stability |
-| **#208** | askeladd | Sandwich-LN normalization to unlock 8L/256d depth |
-| **#209** | frieren | Step-decay LR drop after ep1 (5e-4→1e-4, attacks ep1→ep2 divergence) |
-| **#210** | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads |
-| **#211** | tanjiro | Relative magnitude-based grad-skip (EMA-adaptive) fleet infra |
-| **#212** | noam | Perceiver-IO backbone replacement (2-4× speed → more epochs) |
-| **#213** | nezuko | SAM (Sharpness-Aware Minimization) for flat-minima generalization |
+| PR | Student | Hypothesis | Status |
+|---|---|---|---|
+| **#243** | chihiro | Sweep aux-rel-l2-weight {0.1, 0.5, 1.0} on 10.21 baseline | Training (90-100% GPU) |
+| **#244** | emma | Sweep surface-loss-weight {1.5, 2.0} on 10.21 baseline | Training (90-100% GPU) |
+| **#245** | gilbert | Progressive EMA decay schedule on 10.21 baseline | Training (90-100% GPU) |
+| **#246** | tanjiro | Calibrate LR warmup {500, 1000 steps} on 10.21 baseline | Training (90-100% GPU) |
 
-### Ongoing From Earlier Rounds
+### Earlier-Round PRs Currently Running
 
-| PR | Student | Hypothesis |
-|---|---|---|
-| **#200** | emma | Wall-shear magnitude/direction decomposition loss (τ y/z gap) |
-| **#199** | stark | Smooth tangent-frame wall-shear prediction (continuous e_x-projection) |
-| **#198** | senku | Stochastic Weight Averaging (SWA) free gain |
-| **#197** | gilbert | k-NN local surface attention for tau_y/z gap |
-| **#196** | edward | Lion optimizer sweep vs AdamW |
-| **#193** | thorfinn | Curvature-biased surface point sampling |
-| **#191** | haku | 1-cycle LR max=1e-3 (corrected epoch-limited schedule) |
-| **#183** | fern | Omega-bank frequency sweep |
-| **#171** | norman | Snapshot ensemble with cyclic LR |
-| **#165** | chihiro | mlp_ratio=8 hardened (3-seed) |
-| **#152** | violet | 14-dim analytic geometric moment conditioning |
+| PR | Student | Hypothesis | Notes |
+|---|---|---|---|
+| **#227** | stark | Wall-shear in local surface tangent frame (Morgan's #1 directive) | **NO POD — RBAC blocked provisioning. Issue #248 filed for human operator.** |
+| **#230** | senku | SWA uniform weight averaging for flat-minima generalization | SWA activates ep25–42 of 50 |
+| **#229** | norman | y-flip test-time symmetry augmentation (TTA) | Pod restarted ~18:36 UTC; Iter 1 |
+| **#228** | edward | OHEM hard surface-point weighting for tau_y/z gap | Running |
+| **#225** | haku | Left-right symmetry augmentation (tau_y/z gap) | Arm C surviving; awaiting ep2 |
+| **#224** | fern | Learned Fourier embeddings per-axis freq learning | Arms G/H/I/J relaunched |
+| **#222** | (Round12) | 1-epoch LR warmup before cosine decay | Running |
+| **#221** | violet | Per-channel adaptive loss reweighting toward AB-UPT targets | v6 (lr=3e-4, seed=1) running |
+| **#218** | frieren | SO(3)-equivariant tangent-frame wall shear head | Running |
+| **#214** | gilbert | k-NN local surface attention for wsy/wsz gap | Running |
+| **#213** | nezuko | SAM optimizer for flat-minima generalization | ep1 underperforming control; awaiting ep2 |
+| **#210** | kohaku | Gradient accumulation eff_bs=32 | Training (confirmed GPU activity) |
+| **#209** | frieren | Step-decay LR drop after ep1 (seed=-1, no-warmup relaunches) | Awaiting ep1 vals |
+| **#208** | askeladd | Sandwich-LN to unlock 8L/256d depth | Arm B (8L sandwich-LN, bs=4) running ~18866+ steps |
+| **#207** | alphonse | AGC (NFNets) per-parameter stability | Arms I/J/K running |
+| **#193** | thorfinn | Curvature-biased surface point sampling | alpha=0.25 arm running |
+| **#152** | violet | Per-channel adaptive loss reweighting | v6 running |
 
----
-
-## Round-6 Closed PRs (Negatives)
-
-| PR | Student | Hypothesis | Best Val | Verdict |
-|---|---|---|---:|---|
-| **#168** | askeladd | Normal-consistency penalty λ∈{0.01,0.05,0.10} | 12.285 (ep2) | NEGATIVE — tangentiality enforcement provides no metric gain |
-| **#164** | alphonse | 8L/256d + 1cycle LR | DNF (all diverged) | NEGATIVE — 8L/256d has LR ceiling < 5e-4 |
-| **#123** | frieren | asinh/log wall-shear target normalization | 17.55 (ep1) | NEGATIVE — tail suppression kills the signal |
+### Pod Status (as of 2026-05-01 19:00 UTC)
+- All 17 named student deployments: READY (1/1)
+- `senpai-yi-stark`: **MISSING** — human provisioning required (Issue #248)
 
 ---
 
 ## Current Research Themes
 
-### Theme 1: Coordinate-Frame Hypothesis for tau_y/z Gap (HIGHEST PRIORITY)
+### Theme 1: Coordinate-Frame Hypothesis for tau_y/z Gap (HIGHEST PRIORITY — Morgan's directive)
 **Root question:** Is the 4× tau_y/z error a coordinate-frame problem? AB-UPT achieves equal error on tau_x/y/z (~3.6) while we have 10/14/15.
 
-- **#199 stark:** Full tangent-frame prediction (smooth e_x-projection frame). Morgan's #1 directive.
-- **#200 emma:** Magnitude/direction decomposition loss — decouple scale from alignment learning.
-- **CLOSED NEGATIVE #168 askeladd:** Normal-consistency penalty — model already near-tangential naturally.
-- **CLOSED NEGATIVE #121:** Hard Duff-ONB tangent-frame — discontinuous at t1.x sign-flip.
+- **#227 stark:** Wall-shear prediction in local surface tangent frame {t1, t2, n}. Morgan's #1 directive. **POD MISSING — Issue #248 filed.**
+- **#218 frieren:** SO(3)-equivariant tangent-frame wall shear head.
+- **CLOSED NEGATIVE #121, #168:** Hard Duff-ONB (discontinuous at t1.x sign-flip) and normal-consistency penalty (model already near-tangential).
 
-### Theme 2: Architecture Replacement (BOLD SWINGS — Morgan's directive)
-- **#212 noam (NEW):** Perceiver-IO backbone — cross-attention bottleneck, 2-4× faster per epoch → 5+ epochs in budget. Morgan's #2 priority.
-- **#208 askeladd (NEW):** Sandwich-LN to unlock 8L/256d depth — prior 8L attempts all diverged; sandwich-LN dampens gradient growth across depth.
+### Theme 2: Hyperparameter Calibration (Round 14 Sweep)
+Systematic calibration on 10.21 baseline — four students sweeping complementary hyperparameters:
+- **#243 chihiro:** aux-rel-l2-weight {0.1, 0.5, 1.0}
+- **#244 emma:** surface-loss-weight {1.5, 2.0}
+- **#245 gilbert:** progressive EMA decay schedule
+- **#246 tanjiro:** LR warmup steps {500, 1000}
 
-### Theme 3: Optimizer Stability Infrastructure
-**Four independent confirmations (PRs #123, #168, #165, #164):** Large-but-finite grad spikes bypass PR #169's NaN-skip.
-- **#211 tanjiro (NEW):** Relative magnitude-based grad-skip (EMA-adaptive threshold).
-- **#207 alphonse (NEW):** AGC per-parameter clipping (NFNets). Addresses root cause by making clip threshold proportional to weight norm.
-- Together these form a complementary infra pair; combine if both show promise.
+### Theme 3: Architecture Scaling
+- **#208 askeladd:** Sandwich-LN to unlock 8L/256d depth — Arm B running stably at 18866+ steps.
+- **#235 askeladd:** 4L/512d/8H width frontier — radford champion port.
+- **#240 frieren:** Wider FFN (mlp-ratio=8) for richer per-block representation.
+- **#241 tanjiro:** Width scaling 512→768d with µP-scaled LR.
+- **PRIOR FINDING: Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M) — further depth exploration warranted if sandwich-LN stabilizes 8L.
 
-### Theme 4: LR Schedule Optimization
-- **#209 frieren (NEW):** Step-decay LR drop after ep1 (5e-4→1e-4). Attacks the universal ep1→ep2 train/val divergence observed across 4 normalization variants in PR #123.
-- **CLOSED NEGATIVE #164/#191:** OneCycleLR — 8L/256d and LR ceiling at ~6.5e-4 confirmed.
+### Theme 4: Optimizer and Training Infrastructure
+- **#207 alphonse:** AGC (NFNets) per-parameter clipping. Arms I/J/K running.
+- **#213 nezuko:** SAM optimizer — ep1 underperforming control; ep2 awaited.
+- **#234 senku:** Mirror-symmetry TTA for wsy free gain.
+- **#229 norman:** y-flip TTA (Pod restarted ~18:36 UTC).
+- **#230 senku:** SWA uniform weight averaging.
 
-### Theme 5: Batch Statistics and Gradient Quality
-- **#210 kohaku (NEW):** Gradient accumulation eff_bs=32. Zero VRAM cost; smoother gradient estimates for rare high-|τ| tail points.
-- **#183 fern:** Omega-bank frequency sweep. Three arms healthy.
+### Theme 5: Loss Formulation and Sampling
+- **#236 edward:** Fixed wsy/wsz loss multipliers — direct binding-constraint attack.
+- **#237 haku:** Squared rel-L2 aux loss for hard-sample focusing.
+- **#238 kohaku:** High-shear curriculum oversampling for wsy/wsz tail.
+- **#225 haku:** Left-right symmetry augmentation.
+- **#193 thorfinn:** Curvature-biased surface point sampling (alpha=0.25 arm).
 
-### Theme 6: Physics-Informed Constraints
-- **CLOSED NEGATIVE #201 nezuko:** RANS divergence-free penalty — label contradiction: GT mesh has RMS(τ·n)/|τ|=12%, so (τ·n)=0 no-slip constraint directly opposes labels. No feasible λ.
-- **CLOSED NEGATIVE #168:** Normal-consistency (tangential) constraint.
-- **Theme exhausted at current data contract.** True ∇·u requires velocity head (volume_y is pressure-only).
+### Theme 6: Positional Encoding
+- **#224 fern:** Learned Fourier embeddings per-axis freq. Arms G/H/I/J relaunched.
+- **#239 norman:** Fourier PE num_freqs sweep {16, 32, 64, 128}.
+- **BASELINE: PR #183 (fern):** pos_max_wavelength=1000 ContinuousSincosEmbed — the current 10.21 bar.
 
-### Theme 9: Optimization Landscape (NEW)
-- **#213 nezuko (NEW):** SAM (Sharpness-Aware Minimization) — seeks flat minima explicitly. 500-train vs 50-val geometries → sharp minima risk. SAM's 2× compute cost limits to 2 epochs but flat-minima training may beat 3 sharp-minima epochs.
+### Theme 7: Adaptive Loss Reweighting
+- **#221 violet:** Per-channel adaptive loss reweighting toward AB-UPT targets. v6 running (lr=3e-4, warmup=1000, seed=1).
+- **#228 edward:** OHEM hard surface-point weighting.
 
-### Theme 7: Ensemble and Budget Efficiency
-- **#171 norman:** Snapshot ensemble with cyclic LR (V2).
-- **#198 senku:** SWA — free post-train gain from weight averaging.
-- **#196 edward:** Lion optimizer sweep.
-
-### Theme 8: Data Representation and Sampling
-- **#197 gilbert:** k-NN local surface attention for tau_y/z spatial locality.
-- **#193 thorfinn:** Curvature-biased surface point sampling.
-- **#152 violet:** 14-dim analytic geometric moment conditioning.
+### Theme 8: Architecture Depth Ablation (Round 12 PRs still running)
+- **#231 (slices=64), #232 (heads=4), #233 (layers=3):** Ablate individual architectural dimensions from SOTA.
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,169 +1,151 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 22:35 UTC (yi advisor sweep)
-- **Branches:** `yi` (4L/512d Lion SOTA), `bengio` (4L/256d AdamW Wave 2/3), `tay` (Lion+DDP refactored codebase)
-
----
+- 2026-05-02 (Round 15/16/17 in flight — 17 WIP PRs, 0 idle students)
 
 ## Most Recent Research Direction from Human Researcher Team
 
-**Issue #252 (Morgan, 2026-05-01):** Get inspired by Modded-NanoGPT — review the world-record table and propose specific DrivAerML experiments. ADVISOR acknowledged at 19:48Z; 4 directions now assigned (Muon, linear-warmdown LR, U-net skips, tanh soft-cap).
+**Issue #252** (open, Morgan, 2026-05-01): "Get inspired by Modded-NanoGPT". Directs the advisor to review the modded-nanogpt world record history table and reason carefully about applicability before assigning experiments. Already addressed by Round 15 PRs (see below).
 
-**Issue #18 (Morgan, 2026-04-30, ongoing directive):** Stop incremental tuning. Take bigger architectural swings. Compounding small wins is also OK as long as they keep landing.
+**Issue #248** (open, Morgan): senpai-yi-stark pod requires manual provisioning (orchestrator service account lacks RBAC create/patch on configmaps/deployments). Comment posted directing Morgan to launch via cluster admin. Blocks PR #227 (surface-tangent frame).
 
----
+**Issue #18** (earlier): Stop incremental tuning. Rip out the model architecture and try completely new approaches. Most priority experiments are assigned or closed:
+1. Surface-tangent frame wall-shear prediction — PR #227 (stark), blocked on pod provisioning
+2. Perceiver-IO backbone replacing Transolver — closed as dead end (PRs #122, #212)
+3. asinh/log target normalization for wall shear — PR #249 (tanjiro), in progress
+4. Physics-informed RANS divergence constraint — closed as dead end (PR #124)
+5. 1-cycle LR schedule with higher peak (1e-3) — closed as dead end (PR #191)
 
-## Current Baselines
+## Modded-NanoGPT Mapping (Round 15, Issue #252 response)
 
-### yi branch (advisor branch, primary fleet)
+| modded-nanogpt technique | PR | Student | Branch | Reasoning |
+|---|---|---|---|---|
+| Muon optimizer (Newton-Schulz orthogonalized momentum, record 3) | #261 | norman | yi | Lion stable at lr=1e-4 (PR #222). Muon is a strictly better Newton-step optimizer in weight space — direct fit for our Transolver. |
+| Linear warmdown LR (WSD, records 28/41) | #262 / #269 | nezuko / norman | yi | Cosine cuts LR too early on 9-epoch budget; WSD keeps LR high longer. |
+| Post-attn RMSNorm / sandwich-LN-style highway | #266 | stark | bengio | U-net record 11 analogue: gradient highway across layers helps tau_y/z multi-scale. |
+| tanh output soft-cap (record 18 analogue) | #270 | violet | yi | Bounds physical predictions, prevents NaN-prone runaway in epoch 1. |
+| Tighter grad clip (record 28 stability) | #267 | haku | yi | Reduces variance of crash distribution at lr=5e-4. |
+| Larger width with muP-scaled LR | #271 | senku | yi | hidden_dim=768 with appropriate LR scaling. |
+| LR-min lower bound (1e-5) | #272 | violet | yi | WSD-style minimum LR for plateau gain. |
 
-**Bar to beat: val_abupt = 9.2910% (PR #222 fern, lr_warmup_epochs=1).** W&B run `ut1qmc3i`.
+## Current Baseline: PR #222 (fern) — yi branch — val abupt 9.291%
 
-| Metric | yi best | AB-UPT | Ratio |
+| Metric | yi best (val) | AB-UPT target | Ratio |
 |---|---:|---:|---:|
-| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910** | — | — |
-| `val_primary/surface_pressure_rel_l2_pct` | **5.8707** | 3.82 | 1.54× |
-| `val_primary/wall_shear_rel_l2_pct` | **10.3423** | 7.29 | 1.42× |
-| `val_primary/volume_pressure_rel_l2_pct` | **5.8789** | 6.08 | **0.97×** ✓ |
+| `abupt_axis_mean_rel_l2_pct` | **9.291** | — | — |
+| `surface_pressure_rel_l2_pct` | **5.8707** | 3.82 | 1.54× |
+| `wall_shear_rel_l2_pct` | **10.3423** | 7.29 | 1.42× |
+| `volume_pressure_rel_l2_pct` | **5.8789** | 6.08 | **0.97× (SOLVED)** |
+| `wall_shear_x_rel_l2_pct` | — | 5.35 | — |
+| `wall_shear_y_rel_l2_pct` | — | **3.65** | **~3.7× (major gap)** |
+| `wall_shear_z_rel_l2_pct` | — | **3.63** | **~4.0× (major gap)** |
 
-Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain the gap.
+**Volume pressure is solved (0.97×). Wall_shear_y/z remain the dominant challenge. Surface pressure at 1.54× is the #2 priority.**
 
-### bengio branch (Wave 2/3 long-schedule experiments)
+**Merge bar: 9.291% — any PR must beat this val_abupt to merge.**
 
-**Bar to beat: val_abupt = 7.2091% at ep30 (alphonse `m9775k1v`, 4L/256d, AdamW, T_max=30).**
+## Active WIP PRs (as of 2026-04-29 — 17 WIP PRs)
 
----
-
-## Active WIP PRs (as of 2026-05-01 20:25 UTC)
-
-### yi branch — 17 WIP PRs (zero idle)
-
-Note: PRs assigned to other advisor branches (`tay`: #247, #280; `bengio`: #239) are excluded from this table — they belong to those advisors' fleets.
-
-| PR | Student | Hypothesis | Status |
+| PR | Student | Hypothesis | Round |
 |---|---|---|---|
-| #286 | frieren | **bilateral-symmetry test-time augmentation (TTA)** for tau_y/z gap | NEW (just assigned 22:35Z, replacing closed #209) |
-| #284 | alphonse | 6L/512d depth+width scaling on Lion+warmup SOTA | Awaiting student launch |
-| #273 | edward | focal-loss per-point surface weighting (γ sweep {0,0.5,1,2}) | All 4 arms launched, AdamW-control on yi |
-| #270 | violet | **tanh output soft-cap** (modded-NanoGPT logit-cap analog) | Arm-matrix swap applied; sweep restarted |
-| #262 | nezuko | **linear-warmdown LR schedule** (modded-NanoGPT WSD-style) | Arm C only (skipped A; fern `ut1qmc3i` is published control) |
-| #261 | norman | **Muon optimizer** (Newton-Schulz orthogonalized momentum) | Plan B-modified: AdamW control; Lion port deferred |
-| #249 | tanjiro | asinh wall-shear normalization | TempCollapse fix applied (commit 66cce26); arms relaunched |
-| #245 | gilbert | progressive EMA decay (0.99→0.9999 etc.) | Arm B retry ep1 val landed; Arm C retry crashed at 94% |
-| #244 | emma | surface-loss-weight {1.5, 2.0} | Both arms stable on lr=3e-4 |
-| #243 | chihiro | aux-rel-l2-weight {0.1, 0.5, 1.0} | A r3 + B r2 ep1 vals landed; C r2 still in ep1 |
-| #230 | senku | SWA tail-end weight averaging | v2 sweep (warmup=1000) launched 21:49Z, all 4 arms healthy |
-| #227 | stark | wall-shear in surface tangent frame | **NO POD — RBAC blocked, Issue #248 (still OPEN)** |
-| #225 | haku | mirror symmetry training augmentation | Running, lr=5e-4 instability margin documented |
-| #224 | fern | learned Fourier embeddings per-axis | K/L/N/O surviving; J finding: init=10 beats sincos by 6.7% at matched ep1 |
-| #210 | kohaku | gradient accumulation eff_bs=32 | Arm A switched to lr=3e-4+seed=43 after dual seed=42/43 crashes |
-| #208 | askeladd | sandwich-LN to unlock 8L/256d | Round-7 launched 20:23Z; lr_warmup ramp running |
-| #207 | alphonse | Adaptive Gradient Clipping (AGC) | lr=3e-4 arms only surviving |
-| #193 | thorfinn | curvature-biased surface point sampling | 3 lr=3e-4 arms healthy past warmup; lr=5e-4 path closed |
+| #273 | edward | Focal-loss per-point surface weighting for tau_y/z (γ sweep) | 15 |
+| #270 | violet | tanh output soft-cap for wsy/wsz tail bounding | 15 |
+| #262 | nezuko | Linear-warmdown LR (modded-nanogpt WSD-style) | 15 |
+| #261 | norman | Muon optimizer (Newton-Schulz orthogonalized momentum) | 15 |
+| #249 | tanjiro | asinh normalization for wall-shear targets | 14 |
+| #288 | gilbert | Spectral Fourier loss on wall-shear tau_y/z channels | 16 |
+| #244 | emma | Sweep surface-loss-weight (1.5/2.0) | 13 |
+| #243 | chihiro | Sweep aux-rel-l2-weight (0.1/0.5/1.0) | 13 |
+| #230 | senku | SWA uniform weight averaging for flat-minima generalization | 13 |
+| #227 | stark | Wall-shear in local surface tangent frame **[BLOCKED — no pod, Issue #248]** | 14 |
+| #297 | haku | symm-aug Arm C (include-both bs=4) on stable lr=1e-4/wu=1ep base — follow-up to #225 | 17 |
+| #224 | fern | Learned Fourier embeddings for tau_y/z gap (per-axis freq learning) | 13 |
+| #210 | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads | 13 |
+| #286 | frieren | Bilateral-symmetry TTA (y→-y reflection at inference) | 15 |
+| #284 | alphonse | 6L/512d depth+width scaling — DDP port in progress (awaiting relaunch) | 15 |
+| #208 | askeladd | Sandwich-LN to unlock 8L/256d depth (stability fix) | 13 |
+| #193 | thorfinn | Curvature-biased surface point sampling (tau_y/z gap fix) | 13 |
 
-### Closed since last update (2026-05-01)
-- **PR #209** (frieren step-decay LR drop) — closed 21:22Z. All decay arms (B/C/D) underperformed no-decay control; hypothesis rejected on this lineage.
+## Key Architecture Configuration (PR #222 winning base config)
 
-### bengio branch — 16 WIP PRs (zero idle)
+```bash
+torchrun --standalone --nproc_per_node=8 train.py \
+  --optimizer lion \
+  --lr 1e-4 \
+  --weight-decay 5e-4 \
+  --no-compile-model \
+  --batch-size 4 \
+  --model-layers 4 \
+  --model-hidden-dim 512 \
+  --model-heads 8 \
+  --model-slices 128 \
+  --ema-decay 0.999 \
+  --lr-warmup-epochs 1
+```
 
-| PR | Student | Hypothesis | Status |
-|---|---|---|---|
-| #266 | stark | **U-net long skip connections** (modded-NanoGPT-inspired) | NEW (just assigned) |
-| #260 | thorfinn | model-slices sweep {64, 128, 192} | NEW |
-| #259 | senku | grad-clip-norm sweep {0.5, 2.0} | NEW |
-| #258 | kohaku | squared rel-L2 aux loss (focal-style) | NEW |
-| #257 | haku | high-shear curriculum oversampling | NEW |
-| #256 | frieren | mirror-symmetry TTA | NEW |
-| #255 | edward | fixed wsy/wsz loss multipliers | NEW |
-| #254 | chihiro | raw rel-L2 auxiliary loss sweep | Just launched |
-| #253 | askeladd | FourierEmbed vs ContinuousSincosEmbed | NEW |
-| #239 | norman | (yi-branch — listed above) | — |
-| #221 | violet | per-channel adaptive reweighting | Run A ep5=11.12, gate stalled, second prod posted |
-| #214 | gilbert | k-NN local surface attention | **Strong signal: -1.58pp wsy, -1.22pp wsz at ep2 vs alphonse** |
-| #179 | nezuko | 5L/384d wide-deep + Fourier PE | Rebased; ep10=8.825% gate passed; ep30 needed |
-| #174 | alphonse | 5L/256d + Fourier PE + T_max=50 | `vu4jsiic` ep9=9.10, ep10=8.64 — strong descent |
-| #80 | tanjiro | surface-loss-weight sweep | Trial B1 ep16=8.96 gate passed |
-| #79 | emma | DrivAerML 60k Points + Fourier PE | Merge conflict — rebase requested |
-| #75 | fern | LR sweep with Fourier PE | Trial B ep18=8.47, projected ep30 ~7.95 |
+Note: Lion optimizer (lr=1e-4 with 1-epoch warmup) is now confirmed stable via PR #222. This resolves the earlier Lion instability observed at higher LRs.
 
-### Closed this round
+## Fleet-Wide Stability Constraints
 
-- **PR #229** (norman y-flip TTA, yi) — closed as stale duplicate; norman was actively on PR #239 bengio
-- **PR #152** (violet geom-moment, yi) — closed after 3 cascading divergences on rebased base; architecture mismatch with new SOTA stack
+- **lr=5e-4 is the hard stability ceiling** for AdamW with clip=1.0/bf16.
+- **`--lr-warmup-epochs 1` (or `--lr-warmup-steps 500`) is the dominant stability lever**.
+- **Lion optimizer confirmed stable at lr=1e-4** with 1-epoch warmup (PR #222).
+- **Adam v-saturation ceiling confirmed**: Lion at lr>1e-4 diverges; AdamW at lr=5e-4 NaN-instable.
+- **Kill threshold**: gnorm<300 (not 100).
+- **Per-axis static weight ceiling**: W_y=W_z < 3.0 at lr=5e-4/clip=1.0. W_y=W_z=2 stable (PR #66).
 
----
+## Operational Notes (current round)
 
-## Current Research Themes
+- **Fleet-wide stochastic lr=5e-4 instability**: PRs #243, #244, #245 all hit gradient explosions (gnorm → 100k+) in early epoch 1 caused by seed-dependent init/data orderings, NOT by the experimental interventions. Mitigation: kill at gnorm>300, relaunch at lr=3e-4 or with fresh seed. PR #243 Arms A-r3 (`v4mdrc2h`) and B-r2 (`f2oca4ee`) running healthily at lr=3e-4.
+- **Stale Round-4 PRs closed 2026-05-01**: #75 (fern lr sweep), #79 (emma 60k points), #80 (tanjiro surface-loss-weight=2.0). All three superseded by current 4L/512d SOTA stack.
 
-### Theme 1: Issue #252 / Modded-NanoGPT Inspiration (NEW)
-- **#261 norman:** Muon optimizer (Newton-Schulz orthogonalized momentum)
-- **#262 nezuko:** Linear-warmdown LR schedule (WSD-style)
-- **#266 stark:** U-net long skip connections
-- **#270 violet:** tanh output soft-cap (regression analog of logit-cap)
-- Deferred: FlexAttention, FP8 head, sequence packing
+## Closed Dead Ends (do not re-assign)
 
-### Theme 2: Locality / Receptive Field for wsy/wsz Gap (HOT)
-- **#214 gilbert (bengio):** kNN local surface attention — STRONG ep2 signal
-- **#193 thorfinn (yi):** curvature-biased surface point sampling
-- **#266 stark (bengio):** U-net skip injection of fine-detail to deep layers (mechanism complement to kNN)
+| PR | Result | Reason |
+|---|---|---|
+| #75 fern | Old Round-4 LR sweep on 4L/256d+no-EMA | Architecture superseded by 4L/512d SOTA |
+| #79 emma | 60k points sweep on 4L/256d+no-EMA | Architecture superseded by 4L/512d SOTA |
+| #80 tanjiro | surface-loss-weight=2.0 on 4L/256d | Superseded by emma PR #244 on 4L/512d |
+| #122 emma | Perceiver-IO: 2× worse than baseline | Cross-attn bottleneck loses fine CFD spatial structure |
+| #212 noam | Perceiver-IO: closed (no pod) | No senpai-yi-noam deployment existed |
+| #132 violet | Decoupled wallshear mag+dir: +12.7% worse | Cosine loss scales by sin(θ), not helpful for small-magnitude axes |
+| #127 nezuko | Stochastic depth: all 3 arms worse on tau_y/z | Incoherent layer signal hurts boundary-layer features |
+| #135 tanjiro | T_max=100 cosine LR: +4.74% vs PR #115 SOTA | Schedule lever closed; lr-change dominates |
+| #167 tanjiro | W_y=W_z=3.5 + 1k LR warmup: NaN'd | Adam v-saturation at high static loss weights |
+| #119 edward | RFF encoding: 56% worse | Fixed Gaussian B + non-isotropic coords = unstable |
+| #124 gilbert | RANS divergence: all non-zero λ NaN'd | CFD pressure is NOT smooth — physical mismatch |
+| #197 gilbert | K-NN local surface attention: all arms worse | Locality bias hypothesis falsified; tau_y/z gap is NOT a receptive-field problem |
+| #196 edward | Lion optimizer (high LR): all 12 arms diverged | Lion unstable at lr>=1e-4 (old test, pre-warmup) |
+| #191 haku | 1-cycle LR super-convergence: best 18.43 | OneCycleLR incompatible with time-limited regime |
+| #171 norman | Snapshot ensemble with cosine restarts: V1+V2 failed | Cyclic LR snapshots don't give free gain |
+| #199 stark | Surface-tangent frame: pod never launched | Zero compute attached; reassigned as PR #227 |
+| #144 edward | β2=0.95 sweep: best 11.803 vs baseline 10.69 | β2 not a primary stability lever |
+| #45 | Mamba-2 SSM: diverged | — |
+| #15/#36 | SDF-gated volume attention: no improvement | — |
+| #7/#17 | Area-weighted loss: non-viable | — |
 
-### Theme 3: Loss Formulation
-- **#243 chihiro (yi):** aux-rel-l2-weight sweep
-- **#254 chihiro (bengio):** raw rel-L2 aux loss sweep
-- **#258 kohaku (bengio):** squared rel-L2 aux (focal-style)
-- **#255 edward (bengio):** fixed wsy/wsz multipliers
-- **#244 emma (yi):** surface-loss-weight {1.5, 2.0}
-- **#221 violet (bengio):** adaptive per-channel reweighting toward AB-UPT targets
-- **#270 violet (yi):** tanh output soft-cap (bounds tail predictions)
+## Key Research Insights
 
-### Theme 4: Optimization & Stability
-- **#207 alphonse (yi):** AGC — only lr=3e-4 arms surviving
-- **#247 thorfinn (yi):** cosine T_max=14 schedule
-- **#262 nezuko (yi):** linear-warmdown LR
-- **#259 senku (bengio):** grad-clip-norm sweep
-- **#261 norman (yi):** Muon optimizer
-- **#245 gilbert (yi):** progressive EMA decay
-- **#249 tanjiro (yi):** asinh wall-shear target normalization
+1. **Coordinate anisotropy** (PR #183): pos_max_wavelength=1000 gave +4.5% improvement vs 10000. DrivAerML vehicle bbox is ~8m×2.5m×2m — denser frequency sampling critical.
 
-### Theme 5: Architecture
-- **#208 askeladd (yi):** sandwich-LN for 8L/256d depth
-- **#260 thorfinn (bengio):** model-slices sweep {64, 128, 192}
-- **#179 nezuko (bengio):** 5L/384d wide-deep + Fourier PE — ep10 gate passed
+2. **Bilateral symmetry** of DrivAerML vehicles under y→-y reflection: tau_y anti-symmetric, tau_x/z unchanged. 50% free augmentation. PR #225 confirmed ep1 signal (−28% abupt, −29.4% tau_y/z for include-both Arm C), but lr=5e-4 instability prevented convergence. PR #297 (haku) re-tests Arm C on stable lr=1e-4/wu=1ep base.
 
-### Theme 6: Positional Encoding
-- **#224 fern (yi):** learned Fourier embeddings per-axis (init=10 beats sincos at matched ep1)
-- **#239 norman (bengio):** Fourier PE num_freqs sweep {16, 32, 64, 128}
-- **#253 askeladd (bengio):** FourierEmbed vs ContinuousSincosEmbed standalone test
+3. **The y/z gap is a feature-resolution problem**, not a capacity problem. 6L/256d previously beat 4L/512d; depth beats width. However PR #222 found that 4L/512d with proper LR (1e-4 Lion + warmup) outperforms prior 6L/256d best.
 
-### Theme 8: Core Building Blocks (MLP / Activation)
-- **#280 frieren (yi):** MLP activation ablation (SwiGLU / ReLU² vs GELU) — NEW, modded-NanoGPT-inspired
+4. **Volume pressure is solved** (0.97× AB-UPT). All future experiments should avoid sacrificing p_v for tau gains.
 
-### Theme 7: Symmetry / TTA / Augmentation
-- **#225 haku (yi):** mirror symmetry training augmentation
-- **#286 frieren (yi):** bilateral-symmetry TTA — orthogonal to #225, inference-only, no training cost
-- **#256 frieren (bengio):** mirror-symmetry TTA
-- **#257 haku (bengio):** high-shear curriculum oversampling
-- **#227 stark (yi):** wall-shear in tangent frame — POD MISSING (RBAC, Issue #248)
-- **#230 senku (yi):** SWA tail-end weight averaging
+5. **LR warmup is mandatory for stability** at any optimizer. Single-epoch warmup (PR #222) works better than step-based warmup for Lion.
 
-### Theme 9: Architecture Capacity Scaling
-- **#284 alphonse (yi):** 6L/512d depth+width on Lion+warmup SOTA — tests whether 4L/512d is capacity-bound
+6. **Deep architecture risk**: 8L stability is untested; askeladd (#208) is testing sandwich-LN as stabilizer.
 
----
+## Potential Next Research Directions
 
-## Fleet-Wide Stability Constraints (current)
+After current round completes:
 
-- **lr=5e-4 + 4L/512d is structurally unstable on yi-monolithic AdamW.** Confirmed across 10+ arms across PRs #193/#207/#210/#224/#243/#244/#245. Standard response: relaunch at lr=3e-4 or seed=-1.
-- **yi vs tay infrastructure gap**: PR #222 winning config (Lion + DDP + `--lr-warmup-epochs`) lives on `tay`'s refactored codebase. yi's monolithic `train.py` is **AdamW-only, single-process, has only `--lr-warmup-steps` and `--wandb-group` (dash form)**. All Round-15 yi PRs run AdamW-control comparisons — relative deltas, not absolute 9.291% bar. Lion+DDP port to yi deferred to a single dedicated infra PR (no student assigned yet).
-- **PR #222 SOTA recipe (Lion, lr=1e-4, lr_warmup_epochs=1, 4L/512d) is the only confirmed-stable optimizer point** for the absolute bar — but only reproducible on tay.
-- **Volume pressure now beats AB-UPT (0.97×, 5.88 vs 6.08).** All future experiments should avoid sacrificing p_v for tau gains.
-- **Wall_shear_y/z gap remains 1.4× of AB-UPT** — primary research target.
-- **Issue #248 (stark pod RBAC)**: still OPEN. Two follow-up nudges posted to Morgan; awaiting human cluster admin action.
-
----
-
-## Key Constraints
-
-- Training budget: ~270 min training + ~90 min val/test = 360 min total
-- VRAM: 96 GB per GPU; SOTA recipe uses ~75 GB
-- Gradient clipping: clip_grad_norm=1.0 standard
-- Students have 4 GPUs each; single-process per GPU enables 4 arms in parallel
+- **Ensemble/averaging**: Train 2+ models with different seeds, average predictions. Free ~1–2% compounding win if predictions decorrelate (minimal code complexity, high expected impact).
+- **Deeper investigation into what the model is getting wrong**: Visualize worst-predicted surface regions; are errors concentrated in specific geometric features (wheel arches, side mirrors)?
+- **Bigger effective batch size via gradient accumulation** (#210 kohaku) — if eff_bs=32 shows gains, push to eff_bs=64/128.
+- **Architecture width/depth scaling** — with 1-epoch warmup confirmed working, try 6L/512d or 8L/512d to see if the architecture capacity is still the ceiling.
+- **Multi-scale feature aggregation** — hierarchical point encoding to capture both local surface topology and global geometry simultaneously.
+- **Deformable convolution-style learned sampling** — instead of fixed sampling points, learn which regions to query for each prediction.
+- **Spectral/frequency-domain loss** — optimize in frequency space for tau_y/z to address the heavy-tail distribution issue without asinh heuristics.
+- **Physics-based regularization** (beyond RANS, which failed): symmetry constraints, continuity constraint at boundaries, divergence-free surface pressure gradients.
+- **Cross-validation study**: Are current best metrics stable across folds? A variance analysis of the test set would indicate if further tuning helps or if we're noise-fitting.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -96,11 +96,12 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 | PR | Student | Hypothesis |
 |---|---|---|
-| #20 | nezuko | EMA decay sweep — diagnose train→val divergence |
+| ~~#20~~ | ~~nezuko~~ | ~~EMA decay sweep~~ — CLOSED, verdict (B) confirmed |
 | #21 | kohaku | Normal-component suppression on top of tangential projection |
 | #22 | gilbert | Add gradient clipping to train.py + 4-arm sweep |
 | #23 | frieren | Full composition: FiLM + projection + vol_w=2.0 + bs=8 |
 | #24 | emma | Squared rel-L2 aux loss (drop sqrt, smooth backward) |
+| #26 | nezuko | A01 — ANP cross-attention surface decoder (architecture swap) |
 
 **Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
 SE(3) local-frame coordinate features. Hypothesis remains a top-priority Round-2
@@ -147,9 +148,18 @@ candidate (A02) and will be reassigned to a real idle student.
   timeout fix (`train.py`); cherry-picked onto `yi` as `af92e9a`. Reserves
   `SENPAI_VAL_BUDGET_MINUTES` (default 90). Without this, every 65k-pts run
   silently times out without producing `test_primary/*`.
-- **Follow-up PR #20 (nezuko, EMA decay sweep)** — disambiguates "EMA too
-  slow for our step density" vs "genuine post-epoch-1 degradation". Uses
-  `--validation-every 1`.
+- **PR #20 (nezuko, EMA decay sweep) — CLOSED 2026-04-29 with diagnostic value.**
+  4-arm sweep across `--ema-decay ∈ {0.99, 0.999, 0.9995, 0.99995}`. Verdict:
+  **(B) genuine post-epoch-1 instability**, not EMA lag. Even the most aggressive
+  decay (0.99, window ~100 steps) peaks at epoch 1; train loss is non-monotonic
+  across all four seeds (5–7× higher in epoch 2). Per-step spikes hit 6–22× the
+  median around steps 45–60k — exactly where missing gradient clipping bites.
+  Best arm 0.9995 → abupt 24.74 (above yi baseline; closed because diagnostic
+  not competitive). Confirms `--ema-decay 0.9995` as right default; PR #22
+  (gradient clipping) is the cure for the binding constraint.
+- **Follow-up: nezuko assigned A01 (ANP cross-attention surface decoder)** — the
+  largest architectural win from noam (PR #2379 MERGED, −70% in-domain p_s on
+  TandemFoil). Direct port to DrivAerML.
 
 ### Cross-cutting directives broadcast to all active PRs
 
@@ -165,12 +175,14 @@ candidate (A02) and will be reassigned to a real idle student.
    the hypothesis.
 5. Report any train→val divergence observed.
 
-### Open question
+### Resolved question (2026-04-29)
 
-Train loss decreases while EMA-val degrades after epoch 1 on multiple runs.
-EMA decay too slow for fast initial fit? LR-warmup interplay? Genuine
-overfit? PR #20 (nezuko EMA sweep) and PR #21 (kohaku normsupp sweep, λ=0
-arm) will provide multi-epoch trajectories under different EMA settings.
+**Train→val divergence after epoch 1 = (B) genuine post-epoch-1 instability**,
+diagnosed by PR #20 (nezuko EMA sweep). Train loss explodes 5–7× from epoch 1
+to epoch 2 across all 4 EMA arms; per-step train_loss spikes hit 6–22× median.
+The cure is **gradient clipping** (PR #22 in flight) and likely **LR warmup**
+(PR #5 edward in flight). Both fixes should land before drawing conclusions
+from any other Round-1 PR with `best_epoch=1` lock-in.
 
 ## Constraints
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,24 +1,21 @@
 # SENPAI Research State
-- 2026-05-02 23:10Z (Round 15/16/17 in flight — 16 WIP PRs, 0 idle students)
-- 2026-04-29 00:50Z (post-cleanup: 16 bengio WIP + 10 yi WIP, 0 idle students; 4 stale yi PRs closed)
+- 2026-05-02 (Round 18 assigned — 16 WIP PRs on yi, 0 idle students)
 
-## 2026-04-29 Survey Pass Highlights
-- Closed 4 stale yi PRs (#273 edward focal-loss, #270 violet tanh-cap, #261 norman Muon, #210 kohaku grad-accum) — all four students have active bengio PRs (#304, #301, #239, #307) so the yi versions were dead duplicates.
-- PR #298 (fern learned Fourier embed): rebase merged, 4-arm sweep running healthy at ep0.4 (single-GPU per arm because yi has no DDP). Adaptations approved; ep1 is the call.
-- PR #297 (haku symm-aug Arm C): 4 runs healthy at very early training (~step 2.8-3.0k); waiting for ep1.
-- PR #308 (haku surface-loss-weight): sw=2.0 DDP4 recovery healthy at ep1=13.26%; advisor escalated for missing PR-thread acknowledgment despite urgent message.
-- PR #307 (kohaku ws-rel-l2): kohaku running off-script (asinh-96k 5L 8.69% at ep7, asinh-surfp-32k-4L at 9.07%, grad-accum-A 6L). Advisor demanded PR-thread acknowledgment + scope decision (close PR vs proceed).
-- Bengio cohort: 16 students all WIP, no idle slots.
-- yi cohort: 10 students all WIP after stale cleanup; primary actives are alphonse 6L/512d depth-scaling, askeladd 8L/10L sandwich-LN, gilbert spectral-loss screen, frieren TTA mini, nezuko 3-epoch warmdown, plus chihiro/emma legacy sweeps.
+## Latest Survey Pass (2026-05-02)
+- Round 18 assignments complete: 6 new yi PRs created for edward, kohaku, norman, senku, thorfinn, violet
+- PR #298 (fern learned Fourier embed): 4-arm sweep running (single-GPU per arm; yi has no DDP). ep1 results pending.
+- PR #297 (haku symm-aug Arm C): running on stable lr=1e-4/wu=1ep base; ep1 results pending.
+- PR #288 (gilbert spectral Fourier loss), #286 (frieren TTA), #284 (alphonse 6L/512d), #262 (nezuko WSD): all in progress.
+- All 16 yi student pods active. Zero idle GPUs.
 
 ## Most Recent Research Direction from Human Researcher Team
 
 **Issue #252** (open, Morgan, 2026-05-01): "Get inspired by Modded-NanoGPT". Directs the advisor to review the modded-nanogpt world record history table and reason carefully about applicability before assigning experiments. Already addressed by Round 15 PRs (see below).
 
-**Issue #248** (open, Morgan, last comment 2026-05-01 23:05Z): senpai-yi-stark pod confirmed absent (deployment, ConfigMap, .claude logs all missing). Operator directive: **reassign rather than wait on provisioning.** Acted on 2026-05-02: PR #227 closed, surface-tangent-frame hypothesis re-queued as highest-priority next-idle assignment.
+**Issue #248** (open, Morgan): senpai-yi-stark pod never provisioned. PR #227 closed 2026-05-02. Surface-tangent-frame hypothesis reassigned as PR #312 (edward) 2026-05-02.
 
 **Issue #18** (earlier): Stop incremental tuning. Rip out the model architecture and try completely new approaches. Most priority experiments are assigned or closed:
-1. Surface-tangent frame wall-shear prediction — PR #227 closed 2026-05-02 (no stark pod); hypothesis queued for first idle slot
+1. Surface-tangent frame wall-shear prediction — **PR #312 (edward) assigned 2026-05-02** (first real test)
 2. Perceiver-IO backbone replacing Transolver — closed as dead end (PRs #122, #212)
 3. asinh/log target normalization for wall shear — PR #249 (tanjiro), in progress
 4. Physics-informed RANS divergence constraint — closed as dead end (PR #124)
@@ -52,26 +49,26 @@
 
 **Merge bar: 9.291% — any PR must beat this val_abupt to merge.**
 
-## Active WIP PRs (as of 2026-04-29 — 17 WIP PRs)
+## Active WIP PRs (as of 2026-05-02 — 16 WIP PRs on yi)
 
 | PR | Student | Hypothesis | Round |
 |---|---|---|---|
-| #273 | edward | Focal-loss per-point surface weighting for tau_y/z (γ sweep) | 15 |
-| #270 | violet | tanh output soft-cap for wsy/wsz tail bounding | 15 |
-| #262 | nezuko | Linear-warmdown LR (modded-nanogpt WSD-style) | 15 |
-| #261 | norman | Muon optimizer (Newton-Schulz orthogonalized momentum) | 15 |
-| #249 | tanjiro | asinh normalization for wall-shear targets | 14 |
+| #317 | violet | Huber loss for wall-shear (δ=0.5/1.0/2.0 sweep) | 18 |
+| #316 | thorfinn | GradNorm dynamic per-task loss weighting for tau_y/z | 18 |
+| #315 | senku | MLP expansion ratio sweep (mlp_ratio=2/4/8) | 18 |
+| #314 | norman | Coordinate jitter augmentation sweep (σ=0.002/0.005/0.01) | 18 |
+| #313 | kohaku | Multi-seed ensemble averaging (3-seed variance reduction) | 18 |
+| #312 | edward | Surface-tangent frame wall-shear prediction | 18 |
+| #298 | fern | Learned Fourier embed at stable lr=3e-4 (4-arm sweep) | 17 |
+| #297 | haku | symm-aug Arm C (include-both bs=4) on stable lr=1e-4/wu=1ep base | 17 |
 | #288 | gilbert | Spectral Fourier loss on wall-shear tau_y/z channels | 16 |
+| #286 | frieren | Bilateral-symmetry TTA (y→-y reflection at inference) | 15 |
+| #284 | alphonse | 6L/512d depth+width scaling on Lion+warmup SOTA | 15 |
+| #262 | nezuko | Linear-warmdown LR (WSD-style) on 4L/512d SOTA | 15 |
+| #249 | tanjiro | asinh normalization for wall-shear targets | 14 |
 | #244 | emma | Sweep surface-loss-weight (1.5/2.0) | 13 |
 | #243 | chihiro | Sweep aux-rel-l2-weight (0.1/0.5/1.0) | 13 |
-| #230 | senku | SWA uniform weight averaging for flat-minima generalization | 13 |
-| #297 | haku | symm-aug Arm C (include-both bs=4) on stable lr=1e-4/wu=1ep base — follow-up to #225 | 17 |
-| #224 | fern | Learned Fourier embeddings for tau_y/z gap (per-axis freq learning) | 13 |
-| #210 | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads | 13 |
-| #286 | frieren | Bilateral-symmetry TTA (y→-y reflection at inference) | 15 |
-| #284 | alphonse | 6L/512d depth+width scaling — DDP port in progress (awaiting relaunch) | 15 |
 | #208 | askeladd | Sandwich-LN to unlock 8L/256d depth (stability fix) | 13 |
-| #193 | thorfinn | Curvature-biased surface point sampling (tau_y/z gap fix) | 13 |
 
 ## Key Architecture Configuration (PR #222 winning base config)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -60,16 +60,37 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 | #16 | thorfinn | Test-time bilateral symmetry TTA (xz-plane) | tau_y esp. |
 | #17 | violet | Surface-area-weighted MSE loss (physics-consistent) | p_s / tau |
 
-## Candidate next directions (post round 1)
+## Round 2 plan — bold architecture replacements
 
-- Geometry-aware conditioning (per-case mesh encoder + FiLM/AdaLN)
-- Equivariant / vector-neuron variants of slice attention for vector targets
-- Latent neural-operator decoders for full-resolution surface/volume queries
-- Physics-residual auxiliary losses (continuity, smoothness, log-magnitude
-  wall-shear targets)
-- Attention scaling: linear / Performer / grouped-query for full-resolution
-- Curriculum sampling and hard-example mining once a stable baseline exists
-- Pretraining via self-supervised denoising on volume/surface points
+Full hypothesis pool: `research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.md`
+(16 ideas, generated after mining `wandb/senpai` `noam` and `radford` per Issue #18).
+
+### Top-priority findings to act on
+
+1. **A01 — ANP cross-attention surface decoder is a near-certain win.**
+   noam PR #2379 swapped one head and got -70% in-domain pressure / -48% OOD on a
+   different dataset. Should be among the first Round-2 assignments.
+2. **The Transolver backbone has never been challenged on DrivAerML.** All 200 PRs
+   on `radford` were tuning, not architecture swaps. Backbone-replacement frontier
+   is wide open.
+3. **50 unlabelled test geometries are free pretraining data.** B01 (denoising),
+   B02 (MAE masking), C01 (DPOT transfer) can exploit this — no prior PR has.
+
+### Ranked Round-2 candidates (top 8)
+
+| # | Idea | Backbone change | Target |
+|---|---|---|---|
+| A01 | ANP cross-attention surface decoder | Replace surface MLP head | p_s, tau |
+| A02 | SE(3)-invariant coord features (12-d) | Input augmentation only | all |
+| B04 | Mamba-2 SSM surface decoder (Morton sort) | Replace surface head | p_s, tau |
+| B05 | Soft MoE FFN (4 experts, learned dispatch) | Replace every FFN | all |
+| C02 | Deep Evidential Regression head (NIG) | Replace MSE objective | all |
+| A03 | Perceiver-IO encoder+decoder (1024 latents) | Full backbone swap | all |
+| B01 | Denoising pretraining on geometry then fine-tune | Pretrain stage | all |
+| B02 | MAE 75%-mask point pretraining | Pretrain stage | all |
+
+Round 2 will assign these once Round 1 results come in (so we know which
+loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 ## Constraints
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,14 +1,14 @@
 # SENPAI Research State
-- 2026-05-02 (Round 15/16/17 in flight — 17 WIP PRs, 0 idle students)
+- 2026-05-02 23:10Z (Round 15/16/17 in flight — 16 WIP PRs, 0 idle students)
 
 ## Most Recent Research Direction from Human Researcher Team
 
 **Issue #252** (open, Morgan, 2026-05-01): "Get inspired by Modded-NanoGPT". Directs the advisor to review the modded-nanogpt world record history table and reason carefully about applicability before assigning experiments. Already addressed by Round 15 PRs (see below).
 
-**Issue #248** (open, Morgan): senpai-yi-stark pod requires manual provisioning (orchestrator service account lacks RBAC create/patch on configmaps/deployments). Comment posted directing Morgan to launch via cluster admin. Blocks PR #227 (surface-tangent frame).
+**Issue #248** (open, Morgan, last comment 2026-05-01 23:05Z): senpai-yi-stark pod confirmed absent (deployment, ConfigMap, .claude logs all missing). Operator directive: **reassign rather than wait on provisioning.** Acted on 2026-05-02: PR #227 closed, surface-tangent-frame hypothesis re-queued as highest-priority next-idle assignment.
 
 **Issue #18** (earlier): Stop incremental tuning. Rip out the model architecture and try completely new approaches. Most priority experiments are assigned or closed:
-1. Surface-tangent frame wall-shear prediction — PR #227 (stark), blocked on pod provisioning
+1. Surface-tangent frame wall-shear prediction — PR #227 closed 2026-05-02 (no stark pod); hypothesis queued for first idle slot
 2. Perceiver-IO backbone replacing Transolver — closed as dead end (PRs #122, #212)
 3. asinh/log target normalization for wall shear — PR #249 (tanjiro), in progress
 4. Physics-informed RANS divergence constraint — closed as dead end (PR #124)
@@ -55,7 +55,6 @@
 | #244 | emma | Sweep surface-loss-weight (1.5/2.0) | 13 |
 | #243 | chihiro | Sweep aux-rel-l2-weight (0.1/0.5/1.0) | 13 |
 | #230 | senku | SWA uniform weight averaging for flat-minima generalization | 13 |
-| #227 | stark | Wall-shear in local surface tangent frame **[BLOCKED — no pod, Issue #248]** | 14 |
 | #297 | haku | symm-aug Arm C (include-both bs=4) on stable lr=1e-4/wu=1ep base — follow-up to #225 | 17 |
 | #224 | fern | Learned Fourier embeddings for tau_y/z gap (per-axis freq learning) | 13 |
 | #210 | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads | 13 |

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -48,7 +48,7 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 
 | PR | Student | Hypothesis | Primary target |
 |---|---|---|---|
-| #7 | fern | Gaussian random Fourier features for coordinates | p_s / tau |
+| #7 | fern | Gaussian RFF for coordinates — sent back v5 (coord-norm + cosine EMA) | p_s / tau |
 | #8 | frieren | Per-case geometry FiLM conditioning | all |
 | #9 | gilbert | Volume loss weight sweep 2.0x vs 3.0x | p_v (6.08%) |
 | #10 | haku | Per-axis wall-shear channel loss weights (2x vs 3x) | tau (7.29%) |

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -99,3 +99,10 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
   attention scaling) are the main lever for "more update budget".
 - Read-only files: `data/*`, `pyproject.toml`, `instructions/*`. All edits
   go in `train.py`.
+- **Logging cadence (Issue #19, 2026-04-28):** every Round-2+ assignment
+  MUST include `--gradient-log-every 100 --weight-log-every 100` (or 250
+  if needed) in the reproduce command. Per-step gradient/weight logging
+  bottlenecks training to ~0.44 it/s on the 4L/256d/65k-pts/bs=2 base,
+  preventing the run from reaching epoch 1 inside the 6 h timeout. At
+  every-50 the same config runs at ~6.8 it/s. Slope cadence
+  (`--slope-log-fraction 0.05`) is already efficient and stays.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,215 +1,101 @@
 # SENPAI Research State
+- 2026-04-29 (Round-2 assignments complete)
 
-- **Date:** 2026-04-29
-- **Branch:** `yi`
-- **Target repo:** `morganmcg1/DrivAerML`
-- **W&B:** `wandb-applied-ai-team/senpai-v1-drivaerml`
-- **Most recent direction from human team:** 2026-04-28 — morganmcg1 (Issue #19)
+## Most Recent Research Direction from Human Researcher Team
 
-## Key directives from human research team (Issue #18, 2026-04-28)
+From Issue #18 (open):
+- Use ALL W&B logged metrics — gradient norms, weight histograms, loss slope — not just final val loss
+- Flag epoch-limited runs (still on a downward trajectory at the epoch cap) as promising, not closed
+- Differentiate failure modes: flat/diverging gradients early = fundamental; healthy slope at cutoff = epoch-limited
+- Prioritize convergence speed in new hypotheses (warmup schedules, better init, fast-converging architectures)
 
-1. **Be bolder with architecture changes.** Don't be afraid to completely replace the model backbone. Students can handle radical departures from the reference `train.py` as long as logging, validation, and checkpointing are maintained.
-2. **Cross-branch inspiration.** Before finalizing new hypothesis assignments, scan PRs from the `noam` and `radford` branches in wandb/senpai for prior art on similar techniques — useful for refinement ideas even if the dataset context differs. Similar work on a different dataset is *not* a reason to skip an idea.
-3. **Empower students.** Frame assignments to give students the latitude to make big changes rather than conservative tweaks. Trust students to make great leaps.
+## Current Research Focus and Themes
 
-## Current research focus
+### Yi Best: 13.15 abupt (PR #14, senku 6L/256d, 2026-04-29)
 
-Round 1 calibration on a clean slate. The W&B project has zero prior runs and
-`yi` has no merged baseline; the first wave must both establish a strong baseline
-and surface the strongest single-delta improvements over it.
+**Breakthrough:** Depth is more parameter-efficient than width at this scale.
+6L/256d (4.73M params) crushed 4L/512d (12.7M params) by 21%. Both 5L and 6L
+were still descending at timeout — significant untapped improvement available with
+longer training.
 
-Next wave will prioritize **bold architectural ideas**: completely new model
-backbones, transformer variants, neural operators, equivariant architectures —
-not incremental tuning. Reference `noam` and `radford` branches before
-finalizing hypotheses to avoid duplicating work and to draw inspiration.
+**Key findings from Round-1/2 reviews:**
+1. Depth scaling law: 4L→5L = −18.7%, 5L→6L = −2.7% (diminishing returns, but 7L/8L not yet tested)
+2. Cosine EMA (PR #13) adds 9% orthogonally — now standard on yi
+3. Gradient clipping clip=1.0 is now standard and essential for stability at 6L
+4. FiLM geometry conditioning: 46% relative improvement at 1 epoch on 4L (frieren PR #8 pending rebase)
+5. Volume pressure shows val→test gap (6.93 val ≈ AB-UPT, 13.58 test = 2×) — generalization problem
+6. Wall-shear y/z remain the largest gap (4.4-4.6× AB-UPT) despite 60-70% improvement from Round-1 start
 
-## Known prior art (from outside the `yi` W&B project)
+**Distance to AB-UPT (current best):**
 
-- `codex/optimized-lineage` branch ships a heavier baseline: 4L/256d/4h/128sl,
-  lr 2e-4, wd 5e-4, 65k points, EMA 0.9995. Treated as the proven floor.
-- `wandb/senpai` `radford` branch converged on a 4L/512d/8h champion with
-  fourier features, cosine-T_max=36 LR schedule, EMA 0.9995, metric-aware
-  rel-L2 auxiliary loss, and DomainLayerNorm. Best surface val ≈ 3.6%.
-  The hardest known levers were `wall_shear` and `volume_pressure`.
+| Metric | yi best | AB-UPT | Ratio |
+|---|---:|---:|---:|
+| surface_pressure | 7.64 | 3.82 | 2.0× |
+| wall_shear | 13.47 | 7.29 | 1.8× |
+| volume_pressure | 13.58 | 6.08 | 2.2× |
+| wall_shear_x | 11.53 | 5.35 | 2.2× |
+| wall_shear_y | 16.23 | 3.65 | 4.4× |
+| wall_shear_z | 16.75 | 3.63 | 4.6× |
 
-## Round 1 — active PRs (all 16 students assigned 2026-04-28)
-
-### Stream 1 — exploit existing evidence
-
-| PR | Student | Hypothesis |
-|---|---|---|
-| #2 | alphonse | Stock defaults baseline — calibration floor |
-| #3 | askeladd | codex/optimized-lineage config (4L/256d/4h, 65k pts, lr=2e-4) |
-| ~~#4~~ | ~~chihiro~~ | ~~Large model 4L/512d/8h~~ — MERGED (new yi baseline 16.64) |
-| #5 | edward | Cosine LR + 5% warmup (proven radford winner family) |
-| ~~#6~~ | ~~emma~~ | ~~Metric-aware MSE + rel-L2 aux loss~~ — CLOSED (sqrt instability) |
-
-### Stream 2 — fresh targeted ideas
-
-| PR | Student | Hypothesis | Primary target |
-|---|---|---|---|
-| ~~#7~~ | ~~fern~~ | ~~Gaussian RFF for coordinates~~ — CLOSED 2026-04-29 v5 (bf16 cascade non-viable; per-stream σ + fp32 saved for future) |
-| #8 | frieren | Per-case geometry FiLM conditioning | all |
-| #9 | gilbert | Volume loss weight sweep 2.0x vs 3.0x | p_v (6.08%) |
-| #10 | haku | Per-axis wall-shear channel loss weights (2x vs 3x) | tau (7.29%) |
-| #11 | kohaku | Tangential wall-shear projection loss (physics-aware) | tau axes |
-| #12 | nezuko | Stochastic depth / DropPath regularization | generalization |
-| #13 | norman | Progressive EMA decay anneal 0.99→0.9999 | test checkpoint |
-| #14 | senku | Deeper model 5L/256d/4h (depth ablation) | all |
-| #15 | tanjiro | SDF-gated volume attention bias (near-wall emphasis) | p_v (6.08%) |
-| #16 | thorfinn | Test-time bilateral symmetry TTA (xz-plane) | tau_y esp. |
-| ~~#17~~ | ~~violet~~ | ~~Surface-area-weighted MSE loss~~ — CLOSED 2026-04-29 (heavy-tail variance non-viable) |
-
-## Round 2 plan — bold architecture replacements
-
-Full hypothesis pool: `research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.md`
-(16 ideas, generated after mining `wandb/senpai` `noam` and `radford` per Issue #18).
-
-### Top-priority findings to act on
-
-1. **A01 — ANP cross-attention surface decoder is a near-certain win.**
-   noam PR #2379 swapped one head and got -70% in-domain pressure / -48% OOD on a
-   different dataset. Should be among the first Round-2 assignments.
-2. **The Transolver backbone has never been challenged on DrivAerML.** All 200 PRs
-   on `radford` were tuning, not architecture swaps. Backbone-replacement frontier
-   is wide open.
-3. **50 unlabelled test geometries are free pretraining data.** B01 (denoising),
-   B02 (MAE masking), C01 (DPOT transfer) can exploit this — no prior PR has.
-
-### Ranked Round-2 candidates (top 8)
-
-| # | Idea | Backbone change | Target |
-|---|---|---|---|
-| A01 | ANP cross-attention surface decoder | Replace surface MLP head | p_s, tau |
-| A02 | SE(3)-invariant coord features (12-d) | Input augmentation only | all |
-| B04 | Mamba-2 SSM surface decoder (Morton sort) | Replace surface head | p_s, tau |
-| B05 | Soft MoE FFN (4 experts, learned dispatch) | Replace every FFN | all |
-| C02 | Deep Evidential Regression head (NIG) | Replace MSE objective | all |
-| A03 | Perceiver-IO encoder+decoder (1024 latents) | Full backbone swap | all |
-| B01 | Denoising pretraining on geometry then fine-tune | Pretrain stage | all |
-| B02 | MAE 75%-mask point pretraining | Pretrain stage | all |
-
-Round 2 will assign these once Round 1 results come in (so we know which
-loss/optim/EMA/data-weighting wins to compose with the new backbone).
-
-## Round 2 — active assignments (2026-04-29)
+## Active WIP PRs (Round-2)
 
 | PR | Student | Hypothesis |
 |---|---|---|
-| ~~#20~~ | ~~nezuko~~ | ~~EMA decay sweep~~ — CLOSED, verdict (B) confirmed |
-| #21 | kohaku | Normal-component suppression on top of tangential projection |
-| #22 | gilbert | Add gradient clipping to train.py + 4-arm sweep |
-| #23 | frieren | Full composition: FiLM + projection + vol_w=2.0 + bs=8 |
-| #24 | emma | Squared rel-L2 aux loss (drop sqrt, smooth backward) |
-| #26 | nezuko | A01 — ANP cross-attention surface decoder (architecture swap) |
+| #58 | alphonse | NaN checkpoint guard bugfix (correctness) |
+| #59 | senku | 7L/8L depth sweep beyond 6L win |
+| #60 | chihiro | 6L/512d depth × width composition |
+| #61 | gilbert | Tangential wall-shear projection on 6L |
+| #62 | norman | FiLM geometry conditioning on 6L |
+| #63 | askeladd | Squared rel-L2 aux loss on 6L (w∈{0.1,0.5,1.0}) |
+| #64 | fern | Stochastic depth regularization (p∈{0.05,0.1,0.2}) |
+| #65 | violet | Volume loss weight sweep (1.5/2.0/3.0/4.0) |
+| #66 | thorfinn | Per-axis tau_y/z loss upweighting |
+| #67 | kafka | LR warmup + cosine decay schedule |
+| #21 | kohaku | Normal-suppression rerun on 6L (WIP — sent back) |
+| #15 | tanjiro | SDF-gated volume attention (sigma=0.005, sent back) |
 
-| #28 | norman | A02 — SE(3) equivariant local-frame coord features |
-| #29 | chihiro | B06 — width × FiLM × cosine EMA composition at 512d |
-| #38 | violet | C02 — Deep Evidential Regression (NIG head, lambda sweep 0.01 / 0.1) |
-| #45 | fern | B04 — Mamba-2 SSM Morton-sorted surface decoder |
+## Pending Code Merges
 
-**Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
-SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.
+| PR | Student | Code | Status |
+|---|---|---|---|
+| #8 | frieren | FiLM geometry conditioning code | Needs rebase |
+| #24 | emma | Squared rel-L2 aux loss code | Needs rebase |
+| #28 | norman | SE(3) local-frame features (A02) | Draft, no-status |
+| #23 | frieren | FiLM+projection+protocol composition | Draft, no-status |
 
-## Round 1 — reviewed results (2026-04-29)
+## Potential Next Research Directions
 
-### VERIFIED WINS (pending merge) + MERGED — yi baseline progression
+### Priority 1: Compositional wins on 6L base (highest expected value)
+- FiLM + 6L (norman PR #62) — if FiLM's 46% gain at 1-epoch composes with depth, expect abupt < 11
+- Tangential projection + 6L (gilbert PR #61) — projection may finally work stably with clip=1.0
+- 7L/8L depth (senku PR #59) — depth scaling law may still hold; both 5L/6L descending at timeout
+- 6L/512d (chihiro PR #60) — test if width+depth is additive (hypothesis: abupt ~11-12)
 
-- **PR #13 (norman, cosine EMA 0.99→0.9999) — VERIFIED WIN, pending merge (rebase required). NEW yi BEST.**
-  `abupt_axis_mean = 15.82` (vs 17.39 merged baseline = −9.0%). Run `wio9pqw2`,
-  state=finished, 4 epochs, best_epoch=4. Wins on every test_primary axis. No
-  train→val divergence — val improved monotonically epoch 1→4. Zero new params.
-  Critical revision of (B) verdict: divergence is config-conditional (bs=2 config
-  diverges; bs=8 + vol_w=2.0 does not). EMA cosine code now on `yi` when merged;
-  all future PRs should use `--ema-decay-start 0.99 --ema-decay-end 0.9999`.
-  - Follow-up PR #27 (norman): A02 SE(3) equivariant local-frame coord features.
-- **PR #8 (frieren, per-block FiLM conditioning) — VERIFIED WIN, pending merge (rebase).**
-  `abupt_axis_mean = 16.53` (vs 17.39 baseline = −4.9%). Run `hltti2ec`, 1 epoch.
-  Superseded as standalone best by PR #13 (15.82), but FiLM composes orthogonally
-  with cosine EMA — composition should push below 14. Frieren rebasing.
-  - Follow-up PR #23 (frieren): full composition — FiLM + vol_w=2.0 + projection + bs=8 + cosine EMA.
-- **PR #4 (chihiro, 4L/512d/8h large model) — MERGED 2026-04-29. NEW yi OFFICIAL BASELINE.**
-  `abupt_axis_mean = 16.64` (vs 17.39 prev = −4.3%). Run `pejudvyd`, 3 best epochs.
-  Best per-axis: `volume_pressure = 14.37` (standout win, orthogonal to FiLM/EMA).
-  Key: `lr=5e-5` required (3 runs at 2e-4 diverged), `bs=4` (VRAM limit at 512d).
-  BASELINE.md updated. chihiro reassigned → Round-2 composition run.
-- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) — MERGED, now superseded by PR #4.**
-  `abupt_axis_mean = 17.39`. Run `y2gigs61`, 6 epochs.
-- **PR #11 (kohaku, tangential wall-shear projection) — MERGED.**
-  Code on yi (default off). Composable with any future PR.
-- **Follow-up PR #21 (kohaku, normal-component suppression sweep)** — λ ∈ {0.0, 0.01, 0.1, 1.0}.
-- **Follow-up PR #22 (gilbert, gradient clipping)** — `clip_grad_norm_` + 4-arm sweep.
+### Priority 2: Loss formulation and training dynamics
+- Squared rel-L2 aux loss on 6L (askeladd PR #63) — emma's w=0.5 showed +11% on 4L
+- Per-axis tau_y/z loss weighting (thorfinn PR #66) — direct attack on largest remaining gap
+- Volume loss weight sweep (violet PR #65) — vw=3.0 now safe with clip=1.0
+- LR warmup + cosine decay (kafka PR #67) — convergence speed is rate-limiting
 
-**Five independent wins compounding (next big leap from stacking all):**
-1. Tangential projection (PR #11, default off, `--use-tangential-wallshear-loss`)
-2. Protocol fixes: vol_w=2.0, bs=8, validation-every=1 (PR #9)
-3. **Width scale-up 512d/8h (PR #4, MERGED)**
-4. Per-block FiLM conditioning (PR #8, pending merge)
-5. Cosine EMA 0.99→0.9999 (PR #13, pending merge, `--ema-decay-start 0.99 --ema-decay-end 0.9999`)
-→ PR #23 (frieren) will test FiLM + projection + vol_w + cosine EMA once PRs #8 and #13 land.
-→ chihiro Round-2: 512d × FiLM × cosine EMA composition.
-→ Composition prediction: ~12–13 abupt (−20% from current best pending 15.82).
+### Priority 3: Generalization (volume pressure val→test gap)
+- Stochastic depth regularization (fern PR #64) — drop path targets the generalization gap
+- SDF-gated volume attention with sigma=0.005 (tanjiro PR #15) — near-wall focus
+- Data augmentation: point cloud jitter, geometry reflection during training (not yet tested)
 
-### CLOSED
+### Priority 4: Architecture exploration (longer horizon)
+- SE(3) local-frame coordinate features (norman PR #28 draft) — equivariant features
+- Longer training runs (10-12h) on 6L or 7L — both still descending at 4.5h timeout
+- 6L with all current wins composed (projection + FiLM + EMA + clip + aux_loss)
 
-- **PR #12 (nezuko, DropPath p=0.1) closed.** 81.21 vs 64.66 norman
-  comparator. Underfitting regime (best_epoch=1 on both runs); any
-  regularizer hurts. Wrong tool for the binding constraint.
-- **Critical infrastructure win from PR #12.** nezuko shipped a per-step
-  timeout fix (`train.py`); cherry-picked onto `yi` as `af92e9a`. Reserves
-  `SENPAI_VAL_BUDGET_MINUTES` (default 90). Without this, every 65k-pts run
-  silently times out without producing `test_primary/*`.
-- **PR #20 (nezuko, EMA decay sweep) — CLOSED 2026-04-29 with diagnostic value.**
-  4-arm sweep across `--ema-decay ∈ {0.99, 0.999, 0.9995, 0.99995}`. Verdict:
-  **(B) genuine post-epoch-1 instability**, not EMA lag. Even the most aggressive
-  decay (0.99, window ~100 steps) peaks at epoch 1; train loss is non-monotonic
-  across all four seeds (5–7× higher in epoch 2). Per-step spikes hit 6–22× the
-  median around steps 45–60k — exactly where missing gradient clipping bites.
-  Best arm 0.9995 → abupt 24.74 (above yi baseline; closed because diagnostic
-  not competitive). Confirms `--ema-decay 0.9995` as right default; PR #22
-  (gradient clipping) is the cure for the binding constraint.
-- **Follow-up: nezuko assigned A01 (ANP cross-attention surface decoder)** — the
-  largest architectural win from noam (PR #2379 MERGED, −70% in-domain p_s on
-  TandemFoil). Direct port to DrivAerML.
+## Known Correctness Issues
+1. **NaN checkpoint guard bug**: when EMA becomes NaN, `_finite_mean()` returns 0.0
+   which incorrectly passes the `< best_val` check and overwrites a valid checkpoint.
+   Fix: `improved = math.isfinite(primary_val) and primary_val > 0.0 and primary_val < best_val`.
+   Assigned to alphonse PR #58.
 
-### Cross-cutting directives broadcast to all active PRs
-
-1. Rebase onto `yi` to pick up `af92e9a` + projection code (default off).
-2. **New recommended base config (PR #9 winner):**
-   `--volume-loss-weight 2.0 --batch-size 8 --validation-every 1
-    --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms`
-3. Wall-shear targeted PRs (haku #10, tanjiro #15, thorfinn #16) should
-   compose with `--use-tangential-wallshear-loss` so their delta stacks on
-   the merged baseline.
-4. **Training-stability bug flagged:** until PR #22 lands gradient clipping,
-   sudden train-loss spikes followed by best_epoch lock-in are the bug, not
-   the hypothesis.
-5. Report any train→val divergence observed.
-
-### Resolved question (2026-04-29)
-
-**Train→val divergence after epoch 1 = (B) genuine post-epoch-1 instability**,
-diagnosed by PR #20 (nezuko EMA sweep). Train loss explodes 5–7× from epoch 1
-to epoch 2 across all 4 EMA arms; per-step train_loss spikes hit 6–22× median.
-The cure is **gradient clipping** (PR #22 in flight) and likely **LR warmup**
-(PR #5 edward in flight). Both fixes should land before drawing conclusions
-from any other Round-1 PR with `best_epoch=1` lock-in.
-
-## Constraints
-
-- `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` are fixed by harness — do
-  not override. Throughput improvements (compile, AMP, point-count tuning,
-  attention scaling) are the main lever for "more update budget".
-- Read-only files: `data/*`, `pyproject.toml`, `instructions/*`. All edits
-  go in `train.py`.
-- **Logging cadence (Issue #19, 2026-04-28):** every Round-2+ assignment
-  MUST include `--gradient-log-every 100 --weight-log-every 100` (or 250
-  if needed) in the reproduce command. Per-step gradient/weight logging
-  bottlenecks training to ~0.44 it/s on the 4L/256d/65k-pts/bs=2 base,
-  preventing the run from reaching epoch 1 inside the 6 h timeout. At
-  every-50 the same config runs at ~6.8 it/s. Slope cadence
-  (`--slope-log-fraction 0.05`) is already efficient and stays.
-- **Per-step timeout fix (commit `af92e9a` on `yi`, 2026-04-29):**
-  `SENPAI_VAL_BUDGET_MINUTES` (default 90) is reserved out of
-  `SENPAI_TIMEOUT_MINUTES` for in-loop val + post-loop full_val + test.
-  All new student work must rebase onto `yi` to pick this up.
+## Key Constraints
+- Training budget: ~270 min training + ~90 min val/test = 360 min total
+- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses 75.5 GB; 6L/512d at bs=4 estimated ~80-90 GB
+- Epoch budget: ~3-4 epochs at 6L/256d throughput (~2.1 it/s)
+- Gradient clipping: clip_grad_norm=1.0 is now standard (anything without it is unstable)
+- Baseline: 6L/256d, lr=2e-4, ema-decay-start=0.99/end=0.9999, vol_w=2.0, bs=8, clip=1.0

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-04-30 (Round-5 bold experiments fanning out — all 14 yi students running)
+- 2026-05-01 (Round-6 launched — 9 new student assignments after Round-5 all-negative batch)
 
 ## Most Recent Research Direction from Human Researcher Team
 
@@ -8,20 +8,17 @@ From Issue #18 (open, Morgan — latest message 2026-04-30T20:29:19Z):
 **Overarching directive:** Stop incremental tuning. Rip out the model architecture and try completely new approaches. Students can handle radical departures from the reference train.py as long as logging/validation/checkpointing are maintained.
 
 **Round-5 bold experiment priorities (Morgan's ordered list by impact):**
-1. **Surface-tangent frame wall-shear prediction** — The 4× wall shear y/z error is a coordinate frame mismatch, not a hyperparameter problem. Predict tau in local surface-tangent frame (tau_normal=0, tau_t1, tau_t2), rotate back to global. Requires per-point surface normal computation + rotation head.
-2. **Perceiver-IO backbone replacement** — Replace Transolver entirely. Perceiver-IO uses learned latent queries for unstructured CFD meshes, ~3× faster per epoch = more epochs within budget.
-3. **asinh/log target normalization** — Wall shear spans 4 decades. Predict asinh(tau) to fix MSE over-weighting high-magnitude patches. 10-line change but changes the loss landscape entirely.
-4. **Physics-informed RANS constraint** — Add soft divergence-free penalty (∇·u=0) on predicted velocity at volume points. Pure loss change, no architecture touch.
-5. **1-cycle LR schedule with higher peak** — Warmup to 1e-3, cosine decay to 1e-6, ~20% warmup of total steps. Fern's lr=5e-4 was still converging at epoch cutoff.
+1. **Surface-tangent frame wall-shear prediction** — 4× wall shear y/z error is a coordinate frame mismatch, not a hyperparameter problem
+2. **Perceiver-IO backbone replacement** — Replace Transolver entirely; ~3× faster per epoch = more epochs within budget
+3. **asinh/log target normalization** — Wall shear spans 4 decades; predict asinh(tau) to fix MSE over-weighting
+4. **Physics-informed RANS constraint** — Soft divergence-free penalty on predicted velocity at volume points
+5. **1-cycle LR schedule with higher peak** — Warmup to 1e-3, cosine decay to 1e-6
 
-**Additional guidance from Morgan:**
-- Use W&B gradient norms, weight histograms, and loss slopes to identify epoch-limited runs (healthy slope at cutoff = still converging, worth follow-up)
-- Before finalizing hypotheses, scan PRs from `noam` and `radford` branches for prior art inspiration
-- Gradient metric failure flags: spikes >10 or flat <0.01 = fundamental failure; healthy slope at cutoff = epoch-limited
-
-**Advisor status:** All 5 Morgan directives are actively running (PRs #121–125). Additional complementary Round-5 experiments also in flight (#126–132).
+**Advisor status:** Issue #18 acknowledged and responded. No new messages since 2026-04-30T20:42Z.
 
 ## Current Baseline: PR #99 (fern) — abupt 10.69 — 2026-04-29
+
+Baseline unchanged — all 7 Round-5 PRs were NEGATIVE.
 
 **Compounded wins on `yi` so far:**
 1. PR #11 kohaku — tangential wall-shear projection loss code
@@ -44,13 +41,6 @@ From Issue #18 (open, Morgan — latest message 2026-04-30T20:29:19Z):
 | `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | 3.8× |
 | `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | 4.1× |
 
-**Key structural observations:**
-- Depth (6L/256d, 4.73M params) is far more parameter-efficient than width (4L/512d, 12.7M params)
-- Wall_shear_y and wall_shear_z remain the largest gaps (~4× AB-UPT) despite thorfinn's 2× upweighting + fern's lr boost
-- Volume pressure gap almost closed (1.3× AB-UPT) — sp and ws_x are next priority
-- LR=5e-4 at 5× base dramatically accelerated convergence within epoch budget
-- Both 5L and 6L runs were still descending at timeout — epoch budget is tight
-
 **Standard base config (PR #99 winning arm):**
 ```bash
 python train.py \
@@ -64,85 +54,97 @@ python train.py \
   --gradient-log-every 100 --weight-log-every 100 --no-log-gradient-histograms
 ```
 
-## Active WIP PRs (experiments in flight on PR #99 baseline)
+## Round-5 Closed Results (all NEGATIVE — 2026-05-01)
 
-### Round-4 incremental PRs
+Critical lessons learned from 7 failed experiments:
+
+| PR | Student | Hypothesis | Outcome | Key Finding |
+|---|---|---|---|---|
+| #131 | thorfinn | logmag transform (eps=0.01-1.0) | NEGATIVE abupt=11.03 | Gradient of log1p near 0 is ~1/eps; eps≤0.10 caused 2M+ pre_clip_norm spikes. NaN-skip safeguard (commit 2a8f7e4) is a keeper. |
+| #130 | tanjiro | Curriculum W_y 1→3 ramp | NEGATIVE 6/6 diverged | Adam m/v desync around W_y≈2.7; static weights needed, not curriculum |
+| #124 | gilbert | Laplacian pressure constraint | NEGATIVE wrong physics | ∇²p≈0 is creeping flow; real RANS has advective terms. kNN Laplacian implementation reusable. |
+| #121 | askeladd | Tangent-frame wall-shear | NEGATIVE worse than Cartesian | Duff ONB discontinuous at t1.x sign-flip; non-gauge-equivariant model can't learn it. Channel coupling in Adam. |
+| #118 | chihiro | mlp_ratio sweep 6/8 | AMBIGUOUS 12/16 diverged | Trend toward mlp_ratio=8 but seed-dependent instability prevented convergent comparison. Needs warmup + seed flags. |
+| #129 | senku | Uniform surface_sw sweep | NEGATIVE 7/8 diverged | Uniform sw amplifies all surface incl. already-upweighted W_y=W_z=2. Monotone instability with sw. Per-component is right knob. |
+| #117 | alphonse | 6L/384d + 8L/256d depth | NEGATIVE no merger | 8L/256d time-limited (extrapolated to cross baseline 11 min after timeout). 384d unstable in bf16 at all LRs. Depth (not width) is viable scale-up. |
+
+## Active WIP PRs (in flight)
+
+### Still-running from Round-5 launch batch
 | PR | Student | Branch | Hypothesis |
 |---|---|---|---|
-| #116 | fern | `fern/wallshear-axis-upweight-sweep` | Higher tau_y/z weights on lr=5e-4 base |
-| #117 | alphonse | `alphonse/width-384d-sweep` | 6L/384d width expansion test |
-| #118 | chihiro | `chihiro/mlp-ratio-sweep-r4` | MLP-ratio sweep on PR #99 base |
-| #119 | edward | `edward/rff-coordinate-encoding` | Random Fourier Feature coordinate encoding |
-
-### Round-5 bold PRs (Morgan Issue #18 directives + complementary explorations)
-| PR | Student | Branch | Hypothesis |
-|---|---|---|---|
-| #121 | askeladd | `askeladd/surface-tangent-frame-wallshear` | Predict tau in local {t1, t2, n} frame, rotate back |
-| #122 | emma | `emma/perceiver-io-backbone` | Perceiver-IO backbone replacing Transolver |
-| #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
-| #124 | gilbert | `gilbert/rans-divergence-constraint` | Soft div(u)=0 RANS penalty on volume points |
-| #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR with max=1e-3 peak |
+| #156 | levi | `levi/ohem-hard-case-mining` | OHEM top-25% hard case mining |
+| #155 | armin | `armin/checkpoint-ensemble` | Top-3 checkpoint ensemble |
+| #154 | mikasa | `mikasa/gradient-accumulation` | Grad accum eff-bs=32 |
+| #153 | mob | `mob/lookahead-optimizer` | Lookahead optimizer k=5/10 |
+| #152 | violet | `violet/geom-moment-conditioning` | 14-dim analytic geometry conditioning |
+| #151 | nezuko | `nezuko/symmetry-augmentation` | L/R symmetry augmentation for tau_y gap |
+| #150 | emma | `emma/multi-scale-hierarchy` | Multi-scale point hierarchy (2/3 scales) |
+| #144 | edward | `edward/adamw-beta2-sweep` | AdamW beta2 sweep (0.95 vs 0.999) |
+| #143 | fern | `fern/coord-normalization-sweep` | Coordinate normalization fix for sincos anisotropy |
 | #126 | kohaku | `kohaku/film-conditioning-6l-256d` | FiLM geometry conditioning on PR #99 base |
-| #127 | nezuko | `nezuko/stochastic-depth-regularization` | Stochastic-depth sweep (0.05/0.1/0.2) |
-| #128 | norman | `norman/ema-decay-warmup-schedule` | EMA decay warmup schedule (0.99 -> 0.9999) |
-| #129 | senku | `senku/surface-loss-upweight-sweep` | Surface loss weight sweep (1.5/2.0/3.0) |
-| #130 | tanjiro | `tanjiro/curriculum-tau-yz-weighting` | Curriculum tau_y/z weighting (start=1, ramp to 3-4) |
-| #131 | thorfinn | `thorfinn/log-magnitude-wallshear-targets` | Log-magnitude wall-shear target normalization |
-| #132 | violet | `violet/wallshear-magnitude-direction-decoupled` | Decoupled |tau| + direction (cosine loss) heads |
+| #125 | haku | `haku/onecycle-lr-peak-1e3` | 1cycle LR max=1e-3 |
+| #123 | frieren | `frieren/asinh-log-target-normalization` | asinh wall-shear target normalization |
+
+### Round-6 newly assigned (2026-05-01)
+| PR | Student | Branch | Hypothesis |
+|---|---|---|---|
+| #164 | alphonse | `alphonse/depth-8L-1cycle-recovery` | 8L/256d depth + OneCycleLR (time-limited recovery) |
+| #165 | chihiro | `chihiro/mlp-ratio-8-hardened` | mlp_ratio=8 + 1k warmup + seed=42/1337/7 (3-arm) |
+| #166 | senku | `senku/per-component-wallshear-yz-3` | Static W_y=W_z=3.0 + 500-step LR warmup |
+| #167 | tanjiro | `tanjiro/static-wyz-35-warmup` | Static W_y=W_z=3.5 + 1k LR warmup |
+| #168 | askeladd | `askeladd/normal-penalty-wallshear-yz` | Normal-consistency soft penalty λ∈{0.01,0.05,0.10} |
+| #169 | thorfinn | `thorfinn/nan-skip-utility-cherry-pick` | NaN-skip + seed + LR warmup utility infra |
+| #170 | gilbert | `gilbert/width-384d-qknorm-fp32attn` | 384d + QK-norm + fp32-attention (stability fix) |
+| #171 | norman | `norman/snapshot-ensemble-cyclic-lr` | Snapshot ensemble via cyclic LR (3 ckpts avg) |
+| #172 | stark | `stark/adamw-eps-sweep` | AdamW eps sweep 1e-8/7/6/5 (gradient stability) |
 
 ## Current Research Themes
 
 ### Theme 1: Closing wall_shear_y/z gap (4× AB-UPT — HIGHEST PRIORITY)
-The single biggest lever still not pulled: **why do y/z shear components fail 4× harder than AB-UPT?**
-- #116 fern — higher tau_y/z weights on new lr=5e-4 base
-- #121 askeladd — surface-tangent frame prediction (Morgan #1 priority — coord frame mismatch hypothesis)
-- #130 tanjiro — curriculum tau_y/z weighting (start=1, ramp to 3-4)
-- #132 violet — decoupled |tau| + direction (cosine loss) heads
+The single biggest lever: **why do y/z shear components fail 4× harder than AB-UPT?**
+- #166 senku — per-component W_y=W_z=3.0, static (correct knob vs #129's failed uniform sw)
+- #167 tanjiro — per-component W_y=W_z=3.5, static (complement to senku's 3.0, maps stability ceiling)
+- #168 askeladd — soft normal-consistency penalty λ∈{0.01,0.05,0.10} (physics without frame discontinuity)
+- #123 frieren (in flight) — asinh target normalization (heavy-tail hypothesis)
+- #151 nezuko (in flight) — L/R symmetry augmentation for tau_y gap
 
-### Theme 2: Convergence speed within epoch budget
-Epoch budget is tight (~3-4 epochs). Every schedule/LR decision matters hugely.
-- #99 fern (merged) — lr=5e-4 gave 16.1% win; 5× acceleration effect
-- #125 haku — 1cycle LR max=1e-3 (Morgan #5 priority — warmup to 1e-3, cosine anneal to 1e-6)
-- #128 norman — EMA decay warmup schedule (0.99 → 0.9999 over training)
+### Theme 2: Convergence / Architecture scaling
+Epoch budget is tight (~3-4 epochs). Depth beats width. 8L/256d was time-limited.
+- #164 alphonse — 8L/256d + 1cycle LR (super-convergence to beat 10.69 within budget)
+- #165 chihiro — mlp_ratio=8 + stability hardening (seed + warmup)
+- #170 gilbert — 384d width + QK-norm + fp32 attention (stability for width scale-up)
+- #125 haku (in flight) — 1cycle LR max=1e-3
 
-### Theme 3: Architecture — Backbone replacement and variants
-Currently on 6L/256d Transolver. Bold replacement being tested.
-- #117 alphonse — 6L/384d width expansion
-- #118 chihiro — MLP ratio sweep (6/8)
-- #119 edward — RFF coordinate encoding
-- #122 emma — Perceiver-IO backbone replacing Transolver (Morgan #2 priority — 3× faster per epoch)
-- #126 kohaku — FiLM geometry conditioning on PR #99 6L/256d base
+### Theme 3: Optimizer stability
+Pervasive Round-5 divergences motivate systematic optimizer investigation.
+- #172 stark — AdamW eps sweep (1e-8/7/6/5, maps denominator floor effect)
+- #169 thorfinn — NaN-skip + seed + LR warmup utility PR (infra for all future experiments)
+- #144 edward (in flight) — AdamW beta2 sweep (0.95 vs 0.999)
 
-### Theme 4: Target normalization
-Wall shear spans 4 decades of magnitude. MSE on raw values over-weights large signals.
-- #123 frieren — asinh/log wall-shear target normalization (Morgan #3 priority)
-- #131 thorfinn — log-magnitude wall-shear target normalization (complementary approach)
+### Theme 4: Post-training / test-time gain
+- #171 norman — snapshot ensemble with cyclic LR (free gain from averaging 3 cycle ckpts)
+- #155 armin (in flight) — top-3 checkpoint ensemble
 
-### Theme 5: Physics-informed constraints and loss engineering
-- #124 gilbert — RANS div(u)=0 penalty on volume points (Morgan #4 priority)
-- #129 senku — surface loss weight sweep (1.5/2.0/3.0)
-- #127 nezuko — stochastic depth regularization sweep
+### Theme 5: Data representation and augmentation
+- #143 fern (in flight) — coordinate normalization sweep (sincos anisotropy fix)
+- #151 nezuko (in flight) — L/R symmetry augmentation
+- #152 violet (in flight) — analytic geometry moment conditioning (14-dim)
 
-## Closed Dead Ends (prior architecture experiments)
-- SE(3) equivariant coordinates (#25, #28) — CLOSED: didn't converge, gradient collapse
-- ANP cross-attention decoder (#26, #35) — CLOSED: unstable, no improvement
-- Mamba-2 SSM decoder (#45) — CLOSED: unstable, diverged
-- SDF-gated volume attention (#15, #36) — CLOSED: no improvement vs vanilla
-- AdaLN FiLM (#34) — CLOSED: marginal, superseded by FiLM on 6L (#62 pending)
-- Area-weighted loss v1 (#7, #17) — CLOSED: area-weighted non-viable on prior baselines; retesting on PR #99 base (#95)
+## Key Structural Findings Accumulated
+
+- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M) in param efficiency. 8L/256d promising but time-limited.
+- **Adam m/v coupling:** Mid-run weight schedule changes (curriculum, EMA warmup) cause second-moment desynchronization. Always initialize Adam with the training-time weights.
+- **Uniform surface_sw is the wrong knob:** Amplifies already-upweighted W_y/W_z. Per-component --wallshear-y/z-weight is correct.
+- **384d in bf16 is unstable:** d_head=96 causes pre-softmax logit variance overflow. QK-norm or fp32 attention required.
+- **logmag transform gradient:** gradient of sign(x)*log1p(|x|/eps) is ~1/eps near 0; eps≤0.10 caused 2M+ pre_clip_norm.
+- **Duff ONB discontinuity:** Branchless ONB has sign-flip discontinuity incompatible with non-gauge-equivariant Transolver.
+- **Δp≈0 is wrong RANS physics:** Laplacian pressure constraint only valid for Stokes (creeping) flow.
+- **Volume pressure nearly converged:** 1.3× AB-UPT at baseline — wall_shear_y/z is the main gap.
+- **LR warmup guards:** 500-1000 step linear warmup from 1e-5 is now standard practice for experiments with elevated initial gradients.
 
 ## Key Constraints
 - Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)
-- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses 75.5 GB
-- Epoch budget: ~3-4 epochs at 6L/256d throughput (~2.1 it/s)
-- Gradient clipping: clip_grad_norm=1.0 is standard (anything without it is unstable)
-- Students have 4 GPUs each (but run single-GPU experiments; DDP available for bold architecture tests)
-
-## Next Research Directions (Round-5 Priorities)
-
-1. **Surface-tangent frame wall-shear prediction** — predict tau in local geometric frame, rotate back; directly targets 4× wsy/wsz gap
-2. **Perceiver-IO backbone** — replace Transolver; faster per-epoch enables more epochs within budget
-3. **asinh/log target normalization** — normalize wall shear before loss; heavy-tail problem hypothesis
-4. **1cycle LR with higher peak** (1e-3 max) — squeeze more convergence from limited epochs
-5. **Physics-informed RANS constraint** — div-free volume pressure soft penalty
-6. **Curriculum tau_y/z weighting** — start at W_y=W_z=1, ramp to 3-4 over training
+- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses ~75 GB; 384d requires bs=4
+- Gradient clipping: clip_grad_norm=1.0 is standard
+- Students have 4 GPUs each (DDP available for large architectures)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -48,7 +48,7 @@ finalizing hypotheses to avoid duplicating work and to draw inspiration.
 
 | PR | Student | Hypothesis | Primary target |
 |---|---|---|---|
-| #7 | fern | Gaussian RFF for coordinates — sent back v5 (coord-norm + cosine EMA) | p_s / tau |
+| ~~#7~~ | ~~fern~~ | ~~Gaussian RFF for coordinates~~ — CLOSED 2026-04-29 v5 (bf16 cascade non-viable; per-stream σ + fp32 saved for future) |
 | #8 | frieren | Per-case geometry FiLM conditioning | all |
 | #9 | gilbert | Volume loss weight sweep 2.0x vs 3.0x | p_v (6.08%) |
 | #10 | haku | Per-axis wall-shear channel loss weights (2x vs 3x) | tau (7.29%) |
@@ -106,6 +106,7 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 | #28 | norman | A02 — SE(3) equivariant local-frame coord features |
 | #29 | chihiro | B06 — width × FiLM × cosine EMA composition at 512d |
 | #38 | violet | C02 — Deep Evidential Regression (NIG head, lambda sweep 0.01 / 0.1) |
+| #45 | fern | B04 — Mamba-2 SSM Morton-sorted surface decoder |
 
 **Closed in error 2026-04-29:** PR #25 (assigned to non-existent student `stark`) —
 SE(3) local-frame coordinate features. Now reassigned to norman as PR #28.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,157 +1,157 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 19:00 UTC
-- **Branch:** `yi`
-- **Baseline:** PR #183 (fern, `pos_max_wavelength=1000`), `abupt_axis_mean_rel_l2_pct = 10.21`
+- **Updated:** 2026-05-01 20:25 UTC
+- **Branches:** `yi` (4L/512d Lion SOTA), `bengio` (4L/256d AdamW Wave 2/3)
 
 ---
 
 ## Most Recent Research Direction from Human Researcher Team
 
-**Issue #18 (Morgan, 2026-04-30T20:29:19Z — overarching directive):**
-> Stop incremental tuning. Rip out the model architecture and try completely new approaches. Students can handle radical departures from the reference train.py as long as logging/validation/checkpointing are maintained.
+**Issue #252 (Morgan, 2026-05-01):** Get inspired by Modded-NanoGPT — review the world-record table and propose specific DrivAerML experiments. ADVISOR acknowledged at 19:48Z; 4 directions now assigned (Muon, linear-warmdown LR, U-net skips, tanh soft-cap).
 
-**Morgan's ordered priority list:**
-1. Surface-tangent frame wall-shear prediction — 4× wall shear y/z error is a coordinate frame mismatch
-2. **Perceiver-IO backbone replacement** — ~3× faster per epoch = more epochs within budget (**ASSIGNED #212 noam**)
-3. asinh/log target normalization — tested, **NEGATIVE — tail suppression problem (PR #123)**
-4. Physics-informed RANS constraint — tested, **NEGATIVE — label contradiction: DrivAerML mesh GT has RMS(τ·n)/|τ|=12%, so (τ·n)=0 constraint contradicts labels (PR #201)**
-5. 1-cycle LR schedule with higher peak — tested, **NEGATIVE — budget starvation + stability ceiling (PRs #164, #191)**
+**Issue #18 (Morgan, 2026-04-30, ongoing directive):** Stop incremental tuning. Take bigger architectural swings. Compounding small wins is also OK as long as they keep landing.
 
 ---
 
-## Current Baseline
+## Current Baselines
 
-| Metric | yi best | AB-UPT | Gap |
+### yi branch (advisor branch, primary fleet)
+
+**Bar to beat: val_abupt = 9.2910% (PR #222 fern, lr_warmup_epochs=1).** W&B run `ut1qmc3i`.
+
+| Metric | yi best | AB-UPT | Ratio |
 |---|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **10.21** | — | — |
-| `surface_pressure_rel_l2_pct` | **6.97** | 3.82 | 1.8× |
-| `wall_shear_rel_l2_pct` | **11.69** | 7.29 | 1.6× |
-| `volume_pressure_rel_l2_pct` | **7.85** | 6.08 | 1.3× |
-| `wall_shear_x_rel_l2_pct` | **10.17** | 5.35 | 1.9× |
-| `wall_shear_y_rel_l2_pct` | **13.73** | 3.65 | **3.8×** |
-| `wall_shear_z_rel_l2_pct` | **14.73** | 3.63 | **4.1×** |
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910** | — | — |
+| `val_primary/surface_pressure_rel_l2_pct` | **5.8707** | 3.82 | 1.54× |
+| `val_primary/wall_shear_rel_l2_pct` | **10.3423** | 7.29 | 1.42× |
+| `val_primary/volume_pressure_rel_l2_pct` | **5.8789** | 6.08 | **0.97×** ✓ |
 
-**The wall_shear_y/z gap at 3.8-4.1× AB-UPT is the primary research target.**
+Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain the gap.
+
+### bengio branch (Wave 2/3 long-schedule experiments)
+
+**Bar to beat: val_abupt = 7.2091% at ep30 (alphonse `m9775k1v`, 4L/256d, AdamW, T_max=30).**
 
 ---
 
-## Active WIP PRs (as of 2026-05-01 19:00 UTC)
+## Active WIP PRs (as of 2026-05-01 20:25 UTC)
 
-### Round 14 Baseline Sweep (Just Assigned — ~Round 14)
+### yi branch — 17 WIP PRs (zero idle)
 
 | PR | Student | Hypothesis | Status |
 |---|---|---|---|
-| **#243** | chihiro | Sweep aux-rel-l2-weight {0.1, 0.5, 1.0} on 10.21 baseline | Training (90-100% GPU) |
-| **#244** | emma | Sweep surface-loss-weight {1.5, 2.0} on 10.21 baseline | Training (90-100% GPU) |
-| **#245** | gilbert | Progressive EMA decay schedule on 10.21 baseline | Training (90-100% GPU) |
-| **#246** | tanjiro | Calibrate LR warmup {500, 1000 steps} on 10.21 baseline | Training (90-100% GPU) |
+| #270 | violet | **tanh output soft-cap** (modded-NanoGPT logit-cap analog) | NEW (just assigned) |
+| #262 | nezuko | **linear-warmdown LR schedule** (modded-NanoGPT WSD-style) | NEW (just assigned) |
+| #261 | norman | **Muon optimizer** (Newton-Schulz orthogonalized momentum) | NEW (just assigned) |
+| #249 | tanjiro | asinh wall-shear normalization | Both arms healthy ep1 |
+| #247 | thorfinn | cosine T_max=14 (between 9 and 50) | Run live, mid-ep3 |
+| #245 | gilbert | progressive EMA decay (0.99→0.9999 etc.) | Arm A surviving; B/C retries running |
+| #244 | emma | surface-loss-weight {1.5, 2.0} | Arm A crashed lr=5e-4; Arm B healthy |
+| #243 | chihiro | aux-rel-l2-weight {0.1, 0.5, 1.0} | A/B retries at lr=3e-4; C healthy |
+| #239 | norman | Fourier PE num_freqs sweep (bengio-branch work) | NF=16 running, ep5 gate ~5h |
+| #230 | senku | SWA tail-end weight averaging | All 4 arms running, no signal until ep25+ |
+| #228 | edward | OHEM hard surface-point weighting | Arm B (f=1.0) running |
+| #227 | stark | wall-shear in surface tangent frame | NO POD — RBAC blocked, Issue #248 |
+| #225 | haku | mirror symmetry training augmentation | Running |
+| #224 | fern | learned Fourier embeddings per-axis | K/L/N/O surviving; J finding: init=10 beats sincos by 6.7% at matched ep1 step |
+| #221 | violet | per-channel adaptive loss reweighting | Run A `541ru1pv` ep5=11.12; gate-check stalled (cross-listed, primary on bengio) |
+| #210 | kohaku | gradient accumulation eff_bs=32 | Running |
+| #209 | frieren | step-decay LR drop after ep1 | Running |
+| #208 | askeladd | sandwich-LN to unlock 8L/256d | Arm B running ~18866+ steps |
+| #207 | alphonse | Adaptive Gradient Clipping (AGC) | lr=3e-4 arms only surviving |
+| #193 | thorfinn | curvature-biased surface point sampling | 3 lr=3e-4 arms healthy past warmup |
 
-### Earlier-Round PRs Currently Running
+### bengio branch — 16 WIP PRs (zero idle)
 
-| PR | Student | Hypothesis | Notes |
+| PR | Student | Hypothesis | Status |
 |---|---|---|---|
-| **#227** | stark | Wall-shear in local surface tangent frame (Morgan's #1 directive) | **NO POD — RBAC blocked provisioning. Issue #248 filed for human operator.** |
-| **#230** | senku | SWA uniform weight averaging for flat-minima generalization | SWA activates ep25–42 of 50 |
-| **#229** | norman | y-flip test-time symmetry augmentation (TTA) | Pod restarted ~18:36 UTC; Iter 1 |
-| **#228** | edward | OHEM hard surface-point weighting for tau_y/z gap | Running |
-| **#225** | haku | Left-right symmetry augmentation (tau_y/z gap) | Arm C surviving; awaiting ep2 |
-| **#224** | fern | Learned Fourier embeddings per-axis freq learning | Arms G/H/I/J relaunched |
-| **#222** | (Round12) | 1-epoch LR warmup before cosine decay | Running |
-| **#221** | violet | Per-channel adaptive loss reweighting toward AB-UPT targets | v6 (lr=3e-4, seed=1) running |
-| **#218** | frieren | SO(3)-equivariant tangent-frame wall shear head | Running |
-| **#214** | gilbert | k-NN local surface attention for wsy/wsz gap | Running |
-| **#213** | nezuko | SAM optimizer for flat-minima generalization | ep1 underperforming control; awaiting ep2 |
-| **#210** | kohaku | Gradient accumulation eff_bs=32 | Training (confirmed GPU activity) |
-| **#209** | frieren | Step-decay LR drop after ep1 (seed=-1, no-warmup relaunches) | Awaiting ep1 vals |
-| **#208** | askeladd | Sandwich-LN to unlock 8L/256d depth | Arm B (8L sandwich-LN, bs=4) running ~18866+ steps |
-| **#207** | alphonse | AGC (NFNets) per-parameter stability | Arms I/J/K running |
-| **#193** | thorfinn | Curvature-biased surface point sampling | alpha=0.25 arm running |
-| **#152** | violet | Per-channel adaptive loss reweighting | v6 running |
+| #266 | stark | **U-net long skip connections** (modded-NanoGPT-inspired) | NEW (just assigned) |
+| #260 | thorfinn | model-slices sweep {64, 128, 192} | NEW |
+| #259 | senku | grad-clip-norm sweep {0.5, 2.0} | NEW |
+| #258 | kohaku | squared rel-L2 aux loss (focal-style) | NEW |
+| #257 | haku | high-shear curriculum oversampling | NEW |
+| #256 | frieren | mirror-symmetry TTA | NEW |
+| #255 | edward | fixed wsy/wsz loss multipliers | NEW |
+| #254 | chihiro | raw rel-L2 auxiliary loss sweep | Just launched |
+| #253 | askeladd | FourierEmbed vs ContinuousSincosEmbed | NEW |
+| #239 | norman | (yi-branch — listed above) | — |
+| #221 | violet | per-channel adaptive reweighting | Run A ep5=11.12, gate stalled, second prod posted |
+| #214 | gilbert | k-NN local surface attention | **Strong signal: -1.58pp wsy, -1.22pp wsz at ep2 vs alphonse** |
+| #179 | nezuko | 5L/384d wide-deep + Fourier PE | Rebased; ep10=8.825% gate passed; ep30 needed |
+| #174 | alphonse | 5L/256d + Fourier PE + T_max=50 | `vu4jsiic` ep9=9.10, ep10=8.64 — strong descent |
+| #80 | tanjiro | surface-loss-weight sweep | Trial B1 ep16=8.96 gate passed |
+| #79 | emma | DrivAerML 60k Points + Fourier PE | Merge conflict — rebase requested |
+| #75 | fern | LR sweep with Fourier PE | Trial B ep18=8.47, projected ep30 ~7.95 |
 
-### Pod Status (as of 2026-05-01 19:00 UTC)
-- All 17 named student deployments: READY (1/1)
-- `senpai-yi-stark`: **MISSING** — human provisioning required (Issue #248)
+### Closed this round
+
+- **PR #229** (norman y-flip TTA, yi) — closed as stale duplicate; norman was actively on PR #239 bengio
+- **PR #152** (violet geom-moment, yi) — closed after 3 cascading divergences on rebased base; architecture mismatch with new SOTA stack
 
 ---
 
 ## Current Research Themes
 
-### Theme 1: Coordinate-Frame Hypothesis for tau_y/z Gap (HIGHEST PRIORITY — Morgan's directive)
-**Root question:** Is the 4× tau_y/z error a coordinate-frame problem? AB-UPT achieves equal error on tau_x/y/z (~3.6) while we have 10/14/15.
+### Theme 1: Issue #252 / Modded-NanoGPT Inspiration (NEW)
+- **#261 norman:** Muon optimizer (Newton-Schulz orthogonalized momentum)
+- **#262 nezuko:** Linear-warmdown LR schedule (WSD-style)
+- **#266 stark:** U-net long skip connections
+- **#270 violet:** tanh output soft-cap (regression analog of logit-cap)
+- Deferred: FlexAttention, FP8 head, sequence packing
 
-- **#227 stark:** Wall-shear prediction in local surface tangent frame {t1, t2, n}. Morgan's #1 directive. **POD MISSING — Issue #248 filed.**
-- **#218 frieren:** SO(3)-equivariant tangent-frame wall shear head.
-- **CLOSED NEGATIVE #121, #168:** Hard Duff-ONB (discontinuous at t1.x sign-flip) and normal-consistency penalty (model already near-tangential).
+### Theme 2: Locality / Receptive Field for wsy/wsz Gap (HOT)
+- **#214 gilbert (bengio):** kNN local surface attention — STRONG ep2 signal
+- **#193 thorfinn (yi):** curvature-biased surface point sampling
+- **#266 stark (bengio):** U-net skip injection of fine-detail to deep layers (mechanism complement to kNN)
 
-### Theme 2: Hyperparameter Calibration (Round 14 Sweep)
-Systematic calibration on 10.21 baseline — four students sweeping complementary hyperparameters:
-- **#243 chihiro:** aux-rel-l2-weight {0.1, 0.5, 1.0}
-- **#244 emma:** surface-loss-weight {1.5, 2.0}
-- **#245 gilbert:** progressive EMA decay schedule
-- **#246 tanjiro:** LR warmup steps {500, 1000}
+### Theme 3: Loss Formulation
+- **#243 chihiro (yi):** aux-rel-l2-weight sweep
+- **#254 chihiro (bengio):** raw rel-L2 aux loss sweep
+- **#258 kohaku (bengio):** squared rel-L2 aux (focal-style)
+- **#255 edward (bengio):** fixed wsy/wsz multipliers
+- **#244 emma (yi):** surface-loss-weight {1.5, 2.0}
+- **#221 violet (bengio):** adaptive per-channel reweighting toward AB-UPT targets
+- **#270 violet (yi):** tanh output soft-cap (bounds tail predictions)
 
-### Theme 3: Architecture Scaling
-- **#208 askeladd:** Sandwich-LN to unlock 8L/256d depth — Arm B running stably at 18866+ steps.
-- **#235 askeladd:** 4L/512d/8H width frontier — radford champion port.
-- **#240 frieren:** Wider FFN (mlp-ratio=8) for richer per-block representation.
-- **#241 tanjiro:** Width scaling 512→768d with µP-scaled LR.
-- **PRIOR FINDING: Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M) — further depth exploration warranted if sandwich-LN stabilizes 8L.
+### Theme 4: Optimization & Stability
+- **#207 alphonse (yi):** AGC — only lr=3e-4 arms surviving
+- **#247 thorfinn (yi):** cosine T_max=14 schedule
+- **#262 nezuko (yi):** linear-warmdown LR
+- **#259 senku (bengio):** grad-clip-norm sweep
+- **#261 norman (yi):** Muon optimizer
+- **#245 gilbert (yi):** progressive EMA decay
+- **#249 tanjiro (yi):** asinh wall-shear target normalization
 
-### Theme 4: Optimizer and Training Infrastructure
-- **#207 alphonse:** AGC (NFNets) per-parameter clipping. Arms I/J/K running.
-- **#213 nezuko:** SAM optimizer — ep1 underperforming control; ep2 awaited.
-- **#234 senku:** Mirror-symmetry TTA for wsy free gain.
-- **#229 norman:** y-flip TTA (Pod restarted ~18:36 UTC).
-- **#230 senku:** SWA uniform weight averaging.
-
-### Theme 5: Loss Formulation and Sampling
-- **#236 edward:** Fixed wsy/wsz loss multipliers — direct binding-constraint attack.
-- **#237 haku:** Squared rel-L2 aux loss for hard-sample focusing.
-- **#238 kohaku:** High-shear curriculum oversampling for wsy/wsz tail.
-- **#225 haku:** Left-right symmetry augmentation.
-- **#193 thorfinn:** Curvature-biased surface point sampling (alpha=0.25 arm).
+### Theme 5: Architecture
+- **#208 askeladd (yi):** sandwich-LN for 8L/256d depth
+- **#260 thorfinn (bengio):** model-slices sweep {64, 128, 192}
+- **#179 nezuko (bengio):** 5L/384d wide-deep + Fourier PE — ep10 gate passed
 
 ### Theme 6: Positional Encoding
-- **#224 fern:** Learned Fourier embeddings per-axis freq. Arms G/H/I/J relaunched.
-- **#239 norman:** Fourier PE num_freqs sweep {16, 32, 64, 128}.
-- **BASELINE: PR #183 (fern):** pos_max_wavelength=1000 ContinuousSincosEmbed — the current 10.21 bar.
+- **#224 fern (yi):** learned Fourier embeddings per-axis (init=10 beats sincos at matched ep1)
+- **#239 norman (bengio):** Fourier PE num_freqs sweep {16, 32, 64, 128}
+- **#253 askeladd (bengio):** FourierEmbed vs ContinuousSincosEmbed standalone test
 
-### Theme 7: Adaptive Loss Reweighting
-- **#221 violet:** Per-channel adaptive loss reweighting toward AB-UPT targets. v6 running (lr=3e-4, warmup=1000, seed=1).
-- **#228 edward:** OHEM hard surface-point weighting.
-
-### Theme 8: Architecture Depth Ablation (Round 12 PRs still running)
-- **#231 (slices=64), #232 (heads=4), #233 (layers=3):** Ablate individual architectural dimensions from SOTA.
+### Theme 7: Symmetry / TTA / Augmentation
+- **#225 haku (yi):** mirror symmetry training augmentation
+- **#256 frieren (bengio):** mirror-symmetry TTA
+- **#257 haku (bengio):** high-shear curriculum oversampling
+- **#227 stark (yi):** wall-shear in tangent frame — POD MISSING (RBAC, Issue #248)
+- **#230 senku (yi):** SWA tail-end weight averaging
 
 ---
 
-## Key Structural Findings Accumulated
+## Fleet-Wide Stability Constraints (current)
 
-### Stability
-- **Fleet-wide instability mechanism (CONFIRMED):** Large-but-finite grad spikes bypass PR #169's NaN-skip. clip_grad_norm=1.0 normalizes direction but preserves poison vector → Adam m/v corruption.
-- **FiLM stability axis is LR** (PR #184 closed): lr=4e-4 is the stability boundary; lr=5e-4 kills FiLM regardless of init_scale.
-- **LR ceiling at ~6.5e-4** (PRs #164, #191): OneCycleLR peaks ≥ 6.5e-4 diverge regardless of warmup.
-- **W_y=W_z > 2.0 overfits tau_y/z** (PR #66): W=3 scores 13.18 vs 12.74 for W=2.
-
-### Target Representation
-- **asinh normalization NEGATIVE** (PR #123): Compresses tail → suppresses gradient explosions but also suppresses learning signal where y/z gap lives.
-- **Heavy-tail is real:** Wall shear spans 4 decades. The tail dominates rel_L2 numerator AND denominator. Cannot compress it.
-
-### Architecture
-- **Depth >> Width:** 6L/256d (4.73M) dominates 4L/512d (12.7M).
-- **8L/256d is blocked by LR ceiling** (PRs #144, #164): Cannot train at lr ≥ 5e-4 with current norm structure. Sandwich-LN (PR #208) is the unlock attempt.
-- **Multi-scale hierarchy failed** (PR #150): Receptive field is not the lever for tau_y/z gap.
-
-### Loss/Data Representation
-- **Per-axis wallshear upweighting:** W_y=W_z=2 is optimal (PR #66).
-- **Explicit tangentiality enforcement provides no gain** (PRs #121, #168): Model already learns near-tangential predictions naturally.
-- **Tangent-frame prediction (Duff ONB) discontinuous** at t1.x sign-flip → incompatible with Transolver. Use smooth e_x-projection frame (PR #199).
+- **lr=5e-4 + 4L/512d + Lion is structurally unstable.** Confirmed across 10+ arms across PRs #193/#207/#224/#243/#244/#245. Standard response: relaunch at lr=3e-4 (Lion) or lr=1e-4 (Lion + lr_warmup_epochs=1, the SOTA recipe).
+- **PR #222 SOTA recipe (Lion, lr=1e-4, lr_warmup_epochs=1, 4L/512d) is the only confirmed-stable optimizer point** in this regime.
+- **Volume pressure now beats AB-UPT (0.97×, 5.88 vs 6.08).** All future experiments should avoid sacrificing p_v for tau gains.
+- **Wall_shear_y/z gap remains 1.4× of AB-UPT** — primary research target.
 
 ---
 
 ## Key Constraints
-- Training budget: ~270 min training + ~90 min val/test = 360 min total (~3-4 epochs at 6L/256d)
-- VRAM: 96 GB per GPU; 6L/256d at bs=8 uses ~75 GB
-- Gradient clipping: clip_grad_norm=1.0 standard; clip=0.5 for stability-sensitive experiments
-- LR warmup: 500 steps (1e-5 start) now standard
-- Students have 4 GPUs each
+
+- Training budget: ~270 min training + ~90 min val/test = 360 min total
+- VRAM: 96 GB per GPU; SOTA recipe uses ~75 GB
+- Gradient clipping: clip_grad_norm=1.0 standard
+- Students have 4 GPUs each; single-process per GPU enables 4 arms in parallel

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 11:45 UTC
+- **Updated:** 2026-05-01 12:15 UTC
 - **Branch:** `yi`
 - **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
 
@@ -54,7 +54,7 @@
 | **#165** | chihiro | mlp_ratio=8 hardened (3-seed) | **seed1337 ep3=11.92 (NOT beating 10.69); clip=0.5 go/no-go at 12:20/13:30 UTC** |
 | **#164** | alphonse | 8L/256d + 1cycle LR recovery | WIP |
 | **#152** | violet | 14-dim analytic geometry moment conditioning | WIP |
-| **#151** | nezuko | L/R symmetry augmentation (tau_y gap) | WIP |
+| **#201** | nezuko | Physics-informed RANS divergence-free penalty on volume velocity | JUST ASSIGNED |
 | **#123** | frieren | asinh/log wall-shear target normalization | **Critical finding: asinh-1.0 trades metric for stability; arms A/D/B(v3p1) final results ~12:10-13:51 UTC** |
 
 ---
@@ -79,17 +79,22 @@
 - Also needed: finite-but-pathological loss guard (abort if train_loss > 5× running_median for sustained steps)
 - **This should be an infrastructure PR** — candidate to assign to the next available thorfinn/infra-capable student
 
-### Theme 4: FiLM Geometry Conditioning (Near Complete)
+### Theme 4: Physics-Informed Constraints
+- **#201 nezuko (NEW):** RANS divergence-free penalty — soft constraint λ·mean(∇·u²) on volume velocity predictions. 4-arm sweep: λ∈{0.001, 0.01, 0.1} + control (λ=0.0). Addresses Morgan's #4 directive. Hypothesis: enforcing ∇·u=0 improves near-wall velocity gradient accuracy → reduces tau_y/z errors.
+- **#168 askeladd:** Normal-consistency penalty — related physics-informed constraint from the surface tangentiality direction.
+- **KEY FINDING (PR #151, nezuko) — CLOSED NEGATIVE:** L/R symmetry augmentation — both arms crashed NaN in epoch 2 (val abupt 17.63 and 45.92 vs baseline 10.69). DrivAerML cars have real Y-asymmetries; symmetry label assumption is invalid.
+
+### Theme 5: FiLM Geometry Conditioning (Near Complete)
 - **#184 kohaku:** FiLM stability characterized. 5/5 at lr=5e-4 dead regardless of init_scale. Stability axis is lr alone. Arm B (lr=4e-4) sole survivor, completing ~14:25 UTC.
 - **Key finding:** FiLM requires lr ≤ 4e-4, which may conflict with the lr=5e-4 optimum. The volume_pressure signal from PR #126 Arm-3 (vp=7.05 vs 7.85 baseline) is real — FiLM may still help volume even if it can't close the tau_y/z gap.
 
-### Theme 5: Training Budget Efficiency
+### Theme 6: Training Budget Efficiency
 - **#171 norman:** Snapshot ensemble with cyclic LR. V1 diverged at epoch 3 (50× LR jump); V2 has 10× ratio + clip=0.5, running cleanly, ETA ~17:30 UTC.
 - **#196 edward:** Lion optimizer (round 12) — Lion typically needs ~3× lower LR than AdamW
 - **#198 senku:** SWA — free post-train gain from averaging model weights across last epochs
 - **#197 gilbert:** k-NN local attention — addresses spatial locality for tau_y/z
 
-### Theme 6: Architecture Exploration (Round 12)
+### Theme 7: Architecture Exploration (Round 12)
 - **#191 haku:** 1cycle LR (corrected — calibrated to actual epoch budget)
 - **#164 alphonse:** 8L/256d depth with 1cycle (time-limited recovery — must beat PR #144 ep4 val=12.69)
 
@@ -133,7 +138,7 @@
 4. **Review #183 (fern)** — cross-arm ep2 table at ~12:30 UTC
 5. **Infrastructure PR** — magnitude-based grad-skip (assign to thorfinn when free)
 6. **Perceiver-IO backbone** (Morgan's #2 directive) — not yet assigned; needs careful scoping
-7. **Physics-informed RANS** (Morgan's #4 directive) — not yet assigned
+7. **Physics-informed RANS** (Morgan's #4 directive) — ASSIGNED to nezuko (#201)
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-28
+- **Date:** 2026-04-29
 - **Branch:** `yi`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B:** `wandb-applied-ai-team/senpai-v1-drivaerml`
-- **Most recent direction from human team:** 2026-04-28 — morganmcg1 (Issue #18)
+- **Most recent direction from human team:** 2026-04-28 — morganmcg1 (Issue #19)
 
 ## Key directives from human research team (Issue #18, 2026-04-28)
 
@@ -92,6 +92,26 @@ Full hypothesis pool: `research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.m
 Round 2 will assign these once Round 1 results come in (so we know which
 loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
+## Round 1 — first reviewed result (2026-04-29)
+
+- **PR #12 (nezuko, DropPath p=0.1) closed.** Significantly worse than the closest
+  no-DropPath comparator (norman): 81.21 vs 64.66 abupt_axis_mean. Root cause:
+  runs are in the **underfitting regime** (best_epoch=1, train loss falling while
+  EMA-val degrades), so any regularizer hurts. Stochastic depth is the wrong tool
+  for the current bottleneck.
+- **Critical infrastructure win from PR #12.** nezuko shipped a per-step timeout
+  fix (`train.py`); cherry-picked onto `yi` as `af92e9a`. Reserves
+  `SENPAI_VAL_BUDGET_MINUTES` (default 90), checks wall-clock per step, forces
+  validation on partial epoch when timeout hits. Without this, every 65k-pts
+  run silently times out without producing `test_primary/*`.
+- **Cross-cutting Round-1 directives broadcast to all active PRs (2026-04-29):**
+  rebase onto `yi` to pick up `af92e9a`; set `--validation-every 1` (or 2) for
+  Round-1 sized runs since `validation_every=10` only yields one usable
+  checkpoint inside the budget; report on observed train→val divergence.
+- **Open question for the round:** train loss decreases while EMA-val
+  degrades after epoch 1 on at least two runs. EMA decay too aggressive for
+  the fast initial fit? LR-warmup interplay? Worth a focused diagnostic.
+
 ## Constraints
 
 - `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` are fixed by harness — do
@@ -106,3 +126,7 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
   preventing the run from reaching epoch 1 inside the 6 h timeout. At
   every-50 the same config runs at ~6.8 it/s. Slope cadence
   (`--slope-log-fraction 0.05`) is already efficient and stays.
+- **Per-step timeout fix (commit `af92e9a` on `yi`, 2026-04-29):**
+  `SENPAI_VAL_BUDGET_MINUTES` (default 90) is reserved out of
+  `SENPAI_TIMEOUT_MINUTES` for in-loop val + post-loop full_val + test.
+  All new student work must rebase onto `yi` to pick this up.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 21:40 UTC
-- **Branches:** `yi` (4L/512d Lion SOTA), `bengio` (4L/256d AdamW Wave 2/3)
+- **Updated:** 2026-05-01 22:35 UTC (yi advisor sweep)
+- **Branches:** `yi` (4L/512d Lion SOTA), `bengio` (4L/256d AdamW Wave 2/3), `tay` (Lion+DDP refactored codebase)
 
 ---
 
@@ -37,30 +37,31 @@ Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain th
 
 ### yi branch — 17 WIP PRs (zero idle)
 
+Note: PRs assigned to other advisor branches (`tay`: #247, #280; `bengio`: #239) are excluded from this table — they belong to those advisors' fleets.
+
 | PR | Student | Hypothesis | Status |
 |---|---|---|---|
-| #280 | frieren | **MLP activation ablation** (SwiGLU / ReLU² vs GELU) | NEW (just assigned) |
-| ~~#279~~ | ~~frieren~~ | ~~no-slip BC penalty~~ | CLOSED 21:40Z — duplicates failed PR #201 (GT tau·n RMS=12% contradicts continuum BC) |
-| #270 | violet | **tanh output soft-cap** (modded-NanoGPT logit-cap analog) | NEW (just assigned) |
-| #262 | nezuko | **linear-warmdown LR schedule** (modded-NanoGPT WSD-style) | NEW (just assigned) |
-| #261 | norman | **Muon optimizer** (Newton-Schulz orthogonalized momentum) | NEW (just assigned) |
-| #249 | tanjiro | asinh wall-shear normalization | TempCollapse bug found; advisor authorized `T.clamp(min=1e-2)` + relaunch with `--lr-warmup-epochs 1`; sent back to wip 21:35Z |
-| #247 | thorfinn | cosine T_max=14 (between 9 and 50) | Run live, mid-ep3 |
-| #245 | gilbert | progressive EMA decay (0.99→0.9999 etc.) | Arm A surviving; B/C retries running |
-| #244 | emma | surface-loss-weight {1.5, 2.0} | Arm A crashed lr=5e-4; Arm B healthy |
-| #243 | chihiro | aux-rel-l2-weight {0.1, 0.5, 1.0} | A/B retries at lr=3e-4; C healthy |
-| #239 | norman | Fourier PE num_freqs sweep (bengio-branch work) | NF=16 running, ep5 gate ~5h |
-| #230 | senku | SWA tail-end weight averaging | All 4 arms running, no signal until ep25+ |
-| #228 | edward | OHEM hard surface-point weighting | Arm B (f=1.0) running |
-| #227 | stark | wall-shear in surface tangent frame | NO POD — RBAC blocked, Issue #248 |
-| #225 | haku | mirror symmetry training augmentation | Running |
-| #224 | fern | learned Fourier embeddings per-axis | K/L/N/O surviving; J finding: init=10 beats sincos by 6.7% at matched ep1 step |
-| #221 | violet | per-channel adaptive loss reweighting | Run A `541ru1pv` ep5=11.12; gate-check stalled (cross-listed, primary on bengio) |
-| #210 | kohaku | gradient accumulation eff_bs=32 | Running |
-| ~~#209~~ | ~~frieren~~ | ~~step-decay LR drop after ep1~~ | CLOSED 2026-05-01 21:22 — hypothesis rejected; control 10.08 vs bar 9.291 on legacy stack |
-| #208 | askeladd | sandwich-LN to unlock 8L/256d | Arm B running ~18866+ steps |
+| #286 | frieren | **bilateral-symmetry test-time augmentation (TTA)** for tau_y/z gap | NEW (just assigned 22:35Z, replacing closed #209) |
+| #284 | alphonse | 6L/512d depth+width scaling on Lion+warmup SOTA | Awaiting student launch |
+| #273 | edward | focal-loss per-point surface weighting (γ sweep {0,0.5,1,2}) | All 4 arms launched, AdamW-control on yi |
+| #270 | violet | **tanh output soft-cap** (modded-NanoGPT logit-cap analog) | Arm-matrix swap applied; sweep restarted |
+| #262 | nezuko | **linear-warmdown LR schedule** (modded-NanoGPT WSD-style) | Arm C only (skipped A; fern `ut1qmc3i` is published control) |
+| #261 | norman | **Muon optimizer** (Newton-Schulz orthogonalized momentum) | Plan B-modified: AdamW control; Lion port deferred |
+| #249 | tanjiro | asinh wall-shear normalization | TempCollapse fix applied (commit 66cce26); arms relaunched |
+| #245 | gilbert | progressive EMA decay (0.99→0.9999 etc.) | Arm B retry ep1 val landed; Arm C retry crashed at 94% |
+| #244 | emma | surface-loss-weight {1.5, 2.0} | Both arms stable on lr=3e-4 |
+| #243 | chihiro | aux-rel-l2-weight {0.1, 0.5, 1.0} | A r3 + B r2 ep1 vals landed; C r2 still in ep1 |
+| #230 | senku | SWA tail-end weight averaging | v2 sweep (warmup=1000) launched 21:49Z, all 4 arms healthy |
+| #227 | stark | wall-shear in surface tangent frame | **NO POD — RBAC blocked, Issue #248 (still OPEN)** |
+| #225 | haku | mirror symmetry training augmentation | Running, lr=5e-4 instability margin documented |
+| #224 | fern | learned Fourier embeddings per-axis | K/L/N/O surviving; J finding: init=10 beats sincos by 6.7% at matched ep1 |
+| #210 | kohaku | gradient accumulation eff_bs=32 | Arm A switched to lr=3e-4+seed=43 after dual seed=42/43 crashes |
+| #208 | askeladd | sandwich-LN to unlock 8L/256d | Round-7 launched 20:23Z; lr_warmup ramp running |
 | #207 | alphonse | Adaptive Gradient Clipping (AGC) | lr=3e-4 arms only surviving |
-| #193 | thorfinn | curvature-biased surface point sampling | 3 lr=3e-4 arms healthy past warmup |
+| #193 | thorfinn | curvature-biased surface point sampling | 3 lr=3e-4 arms healthy past warmup; lr=5e-4 path closed |
+
+### Closed since last update (2026-05-01)
+- **PR #209** (frieren step-decay LR drop) — closed 21:22Z. All decay arms (B/C/D) underperformed no-decay control; hypothesis rejected on this lineage.
 
 ### bengio branch — 16 WIP PRs (zero idle)
 
@@ -138,19 +139,25 @@ Volume pressure has now beaten AB-UPT. Surface pressure and wall_shear remain th
 
 ### Theme 7: Symmetry / TTA / Augmentation
 - **#225 haku (yi):** mirror symmetry training augmentation
+- **#286 frieren (yi):** bilateral-symmetry TTA — orthogonal to #225, inference-only, no training cost
 - **#256 frieren (bengio):** mirror-symmetry TTA
 - **#257 haku (bengio):** high-shear curriculum oversampling
 - **#227 stark (yi):** wall-shear in tangent frame — POD MISSING (RBAC, Issue #248)
 - **#230 senku (yi):** SWA tail-end weight averaging
 
+### Theme 9: Architecture Capacity Scaling
+- **#284 alphonse (yi):** 6L/512d depth+width on Lion+warmup SOTA — tests whether 4L/512d is capacity-bound
+
 ---
 
 ## Fleet-Wide Stability Constraints (current)
 
-- **lr=5e-4 + 4L/512d + Lion is structurally unstable.** Confirmed across 10+ arms across PRs #193/#207/#224/#243/#244/#245. Standard response: relaunch at lr=3e-4 (Lion) or lr=1e-4 (Lion + lr_warmup_epochs=1, the SOTA recipe).
-- **PR #222 SOTA recipe (Lion, lr=1e-4, lr_warmup_epochs=1, 4L/512d) is the only confirmed-stable optimizer point** in this regime.
+- **lr=5e-4 + 4L/512d is structurally unstable on yi-monolithic AdamW.** Confirmed across 10+ arms across PRs #193/#207/#210/#224/#243/#244/#245. Standard response: relaunch at lr=3e-4 or seed=-1.
+- **yi vs tay infrastructure gap**: PR #222 winning config (Lion + DDP + `--lr-warmup-epochs`) lives on `tay`'s refactored codebase. yi's monolithic `train.py` is **AdamW-only, single-process, has only `--lr-warmup-steps` and `--wandb-group` (dash form)**. All Round-15 yi PRs run AdamW-control comparisons — relative deltas, not absolute 9.291% bar. Lion+DDP port to yi deferred to a single dedicated infra PR (no student assigned yet).
+- **PR #222 SOTA recipe (Lion, lr=1e-4, lr_warmup_epochs=1, 4L/512d) is the only confirmed-stable optimizer point** for the absolute bar — but only reproducible on tay.
 - **Volume pressure now beats AB-UPT (0.97×, 5.88 vs 6.08).** All future experiments should avoid sacrificing p_v for tau gains.
 - **Wall_shear_y/z gap remains 1.4× of AB-UPT** — primary research target.
+- **Issue #248 (stark pod RBAC)**: still OPEN. Two follow-up nudges posted to Morgan; awaiting human cluster admin action.
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -94,26 +94,35 @@ loss/optim/EMA/data-weighting wins to compose with the new backbone).
 
 ## Round 1 — reviewed results (2026-04-29)
 
-### MERGED — yi baseline progression
+### VERIFIED WIN (pending merge) + MERGED — yi baseline progression
 
-- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED 03:57 UTC — new yi best.**
-  `abupt_axis_mean = 17.39` (vs prior 35.12 = 50.5% reduction). Wall-shear
-  axes -50% to -70%. Surface pressure +1pp. Run A `y2gigs61`, state=finished,
-  6 epochs reached, best_epoch=3. PR was CLI-flag-only (no code diff).
-  Win came primarily from **protocol fixes** (bs=8, validation-every=1,
-  gradient-log-every=100), not from vol_w (which is at worst neutral).
+- **PR #8 (frieren, per-block FiLM conditioning) — VERIFIED WIN, pending merge.**
+  `abupt_axis_mean = 16.53` (vs 17.39 baseline = −4.9%). Run `hltti2ec`,
+  state=finished, 1 epoch, best_epoch=1, bs=2 only. Beats baseline in every
+  test_primary axis. Apples-to-apples vs PR #3 (no FiLM, same config): 30.47 → 16.53
+  = 46% reduction. FiLM mechanistically confirmed (token norm 70× growth, FiLM weights
+  1.8–3.6×). Merge blocked on rebase conflict — frieren rebasing now.
+  **Will be the new yi best once merged.**
+  - Follow-up PR #23 (frieren): full composition — FiLM + vol_w=2.0 + projection + bs=8.
+- **PR #9 (gilbert, vol_w=2.0 + protocol fixes) MERGED 03:57 UTC — current yi best.**
+  `abupt_axis_mean = 17.39` (vs prior 35.12 = 50.5% reduction). Run `y2gigs61`,
+  state=finished, 6 epochs reached, best_epoch=3.
+  Win came primarily from **protocol fixes** (bs=8, validation-every=1, log-cadence).
   - **Infrastructure bug flagged:** `train.py` has no gradient clipping.
-    Multiple Round-1 PRs diverged on this mechanism (chihiro, emma, fern,
-    haku, gilbert run B). Follow-up PR #22 (gilbert) adds it.
-- **PR #11 (kohaku, tangential wall-shear projection) — MERGED earlier,
-  superseded as baseline by PR #9.** Code remains on yi (default off);
-  expected to compose with gilbert's config for further gains.
+    Follow-up PR #22 (gilbert) adds it.
+- **PR #11 (kohaku, tangential wall-shear projection) — MERGED earlier.**
+  Code remains on yi (default off). Expected to compose for further gains.
 - **Follow-up PR #21 (kohaku, normal-component suppression sweep)** —
-  λ ∈ {0.0, 0.01, 0.1, 1.0} of `λ * mean((ws_pred · n_hat)^2)` on top of
-  projection.
+  λ ∈ {0.0, 0.01, 0.1, 1.0} on top of projection.
 - **Follow-up PR #22 (gilbert, gradient clipping)** — adds
   `torch.nn.utils.clip_grad_norm_` + 4-arm sweep. Infrastructure win
   blocking high-LR / high-weight / high-batch sweeps.
+
+**Three independent wins now compounding (next big leap from stacking all):**
+1. Tangential projection (PR #11, default off, `--use-tangential-wallshear-loss`)
+2. Protocol fixes: vol_w=2.0, bs=8, validation-every=1 (PR #9)
+3. Per-block FiLM conditioning (PR #8, pending merge)
+→ PR #23 (frieren) will test all three together.
 
 ### CLOSED
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **Updated:** 2026-05-01 14:30 UTC
+- **Updated:** 2026-05-01 14:45 UTC
 - **Branch:** `yi`
 - **Baseline:** PR #99 (fern), `abupt_axis_mean_rel_l2_pct = 10.69`, W&B run `3hljb0mg`
 
@@ -14,7 +14,7 @@
 1. Surface-tangent frame wall-shear prediction — 4× wall shear y/z error is a coordinate frame mismatch
 2. **Perceiver-IO backbone replacement** — ~3× faster per epoch = more epochs within budget (**ASSIGNED #212 noam**)
 3. asinh/log target normalization — tested, **NEGATIVE — tail suppression problem (PR #123)**
-4. Physics-informed RANS constraint — soft divergence-free penalty (**ASSIGNED #201 nezuko**)
+4. Physics-informed RANS constraint — tested, **NEGATIVE — label contradiction: DrivAerML mesh GT has RMS(τ·n)/|τ|=12%, so (τ·n)=0 constraint contradicts labels (PR #201)**
 5. 1-cycle LR schedule with higher peak — tested, **NEGATIVE — budget starvation + stability ceiling (PRs #164, #191)**
 
 ---
@@ -47,12 +47,12 @@
 | **#210** | kohaku | Gradient accumulation eff_bs=32 for smoother tau_y/z grads |
 | **#211** | tanjiro | Relative magnitude-based grad-skip (EMA-adaptive) fleet infra |
 | **#212** | noam | Perceiver-IO backbone replacement (2-4× speed → more epochs) |
+| **#213** | nezuko | SAM (Sharpness-Aware Minimization) for flat-minima generalization |
 
 ### Ongoing From Earlier Rounds
 
 | PR | Student | Hypothesis |
 |---|---|---|
-| **#201** | nezuko | Physics-informed RANS divergence-free penalty on volume velocity |
 | **#200** | emma | Wall-shear magnitude/direction decomposition loss (τ y/z gap) |
 | **#199** | stark | Smooth tangent-frame wall-shear prediction (continuous e_x-projection) |
 | **#198** | senku | Stochastic Weight Averaging (SWA) free gain |
@@ -106,8 +106,12 @@
 - **#183 fern:** Omega-bank frequency sweep. Three arms healthy.
 
 ### Theme 6: Physics-Informed Constraints
-- **#201 nezuko:** RANS divergence-free penalty on volume velocity. Morgan's #4 directive.
+- **CLOSED NEGATIVE #201 nezuko:** RANS divergence-free penalty — label contradiction: GT mesh has RMS(τ·n)/|τ|=12%, so (τ·n)=0 no-slip constraint directly opposes labels. No feasible λ.
 - **CLOSED NEGATIVE #168:** Normal-consistency (tangential) constraint.
+- **Theme exhausted at current data contract.** True ∇·u requires velocity head (volume_y is pressure-only).
+
+### Theme 9: Optimization Landscape (NEW)
+- **#213 nezuko (NEW):** SAM (Sharpness-Aware Minimization) — seeks flat minima explicitly. 500-train vs 50-val geometries → sharp minima risk. SAM's 2× compute cost limits to 2 epochs but flat-minima training may beat 3 sharp-minima epochs.
 
 ### Theme 7: Ensemble and Budget Efficiency
 - **#171 norman:** Snapshot ensemble with cyclic LR (V2).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -710,3 +710,26 @@ seed1337 ep3=11.92 is 1.23pp above baseline. Slope flattening (ep1→ep2: −5.2
 - **Open finding: universal ep1→ep2 train/val divergence** across all 4 norm variants is a separate failure mode worth pursuing — candidates: train/eval sampling distribution mismatch, overfitting-to-bulk regime, z-score saturation on tails. Suggests assigning a one-shot LR drop after ep1 experiment.
 - **Major contribution to retain:** `--grad-skip-threshold` + always-on NaN/inf grad-skip + W&B `train/grad/skipped_step|skipped_total` metrics. Will land independently on yi.
 - Closed as negative; frieren reassigned.
+
+---
+
+## 2026-05-01 14:30 — PR #201: [nezuko] Physics-informed RANS divergence-free penalty on volume velocity
+- Branch: `nezuko/physics-informed-rans-divergence`
+- Hypothesis: Add soft λ·mean(∇·u²) divergence-free penalty on volume velocity predictions to improve near-wall flow coherence and reduce tau_y/z error.
+- Results: 4-arm sweep λ∈{0.001, 0.01, 0.1, 0.0 control}
+
+| Arm | λ | W&B run | ep1 val_abupt | Fate |
+|---|---:|---|---:|---|
+| A orig | 0.001 | rtoy6zsi | DNF | NaN at step 2873 (>200 non-finite skips) |
+| A clamp | 0.001 | t0ak5zjy | DNF | Clamp(-10,10) didn't help; diverged same step |
+| B orig | 0.01 | xo1vzowt | DNF | NaN at step 5882 |
+| B clamp | 0.01 | qnk5doi7 | DNF | NaN at step 4546 |
+| **C** | **0.1** | **pe2ryffk** | **63.09** | **Stable but catastrophically worse (4×)** |
+| D | 0.0 | 8u7jc8kt | 15.55 | Control — healthy baseline trajectory |
+
+- **CRITICAL DATA FINDING:** GT labels have RMS(τ·n)/|τ| = 12% (τ·n mean=0.113, RMS=0.364, p99=1.722). DrivAerML mesh-discretized normals are not exactly orthogonal to the analytic surface, so the continuum no-slip constraint (τ·n = 0) directly contradicts the ground truth. There is no λ where this penalty can help:
+  - Small λ: batch-variance gradients from squared penalty too large → NaN cascade
+  - Large λ: forces τ_pred·n → 0, but labels have τ·n ≈ 0.36 → 2× train loss inflation, 4× val regression
+- **VOLUME ARCHITECTURE FINDING:** volume_y is scalar pressure only (no velocity in input or output contract). True ∇·u formulation is infeasible without adding a velocity head and separate supervision.
+- **Verdict: NEGATIVE.** Both the surface no-slip-wall penalty and the volume divergence-free penalty are infeasible with the current DrivAerML data contract and ground-truth labels.
+- Closed; nezuko reassigned.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,6 +9,49 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
+## 2026-04-29 03:13 — PR #11: tangential wall-shear projection loss (kohaku) — MERGED, FIRST yi BASELINE
+
+- Branch: `kohaku/round1-tangential-wallshear-loss`
+- Hypothesis: project predicted/target wall-shear onto surface tangent plane
+  before MSE — physics says wall shear has zero normal component on a no-slip
+  wall, so penalising the normal component is unphysical noise.
+- W&B run: `uy0ds6iz` (state=finished, 1 full epoch reached, run pre-dated
+  the per-step timeout fix so timed out at the inter-epoch check).
+
+| Metric | kohaku (PR #11) | norman (akbdunir, no-projection comparator) | nezuko (mdo2p8q7, DropPath) | AB-UPT |
+|---|---:|---:|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **35.12** | 64.66 | 81.21 | — |
+| `test_primary/surface_pressure_rel_l2_pct` | 10.07 | 48.43 | 66.49 | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 43.05 | 66.89 | 84.27 | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 14.99 | 55.54 | 69.42 | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 30.85 | 55.54 | 75.40 | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 42.06 | 90.15 | 102.42 | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 77.65 | 73.66 | 92.32 | 3.63 |
+
+**Result: merged (~46% reduction on `abupt_axis_mean` vs the closest comparator).**
+
+**Key wins:**
+- First yi baseline established. All future PRs measured against PR #11.
+- kohaku's deviation from the PR pseudocode was correct: PR text projected in
+  normalized space, but per-axis wall-shear stds are non-uniform
+  ([2.08, 1.36, 1.11]), so true tangential projection requires
+  denormalize → project → renormalize. Physically motivated and analytically
+  rigorous.
+- New diagnostic `train/wallshear_pred_normal_rms` instruments the predicted
+  normal component — confirmed it grows ~2.4× during a single epoch
+  (0.52 Pa → 1.21 Pa), validating the predicted failure mode.
+
+**Caveats:**
+- Only 1 epoch reached (run pre-dated the per-step timeout fix). Subsequent
+  PRs with the fix + `--validation-every 1` should reach 4–5 epochs.
+- All wall-shear axes still 5–21× from AB-UPT targets — most headroom is in
+  the wall-shear regression, especially `tau_z` (77.65% vs target 3.63%).
+
+**Round-1 follow-up assigned to kohaku (PR #21):** sweep
+`λ * mean((ws_pred · n_hat)^2)` regularizer on top of projection — directly
+addresses the failure mode the diagnostic exposed. Also serves as the first
+multi-epoch run with projection on (the λ=0 arm).
+
 ## 2026-04-29 02:30 — PR #12: stochastic depth / DropPath p=0.1 (nezuko) — CLOSED
 
 - Branch: `nezuko/round1-stochastic-depth`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -533,3 +533,129 @@ Val slopes at end of run: abupt −0.156/1k steps, wall_shear_y −0.191/1k step
   - D3 soft-divergence: anomalous loss spike at lr~6.5e-5 during deep cosine anneal — potential bf16 AMP precision issue at very low loss values. Fleet-wide flag: if future low-LR fine-tuning runs see similar, investigate AMP precision or implement LR floor ~1e-4.
   - OneCycleLR does not help in this epoch-limited regime. LR schedule lever closed for now. **Decision: closed.**
 
+---
+
+## 2026-05-01 07:30 — PR #166: [senku] W_y=W_z=3.0 with 500-step LR warmup — CLOSED NEGATIVE
+- Branch: `senku/per-component-wallshear-yz-3`
+- Hypothesis: Increasing from W_y=W_z=2 (current best) to W_y=W_z=3 with gradual warmup would further focus gradient on tau_y/z axes.
+- Results: CLOSED 2026-05-01T11:09:05Z. No merge.
+- Commentary: W=3 was already tested in PR #66 (thorfinn) where it scored 13.18 vs 12.74 for W=2 — W=3 overfits tau_y/z, degrading abupt. Warmup doesn't change the fundamental overfitting issue. Static W=2 remains the sweet spot.
+
+---
+
+## 2026-05-01 07:30 — PR #167: [tanjiro] W_y=W_z=3.5 with 1k LR warmup — CLOSED NEGATIVE
+- Branch: `tanjiro/static-wyz-35-warmup`
+- Hypothesis: W_y=W_z=3.5 pushes the tau_y/z gradient signal even harder.
+- Results: CLOSED 2026-05-01T09:58:05Z. No merge.
+- Commentary: Extension of the same W=3 overfitting issue. W=3.5 is even more extreme. Warmup does not prevent the channel imbalance. Closed as confirmed negative along with W=3.
+
+---
+
+## 2026-05-01 08:00 — PR #172: [stark] AdamW epsilon sweep 1e-8/7/6/5 — CLOSED NEGATIVE
+- Branch: `stark/adamw-eps-sweep`
+- Results: CLOSED 2026-05-01T08:43:12Z. No merge.
+- Commentary: AdamW epsilon is a secondary numerical stability parameter. Changing it in the range 1e-8 to 1e-5 does not address the root cause of the fleet-wide gradient instability (large-but-finite spikes bypassing the NaN-skip guard). Closed as not the right lever.
+
+---
+
+## 2026-05-01 11:30 — PR #185: [emma] SAM optimizer (ρ=0.05/0.10) — CLOSED NEGATIVE
+- Branch: `emma/sam-sharpness-aware-min`
+- Results: CLOSED 2026-05-01T11:35:49Z. No merge.
+- Commentary: SAM requires 2 forward-backward passes per step, cutting effective steps/epoch in half. In this 3-4 epoch budget this is too expensive. Also does not address the tau_y/z coordinate-frame hypothesis. Closed.
+
+---
+
+## 2026-05-01 — PR #184: [kohaku] FiLM with identity/zero-init (DiT-style) — IN FLIGHT
+- Branch: `kohaku/film-zero-init`
+- Hypothesis: FiLM with zero-initialized gamma/beta (identity transform at init) plus lr=4e-4 is stable where lr=5e-4 is not.
+- Intermediate results (5/5 arms at lr=5e-4 dead; 1 arm at lr=4e-4 healthy):
+
+| Arm | Config | W&B run | Status @ 11:45 UTC |
+|---|---|---|---|
+| A | zero-init/clip=1.0/lr=5e-4 | (prev) | Dead @ step 2455 |
+| A' | zero-init/clip=0.5/lr=5e-4 | (prev) | Dead @ step 1900 |
+| D | zero-init/clip=1.0/WD=1e-3/lr=5e-4 | (prev) | Dead @ step 2400 |
+| C | scale=0.01/clip=1.0/lr=5e-4 | (prev) | Dead @ step 15800 |
+| E | scale=0.001/clip=1.0/lr=5e-4 | gtur4oew | Dead @ step 14706 (scale delays but doesn't prevent divergence) |
+| **B** | **zero-init/clip=0.5/lr=4e-4** | **jov1kcjl** | **Healthy ep2≈99%; ETA ~14:25 UTC** |
+
+- **Key finding:** FiLM stability axis is LR alone, not init_scale. scale=0.001 delayed divergence 6× (step 2455→14706) but failure mode is identical (gamma/beta accumulate bias beyond critical threshold). The "escape path" via aggressive init scaling is falsified. lr=4e-4 (arm B) is the sole viable FiLM configuration. Final results pending ~14:25 UTC.
+
+---
+
+## 2026-05-01 — PR #183: [fern] Omega-bank frequency sweep — IN FLIGHT (PARTIAL RESULTS)
+- Branch: `fern/omega-bank-sweep`
+- Hypothesis: Per-axis sincos positional encodings with different max_wavelength per axis (x=10000, y=2500-1000, z=2000-1000) directly encode the car's geometric anisotropy, helping the model learn the tau_y/z channels.
+- All 4 original non-guarded arms diverged (large-but-finite grad spikes bypassing NaN-skip):
+
+| Arm | Config | Div step | Max grad at div |
+|---|---|---:|---:|
+| A1 | mw=1000 | 7499 | 14.9M |
+| B | mw=100 | 15800 | 252 (sustained) |
+| C1 | 10000,2500,2000 | 14181 | 899 (cascading) |
+| D1/D2 | 5000/10000,1000,1000 | 3555/8799 | NaN/15019 |
+
+- mw=100 (arm B) is **structurally untenable** — 3 independent attempts (B, B2 guarded, B3 guarded+warmup) all diverged within 0.3-1.6 epochs. Falsified.
+- Surviving guarded arms as of 11:35 UTC:
+
+| Arm | Config | W&B run | ep1 val_abupt | ep2 ETA |
+|---|---|---|---:|---|
+| A2 | mw=1000 | bplngfyo | 17.72 | ~12:00 UTC |
+| C3 | 10000,2500,2000 | hm7p3lag | In flight (ep1 ~42%) | ~12:20 UTC |
+| D3 | 10000,1000,1000 | 4r0rd7dx | 17.23 | Ep2 ~12% |
+
+Ep1 for A2/D3 are worse than baseline ep1 (16.47) and worse on targeted tau_y/z axes. Ep3 comparison is the real test.
+- **Fleet-wide infrastructure finding:** PR #169's NaN-skip is necessary but not sufficient. Large-but-finite grad spikes (165, 252, 2.2M confirmed) bypass isfinite() check. Magnitude-based skip needed (pre_clip_norm > N × running_median).
+
+---
+
+## 2026-05-01 — PR #165: [chihiro] mlp_ratio=8 hardened (3-seed + warmup) — IN FLIGHT
+- Branch: `chihiro/mlp-ratio-8-hardened`
+- Intermediate results (clip=1.0 sweep completed, clip=0.5 relaunch in progress):
+
+| Seed | clip | W&B run | Best val abupt | Notes |
+|---|---:|---|---:|---|
+| 42 (orig) | 1.0 | wuyxg6ze | — | NaN @ step 7167 |
+| 42 (r2) | 1.0 | elra20qm | — | NaN @ step 6783 |
+| 7 | 1.0 | 0n1eizhz | 18.50 (ep1 only) | Diverged @ step 13641 |
+| **1337** | **1.0** | **vch5jyhv** | **11.92 (ep3)** | **Finished, clean, does NOT beat 10.69** |
+| 42 (r3) | 0.5 | lkl2xob5 | In flight | Checkpoint ~12:20 UTC (prev div @ 6783) |
+| 7 (r2) | 0.5 | rypx2e36 | In flight | Checkpoint ~13:30 UTC (prev div @ 13641) |
+
+seed1337 ep3=11.92 is 1.23pp above baseline. Slope flattening (ep1→ep2: −5.29, ep2→ep3: −1.15) — would need 5-6+ epochs to possibly reach 10.69. clip=0.5 go/no-go is the active test.
+
+---
+
+## 2026-05-01 — PR #168: [askeladd] Normal-consistency soft penalty — IN FLIGHT
+- Branch: `askeladd/normal-penalty-wallshear-yz`
+- Hypothesis: Soft λ·(τ·n̂)² penalty in normalized space penalizes out-of-plane wall-shear predictions.
+- Intermediate results: v1 (physical-space penalty) FAILED — physical-space amplification of τ_x via std_x²≈4.3 created asymmetric gradient. Correctly diagnosed and relaunched as v2 (normalized-space).
+
+| Arm | λ | clip | W&B run | ep1 val_abupt | Notes |
+|---|---:|---:|---|---:|---|
+| λ=0.01 (v1) | 0.01 | 1.0 | ufi2fg1e | — | NaN (physical-space penalty unstable) |
+| λ=0.05 (v1) | 0.05 | 1.0 | ol7r0oh6 | — | NaN (physical-space penalty spiky) |
+| λ=0.10 (v1) | 0.10 | 1.0 | uyorcld7 | — | NaN ep1 13.7% |
+| **λ=0.10 (v2)** | **0.10** | **1.0** | **gawdh7ah** | **17.103** | **Only stable arm; pen_phys dropping** |
+| λ=0.01 (v2 clip=0.5) | 0.01 | 0.5 | d14ee58k | In flight | Previous NaN @ step 7899 |
+| λ=0.05 (v2 clip=0.5) | 0.05 | 0.5 | (run id) | In flight | Previous NaN @ step 8499 |
+
+- **Key finding:** λ ranking inversion — larger λ MORE stable. Mechanism: at λ=0.01, constraint contribution (~1.6e-3) is too small to push model away from out-of-plane drift; single bad batch drives large squared-dot spike. At λ=0.10, constraint is strong enough to bound τ_pred magnitudes, preventing the spike. This is the opposite of standard regularization intuition.
+- pen_raw plateaus ~0.13 (fixed normalized-space cost); pen_phys drops 0.55→0.07 (physical tangentiality residual decreasing = model IS learning to satisfy geometric constraint).
+
+---
+
+## 2026-05-01 — PR #123: [frieren] asinh/log wall-shear target normalization — IN FLIGHT
+- Branch: `frieren/asinh-log-target-normalization`
+- Intermediate results (key finding: asinh-1.0 trades metric for stability):
+
+| Arm | Normalization | W&B run | ep1 val_abupt | ep2 val_abupt | grad_skips | Notes |
+|---|---|---|---:|---:|---:|---|
+| A (v3p1) | Control | w8ecb8rp | — | 46.69 | 6543 (39%) | Pathological |
+| C (v3) | asinh scale=1.0 | xtx426rb | **17.55** | **45.69** | 5 | ep1 OK, ep2 collapsed |
+| D (v3p1) | log1p | 8oytk5ef | — | 22.35 | 0 | Healthier than control |
+| B (v3p1) | asinh-0.5 | zznrzvw5 | 18.94 | — | 0 | In flight ep2 |
+
+- **Key finding:** asinh-1.0 compresses the heavy tail → suppresses gradient explosions (0 skips vs 50%+) but also suppresses learning signal where the y/z gap lives. Train loss kept descending while val exploded ep2 (17.55→45.69) = classic underfitting of tail domain. asinh-1.0 is not a viable target transformation.
+- D (log1p) and B (asinh-0.5) are healthier but still above baseline trajectory. Final results pending ~12:10-13:51 UTC.
+

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,6 +9,19 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
+## 2026-04-29 06:00 — PR #6: relative-L2 auxiliary loss (emma) — CLOSED, dead end
+
+- Branch: `emma/round1-metric-aware-aux-loss`
+- Hypothesis: add a metric-aligned auxiliary loss `aux_rel_l2_weight * relative_l2_loss(pred, target, mask)` so training optimizes a quantity directly proportional to the AB-UPT eval metric, with `loss = MSE + 0.05 * rel_l2`.
+- W&B runs (all five state=crashed/diverged, no `test_primary/*` produced):
+  - `ylg9cc8h` (Run 1, w=0.05, original snippet) — NaN at step 1 (sqrt(0) backward).
+  - `tq2cs2vo` (Run 2, w=0.05, dual-eps fix) — diverged step ~115700 mid-epoch 3 (grad norm 1.7 → 7e+5 → 2.85e+16).
+  - `*` Run 3a/3b (w=0.01, w=0.02) — diverged step 50600 / 59100. Smaller weight diverged earlier — confirms backward-path instability is the controlling factor, not weight magnitude.
+  - `*` Run 4a/4b (`clip_grad_norm_(1.0)` added) — `total_norm=Inf → coef=0` mathematically still propagates NaN.
+  - `*` Run 5a/5b (full stability stack: ratio.clamp(max=1.0), eps=1e-4, fp32 outside autocast, NaN-skip step) — entered 100% skip-step regime by ~step 30000, training frozen.
+- **Conclusion:** the rel-L2 auxiliary loss as formulated is fundamentally unstable in this codebase. The `sqrt((diff_sum + ε)/(tgt_sum + ε))` backward path produces Inf grads when surface target norms are small in denormalized space; even gradient masking and skip-step cannot rescue it once the regime is reached.
+- **Salvage value:** emma's diagnostic infrastructure (`grad_clip_norm` config + NaN-resistant skip-step pattern) corroborates the design landing in PR #22 (gilbert). Closed in favor of squared-rel-L2 reformulation (drop the sqrt → `ratio.mean()`) as a Round-2 follow-up assigned to emma.
+
 ## 2026-04-29 — PR #8: per-case geometry FiLM conditioning (frieren) — VERIFIED WIN, pending merge (rebase required)
 
 - Branch: `frieren/round1-geometry-film-conditioning`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -201,3 +201,169 @@
 - Hypothesis: Reference floor for stock train.py defaults.
 - Results: W&B run `a1fikrwe`, abupt=87.30
 - Commentary: Confirms massive gap between stock (3L/192d, 40k pts) and optimized protocol. NaN checkpoint guard bug discovered. Closed.
+
+---
+
+## 2026-04-30 14:00 — PR #58: [alphonse] NaN-safe checkpoint guard — MERGED (bugfix)
+- Branch: `alphonse/nan-checkpoint-guard-bugfix`
+- Hypothesis: Guard `best_checkpoint` overwrite against NaN primary_val to prevent EMA NaN from replacing valid checkpoint.
+- Results: Bugfix — no metric change.
+- Commentary: Root cause: `_finite_mean([nan, nan])` returns 0.0, and `0.0 < best_val` fires improved=True, overwriting valid checkpoint with NaN model. Fix: `primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0`. Validated by smoke run `tcyjp36i`. Merged to yi.
+
+---
+
+## 2026-04-30 14:10 — PR #66: [thorfinn] Per-axis tau_y/z loss upweighting W_y=2, W_z=2 — MERGED (NEW BEST)
+- Branch: `thorfinn/surface-loss-weight-and-per-axis-wallshear`
+- Hypothesis: Selectively upweight tau_y and tau_z channels in surface MSE loss (W_y=2, W_z=2, W_x=1) to redirect training gradient toward the two hardest wall-shear axes.
+- Results: 3-arm sweep on 6L/256d base
+
+| Arm | W_y | W_z | W&B run | abupt | wall_shear_y | wall_shear_z |
+|---|---:|---:|---|---:|---:|---:|
+| yw1.5-zw1.5 | 1.5 | 1.5 | `vf3y3z7g` | 13.01 | 15.49 | 15.41 |
+| **yw2-zw2** | **2.0** | **2.0** | **`gvigs86q`** | **12.74** | **15.15** | **15.05** |
+| yw3-zw3 | 3.0 | 3.0 | `w8r0mvf1` | 13.18 | 15.12 | 14.52 |
+
+| Metric | thorfinn yw2-zw2 | PR #14 (6L/256d) | AB-UPT |
+|---|---:|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | 13.15 | — |
+| `test_primary/surface_pressure_rel_l2_pct` | 7.86 | 7.64 | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 12.86 | 13.47 | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 13.14 | 13.58 | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 11.29 | 11.53 | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 15.15 | 16.23 | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 15.05 | 16.75 | 3.63 |
+
+- Commentary: New yi best (12.74, −3.1% vs 13.15). The W=2 sweet spot outperforms W=1.5 and W=3 — W=3 overfits the tau_y/z directions, slightly hurting abupt. The selective approach (upweight only tau_y/z, not tau_x) avoids the divergence seen in haku's uniform weighting PR #10. tau_y and tau_z are the most challenging axes (4× AB-UPT); explicit gradient emphasis works.
+
+---
+
+## 2026-04-30 14:20 — PR #65: [violet] Volume-loss-weight sweep (1.5/2.0/3.0/4.0) — CLOSED
+- Branch: `violet/volume-pressure-loss-weight-sweep`
+- Hypothesis: vol_w=4.0 might further reduce volume_pressure by forcing more gradient toward volume prediction.
+- Results: 4-arm sweep
+
+| Arm | vol_w | W&B run | abupt | vol_pressure |
+|---|---:|---|---:|---:|
+| vw-15 | 1.5 | `n3k58pah` | 13.71 | 13.56 |
+| vw-20 | 2.0 | `ioq7jh9w` | 13.61 | 13.62 |
+| vw-30 | 3.0 | `kj2i4gx3` | 13.72 | 13.45 |
+| vw-40 | 4.0 | `v98qrfmd` | 13.71 | 13.30 |
+
+- Commentary: No arm beats baseline 12.74. vol_w=4.0 marginally improves volume_pressure (13.30 vs 13.58) but hurts wall-shear. The kill-threshold bug (>=N syntax) prematurely killed several arms. vol_w=2.0 confirmed as the correct operating point for composite metric. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #64: [fern] Stochastic depth regularization (3-rate sweep) — CLOSED
+- Branch: `fern/stochastic-depth-regularization`
+- Hypothesis: Stochastic depth (drop-path) regularization at rates 0.05/0.10/0.20 provides regularization to prevent overfitting.
+- Results: 3-arm sweep
+
+| Arm | sdp_rate | W&B run | abupt |
+|---|---:|---|---:|
+| sdp-005 | 0.05 | — (killed by threshold bug) | — |
+| sdp-010 | 0.10 | `q8yv93km` | 13.73 |
+| sdp-020 | 0.20 | `w3bt19pk` | 13.92 |
+
+- Commentary: All arms negative vs baseline 12.74 (+7.8% best). Stochastic depth regularization is redundant at 4-epoch budgets. Gradient clip already provides effective implicit regularization. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #63: [askeladd] Squared rel-L2 aux loss on 6L base — SENT BACK FOR REBASE
+- Branch: `askeladd/squared-rel-l2-aux-on-6l`
+- Hypothesis: Add squared relative-L2 aux loss on 6L base; weight sweep w=0.1/0.3/0.5/1.0.
+- Results: 4-arm sweep
+
+| Arm | weight | W&B run | abupt |
+|---|---:|---|---:|
+| w=0.1 | 0.1 | `qntz7gzr` | 13.42 |
+| w=0.3 | 0.3 | `h5w3vf5y` | 13.11 |
+| **w=0.5** | **0.5** | **`dln9trni`** | **12.94** |
+| w=1.0 | 1.0 | `n9ckb2qe` | 13.77 |
+
+- Commentary: w=0.5 achieved 12.94 — beats PR #14 baseline (13.15) but not new baseline 12.74 (PR #66). The composition of squared rel-L2 aux loss + thorfinn per-axis weights is untested. Sent back to rebase onto thorfinn base and re-run with both --aux-rel-l2-weight 0.5 and --wallshear-y-weight 2.0 --wallshear-z-weight 2.0.
+
+---
+
+## 2026-04-30 14:20 — PR #61: [gilbert] Tangential wall-shear projection on 6L base — CLOSED
+- Branch: `gilbert/tangential-wallshear-on-6l-base`
+- Hypothesis: Tangential projection loss on 6L base (no normal penalty).
+- Results: abupt=34.07 (W&B `x0pyk2yw`) — catastrophic failure. 2.7× baseline.
+- Commentary: Projection without normal penalty allows unbounded normal component growth. Gradient signal is removed in the normal direction but no compensating loss drives it to zero. Tangential projection research line closed.
+
+---
+
+## 2026-04-30 14:20 — PR #60: [chihiro] 6L/512d depth×width composition — CLOSED
+- Branch: `chihiro/depth-width-composition-6l-512d`
+- Hypothesis: Combining 6L depth with 512d width should outperform either alone.
+- Results: abupt=16.00, only 2 epochs completed (data-starved).
+- Commentary: 6L/512d (18.1M params) is too large for the 4.5h budget — only 2 epochs vs 4 for 6L/256d. Data-starvation dominates. 6L/256d is the right operating point. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #59: [senku] Depth 7L/8L sweep — CLOSED
+- Branch: `senku/depth-7l-8l-sweep`
+- Hypothesis: Pushing depth beyond 6L further improves the composite metric.
+- Results: 7L abupt=13.28, 8L abupt=13.57 (both worse than 6L=13.15/12.74 baseline).
+- Commentary: 7L/8L hit kill-threshold bug (>=18 means kill when val drops below 18, so some runs killed prematurely). Even corrected, both are worse than 6L at same compute — more depth = fewer epochs = data starvation at this budget. Depth ceiling confirmed at 6L. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #21: [kohaku] Normal-component suppression on 6L (sweep-v2) — CLOSED
+- Branch: `kohaku/round2-normal-component-suppression`
+- Hypothesis: Penalty λ*(ws_pred·n_hat)² drives predicted normal component to zero; sweep λ∈{0.01, 0.1, 1.0} on 6L base.
+- Results:
+
+| λ | W&B run | abupt |
+|---:|---|---:|
+| 0.01 | `le10xx7e` | 16.06 |
+| 0.1 | `j0gdj2jy` | 17.47 |
+| 1.0 | `fsxvmo08` | 15.93 |
+
+- Commentary: All arms 22–33% worse than baseline 12.74. The suppression mechanism works mechanistically but the projection+suppression combination degrades wall-shear badly (tau_y/z ≈20–26%, far worse than baseline 15-17%). Tangential projection research conclusively closed.
+
+---
+
+## 2026-04-30 14:20 — PR #15: [tanjiro] SDF-gated volume attention (v2, sigma sweep) — CLOSED
+- Branch: `tanjiro/round1-sdf-gated-volume-attention`
+- Hypothesis: Gaussian SDF gate or quantile-rank gate focuses volume attention on near-wall critical points.
+- Results: 3-arm sweep on 6L base
+
+| Arm | W&B run | abupt |
+|---|---|---:|
+| quantile q=0.10 | `l6yfeh31` | 13.26 |
+| gaussian σ=0.005 | `gu2v23cs` | 13.87 |
+| gaussian σ=0.001 | `r7c8jss2` | 36.48 (diverged) |
+
+- Commentary: Best arm (quantile q=0.10) achieves 13.26 — worse than new baseline 12.74. The val→test gap in volume_pressure (12→13.58) is a distribution shift issue that SDF gating cannot address. σ=0.001 diverges. Closing — SDF gating adds instability and doesn't help test generalization. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #10: [haku] Per-axis wall-shear loss weights (uniform w2/w3) — CLOSED
+- Branch: `haku/round1-per-axis-wallshear-loss-weight`
+- Hypothesis: Uniform upweighting of all 3 wall-shear channels (tau_x, tau_y, tau_z) by 2× or 3× should reduce wall-shear error.
+- Results (Round-2, 6L base):
+
+| Arm | weights | W&B run | abupt |
+|---|---|---|---:|
+| Control | (1,1,1,1) | `648ssek0` | 13.15 |
+| w2 | (1,2,2,2) | `s3y7sclb` | 18.35 (diverged ep3) |
+| w3 | (1,3,3,3) | `inpik7c3` | 14.35 (diverged ep4) |
+| w2+tan | (1,2,2,2)+tan | `1cxf7026` | 36.41 |
+
+- Commentary: Uniform upweighting causes divergence — tau_x upweighting destabilizes. Thorfinn's selective approach (W_y=W_z=2, W_x=1) succeeds where uniform fails. Confirmed: tau_x should not be upweighted. Closed.
+
+---
+
+## 2026-04-30 14:20 — PR #24: [emma] Squared rel-L2 aux loss (4L base) — CLOSED
+- Branch: `emma/round2-squared-rel-l2-aux-loss`
+- Hypothesis: Squared rel-L2 aux loss (no sqrt) is stable where round-1 version diverged.
+- Results: w=0.5 → abupt=14.81 (W&B `zv791js1`, 4L base).
+- Commentary: Stable (no divergence) and beats 4L baseline, but 4L superseded. Code was incorporated into PR #63 (askeladd, 6L). Closed — hypothesis lives on in PR #63.
+
+---
+
+## 2026-04-30 14:20 — PR #5: [edward] Cosine LR + FiLM composition on 6L — CLOSED
+- Branch: `edward/round1-cosine-lr-warmup`
+- Hypothesis: Cosine annealing + FiLM conditioning compose orthogonally on 6L base.
+- Results: abupt=19.27 (W&B `duv7m45t`) — best val at epoch 1 (18.44), degraded monotonically thereafter.
+- Commentary: FiLM + cosine LR + cosine EMA on 6L creates a fragile stack. The interaction between the cosine LR schedule and the cosine EMA ramp produces unstable training. Cosine LR alone on 6L (without FiLM) is being tested in PR #67 kafka. Closed.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,7 +9,54 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
-## 2026-04-29 03:13 — PR #11: tangential wall-shear projection loss (kohaku) — MERGED, FIRST yi BASELINE
+## 2026-04-29 03:57 — PR #9: volume loss weight sweep (gilbert) — MERGED, NEW yi BASELINE
+
+- Branch: `gilbert/round1-volume-loss-reweight`
+- Hypothesis: upweight volume loss to 2.0–3.0 to focus gradient budget on
+  the hardest target (`volume_pressure`).
+- Run A (vol_w=2.0): `y2gigs61`, state=finished, 6 epochs reached, best_epoch=3.
+- Run B (vol_w=3.0): `s45dwv6i`, state=finished, 6 epochs reached, best_epoch=1.
+
+**test_primary/* (Run A new yi best vs prior PR #11 baseline):**
+
+| Metric | Run A (vol_w=2.0) | PR #11 (kohaku, prior) | Δ | AB-UPT |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **17.39** | 35.12 | **−50.5%** | — |
+| `surface_pressure_rel_l2_pct` | 11.07 | 10.07 | +9.9% | 3.82 |
+| `wall_shear_rel_l2_pct` | **18.32** | 43.05 | **−57.4%** | 7.29 |
+| `volume_pressure_rel_l2_pct` | 15.21 | 14.99 | +1.5% | 6.08 |
+| `wall_shear_x_rel_l2_pct` | **15.65** | 30.85 | **−49.3%** | 5.35 |
+| `wall_shear_y_rel_l2_pct` | **21.86** | 42.06 | **−48.0%** | 3.65 |
+| `wall_shear_z_rel_l2_pct` | **23.18** | 77.65 | **−70.1%** | 3.63 |
+
+Run B (vol_w=3.0): `abupt=30.08`, diverged at epoch 2 (best_epoch=1).
+**vol_w=3.0 strictly worse than vol_w=2.0**, confirming the PR's question.
+
+**The big confound:** gilbert's run did **not** include
+`--use-tangential-wallshear-loss` (kohaku's projection code is on yi but
+default off). Yet still beat kohaku's projection-loss run by 50%. The bulk
+of the win came from the **protocol fixes**:
+
+- `--batch-size 8` (vs default 2)
+- `--validation-every 1` (vs default 10)
+- `--gradient-log-every 100 --weight-log-every 100` (Issue #19 throughput)
+
+vol_w=2.0 vs vol_w=1.0 single-delta is therefore untested, but vol_w=2.0
+appears at worst neutral. Combining gilbert's config with kohaku's
+projection should compose for further gains.
+
+**Critical bug uncovered (gilbert PR comment):** `train.py` has no gradient
+clipping. Run B and several other Round-1 runs (chihiro, emma, fern, haku)
+diverged on the exact same mechanism. **Round-2 follow-up PR #22 (gilbert)
+adds `torch.nn.utils.clip_grad_norm_` + sweeps clip values.**
+
+**Round-2 follow-ups triggered:**
+- PR #22 (gilbert): add gradient clipping to `train.py` — infrastructure
+  win blocking high-LR / high-weight / high-batch sweeps.
+- BASELINE.md: new winning reproduce config recorded with all four protocol
+  flags + vol_w=2.0.
+
+## 2026-04-29 03:13 — PR #11: tangential wall-shear projection loss (kohaku) — MERGED, prior baseline (superseded by PR #9)
 
 - Branch: `kohaku/round1-tangential-wallshear-loss`
 - Hypothesis: project predicted/target wall-shear onto surface tangent plane

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -478,3 +478,58 @@ Val slopes at end of run: abupt −0.156/1k steps, wall_shear_y −0.191/1k step
 
 - Commentary: Best partial (Arm 3 e2 abupt=11.67) is still 0.98pp worse than baseline 10.69. **lr=3e-4 (Arm 4) failed earlier than lr=4e-4 (Arm 3)** — pure LR reduction is not the lever. Root cause from forensics: `train/film/geom_token_norm_mean` was steady (~0.73-0.81) at all 4 divergence points (geom token is fine); layer-0 `to_gamma_beta/bias grad_to_param_norm=0.567` flagged the FiLM linear projections as the gradient amplification path. FiLM × LR ≥ 3e-4 has a fundamental stability ceiling at default-init. **Promising signal:** Arm 3 e2 vp=7.05 vs baseline 7.85 — FiLM helps volume more than surface, exactly the metric closest to AB-UPT (1.3× away). The direction is right; the failure mode is dynamics, not capability. **Decision: closed** — kohaku reassigned to PR #184 (FiLM with identity/zero-init, DiT-style stable conditioning).
 
+---
+
+## 2026-04-29 15:00 — PR #169: [thorfinn] NaN-skip + seed + LR warmup utility flags (stability infra) — MERGED
+- Branch: `thorfinn/nan-skip-utility-cherry-pick`
+- Hypothesis: N/A — pure infra utilities to improve training stability observability and repeatability.
+- Three new CLI flags added:
+  1. `--seed <int>` — set all RNG seeds for reproducibility
+  2. `--lr-warmup-steps <int>` — linear LR warmup from lr/10 to lr over N steps
+  3. NaN/Inf-skip safeguard — detect non-finite loss/gradients, skip those steps, abort after 200 consecutive skips
+- Also fixed: kill-threshold NaN bug (commit de8f8d0) — `_numeric_metric_items()` was filtering out NaN metrics silently so `check_kill_thresholds()` would never trigger on NaN runs. Now non-finite values trigger kill condition.
+- Validation run: W&B run `e6sgx5ku`, seed=42
+
+| Epoch | val abupt | Expected (spec band) | Notes |
+|---|---:|---|---|
+| 1 | 15.83 | 12.0–13.0 | High init variance from seed=42 — accepted |
+| 2 | **11.20** | 11.0–11.5 | Within spec band — no regression |
+
+- `train/nonfinite_skip_count = 0` throughout (NaN-skip not triggered — confirms baseline is already NaN-free)
+- Commentary: Infra PR merged for code utility. No metric improvement (infra PR, not hypothesis test). Epoch-1 spike (15.83) is seed=42 init variance, not a code bug — confirmed by epoch-2 landing in spec band (11.20). Kill-threshold NaN bug fix is fleet-wide safety. LR-warmup-steps flag is now available for future experiments that need structured warmup without committing to OneCycleLR. **Decision: merged.** Infra contributions on the main path — no regression.
+
+---
+
+## 2026-04-29 15:30 — PR #125: [haku] 1cycle LR max=1e-3 (super-convergence in epoch-limited regime) — CLOSED NEGATIVE
+- Branch: `haku/onecycle-lr-peak-1e3`
+- Hypothesis: OneCycleLR with structured warmup to peak LR then cosine anneal achieves super-convergence in the 3–4 epoch budget, beating flat lr=5e-4.
+- Results: 4-arm sweep (round 1) + 4-arm sweep (round 2 with total_steps bug fixed)
+
+**Round 1 (bug: total_steps=544,150 → schedule nearly flat):**
+
+| Arm | max_lr | W&B run | val ep2 | val ep3 | Notes |
+|---|---:|---|---:|---:|---|
+| A | 1e-3 | pbxxmq1h | NaN ep1 | — | Diverged immediately |
+| B | 7e-4 | — | NaN ep1 | — | Diverged |
+| C | 5e-4 | — | NaN ep1 | — | Diverged |
+| D | 3e-4 | bq11rk5t | 12.01 | 11.83 | Stable but schedule flat (bug) |
+
+**Round 2 (total_steps=36,000 — correct schedule):**
+
+| Arm | max_lr | pct_start | W&B run | val ep1 | val ep2 | val ep3 | val ep4 | test abupt | Notes |
+|---|---:|---:|---|---:|---:|---:|---:|---:|---|
+| A2 | 1e-3 | 0.10 | 1cycl-A2 | NaN | — | — | — | — | Diverged (> stability ceiling) |
+| B2 | 7e-4 | 0.15 | 1cycl-B2 | NaN | — | — | — | — | Diverged (> stability ceiling) |
+| **C3** | **5e-4** | **0.20** | 1cycl-C3 | 12.80 | 11.65 | 11.42 | **11.34** | **12.41** | Best arm; still worse than baseline |
+| D3 | 3e-4 | 0.10 | 1cycl-D3 | 11.89 | 11.63 | 11.48 | 11.46 | 12.20 | Soft-divergence at lr~6.5e-5 (late cosine anneal) |
+
+**Baseline (PR #99):** val=10.69, test=11.73
+
+- Commentary: Clean **negative result**. Two failure modes:
+  1. **Stability ceiling at ~6.5e-4** — confirmed fleet-wide. Even under structured OneCycleLR warmup, peaks ≥6.5e-4 diverge to NaN regardless of pct_start. No warmup schedule overcomes this ceiling.
+  2. **Budget starvation at lower peaks** — with peaks ≤5e-4, OneCycleLR spends ~20% of budget rising to peak and another ~60% falling back below flat baseline; effective average LR is much lower than flat 5e-4, and the model cannot recover in 3–4 epochs.
+  - Best arm C3 (5e-4 peak): all headline metrics regressed — test abupt=12.41 vs baseline 11.73 (+5.8%).
+  - One mild positive signal: C3 volume_pressure=13.33 vs baseline 14.42 — lower average LR may help the volume head specifically. Filed for future per-head LR experiments (e.g., different LR groups for surface vs volume decoder).
+  - D3 soft-divergence: anomalous loss spike at lr~6.5e-5 during deep cosine anneal — potential bf16 AMP precision issue at very low loss values. Fleet-wide flag: if future low-LR fine-tuning runs see similar, investigate AMP precision or implement LR floor ~1e-4.
+  - OneCycleLR does not help in this epoch-limited regime. LR schedule lever closed for now. **Decision: closed.**
+

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -253,3 +253,47 @@ trapped the prior `u38zaxeg` attempt.
 - Recommend `--validation-every 1` (or 2) for all Round-1 runs.
 - Flagged the train→val divergence pattern across runs for all students to
   report and investigate.
+
+## 2026-04-29 — PR #4: large model scale-up 4L/512d/8h (chihiro) — MERGED
+
+- Branch: `chihiro/round1-large-model-512d`
+- Hypothesis: scaling the Transolver width from 256→512d and heads from 4→8h increases model capacity and improves all output fields, especially volume pressure which requires richer volumetric representation than surface fields.
+- W&B run: `pejudvyd` (Run B), state=finished, best_epoch=3, params ~12.7M
+
+**Config deviations from gilbert base:**
+- `--model-hidden-dim 512 --model-heads 8` (hypothesis test)
+- `--lr 5e-5` (3 prior runs at 2e-4 diverged; larger models need smaller LR)
+- `--batch-size 4` (largest power-of-2 fitting 96GB VRAM at 512d)
+- `--clip-grad-norm 1.0` opt-in flag added (overlaps with PR #22, accepted as compatible)
+
+**test_primary/* (PR #4 chihiro vs PR #9 gilbert merged baseline):**
+
+| Metric | PR #4 chihiro Run B (`pejudvyd`) | PR #9 gilbert (prev baseline) | Δ | AB-UPT target |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **16.64** | 17.39 | **−4.3%** | — |
+| `surface_pressure_rel_l2_pct` | **10.65** | 11.07 | −3.8% | 3.82 |
+| `wall_shear_rel_l2_pct` | **17.66** | 18.32 | −3.6% | 7.29 |
+| `volume_pressure_rel_l2_pct` | **14.37** | 15.21 | **−5.5%** | 6.08 |
+| `wall_shear_x_rel_l2_pct` | **14.87** | 15.65 | −5.0% | 5.35 |
+| `wall_shear_y_rel_l2_pct` | **19.89** | 21.86 | −9.0% | 3.65 |
+| `wall_shear_z_rel_l2_pct` | **21.73** | 23.18 | −6.3% | 3.63 |
+
+Beats merged baseline on every axis. Squash-merged into `yi` 2026-04-29.
+
+**Analysis:**
+- Width improvement is orthogonal to FiLM (targets surface token conditioning) and to cosine EMA (targets checkpoint quality). `volume_pressure` win (14.37 vs 15.21) is most notable — the 512d volume is the binding capacity constraint for volumetric fields, as expected.
+- vs pending FiLM (PR #8, 16.53 abupt): chihiro is slightly worse on the headline (16.64 > 16.53) but wins on `volume_pressure` (14.37 < 14.91). The two effects are complementary.
+- vs pending cosine EMA (PR #13, 15.82 abupt): chihiro is worse on every axis — cosine EMA is the dominant improvement in flight. A composition (512d + cosine EMA + FiLM) should push below 15.
+- LR sensitivity is important: µP scaling or explicit LR search needed for any further width increase. Divergence at 2e-4 confirms the 512d model has ≥2× sharper loss landscape.
+- `--clip-grad-norm` flag added to `train.py` as opt-in; will become default when PR #22 (gilbert) lands.
+
+**Compounding wins on yi after this merge:**
+1. PR #11 (kohaku) — tangential wall-shear projection loss
+2. PR #9 (gilbert) — protocol fixes + vol_w=2.0
+3. **PR #4 (chihiro) — width 512d/8h** ← this entry
+
+**Pending merges in rebase queue:**
+- PR #8 frieren FiLM (16.53) — surface geometry conditioning
+- PR #13 norman cosine EMA (15.82) — projected new best once merged
+
+**Round-2 follow-up assigned to chihiro:** composition run — width 512d × FiLM × cosine EMA at the gilbert base config. Hypothesis: if 256d gains are ~16.53 (FiLM) and ~15.82 (EMA), 512d should push below 15 given orthogonal capacity axes.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -331,3 +331,37 @@ Beats merged baseline on every axis. Squash-merged into `yi` 2026-04-29.
 **Bug-fix commit `fdef51e` (gradient clipping with `--grad-clip-max-norm`):** Acknowledged. Compatible with PR #22 (gilbert) which is landing officially. Will inherit on rebase.
 
 **Pass/fail bar for v5:** must beat `abupt_axis_mean = 16.64` (current merged baseline). Stretch target: beat 15.82 (pending PR #13). If v5 also fails, Fourier closes and goes back to idea pool for revisit (per-axis σ, learnable σ, or σ-scheduled annealing).
+
+## 2026-04-29 — PR #17: surface-area-weighted MSE loss (violet) — CLOSED
+
+- Branch: `violet/round1-surface-area-weighted-loss`
+- Hypothesis: weight surface MSE loss by per-cell area (`surface_x` channel 6) so large-area patches contribute proportionally more — physically consistent with integrated drag/lift force computation. Precedent: DoMINO and AB-UPT use area weighting.
+- W&B runs: 8 attempts (`4eewknus`, `0gzvmuk9`, `92ioz6fu`, `t3083tfa`, `adia7jt4`, `pnrrdczx`, `u227tnfi`, `bfx7ktnc`); 7 diverged, 1 stable but uncompetitive
+
+**Final stable run `bfx7ktnc` (only run with `test_primary/*`):**
+
+| Metric | violet area-weighted | yi merged (PR #4) | Δ vs PR #4 |
+|---|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | 24.60 | 16.64 | **+47.6%** |
+| `surface_pressure` | 15.22 | 10.65 | +43% |
+| `wall_shear` | 28.52 | 17.66 | +62% |
+| `volume_pressure` | 14.06 | 14.37 | −2.2% (plausibly noise) |
+| `wall_shear_x/y/z` | 24.60 / 34.72 / 34.39 | 14.87 / 19.89 / 21.73 | +66% / +75% / +58% |
+
+**Required deviations for stability:** `lr=1e-4` (PR spec was 2e-4), `--area-weight-clip 2.0` (clips 17% of points), `--max-grad-norm 0.5`. 7 prior runs at lr=2e-4 all diverged regardless of grad-clip config.
+
+**Key diagnostic finding from violet:** DrivAerML mesh area distribution is heavy-tailed (max=22× mean, p99=13× mean). Heavy clipping (`area-weight-clip 2.0`) saturates 17% of points and the renormalized effective weight collapses to mean=0.568 — the physics signal is erased. So either:
+- area-weight without clipping → diverges (variance overflow into Adam state)
+- area-weight with clipping → no signal (top cells get same weight as median)
+
+There is no run in this experiment where area-weighted MSE beats unweighted MSE at matched config.
+
+**Decision: CLOSE.** +47% regression on the headline metric meets the close threshold; 8-attempt thorough mapping confirms hypothesis is non-viable on this training recipe. Volume_pressure gain (−2.2%) is plausibly noise on n=50.
+
+**Salvageable directions (filed for future):**
+1. **Log-area weighting** `w = log(1 + area / area_med)`: tames heavy tail without saturating, preserves rank order. Different hypothesis worth a fresh PR.
+2. **EMA-based loss reweighting**: focal-loss-style adaptive per-cell weights based on running per-point loss variance. Decouples physics from variance amplification.
+
+**Bug-fix commit `14e4668` (gradient clipping, `--max-grad-norm`):** Compatible with PR #22 (gilbert) canonical version. No separate landing needed.
+
+**Round-2 follow-up assigned to violet:** **C02 — Deep Evidential Regression head** (replace MSE with NIG-based negative log-likelihood; per-cell uncertainty; addresses heavy-tail target distributions at the loss-formulation level). Bold direction, plays to violet's demonstrated loss-analysis strength.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -659,3 +659,54 @@ seed1337 ep3=11.92 is 1.23pp above baseline. Slope flattening (ep1→ep2: −5.2
 - **Key finding:** asinh-1.0 compresses the heavy tail → suppresses gradient explosions (0 skips vs 50%+) but also suppresses learning signal where the y/z gap lives. Train loss kept descending while val exploded ep2 (17.55→45.69) = classic underfitting of tail domain. asinh-1.0 is not a viable target transformation.
 - D (log1p) and B (asinh-0.5) are healthier but still above baseline trajectory. Final results pending ~12:10-13:51 UTC.
 
+
+---
+
+## 2026-05-01 14:00 — PR #168: [askeladd] Normal-consistency penalty (soft tangential constraint)
+- Branch: `askeladd/normal-penalty-wallshear-yz`
+- Hypothesis: Add λ·mean(dot(τ_pred, n̂)²) auxiliary loss in normalized space to softly enforce wall-shear tangentiality without coordinate-frame discontinuities (vs PR #121's hard Duff-ONB reparam).
+- Results: 3 arms swept λ ∈ {0.01, 0.05, 0.10}; all v1 NaN'd in physical-space due to per-axis std mismatch; v2 reverted to normalized-space.
+
+| Arm | λ | W&B run | ep1 val_abupt | ep2 val_abupt | Stability |
+|---|---:|---|---:|---:|---|
+| C | 0.01 | (NaN ep1) | — | — | Diverged ep1 even w/ clip 0.5 |
+| B | 0.05 | 1buc9rh1 | 15.875 | NaN | Best ep1 of any arm; ep2 spike |
+| A | 0.10 | gawdh7ah | — | **12.285** | Stable; ep3 ~14.4 |
+
+- **Counter-intuitive ranking:** larger λ more stable. Small λ insufficient to anchor τ_pred; out-of-plane drift produces a squared-dot loss spike that overwhelms clip=1.0 → corrupts Adam m,v.
+- **Verdict: NEGATIVE.** λ=0.10 ep2 12.285 was the first crossover vs fern PR #99 ep2 trajectory (12.417), but ep3 regressed to 14.4 vs final baseline 10.69.
+- **Combined with PR #121 (hard tangentiality, also negative):** explicit tangentiality enforcement provides no metric improvement on this dataset; the model already learns near-tangential predictions naturally (pen_phys 0.55 → 0.07 unprompted in baseline).
+- Closed as negative; askeladd reassigned.
+
+## 2026-05-01 14:00 — PR #164: [alphonse] 8L/256d depth + 1cycle LR (time-limited recovery)
+- Branch: `alphonse/depth-8L-1cycle-recovery`
+- Hypothesis: Restore 8L/256d depth (PR #144 negative @ const lr=5e-4, val 12.69) by pairing with OneCycleLR super-convergence schedule. Sweep peak ∈ {5e-4, 6e-4, 8e-4} over 3 epochs.
+- Results: All three arms diverged before completing training.
+
+| Arm | Peak LR | Diverged step | Diverged at lr | Cause |
+|---|---:|---:|---:|---|
+| A | 5e-4 | ~10700 | ~5e-4 | pre_clip 4 → 151 → 1369 → 1e9 |
+| B | 6e-4 | ~10599 | ~6e-4 | pre_clip 2 → 229 → cascade |
+| C | 8e-4 | ~8500 | ~7.5e-4 | pre_clip 3.8 → 22 → 5131 → 254611 |
+
+- **Verdict: NEGATIVE.** 8L/256d has a hard LR ceiling below 5e-4 for sustained training. Combined with PR #144 (8L const-lr=5e-4 val=12.69), depth scaling at width=256 is exhausted — neither schedule can clear the throughput needed to beat 10.69.
+- **Future depth work must change architecture (pre-LN/sandwich-LN, AGC clipping, or width=384+) before revisiting depth.**
+- Closed as negative; alphonse reassigned.
+
+## 2026-05-01 14:00 — PR #123: [frieren] asinh/log wall-shear target normalization (heavy-tail fix)
+- Branch: `frieren/asinh-log-target-normalization`
+- Hypothesis: Apply asinh(τ/scale) or log1p(|τ|) target normalization to compress the heavy-tailed wall-shear distribution, expecting better fitted gradients and faster convergence to lower rel_L2.
+- Results: 4 arms in v3/v3p1 with `--grad-skip-threshold` 1k–5k; major contribution was the always-on NaN/inf grad-skip + threshold infra in train.py.
+
+| Arm | Normalization | W&B run | ep1 val_abupt | ep2 val_abupt | Notes |
+|---|---|---|---:|---:|---|
+| A (v3p1) | Control | w8ecb8rp | — | 46.69 | 6543 grad-skips (39%); pathological |
+| C (v3) | asinh scale=1.0 | xtx426rb | **17.55** | 45.69 | ep1 best; ep2 train/val divergence |
+| D (v3p1) | log1p | 8oytk5ef | — | 22.35 | Healthier but well above baseline |
+| B (v3p1) | asinh-0.5 | zznrzvw5 | 18.94 | — | ep2 in flight |
+
+- **Verdict: NEGATIVE.** Best variant (asinh-1.0 ep1) val 17.55 vs baseline 10.69 (64% worse).
+- **Mechanism:** asinh suppresses gradient explosions by compressing the tail (0 grad-skips vs 50%+) but suppresses the very signal where the y/z gap lives. Train loss kept descending while val exploded → classic tail underfit.
+- **Open finding: universal ep1→ep2 train/val divergence** across all 4 norm variants is a separate failure mode worth pursuing — candidates: train/eval sampling distribution mismatch, overfitting-to-bulk regime, z-score saturation on tails. Suggests assigning a one-shot LR drop after ep1 experiment.
+- **Major contribution to retain:** `--grad-skip-threshold` + always-on NaN/inf grad-skip + W&B `train/grad/skipped_step|skipped_total` metrics. Will land independently on yi.
+- Closed as negative; frieren reassigned.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-05-01 21:30 — PR #209: [frieren] Step-decay LR drop after epoch 1 (REJECTED)
+- Branch: `frieren/lr-drop-after-epoch1` (closed, deleted)
+- Hypothesis: Sharp LR drop at ep1→ep2 boundary (step decay 5e-4 → 1e-4) transitions optimizer from exploration to exploitation, fixing the ep1→ep2 divergence seen in PR #123 asinh arms.
+- Results (3 ep, 6L/256d/AdamW config — old architecture):
+
+| Arm | Spec | ep1 | ep2 | ep3 | Best val_abupt | W&B |
+|---|---|---:|---:|---:|---:|---|
+| A | control (no decay) | 16.40 | 11.35 | **10.08** | **10.08** | `5es59xmq` |
+| B | ×0.2 @ ep1 | 16.52 | 11.82 | 11.17 | 11.17 | `z1k3njpq` |
+| C | ×0.1 @ ep1 | 16.67 | 22.20 | 32.44 | 16.67 | `4qtp3s50` |
+| D | ×0.3 @ ep1+ep2 | 17.23 | 11.92 | 11.33 | 11.33 | `17rf02u7` |
+
+- **Outcome:** Hypothesis rejected. All decay arms underperformed the no-decay control. Best result (10.08) is on the OLD 6L/256d/AdamW architecture and is +0.79pp above current SOTA bar (9.291%).
+- Key diagnosis (frieren): step×cosine composition bug — `--lr-step-factor` multiplied the cosine-decayed LR rather than replacing the schedule, so B/C/D effectively ran at much smaller LRs than spec implied. The original premise (ep1→ep2 divergence) does not appear in the control config — no exploration→exploitation gap for step decay to fill.
+- Three crash cycles (seeds 42, 0, random) at lr=5e-4 + warmup=500 confirm fern config sits near a stability ceiling. `--seed=-1` (random) reduced per-launch crash rate.
+- Closed; suggested follow-ups (multi-seed variance band, AMP underflow diagnosis, low-LR Adam drift) noted as future research candidates.
+
+---
+
 ## 2026-04-29 03:00 — PR #11: [kohaku] Tangential wall-shear projection loss
 - Branch: `kohaku/round1-tangential-wallshear-loss`
 - Hypothesis: Project wall-shear predictions onto the tangential plane at each surface point to enforce the no-slip boundary condition physically.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,399 +1,203 @@
-# SENPAI Research Results — DrivAerML (`yi`)
+# SENPAI Research Results
 
-W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`.
-Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
-`volume_pressure 6.08`, `tau_x 5.35`, `tau_y 3.65`, `tau_z 3.63`.
-
-## Round 1 — opened 2026-04-28
-
-Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
-deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
-
-## 2026-04-29 — PR #13: progressive EMA cosine anneal 0.99→0.9999 (norman) — VERIFIED WIN, pending merge (rebase required)
-
-- Branch: `norman/round1-progressive-ema-decay`
-- Hypothesis: anneal `--ema-decay` from 0.99 (start) to 0.9999 (end) via cosine schedule. Early training: fast-tracking EMA (low decay) tracks the live model during rapid change. Late training: high decay averages out stochastic variance for a sharper final checkpoint.
-- W&B run: `wio9pqw2` (`norman-ema-99-9999-v4`), state=finished, 4 epochs, best_epoch=4, peak GPU 52.9 GB
-- Config: `--volume-loss-weight 2.0 --batch-size 8 --validation-every 1 --lr 2e-4 --ema-decay-start 0.99 --ema-decay-end 0.9999` (gilbert protocol + cosine EMA on top)
-
-**test_primary/* (norman PR #13 vs current yi baseline PR #9):**
-
-| Metric | PR #13 norman | PR #9 gilbert (merged baseline) | PR #8 frieren FiLM (pending) | Δ vs PR #9 | AB-UPT |
-|---|---:|---:|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **15.82** | 17.39 | 16.53 | **−9.0%** | — |
-| `surface_pressure_rel_l2_pct` | **9.99** | 11.07 | 10.38 | −9.7% | 3.82 |
-| `wall_shear_rel_l2_pct` | **16.60** | 18.32 | 17.29 | −9.4% | 7.29 |
-| `volume_pressure_rel_l2_pct` | **14.21** | 15.21 | 14.91 | −6.6% | 6.08 |
-| `wall_shear_x_rel_l2_pct` | **14.27** | 15.65 | 14.76 | −8.8% | 5.35 |
-| `wall_shear_y_rel_l2_pct` | **19.49** | 21.86 | 20.59 | −10.8% | 3.65 |
-| `wall_shear_z_rel_l2_pct` | **21.12** | 23.18 | 22.00 | −8.9% | 3.63 |
-
-Win on every axis. Also surpasses pending FiLM PR #8 (16.53 → 15.82, −4.3%).
-
-**Per-epoch trajectory — no divergence:**
-
-| Epoch | train_loss | val_abupt | best? |
-|---:|---:|---:|---|
-| 1 | 0.5414 | 26.24 | ✓ |
-| 2 | 0.1521 | 17.98 | ✓ |
-| 3 | 0.0919 | 15.59 | ✓ |
-| 4 | 0.0657 | **14.71** | ✓ |
-
-**Val improved monotonically through epoch 4.** This directly revises the (B) verdict from PR #20 (nezuko EMA sweep):
-- PR #20 used small-batch config (no bs=8 / vol_w=2.0) → diverged after epoch 1
-- PR #13 used gilbert's protocol (bs=8) → no divergence through epoch 4
-- The binding instability was **config-conditional**: large batch + vol_w=2.0 suppresses it. The cosine EMA late-smoothing may also contribute.
-
-**EMA schedule:** swept 0.990 → 0.9999 over 43,532 steps exactly as designed. Zero new parameters (schedule only).
-
-**Key implication for fleet:** progressive EMA 0.99→0.9999 is now on `yi`. All future PRs should adopt `--ema-decay-start 0.99 --ema-decay-end 0.9999` for the best checkpoint quality. Round-2 follow-up assigned (norm A02 SE(3) equivariant coord features) as PR #27.
-
-**Note:** Merge blocked on rebase conflict (yi updated after branch was cut). Student rebasing now. Results verified and accepted.
-
-## 2026-04-29 — PR #20: EMA decay sweep diagnostic (nezuko) — CLOSED, diagnostic value (verdict (B) confirmed)
-
-- Branch: `nezuko/round2-ema-decay-sweep`
-- Hypothesis: disambiguate (A) EMA-too-slow vs (B) genuine post-epoch-1 instability for the train→val divergence pattern observed across multiple Round-1 runs.
-- 4-arm sweep: `--ema-decay ∈ {0.99, 0.999, 0.9995, 0.99995}` parallel across 4 GPUs, all with `--validation-every 1`. ~2 full epochs + truncated epoch 3 each. Peak GPU 13.3 GB.
-- W&B group: [`nezuko-ema-sweep`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/groups/nezuko-ema-sweep)
-
-| EMA decay | best_epoch | abupt_axis_mean (test_primary) | full_val_primary abupt | E1 train | E2 train | E1 val_abupt | E2 val_abupt |
-|---|:---:|---:|---:|---:|---:|---:|---:|
-| 0.99 | 1 | 27.67 | 26.93 | 0.278 | 1.217 | 26.93 ⭐ | 79.26 |
-| 0.999 | 3 | 69.54 | 69.01 | 0.222 | 0.923 | 76.29 | 73.41 |
-| 0.9995 | **1** | **24.74** | **24.46** | 0.228 | 0.411 | 24.46 ⭐ | 41.26 |
-| 0.99995 | 1 | 36.63 | 36.19 | 0.180 | 0.763 | 36.19 ⭐ | 124.32 |
-
-**Verdict: (B) genuine post-epoch-1 divergence. Decisive.**
-
-Evidence:
-1. **Even the most aggressive EMA arm (0.99, window ~100 steps) peaks at epoch 1.** If (A) were true, this arm — whose shadow ≈ live model — should have kept improving. It did not.
-2. **Train loss is non-monotonic across all four seeds:** every arm has live train loss 5–7× *higher* in epoch 2 vs epoch 1 (e.g. 0.99: 0.278 → 1.217). EMA cannot manufacture this; live optimization is diverging.
-3. **Per-step train/loss spikes hit 6–22× the median** in every arm; min train_loss reached at step 20–45k, then climbs. Divergence onset dates to step ~45–60k — exactly where missing gradient clipping becomes load-bearing under no-warmup, near-constant LR.
-4. The 0.999 outlier (best_val=76.29 at epoch 1) is consistent with this: its specific seed had divergence start *during* epoch 1 so the EMA shadow at step 43k is contaminated by the chaotic post-divergence tail.
-
-**Implications for ongoing work:**
-- **PR #22 (gilbert, gradient clipping) is the cure** for the binding constraint. When that lands, the entire fleet should re-evaluate.
-- **PR #5 (edward, cosine LR + warmup)** is complementary on the LR-schedule side — nezuko's data shows current `T_max=999` makes LR essentially constant at 2e-4 throughout, so the cosine decay is doing nothing.
-- `--ema-decay 0.9995` confirmed as the right default for this step regime; no change needed.
-- **Avoid 0.99995 and progressive 0.999→0.9999 schedule (norman PR #13)** for this step budget — the 0.9999 tail (window ~10k steps) over-averages into the divergent regime.
-
-**Note:** Best arm 24.74 abupt_axis_mean is well above current yi baseline (16.53/17.39). No code changes (CLI sweep only). Closed because it's diagnostic, not competitive.
-
-**Round-2 follow-up:** A01 (ANP cross-attention surface decoder) assigned to nezuko — the largest architectural win from noam branch (PR #2379 MERGED on TandemFoil: −70% in-domain p_s, −48% OOD).
-
-## 2026-04-29 06:00 — PR #6: relative-L2 auxiliary loss (emma) — CLOSED, dead end
-
-- Branch: `emma/round1-metric-aware-aux-loss`
-- Hypothesis: add a metric-aligned auxiliary loss `aux_rel_l2_weight * relative_l2_loss(pred, target, mask)` so training optimizes a quantity directly proportional to the AB-UPT eval metric, with `loss = MSE + 0.05 * rel_l2`.
-- W&B runs (all five state=crashed/diverged, no `test_primary/*` produced):
-  - `ylg9cc8h` (Run 1, w=0.05, original snippet) — NaN at step 1 (sqrt(0) backward).
-  - `tq2cs2vo` (Run 2, w=0.05, dual-eps fix) — diverged step ~115700 mid-epoch 3 (grad norm 1.7 → 7e+5 → 2.85e+16).
-  - `*` Run 3a/3b (w=0.01, w=0.02) — diverged step 50600 / 59100. Smaller weight diverged earlier — confirms backward-path instability is the controlling factor, not weight magnitude.
-  - `*` Run 4a/4b (`clip_grad_norm_(1.0)` added) — `total_norm=Inf → coef=0` mathematically still propagates NaN.
-  - `*` Run 5a/5b (full stability stack: ratio.clamp(max=1.0), eps=1e-4, fp32 outside autocast, NaN-skip step) — entered 100% skip-step regime by ~step 30000, training frozen.
-- **Conclusion:** the rel-L2 auxiliary loss as formulated is fundamentally unstable in this codebase. The `sqrt((diff_sum + ε)/(tgt_sum + ε))` backward path produces Inf grads when surface target norms are small in denormalized space; even gradient masking and skip-step cannot rescue it once the regime is reached.
-- **Salvage value:** emma's diagnostic infrastructure (`grad_clip_norm` config + NaN-resistant skip-step pattern) corroborates the design landing in PR #22 (gilbert). Closed in favor of squared-rel-L2 reformulation (drop the sqrt → `ratio.mean()`) as a Round-2 follow-up assigned to emma.
-
-## 2026-04-29 — PR #8: per-case geometry FiLM conditioning (frieren) — VERIFIED WIN, pending merge (rebase required)
-
-- Branch: `frieren/round1-geometry-film-conditioning`
-- Hypothesis: condition each Transolver block on a per-geometry latent vector via AdaLN-zero FiLM (feature-wise linear modulation), so the model can specialize its weights to the car geometry rather than treating all geometries uniformly.
-- W&B run: `hltti2ec` (state=finished, 1 full epoch reached, best_epoch=1)
-- Param count: 3,388K (+142K = +4.4% vs baseline)
-- Deviation from PR pseudocode: frieren applied FiLM per-block (all 4 layers) with AdaLN-zero init, not just the final layer — correct empirical decision.
-
-**test_primary/* (frieren PR #8 vs current yi baseline PR #9):**
-
-| Metric | PR #8 frieren | PR #9 gilbert (yi baseline) | Δ | AB-UPT |
-|---|---:|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **16.53** | 17.39 | **−4.9%** | — |
-| `surface_pressure_rel_l2_pct` | **10.38** | 11.07 | **−6.2%** | 3.82 |
-| `wall_shear_rel_l2_pct` | **17.29** | 18.32 | **−5.6%** | 7.29 |
-| `volume_pressure_rel_l2_pct` | **14.91** | 15.21 | **−2.0%** | 6.08 |
-| `wall_shear_x_rel_l2_pct` | **14.76** | 15.65 | **−5.7%** | 5.35 |
-| `wall_shear_y_rel_l2_pct` | **20.59** | 21.86 | **−5.8%** | 3.65 |
-| `wall_shear_z_rel_l2_pct` | **22.00** | 23.18 | **−5.1%** | 3.63 |
-
-**Apples-to-apples vs PR #3 (no-FiLM, same config, 1-epoch comparator):** `abupt_axis_mean` 30.47 → 16.53 = **46% reduction**. FiLM is a real lever.
-
-**Diagnostic confirmation:** geometry token L2 norm grew 70× during the epoch (0.18 → 12.4); FiLM weights grew 1.8–3.6×. Layer is being actively used, not bypassed.
-
-**Critical confound:** frieren ran bs=2, 1 epoch only — while gilbert's baseline used bs=8, 6 epochs (with protocol fixes). FiLM reached 16.53 at 1 epoch vs gilbert's 17.39 at 6 epochs. This implies the FiLM conditioning adds real architectural capacity that compounds with convergence.
-
-**Status:** Merge blocked on rebase conflict (yi was updated after frieren's branch was cut). Squash-merge will complete once frieren rebases onto yi. Results verified and accepted.
-
-**Round-2 follow-up triggered (frieren PR #23):** Full composition run stacking all yi wins:
-FiLM + vol_w=2.0 + tangential projection + bs=8 + validation-every=1 + gradient clipping (once PR #22 lands).
-
-## 2026-04-29 03:57 — PR #9: volume loss weight sweep (gilbert) — MERGED, NEW yi BASELINE
-
-- Branch: `gilbert/round1-volume-loss-reweight`
-- Hypothesis: upweight volume loss to 2.0–3.0 to focus gradient budget on
-  the hardest target (`volume_pressure`).
-- Run A (vol_w=2.0): `y2gigs61`, state=finished, 6 epochs reached, best_epoch=3.
-- Run B (vol_w=3.0): `s45dwv6i`, state=finished, 6 epochs reached, best_epoch=1.
-
-**test_primary/* (Run A new yi best vs prior PR #11 baseline):**
-
-| Metric | Run A (vol_w=2.0) | PR #11 (kohaku, prior) | Δ | AB-UPT |
-|---|---:|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **17.39** | 35.12 | **−50.5%** | — |
-| `surface_pressure_rel_l2_pct` | 11.07 | 10.07 | +9.9% | 3.82 |
-| `wall_shear_rel_l2_pct` | **18.32** | 43.05 | **−57.4%** | 7.29 |
-| `volume_pressure_rel_l2_pct` | 15.21 | 14.99 | +1.5% | 6.08 |
-| `wall_shear_x_rel_l2_pct` | **15.65** | 30.85 | **−49.3%** | 5.35 |
-| `wall_shear_y_rel_l2_pct` | **21.86** | 42.06 | **−48.0%** | 3.65 |
-| `wall_shear_z_rel_l2_pct` | **23.18** | 77.65 | **−70.1%** | 3.63 |
-
-Run B (vol_w=3.0): `abupt=30.08`, diverged at epoch 2 (best_epoch=1).
-**vol_w=3.0 strictly worse than vol_w=2.0**, confirming the PR's question.
-
-**The big confound:** gilbert's run did **not** include
-`--use-tangential-wallshear-loss` (kohaku's projection code is on yi but
-default off). Yet still beat kohaku's projection-loss run by 50%. The bulk
-of the win came from the **protocol fixes**:
-
-- `--batch-size 8` (vs default 2)
-- `--validation-every 1` (vs default 10)
-- `--gradient-log-every 100 --weight-log-every 100` (Issue #19 throughput)
-
-vol_w=2.0 vs vol_w=1.0 single-delta is therefore untested, but vol_w=2.0
-appears at worst neutral. Combining gilbert's config with kohaku's
-projection should compose for further gains.
-
-**Critical bug uncovered (gilbert PR comment):** `train.py` has no gradient
-clipping. Run B and several other Round-1 runs (chihiro, emma, fern, haku)
-diverged on the exact same mechanism. **Round-2 follow-up PR #22 (gilbert)
-adds `torch.nn.utils.clip_grad_norm_` + sweeps clip values.**
-
-**Round-2 follow-ups triggered:**
-- PR #22 (gilbert): add gradient clipping to `train.py` — infrastructure
-  win blocking high-LR / high-weight / high-batch sweeps.
-- BASELINE.md: new winning reproduce config recorded with all four protocol
-  flags + vol_w=2.0.
-
-## 2026-04-29 03:13 — PR #11: tangential wall-shear projection loss (kohaku) — MERGED, prior baseline (superseded by PR #9)
-
+## 2026-04-29 03:00 — PR #11: [kohaku] Tangential wall-shear projection loss
 - Branch: `kohaku/round1-tangential-wallshear-loss`
-- Hypothesis: project predicted/target wall-shear onto surface tangent plane
-  before MSE — physics says wall shear has zero normal component on a no-slip
-  wall, so penalising the normal component is unphysical noise.
-- W&B run: `uy0ds6iz` (state=finished, 1 full epoch reached, run pre-dated
-  the per-step timeout fix so timed out at the inter-epoch check).
+- Hypothesis: Project wall-shear predictions onto the tangential plane at each surface point to enforce the no-slip boundary condition physically.
+- Results: W&B run `uy0ds6iz`
 
-| Metric | kohaku (PR #11) | norman (akbdunir, no-projection comparator) | nezuko (mdo2p8q7, DropPath) | AB-UPT |
-|---|---:|---:|---:|---:|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **35.12** | 64.66 | 81.21 | — |
-| `test_primary/surface_pressure_rel_l2_pct` | 10.07 | 48.43 | 66.49 | 3.82 |
-| `test_primary/wall_shear_rel_l2_pct` | 43.05 | 66.89 | 84.27 | 7.29 |
-| `test_primary/volume_pressure_rel_l2_pct` | 14.99 | 55.54 | 69.42 | 6.08 |
-| `test_primary/wall_shear_x_rel_l2_pct` | 30.85 | 55.54 | 75.40 | 5.35 |
-| `test_primary/wall_shear_y_rel_l2_pct` | 42.06 | 90.15 | 102.42 | 3.65 |
-| `test_primary/wall_shear_z_rel_l2_pct` | 77.65 | 73.66 | 92.32 | 3.63 |
+| Metric | Value |
+|---|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | 35.12 |
+| `test_primary/surface_pressure_rel_l2_pct` | 10.07 |
+| `test_primary/wall_shear_rel_l2_pct` | 43.05 |
+| `test_primary/volume_pressure_rel_l2_pct` | 14.99 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 30.85 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 42.06 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 77.65 |
 
-**Result: merged (~46% reduction on `abupt_axis_mean` vs the closest comparator).**
+- Commentary: Established first yi baseline. Only 1 epoch completed due to timeout bug (pre-fix). Projection loss adds physical constraints but alone is insufficient without the protocol fixes.
 
-**Key wins:**
-- First yi baseline established. All future PRs measured against PR #11.
-- kohaku's deviation from the PR pseudocode was correct: PR text projected in
-  normalized space, but per-axis wall-shear stds are non-uniform
-  ([2.08, 1.36, 1.11]), so true tangential projection requires
-  denormalize → project → renormalize. Physically motivated and analytically
-  rigorous.
-- New diagnostic `train/wallshear_pred_normal_rms` instruments the predicted
-  normal component — confirmed it grows ~2.4× during a single epoch
-  (0.52 Pa → 1.21 Pa), validating the predicted failure mode.
+---
 
-**Caveats:**
-- Only 1 epoch reached (run pre-dated the per-step timeout fix). Subsequent
-  PRs with the fix + `--validation-every 1` should reach 4–5 epochs.
-- All wall-shear axes still 5–21× from AB-UPT targets — most headroom is in
-  the wall-shear regression, especially `tau_z` (77.65% vs target 3.63%).
+## 2026-04-29 03:57 — PR #9: [gilbert] Protocol fixes (bs=8, vol_w=2.0, validation-every=1)
+- Branch: `gilbert/round1-protocol-fixes`
+- Hypothesis: Larger batch size and higher volume loss weight stabilize training and improve all metrics.
+- Results: W&B run `y2gigs61`
 
-**Round-1 follow-up assigned to kohaku (PR #21):** sweep
-`λ * mean((ws_pred · n_hat)^2)` regularizer on top of projection — directly
-addresses the failure mode the diagnostic exposed. Also serves as the first
-multi-epoch run with projection on (the λ=0 arm).
+| Metric | Value | Prior (PR #11) |
+|---|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **17.39** | 35.12 |
+| `test_primary/surface_pressure_rel_l2_pct` | 11.07 | 10.07 |
+| `test_primary/wall_shear_rel_l2_pct` | 18.32 | 43.05 |
+| `test_primary/volume_pressure_rel_l2_pct` | 15.21 | 14.99 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 15.65 | 30.85 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 21.86 | 42.06 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 23.18 | 77.65 |
 
-## 2026-04-29 02:30 — PR #12: stochastic depth / DropPath p=0.1 (nezuko) — CLOSED
+- Commentary: 50.5% improvement in headline metric. Flag-only change. Protocol fixes (bs=8, vol_w=2.0) are now the standard base config.
 
-- Branch: `nezuko/round1-stochastic-depth`
-- Hypothesis: linear-schedule DropPath (max p=0.1 at deepest layer) regularizes the
-  Transolver and gives ~10% throughput from skipped residual branches.
+---
 
-| Metric | nezuko (DropPath p=0.1, `mdo2p8q7`) | norman (no DropPath, `akbdunir`) | AB-UPT target |
+## 2026-04-29 — PR #8: [frieren] Per-case geometry FiLM conditioning
+- Branch: `frieren/round1-film-geom-conditioning`
+- Hypothesis: Geometry-conditioned FiLM layers (GeomEncoder → FiLM per block) allow the model to specialize per car geometry.
+- Results: W&B run `hltti2ec` (1 epoch only, timeout)
+
+| Metric | FiLM | No-FiLM (PR #3) | Δ |
 |---|---:|---:|---:|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **81.21** | 64.66 | — |
-| `test_primary/surface_pressure_rel_l2_pct` | 66.49 | 48.43 | 3.82 |
-| `test_primary/wall_shear_rel_l2_pct` | 84.27 | 66.89 | 7.29 |
-| `test_primary/volume_pressure_rel_l2_pct` | 69.42 | 55.54 | 6.08 |
-| `test_primary/wall_shear_x_rel_l2_pct` | 75.40 | 55.54 | 5.35 |
-| `test_primary/wall_shear_y_rel_l2_pct` | 102.42 | 90.15 | 3.65 |
-| `test_primary/wall_shear_z_rel_l2_pct` | 92.32 | 73.66 | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **16.53** | 30.47 | −46% |
+| `test_primary/surface_pressure_rel_l2_pct` | 10.38 | 21.65 | −52% |
+| `test_primary/wall_shear_rel_l2_pct` | 17.29 | 32.51 | −47% |
+| `test_primary/volume_pressure_rel_l2_pct` | 14.91 | 23.73 | −37% |
+| `test_primary/wall_shear_x_rel_l2_pct` | 14.76 | 28.07 | −47% |
+| `test_primary/wall_shear_y_rel_l2_pct` | 20.59 | 39.02 | −47% |
+| `test_primary/wall_shear_z_rel_l2_pct` | 22.00 | 39.88 | −45% |
 
-**Result: rejected (+16.5 pp worse on abupt_axis_mean than no-DropPath).**
+- Commentary: FiLM halves the error at 1 epoch. Mechanistically active (geom_token_norm grew 70× during training). +142k params (+4.4% overhead). Pending rebase to merge.
 
-**Analysis:** both nezuko and norman finished with `best_epoch=1`. Train loss
-keeps falling, EMA-val degrades from epoch 1 onward — the runs are firmly in
-the underfitting regime, not the overfitting regime where regularization helps.
-Stochastic depth adds noise to the residual signal without addressing the
-binding constraint (insufficient optimizer steps to convergence at this
-4L/256d/4h/128sl + 65k-points config inside the 6 h timeout).
+---
 
-**Important byproduct: per-step timeout fix.** nezuko shipped a `train.py` fix
-(commit `1ab3a9b`) that adds a per-step wall-clock timeout check, reserves
-`SENPAI_VAL_BUDGET_MINUTES` (default 90), and forces a final validation when
-mid-epoch timeout fires. Cherry-picked into `yi` as commit `af92e9a` and
-broadcast to all active Round-1 PRs. This unblocks every 65k-points run from
-the silent "epoch longer than timeout → no test_primary" failure mode that
-trapped the prior `u38zaxeg` attempt.
+## 2026-04-29 — PR #13: [norman] Progressive EMA decay anneal 0.99→0.9999
+- Branch: `norman/round1-progressive-ema-decay`
+- Hypothesis: Cosine-annealed EMA from 0.99 (start) to 0.9999 (end) — fast updates early, slow stable averaging late.
+- Results: W&B run `wio9pqw2`
 
-**Round-1 follow-ups triggered:**
-- Recommend `--validation-every 1` (or 2) for all Round-1 runs.
-- Flagged the train→val divergence pattern across runs for all students to
-  report and investigate.
+| Metric | Value | Δ vs PR #9 |
+|---|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **15.82** | −9.0% |
+| `test_primary/surface_pressure_rel_l2_pct` | 9.99 | −9.7% |
+| `test_primary/wall_shear_rel_l2_pct` | 16.60 | −9.4% |
+| `test_primary/volume_pressure_rel_l2_pct` | 14.21 | −6.6% |
+| `test_primary/wall_shear_x_rel_l2_pct` | 14.27 | −8.8% |
+| `test_primary/wall_shear_y_rel_l2_pct` | 19.49 | −10.8% |
+| `test_primary/wall_shear_z_rel_l2_pct` | 21.12 | −8.9% |
 
-## 2026-04-29 — PR #4: large model scale-up 4L/512d/8h (chihiro) — MERGED
+- Commentary: Monotonic val improvement through 4 epochs (no divergence). No new parameters. 9% improvement. Code now on yi; all future runs should use `--ema-decay-start 0.99 --ema-decay-end 0.9999`.
 
-- Branch: `chihiro/round1-large-model-512d`
-- Hypothesis: scaling the Transolver width from 256→512d and heads from 4→8h increases model capacity and improves all output fields, especially volume pressure which requires richer volumetric representation than surface fields.
-- W&B run: `pejudvyd` (Run B), state=finished, best_epoch=3, params ~12.7M
+---
 
-**Config deviations from gilbert base:**
-- `--model-hidden-dim 512 --model-heads 8` (hypothesis test)
-- `--lr 5e-5` (3 prior runs at 2e-4 diverged; larger models need smaller LR)
-- `--batch-size 4` (largest power-of-2 fitting 96GB VRAM at 512d)
-- `--clip-grad-norm 1.0` opt-in flag added (overlaps with PR #22, accepted as compatible)
+## 2026-04-29 — PR #3: [askeladd] Codex/optimized-lineage config (4L/256d)
+- Branch: `askeladd/round1-codex-lineage`
+- Hypothesis: The codex/optimized-lineage config (4L/256d/4h/128sl, lr=2e-4, wd=5e-4, 65k pts, ema=0.9995) is a stronger baseline than stock defaults.
+- Results: W&B run `kv586sse`
 
-**test_primary/* (PR #4 chihiro vs PR #9 gilbert merged baseline):**
+| Metric | Value | PR #13 pending |
+|---|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **15.27** | 15.82 |
+| `test_primary/surface_pressure_rel_l2_pct` | 9.45 | 9.99 |
+| `test_primary/wall_shear_rel_l2_pct` | 15.97 | 16.60 |
+| `test_primary/volume_pressure_rel_l2_pct` | 14.07 | 14.21 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 13.67 | 14.27 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 19.08 | 19.49 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 20.08 | 21.12 |
 
-| Metric | PR #4 chihiro Run B (`pejudvyd`) | PR #9 gilbert (prev baseline) | Δ | AB-UPT target |
-|---|---:|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | **16.64** | 17.39 | **−4.3%** | — |
-| `surface_pressure_rel_l2_pct` | **10.65** | 11.07 | −3.8% | 3.82 |
-| `wall_shear_rel_l2_pct` | **17.66** | 18.32 | −3.6% | 7.29 |
-| `volume_pressure_rel_l2_pct` | **14.37** | 15.21 | **−5.5%** | 6.08 |
-| `wall_shear_x_rel_l2_pct` | **14.87** | 15.65 | −5.0% | 5.35 |
-| `wall_shear_y_rel_l2_pct` | **19.89** | 21.86 | −9.0% | 3.65 |
-| `wall_shear_z_rel_l2_pct` | **21.73** | 23.18 | −6.3% | 3.63 |
+- Commentary: best_epoch=1 only (gradients diverged epoch 2+, clip guarded checkpoint). NaN checkpoint guard bug discovered here. Win is real but fragile — full improvement will require gradient clipping.
 
-Beats merged baseline on every axis. Squash-merged into `yi` 2026-04-29.
+---
 
-**Analysis:**
-- Width improvement is orthogonal to FiLM (targets surface token conditioning) and to cosine EMA (targets checkpoint quality). `volume_pressure` win (14.37 vs 15.21) is most notable — the 512d volume is the binding capacity constraint for volumetric fields, as expected.
-- vs pending FiLM (PR #8, 16.53 abupt): chihiro is slightly worse on the headline (16.64 > 16.53) but wins on `volume_pressure` (14.37 < 14.91). The two effects are complementary.
-- vs pending cosine EMA (PR #13, 15.82 abupt): chihiro is worse on every axis — cosine EMA is the dominant improvement in flight. A composition (512d + cosine EMA + FiLM) should push below 15.
-- LR sensitivity is important: µP scaling or explicit LR search needed for any further width increase. Divergence at 2e-4 confirms the 512d model has ≥2× sharper loss landscape.
-- `--clip-grad-norm` flag added to `train.py` as opt-in; will become default when PR #22 (gilbert) lands.
+## 2026-04-29 — PR #22: [gilbert] Gradient clipping (clip_grad_norm=1.0)
+- Branch: `gilbert/round2-gradient-clipping`
+- Hypothesis: clip_grad_norm=1.0 between backward and optimizer step stabilizes training.
+- Results: 4-arm sweep
 
-**Compounding wins on yi after this merge:**
-1. PR #11 (kohaku) — tangential wall-shear projection loss
-2. PR #9 (gilbert) — protocol fixes + vol_w=2.0
-3. **PR #4 (chihiro) — width 512d/8h** ← this entry
+| Arm | clip | vol_w | W&B run | abupt |
+|---|---:|---:|---|---:|
+| 0 | 0.0 | 2.0 | `ujv64aty` | 16.54 |
+| **1** | **1.0** | **2.0** | **`9ozwna8l`** | **14.80** |
+| 2 | 1.0 | 3.0 | `u1gt9ygf` | NaN |
+| 3 | 5.0 | 3.0 | `owuceuvy` | 18.61 |
 
-**Pending merges in rebase queue:**
-- PR #8 frieren FiLM (16.53) — surface geometry conditioning
-- PR #13 norman cosine EMA (15.82) — projected new best once merged
+- Commentary: clip=1.0 with vol_w=2.0 wins (14.80). vol_w=3.0 is not stabilizable. Pre-clip grad norm median 2.17, p99 19.80, max 31.43 — clipping engaged ~50-60% of steps. Code now on yi as default `--clip-grad-norm 1.0`.
 
-**Round-2 follow-up assigned to chihiro:** composition run — width 512d × FiLM × cosine EMA at the gilbert base config. Hypothesis: if 256d gains are ~16.53 (FiLM) and ~15.82 (EMA), 512d should push below 15 given orthogonal capacity axes.
+---
 
-## 2026-04-29 — PR #7: Gaussian random Fourier features (fern) — REQUEST CHANGES (sent back v5)
+## 2026-04-29 — PR #24: [emma] Squared rel-L2 aux loss (no sqrt)
+- Branch: `emma/round2-squared-rel-l2-aux-loss`
+- Hypothesis: Replace relative-L2 with squared relative-L2 to avoid singularity in backward pass near zero targets.
+- Results: 2-arm sweep
 
-- Branch: `fern/round1-fourier-coordinate-features`
-- Hypothesis: Gaussian RFF replaces raw `(x, y, z)` with `[sin(Bx), cos(Bx)]` to give the input projection a richer spectrum and learn fine spatial frequencies. Proven in radford-branch champion config.
-- W&B runs: `fl3mawj9` (v1, killed for logging cadence), `8fm90m9i` (v2, NaN), `2fqms6xu` (v3 σ=1.0, NaN), `7jm8iurm` (v4 σ=0.5, **only 1 healthy epoch**)
+| Arm | weight | W&B run | abupt |
+|---|---:|---|---:|
+| 0 | 0.1 | `4lz8rjpy` | diverged |
+| **1** | **0.5** | **`zv791js1`** | **14.81** |
 
-**v4 test_primary/* (σ=0.5, EMA epoch-1 checkpoint):**
+- Commentary: w=0.5 won (14.81), trajectory 23.06→17.75→15.13→13.85→14.59 (best epoch 4). Grad norms bounded 1.3–5.8. Pending rebase to merge.
 
-| Metric | v4 fern Fourier σ=0.5 | yi merged (PR #4) | PR #3 baseline (matched config) | Δ vs PR #3 | Δ vs PR #4 |
-|---|---:|---:|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | 22.67 | 16.64 | 30.47 | **−25.6%** | +36.2% |
-| `surface_pressure` | 14.88 | 10.65 | 21.65 | −31.3% | +39.7% |
-| `wall_shear` | 23.96 | 17.66 | 32.51 | −26.3% | +35.7% |
-| `volume_pressure` | 19.17 | 14.37 | 23.73 | −19.2% | +33.4% |
+---
 
-**Result vs current baseline:** +36% regression (above 5% close threshold). However:
+## 2026-04-29 — PR #14: [senku] Depth ablation 5L/6L/256d
+- Branch: `senku/round1-depth-ablation`
+- Hypothesis: Increasing Transolver depth from 4L to 5L/6L while keeping hidden_dim=256 provides compositional capacity that width alone cannot replicate.
+- Results: 2 runs
 
-**Matched-config delta is positive:** vs PR #3 (same arch, no Fourier, no protocol fixes), Fourier adds **−25 to −30% on every axis**. Fourier hypothesis has real signal.
+| Config | W&B run | abupt | Δ vs 4L baseline |
+|---|---|---:|---:|
+| 5L/256d | `t5tv01ch` | **13.52** | −18.7% |
+| **6L/256d** | **`et4ajeqj`** | **13.15** | **−21.0%** |
 
-**Epoch-1 advantage at matched protocol:** fern's val_abupt at epoch 1 = 22.10 vs norman's epoch-1 val of 26.24 (PR #13, no Fourier). That's **−16% relative at the same epoch from Fourier alone**, a real composition signal.
-
-**Binding constraint: bf16 numerical instability.** Both σ=1.0 and σ=0.5 diverged in epoch 2 even with `clip_grad_norm=1.0`. Pattern: clean epoch 1, single-step preclip-norm spike (80–710), runaway, NaN/Inf. Per-step gradient clipping caps optimizer step size but does **not** prevent activation drift past bf16 representable range. Raw-meter coords compound the issue — DrivAerML coords span ~7m × 4m × 3m, so σ=1.0 gives Fourier wavelength ~6m (coarser than the car body) and per-axis grad-norm asymmetry from the anisotropic bbox.
-
-**Decision:** REQUEST CHANGES — sent back as v5 with specific instructions:
-1. Coordinate normalization to [-1, 1] before Fourier (bounds Fourier output regardless of σ)
-2. σ=1.0 on normalized coords (puts wavelength at car-feature scale)
-3. Compose with cosine EMA (`--ema-decay-start 0.99 --ema-decay-end 0.9999`, port from norman PR #13)
-4. NaN-skip-step protection (defensive)
-5. Stay at 256d for v5 (test stability first; width × Fourier as separate composition later)
-
-**Bug-fix commit `fdef51e` (gradient clipping with `--grad-clip-max-norm`):** Acknowledged. Compatible with PR #22 (gilbert) which is landing officially. Will inherit on rebase.
-
-**Pass/fail bar for v5:** must beat `abupt_axis_mean = 16.64` (current merged baseline). Stretch target: beat 15.82 (pending PR #13). If v5 also fails, Fourier closes and goes back to idea pool for revisit (per-axis σ, learnable σ, or σ-scheduled annealing).
-
-## 2026-04-29 — PR #17: surface-area-weighted MSE loss (violet) — CLOSED
-
-- Branch: `violet/round1-surface-area-weighted-loss`
-- Hypothesis: weight surface MSE loss by per-cell area (`surface_x` channel 6) so large-area patches contribute proportionally more — physically consistent with integrated drag/lift force computation. Precedent: DoMINO and AB-UPT use area weighting.
-- W&B runs: 8 attempts (`4eewknus`, `0gzvmuk9`, `92ioz6fu`, `t3083tfa`, `adia7jt4`, `pnrrdczx`, `u227tnfi`, `bfx7ktnc`); 7 diverged, 1 stable but uncompetitive
-
-**Final stable run `bfx7ktnc` (only run with `test_primary/*`):**
-
-| Metric | violet area-weighted | yi merged (PR #4) | Δ vs PR #4 |
+| Metric | 6L/256d | Prior (4L/512d PR #4) | AB-UPT |
 |---|---:|---:|---:|
-| `abupt_axis_mean_rel_l2_pct` | 24.60 | 16.64 | **+47.6%** |
-| `surface_pressure` | 15.22 | 10.65 | +43% |
-| `wall_shear` | 28.52 | 17.66 | +62% |
-| `volume_pressure` | 14.06 | 14.37 | −2.2% (plausibly noise) |
-| `wall_shear_x/y/z` | 24.60 / 34.72 / 34.39 | 14.87 / 19.89 / 21.73 | +66% / +75% / +58% |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **13.15** | 16.64 | — |
+| `test_primary/surface_pressure_rel_l2_pct` | 7.64 | 10.65 | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 13.47 | 17.66 | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 13.58 | 14.37 | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 11.53 | 14.87 | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 16.23 | 19.89 | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 16.75 | 21.73 | 3.63 |
 
-**Required deviations for stability:** `lr=1e-4` (PR spec was 2e-4), `--area-weight-clip 2.0` (clips 17% of points), `--max-grad-norm 0.5`. 7 prior runs at lr=2e-4 all diverged regardless of grad-clip config.
+- Commentary: New yi best. Both runs monotonically improving at timeout — still descending. Depth is more parameter-efficient than width: 6L/256d (4.73M) crushes 4L/512d (12.7M). Volume pressure val→test gap (6.93→13.58) — test generalization issue, not model capacity. Wall_shear axes still 4-5× AB-UPT.
 
-**Key diagnostic finding from violet:** DrivAerML mesh area distribution is heavy-tailed (max=22× mean, p99=13× mean). Heavy clipping (`area-weight-clip 2.0`) saturates 17% of points and the renormalized effective weight collapses to mean=0.568 — the physics signal is erased. So either:
-- area-weight without clipping → diverges (variance overflow into Adam state)
-- area-weight with clipping → no signal (top cells get same weight as median)
+---
 
-There is no run in this experiment where area-weighted MSE beats unweighted MSE at matched config.
+## 2026-04-29 — PR #45: [fern] Mamba-2 SSM surface decoder — FAILED
+- Branch: `fern/b04-mamba2-surface-decoder`
+- Hypothesis: Post-Transolver SSM decoder using Morton Z-order sorted surface tokens.
+- Results: W&B run `322xcrnv`, abupt=27.53 (+65% over baseline)
+- Commentary: Catastrophic failure. No zero-init residual + no gradient clipping → backbone poisoning. mamba-ssm unavailable (no nvcc), fell back to S4D-Lin. Closed.
 
-**Decision: CLOSE.** +47% regression on the headline metric meets the close threshold; 8-attempt thorough mapping confirms hypothesis is non-viable on this training recipe. Volume_pressure gain (−2.2%) is plausibly noise on n=50.
+---
 
-**Salvageable directions (filed for future):**
-1. **Log-area weighting** `w = log(1 + area / area_med)`: tames heavy tail without saturating, preserves rank order. Different hypothesis worth a fresh PR.
-2. **EMA-based loss reweighting**: focal-loss-style adaptive per-cell weights based on running per-point loss variance. Decouples physics from variance amplification.
+## 2026-04-29 — PR #38: [violet] NIG evidential regression — FAILED
+- Branch: `violet/c02-deep-evidential-regression`
+- Hypothesis: NIG-NLL replaces MSE, outputting uncertainty.
+- Results: λ=0.01: abupt=33.54 (`vo9ep9fd`); λ=0.1: abupt=42.63 (`trreny49`)
+- Commentary: NIG parameter collapse (α→1+ε, ν→0) + max grad norm 4.91×10⁷. Fundamental — not just hyperparameter. Closed.
 
-**Bug-fix commit `14e4668` (gradient clipping, `--max-grad-norm`):** Compatible with PR #22 (gilbert) canonical version. No separate landing needed.
+---
 
-**Round-2 follow-up assigned to violet:** **C02 — Deep Evidential Regression head** (replace MSE with NIG-based negative log-likelihood; per-cell uncertainty; addresses heavy-tail target distributions at the loss-formulation level). Bold direction, plays to violet's demonstrated loss-analysis strength.
+## 2026-04-29 — PR #29: [chihiro] 512d × FiLM × cosine-EMA composition — FAILED
+- Branch: `chihiro/b06-width-film-ema-composition`
+- Hypothesis: Compose 4L/512d + FiLM + cosine EMA.
+- Results: W&B run `kk7wkhkv`, abupt=37.08 (+122%)
+- Commentary: EMA schedule bug — denominator set to 50 epochs × steps/epoch but only 3 epochs completed (4% of schedule), so EMA effectively pinned at 0.99. Hypothesis remains valid. Closed.
 
-## 2026-04-29 — PR #7 v5: Fourier features with coord-normalization (fern) — CLOSED
+---
 
-- Branch: `fern/round1-fourier-coordinate-features`
-- Hypothesis (v5 revision): coord-normalize xyz to [-1, 1] using separate surface (~7m bbox) and volume (~120m bbox) bboxes, σ=1.0, compose with cosine EMA, add NaN-skip-step protection.
-- W&B run: `udgrnpvq` (`fern-fourier-v5-normalized`), state=finished, 6h budget, best_epoch=3, 31,474 NaN-skipped steps after epoch-4 divergence
+## 2026-04-29 — PR #21: [kohaku] Normal-component suppression — PENDING RERUN
+- Branch: `kohaku/round2-normal-suppression`
+- Hypothesis: Explicit penalty on (ws_pred · n_hat)² drives predicted normal component to zero.
+- Results: Gradient-clip confounded. Best arm λ=1.0: abupt=18.76. λ=0.01 reached 17.89 before diverging.
+- Commentary: Mechanism works (wallshear_pred_normal_rms drops with λ). All arms hit gradient-clip bug. Sent back for rerun on 6L base with clip=1.0.
 
-**v5 test_primary/* (best EMA epoch 3):**
+---
 
-| Metric | v5 | v4 (raw, σ=0.5) | yi merged (PR #4) | Δ vs PR #4 |
-|---|---:|---:|---:|---:|
-| `abupt_axis_mean` | **21.10** | 22.67 | 16.64 | **+26.8%** |
-| `surface_pressure` | 11.09 | 14.88 | 10.65 | +4.1% |
-| `wall_shear` | 18.44 | 23.96 | 17.66 | +4.4% |
-| `volume_pressure` | **33.09** | 19.17 | 14.37 | **+130%** |
-| `wall_shear_x/y/z` | 15.60 / 22.12 / 23.61 | 20.42 / 29.02 / 29.84 | 14.87 / 19.89 / 21.73 | +4.9 / +11.2 / +8.7% |
+## 2026-04-29 — PR #15: [tanjiro] SDF-gated volume attention — PENDING RERUN
+- Branch: `tanjiro/round1-sdf-gate-volume`
+- Hypothesis: Gaussian gate on |SDF| focuses volume attention on near-wall points.
+- Results: W&B run `iiedyq63`, abupt=17.68 (+1.7% regression vs PR #9)
+- Commentary: Marginal volume_pressure improvement (−0.5%) but overall regression. sigma=0.05 too wide (gate ≈0.97 at q75). Sent back for rerun with sigma=0.005 on 6L base.
 
-**Key findings:**
-- **Coord normalization clearly helps Fourier.** v5 vs v4 (with all else equal): −7% abupt, −25% surface_pressure, −18 to −24% wall-shear axes. Surface metrics now within +4% of merged baseline.
-- **Volume regression is mechanistic.** Surface bbox (~7m) and volume bbox (~120m, sim domain) need different σ. Single shared σ=1.0 → volume Fourier wavelengths too coarse for sim domain. v5 used per-stream bbox normalization but not per-stream σ. **Per-stream σ is the obvious fix.**
-- **bf16 forward-pass amplification cascade is fundamental.** v3/v4 diverged epoch 1; v5 made it through 3 healthy epochs of monotonic val improvement, then exponential blow-up over ~14 steps (preclip grad 6.6e11 → 5.0e18) in epoch 4. Pattern: gradient clipping bounds optimizer step, but activation drift accumulates and crosses ~3e38 bf16 overflow threshold. Identical mode in all 3 substantive Fourier runs.
-- **NaN-skip-step (commit `d194ba8`) saved the run.** 31,474 corrupted steps caught after divergence; EMA frozen at epoch-3 weights produced valid `test_primary/*` instead of NaN.
+---
 
-**Decision: CLOSE.** +27% regression on headline metric; remaining gap-closure path (per-stream σ + fp32 input projection + FiLM composition) is multi-week scope; better to deploy fern's analytical strengths on Round-2 architecture.
+## 2026-04-29 — PR #16: [thorfinn] Bilateral xz-plane TTA — CLOSED
+- Branch: `thorfinn/round1-tta-bilateral-symmetry`
+- Hypothesis: Mirror geometry about xz-plane at inference, average predictions.
+- Results: W&B run `xdjsf4ad`, no-TTA=19.28, TTA=19.40 (TTA hurts)
+- Commentary: Cars are symmetric but model predictions are not variance-reduced. TTA only helps near-equivariant models. Closed.
 
-**Salvageable for future revisits:**
-1. Per-stream σ (surface=1.0, volume=0.25) — clean fix to volume regression
-2. fp32 input projection — clean fix to bf16 overflow
-3. Per-axis σ — addresses anisotropic wall-shear residuals
-4. NaN-skip-step pattern — for any future divergence-prone run
+---
 
-**Round-2 follow-up assigned to fern:** B04 — Mamba-2 SSM surface decoder. Plays to fern's mathematical strengths (state-space model kernel math, stability analysis, numerical diagnostics).
+## 2026-04-29 — PR #2: [alphonse] Stock defaults baseline — CLOSED
+- Hypothesis: Reference floor for stock train.py defaults.
+- Results: W&B run `a1fikrwe`, abupt=87.30
+- Commentary: Confirms massive gap between stock (3L/192d, 40k pts) and optimized protocol. NaN checkpoint guard bug discovered. Closed.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -297,3 +297,37 @@ Beats merged baseline on every axis. Squash-merged into `yi` 2026-04-29.
 - PR #13 norman cosine EMA (15.82) — projected new best once merged
 
 **Round-2 follow-up assigned to chihiro:** composition run — width 512d × FiLM × cosine EMA at the gilbert base config. Hypothesis: if 256d gains are ~16.53 (FiLM) and ~15.82 (EMA), 512d should push below 15 given orthogonal capacity axes.
+
+## 2026-04-29 — PR #7: Gaussian random Fourier features (fern) — REQUEST CHANGES (sent back v5)
+
+- Branch: `fern/round1-fourier-coordinate-features`
+- Hypothesis: Gaussian RFF replaces raw `(x, y, z)` with `[sin(Bx), cos(Bx)]` to give the input projection a richer spectrum and learn fine spatial frequencies. Proven in radford-branch champion config.
+- W&B runs: `fl3mawj9` (v1, killed for logging cadence), `8fm90m9i` (v2, NaN), `2fqms6xu` (v3 σ=1.0, NaN), `7jm8iurm` (v4 σ=0.5, **only 1 healthy epoch**)
+
+**v4 test_primary/* (σ=0.5, EMA epoch-1 checkpoint):**
+
+| Metric | v4 fern Fourier σ=0.5 | yi merged (PR #4) | PR #3 baseline (matched config) | Δ vs PR #3 | Δ vs PR #4 |
+|---|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | 22.67 | 16.64 | 30.47 | **−25.6%** | +36.2% |
+| `surface_pressure` | 14.88 | 10.65 | 21.65 | −31.3% | +39.7% |
+| `wall_shear` | 23.96 | 17.66 | 32.51 | −26.3% | +35.7% |
+| `volume_pressure` | 19.17 | 14.37 | 23.73 | −19.2% | +33.4% |
+
+**Result vs current baseline:** +36% regression (above 5% close threshold). However:
+
+**Matched-config delta is positive:** vs PR #3 (same arch, no Fourier, no protocol fixes), Fourier adds **−25 to −30% on every axis**. Fourier hypothesis has real signal.
+
+**Epoch-1 advantage at matched protocol:** fern's val_abupt at epoch 1 = 22.10 vs norman's epoch-1 val of 26.24 (PR #13, no Fourier). That's **−16% relative at the same epoch from Fourier alone**, a real composition signal.
+
+**Binding constraint: bf16 numerical instability.** Both σ=1.0 and σ=0.5 diverged in epoch 2 even with `clip_grad_norm=1.0`. Pattern: clean epoch 1, single-step preclip-norm spike (80–710), runaway, NaN/Inf. Per-step gradient clipping caps optimizer step size but does **not** prevent activation drift past bf16 representable range. Raw-meter coords compound the issue — DrivAerML coords span ~7m × 4m × 3m, so σ=1.0 gives Fourier wavelength ~6m (coarser than the car body) and per-axis grad-norm asymmetry from the anisotropic bbox.
+
+**Decision:** REQUEST CHANGES — sent back as v5 with specific instructions:
+1. Coordinate normalization to [-1, 1] before Fourier (bounds Fourier output regardless of σ)
+2. σ=1.0 on normalized coords (puts wavelength at car-feature scale)
+3. Compose with cosine EMA (`--ema-decay-start 0.99 --ema-decay-end 0.9999`, port from norman PR #13)
+4. NaN-skip-step protection (defensive)
+5. Stay at 256d for v5 (test stability first; width × Fourier as separate composition later)
+
+**Bug-fix commit `fdef51e` (gradient clipping with `--grad-clip-max-norm`):** Acknowledged. Compatible with PR #22 (gilbert) which is landing officially. Will inherit on rebase.
+
+**Pass/fail bar for v5:** must beat `abupt_axis_mean = 16.64` (current merged baseline). Stretch target: beat 15.82 (pending PR #13). If v5 also fails, Fourier closes and goes back to idea pool for revisit (per-axis σ, learnable σ, or σ-scheduled annealing).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,6 +9,47 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
+## 2026-04-29 — PR #13: progressive EMA cosine anneal 0.99→0.9999 (norman) — VERIFIED WIN, pending merge (rebase required)
+
+- Branch: `norman/round1-progressive-ema-decay`
+- Hypothesis: anneal `--ema-decay` from 0.99 (start) to 0.9999 (end) via cosine schedule. Early training: fast-tracking EMA (low decay) tracks the live model during rapid change. Late training: high decay averages out stochastic variance for a sharper final checkpoint.
+- W&B run: `wio9pqw2` (`norman-ema-99-9999-v4`), state=finished, 4 epochs, best_epoch=4, peak GPU 52.9 GB
+- Config: `--volume-loss-weight 2.0 --batch-size 8 --validation-every 1 --lr 2e-4 --ema-decay-start 0.99 --ema-decay-end 0.9999` (gilbert protocol + cosine EMA on top)
+
+**test_primary/* (norman PR #13 vs current yi baseline PR #9):**
+
+| Metric | PR #13 norman | PR #9 gilbert (merged baseline) | PR #8 frieren FiLM (pending) | Δ vs PR #9 | AB-UPT |
+|---|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **15.82** | 17.39 | 16.53 | **−9.0%** | — |
+| `surface_pressure_rel_l2_pct` | **9.99** | 11.07 | 10.38 | −9.7% | 3.82 |
+| `wall_shear_rel_l2_pct` | **16.60** | 18.32 | 17.29 | −9.4% | 7.29 |
+| `volume_pressure_rel_l2_pct` | **14.21** | 15.21 | 14.91 | −6.6% | 6.08 |
+| `wall_shear_x_rel_l2_pct` | **14.27** | 15.65 | 14.76 | −8.8% | 5.35 |
+| `wall_shear_y_rel_l2_pct` | **19.49** | 21.86 | 20.59 | −10.8% | 3.65 |
+| `wall_shear_z_rel_l2_pct` | **21.12** | 23.18 | 22.00 | −8.9% | 3.63 |
+
+Win on every axis. Also surpasses pending FiLM PR #8 (16.53 → 15.82, −4.3%).
+
+**Per-epoch trajectory — no divergence:**
+
+| Epoch | train_loss | val_abupt | best? |
+|---:|---:|---:|---|
+| 1 | 0.5414 | 26.24 | ✓ |
+| 2 | 0.1521 | 17.98 | ✓ |
+| 3 | 0.0919 | 15.59 | ✓ |
+| 4 | 0.0657 | **14.71** | ✓ |
+
+**Val improved monotonically through epoch 4.** This directly revises the (B) verdict from PR #20 (nezuko EMA sweep):
+- PR #20 used small-batch config (no bs=8 / vol_w=2.0) → diverged after epoch 1
+- PR #13 used gilbert's protocol (bs=8) → no divergence through epoch 4
+- The binding instability was **config-conditional**: large batch + vol_w=2.0 suppresses it. The cosine EMA late-smoothing may also contribute.
+
+**EMA schedule:** swept 0.990 → 0.9999 over 43,532 steps exactly as designed. Zero new parameters (schedule only).
+
+**Key implication for fleet:** progressive EMA 0.99→0.9999 is now on `yi`. All future PRs should adopt `--ema-decay-start 0.99 --ema-decay-end 0.9999` for the best checkpoint quality. Round-2 follow-up assigned (norm A02 SE(3) equivariant coord features) as PR #27.
+
+**Note:** Merge blocked on rebase conflict (yi updated after branch was cut). Student rebasing now. Results verified and accepted.
+
 ## 2026-04-29 — PR #20: EMA decay sweep diagnostic (nezuko) — CLOSED, diagnostic value (verdict (B) confirmed)
 
 - Branch: `nezuko/round2-ema-decay-sweep`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,41 @@
 # SENPAI Research Results
 
+## 2026-05-02 23:10 — PR #227 [stark]: Surface tangent-frame wall shear — CLOSED (pod never provisioned, RBAC blocker)
+
+- Branch: `stark/surface-tangent-frame` (deleted)
+- Hypothesis: Predict wall-shear in local {t1, t2, n} tangent frame (Duff et al. 2017 frame builder) so the network's regression head respects the no-slip BC geometry directly and decouples tau_y / tau_z from the global coordinate system that the current network conflates.
+- Status: Never ran. The `senpai-yi-stark` deployment / ConfigMap / pod never existed in the live `pai-2/default` cluster (operator confirmed via Issue #248 on 2026-05-01 23:05Z). Advisor pod's service account lacks RBAC create/patch on configmaps and deployments.apps, so we could not self-provision.
+- Operator directive: reassign rather than wait. PR #227 closed by advisor 2026-05-02 23:09Z. Issue #248 acknowledged; hypothesis queued as **highest-priority next-idle assignment** off PR #222 baseline (val_abupt = 9.291%).
+- Note: stark slot is not in the active `STUDENT_NAMES` for the `yi` advisor branch (16 active: alphonse, askeladd, chihiro, edward, emma, fern, frieren, gilbert, haku, kohaku, nezuko, norman, senku, tanjiro, thorfinn, violet). Reassignment will go to the first of those to become idle.
+
+## 2026-04-29 14:00 — PR #224: [fern] Learned Fourier embeddings (init-scale sweep) — CLOSED (divergence, no convergence past ep1)
+
+- Branch: `fern/learned-frequency-embeddings` (deleted)
+- Hypothesis: Replace fixed sincos positional encoding with a learned linear projection `W: Linear(3→d//2)`, output `[sin(Wx), cos(Wx)]`. With high init_scale (10–50), W spans high-frequency space but can adapt; hypothesized to improve τ_y/τ_z frequency selectivity.
+
+| Arm | init_scale | lr | clip | ep1 abupt | ep1 tau_y | ep1 tau_z | Outcome |
+|---|---:|---:|---:|---:|---:|---:|---|
+| A (sincos control) | — | 5e-4 | 1.0 | 10.99% | 14.0% | 15.1% | finished (reference) |
+| B (init=1) | 1 | 5e-4 | 1.0 | 12.38% | 15.6% | 17.2% | failed — worse than control |
+| C (init=0.1) | 0.1 | 5e-4 | 1.0 | 12.10% | 15.3% | 16.9% | failed — worse than control |
+| D (init=100) | 100 | 5e-4 | 1.0 | 11.20% | 14.1% | 15.2% | marginally worse |
+| E (init=10) | 10 | 5e-4 | 1.0 | 11.02% | 13.9% | 15.0% | marginal improvement, NaN ~ep4 |
+| F (init=50) | 50 | 5e-4 | 1.0 | 10.98% | 13.8% | 15.0% | marginal, NaN ~ep4 |
+| N (init=10, clip=0.3) | 10 | 5e-4 | 0.3 | 10.94% | 13.9% | 15.0% | slight improvement, NaN ~ep4 |
+| O (init=10, clip=0.5, lr=3e-4) | 10 | 3e-4 | 0.5 | **10.17%** | **12.9%** | **13.9%** | best ep1, NaN step ~19000 |
+| K (best val overall) | 10 | 5e-4 | 1.0 | — | — | — | best val 10.48%, did not beat bar 9.291% |
+
+Baseline: 9.291% val_abupt (PR #222 merge bar)
+
+- **Result:** CLOSED — no arm beat the 9.291% merge bar. Best overall val was arm K at 10.48% (−12.7% vs baseline). The ep1 improvement from init=1 (worse) to init=10 (better) confirmed the frequency selectivity hypothesis is directionally correct, but high-LR instability (NaN ~step 4764–19000 in all runs, fleet-wide bf16 + lr=5e-4) prevented convergence.
+- **Key finding:** Arm O (init=10, clip=0.5, lr=3e-4) showed the strongest ep1 signal: abupt 10.17% vs 10.99% control (−7.5%). However, O also diverged before step ~19000. The ep1 lead is architecturally real.
+- **W row-norm analysis:** Per-axis column norms `||W[:, x]||_2`, `||W[:, y]||_2`, `||W[:, z]||_2` were inconclusive at ep1 — not enough training time to show frequency selectivity emergence.
+- **init=1 pathology:** Learned W with small init is poorly conditioned at ep0 and converges slower than sincos. init≥10 is required.
+- **Fleet instability root cause:** lr=5e-4 + bf16 + clip≥0.5 causes NaN divergence around steps 4764–19000; confirmed across PRs #197, #224, #245.
+- **Follow-up assigned:** PR #298 (fern) — 4-arm sweep at stable lr=3e-4 + clip=0.5 + adamw on 6L/256d base to verify arm O's ep1 advantage persists through convergence.
+
+---
+
 ## 2026-05-02 00:00 — PR #225: [haku] Left-right symmetry augmentation for tau_y/z gap — CLOSED (ep1 signal, no convergence)
 
 - Branch: `haku/symmetry-augmentation` (deleted)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,6 +9,37 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
+## 2026-04-29 — PR #8: per-case geometry FiLM conditioning (frieren) — VERIFIED WIN, pending merge (rebase required)
+
+- Branch: `frieren/round1-geometry-film-conditioning`
+- Hypothesis: condition each Transolver block on a per-geometry latent vector via AdaLN-zero FiLM (feature-wise linear modulation), so the model can specialize its weights to the car geometry rather than treating all geometries uniformly.
+- W&B run: `hltti2ec` (state=finished, 1 full epoch reached, best_epoch=1)
+- Param count: 3,388K (+142K = +4.4% vs baseline)
+- Deviation from PR pseudocode: frieren applied FiLM per-block (all 4 layers) with AdaLN-zero init, not just the final layer — correct empirical decision.
+
+**test_primary/* (frieren PR #8 vs current yi baseline PR #9):**
+
+| Metric | PR #8 frieren | PR #9 gilbert (yi baseline) | Δ | AB-UPT |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **16.53** | 17.39 | **−4.9%** | — |
+| `surface_pressure_rel_l2_pct` | **10.38** | 11.07 | **−6.2%** | 3.82 |
+| `wall_shear_rel_l2_pct` | **17.29** | 18.32 | **−5.6%** | 7.29 |
+| `volume_pressure_rel_l2_pct` | **14.91** | 15.21 | **−2.0%** | 6.08 |
+| `wall_shear_x_rel_l2_pct` | **14.76** | 15.65 | **−5.7%** | 5.35 |
+| `wall_shear_y_rel_l2_pct` | **20.59** | 21.86 | **−5.8%** | 3.65 |
+| `wall_shear_z_rel_l2_pct` | **22.00** | 23.18 | **−5.1%** | 3.63 |
+
+**Apples-to-apples vs PR #3 (no-FiLM, same config, 1-epoch comparator):** `abupt_axis_mean` 30.47 → 16.53 = **46% reduction**. FiLM is a real lever.
+
+**Diagnostic confirmation:** geometry token L2 norm grew 70× during the epoch (0.18 → 12.4); FiLM weights grew 1.8–3.6×. Layer is being actively used, not bypassed.
+
+**Critical confound:** frieren ran bs=2, 1 epoch only — while gilbert's baseline used bs=8, 6 epochs (with protocol fixes). FiLM reached 16.53 at 1 epoch vs gilbert's 17.39 at 6 epochs. This implies the FiLM conditioning adds real architectural capacity that compounds with convergence.
+
+**Status:** Merge blocked on rebase conflict (yi was updated after frieren's branch was cut). Squash-merge will complete once frieren rebases onto yi. Results verified and accepted.
+
+**Round-2 follow-up triggered (frieren PR #23):** Full composition run stacking all yi wins:
+FiLM + vol_w=2.0 + tangential projection + bs=8 + validation-every=1 + gradient clipping (once PR #22 lands).
+
 ## 2026-04-29 03:57 — PR #9: volume loss weight sweep (gilbert) — MERGED, NEW yi BASELINE
 
 - Branch: `gilbert/round1-volume-loss-reweight`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -365,3 +365,35 @@ There is no run in this experiment where area-weighted MSE beats unweighted MSE 
 **Bug-fix commit `14e4668` (gradient clipping, `--max-grad-norm`):** Compatible with PR #22 (gilbert) canonical version. No separate landing needed.
 
 **Round-2 follow-up assigned to violet:** **C02 — Deep Evidential Regression head** (replace MSE with NIG-based negative log-likelihood; per-cell uncertainty; addresses heavy-tail target distributions at the loss-formulation level). Bold direction, plays to violet's demonstrated loss-analysis strength.
+
+## 2026-04-29 — PR #7 v5: Fourier features with coord-normalization (fern) — CLOSED
+
+- Branch: `fern/round1-fourier-coordinate-features`
+- Hypothesis (v5 revision): coord-normalize xyz to [-1, 1] using separate surface (~7m bbox) and volume (~120m bbox) bboxes, σ=1.0, compose with cosine EMA, add NaN-skip-step protection.
+- W&B run: `udgrnpvq` (`fern-fourier-v5-normalized`), state=finished, 6h budget, best_epoch=3, 31,474 NaN-skipped steps after epoch-4 divergence
+
+**v5 test_primary/* (best EMA epoch 3):**
+
+| Metric | v5 | v4 (raw, σ=0.5) | yi merged (PR #4) | Δ vs PR #4 |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean` | **21.10** | 22.67 | 16.64 | **+26.8%** |
+| `surface_pressure` | 11.09 | 14.88 | 10.65 | +4.1% |
+| `wall_shear` | 18.44 | 23.96 | 17.66 | +4.4% |
+| `volume_pressure` | **33.09** | 19.17 | 14.37 | **+130%** |
+| `wall_shear_x/y/z` | 15.60 / 22.12 / 23.61 | 20.42 / 29.02 / 29.84 | 14.87 / 19.89 / 21.73 | +4.9 / +11.2 / +8.7% |
+
+**Key findings:**
+- **Coord normalization clearly helps Fourier.** v5 vs v4 (with all else equal): −7% abupt, −25% surface_pressure, −18 to −24% wall-shear axes. Surface metrics now within +4% of merged baseline.
+- **Volume regression is mechanistic.** Surface bbox (~7m) and volume bbox (~120m, sim domain) need different σ. Single shared σ=1.0 → volume Fourier wavelengths too coarse for sim domain. v5 used per-stream bbox normalization but not per-stream σ. **Per-stream σ is the obvious fix.**
+- **bf16 forward-pass amplification cascade is fundamental.** v3/v4 diverged epoch 1; v5 made it through 3 healthy epochs of monotonic val improvement, then exponential blow-up over ~14 steps (preclip grad 6.6e11 → 5.0e18) in epoch 4. Pattern: gradient clipping bounds optimizer step, but activation drift accumulates and crosses ~3e38 bf16 overflow threshold. Identical mode in all 3 substantive Fourier runs.
+- **NaN-skip-step (commit `d194ba8`) saved the run.** 31,474 corrupted steps caught after divergence; EMA frozen at epoch-3 weights produced valid `test_primary/*` instead of NaN.
+
+**Decision: CLOSE.** +27% regression on headline metric; remaining gap-closure path (per-stream σ + fp32 input projection + FiLM composition) is multi-week scope; better to deploy fern's analytical strengths on Round-2 architecture.
+
+**Salvageable for future revisits:**
+1. Per-stream σ (surface=1.0, volume=0.25) — clean fix to volume regression
+2. fp32 input projection — clean fix to bf16 overflow
+3. Per-axis σ — addresses anisotropic wall-shear residuals
+4. NaN-skip-step pattern — for any future divergence-prone run
+
+**Round-2 follow-up assigned to fern:** B04 — Mamba-2 SSM surface decoder. Plays to fern's mathematical strengths (state-space model kernel math, stability analysis, numerical diagnostics).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,21 +1,112 @@
 # SENPAI Research Results
 
-## 2026-05-01 21:30 — PR #209: [frieren] Step-decay LR drop after epoch 1 (REJECTED)
-- Branch: `frieren/lr-drop-after-epoch1` (closed, deleted)
-- Hypothesis: Sharp LR drop at ep1→ep2 boundary (step decay 5e-4 → 1e-4) transitions optimizer from exploration to exploitation, fixing the ep1→ep2 divergence seen in PR #123 asinh arms.
-- Results (3 ep, 6L/256d/AdamW config — old architecture):
+## 2026-05-02 00:00 — PR #225: [haku] Left-right symmetry augmentation for tau_y/z gap — CLOSED (ep1 signal, no convergence)
 
-| Arm | Spec | ep1 | ep2 | ep3 | Best val_abupt | W&B |
-|---|---|---:|---:|---:|---:|---|
-| A | control (no decay) | 16.40 | 11.35 | **10.08** | **10.08** | `5es59xmq` |
-| B | ×0.2 @ ep1 | 16.52 | 11.82 | 11.17 | 11.17 | `z1k3njpq` |
-| C | ×0.1 @ ep1 | 16.67 | 22.20 | 32.44 | 16.67 | `4qtp3s50` |
-| D | ×0.3 @ ep1+ep2 | 17.23 | 11.92 | 11.33 | 11.33 | `17rf02u7` |
+- Branch: `haku/symmetry-augmentation` (deleted)
+- Hypothesis: Left-right y-axis reflection of DrivAerML surface data addresses tau_y/tau_z gap by teaching the model the bilateral symmetry constraint. `--symmetry-include-both` (orig+flip concat per step, effective bs×2) was tested alongside stochastic flip p=0.5.
 
-- **Outcome:** Hypothesis rejected. All decay arms underperformed the no-decay control. Best result (10.08) is on the OLD 6L/256d/AdamW architecture and is +0.79pp above current SOTA bar (9.291%).
-- Key diagnosis (frieren): step×cosine composition bug — `--lr-step-factor` multiplied the cosine-decayed LR rather than replacing the schedule, so B/C/D effectively ran at much smaller LRs than spec implied. The original premise (ep1→ep2 divergence) does not appear in the control config — no exploration→exploitation gap for step decay to fill.
-- Three crash cycles (seeds 42, 0, random) at lr=5e-4 + warmup=500 confirm fern config sits near a stability ceiling. `--seed=-1` (random) reduced per-launch crash rate.
-- Closed; suggested follow-ups (multi-seed variance band, AMP underflow diagnosis, low-LR Adam drift) noted as future research candidates.
+| Arm | Run | Seeds | ep1 abupt | ep1 tau_y | ep1 tau_z | Outcome |
+|---|---|---|---:|---:|---:|---|
+| A control | zhwlaury/te7uug8u/k3boii9j | 42/7/13 | — | — | — | All crashed before ep1 val |
+| B symm p=0.5 | byxxuehz | 13 | 15.95 (−10.0%) | 20.46 (−11.3%) | 22.53 (−11.1%) | ep1 val OK, crashed ep2 |
+| C symm-both bs=4 | d03gq4om | 101 | **12.75 (−28.0%)** | **16.29 (−29.4%)** | **17.89 (−29.4%)** | ep1 val OK, crashed ep2 |
+| D symm-yzw3 | 2een5w1o | 42 | 15.71 (−11.4%) | 19.96 (−13.5%) | 21.80 (−14.0%) | ep1 val OK, crashed ep2 |
+
+Baseline ep1 comparison: bplngfyo (PR #183 epoch-1 val): abupt=17.72, tau_y=23.07, tau_z=25.35
+
+- **Result:** Win criterion not met — no run survived to final convergence. All 11 attempts in this PR hit NONFINITE_SKIP_ABORT (>200 nonfinite steps), including 3/3 control arm attempts. The instability is structural (fleet-wide lr=5e-4 + warmup=500 issue), not augmentation-induced.
+- **Ep1 signal:** Arm C (symm-include-both, bs=4) showed the strongest signal in the fleet at ep1: −28% abupt and −29.4% tau_y/z vs baseline ep1. The tau_y/z disproportionality ratio is mild (1.05× — most of the win is uniform improvement, partly from effective dataset doubling). Arm B/D (random p=0.5) showed a smaller but consistent −10-14% improvement.
+- **Key insight:** The "include-both" variant (doubling effective data per step) is much more powerful than stochastic flip. This suggests the win is partly a true symmetry prior and partly sample-budget doubling — worth disentangling in a follow-up.
+- **Follow-up assigned:** PR #297 (haku) — re-test Arm C (symm-include-both, bs=4) on the stable PR #222 base config (lr=1e-4, warmup=1 epoch, 8-GPU DDP torchrun). The −28% ep1 signal should survive to convergence on the stable base.
+
+---
+
+## 2026-04-29 12:00 — PR #144: [edward] AdamW beta2 sweep (0.95 vs 0.999, lr 3e-4 and 5e-4) — CLOSED NEGATIVE
+- Branch: `edward/adamw-beta2-sweep`
+- Hypothesis: β2=0.95 in AdamW (faster second-moment adaptation) will reduce the v-saturation collapse driving NaN at lr=5e-4, potentially unlocking lr=5e-4 stability or beyond.
+
+| Arm | Run | Best val_primary | Terminal |
+|---|---|---:|---|
+| A v1 (lr=5e-4, β2=0.999) | 0351xvpg | 11.962 (e2) | NaN ep3 step 32417 |
+| B v1 (lr=5e-4, β2=0.95) | zei4lzb8 | **11.803 (e2)** | NaN ep3 step 30557 |
+| C v1 (lr=3e-4, β2=0.95) | 23nmdpp0 | 19.391 (e1) | kill-threshold ep2 |
+| D v1 (lr=3e-4, β2=0.999) | nnex5o0v | 18.282 (e1) | kill-threshold ep2 |
+| A v2 (lr=5e-4, β2=0.999) | snjasvxx | — | NaN ep1 step 5099 |
+| B v2 (lr=5e-4, β2=0.95) | l6os2f8i | 11.945 (e2) | NaN ep3 step 25501 |
+| C v2 (lr=3e-4, β2=0.95) | oagys1rq | 12.690 (e4) | finished, 4 epochs |
+| D v2 (lr=3e-4, β2=0.999) | oxfn12do | 17.594 (e1) | NaN ep2 ~step 20400 |
+
+Baseline: **10.69** — none of 8 runs reached baseline. Best was B v1 at 11.803 (1.11 pp gap).
+
+- Commentary: **Hypothesis NOT supported. β2=0.95 does not fix the lr=5e-4 instability ceiling.** All 4 lr=5e-4 arm-runs NaN'd in epoch 3 regardless of β2. The dominant stability lever was `--lr-warmup-steps 500`, which pushed NaN onset from ~step 11k (fleet historical) to ~25–32k. β2 shows a weak stability advantage at lr=3e-4 (C v2 survived 4 epochs vs D v2 NaN at epoch 2), but best metric C v2=12.690 is well above baseline 10.69. Infrastructure contribution: `--beta1`, `--beta2`, `--lr-warmup-steps`, `--lr-warmup-start-factor` flags added to train.py — these will be cherry-picked for fleet adoption. Additional finding: kill-threshold operator direction trap (condition is what must hold to continue, NOT to kill — inverted `>=3.0` killed all healthy arms in phase 1).
+
+## 2026-04-29 12:00 — Round 12 assignments: edward #196, gilbert #197, senku #198
+
+Three idle students assigned fresh experiments for Round 12:
+- **PR #196 (edward)** — Lion optimizer (sign-based, immune to v-saturation NaN). Sweep: Lion at lr=1e-4/3e-4/5e-4 + AdamW control with warmup=500. Hypothesis: Lion's bounded-magnitude updates sidestep the heavy-tail gradient distribution collapse.
+- **PR #197 (gilbert)** — K-NN local attention: replace last 1/2/3 transformer layers with k=32 or k=64 nearest-neighbor surface attention. Hypothesis: wall shear is a local physical quantity; global attention is the wrong inductive bias for tau_y/z.
+- **PR #198 (senku)** — Stochastic Weight Averaging (SWA) free gain: collect uniform weight averages over the last 30–50% of training at swa_lr=5e-5–1e-4. Hypothesis: SWA finds wider minima that generalize better than EMA alone; composes orthogonally with EMA.
+
+---
+
+## 2026-05-01 10:15 — PR #167: [tanjiro] Static W_y=W_z=3.5 + 1k LR warmup — CLOSED NEGATIVE
+- Branch: `tanjiro/static-wyz-35-warmup`
+- Hypothesis: Setting static per-component weights W_y=W_z=3.5 from step 0 (vs curriculum ramping in PR #130 that caused Adam desync) with 1000-step LR warmup gives Adam's second moments time to calibrate before full-lr updates hit the higher-weighted channels.
+- W&B run: `ynqjygsa` (tanjiro/static-wyz35-warmup1k)
+
+| Metric | Epoch 1 (only valid epoch) | Baseline (PR #99 best) | AB-UPT target |
+|---|---:|---:|---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | 15.63 | **10.69** | — |
+| `val_primary/wall_shear_y_rel_l2_pct` | 19.59 | 13.73 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 21.84 | 14.73 | 3.63 |
+| `val_primary/surface_pressure_rel_l2_pct` | 11.25 | 6.97 | 3.82 |
+| `val_primary/volume_pressure_rel_l2_pct` | 9.85 | 7.85 | 6.08 |
+
+Pre-clip grad norm trajectory by phase:
+| Phase | n | mean | max |
+|---|---:|---:|---:|
+| Warmup 0–1000 | 10 | 25.98 | 64.77 |
+| Epoch 1 post-warmup (1001–10883) | 98 | 3.17 | 11.36 |
+| Epoch 2 pre-div (1001–15099) | 47 | 554.97 | 13,646.89 |
+| Epoch 2 divergence (≥15100) | 2 | 2,035,679 | 4,046,702 |
+
+- Commentary: **Clear negative — NaN divergence at step 15,300 (mid epoch 2).** Epoch 1 beat baseline epoch 1 (15.63 vs 16.47, +5% better) confirming the signal is real. But grad norms drifted 4 OoM mid-epoch-2: elevated warmup → calm epoch 1 → silent drift → catastrophic explosion → NaN. Sister arm senku #166 (W=3.0) also NaN'd (step 9,699, even earlier). **Per-component stability ceiling is below 3.0** at lr=5e-4/clip=1.0. Static weights from step 0 did not prevent the failure — Adam's second-moment saturation on boosted channels is a post-warmup instability, not a warmup miscalibration. Longer warmup would not help. The direction of upweighting is correct (epoch-1 signals are encouraging) but the mechanism needs a lower LR or tighter per-channel gradient clipping. Decision: closed. LR warmup infrastructure already in train.py via PR #169.
+
+
+## 2026-05-01 10:30 — New assignments: haku #191, tanjiro #192, thorfinn #193
+
+Three idle students (haku, tanjiro, thorfinn) assigned new experiments targeting the tau_y/z gap and training efficiency:
+
+- **PR #191 (haku)** — 1-cycle LR max=1e-3 super-convergence: PyTorch OneCycleLR with peak 1e-3, pct_start=0.3, div_factor=25. Hypothesis: epoch-limited regime benefits from spending more training time at elevated LR. Fallback arm at lr=5e-4 if 1e-3 diverges.
+- **PR #192 (tanjiro)** — asinh target normalization for tau_y/z: apply `torch.asinh` to wall-shear y and z targets before computing loss, invert before metric computation. Targets the heavy-tail distribution causing the 4× gap vs AB-UPT. Isolated to y/z components only.
+- **PR #193 (thorfinn)** — Curvature-biased surface point sampling: sample training surface points with probability proportional to local surface normal variation (curvature proxy), biasing toward wheel arches/mirrors where tau_y/z errors are highest. Eval sampling remains uniform. Two arms: alpha=0.5 (blend) and alpha=1.0 (fully biased).
+
+---
+
+## 2026-04-29 10:45 — PR #191: [haku] 1-cycle LR max=1e-3 super-convergence — CLOSED NEGATIVE
+- Branch: `haku/1cycle-lr-max1e3-superconvergence`
+- Hypothesis: PyTorch OneCycleLR with peak_lr=1e-3, pct_start=0.3, div_factor=25 enables super-convergence in the epoch-limited training regime; spending more time at elevated LR accelerates learning on tau_y/z channels.
+
+Three arms:
+| Arm | Run | Status | Best val_abupt |
+|---|---|---|---:|
+| Main literal (lr=1e-3, epochs=50, total_steps=544150) | d86d7dg9 | Finished | 18.43 |
+| Tuned (lr=1e-3, epochs=4, calibrated total_steps) | 1khqvozw | NaN-abort at step 12,759 | 28.23 |
+| Fallback (lr=5e-4, epochs=4, calibrated total_steps) | 0e3jqcti | NaN-abort at step 14,279 | 27.31 |
+
+Best arm full W&B metrics (d86d7dg9):
+
+| Metric | 1-cycle best | Baseline (PR #183) | Δ |
+|---|---:|---:|---|
+| abupt_axis_mean_rel_l2_pct | 18.43 | **10.21** | +8.22 |
+| surface_pressure_rel_l2_pct | 13.01 | 6.97 | +6.04 |
+| wall_shear_rel_l2_pct | 20.86 | 11.69 | +9.17 |
+| volume_pressure_rel_l2_pct | 10.60 | 6.32 | +4.28 |
+| wall_shear_x_rel_l2_pct | 18.36 | 10.17 | +8.19 |
+| wall_shear_y_rel_l2_pct | 24.42 | 13.73 | +10.69 |
+| wall_shear_z_rel_l2_pct | 25.76 | 14.73 | +11.03 |
+
+- Commentary: **Clear negative. Root cause: fundamental incompatibility between OneCycleLR's peak schedule and the time-limited training regime.** With total_steps=544,150 (epoch=50), the warmup phase extends to step 163,245 — but the actual training run reaches only ~33,263 steps (3–4 epochs/wall-clock). Training terminated at ~20% through the warmup ramp, never reaching the intended super-convergence phase. Best arm scored 18.43 vs baseline 10.21 (+80% worse). The calibrated arms (total_steps matched to actual budget) failed with NaN-abort at peak LR because the steep 5e-4 → 1e-3 ramp triggered gradient instability before any benefit could materialize. Epoch progression shows steady improvement (35.16→23.84→18.64→18.43) but all below baseline. OneCycleLR is not viable in this regime without either: (a) drastically reducing total_steps to match actual training steps, AND (b) capping peak LR to avoid NaN — by which point it degrades to a standard warmup schedule.
 
 ---
 
@@ -223,279 +314,117 @@
 
 ---
 
-## 2026-04-30 14:00 — PR #58: [alphonse] NaN-safe checkpoint guard — MERGED (bugfix)
-- Branch: `alphonse/nan-checkpoint-guard-bugfix`
-- Hypothesis: Guard `best_checkpoint` overwrite against NaN primary_val to prevent EMA NaN from replacing valid checkpoint.
-- Results: Bugfix — no metric change.
-- Commentary: Root cause: `_finite_mean([nan, nan])` returns 0.0, and `0.0 < best_val` fires improved=True, overwriting valid checkpoint with NaN model. Fix: `primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0`. Validated by smoke run `tcyjp36i`. Merged to yi.
-
----
-
-## 2026-04-30 14:10 — PR #66: [thorfinn] Per-axis tau_y/z loss upweighting W_y=2, W_z=2 — MERGED (NEW BEST)
-- Branch: `thorfinn/surface-loss-weight-and-per-axis-wallshear`
-- Hypothesis: Selectively upweight tau_y and tau_z channels in surface MSE loss (W_y=2, W_z=2, W_x=1) to redirect training gradient toward the two hardest wall-shear axes.
-- Results: 3-arm sweep on 6L/256d base
-
-| Arm | W_y | W_z | W&B run | abupt | wall_shear_y | wall_shear_z |
-|---|---:|---:|---|---:|---:|---:|
-| yw1.5-zw1.5 | 1.5 | 1.5 | `vf3y3z7g` | 13.01 | 15.49 | 15.41 |
-| **yw2-zw2** | **2.0** | **2.0** | **`gvigs86q`** | **12.74** | **15.15** | **15.05** |
-| yw3-zw3 | 3.0 | 3.0 | `w8r0mvf1` | 13.18 | 15.12 | 14.52 |
-
-| Metric | thorfinn yw2-zw2 | PR #14 (6L/256d) | AB-UPT |
-|---|---:|---:|---:|
-| `test_primary/abupt_axis_mean_rel_l2_pct` | **12.74** | 13.15 | — |
-| `test_primary/surface_pressure_rel_l2_pct` | 7.86 | 7.64 | 3.82 |
-| `test_primary/wall_shear_rel_l2_pct` | 12.86 | 13.47 | 7.29 |
-| `test_primary/volume_pressure_rel_l2_pct` | 13.14 | 13.58 | 6.08 |
-| `test_primary/wall_shear_x_rel_l2_pct` | 11.29 | 11.53 | 5.35 |
-| `test_primary/wall_shear_y_rel_l2_pct` | 15.15 | 16.23 | 3.65 |
-| `test_primary/wall_shear_z_rel_l2_pct` | 15.05 | 16.75 | 3.63 |
-
-- Commentary: New yi best (12.74, −3.1% vs 13.15). The W=2 sweet spot outperforms W=1.5 and W=3 — W=3 overfits the tau_y/z directions, slightly hurting abupt. The selective approach (upweight only tau_y/z, not tau_x) avoids the divergence seen in haku's uniform weighting PR #10. tau_y and tau_z are the most challenging axes (4× AB-UPT); explicit gradient emphasis works.
-
----
-
-## 2026-04-30 14:20 — PR #65: [violet] Volume-loss-weight sweep (1.5/2.0/3.0/4.0) — CLOSED
-- Branch: `violet/volume-pressure-loss-weight-sweep`
-- Hypothesis: vol_w=4.0 might further reduce volume_pressure by forcing more gradient toward volume prediction.
-- Results: 4-arm sweep
-
-| Arm | vol_w | W&B run | abupt | vol_pressure |
-|---|---:|---|---:|---:|
-| vw-15 | 1.5 | `n3k58pah` | 13.71 | 13.56 |
-| vw-20 | 2.0 | `ioq7jh9w` | 13.61 | 13.62 |
-| vw-30 | 3.0 | `kj2i4gx3` | 13.72 | 13.45 |
-| vw-40 | 4.0 | `v98qrfmd` | 13.71 | 13.30 |
-
-- Commentary: No arm beats baseline 12.74. vol_w=4.0 marginally improves volume_pressure (13.30 vs 13.58) but hurts wall-shear. The kill-threshold bug (>=N syntax) prematurely killed several arms. vol_w=2.0 confirmed as the correct operating point for composite metric. Closed.
-
----
-
-## 2026-04-30 14:20 — PR #64: [fern] Stochastic depth regularization (3-rate sweep) — CLOSED
-- Branch: `fern/stochastic-depth-regularization`
-- Hypothesis: Stochastic depth (drop-path) regularization at rates 0.05/0.10/0.20 provides regularization to prevent overfitting.
-- Results: 3-arm sweep
-
-| Arm | sdp_rate | W&B run | abupt |
-|---|---:|---|---:|
-| sdp-005 | 0.05 | — (killed by threshold bug) | — |
-| sdp-010 | 0.10 | `q8yv93km` | 13.73 |
-| sdp-020 | 0.20 | `w3bt19pk` | 13.92 |
-
-- Commentary: All arms negative vs baseline 12.74 (+7.8% best). Stochastic depth regularization is redundant at 4-epoch budgets. Gradient clip already provides effective implicit regularization. Closed.
-
----
-
-## 2026-04-30 14:20 — PR #63: [askeladd] Squared rel-L2 aux loss on 6L base — SENT BACK FOR REBASE
-- Branch: `askeladd/squared-rel-l2-aux-on-6l`
-- Hypothesis: Add squared relative-L2 aux loss on 6L base; weight sweep w=0.1/0.3/0.5/1.0.
-- Results: 4-arm sweep
-
-| Arm | weight | W&B run | abupt |
-|---|---:|---|---:|
-| w=0.1 | 0.1 | `qntz7gzr` | 13.42 |
-| w=0.3 | 0.3 | `h5w3vf5y` | 13.11 |
-| **w=0.5** | **0.5** | **`dln9trni`** | **12.94** |
-| w=1.0 | 1.0 | `n9ckb2qe` | 13.77 |
-
-- Commentary: w=0.5 achieved 12.94 — beats PR #14 baseline (13.15) but not new baseline 12.74 (PR #66). The composition of squared rel-L2 aux loss + thorfinn per-axis weights is untested. Sent back to rebase onto thorfinn base and re-run with both --aux-rel-l2-weight 0.5 and --wallshear-y-weight 2.0 --wallshear-z-weight 2.0.
-
----
-
-## 2026-04-30 14:20 — PR #61: [gilbert] Tangential wall-shear projection on 6L base — CLOSED
-- Branch: `gilbert/tangential-wallshear-on-6l-base`
-- Hypothesis: Tangential projection loss on 6L base (no normal penalty).
-- Results: abupt=34.07 (W&B `x0pyk2yw`) — catastrophic failure. 2.7× baseline.
-- Commentary: Projection without normal penalty allows unbounded normal component growth. Gradient signal is removed in the normal direction but no compensating loss drives it to zero. Tangential projection research line closed.
-
----
-
-## 2026-04-30 14:20 — PR #60: [chihiro] 6L/512d depth×width composition — CLOSED
-- Branch: `chihiro/depth-width-composition-6l-512d`
-- Hypothesis: Combining 6L depth with 512d width should outperform either alone.
-- Results: abupt=16.00, only 2 epochs completed (data-starved).
-- Commentary: 6L/512d (18.1M params) is too large for the 4.5h budget — only 2 epochs vs 4 for 6L/256d. Data-starvation dominates. 6L/256d is the right operating point. Closed.
-
----
-
-## 2026-04-30 14:20 — PR #59: [senku] Depth 7L/8L sweep — CLOSED
-- Branch: `senku/depth-7l-8l-sweep`
-- Hypothesis: Pushing depth beyond 6L further improves the composite metric.
-- Results: 7L abupt=13.28, 8L abupt=13.57 (both worse than 6L=13.15/12.74 baseline).
-- Commentary: 7L/8L hit kill-threshold bug (>=18 means kill when val drops below 18, so some runs killed prematurely). Even corrected, both are worse than 6L at same compute — more depth = fewer epochs = data starvation at this budget. Depth ceiling confirmed at 6L. Closed.
-
----
-
-## 2026-04-30 14:20 — PR #21: [kohaku] Normal-component suppression on 6L (sweep-v2) — CLOSED
-- Branch: `kohaku/round2-normal-component-suppression`
-- Hypothesis: Penalty λ*(ws_pred·n_hat)² drives predicted normal component to zero; sweep λ∈{0.01, 0.1, 1.0} on 6L base.
+## 2026-05-01 01:18 — PR #119: [edward] RFF coordinate encoding (Tancik 2020) — CLOSED
+- Branch: `edward/rff-coordinate-encoding`
+- Hypothesis: Replace ContinuousSincosEmbed with Random Fourier Features (Tancik 2020) to give the model access to learnable coordinate frequencies, potentially improving high-frequency surface detail.
 - Results:
 
-| λ | W&B run | abupt |
-|---:|---|---:|
-| 0.01 | `le10xx7e` | 16.06 |
-| 0.1 | `j0gdj2jy` | 17.47 |
-| 1.0 | `fsxvmo08` | 15.93 |
+| Arm | σ | features | W&B run | val abupt (best epoch) | test abupt | Final state |
+|---|---:|---:|---|---:|---:|---|
+| 1 (fnyhm654) | 1.0 | 64 | fnyhm654 | NaN | — | crashed (NaN @step ~2300, epoch 1) |
+| 1-r2 (n77zkyc8) | 1.0 | 64 | n77zkyc8 | NaN | — | crashed (NaN @step ~7500, epoch 1) |
+| 2 (3s9qatve) | 5.0 | 64 | 3s9qatve | 130.01 (epoch 3) | 88.55 | loss explosion @step ~7700; stuck at ~3.5 forever |
+| 3 (fig141q6) | 2.0 | 128 | fig141q6 | 17.45 (epoch 1) | 18.28 | NaN @step 17269 (mid epoch 2) |
 
-- Commentary: All arms 22–33% worse than baseline 12.74. The suppression mechanism works mechanistically but the projection+suppression combination degrades wall-shear badly (tau_y/z ≈20–26%, far worse than baseline 15-17%). Tangential projection research conclusively closed.
-
----
-
-## 2026-04-30 14:20 — PR #15: [tanjiro] SDF-gated volume attention (v2, sigma sweep) — CLOSED
-- Branch: `tanjiro/round1-sdf-gated-volume-attention`
-- Hypothesis: Gaussian SDF gate or quantile-rank gate focuses volume attention on near-wall critical points.
-- Results: 3-arm sweep on 6L base
-
-| Arm | W&B run | abupt |
-|---|---|---:|
-| quantile q=0.10 | `l6yfeh31` | 13.26 |
-| gaussian σ=0.005 | `gu2v23cs` | 13.87 |
-| gaussian σ=0.001 | `r7c8jss2` | 36.48 (diverged) |
-
-- Commentary: Best arm (quantile q=0.10) achieves 13.26 — worse than new baseline 12.74. The val→test gap in volume_pressure (12→13.58) is a distribution shift issue that SDF gating cannot address. σ=0.001 diverges. Closing — SDF gating adds instability and doesn't help test generalization. Closed.
+- Commentary: Clean negative result — all 3 sigma values unstable at lr=5e-4/clip=1.0/bf16/raw-meter-coords. Best arm (σ=2.0, 128 features) test abupt=18.28 (56% worse than baseline 11.73). Wall_shear_y/z worst per-axis (21.3%, 23.2%) — consistent with anisotropy hypothesis (σ isotropic on non-isotropic meters). RFF fixed-Gaussian-B amplifies certain coordinate-frequency components creating unstable training unlike ContinuousSincosEmbed (deterministic, balanced). Suggests coord normalization to [-1,1] before RFF would be needed. Assigned follow-up PR #143 (fern, coord normalization) to test this hypothesis. Closed.
 
 ---
 
-## 2026-04-30 14:20 — PR #10: [haku] Per-axis wall-shear loss weights (uniform w2/w3) — CLOSED
-- Branch: `haku/round1-per-axis-wallshear-loss-weight`
-- Hypothesis: Uniform upweighting of all 3 wall-shear channels (tau_x, tau_y, tau_z) by 2× or 3× should reduce wall-shear error.
-- Results (Round-2, 6L base):
+## 2026-05-01 (in progress) — PR #117: [alphonse] Width+depth scale-up (6L/384d, 8L/256d) — WIP
+- Branch: `alphonse/width-depth-scale-up`
+- Hypothesis: Increasing Transolver from 6L/256d (4.73M params) to 6L/384d (~9M) or 8L/256d (~6M) provides additional capacity to resolve the tau_y/z fine-scale surface features.
+- Results (intermediate — running at lr=3e-4 after fleet-wide stability discovery):
 
-| Arm | weights | W&B run | abupt |
-|---|---|---|---:|
-| Control | (1,1,1,1) | `648ssek0` | 13.15 |
-| w2 | (1,2,2,2) | `s3y7sclb` | 18.35 (diverged ep3) |
-| w3 | (1,3,3,3) | `inpik7c3` | 14.35 (diverged ep4) |
-| w2+tan | (1,2,2,2)+tan | `1cxf7026` | 36.41 |
+Round 1 at lr=5e-4: all 3 arms diverged (6L/384d/4h @step 3206, 8L/256d @step 8899, 6L/384d/6h @step 11099). Round 2 at lr=3e-4: stable as of ~01:00 UTC May 1.
 
-- Commentary: Uniform upweighting causes divergence — tau_x upweighting destabilizes. Thorfinn's selective approach (W_y=W_z=2, W_x=1) succeeds where uniform fails. Confirmed: tau_x should not be upweighted. Closed.
+| Arm | Config | W&B run | Step (~01:00) | train/loss | State |
+|---|---|---|---:|---:|---|
+| A | 8L/256d | xl92i3f5 | stable | healthy | running |
+| B | 6L/384d/4h | hbahy1ob | stable | healthy | running |
+| C | 6L/384d/6h | 3m4cqwg3 | stable | healthy | running |
 
----
-
-## 2026-04-30 14:20 — PR #24: [emma] Squared rel-L2 aux loss (4L base) — CLOSED
-- Branch: `emma/round2-squared-rel-l2-aux-loss`
-- Hypothesis: Squared rel-L2 aux loss (no sqrt) is stable where round-1 version diverged.
-- Results: w=0.5 → abupt=14.81 (W&B `zv791js1`, 4L base).
-- Commentary: Stable (no divergence) and beats 4L baseline, but 4L superseded. Code was incorporated into PR #63 (askeladd, 6L). Closed — hypothesis lives on in PR #63.
+- Commentary: Confirms lr=5e-4 is hard stability ceiling for scale-up experiments. 6L/384d/4h has d_head=96 (vs standard 64) — possible bf16 attention overflow. lr=3e-4 resolves all arms. Awaiting first val checkpoint.
 
 ---
 
-## 2026-04-30 14:20 — PR #5: [edward] Cosine LR + FiLM composition on 6L — CLOSED
-- Branch: `edward/round1-cosine-lr-warmup`
-- Hypothesis: Cosine annealing + FiLM conditioning compose orthogonally on 6L base.
-- Results: abupt=19.27 (W&B `duv7m45t`) — best val at epoch 1 (18.44), degraded monotonically thereafter.
-- Commentary: FiLM + cosine LR + cosine EMA on 6L creates a fragile stack. The interaction between the cosine LR schedule and the cosine EMA ramp produces unstable training. Cosine LR alone on 6L (without FiLM) is being tested in PR #67 kafka. Closed.
+## 2026-05-01 (in progress) — PR #119 companion: RFF → coord-normalization insight
+- Key insight from edward #119: raw DrivAerML coords are anisotropic (x~8m, y/z~2m). ContinuousSincosEmbed's omega is tuned for the x-range, leaving y/z under-sampled in frequency. This is likely a direct cause of the 4× tau_y/z gap. Assigned as PR #143 (fern, coord normalization sweep).
 
 ---
 
-## 2026-05-01 06:30 — PR #131: [thorfinn] Log-magnitude wall-shear target normalization — CLOSED NEGATIVE
-- Branch: `thorfinn/log-magnitude-wallshear-targets`
-- Hypothesis: sign(x)*log1p(|x|/eps) normalization compresses heavy-tailed wall-shear distribution, improving y/z gap.
-- Results: best arm (eps=1.0, eps_low=0.10) → val abupt=11.03 vs baseline 10.69. wall_shear_y/z both regressed. Smaller eps (0.01, 0.10) caused pre_clip_norm spikes to 2M+ and NaNs (gradient of log1p near 0 is ~1/eps).
-- Commentary: NEGATIVE on primary metric and on the targeted sub-metric. The NaN/Inf-skip safeguard added in this PR (commit 2a8f7e4) is structurally valuable and orthogonal — should be cherry-picked into a utility PR. asinh transform (frieren #123, in-flight) is the smoother alternative.
+## 2026-05-01 02:28 — PR #132: [violet] Decoupled wall-shear magnitude + direction prediction — CLOSED
+- Branch: `violet/wallshear-magnitude-direction-decoupled`
+- Hypothesis: Factorize tau into |tau| (log-MSE) + tau_dir (cosine loss) heads to reduce magnitude-dominated gradients and preferentially help the small-magnitude tau_y/tau_z axes (currently 3.8×/4.1× AB-UPT gap).
+- Results: 6-arm sweep — only B and D survived to terminal epoch.
+
+| Arm | mw | dw | mag-weighted dir | W&B status | test abupt | tau_y | tau_z | p_s | p_v |
+|---|---:|---:|---|---|---:|---:|---:|---:|---:|
+| A | 1 | 1 | no | stuck | — | — | — | — | — |
+| B | 0.5 | 2 | no | finished | **13.22** | 16.60 | 18.14 | **6.42** | **13.57** |
+| C | 1 | 1 | yes | NaN ep1 | — | — | — | — | — |
+| D | 1 | 1 | yes (mw=1) | finished | 13.74 | 17.28 | 18.84 | 7.17 | 13.89 |
+| E | 0.5 | 2 | yes | NaN ep1 | — | — | — | — | — |
+| F | 2 | 0.5 | no | diverged ep1 | — | — | — | — | — |
+| **PR #99 baseline** | — | — | — | — | **11.73** | 13.53 | 13.98 | 6.64 | 14.42 |
+
+- Commentary: Clean **negative result** on the headline. Best surviving arm (B) +12.7% worse than baseline; the very axes the PR was designed to fix (tau_y, tau_z) regressed 23–30%. Three diagnostic findings:
+  1. **Cosine direction loss has perverse axis priority.** Gradient scales by sin(θ); once tau_x dominant alignment is learned, the small y/z residual contributes near-zero gradient. Reformulation does the *opposite* of preferentially upweighting transverse components.
+  2. **Magnitude-weighted direction loss is destructively unstable.** 3 of 4 mag-weighted arms NaN'd. Arm D's cos_sim trajectory `0.531→0.899→0.930→0.951→collapse to 0.404 in ~11 steps` is textbook bf16 overflow as residual high-|tau| points dominate post-convergence.
+  3. **Pressure side-effect is interesting but not load-bearing.** Arm B's p_s 6.42 (−3.3%) and p_v 13.57 (−5.9%) beat baseline. Plausible: the magnitude head's log-MSE is acting as a soft regularizer on the shared trunk. Worth a narrow ablation (`--wallshear-magnitude-loss-weight 0.5 --wallshear-direction-loss-weight 0`) but not from this PR.
+- **Direction forward**: For the y/z gap, PR #121 (askeladd surface-tangent frame) attacks the *coordinate frame* of the loss rather than the output reformulation — better-targeted lever. Output-side decoupling is closed-door pending a fundamentally different magnitude weighting scheme. Violet reassigned.
 
 ---
 
-## 2026-05-01 06:31 — PR #130: [tanjiro] Curriculum tau_y/z weighting schedule — CLOSED NEGATIVE
-- Branch: `tanjiro/curriculum-tau-yz-weighting`
-- Hypothesis: Linearly ramping W_y from 1→3 (and W_z parallel) across early training stabilizes Adam moments before reaching final upweight.
-- Results: 6/6 arm launches diverged. All hit Adam-second-moment desynchronization band around W_y≈2.7.
-- Commentary: NEGATIVE. Curriculum reweighting on top of existing W_y=W_z=2 base (effective surface gradient already ~3× volume) is structurally incompatible with Adam state. Per-component static reweighting at start (so m/v initialize correctly per channel) is the better path.
+## 2026-05-01 02:19 — PR #122: [emma] Perceiver-IO backbone replacing Transolver — CLOSED
+- Branch: `emma/perceiver-io-backbone`
+- Hypothesis: Perceiver-IO with M latent tokens (cross-attention bottleneck) trains 2× faster per step than Transolver with comparable accuracy, buying more epochs in the 6h budget.
+- Results: Throughput won, accuracy lost decisively.
+
+| Arm | Config | W&B | Steps/sec | VRAM | test abupt | val abupt (best epoch 6) |
+|---|---|---|---:|---:|---:|---:|
+| A | Transolver 6L/256d/128sl (control) | 1iilxfvs | 2.15 | 76 GB | NaN ep1 | — |
+| B | Perceiver-IO M=512, 6L/256d | jyesq3i4 | 4.29 | 17 GB | 24.46 | 23.69 |
+| C | Perceiver-IO M=1024, 6L/256d | 8b8yd2c8 | 3.54 | 17 GB | **22.46** | **21.43** |
+| **PR #99 baseline (Transolver)** | 6L/256d/128sl | 3hljb0mg | 2.15 | 76 GB | **11.73** | **10.69** |
+
+- Per-axis: C tau_y=27.11, tau_z=28.40 vs baseline 13.53 / 13.98 (~2× worse on the very gap PR was meant to help).
+- Commentary: Perceiver-IO is **architecturally mismatched** for DrivAerML CFD. Latent cross-attention bottleneck loses fine-grained spatial structure; Transolver's slice-based attention preserves it. Despite 2× speedup and 5× VRAM savings, accuracy gap is prohibitive — even with the throughput-bought 6 vs 3 epochs, val abupt floor is ~21% vs ~11% for Transolver. Diminishing returns clear: Arm C's per-epoch deltas were −8.65, −2.18, −1.99, −0.85, −0.09 → asymptote near 21%. Arm A control NaN'd at step 6676 ep1 (independent flake; not Perceiver-related). **Decision: closed.** Backbone replacement is a dead-end direction for this geometry. Emma reassigned.
 
 ---
 
-## 2026-05-01 06:32 — PR #124: [gilbert] RANS divergence constraint (Laplacian on pressure) — CLOSED NEGATIVE
-- Branch: `gilbert/rans-divergence-constraint`
-- Hypothesis: Soft penalty ∇²p ≈ 0 (kNN inverse-distance Laplacian, k=8, sdf_threshold=0.05) acts as physics-informed regularizer.
-- Results: λ≥0.01 destabilized training, λ=0.001 was a no-op. No signal at any λ.
-- Commentary: NEGATIVE — wrong physics. Δp=0 is incompressible-Stokes (creeping flow); real RANS has advective and turbulent stress terms. The right divergence constraint is ∇·u=0 on velocity targets, which requires loader changes to expose u. Reusable kNN Laplacian implementation is a keeper for future physics work.
+## 2026-05-01 02:19 — PR #127: [nezuko] Stochastic depth regularization sweep — CLOSED
+- Branch: `nezuko/stochastic-depth-regularization`
+- Hypothesis: DropPath stochastic depth at rates {0.05, 0.10, 0.20} provides regularization that closes the wall-shear y/z gap by preventing layer-specialization.
+- Results: All arms regress on wall-shear; hypothesis refuted.
+
+| Arm | sd_prob | W&B | test abupt | p_s | tau_vec | tau_x | tau_y | tau_z | p_v |
+|---|---:|---|---:|---:|---:|---:|---:|---:|---:|
+| **PR #99 baseline** | 0.0 | 3hljb0mg | **11.727** | 6.637 | 11.484 | 10.064 | 13.529 | 13.980 | 14.424 |
+| A | 0.05 | u0s413c0 | 11.707 (−0.020) | 6.743 (+) | 11.762 (+) | 10.262 (+) | 13.962 (+0.43) | 14.318 (+0.34) | **13.251 (−1.17)** |
+| B | 0.10 | i5kk7ng0 | 14.02 (NaN ep3) | 8.68 | 14.40 | 12.63 | 16.80 | 17.76 | 14.24 |
+| C | 0.20 | lyjnyi3a | 13.07 (+11%) | 7.88 | 13.37 | 11.79 | 15.61 | 16.23 | 13.83 |
+
+- Commentary: Arm A's −0.020 abupt is within noise; all wall-shear axes regress (+0.20–0.43 pp on tau_x/y/z). The PR's target was the y/z gap — stochastic depth widens it, not closes it. Arm B diverged at step 23705 ep3 (single-seed flake). Arm C clearly worse. **Mechanistic read:** wall-shear prediction needs coherent multi-layer feature propagation through the fine boundary layer geometry; randomly dropping residual branches injects noise that the model can't recover from in 9 epochs. **Volume pressure note:** Arm A's −1.17 p_v is interesting but isolated — possibly the dropout is a soft regularizer on volume features specifically. Not enough to justify the shear regression. **Decision: closed.** Stochastic depth ruled out for this regime. Nezuko reassigned.
 
 ---
 
-## 2026-05-01 06:33 — PR #121: [askeladd] Surface-tangent-frame wall-shear head — CLOSED NEGATIVE
-- Branch: `askeladd/surface-tangent-frame-wallshear`
-- Hypothesis: Reparametrize wall-shear prediction as τ = a·t1 + b·t2 in tangent frame (Duff 2017 ONB) to factor out normal direction and improve y/z accuracy.
-- Results: Worse than global Cartesian baseline at every checkpoint. Lr=3e-4, clip=0.3 delayed but didn't prevent gradient explosion.
-- Commentary: NEGATIVE. Two structural problems: (1) Duff branchless ONB is discontinuous along t1.x sign-flip — adjacent surface patches with similar normals map to opposite (a,b) targets, and a non-gauge-equivariant Transolver can't learn discontinuous frames. (2) τ_y/τ_z share (a,b) weights → channel coupling in Adam → correlated gradient spikes. Continuous frame (heat-method, PCA-aligned) or soft normal-component penalty are the right alternatives.
+## 2026-05-01 02:24 — PR #135: [tanjiro] T_max=100 cosine LR sweep extension (tay branch) — CLOSED
+- Branch: `tanjiro/round9-lion-tmax100-ema999`
+- Hypothesis: Extend cosine schedule T_max from 50 → 100 to test if "less LR decay is better" trend continues at the wider end on the tay branch.
+- Results: Narrow win vs PR #111 SOTA-at-the-time, but superseded by PR #115 lr-change.
 
----
+| Metric | PR #135 (T_max=100) | PR #111 SOTA-at-launch (T_max=50) | PR #115 actual SOTA (lr=1e-4) | Δ vs PR #115 |
+|---|---:|---:|---:|---:|
+| `test_primary/abupt_axis_mean` | 11.082 | 11.142 | **10.580** | **+4.74% regression** |
+| `surface_pressure` | 6.138 | 6.209 | — | — |
+| `wall_shear` | 11.039 | 11.138 | — | — |
+| `volume_pressure` | 12.665 | 12.548 | — | — |
+| `tau_y` | 13.469 | 13.525 | — | — |
+| `tau_z` | 13.791 | 13.992 | — | — |
+| `best_val_primary/abupt` (ep9) | 9.886 | 9.989 | — | — |
 
-## 2026-05-01 06:34 — PR #118: [chihiro] MLP ratio sweep 6/8 — CLOSED AMBIGUOUS
-- Branch: `chihiro/mlp-ratio-sweep-r4`
-- Hypothesis: Wider FFN intermediate dim (mlp_ratio=6 or 8) increases capacity per layer without depth penalty.
-- Results: 12/16 runs diverged. 4 valid epoch-1 vals; mlp_ratio=8 trended slightly better than mlp_ratio=4 baseline but no convergent comparison vs 10.69.
-- Commentary: AMBIGUOUS — seed-dependent gradient instability (same as alphonse #117). Recommend re-running mlp_ratio=8 under stability-hardened recipe: 1k-step linear LR warmup from 1e-5, --seed flag, lr=3e-4. If stabilized, +3M params with clear epoch-1 trend signal is worth pursuing.
-
----
-
-## 2026-05-01 06:35 — PR #129: [senku] Surface loss weight sweep on PR #99 base — CLOSED NEGATIVE
-- Branch: `senku/surface-loss-upweight-sweep`
-- Hypothesis: Uniform surface_loss_weight ∈ {1.5, 2.0, 2.5, 3.0} on PR #99 base improves surface metrics.
-- Results: 8 arms total (A/B/C/D + R1/R2/R3/R4 rescue at lr=3e-4, lr=2e-4, varying clips). 7 diverged. R4 (lr=2e-4, clip=0.5, 1k warmup, W&B `jtx73lg0`) was only stable arm but killed by external pod restart at step 27752 mid-ep3. Best partial: R3 ep2 abupt=12.84 vs baseline ep2=12.42 (already behind, then destabilized).
-- Commentary: NEGATIVE. Monotone instability with sw confirmed: D@8k → A@18.6k → C@19.7k → B@20.7k. Base config already has W_y=W_z=2 (effective surface gradient ~3× volume); uniform sw≥1.5 amplifies the entire bundle including upweighted y/z, exceeding stability ceiling. Per-component reweighting (--wallshear-y/z-weight only) is the right knob, not uniform --surface-loss-weight.
-
----
-
-## 2026-05-01 06:36 — PR #117: [alphonse] Width scale-up sweep 384d + 8L depth — CLOSED NEGATIVE (PROMISING SIGNAL)
-- Branch: `alphonse/width-384d-sweep`
-- Hypothesis: Scale up Transolver width to 384d (4h or 6h) or depth to 8L for capacity gain.
-- Results: 8L/256d (W&B `xl92i3f5`, lr=3e-4) reached val abupt=11.33 at partial ep3, slope -0.59 abupt-pct/1k steps; extrapolated baseline crossing at ~step 26,500 but train_timeout=270min fired at step ~25,400. Test: abupt=12.44, volume_pressure=13.84 (only sub-metric beating baseline 14.42). Both 6L/384d arms diverged at all LRs (5e-4, 3e-4, 2e-4); d_head=96 destabilized earlier than d_head=64.
-- Commentary: NEGATIVE on merge bar but PROMISING. 8L/256d was time-limited not architecture-limited — depth is the viable scale-up direction. Width 384d needs QK-norm or fp32 attention to be stable in bf16. Round-6 priority: revisit 8L/256d combined with 1cycle LR for super-convergence.
-
----
-
-## 2026-05-01 07:30 — PR #143: [fern] coordinate normalization sweep — CLOSED NEGATIVE
-- Branch: `fern/coord-normalization-sweep`
-- Hypothesis: Anisotropic bbox (x~8m, y/z~2-2.5m) makes `ContinuousSincosEmbed` give x-axis ~3-4× more frequency resolution than y/z, contributing to the 4× tau_y/z gap. Adding `--coord-normalize {none, global-scale, per-axis}` should restore isotropy.
-- Results: Hypothesis falsified across 9 attempts.
-
-| Mode | First-epoch abupt | vs control | Notes |
-|---|---:|---:|---|
-| none (control) | ~16.20 | — | matches PR #99 e1, then hits fleet-wide stochastic divergence in e2 |
-| global-scale | 24.85 | +8.65 (+53%) | normalizing to unit cube destroys sincos expressiveness — omega bank is calibrated for meter-scale geometry |
-| per-axis (4 variants) | diverged | — | volume tokens (~25× wider domain than vehicle bbox) get extreme out-of-range coords → MLP bias → slice attention gradient explosion |
-
-- Commentary: Coordinate normalization is the wrong lever — it breaks the fixed-frequency `omega` bank tuned for meter-scale wavelengths. The 4× tau_y/z gap is **NOT primarily** a sincos-anisotropy problem. Right next attack: tune the omega bank directly in physical-meter coords (denser/per-axis frequency basis on y/z), preserving meter-scale calibration. **Bug-fix side-discovery:** confirmed ~50% fleet-wide divergence at lr=5e-4. Non-finite/large-grad skip guard from haku (commit `6e8b674`) is already on `yi` so future runs are protected. **Decision: closed** — coord-normalize feature not merged. Fern reassigned to PR #183 (omega-bank anisotropic frequency sweep).
-
----
-
-## 2026-05-01 08:22 — PR #150: [emma] Multi-scale point hierarchy for tau_y/z gap — CLOSED NEGATIVE
-
-- Branch: `emma/multi-scale-hierarchy`
-- Hypothesis: PointNet++-style SetAbstraction coarsening (65536→16384→4096) wrapping Transolver with cross-scale attention will capture multi-scale spatial context and reduce tau_y/z error, which we hypothesize involves both large-scale flow structure and fine-scale boundary-layer gradients.
-- Results: 3 arms — 2-scale (stable), 3-scale (NaN divergence), 3-scale+stop-grad (plateau). W&B runs: `c4kc4465` (Arm A 2-scale), `k4glpuqg` (Arm B 3-scale), `kq3fvrvd` (Arm C 3-scale stop-grad).
-
-| Metric | Arm A 2-scale val | Baseline val | vs Baseline |
-|---|---:|---:|:---|
-| `abupt_axis_mean_rel_l2_pct` | 11.085 | **10.69** | WORSE +0.40pp |
-| `surface_pressure_rel_l2_pct` | 7.416 | **6.97** | WORSE +0.45pp |
-| `wall_shear_rel_l2_pct` | 12.437 | **11.69** | WORSE +0.75pp |
-| `wall_shear_y_rel_l2_pct` | 14.562 | **13.73** | WORSE +0.83pp |
-| `wall_shear_z_rel_l2_pct` | 15.701 | **14.73** | WORSE +0.97pp |
-| `volume_pressure_rel_l2_pct` | 6.912 | 7.85 | **BETTER −12%** |
-
-Test metrics (Arm A 2-scale, run `c4kc4465`): abupt 12.177 (vs 11.73 baseline, WORSE); volume_pressure 13.557 (vs 14.42 baseline, BETTER ~6%).
-
-Val slopes at end of run: abupt −0.156/1k steps, wall_shear_y −0.191/1k steps, wall_shear_z −0.234/1k steps (still converging, budget-limited, but gap of 0.4pp unlikely to close).
-
-- Commentary: Multi-scale SetAbstraction hierarchy did not improve tau_y/z as hypothesized. 3-scale arms both failed: NaN divergence (k4glpuqg, ~step 23.5k epoch 2.16) and loss plateau at 5.4 (kq3fvrvd). The 2-scale arm was stable but all primary metrics were worse than baseline. The only positive signal is volume_pressure (~12% improvement on val, ~6% on test) — possibly because coarse-scale aggregation acts as a spatial smoother on volumetric quantities. The tau_y/z failure reinforces that the 4× gap is not a spatial-receptive-field problem — it appears to be a loss/target-representation or coordinate-frame problem. **Decision: closed** — emma reassigned to PR #185 (SAM optimizer, ρ=0.05/0.10).
-
----
-
-## 2026-05-01 07:30 — PR #126: [kohaku] FiLM geometry conditioning on PR #99 6L/256d base — CLOSED NEGATIVE (PROMISING SIGNAL)
-- Branch: `kohaku/film-conditioning-6l-256d`
-- Hypothesis: FiLM (PR #8 frieren code) + lr=5e-4 (PR #99 fern base) is additive — global geometry prior plus fast convergence.
-- Results: Hypothesis falsified across all 4 arms.
-
-| Arm | lr | clip | Diverge step | Best partial | W&B |
-|---|---:|---:|---:|---|---|
-| 1 | 5e-4 | 1.0 | ~15.3k (mid e2) | n/a | h6nlfcdr |
-| 2 | 5e-4 | 0.5 | ~12.4k (mid e2) | n/a | 3ddue2xd |
-| 3 | 4e-4 | 0.5 | ~30.1k (mid e3) | abupt=11.67, **vp=7.05** (e2) | sudqmuo9 |
-| 4 | 3e-4 | 0.5 | ~19.0k (mid e2) | n/a | jd1acg1t |
-
-- Commentary: Best partial (Arm 3 e2 abupt=11.67) is still 0.98pp worse than baseline 10.69. **lr=3e-4 (Arm 4) failed earlier than lr=4e-4 (Arm 3)** — pure LR reduction is not the lever. Root cause from forensics: `train/film/geom_token_norm_mean` was steady (~0.73-0.81) at all 4 divergence points (geom token is fine); layer-0 `to_gamma_beta/bias grad_to_param_norm=0.567` flagged the FiLM linear projections as the gradient amplification path. FiLM × LR ≥ 3e-4 has a fundamental stability ceiling at default-init. **Promising signal:** Arm 3 e2 vp=7.05 vs baseline 7.85 — FiLM helps volume more than surface, exactly the metric closest to AB-UPT (1.3× away). The direction is right; the failure mode is dynamics, not capability. **Decision: closed** — kohaku reassigned to PR #184 (FiLM with identity/zero-init, DiT-style stable conditioning).
+- W&B run: `wtfrhy2n`. T_max sweep series across three values: T_max=24→50 gave −3.1pp; T_max=50→100 gave −0.54%pp — clear diminishing returns.
+- Commentary: This run launched against PR #111 SOTA (11.142) and would have been a clean +0.5% win at that time. During the run, PR #115 (lr=1e-4 change) merged to tay and moved SOTA to 10.580 — making PR #135's 11.082 a +4.74% regression against the current frontier. Schedule lever (T_max) is **closed-door on tay**: sweet spot is T_max=50 (already merged in PR #110), and gains are sub-percentage and dominated by lr-based wins. **Decision: closed.** Tanjiro reassigned to PR #149 (per-axis tau_y/tau_z conservative weighting on tay's new SOTA stack).
 
 ---
 
@@ -552,203 +481,40 @@ Val slopes at end of run: abupt −0.156/1k steps, wall_shear_y −0.191/1k step
   - D3 soft-divergence: anomalous loss spike at lr~6.5e-5 during deep cosine anneal — potential bf16 AMP precision issue at very low loss values. Fleet-wide flag: if future low-LR fine-tuning runs see similar, investigate AMP precision or implement LR floor ~1e-4.
   - OneCycleLR does not help in this epoch-limited regime. LR schedule lever closed for now. **Decision: closed.**
 
----
+## 2026-05-01 — PR #245: [gilbert] Progressive EMA decay schedule (ramp 0.99→0.9999 vs fixed 0.9995) — CLOSED INCONCLUSIVE
+- Branch: `gilbert/ema-decay-schedule`
+- Hypothesis: Progressive EMA warmup — ramping decay from low (fast adaptation) to high (slow adaptation) over training — allows the model to track loss-landscape changes quickly early on and then stabilize to a smooth EMA trajectory for inference, outperforming fixed EMA decay.
 
-## 2026-05-01 07:30 — PR #166: [senku] W_y=W_z=3.0 with 500-step LR warmup — CLOSED NEGATIVE
-- Branch: `senku/per-component-wallshear-yz-3`
-- Hypothesis: Increasing from W_y=W_z=2 (current best) to W_y=W_z=3 with gradual warmup would further focus gradient on tau_y/z axes.
-- Results: CLOSED 2026-05-01T11:09:05Z. No merge.
-- Commentary: W=3 was already tested in PR #66 (thorfinn) where it scored 13.18 vs 12.74 for W=2 — W=3 overfits tau_y/z, degrading abupt. Warmup doesn't change the fundamental overfitting issue. Static W=2 remains the sweet spot.
+**W&B-verified ep1 metrics (merge bar = 9.291, PR #222):**
 
----
+| Run | Arm | State | abupt (primary) | surf press | vol press | wall shear |
+|-----|-----|-------|----------------|------------|-----------|------------|
+| xpoz88lg | A: ramp 0.99→0.9999, lr=5e-4 | failed (ep2 grad explosion) | 14.41% | 10.18% | 8.29% | 16.20% |
+| f6acdprl | B: ramp 0.999→0.9999, lr=5e-4 | crashed (ep2 grad explosion) | 14.63% | 10.41% | 8.50% | 16.41% |
+| buch3nry | C: fixed 0.9995, lr=3e-4 | ep1 only (stopped) | 18.93% | 13.63% | 10.96% | 21.19% |
 
-## 2026-05-01 07:30 — PR #167: [tanjiro] W_y=W_z=3.5 with 1k LR warmup — CLOSED NEGATIVE
-- Branch: `tanjiro/static-wyz-35-warmup`
-- Hypothesis: W_y=W_z=3.5 pushes the tau_y/z gradient signal even harder.
-- Results: CLOSED 2026-05-01T09:58:05Z. No merge.
-- Commentary: Extension of the same W=3 overfitting issue. W=3.5 is even more extreme. Warmup does not prevent the channel imbalance. Closed as confirmed negative along with W=3.
+- Commentary: Experiment dominated by the fleet-wide lr=5e-4 gradient explosion (pre-clip grad norms reaching 1e7–1e9). Arms A and B both crashed in epoch 2 before producing comparable multi-epoch metrics. The ep1 A/B gap (14.41 vs 14.63) is within run-to-run noise — no valid signal on EMA ramp schedule. Arm C (fixed 0.9995) used lr=3e-4 after two lr=5e-4 failures, and only produced ep1 metrics (18.93% — underfitting after 1 epoch at lower lr). Cannot serve as the matched fixed-decay control. Research decision: EMA ramp hypothesis remains untested in clean conditions. Keeping default --ema-decay 0.9995 unchanged. Deprioritized in favour of higher-leverage experiments (architecture, loss formulation). If revisited, all arms must use lr=3e-4 (or lr=5e-4 with 1k-step warmup) and include a matched fixed-decay control at the same lr.
 
 ---
 
-## 2026-05-01 08:00 — PR #172: [stark] AdamW epsilon sweep 1e-8/7/6/5 — CLOSED NEGATIVE
-- Branch: `stark/adamw-eps-sweep`
-- Results: CLOSED 2026-05-01T08:43:12Z. No merge.
-- Commentary: AdamW epsilon is a secondary numerical stability parameter. Changing it in the range 1e-8 to 1e-5 does not address the root cause of the fleet-wide gradient instability (large-but-finite spikes bypassing the NaN-skip guard). Closed as not the right lever.
+## 2026-05-01 — PR #197: [gilbert] K-NN local surface attention for tau_y/z gap — CLOSED NEGATIVE
+- Branch: `gilbert/knn-local-attention-r12`
+- Hypothesis: K-nearest-neighbor local surface attention introduces a locality bias that disproportionately improves tau_y/z prediction by giving the model better access to fine-grained boundary-layer geometry near each query point. The 4× tau_y/z gap was hypothesized to stem from insufficient local receptive field.
+- Results:
 
----
+| Arm | Config | W&B run | val_primary (abupt) | wall_shear_y | wall_shear_z | surface_pressure | volume_pressure | Final state |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| A (control) | 0L KNN | haibegok | 17.64 | 23.38 | 24.89 | 12.57 | 9.99 | crashed |
+| B | 1L KNN k=32 | 77yqqenp | — | — | — | — | — | crashed (no metrics) |
+| C | 2L KNN k=32 | hvey8no6 | 19.91 | 25.55 | 27.32 | 13.73 | 13.89 | completed |
+| D | 2L KNN k=64 | 7vmm33nz | 24.10 | 30.46 | 32.40 | 16.69 | 18.21 | completed |
+| **yi baseline** | PR #183 | — | **10.21** | **13.47** | **14.52** | **6.85** | **6.32** | — |
 
-## 2026-05-01 11:30 — PR #185: [emma] SAM optimizer (ρ=0.05/0.10) — CLOSED NEGATIVE
-- Branch: `emma/sam-sharpness-aware-min`
-- Results: CLOSED 2026-05-01T11:35:49Z. No merge.
-- Commentary: SAM requires 2 forward-backward passes per step, cutting effective steps/epoch in half. In this 3-4 epoch budget this is too expensive. Also does not address the tau_y/z coordinate-frame hypothesis. Closed.
-
----
-
-## 2026-05-01 — PR #184: [kohaku] FiLM with identity/zero-init (DiT-style) — IN FLIGHT
-- Branch: `kohaku/film-zero-init`
-- Hypothesis: FiLM with zero-initialized gamma/beta (identity transform at init) plus lr=4e-4 is stable where lr=5e-4 is not.
-- Intermediate results (5/5 arms at lr=5e-4 dead; 1 arm at lr=4e-4 healthy):
-
-| Arm | Config | W&B run | Status @ 11:45 UTC |
-|---|---|---|---|
-| A | zero-init/clip=1.0/lr=5e-4 | (prev) | Dead @ step 2455 |
-| A' | zero-init/clip=0.5/lr=5e-4 | (prev) | Dead @ step 1900 |
-| D | zero-init/clip=1.0/WD=1e-3/lr=5e-4 | (prev) | Dead @ step 2400 |
-| C | scale=0.01/clip=1.0/lr=5e-4 | (prev) | Dead @ step 15800 |
-| E | scale=0.001/clip=1.0/lr=5e-4 | gtur4oew | Dead @ step 14706 (scale delays but doesn't prevent divergence) |
-| **B** | **zero-init/clip=0.5/lr=4e-4** | **jov1kcjl** | **Healthy ep2≈99%; ETA ~14:25 UTC** |
-
-- **Key finding:** FiLM stability axis is LR alone, not init_scale. scale=0.001 delayed divergence 6× (step 2455→14706) but failure mode is identical (gamma/beta accumulate bias beyond critical threshold). The "escape path" via aggressive init scaling is falsified. lr=4e-4 (arm B) is the sole viable FiLM configuration. Final results pending ~14:25 UTC.
-
----
-
-## 2026-05-01 — PR #183: [fern] Omega-bank frequency sweep — IN FLIGHT (PARTIAL RESULTS)
-- Branch: `fern/omega-bank-sweep`
-- Hypothesis: Per-axis sincos positional encodings with different max_wavelength per axis (x=10000, y=2500-1000, z=2000-1000) directly encode the car's geometric anisotropy, helping the model learn the tau_y/z channels.
-- All 4 original non-guarded arms diverged (large-but-finite grad spikes bypassing NaN-skip):
-
-| Arm | Config | Div step | Max grad at div |
-|---|---|---:|---:|
-| A1 | mw=1000 | 7499 | 14.9M |
-| B | mw=100 | 15800 | 252 (sustained) |
-| C1 | 10000,2500,2000 | 14181 | 899 (cascading) |
-| D1/D2 | 5000/10000,1000,1000 | 3555/8799 | NaN/15019 |
-
-- mw=100 (arm B) is **structurally untenable** — 3 independent attempts (B, B2 guarded, B3 guarded+warmup) all diverged within 0.3-1.6 epochs. Falsified.
-- Surviving guarded arms as of 11:35 UTC:
-
-| Arm | Config | W&B run | ep1 val_abupt | ep2 ETA |
-|---|---|---|---:|---|
-| A2 | mw=1000 | bplngfyo | 17.72 | ~12:00 UTC |
-| C3 | 10000,2500,2000 | hm7p3lag | In flight (ep1 ~42%) | ~12:20 UTC |
-| D3 | 10000,1000,1000 | 4r0rd7dx | 17.23 | Ep2 ~12% |
-
-Ep1 for A2/D3 are worse than baseline ep1 (16.47) and worse on targeted tau_y/z axes. Ep3 comparison is the real test.
-- **Fleet-wide infrastructure finding:** PR #169's NaN-skip is necessary but not sufficient. Large-but-finite grad spikes (165, 252, 2.2M confirmed) bypass isfinite() check. Magnitude-based skip needed (pre_clip_norm > N × running_median).
-
----
-
-## 2026-05-01 — PR #165: [chihiro] mlp_ratio=8 hardened (3-seed + warmup) — IN FLIGHT
-- Branch: `chihiro/mlp-ratio-8-hardened`
-- Intermediate results (clip=1.0 sweep completed, clip=0.5 relaunch in progress):
-
-| Seed | clip | W&B run | Best val abupt | Notes |
-|---|---:|---|---:|---|
-| 42 (orig) | 1.0 | wuyxg6ze | — | NaN @ step 7167 |
-| 42 (r2) | 1.0 | elra20qm | — | NaN @ step 6783 |
-| 7 | 1.0 | 0n1eizhz | 18.50 (ep1 only) | Diverged @ step 13641 |
-| **1337** | **1.0** | **vch5jyhv** | **11.92 (ep3)** | **Finished, clean, does NOT beat 10.69** |
-| 42 (r3) | 0.5 | lkl2xob5 | In flight | Checkpoint ~12:20 UTC (prev div @ 6783) |
-| 7 (r2) | 0.5 | rypx2e36 | In flight | Checkpoint ~13:30 UTC (prev div @ 13641) |
-
-seed1337 ep3=11.92 is 1.23pp above baseline. Slope flattening (ep1→ep2: −5.29, ep2→ep3: −1.15) — would need 5-6+ epochs to possibly reach 10.69. clip=0.5 go/no-go is the active test.
-
----
-
-## 2026-05-01 — PR #168: [askeladd] Normal-consistency soft penalty — IN FLIGHT
-- Branch: `askeladd/normal-penalty-wallshear-yz`
-- Hypothesis: Soft λ·(τ·n̂)² penalty in normalized space penalizes out-of-plane wall-shear predictions.
-- Intermediate results: v1 (physical-space penalty) FAILED — physical-space amplification of τ_x via std_x²≈4.3 created asymmetric gradient. Correctly diagnosed and relaunched as v2 (normalized-space).
-
-| Arm | λ | clip | W&B run | ep1 val_abupt | Notes |
-|---|---:|---:|---|---:|---|
-| λ=0.01 (v1) | 0.01 | 1.0 | ufi2fg1e | — | NaN (physical-space penalty unstable) |
-| λ=0.05 (v1) | 0.05 | 1.0 | ol7r0oh6 | — | NaN (physical-space penalty spiky) |
-| λ=0.10 (v1) | 0.10 | 1.0 | uyorcld7 | — | NaN ep1 13.7% |
-| **λ=0.10 (v2)** | **0.10** | **1.0** | **gawdh7ah** | **17.103** | **Only stable arm; pen_phys dropping** |
-| λ=0.01 (v2 clip=0.5) | 0.01 | 0.5 | d14ee58k | In flight | Previous NaN @ step 7899 |
-| λ=0.05 (v2 clip=0.5) | 0.05 | 0.5 | (run id) | In flight | Previous NaN @ step 8499 |
-
-- **Key finding:** λ ranking inversion — larger λ MORE stable. Mechanism: at λ=0.01, constraint contribution (~1.6e-3) is too small to push model away from out-of-plane drift; single bad batch drives large squared-dot spike. At λ=0.10, constraint is strong enough to bound τ_pred magnitudes, preventing the spike. This is the opposite of standard regularization intuition.
-- pen_raw plateaus ~0.13 (fixed normalized-space cost); pen_phys drops 0.55→0.07 (physical tangentiality residual decreasing = model IS learning to satisfy geometric constraint).
-
----
-
-## 2026-05-01 — PR #123: [frieren] asinh/log wall-shear target normalization — IN FLIGHT
-- Branch: `frieren/asinh-log-target-normalization`
-- Intermediate results (key finding: asinh-1.0 trades metric for stability):
-
-| Arm | Normalization | W&B run | ep1 val_abupt | ep2 val_abupt | grad_skips | Notes |
-|---|---|---|---:|---:|---:|---|
-| A (v3p1) | Control | w8ecb8rp | — | 46.69 | 6543 (39%) | Pathological |
-| C (v3) | asinh scale=1.0 | xtx426rb | **17.55** | **45.69** | 5 | ep1 OK, ep2 collapsed |
-| D (v3p1) | log1p | 8oytk5ef | — | 22.35 | 0 | Healthier than control |
-| B (v3p1) | asinh-0.5 | zznrzvw5 | 18.94 | — | 0 | In flight ep2 |
-
-- **Key finding:** asinh-1.0 compresses the heavy tail → suppresses gradient explosions (0 skips vs 50%+) but also suppresses learning signal where the y/z gap lives. Train loss kept descending while val exploded ep2 (17.55→45.69) = classic underfitting of tail domain. asinh-1.0 is not a viable target transformation.
-- D (log1p) and B (asinh-0.5) are healthier but still above baseline trajectory. Final results pending ~12:10-13:51 UTC.
-
-
----
-
-## 2026-05-01 14:00 — PR #168: [askeladd] Normal-consistency penalty (soft tangential constraint)
-- Branch: `askeladd/normal-penalty-wallshear-yz`
-- Hypothesis: Add λ·mean(dot(τ_pred, n̂)²) auxiliary loss in normalized space to softly enforce wall-shear tangentiality without coordinate-frame discontinuities (vs PR #121's hard Duff-ONB reparam).
-- Results: 3 arms swept λ ∈ {0.01, 0.05, 0.10}; all v1 NaN'd in physical-space due to per-axis std mismatch; v2 reverted to normalized-space.
-
-| Arm | λ | W&B run | ep1 val_abupt | ep2 val_abupt | Stability |
-|---|---:|---|---:|---:|---|
-| C | 0.01 | (NaN ep1) | — | — | Diverged ep1 even w/ clip 0.5 |
-| B | 0.05 | 1buc9rh1 | 15.875 | NaN | Best ep1 of any arm; ep2 spike |
-| A | 0.10 | gawdh7ah | — | **12.285** | Stable; ep3 ~14.4 |
-
-- **Counter-intuitive ranking:** larger λ more stable. Small λ insufficient to anchor τ_pred; out-of-plane drift produces a squared-dot loss spike that overwhelms clip=1.0 → corrupts Adam m,v.
-- **Verdict: NEGATIVE.** λ=0.10 ep2 12.285 was the first crossover vs fern PR #99 ep2 trajectory (12.417), but ep3 regressed to 14.4 vs final baseline 10.69.
-- **Combined with PR #121 (hard tangentiality, also negative):** explicit tangentiality enforcement provides no metric improvement on this dataset; the model already learns near-tangential predictions naturally (pen_phys 0.55 → 0.07 unprompted in baseline).
-- Closed as negative; askeladd reassigned.
-
-## 2026-05-01 14:00 — PR #164: [alphonse] 8L/256d depth + 1cycle LR (time-limited recovery)
-- Branch: `alphonse/depth-8L-1cycle-recovery`
-- Hypothesis: Restore 8L/256d depth (PR #144 negative @ const lr=5e-4, val 12.69) by pairing with OneCycleLR super-convergence schedule. Sweep peak ∈ {5e-4, 6e-4, 8e-4} over 3 epochs.
-- Results: All three arms diverged before completing training.
-
-| Arm | Peak LR | Diverged step | Diverged at lr | Cause |
-|---|---:|---:|---:|---|
-| A | 5e-4 | ~10700 | ~5e-4 | pre_clip 4 → 151 → 1369 → 1e9 |
-| B | 6e-4 | ~10599 | ~6e-4 | pre_clip 2 → 229 → cascade |
-| C | 8e-4 | ~8500 | ~7.5e-4 | pre_clip 3.8 → 22 → 5131 → 254611 |
-
-- **Verdict: NEGATIVE.** 8L/256d has a hard LR ceiling below 5e-4 for sustained training. Combined with PR #144 (8L const-lr=5e-4 val=12.69), depth scaling at width=256 is exhausted — neither schedule can clear the throughput needed to beat 10.69.
-- **Future depth work must change architecture (pre-LN/sandwich-LN, AGC clipping, or width=384+) before revisiting depth.**
-- Closed as negative; alphonse reassigned.
-
-## 2026-05-01 14:00 — PR #123: [frieren] asinh/log wall-shear target normalization (heavy-tail fix)
-- Branch: `frieren/asinh-log-target-normalization`
-- Hypothesis: Apply asinh(τ/scale) or log1p(|τ|) target normalization to compress the heavy-tailed wall-shear distribution, expecting better fitted gradients and faster convergence to lower rel_L2.
-- Results: 4 arms in v3/v3p1 with `--grad-skip-threshold` 1k–5k; major contribution was the always-on NaN/inf grad-skip + threshold infra in train.py.
-
-| Arm | Normalization | W&B run | ep1 val_abupt | ep2 val_abupt | Notes |
-|---|---|---|---:|---:|---|
-| A (v3p1) | Control | w8ecb8rp | — | 46.69 | 6543 grad-skips (39%); pathological |
-| C (v3) | asinh scale=1.0 | xtx426rb | **17.55** | 45.69 | ep1 best; ep2 train/val divergence |
-| D (v3p1) | log1p | 8oytk5ef | — | 22.35 | Healthier but well above baseline |
-| B (v3p1) | asinh-0.5 | zznrzvw5 | 18.94 | — | ep2 in flight |
-
-- **Verdict: NEGATIVE.** Best variant (asinh-1.0 ep1) val 17.55 vs baseline 10.69 (64% worse).
-- **Mechanism:** asinh suppresses gradient explosions by compressing the tail (0 grad-skips vs 50%+) but suppresses the very signal where the y/z gap lives. Train loss kept descending while val exploded → classic tail underfit.
-- **Open finding: universal ep1→ep2 train/val divergence** across all 4 norm variants is a separate failure mode worth pursuing — candidates: train/eval sampling distribution mismatch, overfitting-to-bulk regime, z-score saturation on tails. Suggests assigning a one-shot LR drop after ep1 experiment.
-- **Major contribution to retain:** `--grad-skip-threshold` + always-on NaN/inf grad-skip + W&B `train/grad/skipped_step|skipped_total` metrics. Will land independently on yi.
-- Closed as negative; frieren reassigned.
-
----
-
-## 2026-05-01 14:30 — PR #201: [nezuko] Physics-informed RANS divergence-free penalty on volume velocity
-- Branch: `nezuko/physics-informed-rans-divergence`
-- Hypothesis: Add soft λ·mean(∇·u²) divergence-free penalty on volume velocity predictions to improve near-wall flow coherence and reduce tau_y/z error.
-- Results: 4-arm sweep λ∈{0.001, 0.01, 0.1, 0.0 control}
-
-| Arm | λ | W&B run | ep1 val_abupt | Fate |
-|---|---:|---|---:|---|
-| A orig | 0.001 | rtoy6zsi | DNF | NaN at step 2873 (>200 non-finite skips) |
-| A clamp | 0.001 | t0ak5zjy | DNF | Clamp(-10,10) didn't help; diverged same step |
-| B orig | 0.01 | xo1vzowt | DNF | NaN at step 5882 |
-| B clamp | 0.01 | qnk5doi7 | DNF | NaN at step 4546 |
-| **C** | **0.1** | **pe2ryffk** | **63.09** | **Stable but catastrophically worse (4×)** |
-| D | 0.0 | 8u7jc8kt | 15.55 | Control — healthy baseline trajectory |
-
-- **CRITICAL DATA FINDING:** GT labels have RMS(τ·n)/|τ| = 12% (τ·n mean=0.113, RMS=0.364, p99=1.722). DrivAerML mesh-discretized normals are not exactly orthogonal to the analytic surface, so the continuum no-slip constraint (τ·n = 0) directly contradicts the ground truth. There is no λ where this penalty can help:
-  - Small λ: batch-variance gradients from squared penalty too large → NaN cascade
-  - Large λ: forces τ_pred·n → 0, but labels have τ·n ≈ 0.36 → 2× train loss inflation, 4× val regression
-- **VOLUME ARCHITECTURE FINDING:** volume_y is scalar pressure only (no velocity in input or output contract). True ∇·u formulation is infeasible without adding a velocity head and separate supervision.
-- **Verdict: NEGATIVE.** Both the surface no-slip-wall penalty and the volume divergence-free penalty are infeasible with the current DrivAerML data contract and ground-truth labels.
-- Closed; nezuko reassigned.
+- Commentary: Clean negative. Locality bias hypothesis falsified. Key findings:
+  1. **No tau_y/z-specific improvement** — all metrics degrade uniformly with more KNN layers; the gap ratio is not selectively reduced.
+  2. **Monotonic degradation**: 0L=17.64 → 2L k=32=19.91 → 2L k=64=24.10. Every additional KNN layer hurts.
+  3. **KNN compute overhead ~4–9× per step** means Arms C/D ran less than 1 epoch in the 270-min budget, so comparisons are slightly biased against KNN arms — but the directional signal is unambiguous.
+  4. **Volume pressure catastrophic regression**: +39% (Arm C) to +82% (Arm D) vs control, suggesting the shared FFN between surface KNN tokens and volume global-attention tokens acts as a leak path degrading the well-solved volume-pressure head.
+  5. **The tau_y/z gap is NOT a locality/receptive-field problem.** The Transolver global-attention mechanism already has sufficient receptive field; adding KNN locality layers actively interferes with the learned global representation.
+  - Peak VRAM: A=74.8GB, B=72.1GB, C=71.4GB, D=72.2GB on H200 96GB.
+  - Direction closed. Do not re-assign local surface attention variants.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -367,3 +367,60 @@
 - Hypothesis: Cosine annealing + FiLM conditioning compose orthogonally on 6L base.
 - Results: abupt=19.27 (W&B `duv7m45t`) — best val at epoch 1 (18.44), degraded monotonically thereafter.
 - Commentary: FiLM + cosine LR + cosine EMA on 6L creates a fragile stack. The interaction between the cosine LR schedule and the cosine EMA ramp produces unstable training. Cosine LR alone on 6L (without FiLM) is being tested in PR #67 kafka. Closed.
+
+---
+
+## 2026-05-01 06:30 — PR #131: [thorfinn] Log-magnitude wall-shear target normalization — CLOSED NEGATIVE
+- Branch: `thorfinn/log-magnitude-wallshear-targets`
+- Hypothesis: sign(x)*log1p(|x|/eps) normalization compresses heavy-tailed wall-shear distribution, improving y/z gap.
+- Results: best arm (eps=1.0, eps_low=0.10) → val abupt=11.03 vs baseline 10.69. wall_shear_y/z both regressed. Smaller eps (0.01, 0.10) caused pre_clip_norm spikes to 2M+ and NaNs (gradient of log1p near 0 is ~1/eps).
+- Commentary: NEGATIVE on primary metric and on the targeted sub-metric. The NaN/Inf-skip safeguard added in this PR (commit 2a8f7e4) is structurally valuable and orthogonal — should be cherry-picked into a utility PR. asinh transform (frieren #123, in-flight) is the smoother alternative.
+
+---
+
+## 2026-05-01 06:31 — PR #130: [tanjiro] Curriculum tau_y/z weighting schedule — CLOSED NEGATIVE
+- Branch: `tanjiro/curriculum-tau-yz-weighting`
+- Hypothesis: Linearly ramping W_y from 1→3 (and W_z parallel) across early training stabilizes Adam moments before reaching final upweight.
+- Results: 6/6 arm launches diverged. All hit Adam-second-moment desynchronization band around W_y≈2.7.
+- Commentary: NEGATIVE. Curriculum reweighting on top of existing W_y=W_z=2 base (effective surface gradient already ~3× volume) is structurally incompatible with Adam state. Per-component static reweighting at start (so m/v initialize correctly per channel) is the better path.
+
+---
+
+## 2026-05-01 06:32 — PR #124: [gilbert] RANS divergence constraint (Laplacian on pressure) — CLOSED NEGATIVE
+- Branch: `gilbert/rans-divergence-constraint`
+- Hypothesis: Soft penalty ∇²p ≈ 0 (kNN inverse-distance Laplacian, k=8, sdf_threshold=0.05) acts as physics-informed regularizer.
+- Results: λ≥0.01 destabilized training, λ=0.001 was a no-op. No signal at any λ.
+- Commentary: NEGATIVE — wrong physics. Δp=0 is incompressible-Stokes (creeping flow); real RANS has advective and turbulent stress terms. The right divergence constraint is ∇·u=0 on velocity targets, which requires loader changes to expose u. Reusable kNN Laplacian implementation is a keeper for future physics work.
+
+---
+
+## 2026-05-01 06:33 — PR #121: [askeladd] Surface-tangent-frame wall-shear head — CLOSED NEGATIVE
+- Branch: `askeladd/surface-tangent-frame-wallshear`
+- Hypothesis: Reparametrize wall-shear prediction as τ = a·t1 + b·t2 in tangent frame (Duff 2017 ONB) to factor out normal direction and improve y/z accuracy.
+- Results: Worse than global Cartesian baseline at every checkpoint. Lr=3e-4, clip=0.3 delayed but didn't prevent gradient explosion.
+- Commentary: NEGATIVE. Two structural problems: (1) Duff branchless ONB is discontinuous along t1.x sign-flip — adjacent surface patches with similar normals map to opposite (a,b) targets, and a non-gauge-equivariant Transolver can't learn discontinuous frames. (2) τ_y/τ_z share (a,b) weights → channel coupling in Adam → correlated gradient spikes. Continuous frame (heat-method, PCA-aligned) or soft normal-component penalty are the right alternatives.
+
+---
+
+## 2026-05-01 06:34 — PR #118: [chihiro] MLP ratio sweep 6/8 — CLOSED AMBIGUOUS
+- Branch: `chihiro/mlp-ratio-sweep-r4`
+- Hypothesis: Wider FFN intermediate dim (mlp_ratio=6 or 8) increases capacity per layer without depth penalty.
+- Results: 12/16 runs diverged. 4 valid epoch-1 vals; mlp_ratio=8 trended slightly better than mlp_ratio=4 baseline but no convergent comparison vs 10.69.
+- Commentary: AMBIGUOUS — seed-dependent gradient instability (same as alphonse #117). Recommend re-running mlp_ratio=8 under stability-hardened recipe: 1k-step linear LR warmup from 1e-5, --seed flag, lr=3e-4. If stabilized, +3M params with clear epoch-1 trend signal is worth pursuing.
+
+---
+
+## 2026-05-01 06:35 — PR #129: [senku] Surface loss weight sweep on PR #99 base — CLOSED NEGATIVE
+- Branch: `senku/surface-loss-upweight-sweep`
+- Hypothesis: Uniform surface_loss_weight ∈ {1.5, 2.0, 2.5, 3.0} on PR #99 base improves surface metrics.
+- Results: 8 arms total (A/B/C/D + R1/R2/R3/R4 rescue at lr=3e-4, lr=2e-4, varying clips). 7 diverged. R4 (lr=2e-4, clip=0.5, 1k warmup, W&B `jtx73lg0`) was only stable arm but killed by external pod restart at step 27752 mid-ep3. Best partial: R3 ep2 abupt=12.84 vs baseline ep2=12.42 (already behind, then destabilized).
+- Commentary: NEGATIVE. Monotone instability with sw confirmed: D@8k → A@18.6k → C@19.7k → B@20.7k. Base config already has W_y=W_z=2 (effective surface gradient ~3× volume); uniform sw≥1.5 amplifies the entire bundle including upweighted y/z, exceeding stability ceiling. Per-component reweighting (--wallshear-y/z-weight only) is the right knob, not uniform --surface-loss-weight.
+
+---
+
+## 2026-05-01 06:36 — PR #117: [alphonse] Width scale-up sweep 384d + 8L depth — CLOSED NEGATIVE (PROMISING SIGNAL)
+- Branch: `alphonse/width-384d-sweep`
+- Hypothesis: Scale up Transolver width to 384d (4h or 6h) or depth to 8L for capacity gain.
+- Results: 8L/256d (W&B `xl92i3f5`, lr=3e-4) reached val abupt=11.33 at partial ep3, slope -0.59 abupt-pct/1k steps; extrapolated baseline crossing at ~step 26,500 but train_timeout=270min fired at step ~25,400. Test: abupt=12.44, volume_pressure=13.84 (only sub-metric beating baseline 14.42). Both 6L/384d arms diverged at all LRs (5e-4, 3e-4, 2e-4); d_head=96 destabilized earlier than d_head=64.
+- Commentary: NEGATIVE on merge bar but PROMISING. 8L/256d was time-limited not architecture-limited — depth is the viable scale-up direction. Width 384d needs QK-norm or fp32 attention to be stable in bf16. Round-6 priority: revisit 8L/256d combined with 1cycle LR for super-convergence.
+

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -424,3 +424,34 @@
 - Results: 8L/256d (W&B `xl92i3f5`, lr=3e-4) reached val abupt=11.33 at partial ep3, slope -0.59 abupt-pct/1k steps; extrapolated baseline crossing at ~step 26,500 but train_timeout=270min fired at step ~25,400. Test: abupt=12.44, volume_pressure=13.84 (only sub-metric beating baseline 14.42). Both 6L/384d arms diverged at all LRs (5e-4, 3e-4, 2e-4); d_head=96 destabilized earlier than d_head=64.
 - Commentary: NEGATIVE on merge bar but PROMISING. 8L/256d was time-limited not architecture-limited — depth is the viable scale-up direction. Width 384d needs QK-norm or fp32 attention to be stable in bf16. Round-6 priority: revisit 8L/256d combined with 1cycle LR for super-convergence.
 
+---
+
+## 2026-05-01 07:30 — PR #143: [fern] coordinate normalization sweep — CLOSED NEGATIVE
+- Branch: `fern/coord-normalization-sweep`
+- Hypothesis: Anisotropic bbox (x~8m, y/z~2-2.5m) makes `ContinuousSincosEmbed` give x-axis ~3-4× more frequency resolution than y/z, contributing to the 4× tau_y/z gap. Adding `--coord-normalize {none, global-scale, per-axis}` should restore isotropy.
+- Results: Hypothesis falsified across 9 attempts.
+
+| Mode | First-epoch abupt | vs control | Notes |
+|---|---:|---:|---|
+| none (control) | ~16.20 | — | matches PR #99 e1, then hits fleet-wide stochastic divergence in e2 |
+| global-scale | 24.85 | +8.65 (+53%) | normalizing to unit cube destroys sincos expressiveness — omega bank is calibrated for meter-scale geometry |
+| per-axis (4 variants) | diverged | — | volume tokens (~25× wider domain than vehicle bbox) get extreme out-of-range coords → MLP bias → slice attention gradient explosion |
+
+- Commentary: Coordinate normalization is the wrong lever — it breaks the fixed-frequency `omega` bank tuned for meter-scale wavelengths. The 4× tau_y/z gap is **NOT primarily** a sincos-anisotropy problem. Right next attack: tune the omega bank directly in physical-meter coords (denser/per-axis frequency basis on y/z), preserving meter-scale calibration. **Bug-fix side-discovery:** confirmed ~50% fleet-wide divergence at lr=5e-4. Non-finite/large-grad skip guard from haku (commit `6e8b674`) is already on `yi` so future runs are protected. **Decision: closed** — coord-normalize feature not merged. Fern reassigned to PR #183 (omega-bank anisotropic frequency sweep).
+
+---
+
+## 2026-05-01 07:30 — PR #126: [kohaku] FiLM geometry conditioning on PR #99 6L/256d base — CLOSED NEGATIVE (PROMISING SIGNAL)
+- Branch: `kohaku/film-conditioning-6l-256d`
+- Hypothesis: FiLM (PR #8 frieren code) + lr=5e-4 (PR #99 fern base) is additive — global geometry prior plus fast convergence.
+- Results: Hypothesis falsified across all 4 arms.
+
+| Arm | lr | clip | Diverge step | Best partial | W&B |
+|---|---:|---:|---:|---|---|
+| 1 | 5e-4 | 1.0 | ~15.3k (mid e2) | n/a | h6nlfcdr |
+| 2 | 5e-4 | 0.5 | ~12.4k (mid e2) | n/a | 3ddue2xd |
+| 3 | 4e-4 | 0.5 | ~30.1k (mid e3) | abupt=11.67, **vp=7.05** (e2) | sudqmuo9 |
+| 4 | 3e-4 | 0.5 | ~19.0k (mid e2) | n/a | jd1acg1t |
+
+- Commentary: Best partial (Arm 3 e2 abupt=11.67) is still 0.98pp worse than baseline 10.69. **lr=3e-4 (Arm 4) failed earlier than lr=4e-4 (Arm 3)** — pure LR reduction is not the lever. Root cause from forensics: `train/film/geom_token_norm_mean` was steady (~0.73-0.81) at all 4 divergence points (geom token is fine); layer-0 `to_gamma_beta/bias grad_to_param_norm=0.567` flagged the FiLM linear projections as the gradient amplification path. FiLM × LR ≥ 3e-4 has a fundamental stability ceiling at default-init. **Promising signal:** Arm 3 e2 vp=7.05 vs baseline 7.85 — FiLM helps volume more than surface, exactly the metric closest to AB-UPT (1.3× away). The direction is right; the failure mode is dynamics, not capability. **Decision: closed** — kohaku reassigned to PR #184 (FiLM with identity/zero-init, DiT-style stable conditioning).
+

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -6,6 +6,43 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 
 ## Round 1 — opened 2026-04-28
 
-_No completed PRs yet. Round 1 launches 16 parallel experiments: 5 known-good
-baselines / proven-additive deltas (Stream 1) and 11 fresh single-delta hypotheses
-(Stream 2)._
+Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
+deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
+
+## 2026-04-29 02:30 — PR #12: stochastic depth / DropPath p=0.1 (nezuko) — CLOSED
+
+- Branch: `nezuko/round1-stochastic-depth`
+- Hypothesis: linear-schedule DropPath (max p=0.1 at deepest layer) regularizes the
+  Transolver and gives ~10% throughput from skipped residual branches.
+
+| Metric | nezuko (DropPath p=0.1, `mdo2p8q7`) | norman (no DropPath, `akbdunir`) | AB-UPT target |
+|---|---:|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **81.21** | 64.66 | — |
+| `test_primary/surface_pressure_rel_l2_pct` | 66.49 | 48.43 | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 84.27 | 66.89 | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 69.42 | 55.54 | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 75.40 | 55.54 | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 102.42 | 90.15 | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 92.32 | 73.66 | 3.63 |
+
+**Result: rejected (+16.5 pp worse on abupt_axis_mean than no-DropPath).**
+
+**Analysis:** both nezuko and norman finished with `best_epoch=1`. Train loss
+keeps falling, EMA-val degrades from epoch 1 onward — the runs are firmly in
+the underfitting regime, not the overfitting regime where regularization helps.
+Stochastic depth adds noise to the residual signal without addressing the
+binding constraint (insufficient optimizer steps to convergence at this
+4L/256d/4h/128sl + 65k-points config inside the 6 h timeout).
+
+**Important byproduct: per-step timeout fix.** nezuko shipped a `train.py` fix
+(commit `1ab3a9b`) that adds a per-step wall-clock timeout check, reserves
+`SENPAI_VAL_BUDGET_MINUTES` (default 90), and forces a final validation when
+mid-epoch timeout fires. Cherry-picked into `yi` as commit `af92e9a` and
+broadcast to all active Round-1 PRs. This unblocks every 65k-points run from
+the silent "epoch longer than timeout → no test_primary" failure mode that
+trapped the prior `u38zaxeg` attempt.
+
+**Round-1 follow-ups triggered:**
+- Recommend `--validation-every 1` (or 2) for all Round-1 runs.
+- Flagged the train→val divergence pattern across runs for all students to
+  report and investigate.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -9,6 +9,38 @@ Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
 Round 1 launches 16 parallel experiments: 5 known-good baselines / proven-additive
 deltas (Stream 1) and 11 fresh single-delta hypotheses (Stream 2).
 
+## 2026-04-29 — PR #20: EMA decay sweep diagnostic (nezuko) — CLOSED, diagnostic value (verdict (B) confirmed)
+
+- Branch: `nezuko/round2-ema-decay-sweep`
+- Hypothesis: disambiguate (A) EMA-too-slow vs (B) genuine post-epoch-1 instability for the train→val divergence pattern observed across multiple Round-1 runs.
+- 4-arm sweep: `--ema-decay ∈ {0.99, 0.999, 0.9995, 0.99995}` parallel across 4 GPUs, all with `--validation-every 1`. ~2 full epochs + truncated epoch 3 each. Peak GPU 13.3 GB.
+- W&B group: [`nezuko-ema-sweep`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/groups/nezuko-ema-sweep)
+
+| EMA decay | best_epoch | abupt_axis_mean (test_primary) | full_val_primary abupt | E1 train | E2 train | E1 val_abupt | E2 val_abupt |
+|---|:---:|---:|---:|---:|---:|---:|---:|
+| 0.99 | 1 | 27.67 | 26.93 | 0.278 | 1.217 | 26.93 ⭐ | 79.26 |
+| 0.999 | 3 | 69.54 | 69.01 | 0.222 | 0.923 | 76.29 | 73.41 |
+| 0.9995 | **1** | **24.74** | **24.46** | 0.228 | 0.411 | 24.46 ⭐ | 41.26 |
+| 0.99995 | 1 | 36.63 | 36.19 | 0.180 | 0.763 | 36.19 ⭐ | 124.32 |
+
+**Verdict: (B) genuine post-epoch-1 divergence. Decisive.**
+
+Evidence:
+1. **Even the most aggressive EMA arm (0.99, window ~100 steps) peaks at epoch 1.** If (A) were true, this arm — whose shadow ≈ live model — should have kept improving. It did not.
+2. **Train loss is non-monotonic across all four seeds:** every arm has live train loss 5–7× *higher* in epoch 2 vs epoch 1 (e.g. 0.99: 0.278 → 1.217). EMA cannot manufacture this; live optimization is diverging.
+3. **Per-step train/loss spikes hit 6–22× the median** in every arm; min train_loss reached at step 20–45k, then climbs. Divergence onset dates to step ~45–60k — exactly where missing gradient clipping becomes load-bearing under no-warmup, near-constant LR.
+4. The 0.999 outlier (best_val=76.29 at epoch 1) is consistent with this: its specific seed had divergence start *during* epoch 1 so the EMA shadow at step 43k is contaminated by the chaotic post-divergence tail.
+
+**Implications for ongoing work:**
+- **PR #22 (gilbert, gradient clipping) is the cure** for the binding constraint. When that lands, the entire fleet should re-evaluate.
+- **PR #5 (edward, cosine LR + warmup)** is complementary on the LR-schedule side — nezuko's data shows current `T_max=999` makes LR essentially constant at 2e-4 throughout, so the cosine decay is doing nothing.
+- `--ema-decay 0.9995` confirmed as the right default for this step regime; no change needed.
+- **Avoid 0.99995 and progressive 0.999→0.9999 schedule (norman PR #13)** for this step budget — the 0.9999 tail (window ~10k steps) over-averages into the divergent regime.
+
+**Note:** Best arm 24.74 abupt_axis_mean is well above current yi baseline (16.53/17.39). No code changes (CLI sweep only). Closed because it's diagnostic, not competitive.
+
+**Round-2 follow-up:** A01 (ANP cross-attention surface decoder) assigned to nezuko — the largest architectural win from noam branch (PR #2379 MERGED on TandemFoil: −70% in-domain p_s, −48% OOD).
+
 ## 2026-04-29 06:00 — PR #6: relative-L2 auxiliary loss (emma) — CLOSED, dead end
 
 - Branch: `emma/round1-metric-aware-aux-loss`

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -441,6 +441,29 @@
 
 ---
 
+## 2026-05-01 08:22 — PR #150: [emma] Multi-scale point hierarchy for tau_y/z gap — CLOSED NEGATIVE
+
+- Branch: `emma/multi-scale-hierarchy`
+- Hypothesis: PointNet++-style SetAbstraction coarsening (65536→16384→4096) wrapping Transolver with cross-scale attention will capture multi-scale spatial context and reduce tau_y/z error, which we hypothesize involves both large-scale flow structure and fine-scale boundary-layer gradients.
+- Results: 3 arms — 2-scale (stable), 3-scale (NaN divergence), 3-scale+stop-grad (plateau). W&B runs: `c4kc4465` (Arm A 2-scale), `k4glpuqg` (Arm B 3-scale), `kq3fvrvd` (Arm C 3-scale stop-grad).
+
+| Metric | Arm A 2-scale val | Baseline val | vs Baseline |
+|---|---:|---:|:---|
+| `abupt_axis_mean_rel_l2_pct` | 11.085 | **10.69** | WORSE +0.40pp |
+| `surface_pressure_rel_l2_pct` | 7.416 | **6.97** | WORSE +0.45pp |
+| `wall_shear_rel_l2_pct` | 12.437 | **11.69** | WORSE +0.75pp |
+| `wall_shear_y_rel_l2_pct` | 14.562 | **13.73** | WORSE +0.83pp |
+| `wall_shear_z_rel_l2_pct` | 15.701 | **14.73** | WORSE +0.97pp |
+| `volume_pressure_rel_l2_pct` | 6.912 | 7.85 | **BETTER −12%** |
+
+Test metrics (Arm A 2-scale, run `c4kc4465`): abupt 12.177 (vs 11.73 baseline, WORSE); volume_pressure 13.557 (vs 14.42 baseline, BETTER ~6%).
+
+Val slopes at end of run: abupt −0.156/1k steps, wall_shear_y −0.191/1k steps, wall_shear_z −0.234/1k steps (still converging, budget-limited, but gap of 0.4pp unlikely to close).
+
+- Commentary: Multi-scale SetAbstraction hierarchy did not improve tau_y/z as hypothesized. 3-scale arms both failed: NaN divergence (k4glpuqg, ~step 23.5k epoch 2.16) and loss plateau at 5.4 (kq3fvrvd). The 2-scale arm was stable but all primary metrics were worse than baseline. The only positive signal is volume_pressure (~12% improvement on val, ~6% on test) — possibly because coarse-scale aggregation acts as a spatial smoother on volumetric quantities. The tau_y/z failure reinforces that the 4× gap is not a spatial-receptive-field problem — it appears to be a loss/target-representation or coordinate-frame problem. **Decision: closed** — emma reassigned to PR #185 (SAM optimizer, ρ=0.05/0.10).
+
+---
+
 ## 2026-05-01 07:30 — PR #126: [kohaku] FiLM geometry conditioning on PR #99 6L/256d base — CLOSED NEGATIVE (PROMISING SIGNAL)
 - Branch: `kohaku/film-conditioning-6l-256d`
 - Hypothesis: FiLM (PR #8 frieren code) + lr=5e-4 (PR #99 fern base) is additive — global geometry prior plus fast convergence.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,0 +1,11 @@
+# SENPAI Research Results — DrivAerML (`yi`)
+
+W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`.
+Targets to beat (lower is better): `surface_pressure 3.82`, `wall_shear 7.29`,
+`volume_pressure 6.08`, `tau_x 5.35`, `tau_y 3.65`, `tau_z 3.63`.
+
+## Round 1 — opened 2026-04-28
+
+_No completed PRs yet. Round 1 launches 16 parallel experiments: 5 known-good
+baselines / proven-additive deltas (Stream 1) and 11 fresh single-delta hypotheses
+(Stream 2)._

--- a/research/RESEARCH_IDEAS_2026-04-28_INITIAL.md
+++ b/research/RESEARCH_IDEAS_2026-04-28_INITIAL.md
@@ -1,0 +1,52 @@
+# DrivAerML Round 1 — Hypothesis Pool
+**Generated:** 2026-04-28 · **Researcher:** researcher-agent
+
+Targets (AB-UPT, lower is better): `p_s=3.82%`, `tau=7.29%`, `p_v=6.08%`,
+`tau_x=5.35%`, `tau_y=3.65%`, `tau_z=3.63%`
+
+Ranked by expected impact / implementation cost ratio.
+Bias toward `wall_shear` and `volume_pressure` (hardest metrics).
+
+---
+
+## Tier 1 — high impact, low complexity
+
+| # | Name | Summary | Target | PR |
+|---|---|---|---|---|
+| H01 | Per-Axis Wall-Shear Loss Weights | Upweight tau_x/y/z channels (2–4x) vs cp; MSE blind to 2x error gap | tau (7.29%) | #10 (haku) |
+| H02 | Volume Loss Upweighting | Single `--volume-loss-weight 2–3` flag; volume head undertrained vs surface | p_v (6.08%) | #9 (gilbert) |
+| H04 | Tangential Wall-Shear Projection | Project predicted/target wall-shear onto tangent plane; removes unphysical normal component | tau axes | #11 (kohaku) |
+| H07 | Scale slices+hidden | slices 96→192, hidden 192→256; capacity-limited architecture | all | (askeladd #3 covers this) |
+| H08 | Deeper Model 5L | model_layers 3→5; depth for multi-scale flow features | all | #14 (senku) |
+
+## Tier 2 — medium impact, targeted mechanism
+
+| # | Name | Summary | Target | PR |
+|---|---|---|---|---|
+| H06 | SDF-Gated Volume Attention | Bias slice routing toward near-wall volume points (small |SDF|) | p_v (6.08%) | #15 (tanjiro) |
+| H09 | Progressive EMA Decay | Anneal EMA 0.99→0.9999 cosine; diffusion model recipe for sharper final ckpt | test ckpt | #13 (norman) |
+| H15 | Stochastic Depth | Linear DropPath 0–10%; regularizer + ~10% throughput gain | generalization | #12 (nezuko) |
+| H18 | TTA Bilateral Symmetry | Mirror xz-plane at inference, average; free ensemble at zero training cost | tau_y | #16 (thorfinn) |
+| H10 | Dropout Reg | `model_dropout=0.05`; small-data transformer standard | generalization | (reserved) |
+
+## Tier 3 — novel physics-informed ideas
+
+| # | Name | Summary | Target | Complexity |
+|---|---|---|---|---|
+| H03 | Joint H01+H02 | Combined channel rebalancing (stack H01 and H02 wins) | all | Small |
+| H05 | Spectral Gradient Loss | Penalize spatial smoothness errors via finite-diff gradient on surface k-NN | tau | Medium |
+| H11 | Divergence-Free Wall-Shear | Penalize surface divergence of predicted wall-shear (should → 0 at no-slip wall) | tau | Medium-Large |
+| H12 | Curvature Feature Augment | Append mean/Gaussian curvature to surface_x (7D→9D); explicit shape signal | p_s, tau | Large |
+| H13 | Geometry Complexity Curriculum | Train on simpler cars first; only useful if hard-case gap is the bottleneck | p_s, tau | Medium |
+| H14 | Multi-Resolution Volume | SDF-stratified near-wall oversampling or hierarchical cross-attention | p_v | Medium-Large |
+| H16 | Delta Learning from Prior | Predict RANS residual from inviscid prior; reduces target dynamic range 50-80% | all | Large |
+| H17 | SO(3) Frame Normalization | Canonicalize vehicle orientation; reduces orientation variance in xyz features | all | Medium |
+| H19 | Weight Decay Sweep | AdamW wd sweep [0.001, 0.01, 0.05]; standard small-data regularization | all | Small |
+| H20 | K-Means Slice Init | Seed slice tokens from K-Means on training geometry; warm-start routing | all | Medium |
+
+---
+
+## Round 1 coverage
+
+All Tier 1 and most Tier 2 ideas are covered by the 16 Round-1 PRs (#2–#17).
+Tier 3 and H03 (combination) reserved for Round 2 once baseline is established.

--- a/research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.md
+++ b/research/RESEARCH_IDEAS_2026-04-28_ROUND2_ARCHITECTURES.md
@@ -1,0 +1,772 @@
+# DrivAerML Round 2 — Bold Architecture Replacements
+**Generated:** 2026-04-28 · **Researcher:** researcher-agent · **Trigger:** Issue #18
+
+Targets (AB-UPT, lower is better): `p_s=3.82%`, `tau=7.29%`, `p_v=6.08%`,
+`tau_x=5.35%`, `tau_y=3.65%`, `tau_z=3.63%`
+
+**Motivation:** Issue #18 directs Round 2 to be architecturally bold — completely
+replacing the Transolver backbone is explicitly on the table. All H01–H20 from
+Round 1 are excluded from this list. Cross-reference findings from the `noam`
+branch (2D TandemFoil dataset, architecturally informative) and `radford` branch
+(DrivAerML 3D, incremental tuning only) are incorporated below.
+
+**Model interface contract (must be preserved):**
+```python
+out = model(
+    surface_x=batch.surface_x,   # [B, N_surface, 7]  (x,y,z,nx,ny,nz,area)
+    surface_mask=batch.surface_mask,
+    volume_x=batch.volume_x,     # [B, N_volume, 4]   (x,y,z,sdf)
+    volume_mask=batch.volume_mask,
+)
+surface_pred_norm = out["surface_preds"]  # [B, N_surface, 4]
+volume_pred_norm  = out["volume_preds"]   # [B, N_volume, 1]
+```
+
+---
+
+## Architecture Family Cross-Reference from noam Branch
+
+Key confirmed wins on TandemFoil (2D; lessons transfer to 3D structure):
+
+| PR | Idea | Outcome |
+|---|---|---|
+| #2379 MERGED | **ANP cross-attention decoder** — query surface nodes attend to all context nodes | p_in -70%, p_oodc -48%, p_tan -59% — largest single improvement in programme history |
+| #2377 MERGED | **SE(2)-equivariant geometry encoding** — rotation-invariant relative coordinates | Robust improvement across split types |
+| #2376 MERGED | **Mamba SSM surface decoder** — arc-length-ordered state-space traversal of surface | Clean gain over MLP decoder |
+| #2364 CLOSED | **DPOT pretrained backbone** — ICML 2024 universal PDE operator transfer | Inconclusive on TandemFoil; may be better suited to 3D geometry richness |
+| #2403 CLOSED | **Multi-fidelity panel pretraining** — 100k synthetic panel solutions then fine-tune | Promising but insufficient compute in original run |
+| #2366 CLOSED | **MoE domain-expert FFN** — deterministic routing per foil region | Routing collapse; soft routing worth retrying |
+| #2370 CLOSED | **Surface-intrinsic B-GNN decoder** — boundary graph over mesh connectivity | Degraded, likely due to graph construction mismatch at inference |
+| #2371 CLOSED | **1D surface FNO decoder** — spectral convolution on arc-length sequence | Mixed; spectral basis may not generalise to 3D closed surfaces |
+| #2402 CLOSED | **Flow matching generative surface head** — rectified flow decoder | Slow convergence; architecture mismatch for regression |
+| #2378 CLOSED | **Contrastive geometry pretraining** | Not tried on 3D; has clear 3D analogue |
+
+**Radford branch finding:** zero genuine backbone-replacement experiments for
+DrivAerML in 200 PRs. All radford is incremental optimisation. The 3D
+architecture space is essentially untouched.
+
+---
+
+## Tier A — Highest Priority (clear mechanism, strong prior art)
+
+### A01 · Attentive Neural Process (ANP) Surface Decoder
+**Architectural change:** Replace Transolver's MLP projection head on the surface
+stream with a cross-attention ANP decoder. Surface query points attend (scaled
+dot-product) to a latent context set built from the Transolver encoder's slice
+tokens. The latent context captures global shape; queries resolve local geometry.
+
+**Mechanism:** The ANP win on TandemFoil (#2379, MERGED) is the single largest
+improvement in programme history. The key insight is that surface predictions at
+each point should be conditioned on all other surface points via attention — not
+just the local slice token. DrivAerML has 3D geometry that is strictly richer
+than 2D foil, so the global context signal should be at least as strong.
+**Primary target:** tau (7.29%), tau_x (5.35%) — wall-shear has high spatial
+correlation across the surface; ANP's global context can exploit this.
+
+**Implementation sketch:**
+1. Keep the existing Transolver encoder (slice pooling → slice tokens → transformer blocks) as the context encoder.
+2. After the encoder, project slice tokens to a context set `C ∈ R^[B, S, D]` (S = num_slices).
+3. Replace the surface MLP head with a multi-head cross-attention block: queries from `surface_x` positional encoding, keys/values from `C`.
+4. Stack 2–3 cross-attention layers followed by a small MLP projector → 4D surface output.
+5. Volume head unchanged.
+
+**Key hyperparameters:** num_cross_attn_heads=8, cross_attn_depth=2,
+context_dim=256. Tie context_dim to existing model width.
+
+**Risk / failure mode:** The context set (slice tokens) may be too compressed
+to carry sufficient spatial resolution for shear stress. Mitigation: include
+a residual path that also passes surface encoder features directly.
+
+**noam cross-reference:** Direct port of PR #2379. Architecture is near-identical;
+main adaptation is from 1D arc-length to 3D spatial queries.
+
+**Complexity:** Medium. Replaces only the surface head — backbone unchanged.
+
+---
+
+### A02 · SE(3)-Equivariant Coordinate Encoding
+**Architectural change:** Replace the raw `[x, y, z, nx, ny, nz, area]` surface
+features and raw `[x, y, z, sdf]` volume features with SE(3)-equivariant relative
+features: for each point, compute pairwise or neighbourhood-relative vectors
+transformed via learned frame alignment (e.g. PCA of the local k-NN centred at
+each point, then express all coordinates in that local frame).
+
+**Mechanism:** The current Transolver uses absolute Cartesian coordinates. A
+rigid-body shift or rotation of the input geometry should not change flow predictions,
+yet the model must learn this invariance from scratch across 400 training cases.
+Equivariant encoding removes this burden. noam PR #2377 (MERGED) confirmed a
+robust gain from SE(2) on foil data. DrivAerML cars have full 3D orientation
+variance (yaw, road clearance variation). **Primary target:** tau axes — the
+wall-shear components transform as pseudo-vectors under rotation; encoding them
+in a local equivariant frame reduces the learning burden for tau_x/y/z directly.
+
+**Implementation sketch:**
+1. For each surface/volume point, compute the 3D PCA frame of its 16-NN in the
+   point cloud (or use the normal vector + tangent from cross-product as the frame).
+2. Express all pairwise offset vectors in this local frame.
+3. Concatenate relative distance, relative normal dot products, local frame
+   coordinates as additional features (surface: 7D → 13D, volume: 4D → 8D).
+4. Keep the Transolver backbone unchanged — only the feature encoder changes.
+5. For tau prediction: additionally express the target and prediction in the
+   local surface tangent frame (this is H04's tangential projection, but now
+   applied to the feature representation not just the loss — complementary).
+
+**Key hyperparameters:** k=16 for NN frame, frame_dim=6 (2 tangent vectors + 1
+normal, each 3D).
+
+**Risk / failure mode:** Frame discontinuities at saddle points of the local PCA.
+Mitigation: use the known surface normal (already in the input) as the primary
+frame axis.
+
+**noam cross-reference:** Direct 3D extension of PR #2377. PCA frame generalises
+SE(2) rotation alignment to 3D.
+
+**Complexity:** Small–Medium. Feature preprocessing only; backbone unchanged.
+
+---
+
+### A03 · Perceiver IO Latent Decoder (Replace Transolver End-to-End)
+**Architectural change:** Replace the entire Transolver with a Perceiver IO
+architecture. A fixed-size latent array (`M=512` latent tokens, learned) is
+cross-attended to by the input surface/volume points, then all latent-to-latent
+self-attention is performed in the compressed latent space, then a second
+cross-attention decodes from latent tokens back to output query points.
+
+**Mechanism:** Transolver's slice attention is a special case of cross-attention
+where the latent tokens (slices) are adaptive. Perceiver IO generalises this
+with a cleaner separation: encoding is fully separate from decoding, the latent
+bottleneck is a hard capacity constraint that encourages global integration, and
+the decode step is a learned query per output point. This architecture was
+designed for irregular point-cloud inputs and has been applied to 3D mesh
+simulation (DeepMind's Perceiver IO, 2021; extended to physical systems in
+multiple follow-ups). **Primary target:** p_v (6.08%) — volume points are the
+most irregular, and Perceiver IO's input-agnostic latent compression should
+generalise to sparse volume query sets better than slice pooling.
+
+**Implementation sketch:**
+1. Concatenate surface and volume points as a single input set with a modality
+   embedding token (1 for surface, 0 for volume). Total input up to 70k points.
+2. Cross-attention from M=512 latent tokens to the input set (with learned latent
+   init). Standard multi-head attention with Flash attention for memory.
+3. 4–6 self-attention blocks on the latent array.
+4. Two decode heads: surface cross-attention from N_surface query embeddings to
+   latent → 4D; volume cross-attention from N_volume query embeddings to latent → 1D.
+5. Use RoPE positional encoding on spatial coordinates in both encode and decode.
+
+**Key hyperparameters:** num_latents=512, latent_dim=512, num_encode_heads=8,
+num_decode_heads=8, encode_depth=2, latent_depth=4, decode_depth=2.
+
+**Risk / failure mode:** The fixed latent bottleneck may be too small to retain
+fine-grained shear stress variation (tau has high spatial frequency near edges).
+Mitigation: increase M to 1024 or use a hierarchical Perceiver with two levels.
+
+**External evidence:** Perceiver IO (Jaegle et al., NeurIPS 2021) demonstrated
+strong performance on 3D point-cloud regression and optical flow. Applied to CFD
+by multiple groups (e.g., Lienen & Günnemann, ICLR 2022).
+
+**Complexity:** Large. Full backbone replacement. Requires careful memory
+management for 70k-point cross-attention.
+
+---
+
+### A04 · MeshGraphNet-Style Global+Local GNN
+**Architectural change:** Replace Transolver with a two-level GNN: (1) a local
+message-passing GNN over k-NN graphs built on surface and volume separately
+(radius graph, r=0.05 m), then (2) a global cross-attention step between the
+surface and volume graphs via a set of global aggregate tokens. Output heads
+are node-level MLPs.
+
+**Mechanism:** GNNs over physical meshes have been the dominant approach for
+CFD surrogate modelling (MeshGraphNet, DeepMind 2021; GNS, 2022). The key
+advantage over Transolver is that message passing respects the graph structure
+of CFD meshes — nearby points communicate directly at each layer, not through
+a global bottleneck. This should improve tau prediction quality in high-gradient
+regions (near A/B pillars, wheel arches) because local gradient information
+propagates more faithfully. **Primary target:** tau (7.29%) — wall shear stress
+is strongly determined by local flow gradients, which GNN local message passing
+captures better than global pooling.
+
+**Implementation sketch:**
+1. Build radius graph G_s on surface (radius=0.05, max_neighbours=32) and G_v
+   on volume (radius=0.1) at each forward pass.
+2. 4–6 Edge-Conv or GATv2 layers on each graph separately (node + edge features
+   include relative displacement, distance, normal dot product).
+3. Global mean-pooling of surface features → global token; cross-attend volume
+   nodes to global token.
+4. MLP heads for surface [N_surface, 4] and volume [N_volume, 1].
+5. Use torch_geometric for graph ops; precompute graphs in the dataloader
+   collate_fn to avoid per-forward overhead.
+
+**Key hyperparameters:** gnn_depth=6, gnn_hidden=256, edge_hidden=64,
+radius_surface=0.05, radius_volume=0.1, max_nbrs=32.
+
+**Risk / failure mode:** Radius graph construction at every forward pass is
+expensive (~50ms per batch). Mitigation: precompute in dataloader on CPU and
+pass as sparse adjacency in the batch.
+
+**External evidence:** MeshGraphNet (Pfaff et al., ICLR 2021); GNS (Sanchez-
+Gonzalez et al., ICML 2020). B-GNN (Jena et al., arXiv:2503.18638) is a
+recent variant specifically for boundary layers in CFD — close match.
+
+**Complexity:** Large. New dependency (torch_geometric or dgl).
+
+---
+
+### A05 · Neural Operator via Implicit Neural Field (INF) Decoder
+**Architectural change:** After the Transolver encoder, replace the MLP surface
+head with a coordinate-based neural field (NeRF/SIREN-style MLP conditioned on
+slice-token latents via FiLM). Each surface/volume point query is evaluated by
+a shared INF conditioned on a global latent extracted from the encoder.
+
+**Mechanism:** Neural fields (NeRF, SIREN, DeepSDF) proved that small MLP
+networks with sinusoidal activations can represent high-frequency spatial
+functions when conditioned on a global latent. For CFD: the pressure and shear
+fields are continuous functions of position on the surface manifold. An INF
+decoder can represent these with higher spatial resolution than a slice-indexed
+MLP head, especially near high-gradient regions (stagnation point, wheel arch).
+**Primary target:** p_s (3.82%), tau axes — pressure and shear are smooth
+functions of position that an INF should represent efficiently.
+
+**Implementation sketch:**
+1. Keep encoder unchanged (Transolver up to final layer).
+2. Project final slice tokens to a global latent `z ∈ R^[B, 256]` via mean-pool.
+3. INF decoder: 4-layer SIREN MLP (omega_0=30, hidden=256) that takes `[xyz, z]`
+   as input via FiLM (scale/shift from `z`, input coordinates transformed with
+   sin(omega_0 * Wx)).
+4. Separate INF heads for surface (output 4D) and volume (output 1D).
+5. Optionally: condition on local normal / SDF in addition to global `z`.
+
+**Key hyperparameters:** siren_omega=30, siren_depth=4, siren_hidden=256,
+film_hidden=128. Initialise SIREN weights per Sitzmann et al. (2020) scheme.
+
+**Risk / failure mode:** SIREN is sensitive to weight initialisation; wrong
+omega_0 leads to spectral collapse. Mitigation: use the analytic init from the
+original SIREN paper (NeurIPS 2020), or use Fourier features (Tancik et al.,
+NeurIPS 2020) as a safer alternative.
+
+**External evidence:** SIREN (Sitzmann et al., NeurIPS 2020); Fourier Features
+Network (Tancik et al., NeurIPS 2020); Neural Radiance Fields applied to flow
+(FlowNeRF, multiple papers 2022–2024).
+
+**Complexity:** Medium. Replaces only the prediction head; encoder unchanged.
+
+---
+
+## Tier B — Strong Mechanistic Basis, Moderate Risk
+
+### B01 · Denoising Diffusion Pretraining then Fine-Tune
+**Architectural change:** Pretrain the Transolver backbone (or Perceiver IO from
+A03) as a denoising score network on the combined surface+volume point cloud:
+corrupt input coordinates and features with Gaussian noise, train the encoder
+to reconstruct the clean signal. Then fine-tune the pretrained backbone on the
+supervised CFD regression task with a small learning rate on the encoder and
+full LR on the prediction heads.
+
+**Mechanism:** With only 400 training cases, the backbone may underfit to the
+geometric distribution of car shapes. Denoising pretraining forces the model
+to learn a rich representation of the point cloud geometry — independent of
+the regression targets. At fine-tune time, these learned geometry features
+should provide better initialisation than random weights. This is the CFD
+analogue of ImageNet pretraining for vision models. SSL by denoising was
+confirmed as promising on noam (PR #2378 contrastive pretraining; PR #2403
+multi-fidelity panel pretraining). **Primary target:** p_v (6.08%), tau (7.29%)
+— the hardest targets, most likely to benefit from richer geometry representations.
+
+**Implementation sketch:**
+1. Pretraining phase: add Gaussian noise to `surface_x` coordinates (std=0.01 m)
+   and train the encoder + a lightweight decoder head to reconstruct the original
+   coordinates. Use DDPM-style noise schedule (cosine, T=100 discrete steps).
+   Loss = MSE on denoised coordinates only (no regression targets).
+   Pretraining data: augment with the 50 test-set point clouds (geometry only,
+   no labels) — this is legal since labels are withheld.
+2. Fine-tune phase: load pretrained encoder weights, freeze for 5 epochs, then
+   unfreeze with lr_encoder=1e-5, lr_heads=5e-4.
+3. The 50 test geometry point clouds can be used for pretraining (no labels
+   needed) — gives 50 extra geometry samples.
+
+**Key hyperparameters:** pretrain_epochs=20, noise_std=0.01,
+freeze_encoder_epochs=5, lr_encoder_finetune=1e-5.
+
+**Risk / failure mode:** Pretraining on geometry denoising may not transfer to
+pressure/shear prediction if the geometric features most useful for denoising
+are not the ones useful for regression. Mitigation: ablate with and without
+frozen encoder period.
+
+**noam cross-reference:** PR #2403 (multi-fidelity panel pretraining, CLOSED)
+showed promising direction but was compute-limited. PR #2378 (contrastive
+pretraining, CLOSED) is a related SSL idea.
+
+**Complexity:** Medium. Requires a two-stage training loop but no new model
+architecture.
+
+---
+
+### B02 · MAE-Style Masked Point Cloud Pretraining (then Fine-Tune)
+**Architectural change:** Port the Masked Autoencoder (MAE, He et al. 2022)
+paradigm to the point cloud setting. Mask 75% of input surface/volume points,
+encode the visible tokens with the Transolver encoder, then decode the masked
+positions with a lightweight decoder that predicts their feature values. Pretrain
+on geometry+feature reconstruction, then fine-tune on CFD regression.
+
+**Mechanism:** MAE pretraining proved more effective than contrastive pretraining
+for vision and point clouds (Point-MAE, Pang et al. 2022, ECCV). The key
+difference from B01 (denoising) is that masking is a harder auxiliary task that
+forces the model to learn long-range structural dependencies — exactly what is
+needed for global pressure fields. 75% mask ratio is the sweet spot from MAE
+literature. **Primary target:** p_s (3.82%), p_v (6.08%) — pressure fields have
+long-range dependencies (upstream separation affects downstream pressure).
+
+**Implementation sketch:**
+1. During pretraining, randomly mask 75% of surface tokens (by group, not
+   individual points) and 75% of volume tokens.
+2. Encode visible tokens with the Transolver encoder.
+3. A small decoder (2-layer transformer) reconstructs the masked point features
+   (coordinates + normals for surface, coordinates + SDF for volume).
+4. Loss = MSE on reconstructed features at masked positions only.
+5. After pretraining, discard the MAE decoder and add CFD regression heads; fine-tune.
+
+**Key hyperparameters:** mask_ratio=0.75, pretrain_epochs=25, decoder_depth=2,
+decoder_dim=128. Match masking granularity to slice grouping (mask entire slices,
+not random points) for compatibility with Transolver's slice attention.
+
+**Risk / failure mode:** Point-MAE masking strategies from image patches
+don't translate directly to irregular point clouds. Random masking may leave
+unmasked points that trivially predict masked ones from proximity. Mitigation:
+use farthest-point sampling to ensure masked and visible sets are spatially
+separated.
+
+**External evidence:** MAE (He et al., CVPR 2022); Point-MAE (Pang et al.,
+ECCV 2022); PointGPT (Chen et al., NeurIPS 2023); Point-BERT (Yu et al., CVPR 2022).
+
+**Complexity:** Medium. Two-phase training, no new architecture needed.
+
+---
+
+### B03 · Geo-FNO / GINO: Fourier Neural Operator with Geometry Lifting
+**Architectural change:** Replace the Transolver backbone with a Geometry-Informed
+Neural Operator (GINO, Li et al. ICLR 2024). GINO lifts the irregular 3D point
+cloud to a regular voxel grid via learned point-to-grid scatter (or a fixed
+radial basis function kernel), applies FNO layers in the regular grid (spectral
+convolution in frequency space), then unlifts back to the original query points
+via grid-to-point interpolation.
+
+**Mechanism:** FNO is provably universal for mapping between function spaces and
+has beaten CNN baselines on multiple PDE benchmarks (Navier-Stokes, Darcy flow).
+The limitation on irregular grids is solved by GINO's lifting step. For DrivAerML,
+the car geometry is naturally a bounded 3D region; FNO's spectral convolutions
+can capture long-range pressure correlations (e.g., between hood and underbody)
+that Transolver's slice pooling misses. **Primary target:** p_v (6.08%) —
+volume pressure is a global field; spectral operators with global receptive field
+should excel. tau secondary benefit from better encoder features.
+
+**Implementation sketch:**
+1. Voxelise the bounding box at resolution 64^3 (or 32^3 for memory budget).
+2. Lift: scatter surface and volume point features to voxel grid via trilinear
+   interpolation (or learned scatter from torch_scatter).
+3. Apply 4 FNO layers in the voxel grid (modes=12^3 for 64^3 grid; each layer
+   = spectral conv + pointwise MLP).
+4. Unlift: bilinear interpolation from voxel grid back to surface query points
+   → surface head MLP → 4D; and volume query points → volume head → 1D.
+
+**Key hyperparameters:** voxel_res=32 (memory safe at 4×96GB), fno_modes=12,
+fno_width=64, fno_depth=4. Increase to 64^3 if VRAM allows.
+
+**Risk / failure mode:** Voxelisation at 32^3 may be too coarse to resolve near-wall
+features. Mitigation: use a two-level hierarchy (coarse 16^3 FNO for global context
++ fine 64^3 attention near surface for shear).
+
+**External evidence:** FNO (Li et al., ICLR 2021, 10k+ cites); GINO (Li et al.,
+ICLR 2024); Geo-FNO (Li et al., NeurIPS 2023). All applied to PDE problems.
+
+**Complexity:** Large. Requires voxelisation pipeline and FNO implementation.
+`neuraloperator` PyPI package provides FNO layers directly.
+
+---
+
+### B04 · Mamba SSM Surface Decoder (3D Extension)
+**Architectural change:** After the Transolver encoder, replace the surface MLP
+head with a Mamba-2 state-space model decoder that processes surface points in
+a spatially ordered sequence (z-order curve / Hilbert curve ordering of 3D
+surface points), producing per-point outputs via the SSM recurrence.
+
+**Mechanism:** noam PR #2376 (MERGED) confirmed that Mamba SSM over arc-length-
+ordered surface nodes gave a clean gain on TandemFoil. The 3D extension requires
+a space-filling curve (z-order or Hilbert) to impose a 1D ordering on the
+surface point cloud. SSMs are extremely memory-efficient for long sequences
+(O(L) vs O(L^2) for attention) and can process the full 60k+ surface point set
+that Transolver must subsample. **Primary target:** tau (7.29%) — surface shear
+stress is a local field that varies smoothly along the surface; the SSM's
+sequential inductive bias matches this structure.
+
+**Implementation sketch:**
+1. Keep the Transolver encoder as a context encoder.
+2. Sort surface points by Morton z-order code (computed from quantised 3D
+   coordinates: `morton_code = x_q * 2^20 + y_q * 2^10 + z_q`).
+3. Feed the sorted sequence of surface point features (7D input + encoder
+   context via cross-attention or FiLM conditioning) into a Mamba-2 block.
+4. Read out per-point predictions from the Mamba hidden state → 4D surface preds.
+5. Volume head unchanged (MLP or a separate short Mamba sequence by SDF order).
+
+**Key hyperparameters:** mamba_d_model=256, mamba_d_state=64, mamba_depth=4,
+ordering='z_order'. Use `mamba-ssm` PyPI package (state-spaces/mamba).
+
+**Risk / failure mode:** Z-order curve does not perfectly capture surface
+topology — points that are close in space but far along the z-curve will have
+poor sequential dependencies. Mitigation: use Hilbert curve (smoother spatial
+locality) or add a short cross-attention layer before Mamba to correct for
+ordering artifacts.
+
+**noam cross-reference:** Direct 3D extension of PR #2376. Main adaptation is
+the ordering strategy (1D arc-length in 2D → space-filling curve in 3D).
+
+**Complexity:** Medium. `mamba-ssm` package provides SSM layers; main work is
+the z-order sorting and the context conditioning.
+
+---
+
+### B05 · MoE Surface+Volume Expert Routing (Soft Gates)
+**Architectural change:** Replace the single shared FFN in each Transolver
+transformer block with a Mixture-of-Experts FFN (4 experts, top-2 soft routing).
+Use 2 surface-specialised experts and 2 volume-specialised experts, with a
+learned router that receives the modality token as additional context.
+
+**Mechanism:** noam PR #2366 (MoE domain-expert FFN, CLOSED) failed due to
+routing collapse with hard routing. Soft-routing (combine top-2 expert outputs
+weighted by softmax scores) is more stable. The rationale: surface shear stress
+and volume pressure are fundamentally different functions of the input — one is
+a vector field on a 2D manifold, the other is a scalar field in 3D. A shared
+FFN must represent both. MoE allows specialisation with essentially free capacity
+increase. **Primary target:** tau (7.29%) / p_v (6.08%) — the two hardest
+metrics correspond to the two most different function types.
+
+**Implementation sketch:**
+1. In each transformer block, replace the 2-layer FFN with 4 expert FFNs
+   (same architecture: 2-layer MLP, d_ffn=4*d_model).
+2. Router: linear(d_model → 4) + softmax, taking [token_features + modality_emb]
+   as input. Modality embedding: 0 for surface, 1 for volume.
+3. Output = sum of top-2 expert outputs weighted by router scores.
+4. Add auxiliary load-balancing loss (alpha=0.01) to prevent router collapse:
+   `L_aux = alpha * sum_experts(f_e * P_e)` where f_e is expert assignment
+   fraction and P_e is router score average.
+5. Start with 4 experts, scale to 8 if VRAM allows.
+
+**Key hyperparameters:** num_experts=4, top_k=2, aux_loss_weight=0.01,
+expert_hidden_mult=4. MoE only in FFN layers, not attention.
+
+**Risk / failure mode:** Routing collapse (all tokens go to 1–2 experts). The
+auxiliary load-balancing loss mitigates this but requires careful weight tuning.
+Also: 4x expert increase in FFN parameter count may exceed VRAM at full batch.
+Mitigation: reduce batch size by 2x when using MoE.
+
+**noam cross-reference:** PR #2366 failed with hard routing; this is the soft-
+routing fix. The mechanism is preserved; the implementation risk is addressed.
+
+**Complexity:** Medium. Can be implemented within existing transformer block by
+replacing the FFN module.
+
+---
+
+### B06 · Point Transformer v3 Backbone
+**Architectural change:** Replace the entire Transolver with Point Transformer v3
+(PTv3, Wu et al. 2024), a serialisation-based point cloud transformer designed
+for large-scale 3D understanding tasks (indoor/outdoor scene segmentation,
+lidar). PTv3 processes point clouds via serialised z-order partitioning with
+local window attention + shifted windows, avoiding explicit radius graph
+construction.
+
+**Mechanism:** PTv3 achieves state-of-the-art on ScanNet, nuScenes, and S3DIS
+with a single model. Its key advantages for DrivAerML: (1) handles 100k+ points
+natively via serialised local windows, avoiding Transolver's subsampling; (2)
+window attention + shifted windows is memory-efficient and retains local
+structure; (3) multi-scale pooling hierarchy captures both fine surface geometry
+and global shape simultaneously. **Primary target:** tau (7.29%) — local shear
+features require fine-grained local context that window attention provides.
+
+**Implementation sketch:**
+1. Use the PTv3 implementation from `Pointcept` (github.com/Pointcept/Pointcept).
+2. Concatenate surface and volume points as a single set with modality flag as
+   additional feature channel.
+3. PTv3 backbone produces per-point features of dim D.
+4. Separate linear heads: surface MLP([N_surface, D] → [N_surface, 4]) and
+   volume MLP([N_volume, D] → [N_volume, 1]).
+5. Mask modality: only compute surface head for surface points, volume head for
+   volume points.
+6. Use PTv3-base config: enc_dim=48, enc_depth=[2,2,6,2], stride=[2,2,2,2].
+
+**Key hyperparameters:** from Pointcept PTv3 config; grid_size=0.02 for 3D
+bounding box ~4m×2m×1.5m.
+
+**Risk / failure mode:** PTv3 is designed for semantic segmentation (class
+labels per point), not regression. The FPN (feature pyramid network) upsampling
+stage may not transfer cleanly to regression. Mitigation: remove FPN and use
+only the encoder trunk with a regression head.
+
+**External evidence:** PTv3 (Wu et al., CVPR 2024); applied to outdoor LiDAR
+(Waymo), indoor (ScanNet), and recently to CFD point clouds in several papers.
+
+**Complexity:** Large. External dependency (Pointcept). Requires careful
+adaptation of backbone outputs to the CFD regression contract.
+
+---
+
+## Tier C — Novel Physics-Informed Architectures
+
+### C01 · DPOT Universal PDE Operator Transfer (3D Adaptation)
+**Architectural change:** Load DPOT pretrained weights (Hao et al., ICML 2024,
+trained on 10+ PDE datasets including Navier-Stokes and turbulence). Adapt the
+input projector to accept the DrivAerML 7D/4D feature format, and fine-tune
+the entire model on DrivAerML with a small learning rate (1e-5) for the pretrained
+backbone and a higher rate (5e-4) for the output heads.
+
+**Mechanism:** DPOT is pretrained on 10+ PDE datasets including NS, advection,
+reaction-diffusion, and turbulence at multiple Reynolds numbers. DrivAerML
+is an external turbulent aerodynamics dataset — the closest in-distribution
+case for the volume pressure field. Transfer from DPOT has not been tried on 3D
+data (noam PR #2364 was on 2D TandemFoil and was inconclusive likely due to
+domain gap; 3D turbulence in DPOT's training set is a better match). **Primary
+target:** p_v (6.08%) — volume pressure is the field most similar to DPOT's
+training data.
+
+**Implementation sketch:**
+1. Download DPOT checkpoint from Hao et al. (github.com/HaoZhongkai/DPOT).
+2. Adapt input projector: map [x,y,z,sdf] → DPOT expected token format. DPOT
+   uses a patch-tokenisation similar to ViT; adapt to point tokens with a linear
+   projector.
+3. Freeze first 6 of 12 DPOT transformer blocks; fine-tune last 6 + output heads.
+4. Use differential learning rates: pretrained = 1e-5, heads = 5e-4.
+5. If DPOT checkpoint is too large for VRAM: use only the first 6 blocks as
+   feature extractor, discard the rest, and add a small 2-block custom head.
+
+**Key hyperparameters:** dpot_blocks_frozen=6, lr_pretrained=1e-5, lr_heads=5e-4,
+warmup_epochs=3.
+
+**Risk / failure mode:** DPOT input format assumes uniform grid functions, not
+irregular point clouds. The patch-token adaptation may lose spatial fidelity.
+Mitigation: voxelise surface and volume as in B03 to match DPOT's expected input.
+
+**noam cross-reference:** PR #2364 tried DPOT on TandemFoil (2D, inconclusive).
+The 3D turbulence case in DPOT's training set is a stronger prior for 3D DrivAerML.
+
+**Complexity:** Large. Requires DPOT model download and input format adaptation.
+
+---
+
+### C02 · Deep Evidential Regression + Uncertainty-Weighted Loss
+**Architectural change:** Replace the MSE regression head with a deep evidential
+regression head that predicts a Normal-Inverse-Gamma (NIG) distribution over
+outputs. The evidence parameters {gamma, nu, alpha, beta} are predicted for each
+output channel, yielding both a mean prediction and an aleatoric+epistemic
+uncertainty estimate. The loss is the NIG negative log-likelihood plus an
+evidence regulariser.
+
+**Mechanism:** The current MSE loss treats every point equally. CFD data has
+high heteroscedastic variance: high-gradient regions (A-pillar separation, wheel
+arch, underbody) are genuinely harder to predict and may be overfit or underfit
+by a uniform MSE. Evidential regression automatically reweights the loss by
+predicted uncertainty — hard-to-predict points receive lower gradients, easy
+points push harder. This is particularly relevant for tau (7.29%) where spatial
+variance is very non-uniform. **Primary target:** tau (7.29%) — wall-shear is
+most non-uniform spatially; uncertainty weighting should focus learning on the
+high-information regions.
+
+**Implementation sketch:**
+1. Add a 4-output evidential head for surface (predicts gamma, nu, alpha, beta
+   for each of the 4 surface channels) and a 1-output evidential head for volume.
+2. Loss = NIG-NLL(gamma, nu, alpha, beta, target) + lambda_evid * |NIG_regulariser|.
+3. At inference: return `mu = gamma` as the point prediction; uncertainty for
+   optional visualisation.
+4. Adjust lambda_evid via a sweep: [0.01, 0.1, 1.0].
+
+**Key hyperparameters:** lambda_evid=0.01 (start small), head_hidden=64,
+head_depth=2. Evidential head replaces only the final linear projection.
+
+**Risk / failure mode:** Evidential regression heads can produce negative `nu`
+or `alpha` values during early training without careful clamping. Use softplus
+activations on those outputs. Also: NIG-NLL can dominate MSE early, slowing
+convergence. Use a warmup period of 5 epochs with pure MSE before enabling the
+evidential loss.
+
+**External evidence:** Deep Evidential Regression (Amini et al., NeurIPS 2020);
+applied to physics and fluid dynamics multiple times; Kaggle practitioners
+frequently use this for heteroscedastic regression on tabular + field data.
+
+**Complexity:** Small. Head-only change, no backbone modification.
+
+---
+
+### C03 · Volume Pressure via SDF-Conditioned Neural Field
+**Architectural change:** For the volume prediction head specifically, replace
+the MLP head with a coordinate-based neural field that takes `[xyz, sdf]` as
+query input, conditioned on the global encoder latent. The field is trained to
+predict p_v as a smooth function of 3D position, with the SDF providing an
+implicit boundary condition (p_v near SDF=0 should connect smoothly to wall
+pressure p_s).
+
+**Mechanism:** The volume pressure field is a smooth function of 3D space that
+satisfies the Poisson equation. Neural fields (Occupancy Networks, NeRF-style
+decoders) represent smooth spatial functions with significantly better
+interpolation than point-indexed MLPs. The SDF is a natural coordinate for
+encoding proximity to the wall — by including it as a feature in the neural
+field, we give the model an inductive bias that p_v transitions smoothly as
+SDF → 0 (matching the wall condition). **Primary target:** p_v (6.08%) —
+this is the only volume target; the neural field is custom-designed for it.
+
+**Implementation sketch:**
+1. After the Transolver encoder, extract a global latent `z ∈ R^[B, 256]`.
+2. For each volume query `[x, y, z, sdf]`, compute:
+   - Positional encoding: Fourier features of xyz (10 frequencies each = 60D)
+   - SDF encoding: log(|sdf| + eps) sign(sdf) as an additional channel
+   - Condition on `z` via FiLM: `scale, shift = linear(z)`, apply to hidden layer
+3. 4-layer MLP with residual connections → 1D p_v prediction.
+4. Surface head unchanged (standard MLP).
+
+**Key hyperparameters:** fourier_freqs=10, sdf_encoding='signed_log',
+film_from_latent=True, field_hidden=256, field_depth=4.
+
+**Risk / failure mode:** The global latent may not carry sufficient spatial
+variation for fine-grained volume predictions (same z for all query points).
+Mitigation: concatenate local slice-token features interpolated from nearest
+slice to each volume point.
+
+**Complexity:** Medium. Volume head replacement only; encoder unchanged.
+
+---
+
+## Tier D — Experimental / High-Risk High-Reward
+
+### D01 · Score-Based Diffusion Model as Surrogate (DDPM → Flow-Matching)
+**Architectural change:** Completely replace the regression training objective
+with a flow-matching (rectified flow) generative model that learns the joint
+distribution p(y | geometry). At inference, solve the ODE from noise → prediction
+in 20 NFE (neural function evaluations). The backbone is a standard Transolver
+or Perceiver conditioned on geometry features.
+
+**Mechanism:** Flow matching (Lipman et al. 2022, Liu et al. 2022) has replaced
+DDPM in state-of-the-art generative models. For CFD: the conditional flow-matching
+framing allows the model to represent multimodal aleatoric uncertainty in
+predictions (not just a point estimate) and provides implicit data augmentation
+via the noisy training trajectories. noam PR #2402 (flow matching, CLOSED) was
+tried on TandemFoil but converged slowly — this may be a hyperparameter issue
+(NFE too low, lr too high) rather than a fundamental problem. **Primary target:**
+tau (7.29%) — the most uncertain field; a generative model's distributional
+coverage may improve average error via ensemble averaging at inference.
+
+**Implementation sketch:**
+1. Train a vector field network `v_theta(t, y_t | x)` where `y_t = t*y + (1-t)*noise`
+   is the interpolant and `x` is the geometry encoding.
+2. Loss = MSE(v_theta(t, y_t | x), y - noise) with t ~ U(0,1).
+3. At inference: solve `dy/dt = v_theta(t, y_t | x)` with Euler ODE, T=20 steps.
+4. Average 5–10 samples for final prediction (Monte Carlo ensemble).
+5. Use the Transolver encoder as the geometry conditioning network.
+
+**Key hyperparameters:** flow_match_NFE=20, inference_samples=8, lr=2e-4,
+diffusion_dim same as model dim. Reference: Stable Diffusion 3 (Esser et al. 2024)
+uses the same flow-matching formulation.
+
+**Risk / failure mode:** Flow-matching convergence for regression is much slower
+than direct MSE. The model may need 2–3x more epochs to match MSE baseline.
+With SENPAI_MAX_EPOCHS constraint, this may be too slow. A staged approach:
+pretrain 10 epochs with MSE → switch to flow-matching for remaining epochs.
+
+**noam cross-reference:** PR #2402 (CLOSED, TandemFoil). Failure was likely
+under-training + lr mismatch. Architecture otherwise sound.
+
+**Complexity:** Large. New training loop, new loss, new inference path.
+
+---
+
+### D02 · Hybrid Voxel-CNN + Transolver Cross-Attention
+**Architectural change:** Add a voxel CNN encoder alongside the Transolver: the
+geometry is voxelised at 32^3 resolution, processed by a 5-layer 3D U-Net to
+produce dense voxel features. These voxel features are then used as an additional
+cross-attention source in the Transolver's slice attention step (in addition to
+the learned slice tokens). This is analogous to early fusion in multi-modal
+transformers.
+
+**Mechanism:** Transolver's slice pooling operates on unordered point clouds;
+it has no explicit concept of 3D spatial structure. A voxel CNN provides a
+spatially-structured inductive bias at negligible extra cost (32^3 = 32k voxels,
+much smaller than 70k points). The U-Net features can capture meso-scale flow
+structures (separation bubbles, wake regions) that are difficult for point-cloud
+attention to resolve. **Primary target:** p_v (6.08%) — volume pressure is
+best described in 3D volumetric terms; voxel features are the natural encoding.
+
+**Implementation sketch:**
+1. Add a VoxelEncoder: `grid = scatter_mean(volume_x → 32^3)` + 3D U-Net
+   (3 encode + 3 decode blocks, channels=[32,64,128]).
+2. Reshape U-Net output to [B, 32768, 128] as an additional key-value set.
+3. In the Transolver transformer blocks, add a cross-attention layer from slice
+   tokens to voxel features (after self-attention, before FFN).
+4. Keep all other Transolver components unchanged.
+5. Optionally: bilinearly interpolate U-Net features at each surface query point
+   as an additional feature for the surface head.
+
+**Key hyperparameters:** voxel_res=32, unet_channels=[32,64,128],
+cross_attn_to_voxels=True, voxel_cross_attn_heads=4.
+
+**Risk / failure mode:** Scatter-mean voxelisation loses density information near
+the wall (sparse near-wall points all average into a few voxels). Mitigation: use
+sum-then-normalise voxelisation and include the point count per voxel as an
+additional feature.
+
+**Complexity:** Medium-Large. New voxelisation pipeline + small U-Net module added
+to the existing Transolver.
+
+---
+
+## Summary Table
+
+| ID | Name | Family | Primary Target | Complexity | noam Evidence |
+|---|---|---|---|---|---|
+| A01 | ANP Surface Decoder | Cross-Attention Decoder | tau (7.29%) | Medium | Strong — direct port of #2379 MERGED |
+| A02 | SE(3) Equivariant Coords | Equivariant | tau axes | Small | Strong — port of #2377 MERGED |
+| A03 | Perceiver IO | Latent-Set Decoder | p_v (6.08%) | Large | Indirect — architecture class |
+| A04 | MeshGraphNet GNN | Graph Neural Net | tau (7.29%) | Large | Indirect — B-GNN #2370 |
+| A05 | SIREN INF Decoder | Neural Field | p_s, tau | Medium | None (fresh idea) |
+| B01 | Denoising Pretraining | SSL Pretraining | p_v, tau | Medium | #2403, #2378 (promising direction) |
+| B02 | MAE-Style Masking | SSL Pretraining | p_s, p_v | Medium | Indirect (Point-MAE literature) |
+| B03 | Geo-FNO / GINO | Neural Operator | p_v (6.08%) | Large | #2371 (1D FNO, mixed) |
+| B04 | Mamba SSM Decoder | State-Space Model | tau (7.29%) | Medium | Strong — direct port of #2376 MERGED |
+| B05 | Soft MoE FFN | Mixture-of-Experts | tau, p_v | Medium | #2366 (hard MoE failed — soft is fix) |
+| B06 | Point Transformer v3 | Point Cloud Arch | tau (7.29%) | Large | None (fresh, strong external evidence) |
+| C01 | DPOT Transfer | Pretrained Operator | p_v (6.08%) | Large | #2364 (inconclusive on 2D) |
+| C02 | Deep Evidential Reg | Uncertainty Head | tau (7.29%) | Small | None (fresh idea) |
+| C03 | SDF Neural Field Volume | Neural Field | p_v (6.08%) | Medium | None (fresh idea) |
+| D01 | Flow-Matching Generative | Diffusion | tau (7.29%) | Large | #2402 (underpowered on 2D) |
+| D02 | Voxel-CNN + Transolver | Hybrid | p_v (6.08%) | Medium-Large | None (fresh idea) |
+
+---
+
+## Pretraining Ideas Summary (≥3 required by Issue #18)
+
+1. **B01 — Denoising Diffusion Pretraining:** Corrupt and reconstruct point cloud geometry. Use unlabelled test geometry (50 cases) for free SSL data.
+2. **B02 — MAE-Style Masked Point Cloud Pretraining:** Mask 75% of surface/volume tokens, reconstruct. Slice-aligned masking for Transolver compatibility.
+3. **C01 — DPOT Universal PDE Operator Transfer:** Fine-tune from ICML 2024 pretrained backbone trained on 10+ PDE datasets including turbulent flow.
+
+---
+
+## Recommended Priority Order for Assignment
+
+Ranked by (impact × evidence strength / implementation risk):
+
+1. **A01 — ANP Surface Decoder** (direct port of largest win in programme history)
+2. **A02 — SE(3) Equivariant Coords** (small change, strong evidence, targets tau)
+3. **B04 — Mamba SSM Decoder** (direct port of MERGED noam win, medium complexity)
+4. **B05 — Soft MoE FFN** (fixes known failure mode of hard routing from noam)
+5. **C02 — Deep Evidential Regression** (small, no backbone change, novel mechanism)
+6. **C03 — SDF Neural Field Volume** (targeted at hardest metric p_v, medium cost)
+7. **B01 — Denoising Pretraining** (SSL, uses free geometry data, medium cost)
+8. **B02 — MAE Masking Pretraining** (SSL, strongest evidence from Point-MAE)
+9. **B03 — Geo-FNO** (large but strongest theory for p_v)
+10. **A03 — Perceiver IO** (large, most radical backbone replacement)
+11. **D02 — Voxel-CNN hybrid** (medium-large, pragmatic innovation)
+12. **A04 — MeshGraphNet GNN** (large, strong external evidence)
+13. **A05 — SIREN INF Decoder** (medium, novel, limited prior art in CFD)
+14. **B06 — Point Transformer v3** (large, best external evidence but big adaptation)
+15. **C01 — DPOT Transfer** (large, inconclusive on 2D, worth trying on 3D)
+16. **D01 — Flow-Matching** (large, slow convergence risk under epoch budget)
+
+---
+
+*All H01–H20 from Round 1 are distinct and not duplicated above.*
+*Every hypothesis targets tau (7.29%) or p_v (6.08%) as the primary improvement lever.*

--- a/research/RESEARCH_IDEAS_2026-04-30_1440.md
+++ b/research/RESEARCH_IDEAS_2026-04-30_1440.md
@@ -1,0 +1,72 @@
+# SENPAI Research Ideas — 2026-04-30 14:40
+
+Generated after Round-2 review. All ideas are for the yi branch DrivAerML target.
+Current baseline: abupt=12.74 (PR #66 thorfinn, 6L/256d + W_y=W_z=2).
+
+## Ideas Assigned in Round-3
+
+| PR | Student | Hypothesis |
+|---|---|---|
+| #95 | alphonse | Area-weighted surface MSE loss |
+| #96 | chihiro | MLP ratio sweep (4 vs 6 vs 8) |
+| #97 | edward | Slice count sweep (128 vs 192 vs 256) |
+| #98 | emma | Weight decay sweep (1e-4/5e-4/2e-3/5e-3) |
+| #99 | fern | LR peak sweep (1e-4/2e-4/3e-4/5e-4) |
+| #100 | frieren | cp-channel upweight (1.5/2.0/3.0) |
+| #101 | gilbert | Larger point budget (131072 vs 65536) |
+| #102 | haku | Dropout sweep (0/0.05/0.10/0.20) |
+| #103 | kohaku | Volume-surface cross-attention |
+| #104 | senku | EMA decay sweep (0.999/0.9995/0.9997/0.9999) |
+| #105 | tanjiro | Huber surface loss (delta=0.05/0.10) |
+| #106 | thorfinn | Finer tau_y/z weight sweep (2.0/2.5/3.0 + asym) |
+| #107 | violet | Volume loss decay schedule (4->1.5, 3->1.5) |
+
+## Ideas for Round-4
+
+### Architecture Ideas (Bold Swings)
+
+1. **Separate surface/volume backbone branches** — Dedicated 6L/256d surface backbone + 3L/128d volume backbone, specialized per modality.
+
+2. **Point cloud hierarchy (multi-scale attention)** — Group 65536 points into coarse clusters, apply SetAbstraction-style attention at multiple scales. Better spatial resolution for tau_y/z.
+
+3. **Fourier position encodings** — sin/cos at multiple frequencies added to xyz coords, giving explicit spatial frequency decomposition.
+
+4. **Mixture-of-Experts per surface region** — Route 4-8 experts based on point position (wheel arch, underbody, roof, stagnation zone have different flow regimes).
+
+### Loss / Training Ideas
+
+5. **Laplacian smoothness regularization** — Penalize discontinuities in volume pressure gradient fields.
+
+6. **Surface-volume consistency aux loss** — Enforce p_s = p_v at the boundary (SDF~0 volume points).
+
+7. **Adversarial domain adaptation** — Gradient-reversal layer to make backbone invariant to train/test geometry distribution shift, targeting the structural val-test gap.
+
+8. **Online hard example mining (OHEM)** — Upweight hard cases in batch sampling based on per-case rolling val L2 error.
+
+### Data / Augmentation Ideas
+
+9. **Point cloud jitter augmentation** — Small Gaussian noise (sigma=0.001 in normalized coords) on surface xyz during training.
+
+10. **Radial feature augmentation** — Add |r| and theta (polar angle around car axis) as additional input features.
+
+11. **Geometric moment conditioning** — Per-case bounding box, surface area, volume as global conditioning signals (cheaper than FiLM neural encoder).
+
+### Optimization Ideas
+
+12. **SAM (Sharpness-Aware Minimization)** — Seek flatter minima via weight perturbation + gradient at perturbed point. Directly targets val->test gap.
+
+13. **Gradient accumulation with effective bs=32** — 4 accumulation steps at bs=8, better gradient estimates without VRAM increase.
+
+14. **AdaGrad layer-wise LR (discriminative fine-tuning)** — Earlier layers get lower LR (carry learned features), later layers get higher LR.
+
+### Ensemble / Post-processing Ideas
+
+15. **Multi-checkpoint ensemble** — Average best checkpoints from epochs N-2, N-1, N post-hoc.
+
+16. **TTA on mature model** — Test-time bilateral symmetry averaging. Failed at epoch 1 (PR #16) but may help on the better-trained 12.74 model.
+
+### Physics-Informed Ideas
+
+17. **Divergence-free constraint on wall-shear** — Surface divergence of wall shear stress is constrained by the pressure Laplacian; add soft regularization.
+
+18. **Bernoulli-consistency aux loss** — In potential flow regions, enforce approximate p + 0.5*rho*|v|^2 = const.

--- a/train.py
+++ b/train.py
@@ -553,6 +553,8 @@ class Config:
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
     use_tangential_wallshear_loss: bool = False
+    wallshear_y_weight: float = 1.0
+    wallshear_z_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1241,6 +1243,35 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def weighted_masked_mse_per_channel(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    channel_weights: Iterable[float],
+) -> tuple[torch.Tensor, list[float]]:
+    """Per-channel weighted masked MSE for surface predictions.
+
+    pred, target: [B, N, C]. mask: [B, N] bool.
+    Returns the weighted scalar loss plus an unweighted per-channel mean for
+    diagnostic logging. With all weights == 1 this is numerically equivalent
+    to F.mse_loss(pred[mask], target[mask]).
+    """
+    weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
+    if not bool(mask.any()):
+        per_axis = [0.0] * int(weights.numel())
+        return pred.sum() * 0.0, per_axis
+    diff_sq = (pred - target).pow(2)  # [B, N, C]
+    mask_f = mask.unsqueeze(-1).to(pred.dtype)
+    valid = mask_f.sum().clamp_min(1)
+    n_channels = diff_sq.shape[-1]
+    weighted_diff = diff_sq * weights.view(1, 1, -1)
+    weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
+    per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
+    per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
+    return weighted_loss, per_axis_mean
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1263,6 +1294,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    wallshear_y_weight: float = 1.0,
+    wallshear_z_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1302,12 +1335,21 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
+        surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
+            surface_pred_used,
+            surface_target_used,
+            batch.surface_mask,
+            channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+        )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
+        "loss_cp": per_axis_unweighted[0],
+        "loss_tau_x": per_axis_unweighted[1],
+        "loss_tau_y": per_axis_unweighted[2],
+        "loss_tau_z": per_axis_unweighted[3],
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
@@ -1723,6 +1765,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                wallshear_y_weight=config.wallshear_y_weight,
+                wallshear_z_weight=config.wallshear_z_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1775,6 +1819,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
                 "train/volume_loss": batch_loss_metrics["volume_loss"],
+                "train/loss_cp": batch_loss_metrics["loss_cp"],
+                "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
+                "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
+                "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,

--- a/train.py
+++ b/train.py
@@ -590,6 +590,12 @@ class Config:
     clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
+    seed: int = -1
+    lr_warmup_steps: int = 0
+    lr_warmup_start_lr: float = 1e-5
+
+
+NONFINITE_SKIP_ABORT = 200
 
 
 class TargetTransform:
@@ -1665,6 +1671,15 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    if config.seed >= 0:
+        import random
+
+        import numpy as np
+
+        random.seed(config.seed)
+        np.random.seed(config.seed)
+        torch.manual_seed(config.seed)
+        torch.cuda.manual_seed_all(config.seed)
     kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
     max_epochs = min(config.epochs, 3) if config.debug else config.epochs
     timeout_minutes = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30"))
@@ -1740,6 +1755,9 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
+    wandb.define_metric("train/lr", step_metric="global_step")
+    wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
+    wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1751,6 +1769,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
     global_step = 0
+    nonfinite_skip_count = 0
     early_stop_reason: str | None = None
     timeout_hit = False
     train_start = time.time()
@@ -1784,6 +1803,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
             )
             optimizer.zero_grad(set_to_none=True)
+            loss_is_finite = bool(torch.isfinite(loss).item())
+            if not loss_is_finite:
+                nonfinite_skip_count += 1
+                wandb.log(
+                    {
+                        "train/nonfinite_skip_count": nonfinite_skip_count,
+                        "train/nonfinite_skip_kind": 1,
+                        "global_step": global_step,
+                    }
+                )
+                if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                    raise RuntimeError(
+                        f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                        f"loss/grad steps; training is structurally broken."
+                    )
+                global_step += 1
+                continue
             loss.backward()
             should_log_gradients = (
                 config.gradient_log_every > 0
@@ -1801,13 +1837,42 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            grad_is_finite = True
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), max_norm=config.clip_grad_norm
                 )
+                grad_is_finite = bool(torch.isfinite(pre_clip_norm).item())
                 if should_log_gradients:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
+            if not grad_is_finite:
+                optimizer.zero_grad(set_to_none=True)
+                nonfinite_skip_count += 1
+                wandb.log(
+                    {
+                        "train/nonfinite_skip_count": nonfinite_skip_count,
+                        "train/nonfinite_skip_kind": 2,
+                        "global_step": global_step,
+                    }
+                )
+                if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                    raise RuntimeError(
+                        f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                        f"loss/grad steps; training is structurally broken."
+                    )
+                global_step += 1
+                continue
+            if config.lr_warmup_steps > 0:
+                if global_step < config.lr_warmup_steps:
+                    warmup_lr = config.lr_warmup_start_lr + (
+                        config.lr - config.lr_warmup_start_lr
+                    ) * (global_step / config.lr_warmup_steps)
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = warmup_lr
+                elif global_step == config.lr_warmup_steps:
+                    for pg in optimizer.param_groups:
+                        pg["lr"] = config.lr
             optimizer.step()
             ema_decay_now: float | None = None
             if ema is not None:
@@ -1838,6 +1903,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_x": batch_loss_metrics["loss_tau_x"],
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
+                "train/lr": float(optimizer.param_groups[0]["lr"]),
+                "train/nonfinite_skip_count": nonfinite_skip_count,
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,

--- a/train.py
+++ b/train.py
@@ -552,6 +552,7 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    aux_rel_l2_weight: float = 0.0
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
@@ -1293,6 +1294,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    aux_rel_l2_weight: float = 0.0,
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
@@ -1343,6 +1345,16 @@ def train_loss(
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        aux_rel_l2_value: float | None = None
+        if aux_rel_l2_weight > 0.0:
+            surf_pred_f = surface_pred_norm.float()
+            surf_true_f = surface_target.float()
+            mask_f = batch.surface_mask.float().unsqueeze(-1)
+            num = ((surf_pred_f - surf_true_f) ** 2 * mask_f).sum()
+            den = (surf_true_f ** 2 * mask_f).sum().clamp_min(1e-8)
+            aux_rel_l2 = num / den
+            loss = loss + aux_rel_l2_weight * aux_rel_l2
+            aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1351,6 +1363,8 @@ def train_loss(
         "loss_tau_y": per_axis_unweighted[2],
         "loss_tau_z": per_axis_unweighted[3],
     }
+    if aux_rel_l2_value is not None:
+        metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1764,6 +1778,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
+                aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
@@ -1830,6 +1845,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "aux_rel_l2_loss" in batch_loss_metrics:
+                train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
+                    "aux_rel_l2_loss"
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now

--- a/train.py
+++ b/train.py
@@ -424,6 +424,9 @@ class EMA:
         }
         self.backup: dict[str, torch.Tensor] | None = None
 
+    def set_decay(self, new_decay: float) -> None:
+        self.decay = float(new_decay)
+
     @torch.no_grad()
     def update(self, model: nn.Module) -> None:
         self.step_counter += 1
@@ -497,6 +500,8 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_start: float = 0.0
+    ema_decay_end: float = 0.9999
     gradient_log_every: int = 1
     log_gradient_histograms: bool = True
     weight_log_every: int = 1
@@ -1658,7 +1663,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
                     gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
+            ema_decay_now: float | None = None
             if ema is not None:
+                if config.ema_decay_start > 0.0:
+                    progress = min(global_step / max(total_estimated_steps, 1), 1.0)
+                    cos_val = (1.0 - math.cos(math.pi * progress)) / 2.0
+                    ema_decay_now = config.ema_decay_start + cos_val * (
+                        config.ema_decay_end - config.ema_decay_start
+                    )
+                    ema.set_decay(ema_decay_now)
                 ema.update(model)
             weight_metrics = (
                 collect_weight_metrics(
@@ -1683,6 +1696,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
+            if ema_decay_now is not None:
+                train_log["train/ema_decay"] = ema_decay_now
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -232,6 +232,48 @@ class TransformerBlock(nn.Module):
         return x
 
 
+class GeomEncoder(nn.Module):
+    """Mean-pooled MLP encoder over surface points to a per-case geometry token."""
+
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, out_dim),
+        )
+        self.net.apply(_init_linear)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        # x: [B, N, in_dim], mask: [B, N] (1=valid, 0=padding)
+        mask_f = mask.to(dtype=x.dtype).unsqueeze(-1)
+        x_masked = x * mask_f
+        n_valid = mask_f.sum(dim=1).clamp(min=1.0)  # [B, 1]
+        x_mean = x_masked.sum(dim=1) / n_valid  # [B, in_dim]
+        return self.net(x_mean)  # [B, out_dim]
+
+
+class FiLMLayer(nn.Module):
+    """FiLM with AdaLN-zero init: gamma=0, beta=0 at start so output equals input.
+
+    Applies h' = h * (1 + gamma) + beta where (gamma, beta) come from a linear
+    projection of the per-case geometry token. Final linear is zero-initialized
+    so the layer is identity at training start (residual modulation).
+    """
+
+    def __init__(self, geom_dim: int, hidden_dim: int):
+        super().__init__()
+        self.to_gamma_beta = nn.Linear(geom_dim, 2 * hidden_dim)
+        nn.init.zeros_(self.to_gamma_beta.weight)
+        nn.init.zeros_(self.to_gamma_beta.bias)
+
+    def forward(self, h: torch.Tensor, geom: torch.Tensor) -> torch.Tensor:
+        # h: [B, N, hidden_dim], geom: [B, geom_dim]
+        gb = self.to_gamma_beta(geom)  # [B, 2*hidden_dim]
+        gamma, beta = gb.chunk(2, dim=-1)
+        return h * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+
+
 class Transformer(nn.Module):
     def __init__(
         self,
@@ -242,6 +284,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
+        film_geom_dim: int = 0,
     ):
         super().__init__()
         if depth <= 1:
@@ -263,10 +306,25 @@ class Transformer(nn.Module):
                 for i in range(depth)
             ]
         )
+        self.film_layers = (
+            nn.ModuleList(
+                [FiLMLayer(film_geom_dim, hidden_dim) for _ in range(depth)]
+            )
+            if film_geom_dim > 0
+            else None
+        )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        for block in self.blocks:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        geom_token: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        for index, block in enumerate(self.blocks):
             x = block(x, attn_mask=attn_mask)
+            if self.film_layers is not None and geom_token is not None:
+                x = self.film_layers[index](x, geom_token)
+                x = _apply_token_mask(x, attn_mask)
         return x
 
 
@@ -288,6 +346,8 @@ class SurfaceTransolver(nn.Module):
         mlp_ratio: int = 4,
         slice_num: int = 96,
         stochastic_depth_prob: float = 0.0,
+        use_film: bool = False,
+        film_encoder_dim: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -297,6 +357,8 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+        self.use_film = use_film
+        self.film_encoder_dim = film_encoder_dim
 
         self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -309,6 +371,11 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        self.geom_encoder = (
+            GeomEncoder(self.surface_input_dim, film_encoder_dim * 2, film_encoder_dim)
+            if use_film
+            else None
+        )
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -317,6 +384,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
+            film_geom_dim=film_encoder_dim if use_film else 0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -382,7 +450,10 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        geom_token: torch.Tensor | None = None
+        if self.use_film and self.geom_encoder is not None and surface_x is not None:
+            geom_token = self.geom_encoder(surface_x, surface_mask)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, geom_token=geom_token)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -403,13 +474,16 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        result = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if geom_token is not None:
+            result["geom_token"] = geom_token
+        return result
 
 
 class EMA:
@@ -492,6 +566,8 @@ class Config:
     model_slices: int = 96
     model_dropout: float = 0.0
     stochastic_depth_prob: float = 0.0
+    use_film: bool = False
+    film_encoder_dim: int = 64
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -649,6 +725,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
         stochastic_depth_prob=config.stochastic_depth_prob,
+        use_film=config.use_film,
+        film_encoder_dim=config.film_encoder_dim,
     )
 
 
@@ -1227,12 +1305,20 @@ def train_loss(
         surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
-    metrics = {
+    metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
     }
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if "geom_token" in out:
+        geom_token = out["geom_token"].detach().float()
+        metrics["film/geom_token_norm_mean"] = float(
+            geom_token.norm(dim=-1).mean().cpu().item()
+        )
+        metrics["film/geom_token_abs_mean"] = float(
+            geom_token.abs().mean().cpu().item()
+        )
     return loss, metrics
 
 
@@ -1596,6 +1682,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_type/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
+    wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
@@ -1698,6 +1785,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 ]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
+            for key, value in batch_loss_metrics.items():
+                if key.startswith("film/"):
+                    train_log[f"train/{key}"] = value
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class ContinuousSincosEmbed(nn.Module):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
+        self.max_wavelength = max_wavelength
         padding = hidden_dim % input_dim
         dim_per_axis = (hidden_dim - padding) // input_dim
         sincos_padding = dim_per_axis % 2
@@ -348,6 +349,7 @@ class SurfaceTransolver(nn.Module):
         stochastic_depth_prob: float = 0.0,
         use_film: bool = False,
         film_encoder_dim: int = 64,
+        pos_max_wavelength: int = 1000,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -359,8 +361,13 @@ class SurfaceTransolver(nn.Module):
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
+        self.pos_max_wavelength = pos_max_wavelength
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        self.pos_embed = ContinuousSincosEmbed(
+            hidden_dim=n_hidden,
+            input_dim=space_dim,
+            max_wavelength=pos_max_wavelength,
+        )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -571,6 +578,7 @@ class Config:
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
+    pos_max_wavelength: int = 1000
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -736,6 +744,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         stochastic_depth_prob=config.stochastic_depth_prob,
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
+        pos_max_wavelength=config.pos_max_wavelength,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -63,6 +63,27 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+class DropPath(nn.Module):
+    """Stochastic depth: drop entire residual branch with probability `drop_prob`."""
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = float(drop_prob)
+
+    def extra_repr(self) -> str:
+        return f"drop_prob={self.drop_prob:.4f}"
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        # Sample in fp32 so the gate is not quantized to ~32 bf16 levels.
+        random_tensor = torch.rand(shape, dtype=torch.float32, device=x.device)
+        random_tensor = torch.floor(random_tensor + keep_prob).to(x.dtype)
+        return x / keep_prob * random_tensor
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -187,6 +208,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        drop_path_prob: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -199,12 +221,13 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path = DropPath(drop_path_prob)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -218,8 +241,15 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        stochastic_depth_prob: float = 0.0,
     ):
         super().__init__()
+        if depth <= 1:
+            drop_path_rates = [stochastic_depth_prob] * depth
+        else:
+            drop_path_rates = [
+                stochastic_depth_prob * i / (depth - 1) for i in range(depth)
+            ]
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -228,8 +258,9 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    drop_path_prob=drop_path_rates[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -256,6 +287,7 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        stochastic_depth_prob: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -284,6 +316,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            stochastic_depth_prob=stochastic_depth_prob,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -454,6 +487,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    stochastic_depth_prob: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -607,6 +641,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        stochastic_depth_prob=config.stochastic_depth_prob,
     )
 
 
@@ -1523,7 +1558,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     best_metrics: dict[str, float] = {}
     global_step = 0
     early_stop_reason: str | None = None
+    timeout_hit = False
     train_start = time.time()
+    val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
+    train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
@@ -1605,6 +1643,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             if early_stop_reason is not None:
                 print(early_stop_reason)
                 break
+            if (time.time() - train_start) / 60.0 >= train_timeout_minutes:
+                print(
+                    f"Train timeout ({train_timeout_minutes:.1f} min) mid-epoch "
+                    f"at step {global_step}. Forcing validation and stopping."
+                )
+                timeout_hit = True
+                break
 
         scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
@@ -1614,6 +1659,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             epoch == 0
             or (epoch + 1) % max(config.validation_every, 1) == 0
             or epoch + 1 == max_epochs
+            or (timeout_hit and n_batches > 0)
         )
 
         log_metrics = {
@@ -1721,6 +1767,8 @@ def main(argv: Iterable[str] | None = None) -> None:
         print_metrics("val_surface", val_metrics["val_surface"])
         if early_stop_reason is not None:
             print(early_stop_reason)
+            break
+        if timeout_hit:
             break
 
     total_minutes = (time.time() - train_start) / 60.0

--- a/train.py
+++ b/train.py
@@ -503,6 +503,7 @@ class Config:
     log_weight_histograms: bool = False
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
+    clip_grad_norm: float = 0.0
     compile_model: bool = True
     debug: bool = False
 
@@ -1649,6 +1650,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            if config.clip_grad_norm > 0:
+                pre_clip_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), max_norm=config.clip_grad_norm
+                )
+                if should_log_gradients:
+                    gradient_metrics["train/grad/pre_clip_norm"] = float(pre_clip_norm)
+                    gradient_metrics["train/grad/clip_threshold"] = config.clip_grad_norm
             optimizer.step()
             if ema is not None:
                 ema.update(model)

--- a/train.py
+++ b/train.py
@@ -1900,7 +1900,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             log_metrics["early_stop/triggered"] = 1.0
         wandb.log(log_metrics)
 
-        improved = primary_val < best_val
+        primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0
+        improved = primary_val_is_valid and primary_val < best_val
         if improved:
             best_val = primary_val
             best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}

--- a/train.py
+++ b/train.py
@@ -475,6 +475,7 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    use_tangential_wallshear_loss: bool = False
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1156,6 +1157,18 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
+    """Project per-point 3-vectors onto the local tangent plane.
+
+    vec, normals: [B, N, 3] in matching coordinate frames.
+    Returns vec - (vec . n_hat) * n_hat. fp32 internally for bf16 stability.
+    """
+    vec_f = vec.float()
+    n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+    dot = (vec_f * n_hat).sum(dim=-1, keepdim=True)
+    return (vec_f - dot * n_hat).to(vec.dtype)
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1165,6 +1178,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    use_tangential_wallshear_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1176,13 +1190,44 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_pred_norm = out["surface_preds"]
+        normal_rms = float("nan")
+        if use_tangential_wallshear_loss:
+            # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
+            # in normalized space does not equal physical-space tangent projection.
+            # Denormalize -> project in physical space -> renormalize.
+            normals = batch.surface_x[..., 3:6]
+            ws_std = transform.surface_y_std[1:4]
+            ws_mean = transform.surface_y_mean[1:4]
+            ws_pred_norm = surface_pred_norm[..., 1:4]
+            ws_true_norm = surface_target[..., 1:4]
+            ws_pred_phys = ws_pred_norm * ws_std + ws_mean
+            ws_true_phys = ws_true_norm * ws_std + ws_mean
+            ws_pred_tan = project_tangential(ws_pred_phys, normals)
+            ws_true_tan = project_tangential(ws_true_phys, normals)
+            ws_pred_tan_norm = (ws_pred_tan - ws_mean) / ws_std
+            ws_true_tan_norm = (ws_true_tan - ws_mean) / ws_std
+            surface_pred_used = torch.cat([surface_pred_norm[..., :1], ws_pred_tan_norm], dim=-1)
+            surface_target_used = torch.cat([surface_target[..., :1], ws_true_tan_norm], dim=-1)
+            if bool(batch.surface_mask.any()):
+                n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+                normal_dot = (ws_pred_phys.float() * n_hat).sum(dim=-1)
+                normal_rms = float(
+                    normal_dot[batch.surface_mask].square().mean().sqrt().detach().cpu().item()
+                )
+        else:
+            surface_pred_used = surface_pred_norm
+            surface_target_used = surface_target
+        surface_loss = masked_mse(surface_pred_used, surface_target_used, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
-    return loss, {
+    metrics = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
     }
+    if use_tangential_wallshear_loss:
+        metrics["wallshear_pred_normal_rms"] = normal_rms
+    return loss, metrics
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -1584,6 +1629,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
+                use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
             )
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
@@ -1625,6 +1671,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 **gradient_metrics,
                 **weight_metrics,
             }
+            if "wallshear_pred_normal_rms" in batch_loss_metrics:
+                train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
+                    "wallshear_pred_normal_rms"
+                ]
             train_log.update(
                 train_slope_tracker.update(
                     global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Does `--surface-loss-weight 2.0` compound with the current SOTA config (4L/512d Lion, lr_warmup_epochs=1 from PR #222)?

PR #244 established that slw=2.0 is more stable than slw=1.5 on 6L/256d AdamW (Arm A crashed 3/3 times at lr=3e-4; Arm B ran cleanly). However, PR #244 ran on a now-obsolete architecture and showed 10.63% — well above the merge bar. The stability signal is scientifically real. This experiment tests whether slw=2.0 **stacks** on the current best configuration.

Default (`surface_loss_weight=1.0`) means surface loss and volume loss are weighted equally. The DrivAerML metrics at PR #222 show surface_pressure (5.87%) is roughly equal to volume_pressure (5.88%), but wall_shear (10.34%) lags far behind. Boosting surface loss weight gives the model stronger gradient signal from surface fields (Cp + wall shear together), which may close the wall_shear gap.

## Experiment Design

Single arm: SOTA config + `--surface-loss-weight 2.0`.

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent emma \
  --wandb-group yi-slw2-on-sota \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --surface-loss-weight 2.0
```

Run for **9 epochs** to match the PR #222 training budget. Use all 8 GPUs via `torchrun --nproc_per_node=8`.

## Baseline to Beat

**Merge bar: 9.291% `val_primary/abupt_axis_mean_rel_l2_pct`** (PR #222, W&B run `ut1qmc3i`)

PR #222 per-epoch metrics for comparison:

| Epoch | val_abupt | surf_pres | vol_pres | wall_shear |
|-------|-----------|-----------|----------|------------|
| 7     | 9.8759%   | 6.3077%   | 6.0145%  | 11.0603%   |
| 8     | 9.4516%   | 6.0019%   | 5.7614%  | 10.5847%   |
| **9** | **9.2910%** | **5.8707%** | **5.8789%** | **10.3423%** |

## Results Reporting

Please report:
- W&B run ID and group
- Per-epoch val_abupt table (all epochs)
- Best epoch: `full_val_primary/abupt_axis_mean_rel_l2_pct`, `surface_pressure_rel_l2_pct`, `wall_shear_rel_l2_pct`, `volume_pressure_rel_l2_pct`
- Per-axis wall_shear: `wall_shear_x_rel_l2_pct`, `wall_shear_y_rel_l2_pct`, `wall_shear_z_rel_l2_pct`
- Gradient telemetry: any `train/grad/global_norm` spikes or non-finite counts vs PR #222 baseline?
- Did slw=2.0 help wall_shear while keeping surface_pressure and volume_pressure competitive?

## Context

- PR #244 (surface-loss-weight sweep on 6L/256d AdamW) found: slw=2.0 is stable; slw=1.5 crashed 3/3 times. That run showed 10.63% (obsolete architecture). This run tests the same direction on current SOTA.
- `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0` are already baked into the yi baseline (PR #66 / thorfinn). `--surface-loss-weight 2.0` is orthogonal — it upweights the entire surface field branch (Cp + wall shear together) relative to the volume branch.
- Keep all other flags exactly as BASELINE.md specifies. Only change is `--surface-loss-weight 2.0`.