### PR TITLE
[gilbert] Mesh-Laplacian GFT spectral loss on surface predictions

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,10 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    gft_spectral_loss_weight: float = 0.0
+    gft_n_subsample: int = 4096
+    gft_k_nn: int = 16
+    gft_k_modes: int = 64
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1300,6 +1304,126 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+@torch.no_grad()
+def _build_knn_gft_basis(
+    xyz: torch.Tensor,
+    *,
+    k_nn: int,
+    k_modes: int,
+) -> torch.Tensor:
+    """Compute symmetric-normalized graph Laplacian eigenvectors from a kNN graph.
+
+    xyz: [B, N, 3] point coordinates (no padding inside the active rows).
+    Returns U [B, N, k_modes], the eigenvectors corresponding to the k_modes
+    smallest eigenvalues of L_sym = I - D^-1/2 A D^-1/2 with binary kNN A
+    (symmetrized OR). Use within ``torch.no_grad`` — eigenvectors should not
+    contribute gradient to model parameters.
+    """
+    B, N, _ = xyz.shape
+    device = xyz.device
+    xyz_f = xyz.float()
+    # kNN
+    dist = torch.cdist(xyz_f, xyz_f)  # [B, N, N]
+    _, knn_idx = torch.topk(dist, k_nn + 1, largest=False, dim=2)
+    knn_idx = knn_idx[:, :, 1:]  # drop self [B, N, k_nn]
+    # Dense symmetric adjacency (binary OR)
+    adj = torch.zeros(B, N, N, device=device)
+    batch_index = torch.arange(B, device=device).view(B, 1, 1).expand(-1, N, k_nn)
+    row_index = torch.arange(N, device=device).view(1, N, 1).expand(B, -1, k_nn)
+    adj[batch_index, row_index, knn_idx] = 1.0
+    adj = ((adj + adj.transpose(1, 2)) > 0).float()
+    deg = adj.sum(dim=2)
+    deg_inv_sqrt = torch.where(deg > 0, deg.pow(-0.5), torch.zeros_like(deg))
+    eye = torch.eye(N, device=device).unsqueeze(0)
+    laplacian = eye - deg_inv_sqrt.unsqueeze(2) * adj * deg_inv_sqrt.unsqueeze(1)
+    eigvals, eigvecs = torch.linalg.eigh(laplacian)
+    # eigvals ascending; take first k_modes for the lowest-frequency modes
+    return eigvecs[:, :, :k_modes].contiguous()
+
+
+def gft_spectral_relative_l2_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    xyz: torch.Tensor,
+    *,
+    n_subsample: int,
+    k_nn: int,
+    k_modes: int,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Mesh-Laplacian GFT relative-L2 spectral loss for surface fields.
+
+    Builds a per-sample kNN graph on a random valid-point subsample, takes the
+    eigenvectors of its symmetric-normalized Laplacian as the GFT basis, then
+    penalises mismatch in spectral coefficients via relative-L2.
+
+    pred, target: [B, N, C] surface predictions/targets in normalized space.
+    mask: [B, N] valid-point mask (True for non-padding).
+    xyz: [B, N, 3] surface point coordinates.
+    Returns (loss_scalar, diag_metrics).
+    """
+    B, N, _ = pred.shape
+    device = pred.device
+    diag: dict[str, float] = {}
+    if B == 0 or N == 0:
+        return pred.new_zeros(()), diag
+    n_required = max(k_nn + 1, k_modes + 1, 8)
+    valid_counts = mask.sum(dim=1)  # [B]
+    eligible = valid_counts >= n_required
+    if not bool(eligible.any()):
+        return pred.new_zeros(()), diag
+    eligible_indices = torch.where(eligible)[0].tolist()
+    n_sub_per_sample = []
+    sub_idx_list = []
+    for b in eligible_indices:
+        n_valid = int(valid_counts[b].item())
+        n_sub = min(n_subsample, n_valid)
+        valid_idx = torch.where(mask[b])[0]
+        perm = torch.randperm(n_valid, device=device)[:n_sub]
+        sub_idx_list.append(valid_idx[perm])
+        n_sub_per_sample.append(n_sub)
+    # If all eligible samples agree on n_sub we can batch the eigh together.
+    n_sub_uniform = n_sub_per_sample[0]
+    same_n = all(n == n_sub_uniform for n in n_sub_per_sample)
+    pred_f = pred.float()
+    target_f = target.float()
+    sample_losses: list[torch.Tensor] = []
+    if same_n:
+        sub_idx = torch.stack(sub_idx_list, dim=0)  # [Beff, n_sub]
+        beff = sub_idx.shape[0]
+        # Gather using advanced indexing
+        bidx = torch.tensor(eligible_indices, device=device)
+        bsel = bidx.view(-1, 1).expand(-1, n_sub_uniform)
+        p_sub = pred_f[bsel, sub_idx]      # [Beff, n_sub, C]
+        t_sub = target_f[bsel, sub_idx]    # [Beff, n_sub, C]
+        x_sub = xyz[bsel, sub_idx].float()  # [Beff, n_sub, 3]
+        U = _build_knn_gft_basis(x_sub, k_nn=k_nn, k_modes=k_modes)  # [Beff, n_sub, k_modes]
+        c_pred = torch.einsum("bnk,bnc->bkc", U, p_sub)
+        c_true = torch.einsum("bnk,bnc->bkc", U, t_sub)
+        diff_sq = (c_pred - c_true).pow(2).sum(dim=(1, 2))  # [Beff]
+        denom = c_true.pow(2).sum(dim=(1, 2)).clamp_min(1e-8)
+        per_sample = diff_sq / denom
+        sample_losses = [per_sample.mean()]
+        diag["gft_n_subsample"] = float(n_sub_uniform)
+        diag["gft_eligible_batch"] = float(beff)
+    else:
+        for b, sub_idx, n_sub in zip(eligible_indices, sub_idx_list, n_sub_per_sample):
+            p_sub = pred_f[b, sub_idx].unsqueeze(0)
+            t_sub = target_f[b, sub_idx].unsqueeze(0)
+            x_sub = xyz[b, sub_idx].float().unsqueeze(0)
+            U = _build_knn_gft_basis(x_sub, k_nn=k_nn, k_modes=k_modes)
+            c_pred = torch.einsum("bnk,bnc->bkc", U, p_sub)
+            c_true = torch.einsum("bnk,bnc->bkc", U, t_sub)
+            diff_sq = (c_pred - c_true).pow(2).sum()
+            denom = c_true.pow(2).sum().clamp_min(1e-8)
+            sample_losses.append(diff_sq / denom)
+        diag["gft_n_subsample"] = float(sum(n_sub_per_sample) / max(len(n_sub_per_sample), 1))
+        diag["gft_eligible_batch"] = float(len(eligible_indices))
+    if not sample_losses:
+        return pred.new_zeros(()), diag
+    return torch.stack(sample_losses).mean(), diag
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1313,6 +1437,10 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    gft_spectral_loss_weight: float = 0.0,
+    gft_n_subsample: int = 4096,
+    gft_k_nn: int = 16,
+    gft_k_modes: int = 64,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1370,6 +1498,23 @@ def train_loss(
             aux_rel_l2 = num / den
             loss = loss + aux_rel_l2_weight * aux_rel_l2
             aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
+        gft_spectral_value: float | None = None
+        gft_diag: dict[str, float] = {}
+        if gft_spectral_loss_weight > 0.0:
+            ws_pred = surface_pred_norm[..., 1:4]
+            ws_true = surface_target[..., 1:4]
+            xyz = batch.surface_x[..., :3]
+            gft_loss, gft_diag = gft_spectral_relative_l2_loss(
+                ws_pred,
+                ws_true,
+                batch.surface_mask,
+                xyz,
+                n_subsample=gft_n_subsample,
+                k_nn=gft_k_nn,
+                k_modes=gft_k_modes,
+            )
+            loss = loss + gft_spectral_loss_weight * gft_loss
+            gft_spectral_value = float(gft_loss.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1380,6 +1525,10 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if gft_spectral_value is not None:
+        metrics["gft_spectral_loss"] = gft_spectral_value
+        for key, value in gft_diag.items():
+            metrics[key] = value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1810,6 +1959,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                gft_spectral_loss_weight=config.gft_spectral_loss_weight,
+                gft_n_subsample=config.gft_n_subsample,
+                gft_k_nn=config.gft_k_nn,
+                gft_k_modes=config.gft_k_modes,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -1926,6 +2079,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
                 ]
+            if "gft_spectral_loss" in batch_loss_metrics:
+                train_log["train/gft_spectral_loss"] = batch_loss_metrics[
+                    "gft_spectral_loss"
+                ]
+                for key in ("gft_n_subsample", "gft_eligible_batch"):
+                    if key in batch_loss_metrics:
+                        train_log[f"train/{key}"] = batch_loss_metrics[key]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():


### PR DESCRIPTION
## Hypothesis

Index-domain FFT is a weak spectral basis for unstructured CFD meshes because node ordering is arbitrary — "frequency" has no geometric meaning. PR #288 showed this: the FFT-based spectral loss produced a real but sub-threshold signal (0.32pp at λ=0.10). The correct spectral tool for irregular meshes is the **Graph Fourier Transform (GFT)** using mesh Laplacian eigenvectors. In the GFT, each spectral mode corresponds to a smooth variation pattern over the mesh geometry — modes with small eigenvalues are global/low-frequency, modes with large eigenvalues are local/high-frequency. This is physically principled and has a direct analogy to Fourier analysis on regular grids.

**Key insight:** The mesh Laplacian L = D - A encodes mesh topology. Its eigenvectors U (Laplacian eigenbasis) form an orthonormal basis where the GFT of a signal x is simply Ux. The spectral loss in this basis penalizes mismatches in geometrically-meaningful frequency content rather than arbitrary index-domain frequencies.

Reference: [Signal Processing on Graphs (Shuman et al., 2013)](https://arxiv.org/abs/1211.0053)

## Instructions

Implement a mesh-Laplacian GFT spectral auxiliary loss as a replacement for the index-FFT spectral loss from PR #288. Add this as a new auxiliary loss option to `target/train.py`.

### Step 1: Build the graph Laplacian from surface mesh connectivity

The surface mesh connectivity is available from the dataset. For each sample, build the adjacency matrix from surface mesh edges:

```python
import torch
import torch.nn.functional as F

def build_graph_laplacian(pos: torch.Tensor, edges: torch.Tensor) -> torch.Tensor:
    """
    pos: [N, 3] surface node positions
    edges: [E, 2] edge list (source, dest) — from mesh connectivity
    Returns: L [N, N] normalized graph Laplacian (symmetric normalized: I - D^{-1/2} A D^{-1/2})
    """
    N = pos.shape[0]
    row, col = edges[:, 0], edges[:, 1]
    # Build symmetric adjacency
    adj = torch.zeros(N, N, device=pos.device)
    adj[row, col] = 1.0
    adj[col, row] = 1.0
    # Degree matrix
    deg = adj.sum(dim=1)  # [N]
    deg_inv_sqrt = torch.where(deg > 0, deg.pow(-0.5), torch.zeros_like(deg))
    # Symmetric normalized Laplacian: L = I - D^{-1/2} A D^{-1/2}
    D_inv_sqrt = torch.diag(deg_inv_sqrt)
    L = torch.eye(N, device=pos.device) - D_inv_sqrt @ adj @ D_inv_sqrt
    return L
```

### Step 2: Compute truncated GFT basis (top-k eigenvectors)

Full eigendecomposition is O(N³) — too slow for N=65536. Use only the first k eigenvectors (smallest eigenvalues = lowest frequency modes):

```python
def get_gft_basis(L: torch.Tensor, k: int = 256) -> torch.Tensor:
    """
    Returns: U [N, k] — first k eigenvectors of L (sorted by eigenvalue)
    """
    # torch.linalg.eigh is faster for symmetric matrices
    eigenvalues, eigenvectors = torch.linalg.eigh(L)
    # eigenvalues are sorted ascending for eigh
    return eigenvectors[:, :k]  # [N, k] — first k eigenvectors
```

**Practical note:** Computing L and its eigenvectors per-sample in the training loop will be slow. Instead, cache the GFT basis per-mesh-id and pre-compute before training, or compute once per sample and reuse across epochs. If the dataset provides consistent connectivity across samples (same car body at different conditions), the Laplacian is shared across samples and can be computed once.

**Alternative (faster):** Use `scipy.sparse.linalg.eigsh` on the sparse Laplacian to get just the first k eigenvectors. For N=65536, k=128, this takes ~1-2 seconds — acceptable for precomputation but not per-step.

If full computation is too slow, fall back to **k=64 with a smaller N** (subsample the surface to ~8192 points for the spectral loss only, using random subsampling per batch).

### Step 3: GFT spectral loss

```python
def gft_spectral_loss(
    pred: torch.Tensor,    # [B, N, C] — predicted surface fields
    target: torch.Tensor,  # [B, N, C]
    mask: torch.Tensor,    # [B, N] — valid points
    U: torch.Tensor,       # [N, k] — GFT basis (precomputed)
) -> torch.Tensor:
    """
    Spectral relative-L2 loss in GFT basis.
    """
    losses = []
    for b in range(pred.shape[0]):
        m = mask[b]  # [N]
        N_valid = m.sum().item()
        if N_valid < 64:
            continue
        p = pred[b][m]    # [N_valid, C]
        t = target[b][m]  # [N_valid, C]
        # Project onto GFT basis (only valid points)
        U_valid = U[m]    # [N_valid, k]
        p_gft = U_valid.T @ p   # [k, C]
        t_gft = U_valid.T @ t   # [k, C]
        diff = (p_gft - t_gft).pow(2).sum()
        denom = t_gft.pow(2).sum().clamp(min=1e-8)
        losses.append(diff / denom)
    if not losses:
        return pred.new_zeros(1).squeeze()
    return torch.stack(losses).mean()
```

### Step 4: Add CLI flag and integrate into training loop

Add `--gft-spectral-loss-weight` flag (default 0.0, disabled). Apply to surface prediction only (wall-shear channels tau_x/y/z, indices 1-3 in surface_y). Total loss:

```python
total_loss = main_loss + args.gft_spectral_loss_weight * gft_loss
```

### Step 5: Sweep λ values

Run 4 arms, same screening config as PR #288 (4L/256d, single-GPU for speed, bs=8):

| Arm | λ (gft_spectral_loss_weight) |
|-----|------------------------------|
| A   | 0.0 (control)                |
| B   | 0.05                         |
| C   | 0.10                         |
| D   | 0.20                         |

**Expected:** GFT should show a stronger and sharper peaked response than FFT (better geometric alignment → cleaner spectral signal), potentially at similar λ values.

```bash
# Arm A (control)
python train.py --agent gilbert --lr 1e-4 --weight-decay 5e-4 --batch-size 8 \
  --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 96 \
  --ema-decay 0.999 --lr-warmup-steps 2000 --validation-every 1 \
  --gft-spectral-loss-weight 0.0 \
  --wandb-group gft-spectral-loss-sweep --wandb-name arm-A-control

# Arm B (λ=0.05)
python train.py --agent gilbert --lr 1e-4 --weight-decay 5e-4 --batch-size 8 \
  --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 96 \
  --ema-decay 0.999 --lr-warmup-steps 2000 --validation-every 1 \
  --gft-spectral-loss-weight 0.05 \
  --wandb-group gft-spectral-loss-sweep --wandb-name arm-B-gft-0.05

# Arms C and D analogously with λ=0.10 and λ=0.20
```

**If GFT precomputation is too slow:** Fall back to reporting results on the k=64 truncated basis with N=8192 subsampled surface points for the spectral loss — it's still geometrically principled. Document the computational trade-off in the PR.

## Baseline

Current best: `val_primary/abupt_axis_mean_rel_l2_pct` = **9.2910%** (PR #222, W&B run `ut1qmc3i`)

**Merge bar: 9.291%** — must beat this to merge (will need to scale to 4L/512d for final comparison).

This screening uses 4L/256d for speed; if GFT spectral loss shows >0.5pp improvement over the λ=0 control, scale up to 4L/512d for the final PR.

**Prior FFT spectral loss results (PR #288, for comparison):**

| λ | val_abupt | Δ vs control |
|---|-----------|--------------|
| 0.0 (control) | 16.79% | — |
| 0.05 | 17.18% | +0.39pp (worse) |
| 0.10 | 16.47% | **-0.32pp** (best) |
| 0.20 | 17.45% | +0.66pp (worse) |

Target: GFT should show a stronger and/or broader improvement than the FFT's 0.32pp.
