### PR TITLE
[nezuko] Dedicated 2-block wall-shear sub-decoder (split surface head)

### DIFF
--- a/model.py
+++ b/model.py
@@ -121,6 +121,30 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class ShearSubDecoder(nn.Module):
+    """Dedicated 2-block residual MLP head for the wall-shear vector.
+
+    Each block is pre-LayerNorm + UpActDownMlp(D -> mlp_hidden -> D) with a
+    residual connection. The final projection to 3 channels is zero-initialized
+    so wall-shear predictions match the baseline-init behaviour at step 0.
+    """
+
+    def __init__(self, hidden_dim: int, mlp_hidden_dim: int, output_dim: int = 3):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.mlp1 = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.mlp2 = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.out = nn.Linear(hidden_dim, output_dim)
+        nn.init.zeros_(self.out.weight)
+        nn.init.zeros_(self.out.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.mlp1(self.norm1(x))
+        x = x + self.mlp2(self.norm2(x))
+        return self.out(x)
+
+
 class TransolverAttention(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
         super().__init__()
@@ -251,6 +275,7 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         fourier_pe: bool = False,
         fourier_pe_num_freqs: int = 8,
+        shear_head_mlp_ratio: int | float = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -286,7 +311,18 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        if self.surface_output_dim != 4:
+            raise ValueError(
+                "Split surface head expects surface_output_dim == 4 "
+                "([surface_pressure, wall_shear_x, wall_shear_y, wall_shear_z])"
+            )
+        self.pressure_out = LinearProjection(n_hidden, 1)
+        shear_mlp_hidden = int(math.ceil(n_hidden * shear_head_mlp_ratio))
+        self.shear_out = ShearSubDecoder(
+            hidden_dim=n_hidden,
+            mlp_hidden_dim=shear_mlp_hidden,
+            output_dim=3,
+        )
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -359,7 +395,9 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            sp_pred = self.pressure_out(surface_hidden)
+            ws_pred = self.shear_out(surface_hidden)
+            surface_preds = torch.cat([sp_pred, ws_pred], dim=-1) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)


### PR DESCRIPTION
## Hypothesis

The current model uses **a single shared linear head** to produce all 4 surface channels `[sp, wsx, wsy, wsz]`. This means the same trunk hidden representation must serve both surface_pressure (a smooth scalar field, val=4.80%) and the wall-shear vector field (very high-frequency, val=8.16% mean), which puts these channels in competition for representational capacity.

Edward PR #304 demonstrated that loss-reweighting alone does not unlock wsy/wsz. The **fundamental pressure↔shear capacity competition** in the surface head is structural — solving it requires architectural separation.

**Hypothesis**: Replacing the single-linear surface head with a **deeper, dedicated wall-shear sub-decoder** — a small 2-block MLP specifically for wsx/wsy/wsz, while keeping sp on the simple linear head — should reduce pressure↔shear interference and improve wsy/wsz. Parallel and orthogonal to gilbert's FiLM #346 and frieren's tangent-frame head #337, so a winning approach can later be stacked.

**Your previous 5L/384d scaling experiment was falsified at ep65 (abupt=8.008%) — capacity is not the bottleneck. We are now putting capacity exactly where the binding constraint lives.**

## Instructions

Modify `target/model.py` to split the surface head.

### Code edit plan

1. **Locate the surface head** — currently a single `Linear(hidden_dim → 4)`.

2. **Split into two heads** sharing the same trunk hidden state `h ∈ (B, N, D)`:
   - **Pressure head**: `Linear(D → 1)` for surface_pressure. Same as today.
   - **Shear sub-decoder**: a small 2-block MLP on `h`:
     - Block 1: `LayerNorm + Linear(D → mlp_ratio*D) + GELU + Linear(mlp_ratio*D → D)` (residual)
     - Block 2: same shape (residual)
     - Output projection: `Linear(D → 3)` for `(wsx, wsy, wsz)`.
   - Concat `[sp_pred, ws_pred]` along last dim → `(B, N, 4)` to match the existing pipeline.

3. **Initialize the shear sub-decoder's final projection to zeros** so at step 0 the wall-shear output is zero (matching baseline-init shear behaviour). Verify with a 1-step smoke-test:
   ```bash
   cd target/ && python train.py --debug --epochs 1 --no-compile-model 2>&1 | tail -50
   ```

4. **Volume trunk + head: do not touch.** Surface-only.

5. **Param-count budget**: aim ~150-300k extra params. Baseline `n_params=3,249,813`. Report your exact count.

### Run

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --no-compile-model \
  --wandb-group bengio-wave8-shear-subdecoder \
  --wandb-name nezuko/shear-subdec-rank0 \
  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct<22,200000:val_primary/abupt_axis_mean_rel_l2_pct<11.5,500000:val_primary/abupt_axis_mean_rel_l2_pct<8.5"
```

### CRITICAL guardrails

- Keep `--model-layers 4 --model-hidden-dim 256` exactly. 5L/384d (your `ud5iddlc`) was worse. The hypothesis: **specialized capacity at the head, not more capacity in the trunk**.
- Do NOT combine with FiLM, tangent-frame head, mirror-aug, EMA, or any other knob. Isolate.
- Watch surface_pressure at ep5 — if sp regresses > 0.5pp, the split hurt the pressure head; investigate.
- If wsy/wsz haven't moved by ep10, kill rather than burning to ep30.

### Kill thresholds explained

`STEP:metric<VALUE` = "kill the run if `metric` is **≥** VALUE at step STEP". Pass condition uses `<`. Do NOT invert the operator.

## Baseline

- `val_primary/abupt_axis_mean_rel_l2_pct` = **7.2091%** (PR #74, alphonse, run `m9775k1v`, ep30, n_params=3,249,813)
- AB-UPT axis_mean target ~4.51% (test_primary)
- Channel breakdown (val): sp=4.802%, wsx=7.109%, wsy=9.100%, wsz=10.869%, vol_p=4.166%
- Reproduce baseline: see `/BASELINE.md`
- Edward PR #304 (parallel evidence): per-channel MSE reweighting **does not** help wsy/wsz.
- Your `ud5iddlc` 5L/384d (parallel evidence): more uniform capacity in the trunk **does not** help (ep65 abupt=8.008%).

### Pass criteria

- **Win**: val_abupt < 7.2091% at ep30
- **Promising**: wsy AND wsz both improve > 0.5pp at ep30
- **Negative**: wsy/wsz unchanged at ep15 — close as specialized-head-capacity is exhausted

## Reporting

1. Confirm the smoke-test passes; post `n_params` and a summary of the code edit.
2. Post W&B run ID immediately after launch.
3. Final comment: ep30 metrics table vs baseline with explicit wsy/wsz delta and `n_params`.
