### PR TITLE
norman: MAE-style point masking (--point-mask-ratio sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -63,6 +63,21 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+def apply_point_mask(mask: torch.Tensor, mask_ratio: float) -> torch.Tensor:
+    """Bernoulli-drop currently-valid positions for MAE-style point masking.
+
+    Each True position in `mask` is independently kept with probability
+    (1 - mask_ratio). Already-invalid (False) positions remain False.
+    Returns the input mask unchanged when mask_ratio <= 0.0.
+    """
+    if mask_ratio <= 0.0:
+        return mask
+    if mask_ratio >= 1.0:
+        raise ValueError(f"point_mask_ratio must be < 1.0, got {mask_ratio}")
+    keep = torch.rand(mask.shape, device=mask.device, dtype=torch.float32) >= mask_ratio
+    return mask & keep
+
+
 class DropPath(nn.Module):
     """Stochastic depth: drop entire residual branch with probability `drop_prob`."""
 
@@ -601,6 +616,7 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    point_mask_ratio: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1784,6 +1800,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     train_start = time.time()
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
+    point_mask_logged = False
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
@@ -1798,6 +1815,31 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if config.point_mask_ratio > 0.0:
+                surface_valid_before = int(batch.surface_mask.sum().item())
+                volume_valid_before = int(batch.volume_mask.sum().item())
+                batch.surface_mask = apply_point_mask(batch.surface_mask, config.point_mask_ratio)
+                batch.volume_mask = apply_point_mask(batch.volume_mask, config.point_mask_ratio)
+                if not point_mask_logged:
+                    surface_valid_after = int(batch.surface_mask.sum().item())
+                    volume_valid_after = int(batch.volume_mask.sum().item())
+                    surface_dropped = surface_valid_before - surface_valid_after
+                    volume_dropped = volume_valid_before - volume_valid_after
+                    surface_realized = (
+                        surface_dropped / max(surface_valid_before, 1)
+                    )
+                    volume_realized = (
+                        volume_dropped / max(volume_valid_before, 1)
+                    )
+                    print(
+                        f"[point_mask] ratio={config.point_mask_ratio:.3f} "
+                        f"surface dropped={surface_dropped}/{surface_valid_before} "
+                        f"({surface_realized:.4f}) "
+                        f"volume dropped={volume_dropped}/{volume_valid_before} "
+                        f"({volume_realized:.4f})",
+                        flush=True,
+                    )
+                    point_mask_logged = True
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,


### PR DESCRIPTION
## Hypothesis

**MAE-style point masking improves wall-shear generalization (especially τy/τz) by forcing the model to learn global geometry rather than local correlations.**

Random coordinate jitter (PR #314) was rejected — at all noise levels (σ=0.002/0.005/0.01) it monotonically degraded val_abupt, with τy/τz the most damaged axes. Root cause: at ~12k training steps the model is not overfitting locally, so adding noise just dilutes signal.

A more principled regularizer for the wall-shear gap is **point masking** (the MAE / dropout-style alternative). During training, randomly drop a fraction of surface and volume query points from the decoder query set; the model still has to predict the remaining points conditioned on a strict subset of the original geometric context. This:

1. Creates an inpainting-style objective that rewards leveraging neighborhood/global geometry.
2. Targets the failure mode for τy/τz directly — the lateral/vertical wall-shear components are the most sensitive to whether the network learned global flow structure or only point-local features.
3. Is essentially free at training time (just index-mask) and **disabled at validation** so reported metrics remain comparable.

This experiment is the natural follow-up to the advisor's close comment on PR #314.

## Implementation

Add a new flag to `train.py`:

```
--point-mask-ratio FLOAT   # default 0.0 (disabled)
```

Behavior:
- Applied **only during training**, never at validation/test.
- For each batch, after sampling surface and volume query points (`--train-surface-points 65536`, `--train-volume-points 65536`), randomly select a fraction `p = point-mask-ratio` of the **query points** to drop. Drop them from both the queries fed to the decoder AND the corresponding ground-truth targets used in the loss (so masked points contribute zero loss and zero gradient).
- Apply the same ratio independently to surface and volume query sets.
- The encoder context (input mesh / point cloud) is **not** masked — only the decoder queries.
- At eval time `--point-mask-ratio` is force-set to 0.0 regardless of CLI value.

Reuse existing seeded `torch.randperm` / index sampling so the mask is reproducible per `--seed`.

Important: `--point-mask-ratio 0.0` MUST be a no-op (i.e. a control arm at p=0.0 should match baseline metrics within stochastic noise). Add a unit test or print-once log line confirming the masked count.

## Sweep plan

W&B group: `norman-point-mask-r19` (project: `wandb-applied-ai-team/senpai-v1-drivaerml`)

4 arms, identical config except for `--point-mask-ratio`:

| Arm | --point-mask-ratio | --wandb_name |
|-----|--------------------|--------------|
| A   | 0.00               | norman-pmask-control |
| B   | 0.10               | norman-pmask-p10     |
| C   | 0.20               | norman-pmask-p20     |
| D   | 0.30               | norman-pmask-p30     |

Run all 4 arms. The control (Arm A) is required to confirm the implementation is a faithful no-op when disabled.

## Reproduce command (per arm)

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent norman \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --point-mask-ratio <P> \
  --wandb_group norman-point-mask-r19 \
  --wandb_name <ARM_NAME>
```

## Reporting

In your results comment on this PR, include for each arm:

- W&B run ID
- Best `val_primary/abupt_axis_mean_rel_l2_pct` (and the epoch it occurred at)
- Best-epoch breakdown of:
  - `val_primary/surface_pressure_rel_l2_pct`
  - `val_primary/volume_pressure_rel_l2_pct`
  - `val_primary/wall_shear_rel_l2_pct`
  - `val_primary/wall_shear_x_rel_l2_pct`
  - `val_primary/wall_shear_y_rel_l2_pct`
  - `val_primary/wall_shear_z_rel_l2_pct`
- Confirmation that Arm A (p=0.0) matches baseline within ~0.1pp (validates implementation).

## Baseline to beat

Current best on `yi` (PR #222, W&B `ut1qmc3i`):

| Metric | Value |
|---|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.291** |
| `val_primary/surface_pressure_rel_l2_pct` | 5.871 |
| `val_primary/volume_pressure_rel_l2_pct` | 5.879 |
| `val_primary/wall_shear_rel_l2_pct` | 10.342 |

AB-UPT public references (the eventual targets):
- wall_shear_y: **3.65**
- wall_shear_z: **3.63**

τy/τz are the largest gaps from AB-UPT; this experiment targets them directly.

**Merge bar: any arm must beat val_abupt = 9.291% to merge.**

## Architecture / config (do NOT change)

- 4L / 512d / 8H / 128 slices
- Lion optimizer, lr=1e-4, weight_decay=5e-4
- batch_size=4, 8-GPU DDP via torchrun
- lr_warmup_epochs=1, then cosine
- ema_decay=0.999
- 65536 surface + 65536 volume points, train and eval

Only `--point-mask-ratio` varies between arms.
