### PR TITLE
Surface tangent-frame vectors as encoder input features

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,8 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    surface_tangent_frame_input: bool = False
+    max_steps_per_epoch: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -734,7 +736,8 @@ def make_loaders(
 
 
 def build_model(config: Config) -> SurfaceTransolver:
-    return SurfaceTransolver(
+    surface_input_dim = SURFACE_X_DIM + (9 if config.surface_tangent_frame_input else 0)
+    model = SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
         dropout=config.model_dropout,
@@ -745,7 +748,15 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        surface_input_dim=surface_input_dim,
     )
+    # Zero-init the surface projection columns for the new tangent-frame channels so
+    # the model is mathematically identical to the no-frame baseline at init; the
+    # optimizer learns to use the new channels from gradient signal.
+    if config.surface_tangent_frame_input and model.project_surface_features is not None:
+        with torch.no_grad():
+            model.project_surface_features.project.weight[:, -9:].zero_()
+    return model
 
 
 def _metric_path(name: str) -> str:
@@ -1288,6 +1299,32 @@ def weighted_masked_mse_per_channel(
     return weighted_loss, per_axis_mean
 
 
+def compute_surface_tangent_frame(surface_x: torch.Tensor) -> torch.Tensor:
+    """Compute [t1, t2, n] tangent frame from normals in surface_x[..., 3:6].
+
+    Returns tensor of shape (..., 9) = [t1(3), t2(3), n(3)].
+    Uses fp32 internally for numerical stability regardless of input dtype.
+    The construction is deterministic: for each surface normal n,
+      ref = (0,1,0) when |n.x| > 0.9, else (1,0,0)
+      t1 = normalize(cross(ref, n))
+      t2 = cross(n, t1)
+    This gives a right-handed orthonormal frame.
+    """
+    orig_dtype = surface_x.dtype
+    n = F.normalize(surface_x[..., 3:6].float(), dim=-1, eps=1e-8)
+    # Reference vectors: (1,0,0) by default, fallback (0,1,0) near x-axis
+    ref_x = torch.zeros_like(n)
+    ref_x[..., 0] = 1.0
+    ref_y = torch.zeros_like(n)
+    ref_y[..., 1] = 1.0
+    use_fallback = (n[..., 0].abs() > 0.9).unsqueeze(-1)
+    ref = torch.where(use_fallback, ref_y, ref_x)
+    t1 = F.normalize(torch.linalg.cross(ref, n), dim=-1, eps=1e-8)
+    t2 = torch.linalg.cross(n, t1)
+    frame = torch.cat([t1, t2, n], dim=-1)
+    return frame.to(orig_dtype)
+
+
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
     """Project per-point 3-vectors onto the local tangent plane.
 
@@ -1313,13 +1350,18 @@ def train_loss(
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
+    surface_tangent_frame_input: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    surface_x = batch.surface_x
+    if surface_tangent_frame_input:
+        frame = compute_surface_tangent_frame(surface_x)
+        surface_x = torch.cat([surface_x, frame], dim=-1)
     with autocast_context(device, amp_mode):
         out = model(
-            surface_x=batch.surface_x,
+            surface_x=surface_x,
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
@@ -1441,6 +1483,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    surface_tangent_frame_input: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -1471,9 +1514,13 @@ def evaluate_split(
         batch = batch.to(device)
         surface_target_norm = transform.apply_surface(batch.surface_y)
         volume_target_norm = transform.apply_volume(batch.volume_y)
+        surface_x = batch.surface_x
+        if surface_tangent_frame_input:
+            frame = compute_surface_tangent_frame(surface_x)
+            surface_x = torch.cat([surface_x, frame], dim=-1)
         with autocast_context(device, amp_mode):
             out = model(
-                surface_x=batch.surface_x,
+                surface_x=surface_x,
                 surface_mask=batch.surface_mask,
                 volume_x=batch.volume_x,
                 volume_mask=batch.volume_mask,
@@ -1712,7 +1759,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
-    total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    effective_loader_len = max(len(train_loader), 1)
+    if config.max_steps_per_epoch > 0:
+        effective_loader_len = min(effective_loader_len, config.max_steps_per_epoch)
+    total_estimated_steps = max(1, max_epochs * effective_loader_len)
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1796,8 +1846,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         model.train()
         train_loss_sum = 0.0
         n_batches = 0
+        epoch_steps_done = 0
+        epoch_step_cap = config.max_steps_per_epoch if config.max_steps_per_epoch > 0 else None
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if epoch_step_cap is not None and epoch_steps_done >= epoch_step_cap:
+                break
+            epoch_steps_done += 1
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,
@@ -1810,6 +1865,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
+                surface_tangent_frame_input=config.surface_tangent_frame_input,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2001,7 +2057,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, surface_tangent_frame_input=config.surface_tangent_frame_input)
             for name, loader in val_loaders.items()
         }
         if ema is not None:
@@ -2116,7 +2172,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, surface_tangent_frame_input=config.surface_tangent_frame_input)
         for name, loader in val_loaders.items()
     }
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -2150,7 +2206,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, surface_tangent_frame_input=config.surface_tangent_frame_input)
         for name, loader in test_loaders.items()
     }
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]


### PR DESCRIPTION
## Hypothesis

Surface mesh normals and tangent frame vectors encode **rich local geometric information** that the current encoder does not use. We hypothesize that concatenating the local surface frame [t1, t2, n] into each surface point token as **input features** will improve wall-shear prediction — particularly the hard τy and τz axes — because:

1. The model can learn to decompose flow quantities along physically meaningful local frame directions
2. τy and τz correspond to cross-flow components; the global Cartesian frame poorly expresses these relative to local surface orientation
3. Adding frame vectors as *input* is zero-risk to the loss geometry (we keep Cartesian output heads) — the only change is richer geometric context in the encoder

This is distinct from PR #312 (closed), which transformed *output targets* into the tangent frame (hurt τy/τz due to n_target_phys_rms ≈ 0.33). Here we use the tangent frame purely as **additional input features** — the encoder learns whether/how to use them.

**Previous experiment (PR #312 — closed)**: Rotating output wall-shear targets to [t1, t2, n] frame hurt τy (+1.27pp) and τz (+1.24pp) vs control. Root cause: DrivAerML wall-shear is not purely tangential (n_target_phys_rms ≈ 0.33), so adding a third n-axis and destroying global flow-alignment made cross-flow prediction harder. τx improved (-0.80pp) since rotation concentrates streamwise signal on t1.

**This experiment is the opposite direction**: no target rotation, no loss change — just concatenate [t1, t2, n] into encoder input tokens so the model knows its local frame while predicting in Cartesian space.

## Instructions

Add a new `--surface-tangent-frame-input` flag to `train.py` that, when enabled, concatenates the local surface frame vectors into each surface point token before the surface encoder.

### Implementation Details

1. **Frame computation**: Reuse the deterministic mesh-normal cross-product method from PR #312 (`edward/surface-tangent-frame` branch):
   - n = mesh face/vertex normal (already available as a surface point feature)
   - t1 = (arbitrary reference × n).normalize()   e.g. reference = (1, 0, 0), fallback to (0, 1, 0) if nearly parallel
   - t2 = (n × t1).normalize()
   - The frame from PR #312 had det=1.0 and nan_count=0 — good numerical quality

2. **Token augmentation**: For each surface point, concatenate [t1, t2, n] (9 floats: 3 × 3D vectors) to the existing surface point features before the surface encoder projection layer. The encoder projection dim grows by 9; the model internally handles this through the first linear layer.

3. **Flag**: `--surface-tangent-frame-input` (boolean, default False). No `--no-surface-tangent-frame-input` needed — this is a new feature, default off.

4. **Volume points**: No change — tangent frames are defined on the surface mesh only.

5. **Output heads**: Keep all output heads in Cartesian (x, y, z) — do NOT rotate targets.

### Ablation Design

Run 2 arms using `--wandb_group edward-tangent-input-r19`:

**Arm A — Control (baseline config)**:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --wandb_group edward-tangent-input-r19 \
  --wandb_name edward-tangent-input-control \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1
```

**Arm B — Tangent-frame input**:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --wandb_group edward-tangent-input-r19 \
  --wandb_name edward-tangent-input-tfi \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --surface-tangent-frame-input
```

Use your 4 GPUs to run both arms in parallel (2 GPUs each if needed, or sequence if memory is tight).

### Success Metrics

Report for **each arm** at best epoch:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary metric — merge bar: **9.291%**)
- `val_primary/wall_shear_y_rel_l2_pct`
- `val_primary/wall_shear_z_rel_l2_pct`
- `val_primary/wall_shear_x_rel_l2_pct`
- `val_primary/surface_pressure_rel_l2_pct`
- `val_primary/volume_pressure_rel_l2_pct`

**If val_abupt(Arm B) < val_abupt(Arm A)**: merge candidate
**If val_abupt(Arm B) >= val_abupt(Arm A)**: close; geometric input features not helpful at this scale

## Baseline

Current best: **PR #222** (fern, lr_warmup_epochs=1, 4L/512d/8H/128S, Lion lr=1e-4, bs=4×8GPU)

| Metric | Baseline (PR #222, W&B `ut1qmc3i`) |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.2910%** |
| `val_primary/surface_pressure_rel_l2_pct` | **5.8707%** |
| `val_primary/wall_shear_rel_l2_pct` | **10.3423%** |
| `val_primary/volume_pressure_rel_l2_pct` | **5.8789%** |
| `val_primary/wall_shear_y_rel_l2_pct` | ~13–22% (critical gap) |
| `val_primary/wall_shear_z_rel_l2_pct` | ~13–22% (critical gap) |

**Merge bar: 9.291% — beat this to merge.**

AB-UPT public targets for reference:
- surface_pressure: 3.82%  |  wall_shear: 7.29%  |  volume_pressure: 6.08%
- wall_shear_x: 5.35%  |  **wall_shear_y: 3.65%**  |  **wall_shear_z: 3.63%**

Note: wall_shear_y and wall_shear_z (~13–22% vs 3.65%/3.63% target) are the **primary gap** — the tangent-frame input feature targets exactly this weakness.

