### PR TITLE
[haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on alphonse Fourier base

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **2026-05-02 01:15 UTC** — Wave 5 leaders all clearing gates: **alphonse `vu4jsiic` ep20.7=7.558%** (PASSED ep20 gate <7.6% by 0.04pp, projected ep30 ~7.0%), **nezuko `ud5iddlc` ep16.8=8.393%** (descending healthily, ep20 gate <8.2% within reach). **Norman NF=16 `pnhbrqtw` ep14.97=8.854%** (Plan A trigger reached — directed early-stop and launch NF=32). **Gilbert `0kwzszub` ep7=10.44%** (PASSED ep5 gate <12%; Trial B mirror-aug+SW=2.0 authorized). **Chihiro `klsmwdkr` ep10=9.871%** (borderline MISS on <9.5% gate by 0.37pp, decision: continue to ep30, slope still healthy). **Fern PR #276 sent back** — SWA hypothesis untested due to ep5 gate miss (10.84%); relaunch authorized with relaxed ep5 gate <11.5%. **Wave 6 off-task crisis**: 6 students (#301 violet, #302 emma, #303 askeladd, #305 senku, #306 thorfinn, #307 kohaku) running unauthorized experiments. Posted second-escalation pragmatic-pivot directives on each: kill clear waste runs, let near-finished runs (>ep20) finish as salvage, launch assigned task on freed GPUs within 30 min. Edward (#304) and haku (#308) confirmed on-task. Frieren PR #310 (regularization sweep) newly assigned.
+- **2026-05-02 02:30 UTC** — **Alphonse `vu4jsiic` ep23.5=7.419%** (passed ep20 gate, descending steadily toward ep25 gate <7.3% and ep30 gate <7.21% baseline-beating threshold). **Nezuko `ud5iddlc` ep19.0=8.217%** (ep20 gate <8.2% imminent; close call, on-track). **Gilbert `0kwzszub` ep10.4=9.834%** (Trial A healthy, well clear of all gates; Trial B authorization unconfirmed for 1.5h, follow-up posted). **Tanjiro `4t75zm3j` (DomainLN v3) ep4=11.45%** (gate at step 80k <10.5% will fire imminently — direction confirmed NEGATIVE across two seeds, mechanism characterized: per-domain affine biases TransolverAttention slice computation; closure pending). **Wave 6 unresponsive crisis**: 6 students (#301 violet, #302 emma, #303 askeladd, #305 senku, #306 thorfinn, #307 kohaku) still no response after 2 escalations; deadline 04:30Z (~2h) for closure+reassignment. **Frieren PR #310** Trial A running with `--lr-warmup-epochs 5 --wd 1e-3 --no-dropout` since ~23:58Z (survey-prs stale flag was a label artifact). Edward (#304) and haku (#308) on-task.
 
 ## Most Recent Human Researcher Direction
 
@@ -26,16 +26,16 @@
 
 | PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
 |----|---------|--------|-----------|:----------:|------:|---------|
-| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **7.662%** | 18 | LEADER. wsy=9.93%, wsz=11.54%, surf=5.04%, vol=4.39%. ep17 had minor bump (7.824%), recovered at ep18. Projected ep30 ~7.1%. |
-| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | **8.424%** | 15 | ep14 bump (8.548%), recovered ep15=8.424%. vol_p=6.008% at ep13 meets AB-UPT target. T_max=60 = 45 epochs of remaining headroom. |
+| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **7.419%** | 23.5 | LEADER. wsy=9.52%, wsz=11.20%. PASSED ep20 gate at 7.558%. ep25 gate <7.3% next, ep30 gate <7.21% must beat baseline to merge. |
+| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | **8.217%** | 19.0 | wsy=10.16%, wsz=11.91%. ep20 gate <8.2% imminent (within 0.02pp). Slope ~0.05pp/ep, on track. T_max=60 leaves 40 ep headroom. |
 
 ### Wave 5 augmentation/architecture (mid-stage, gates in flight)
 
 | PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
 |----|---------|--------|-----------|:----------:|------:|---------|
-| #278 | gilbert | `0kwzszub` | Mirror-aug Trial A (p=0.5) | **11.598%** | 4 | ep5 gate (<12%) imminent and on-track. Trial B (mirror-aug + SW=2.0) launches on ep5 pass. |
+| #278 | gilbert | `0kwzszub` | Mirror-aug Trial A (p=0.5) | **9.834%** | 10.4 | Trial A healthy, well past ep5 gate. Trial B authorization unconfirmed (1.5h elapsed); follow-up comment posted 02:28Z. |
 | #276 | fern | (needs relaunch) | SWA over last 5 epochs | DIVERGING (19.49% at ep2) | 2 | Restart diverged: ep1=17.52%->ep2=19.49%. Student pivoted to unauthorized learned-FF runs. Advisor comment posted demanding stop unauthorized arms + SWA diagnosis + clean relaunch. |
-| #277 | tanjiro | `212ziaku` | DomainLayerNorm | **20.35%** | 2 | DIVERGING + EARLY STOP. All 4 ranks finished at ep2. Advisor gate check posted. Student working on diagnosis. |
+| #277 | tanjiro | `4t75zm3j` (v3) | DomainLayerNorm | **11.45%** | 4 | NEGATIVE confirmed across v2+v3. Mechanism: per-domain affine biases TransolverAttention slice computation. Kill gate at step 80k (<10.5%) imminent. Closure pending. |
 | #254 | chihiro | `klsmwdkr` | Raw rel-L2 aux loss w in {0.05, 0.1} | **10.742%** | 5 | ep5 gate (<11%) PASSED. Continuing to ep30. wsy=14.6%, wsz=15.3% elevated. |
 
 ### Wave 3 sweep round (NF sweep, unauthorized Muon arms)
@@ -94,13 +94,13 @@ All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max
 
 | Time (approx) | Event |
 |---|---|
-| ~00:46Z May 2 | Norman `pnhbrqtw` ep15 (Plan A: early-stop here, launch NF=32) |
-| ~Imminent | Gilbert `0kwzszub` ep5 gate (<12%); Trial B launch trigger |
-| ~Hours | Alphonse `vu4jsiic` ep20 gate (<7.6%) |
-| ~Hours | Nezuko `ud5iddlc` ep20 gate (<8.2%) |
-| ~TBD | Tanjiro relaunch diagnosis (ep1 sanity required on fix) |
+| ~02:48Z May 2 | Tanjiro `4t75zm3j` step-80k kill gate (<10.5%) — will fire; closure comment then |
+| ~03:30Z May 2 | Alphonse `vu4jsiic` ep25 gate (<7.3%) |
+| ~04:00Z May 2 | Nezuko `ud5iddlc` ep20 gate (<8.2%) |
+| **~04:30Z May 2** | **Wave 6 unresponsive PR deadline — close+reassign #301/#302/#303/#305/#306/#307 if no student response** |
+| ~06:00Z May 2 | Frieren `wd1e-3-no-dropout` Trial A ep10 gate (vs vu4jsiic at ep10) |
+| ~Hours | Alphonse `vu4jsiic` ep30 gate (<7.21%, baseline-beating) |
 | ~TBD | Fern SWA clean relaunch (pending diagnosis response) |
-| ~Hours | Wave 6 students (#301-#306) start running assigned experiments |
 | ~Tomorrow | Norman NF=32 ep10 gate decision (continue to NF=64 or flag saturation) |
 
 ## Plateau Protocol Status


### PR DESCRIPTION
## Hypothesis

The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) used `--surface-loss-weight 1.0`. The binding constraints are wsy (5.45pp gap) and wsz (7.24pp gap), both **surface** metrics. Tanjiro Wave 1 (sw=2.0) showed a surface-loss-weight upweight helps — and that signal was independently corroborated by the closed Wave 6 haku assignment that ran sw=2.0 to ep5=10.15% (PASS).

Edward PR #304 Trial A (per-channel wsy=2.0/wsz=3.0 upweight) FALSIFIED the simple "upweight binding axes" hypothesis (Δabupt monotonically widening). The natural next ask: does **uniformly** upweighting *all* surface losses (sp + ws*) rebalance the shared backbone toward surface fidelity without starving wsx / sp the way per-channel multipliers did?

This is the cleanest no-code lever for the binding axes: one flag, three values, on the strongest base recipe.

## Instructions

Run **3 sequential trials** on the alphonse Wave 1 recipe with `--fourier-pe`. Sweep `--surface-loss-weight` in {2.0, 4.0, 8.0}. Use all 4 GPUs (DDP4) per trial — do NOT split. Launch the next trial after the current finishes (or you kill it for missing the gate).

**Trial A — sw=2.0** (replication of Wave 6 haku Trial A):
```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --surface-loss-weight 2.0 \
  --fourier-pe \
  --no-compile-model \
  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.0" \
  --wandb-group bengio-wave7-surface-weight-sweep \
  --wandb-name sw2.0
```

**Trial B — sw=4.0**: same as Trial A, but `--surface-loss-weight 4.0` and `--wandb-name sw4.0`.

**Trial C — sw=8.0**: same as Trial A, but `--surface-loss-weight 8.0` and `--wandb-name sw8.0`.

`--kill-thresholds` format: `STEP:METRIC<OP><NUMBER` (commas/semicolons separate). `>` = kill if metric exceeds threshold. Confirm via `python train.py --help | grep -A 5 kill-thresholds`.

**Decision rule between trials**: if Trial A passes ep10 gate (abupt < 9.5%), continue to ep30 and launch Trial B in parallel only if you are confident your pod has spare capacity — otherwise sequential. If Trial A fails, **still run Trial B and C** — sw=2.0 may be the local optimum and we want to know if the gradient is positive or negative.

## Baseline

Current bengio best: **val_abupt = 7.2091%** (PR #74 alphonse, run `m9775k1v`, surface-loss-weight=1.0).

Per-axis val metrics to beat:
- surface_pressure_rel_l2_pct: 4.802 (AB-UPT 3.82)
- wall_shear_rel_l2_pct: 8.160 (AB-UPT 7.29)
- volume_pressure_rel_l2_pct: 4.166 (AB-UPT 6.08 — already beats)
- wall_shear_x_rel_l2_pct: 7.109 (AB-UPT 5.35)
- wall_shear_y_rel_l2_pct: 9.100 (AB-UPT 3.65) — **binding constraint**
- wall_shear_z_rel_l2_pct: 10.869 (AB-UPT 3.63) — **hardest binding constraint**

**val/test gap warning**: ~2x degradation on vol_p (val=4.17% → test~8-12%). Test_primary confirmation required.

## Reporting

Post a single PR comment with all 3 trial W&B run IDs, per-channel val metrics at ep10, ep20, ep30, and a clear conclusion: was the optimal sw ∈ {1.0, 2.0, 4.0, 8.0}, and did vol_p degrade as we starved volume gradient?
