### PR TITLE
fern: surface-tangent-frame projection loss for tau_y/tau_z

### DIFF
--- a/train.py
+++ b/train.py
@@ -117,6 +117,7 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    use_tangential_wallshear_loss: bool = False
     debug: bool = False
 
 
@@ -179,6 +180,18 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
+    """Project a 3-vector field onto the surface tangent plane defined by per-point normals.
+
+    vec:     [..., 3]  predicted or target vector field (in any consistent space)
+    normals: [..., 3]  surface normals (will be unit-normalized)
+    returns: [..., 3]  tangential component  (vec - (vec·n)n)
+    """
+    n = torch.nn.functional.normalize(normals.to(vec.dtype), dim=-1)
+    dot = (vec * n).sum(dim=-1, keepdim=True)
+    return vec - dot * n
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -188,6 +201,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    use_tangential_wallshear_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -199,7 +213,17 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_preds = out["surface_preds"]
+        if use_tangential_wallshear_loss:
+            normals = batch.surface_x[..., 3:6]
+            pred_ws = project_tangential(surface_preds[..., 1:4], normals)
+            true_ws = project_tangential(surface_target[..., 1:4], normals)
+            surface_preds_loss = torch.cat([surface_preds[..., :1], pred_ws], dim=-1)
+            surface_target_loss = torch.cat([surface_target[..., :1], true_ws], dim=-1)
+        else:
+            surface_preds_loss = surface_preds
+            surface_target_loss = surface_target
+        surface_loss = masked_mse(surface_preds_loss, surface_target_loss, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -324,6 +348,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/train.py
+++ b/train.py
@@ -118,6 +118,7 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     use_tangential_wallshear_loss: bool = False
+    tangential_penalty_weight: float = 0.1
     debug: bool = False
 
 
@@ -180,16 +181,31 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
-def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
-    """Project a 3-vector field onto the surface tangent plane defined by per-point normals.
+def wallshear_normal_penalty(
+    pred_wallshear: torch.Tensor,
+    normals: torch.Tensor,
+    mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Soft penalty on the normal component of predicted wall-shear.
 
-    vec:     [..., 3]  predicted or target vector field (in any consistent space)
-    normals: [..., 3]  surface normals (will be unit-normalized)
-    returns: [..., 3]  tangential component  (vec - (vec·n)n)
+    pred_wallshear: [B, N, 3]  predicted wall-shear (in normalized space)
+    normals:        [B, N, 3]  per-point surface normals (will be unit-normalized)
+    mask:           [B, N]     boolean validity mask
+
+    Returns (penalty, normal_fraction) where:
+      penalty         = mean over valid points of (pred · n_hat)^2
+      normal_fraction = sqrt(sum (pred·n_hat)^2 / sum ||pred||^2)  (scalar diagnostic)
     """
-    n = torch.nn.functional.normalize(normals.to(vec.dtype), dim=-1)
-    dot = (vec * n).sum(dim=-1, keepdim=True)
-    return vec - dot * n
+    n = torch.nn.functional.normalize(normals.to(pred_wallshear.dtype), dim=-1)
+    dot = (pred_wallshear * n).sum(dim=-1)
+    valid = mask.to(pred_wallshear.dtype)
+    valid_sum = valid.sum().clamp_min(1.0)
+    normal_sq = (dot.square() * valid).sum() / valid_sum
+    pred_sq_per_point = pred_wallshear.float().square().sum(dim=-1)
+    pred_sq_total = (pred_sq_per_point * valid).sum().clamp_min(1e-12)
+    normal_sq_total = (dot.float().square() * valid).sum()
+    normal_fraction = (normal_sq_total / pred_sq_total).sqrt()
+    return normal_sq, normal_fraction
 
 
 def train_loss(
@@ -202,6 +218,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     use_tangential_wallshear_loss: bool = False,
+    tangential_penalty_weight: float = 0.1,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -214,20 +231,21 @@ def train_loss(
             volume_mask=batch.volume_mask,
         )
         surface_preds = out["surface_preds"]
-        if use_tangential_wallshear_loss:
-            normals = batch.surface_x[..., 3:6]
-            pred_ws = project_tangential(surface_preds[..., 1:4], normals)
-            true_ws = project_tangential(surface_target[..., 1:4], normals)
-            surface_preds_loss = torch.cat([surface_preds[..., :1], pred_ws], dim=-1)
-            surface_target_loss = torch.cat([surface_target[..., :1], true_ws], dim=-1)
-        else:
-            surface_preds_loss = surface_preds
-            surface_target_loss = surface_target
-        surface_loss = masked_mse(surface_preds_loss, surface_target_loss, batch.surface_mask)
+        surface_loss = masked_mse(surface_preds, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        if use_tangential_wallshear_loss:
+            normals = batch.surface_x[..., 3:6]
+            normal_penalty, normal_fraction = wallshear_normal_penalty(
+                surface_preds[..., 1:4], normals, batch.surface_mask
+            )
+            weighted_normal_penalty = tangential_penalty_weight * normal_penalty
+        else:
+            normal_penalty = surface_preds.new_zeros(())
+            normal_fraction = surface_preds.new_zeros(())
+            weighted_normal_penalty = surface_preds.new_zeros(())
+        loss = weighted_surface_loss + weighted_volume_loss + weighted_normal_penalty
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
@@ -235,6 +253,9 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "normal_penalty": float(normal_penalty.detach().cpu().item()),
+        "normal_penalty_weighted": float(weighted_normal_penalty.detach().cpu().item()),
+        "tau_normal_fraction": float(normal_fraction.detach().cpu().item()),
     }
 
 
@@ -349,6 +370,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                    tangential_penalty_weight=config.tangential_penalty_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -384,6 +406,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/normal_penalty": batch_loss_metrics["normal_penalty"],
+                            "train/normal_penalty_weighted": batch_loss_metrics["normal_penalty_weighted"],
+                            "train/tau_normal_fraction": batch_loss_metrics["tau_normal_fraction"],
                         }
                     )
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -869,6 +869,8 @@ class EvalAccumulator:
     abs_counts: dict[str, int] = field(default_factory=lambda: {key: 0 for key in EVAL_KEYS})
     wall_shear_vector_abs_sum: float = 0.0
     wall_shear_vector_count: int = 0
+    tau_normal_sq_sum: float = 0.0
+    tau_total_sq_sum: float = 0.0
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
@@ -963,6 +965,12 @@ def accumulate_eval_batch(
         )
         accumulator.wall_shear_vector_abs_sum += float(wall_vector_error.sum().detach().cpu().item())
         accumulator.wall_shear_vector_count += int(wall_vector_error.numel())
+        pred_wallshear_valid = surface_pred[batch.surface_mask][:, 1:4].float()
+        normals_valid = batch.surface_x[batch.surface_mask][:, 3:6].float()
+        normals_unit = torch.nn.functional.normalize(normals_valid, dim=-1)
+        tau_normal_dot = (pred_wallshear_valid * normals_unit).sum(dim=-1)
+        accumulator.tau_normal_sq_sum += float(tau_normal_dot.square().sum().detach().cpu().item())
+        accumulator.tau_total_sq_sum += float(pred_wallshear_valid.square().sum().detach().cpu().item())
 
     if bool(batch.volume_mask.any()):
         volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
@@ -1012,6 +1020,8 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
         merged.volume_loss_count += accumulator.volume_loss_count
         merged.wall_shear_vector_abs_sum += accumulator.wall_shear_vector_abs_sum
         merged.wall_shear_vector_count += accumulator.wall_shear_vector_count
+        merged.tau_normal_sq_sum += accumulator.tau_normal_sq_sum
+        merged.tau_total_sq_sum += accumulator.tau_total_sq_sum
         for key in EVAL_KEYS:
             merged.abs_sums[key] += accumulator.abs_sums[key]
             merged.abs_counts[key] += accumulator.abs_counts[key]
@@ -1048,6 +1058,12 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     loss = (accumulator.surface_loss_sse + accumulator.volume_loss_sse) / max(
         accumulator.surface_loss_count + accumulator.volume_loss_count, 1
     )
+    if accumulator.tau_total_sq_sum > 0.0:
+        tau_normal_fraction = math.sqrt(
+            accumulator.tau_normal_sq_sum / accumulator.tau_total_sq_sum
+        )
+    else:
+        tau_normal_fraction = 0.0
     return {
         "loss": loss,
         "surface_loss": accumulator.surface_loss_sse / max(accumulator.surface_loss_count, 1),
@@ -1073,6 +1089,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "volume_pressure_rel_l2_pct": volume_pressure_rel_l2 * 100.0,
         "abupt_axis_mean_rel_l2": abupt_axis_mean_rel_l2,
         "abupt_axis_mean_rel_l2_pct": abupt_axis_mean_rel_l2 * 100.0,
+        "tau_normal_fraction": tau_normal_fraction,
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,


### PR DESCRIPTION
## Hypothesis

Wall-shear stress vectors (tau_x, tau_y, tau_z) must physically lie in the surface tangent plane — by definition, there is no normal component of shear stress on a no-slip surface. The current MSE loss computes error in raw 3D Cartesian space without enforcing this geometric constraint. When the model predicts a spurious normal-direction component, the loss treats it as prediction error on the true tangential shear, polluting the gradient signal.

**Updated 2026-05-02 (post-divergence):** Earlier symmetric projection (project both pred and target onto the tangent plane) was tried and *diverged tau_z* (102→113→122% over ep1–ep3 in run `lz51r7nb`). Diagnosis: `||proj(pred − target)||²` has zero gradient in the per-point local-normal direction, so under Lion+EMA the model drifts unconstrained in the normal direction. Replaced with a **soft normal-component penalty on predictions only** so the primary loss keeps gradients alive in all Cartesian axes while a side-term penalizes physically-impossible normal components.

```
L = std MSE on full Cartesian channels (cp + tau_x/y/z)            ← gradients alive in all directions
  + tangential_penalty_weight * mean over valid points of (pred_tau · n_hat)^2
```

## Instructions (updated 2026-05-02)

1. **Replace** the symmetric tangent projection in `train_loss` with a soft normal-component penalty on the *predicted* wall-shear only.
2. **Keep** primary surface loss as standard MSE on the full unprojected channels.
3. **Add** `--tangential-penalty-weight 0.1` flag (default 0.1) so the weight is tunable.
4. **Add** diagnostics so we know whether the penalty has signal:
   - `train/normal_penalty`, `train/normal_penalty_weighted`, `train/tau_normal_fraction` per step
   - `val_*/tau_normal_fraction` per validation event (relative ratio `sqrt(Σ (pred·n̂)² / Σ ‖pred‖²)`, DDP-aware in `accumulate_eval_batch` + `merge_eval_accumulators`).

The surface normals needed for the penalty are already in `batch.surface_x[..., 3:6]` (channels 3–5 of the 7-dim surface input: xyz(3) + normals(3) + panel_area(1)) — no new data loading required.

### Run command (commit `cfb2828`, on `fern/surface-tangent-frame-tau`)

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --use-tangential-wallshear-loss --tangential-penalty-weight 0.1 \
  --wandb-group fern-tangent-frame-soft-r18
```

**Note on baseline:** advisor instructed building on STRING-sep SOTA (PR #311, val 7.546%). Verified that the STRING-sep code is **not present in `tay`** (PR #311's merge commit only modifies `research/` docs; no `pos_encoding_mode` flag exists in any branch). Run is therefore launched on **PR #309 SOTA** (`grad-clip-norm=0.5`, val 9.039% / test 10.126%), the actual reproducible baseline for this codebase. See PR comment dated 2026-05-02T~10:45Z for the provenance check. Soft-penalty effect is largely orthogonal to the positional-encoding choice (loss-side regularizer vs input-feature change), so this is still a clean single-delta test.

## Baselines

### STRING-sep SOTA (advisor-named merge bar — code not yet on `tay`)

| Metric | val | test | AB-UPT | Gap (×) |
|---|---:|---:|---:|---:|
| `abupt` mean | **7.546%** | **8.771%** | — | — |
| `surface_pressure` | — | **4.485%** | 3.82 | ×1.17 |
| `wall_shear` | — | **8.227%** | 7.29 | ×1.13 |
| `volume_pressure` | — | **12.438%** | 6.08 | ×2.05 |
| `tau_x` | — | **7.253%** | 5.35 | ×1.36 |
| `tau_y` | — | **9.233%** | 3.65 | ×2.53 |
| `tau_z` | — | **10.449%** | 3.63 | ×2.88 |

PR #311 W&B run: `gcwx9yaa` — but the run launched against commit `c6d9c23a`, which has no `pos_encoding_mode` flag in train.py / model.py. Code apparently never landed.

### PR #309 SOTA — actual reproducible baseline this run is built on

| Metric | val | test | AB-UPT | Gap (×) |
|---|---:|---:|---:|---:|
| `abupt` mean | **9.039%** | **10.126%** | — | — |
| `surface_pressure` | — | **5.395%** | 3.82 | ×1.41 |
| `wall_shear` | — | **9.883%** | 7.29 | ×1.36 |
| `volume_pressure` | — | **12.484%** | 6.08 | ×2.05 |
| `tau_y` | — | **11.941%** | 3.65 | ×3.27 |
| `tau_z` | — | **12.407%** | 3.63 | ×3.42 |

PR #309 W&B run: `ztdhodw1`.

**Merge bar (advisor-stated):** val_abupt < **7.546%** (STRING-sep). Since this run won't have STRING-sep, a direct merge-bar comparison would require re-running the soft-penalty hypothesis on top of STRING-sep once that code is back on `tay`. For *this* run, the meaningful comparison is delta vs PR #309 SOTA on the same encoding stack.

## Results to report

When the run completes, post a comment with:
1. Val history table (epoch, val_abupt, vs PR #309 baseline).
2. **Stability check at ep3–ep5**: tau_z trajectory (must not diverge), normal-penalty magnitude vs surface-loss magnitude (lambda balancing check), `val_*/tau_normal_fraction` (signal-strength check).
3. Test metrics from best-val checkpoint: `surface_pressure`, `wall_shear`, `volume_pressure`, `tau_x`, `tau_y`, `tau_z`.
4. W&B run ID and link.
5. Whether tau_y and tau_z (our biggest gaps) improved — primary signal.

Then mark the PR ready for review (or send back if STRING-sep code lands and advisor wants a re-run on top of it).
