### PR TITLE
tanjiro: per-channel MLP output heads for tau_y/z gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -97,6 +97,61 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+class PerChannelMLPHeads(nn.Module):
+    """One 2-layer MLP per output channel, sharing the same input representation.
+
+    All Linear layers use the model's standard trunc_normal(std=0.02) init.
+    Failure-mode notes from prior revisions on the yi base (6L/256d AdamW):
+      - Zero-init outer Linear (LoRA / T-Fixup convention) created a dead-grad
+        at step 0 for the inner Linear (zero outer weight ⇒ zero gradient flow
+        back) which caused asymmetric ramp-up and NaN grads at ~step 3K under
+        bf16.
+      - Standard init alone trained cleanly to step ~7100 then suddenly diverged
+        (loss 0.21→3.5, backbone-LN grads exploded to ~10^4-10^6) while the
+        linear-baseline control on the same backbone stayed at loss ~0.12. The
+        head's intermediate (hidden_dim, post-GELU) is unbounded, and once the
+        upstream representation grew, the heads amplified it into a runaway
+        backward signal through the backbone LayerNorms.
+    The use_norm flag inserts a LayerNorm between GELU and the outer Linear in
+    each head, bounding the post-GELU intermediate (standard transformer-FFN
+    style) and breaking the runaway loop.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_channels: int,
+        hidden_dim: int,
+        use_norm: bool = False,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.num_channels = num_channels
+        self.hidden_dim = hidden_dim
+        self.use_norm = use_norm
+
+        def _build_head() -> nn.Sequential:
+            layers: list[nn.Module] = [
+                nn.Linear(input_dim, hidden_dim),
+                nn.GELU(),
+            ]
+            if use_norm:
+                layers.append(nn.LayerNorm(hidden_dim, eps=1e-6))
+            layers.append(nn.Linear(hidden_dim, 1))
+            return nn.Sequential(*layers)
+
+        self.heads = nn.ModuleList([_build_head() for _ in range(num_channels)])
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        for head in self.heads:
+            head.apply(_init_linear)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        outs = [head(x) for head in self.heads]
+        return torch.cat(outs, dim=-1)
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -350,6 +405,9 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        use_per_channel_heads: bool = False,
+        per_channel_head_hidden: int = 256,
+        per_channel_head_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,6 +420,9 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.use_per_channel_heads = use_per_channel_heads
+        self.per_channel_head_hidden = per_channel_head_hidden
+        self.per_channel_head_norm = per_channel_head_norm
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -394,7 +455,15 @@ class SurfaceTransolver(nn.Module):
             film_geom_dim=film_encoder_dim if use_film else 0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        if use_per_channel_heads:
+            self.surface_out = PerChannelMLPHeads(
+                input_dim=n_hidden,
+                num_channels=self.surface_output_dim,
+                hidden_dim=per_channel_head_hidden,
+                use_norm=per_channel_head_norm,
+            )
+        else:
+            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -579,6 +648,9 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    use_per_channel_heads: bool = False
+    per_channel_head_hidden: int = 256
+    per_channel_head_norm: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -745,6 +817,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        use_per_channel_heads=config.use_per_channel_heads,
+        per_channel_head_hidden=config.per_channel_head_hidden,
+        per_channel_head_norm=config.per_channel_head_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current `SurfaceTransolver` produces all 4 surface channels (surface_pressure, tau_x, tau_y, tau_z) from a **single shared linear projection** `self.surface_out = LinearProjection(n_hidden, 4)`. This is a 512×4 matrix — all channels share an identical hidden representation with no per-channel non-linear capacity.

This is a strong candidate explanation for the persistent tau_y/z gap (~3.7-4.0× AB-UPT):

1. **Gradient interference**: In a single 512×4 projection, tau_x's loss gradient and tau_y's loss gradient flow through the same weights. Since tau_x has ~3-4× larger magnitude than tau_y (DrivAerML longitudinal flow dominance), tau_x's gradient dominates and tau_y/z get whatever residual capacity remains.
2. **No per-channel non-linearity**: tau_y/z must be linearly decodable from the *same* 512-dim representation that decodes tau_x and surface_p. If the optimal feature subspace for tau_y/z differs, a linear head cannot rotate to it.
3. **Orthogonal to all current in-flight interventions**: PR #324 (z-score) — input-side; PR #317 (Huber) — loss; PR #316/#335 (GradNorm/curriculum) — loss weighting; PR #312 (surface-tangent) — coordinates. This PR attacks **representational capacity allocation**.

Fix: replace the single 4-channel linear head with **4 independent 2-layer MLP heads** (one per surface channel), each with its own non-linear projection from the shared 512-dim backbone.

## Baseline (PR #222, merge bar = 9.291% val_abupt)

| Metric | Current best | AB-UPT target | Gap |
|---|---:|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.291** | — | merge bar |
| `surface_pressure_rel_l2_pct` | 5.871 | 3.82 | 1.54× |
| `wall_shear_rel_l2_pct` | 10.342 | 7.29 | 1.42× |
| `volume_pressure_rel_l2_pct` | 5.879 | 6.08 | **0.97× (solved)** |
| `wall_shear_y_rel_l2_pct` | ~13.5 | 3.65 | ~3.7× |
| `wall_shear_z_rel_l2_pct` | ~14.5 | 3.63 | ~4.0× |

Reproduce baseline: `torchrun --standalone --nproc_per_node=8 train.py --optimizer lion --lr 1e-4 --weight-decay 5e-4 --no-compile-model --batch-size 4 --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 --ema-decay 0.999 --lr-warmup-steps 2720 --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 --epochs 9`

## Instructions

### Step 1 — Add flags to `train.py`

```python
parser.add_argument(
    "--use-per-channel-heads",
    action="store_true",
    default=False,
    help="Use per-channel MLP output heads for surface (4 heads: surface_p, tau_x, tau_y, tau_z) "
         "instead of a single shared linear projection.",
)
parser.add_argument(
    "--per-channel-head-hidden",
    type=int,
    default=256,
    help="Hidden dim for each per-channel MLP head (default 256). Only used if --use-per-channel-heads.",
)
```

### Step 2 — Add `PerChannelMLPHeads` module (near `SurfaceTransolver`)

```python
class PerChannelMLPHeads(nn.Module):
    """One 2-layer MLP per output channel, sharing the same input representation."""

    def __init__(self, input_dim: int, num_channels: int, hidden_dim: int):
        super().__init__()
        self.heads = nn.ModuleList([
            nn.Sequential(
                nn.Linear(input_dim, hidden_dim),
                nn.GELU(),
                nn.Linear(hidden_dim, 1),
            )
            for _ in range(num_channels)
        ])

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: (B, N, input_dim) -> output: (B, N, num_channels)
        outs = [head(x) for head in self.heads]
        return torch.cat(outs, dim=-1)
```

### Step 3 — Wire into `SurfaceTransolver.__init__`

Replace `self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)` with:

```python
if use_per_channel_heads:
    self.surface_out = PerChannelMLPHeads(
        input_dim=n_hidden,
        num_channels=self.surface_output_dim,  # 4
        hidden_dim=per_channel_head_hidden,
    )
else:
    self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)  # unchanged
```

Plumb `use_per_channel_heads` and `per_channel_head_hidden` through the model dataclass and factory. Volume head is left as a linear projection (volume pressure is solved at 0.97×).

**Sanity check**: parameter count should increase by ~528K params (`4 × (512×256 + 256 + 256×1 + 1)`) on top of the 12.7M baseline (~4% increase).

### Step 4 — Run 2-arm ablation

Use `--wandb_group tanjiro-per-channel-heads-r0` so both arms group in W&B.

**Arm A (control)**:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb_group tanjiro-per-channel-heads-r0 \
  --wandb_name tanjiro/per-channel-heads-r0/A-control \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --no-compile-model \
  --batch-size 4 --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --model-slices 128 --ema-decay 0.999 \
  --lr-warmup-steps 2720 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --epochs 9
```

**Arm B (per-channel MLP heads)**:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb_group tanjiro-per-channel-heads-r0 \
  --wandb_name tanjiro/per-channel-heads-r0/B-per-channel-h256 \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --no-compile-model \
  --batch-size 4 --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --model-slices 128 --ema-decay 0.999 \
  --lr-warmup-steps 2720 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --use-per-channel-heads --per-channel-head-hidden 256 \
  --epochs 9
```

If 8-GPU DDP is unavailable, fall back to 4-GPU with `--nproc_per_node=4` and `--lr-warmup-steps 5440` (warmup scales with steps/epoch; 4-GPU doubles them vs 8-GPU). Do not run on fewer than 4 GPUs.

### Step 5 — Decision criteria

- **Merge** if Arm B beats 9.291% val_abupt by any margin.
- **Request changes (send back)** if Arm B beats Arm A but not the bar — suggest: `--per-channel-head-hidden 512`, or per-channel heads on wall-shear only (3 heads), or add LayerNorm before each head.
- **Close** if Arm B is >5% worse than Arm A on val_abupt, or NaN'd.

### Step 6 — Report in a PR comment

Include: val_abupt, surface_p_rel_l2, wall_shear_rel_l2, volume_p_rel_l2, and per-axis tau_x/y/z splits (if available) for both arms at best-val checkpoint. Include W&B run IDs and per-epoch trajectory table. Specifically note whether tau_y/z improved disproportionately — that is the target.

## Notes

- This follows the closure of PR #249 (asinh normalization). The asinh result tells us the model handles heavy tails fine in raw target space. Per-channel heads give richer output *capacity* without touching the target distribution — the architecturally sound complement to the failed asinh approach.
- Do not stack with other tau_y/z interventions in this PR. One hypothesis per PR.
- `python train.py --help` to confirm exact flag spellings before launching.
