### PR TITLE
[gilbert] FiLM normal-conditioning at every transformer block (surface trunk)

### DIFF
--- a/model.py
+++ b/model.py
@@ -180,6 +180,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        film_dim: int | None = None,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -192,12 +193,39 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if film_dim is not None and film_dim > 0:
+            # Per-block (gamma, beta) projection. Zero-init so the block starts as identity FiLM
+            # and the model is numerically equivalent to the no-FiLM baseline at step 0.
+            self.film_proj = nn.Linear(film_dim, 2 * hidden_dim)
+            nn.init.zeros_(self.film_proj.weight)
+            nn.init.zeros_(self.film_proj.bias)
+        else:
+            self.film_proj = None
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        film_cond_surface: torch.Tensor | None = None,
+        num_surface_tokens: int = 0,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
         x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
+        if (
+            self.film_proj is not None
+            and film_cond_surface is not None
+            and num_surface_tokens > 0
+        ):
+            gb = self.film_proj(film_cond_surface)
+            gamma, beta = gb.chunk(2, dim=-1)
+            x_surface = x[:, :num_surface_tokens]
+            x_surface = (1.0 + gamma) * x_surface + beta
+            if x.shape[1] > num_surface_tokens:
+                x = torch.cat([x_surface, x[:, num_surface_tokens:]], dim=1)
+            else:
+                x = x_surface
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -211,6 +239,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        film_dim: int | None = None,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -221,14 +250,26 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    film_dim=film_dim,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        film_cond_surface: torch.Tensor | None = None,
+        num_surface_tokens: int = 0,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(
+                x,
+                attn_mask=attn_mask,
+                film_cond_surface=film_cond_surface,
+                num_surface_tokens=num_surface_tokens,
+            )
         return x
 
 
@@ -251,6 +292,8 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         fourier_pe: bool = False,
         fourier_pe_num_freqs: int = 8,
+        film_normal: bool = False,
+        film_hidden_dim: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -258,6 +301,8 @@ class SurfaceTransolver(nn.Module):
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
+        self.film_normal = film_normal
+        self.film_hidden_dim = film_hidden_dim if film_normal else 0
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -277,6 +322,15 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        if film_normal:
+            self.film_normal_encoder = nn.Sequential(
+                nn.Linear(space_dim, film_hidden_dim),
+                nn.GELU(),
+                nn.Linear(film_hidden_dim, film_hidden_dim),
+            )
+            self.film_normal_encoder.apply(_init_linear)
+        else:
+            self.film_normal_encoder = None
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -284,6 +338,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            film_dim=film_hidden_dim if film_normal else None,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -349,7 +404,18 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        film_cond_surface = None
+        if self.film_normal_encoder is not None and surface_x is not None and surface_tokens > 0:
+            normals = surface_x[:, :, self.space_dim : self.space_dim + 3]
+            film_cond_surface = self.film_normal_encoder(normals)
+
+        hidden = self.backbone(
+            hidden,
+            attn_mask=attn_mask,
+            film_cond_surface=film_cond_surface,
+            num_surface_tokens=surface_tokens,
+        )
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -252,6 +252,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            if config.film_normal:
+                # FiLM modules are gated on `surface_tokens > 0`; point-view sampling can
+                # produce empty-surface views (see program.md "Point-View Sampling"),
+                # so the FiLM params are conditionally used. Without this, DDP hangs
+                # at the next backward when one rank skips FiLM and others don't.
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:

--- a/train.py
+++ b/train.py
@@ -117,6 +117,8 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    film_normal: bool = False
+    film_hidden_dim: int = 64
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -154,6 +156,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         fourier_pe=config.fourier_pe,
         fourier_pe_num_freqs=config.fourier_pe_num_freqs,
+        film_normal=config.film_normal,
+        film_hidden_dim=config.film_hidden_dim,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Edward PR #304 (loss-weighting) and frieren PR #337 (tangent-frame head) approach the wsy/wsz binding constraint from two angles. A **third orthogonal lever** is **conditioning the trunk's hidden representation on the surface normal at every layer** rather than only at input.

**Mechanism**: Wall shear magnitude and direction depend strongly on the local surface orientation. Currently the normal enters via `surface_x` (channels 3:6) at input, gets mixed into the embedding, and is then "forgotten" through the transformer trunk. **FiLM (feature-wise linear modulation) conditioning** injects the normal `n` back into every transformer block as a per-channel scale + shift `h ← γ(n) ⊙ h + β(n)`, keeping the orientation signal accessible at all depths.

This is well-validated in vision (StyleGAN, ResBlocks-FiLM) and recently re-emerged in graph/point-cloud nets for boundary-condition-conditioned PDE surrogates. It is **architecturally orthogonal** to both per-channel loss weights and tangent-frame output rotation, so we can later stack winners.

**This is a fresh Wave 8 architectural direction** — distinct from frieren #337 (which is the tangent-frame OUTPUT head). Both can run in parallel.

## Instructions

Add a small FiLM conditioning module that takes per-point normals and emits a `(γ, β)` pair for every transformer block in the surface trunk. Apply post-attention or post-MLP (pick one consistently; post-MLP is the common choice).

### Code edit plan (target/model.py)

1. **Add a `FiLMNormalConditioner` module** — a small 2-layer MLP that maps `n` (3-d normal) → `2 * hidden_dim * num_layers` activations, split into (γ_l, β_l) per layer. Or, simpler, one MLP shared across layers with a per-layer linear projection on top.

2. **Apply at each transformer block** in the surface trunk: after the existing block output `h`, compute `h ← (1 + γ) * h + β` (the `1+γ` form is common to keep gradient flow intact at init when γ is near 0).

3. **Initialize γ, β to ~0** (`zeros_init` on the final FiLM linear layers) so the model **starts numerically equivalent to the baseline** at step 0. This is critical — verify by running a short smoke-test and confirming step-0 loss matches baseline within numerical noise.

4. **Volume head**: leave volume trunk unchanged. FiLM is surface-only — that's the binding constraint axis.

### Smoke-test before sweep

```bash
cd target/ && python train.py --debug --epochs 1 --no-compile-model 2>&1 | tail -50
```
With γ, β initialized to 0, **step-0 loss should be very close to baseline** at the same seed. If it isn't, the FiLM injection has a sign/shape bug — fix before launching.

### Run

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --no-compile-model \
  --wandb-group bengio-wave8-film-normal \
  --wandb-name gilbert/film-normal-rank0 \
  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct<22,200000:val_primary/abupt_axis_mean_rel_l2_pct<11.5,500000:val_primary/abupt_axis_mean_rel_l2_pct<8.5"
```

### CRITICAL guardrails

- **Do NOT add mirror-aug, EMA, dropout, or any other knob in this PR.** Isolate the FiLM normal-conditioning lever.
- **Do NOT modify the wall-shear output head** — that's frieren PR #337's territory.
- Watch parameter count — the FiLM MLP adds maybe 50-200k params depending on width. Report `n_params` in your launch comment so we can compare apples-to-apples.
- If wsy/wsz don't show signal by ep10, kill the run rather than burning ep30.

### Kill thresholds explained

`STEP:metric<VALUE` = "kill the run if `metric` is **≥** VALUE at step STEP". Pass condition uses `<`. Do NOT invert the operator.

## Baseline

- `val_primary/abupt_axis_mean_rel_l2_pct` = **7.2091%** (PR #74, alphonse, run `m9775k1v`, ep30, n_params=3,249,813)
- AB-UPT axis_mean target ~4.51% (test_primary)
- Channel breakdown (val): sp=4.802%, wsx=7.109%, wsy=9.100%, wsz=10.869%, vol_p=4.166%
- Reproduce baseline: see `/BASELINE.md`
- Edward PR #304 confirmed loss-weighting on wsy/wsz **does not** help. We are now exploring representation/conditioning levers.

### Pass criteria

- **Win**: val_abupt < 7.2091% at ep30
- **Promising**: wsy AND wsz both improve > 0.5pp from baseline at ep30, even if abupt is similar
- **Negative**: wsy/wsz unchanged at ep15 — close as FiLM-on-normal is exhausted

## Reporting

1. Confirm the smoke-test passes; post the parameter count and a summary of the code edit.
2. Post the W&B run ID immediately after launch.
3. Final comment: ep30 metrics table vs baseline, with explicit wsy/wsz delta.
