### PR TITLE
senku: mlp_ratio=8 vs 12 head-to-head (single-GPU follow-up to #315)

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,7 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    max_steps_per_epoch: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1797,7 +1798,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        epoch_step_limit = config.max_steps_per_epoch if config.max_steps_per_epoch > 0 else None
+        epoch_step_idx = 0
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if epoch_step_limit is not None and epoch_step_idx >= epoch_step_limit:
+                break
+            epoch_step_idx += 1
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,


### PR DESCRIPTION
## Hypothesis

Follow-up to #315 (mlp_ratio screening). In that 3-arm sweep, `mlp_ratio=8` won monotonically over `4` and `2` across every primary and per-axis metric through ep9, with all 3 arms still descending. Advisor's question for this round (Option A in #315 final comment):

> *Does the trend continue at `mlp_ratio=12`, or does it plateau / regress? If `mlp_ratio=12` also wins monotonically, that informs the architecture-arm choice for the eventual ddp8 confirmation run. If it plateaus or regresses, mlp_ratio=8 is the locked-in choice.*

`mlp_ratio=12` is roughly +66% FFN params over `mlp_ratio=8` (~28M vs ~21M). On the existing single-GPU pod at 96 GB, `mlp_ratio=8` already peaks at 85.5 GB at bs=4 + 65k volume points; the advisor's reproduce command therefore drops to bs=2 + train/eval volume points = 32 768 to fit. The matched protocol is also re-run for `mlp_ratio=8` so the head-to-head is at identical conditions.

## Protocol (advisor-supplied)

Two arms, identical config except `--model-mlp-ratio`:

| Arm | mlp_ratio | GPU |
|-----|-----------|-----|
| Arm 8 (re-run, matched) | 8 | 0 |
| Arm 12 (new) | 12 | 1 |

Both arms: bs=2, surface points 65 536, **train+eval volume points 32 768**, 9 epochs, `--max-steps-per-epoch 2000` (18 000 train steps total), AdamW, lr=5e-4, lr-warmup-steps=500, clip-grad-norm=1.0, ema-decay=0.999, wallshear-y/z weights=2.0, no compile.

### Reproduce — Arm 12 (verbatim from #315 advisor comment)

```bash
CUDA_VISIBLE_DEVICES=1 python train.py \
  --agent senku --wandb-group senku-mlp-ratio-r19 --wandb-name mlp-ratio-12 \
  --model-mlp-ratio 12 \
  --lr 5e-4 --weight-decay 1e-4 --lr-warmup-steps 500 --clip-grad-norm 1.0 \
  --no-compile-model --batch-size 2 --epochs 9 --max-steps-per-epoch 2000 \
  --gradient-log-every 200 --weight-log-every 200 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 32768 --eval-volume-points 32768 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --wallshear-y-weight 2.0 --wallshear-z-weight 2.0
```

### Reproduce — Arm 8 (matched protocol, do not reuse #315 Arm C numbers)

Same as Arm 12 except `CUDA_VISIBLE_DEVICES=0`, `--model-mlp-ratio 8`, `--wandb-name mlp-ratio-8`.

## What to report

1. 2-arm table: `mlp_ratio`, params, peak_GB, epoch_time_s, val_abupt (best), test_abupt, surface_p, wall_shear, vol_p, tau_x/y/z
2. Per-epoch val_abupt trajectory comparison (`mlp8` vs `mlp12`)
3. W&B run IDs for both arms (group `senku-mlp-ratio-r19`)
4. Stability check: NaN skips, OOM, early stops
5. Steps/sec comparison (compute cost of `mlp_ratio=12`)

## Baseline (within-experiment, from #315 Arm C at unmatched protocol)

Reference only — Arm 8 here is at a **different protocol** (bs=2 + eval-volume=32k vs bs=4 + eval-volume=65k in #315), so absolute numbers will differ. The relevant comparison is Arm 12 vs Arm 8 *at this protocol*.

| Metric | #315 Arm C (mlp8, unmatched) | This PR Arm 8 (matched) | This PR Arm 12 |
|--------|------------------------------:|-------------------------:|---------------:|
| best val_abupt | 10.897 % | TBD | TBD |
| test_abupt | 11.981 % | TBD | TBD |
| test_p_s | 7.098 % | TBD | TBD |
| test_tau | 12.059 % | TBD | TBD |
| test_p_v | 13.454 % | TBD | TBD |

The merge bar (9.291% from PR #222) cannot be reached on this protocol — that confirmation needs the alphonse #284 infra (Lion + lr-warmup-epochs + 8-GPU DDP), routed by the advisor to a ddp8 student in a future round.

## Includes

- The `--max-steps-per-epoch` infra fix from #315 (cherry-picked, same 5-line patch).

## Predecessor

PR #315 — 3-arm screening showing `mlp8 < mlp4 < mlp2` monotonic ordering. This PR adds the `mlp12` cost point and produces a matched `mlp8` reference for direct comparison.