### PR TITLE
tanjiro: 2-layer MLP volume decoder head (vol_pressure 2.08× gap)

### DIFF
--- a/model.py
+++ b/model.py
@@ -253,6 +253,7 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        vol_decoder_depth: int = 1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -302,7 +303,24 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
-        self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        if vol_decoder_depth >= 2:
+            # Pre-norm head (advisor Option A after epoch-9 divergence in
+            # ux5s5id6): LayerNorm → Linear → GELU → Linear. Tail Linear is
+            # zero-bias, std=1e-2 trunc_normal so the head starts close to a
+            # tiny near-zero readout, letting the trunk shape the signal
+            # before the new MLP capacity adds variance.
+            self.volume_out = nn.Sequential(
+                nn.LayerNorm(n_hidden, eps=1e-6),
+                nn.Linear(n_hidden, n_hidden),
+                nn.GELU(),
+                nn.Linear(n_hidden, self.volume_output_dim),
+            )
+            # First Linear: standard trunc_normal std=0.02 (matches rest of
+            # backbone). Final Linear: std=1e-2, near-identity start.
+            _init_linear(self.volume_out[1], std=0.02)
+            _init_linear(self.volume_out[3], std=1e-2)
+        else:
+            self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
         self,

--- a/train.py
+++ b/train.py
@@ -91,6 +91,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    model_vol_decoder_depth: int = 1   # 1=linear (baseline), 2=MLP decoder
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     amp_mode: str = "bf16"
@@ -176,6 +177,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        vol_decoder_depth=config.model_vol_decoder_depth,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**A dedicated 2-layer MLP volume decoder head will close the 2.08× gap between our volume pressure (12.656%) and the AB-UPT reference (6.08%).**

The current `SurfaceTransolver` uses a bare `nn.Linear` (`LinearProjection`) as the volume output head — a single linear step from the 512-d backbone to the 1-d volume pressure output. Surface and volume targets are solved jointly in the shared backbone, but readout capacity is symmetric even though volume pressure shows the largest per-axis gap in our results (12.656% vs 6.08% reference — 2.08×).

A 2-layer MLP decoder (hidden → hidden → output with GELU + LayerNorm) provides additional non-linear capacity after the backbone for the volume field without touching the shared representation or surface decoder. This is a targeted capacity increase for exactly the hardest axis.

**Prediction**: Replacing the linear `volume_out` head with a 2-layer MLP will specifically reduce `vol_pressure_rel_l2_pct` and drag down `val_abupt` overall.

**Why this matters**: Wall-shear axes (tau_y 11.952%, tau_z 12.447%) and volume pressure (12.656%) are the three biggest gaps vs AB-UPT. Improving volume pressure is the highest-leverage axis to target — a single non-linear decoder head change.

## Instructions

You must modify **`target/model.py`** and **`target/train.py`**. No other files.

### 1. Add `model_vol_decoder_depth` to `Config` in `train.py`

In the `Config` dataclass (around line 88), add after `model_dropout`:

```python
model_vol_decoder_depth: int = 1   # 1=linear (baseline), 2=MLP decoder
```

This auto-registers as `--model-vol-decoder-depth INT` CLI flag. Default `1` preserves existing behaviour exactly.

### 2. Pass `vol_decoder_depth` to `SurfaceTransolver` in `train.py`

In `build_model()` (around line 170), add the new kwarg:

```python
def build_model(config: Config) -> SurfaceTransolver:
    return SurfaceTransolver(
        n_layers=config.model_layers,
        n_hidden=config.model_hidden_dim,
        dropout=config.model_dropout,
        n_head=config.model_heads,
        mlp_ratio=config.model_mlp_ratio,
        slice_num=config.model_slices,
        rff_num_features=config.rff_num_features,
        rff_sigma=config.rff_sigma,
        vol_decoder_depth=config.model_vol_decoder_depth,   # <-- add this
    )
```

### 3. Replace `volume_out` in `SurfaceTransolver.__init__` in `model.py`

Add `vol_decoder_depth: int = 1` to `SurfaceTransolver.__init__`'s signature.

Then replace the fixed linear head with a depth-conditional head:

```python
# Replace this line:
#   self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
# With:
if vol_decoder_depth >= 2:
    self.volume_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.GELU(),
        nn.LayerNorm(n_hidden, eps=1e-6),
        nn.Linear(n_hidden, self.volume_output_dim),
    )
else:
    self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
```

No changes needed to `SurfaceTransolver.forward()` — `self.volume_out(volume_hidden)` works for both `nn.Sequential` and `LinearProjection`.

## Experiment — Two-arm sweep

Use `--wandb-group tanjiro-vol-decoder` so both arms are grouped in W&B:

**Arm A — 2-layer MLP volume decoder (experimental)**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-group tanjiro-vol-decoder \
  --wandb-name tanjiro-vol-decoder-depth2 \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --model-vol-decoder-depth 2
```

**Arm B — Baseline control (linear head, depth=1)**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-group tanjiro-vol-decoder \
  --wandb-name tanjiro-vol-decoder-depth1-ctrl \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --model-vol-decoder-depth 1
```

Run Arm A first, then Arm B (sequential, single pod).

## Baseline (beat this to win)

Current SOTA: PR #232, askeladd, W&B run `r8s2dtnq`

| Metric | SOTA (val) | AB-UPT ref (test) |
|---|---|---|
| `val_abupt` (primary) | **9.065%** | — |
| `surface_pressure` | 5.703% | 3.82% |
| `volume_pressure` | 5.830% | 6.08% |
| `wall_shear` | 10.089% | 7.29% |
| `tau_y` | — | 3.65% |
| `tau_z` | — | 3.63% |

**Target: val_primary/abupt_axis_mean_rel_l2_pct < 9.065%**

SOTA reproduce command:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1
```

## Reporting

Post results as a PR comment with this table:

| Arm | vol_decoder_depth | val_abupt | surface_pressure | volume_pressure | tau_y | tau_z | W&B run |
|-----|------|------|------|------|------|------|------|
| A (MLP, depth=2) | 2 | … | … | … | … | … | … |
| B (linear ctrl, depth=1) | 1 | … | … | … | … | … | … |
| SOTA baseline | 1 (linear) | 9.065% | 5.703% | 5.830% | 11.952% | 12.447% | r8s2dtnq |

Key question: does `volume_pressure` specifically improve in Arm A vs Arm B control, and does this drag down `val_abupt` overall?
