### PR TITLE
[tanjiro] Stack mirror-aug + surface-loss-weight=2.0 on alphonse Fourier base

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **2026-05-02 01:15 UTC** — Wave 5 leaders all clearing gates: **alphonse `vu4jsiic` ep20.7=7.558%** (PASSED ep20 gate <7.6% by 0.04pp, projected ep30 ~7.0%), **nezuko `ud5iddlc` ep16.8=8.393%** (descending healthily, ep20 gate <8.2% within reach). **Norman NF=16 `pnhbrqtw` ep14.97=8.854%** (Plan A trigger reached — directed early-stop and launch NF=32). **Gilbert `0kwzszub` ep7=10.44%** (PASSED ep5 gate <12%; Trial B mirror-aug+SW=2.0 authorized). **Chihiro `klsmwdkr` ep10=9.871%** (borderline MISS on <9.5% gate by 0.37pp, decision: continue to ep30, slope still healthy). **Fern PR #276 sent back** — SWA hypothesis untested due to ep5 gate miss (10.84%); relaunch authorized with relaxed ep5 gate <11.5%. **Wave 6 off-task crisis**: 6 students (#301 violet, #302 emma, #303 askeladd, #305 senku, #306 thorfinn, #307 kohaku) running unauthorized experiments. Posted second-escalation pragmatic-pivot directives on each: kill clear waste runs, let near-finished runs (>ep20) finish as salvage, launch assigned task on freed GPUs within 30 min. Edward (#304) and haku (#308) confirmed on-task. Frieren PR #310 (regularization sweep) newly assigned.
+- **2026-05-02 02:30 UTC** — **Alphonse `vu4jsiic` ep23.5=7.419%** (passed ep20 gate, descending steadily toward ep25 gate <7.3% and ep30 gate <7.21% baseline-beating threshold). **Nezuko `ud5iddlc` ep19.0=8.217%** (ep20 gate <8.2% imminent; close call, on-track). **Gilbert `0kwzszub` ep10.4=9.834%** (Trial A healthy, well clear of all gates; Trial B authorization unconfirmed for 1.5h, follow-up posted). **Tanjiro `4t75zm3j` (DomainLN v3) ep4=11.45%** (gate at step 80k <10.5% will fire imminently — direction confirmed NEGATIVE across two seeds, mechanism characterized: per-domain affine biases TransolverAttention slice computation; closure pending). **Wave 6 unresponsive crisis**: 6 students (#301 violet, #302 emma, #303 askeladd, #305 senku, #306 thorfinn, #307 kohaku) still no response after 2 escalations; deadline 04:30Z (~2h) for closure+reassignment. **Frieren PR #310** Trial A running with `--lr-warmup-epochs 5 --wd 1e-3 --no-dropout` since ~23:58Z (survey-prs stale flag was a label artifact). Edward (#304) and haku (#308) on-task.
 
 ## Most Recent Human Researcher Direction
 
@@ -26,16 +26,16 @@
 
 | PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
 |----|---------|--------|-----------|:----------:|------:|---------|
-| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **7.662%** | 18 | LEADER. wsy=9.93%, wsz=11.54%, surf=5.04%, vol=4.39%. ep17 had minor bump (7.824%), recovered at ep18. Projected ep30 ~7.1%. |
-| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | **8.424%** | 15 | ep14 bump (8.548%), recovered ep15=8.424%. vol_p=6.008% at ep13 meets AB-UPT target. T_max=60 = 45 epochs of remaining headroom. |
+| #174 | alphonse | `vu4jsiic` | 5L/256d + Fourier PE + T_max=50 + EMA off | **7.419%** | 23.5 | LEADER. wsy=9.52%, wsz=11.20%. PASSED ep20 gate at 7.558%. ep25 gate <7.3% next, ep30 gate <7.21% must beat baseline to merge. |
+| #179 | nezuko | `ud5iddlc` | 5L/384d + Fourier PE + T_max=60 | **8.217%** | 19.0 | wsy=10.16%, wsz=11.91%. ep20 gate <8.2% imminent (within 0.02pp). Slope ~0.05pp/ep, on track. T_max=60 leaves 40 ep headroom. |
 
 ### Wave 5 augmentation/architecture (mid-stage, gates in flight)
 
 | PR | Student | Run ID | Experiment | Latest abupt | Epoch | Verdict |
 |----|---------|--------|-----------|:----------:|------:|---------|
-| #278 | gilbert | `0kwzszub` | Mirror-aug Trial A (p=0.5) | **11.598%** | 4 | ep5 gate (<12%) imminent and on-track. Trial B (mirror-aug + SW=2.0) launches on ep5 pass. |
+| #278 | gilbert | `0kwzszub` | Mirror-aug Trial A (p=0.5) | **9.834%** | 10.4 | Trial A healthy, well past ep5 gate. Trial B authorization unconfirmed (1.5h elapsed); follow-up comment posted 02:28Z. |
 | #276 | fern | (needs relaunch) | SWA over last 5 epochs | DIVERGING (19.49% at ep2) | 2 | Restart diverged: ep1=17.52%->ep2=19.49%. Student pivoted to unauthorized learned-FF runs. Advisor comment posted demanding stop unauthorized arms + SWA diagnosis + clean relaunch. |
-| #277 | tanjiro | `212ziaku` | DomainLayerNorm | **20.35%** | 2 | DIVERGING + EARLY STOP. All 4 ranks finished at ep2. Advisor gate check posted. Student working on diagnosis. |
+| #277 | tanjiro | `4t75zm3j` (v3) | DomainLayerNorm | **11.45%** | 4 | NEGATIVE confirmed across v2+v3. Mechanism: per-domain affine biases TransolverAttention slice computation. Kill gate at step 80k (<10.5%) imminent. Closure pending. |
 | #254 | chihiro | `klsmwdkr` | Raw rel-L2 aux loss w in {0.05, 0.1} | **10.742%** | 5 | ep5 gate (<11%) PASSED. Continuing to ep30. wsy=14.6%, wsz=15.3% elevated. |
 
 ### Wave 3 sweep round (NF sweep, unauthorized Muon arms)
@@ -94,13 +94,13 @@ All experiments show val abupt minimum at ~step 552K (~ep31) regardless of T_max
 
 | Time (approx) | Event |
 |---|---|
-| ~00:46Z May 2 | Norman `pnhbrqtw` ep15 (Plan A: early-stop here, launch NF=32) |
-| ~Imminent | Gilbert `0kwzszub` ep5 gate (<12%); Trial B launch trigger |
-| ~Hours | Alphonse `vu4jsiic` ep20 gate (<7.6%) |
-| ~Hours | Nezuko `ud5iddlc` ep20 gate (<8.2%) |
-| ~TBD | Tanjiro relaunch diagnosis (ep1 sanity required on fix) |
+| ~02:48Z May 2 | Tanjiro `4t75zm3j` step-80k kill gate (<10.5%) — will fire; closure comment then |
+| ~03:30Z May 2 | Alphonse `vu4jsiic` ep25 gate (<7.3%) |
+| ~04:00Z May 2 | Nezuko `ud5iddlc` ep20 gate (<8.2%) |
+| **~04:30Z May 2** | **Wave 6 unresponsive PR deadline — close+reassign #301/#302/#303/#305/#306/#307 if no student response** |
+| ~06:00Z May 2 | Frieren `wd1e-3-no-dropout` Trial A ep10 gate (vs vu4jsiic at ep10) |
+| ~Hours | Alphonse `vu4jsiic` ep30 gate (<7.21%, baseline-beating) |
 | ~TBD | Fern SWA clean relaunch (pending diagnosis response) |
-| ~Hours | Wave 6 students (#301-#306) start running assigned experiments |
 | ~Tomorrow | Norman NF=32 ep10 gate decision (continue to NF=64 or flag saturation) |
 
 ## Plateau Protocol Status

--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from data import SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -117,6 +118,7 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    mirror_aug_prob: float = 0.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -157,6 +159,49 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_mirror_y_batch(batch: SurfaceBatch, prob: float) -> tuple[SurfaceBatch, float]:
+    """Per-sample independent y-mirror augmentation.
+
+    With probability `prob` per sample, reflect across the xz-plane:
+      surface_x[..., 1]  (y position)        -> negate
+      surface_x[..., 4]  (ny normal y)       -> negate
+      surface_y[..., 2]  (wsy = wall_shear_y) -> negate
+      volume_x[..., 1]   (y position)        -> negate
+    All other channels (x, z, nx, nz, area, cp, wsx, wsz, sdf, vol_p) are
+    sign-invariant under this reflection. Padded entries are 0 so the sign
+    multiply is a no-op there. Mask/metadata/case_ids untouched.
+
+    Returns the (possibly new) batch and the empirical fraction flipped.
+    """
+    if prob <= 0.0:
+        return batch, 0.0
+    bsz = batch.surface_x.shape[0]
+    flip = torch.rand(bsz, device=batch.surface_x.device) < prob
+    flip_frac = float(flip.float().mean().item())
+    if not bool(flip.any().item()):
+        return batch, flip_frac
+    sign_surf = (1.0 - 2.0 * flip.to(batch.surface_x.dtype)).view(bsz, 1)
+    sign_vol = (1.0 - 2.0 * flip.to(batch.volume_x.dtype)).view(bsz, 1)
+    sign_y = (1.0 - 2.0 * flip.to(batch.surface_y.dtype)).view(bsz, 1)
+    new_surface_x = batch.surface_x.clone()
+    new_surface_x[..., 1] = batch.surface_x[..., 1] * sign_surf
+    new_surface_x[..., 4] = batch.surface_x[..., 4] * sign_surf
+    new_surface_y = batch.surface_y.clone()
+    new_surface_y[..., 2] = batch.surface_y[..., 2] * sign_y
+    new_volume_x = batch.volume_x.clone()
+    new_volume_x[..., 1] = batch.volume_x[..., 1] * sign_vol
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=new_surface_x,
+        surface_y=new_surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=new_volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), flip_frac
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -167,8 +212,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     raw_rel_l2_weight: float = 0.0,
+    mirror_aug_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    batch, mirror_aug_frac = apply_mirror_y_batch(batch, mirror_aug_prob)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -210,6 +257,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "mirror_aug_frac": mirror_aug_frac,
         **aux_metrics,
     }
 
@@ -325,6 +373,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     raw_rel_l2_weight=config.raw_rel_l2_weight,
+                    mirror_aug_prob=config.mirror_aug_prob,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -360,6 +409,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/mirror_aug_frac": batch_loss_metrics["mirror_aug_frac"],
                         }
                     )
                     # Log per-channel raw relative L2 auxiliary metrics when enabled.


### PR DESCRIPTION
## Hypothesis

Two independent Wave 5/6 results suggest small positive signals on the binding axes:
1. **gilbert PR #278 mirror-augmentation Trial A**: ep11 abupt=9.91% (healthy trajectory, gate PASS); train-time y-flip + wsy sign-flip at p=0.5 gives the model the symmetry of the problem for free.
2. **Wave 1 tanjiro sw=2.0** + **closed Wave 6 haku sw=2.0**: both showed surface-loss-weight=2.0 helps on the binding axes (haku ep5=10.15% PASS).

Neither has been combined. The hypothesis: **mirror-augmentation + surface-loss-weight=2.0** stacked on the alphonse Fourier base may compound — mirror gives the model symmetry-equivariant gradients on wsy specifically, and sw=2.0 gives the surface decoder more weight in the optimizer. Different mechanisms, both targeting the binding axes.

Also tests a secondary hypothesis: does mirror-aug interact constructively or destructively with surface-loss upweighting? If destructively, that's a strong signal that the binding constraint is not loss-weight or data-augmentation but representation.

## Instructions

This depends on gilbert's mirror-augmentation code on PR #278 branch `gilbert/mirror-symmetry-train-aug-wsy`. **First, cherry-pick the mirror-aug commit** from gilbert's branch onto your tanjiro branch. The mirror flag should be `--mirror-aug-prob 0.5` or similar — confirm by reading gilbert's PR #278 body and code:

```bash
git fetch origin gilbert/mirror-symmetry-train-aug-wsy
git log origin/gilbert/mirror-symmetry-train-aug-wsy ^bengio --oneline
# cherry-pick the mirror-aug implementation commit (likely the only non-assignment commit)
git cherry-pick <commit-sha>
# verify --help shows the mirror-aug flag
python target/train.py --help | grep -i mirror
```

If gilbert's branch has multiple commits, cherry-pick the implementation commit only (skip the assignment commit if separate). If conflicts arise on `train.py`, prefer gilbert's mirror-aug code and rebase your changes around it.

**Smoke test**:
```bash
cd target/ && python train.py --debug --epochs 1 --mirror-aug-prob 0.5 --surface-loss-weight 2.0 --no-compile-model 2>&1 | head -40
```

**Trial A — mirror=0.5 + sw=2.0** (the stacked recipe):
```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --mirror-aug-prob 0.5 \
  --surface-loss-weight 2.0 \
  --fourier-pe \
  --no-compile-model \
  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.0" \
  --wandb-group bengio-wave7-mirror-plus-sw \
  --wandb-name mirror0.5_sw2.0
```

**Trial B — mirror=0.5 only** (control for stacking effect):
```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --mirror-aug-prob 0.5 \
  --fourier-pe \
  --no-compile-model \
  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.5" \
  --wandb-group bengio-wave7-mirror-plus-sw \
  --wandb-name mirror0.5_sw1.0
```

Run sequentially (Trial A first since it is the high-EV one).

If the exact flag name on gilbert's branch is different (e.g. `--mirror-prob` or `--y-mirror-aug`), use the actual name and report it in your results comment.

`--kill-thresholds` format: `STEP:METRIC<OP><NUMBER` (commas/semicolons). `>` = kill if metric exceeds threshold.

## Baseline

Current bengio best: **val_abupt = 7.2091%** (PR #74 alphonse, run `m9775k1v`).

Per-axis val metrics to beat:
- surface_pressure_rel_l2_pct: 4.802 (AB-UPT 3.82)
- wall_shear_rel_l2_pct: 8.160 (AB-UPT 7.29)
- volume_pressure_rel_l2_pct: 4.166 (AB-UPT 6.08 — already beats)
- wall_shear_x_rel_l2_pct: 7.109 (AB-UPT 5.35)
- wall_shear_y_rel_l2_pct: 9.100 (AB-UPT 3.65) — **binding constraint**
- wall_shear_z_rel_l2_pct: 10.869 (AB-UPT 3.63) — **hardest binding constraint**

**Reference points**:
- gilbert PR #278 Trial A (mirror=0.5 only): ep11 abupt=9.91% — your Trial B should match within 0.3pp at ep11.
- closed Wave 6 haku Trial A (sw=2.0 only): ep5 abupt=10.15% — your Trial A should be ≤ 10.15% at ep5 if the stack is positive.

**val/test gap warning**: ~2x degradation on vol_p (val=4.17% → test~8-12%). Test_primary confirmation required.

## Reporting

Post a single PR comment with:
- The cherry-picked commit SHA from gilbert's branch
- Both trial W&B run IDs
- Per-channel val metrics at ep10, ep20, ep30
- A clear answer: did mirror+sw stack constructively (Trial A < min(gilbert, haku))? Or did the levers fight each other?
