### PR TITLE
askeladd: channel-selective Huber loss on tau channels (target tau_y/tau_z gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -49,6 +49,7 @@ from trainer_runtime import (
     init_wandb_run,
     is_valid_primary_metric,
     make_loaders,
+    masked_huber,
     masked_mse,
     metric_namespace,
     parse_kill_thresholds,
@@ -79,6 +80,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    tau_loss_type: str = "rel_l2"
+    tau_huber_delta: float = 0.5
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -188,6 +191,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    tau_loss_type: str = "rel_l2",
+    tau_huber_delta: float = 0.5,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -199,19 +204,43 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        if tau_loss_type == "huber":
+            sp_loss = masked_mse(
+                out["surface_preds"][..., 0:1],
+                surface_target[..., 0:1],
+                batch.surface_mask,
+            )
+            tau_loss = masked_huber(
+                out["surface_preds"][..., 1:4],
+                surface_target[..., 1:4],
+                batch.surface_mask,
+                delta=tau_huber_delta,
+            )
+            surface_loss = sp_loss + tau_loss
+        elif tau_loss_type == "rel_l2":
+            sp_loss = None
+            tau_loss = None
+            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        else:
+            raise ValueError(
+                f"Unknown tau_loss_type '{tau_loss_type}'. Supported: rel_l2, huber."
+            )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if sp_loss is not None:
+        metrics["surface_pressure_loss"] = float(sp_loss.detach().cpu().item())
+        metrics["tau_loss"] = float(tau_loss.detach().cpu().item())
+    return loss, metrics
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -324,6 +353,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    tau_loss_type=config.tau_loss_type,
+                    tau_huber_delta=config.tau_huber_delta,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -361,6 +392,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if "surface_pressure_loss" in batch_loss_metrics:
+                        train_log["train/surface_pressure_loss"] = batch_loss_metrics["surface_pressure_loss"]
+                        train_log["train/tau_loss"] = batch_loss_metrics["tau_loss"]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -832,6 +832,20 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_huber(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float = 0.5,
+) -> torch.Tensor:
+    e = pred - target
+    abs_e = e.abs()
+    quadratic = torch.minimum(abs_e, torch.full_like(abs_e, delta))
+    linear = abs_e - quadratic
+    loss = 0.5 * quadratic.square() + delta * linear
+    return masked_mean(loss, mask)
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**Channel-selective Huber loss for tau channels.** Replace MSE with Huber(delta=0.5) specifically for the three tau (wall-shear) channels of the surface output (`surface_preds[:, 1:4]` = tau_x, tau_y, tau_z), keeping MSE for surface_pressure (channel 0) and all volume channels.

**Why this should help.** Wall-shear distributions are heavy-tailed: a small fraction of high-curvature / separation regions produce shear magnitudes much larger than typical. Squared error gives those outlier residuals an outsized gradient, biasing the model toward fitting tail samples at the expense of the bulk distribution. Huber loss caps the gradient magnitude at `delta` for any residual exceeding `delta`, decoupling the bulk-fit objective from outlier influence — the standard remedy for heavy-tailed regression targets.

The current SOTA (PR #309, val_abupt=9.0389%) is bottlenecked precisely on these channels:

| Channel | SOTA test | AB-UPT | Gap |
|---|---:|---:|---:|
| surface_pressure | 5.395 | 3.82 | x1.41 |
| tau_x | 8.402 | 5.35 | x1.57 |
| **tau_y** | **11.941** | **3.65** | **x3.27** |
| **tau_z** | **12.407** | **3.63** | **x3.42** |
| volume_pressure | 12.484 | 6.08 | x2.05 |

tau_y and tau_z are the two largest remaining axis gaps to AB-UPT. Surface_pressure (x1.41) is a soft-tailed channel and well-fit by MSE; mixing loss families lets each channel use the loss best matched to its residual distribution.

**Expected lift:** -0.5 to -1.5 abupt, concentrated on tau_y/tau_z axes.

**Why now:** Channel-selective losses are a low-cost, near-orthogonal lever — independent of the architecture deltas currently in-flight (STRING-separable PE, QK-norm, per-channel output-head scaling, tangent-frame projection). If it works it stacks cleanly with whatever wins the architecture race.

## Instructions

Implement a channel-selective Huber loss for the surface tau channels with a CLI-gated switch (default OFF, so existing runs are unchanged).

**Surface channel ordering** (confirmed from `trainer_runtime.py`): index 0 = surface_pressure, index 1 = tau_x, index 2 = tau_y, index 3 = tau_z.

### 1. Add `masked_huber()` to `trainer_runtime.py`

Add directly after `masked_mse()` (around line 831):

```python
def masked_huber(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    delta: float = 0.5,
) -> torch.Tensor:
    e = pred - target
    abs_e = e.abs()
    quadratic = torch.minimum(abs_e, torch.full_like(abs_e, delta))
    linear = abs_e - quadratic
    loss = 0.5 * quadratic.square() + delta * linear
    return masked_mean(loss, mask)
```

(The `torch.minimum` / `linear` formulation is preferred over `torch.where` because it stays differentiable across the kink and avoids a NaN-on-backward edge case some PyTorch versions hit with `where`.)

### 2. Export and import `masked_huber`

In `train.py` line 52, extend the existing `from trainer_runtime import ...` to include `masked_huber` alongside `masked_mse`.

### 3. Add CLI flags to `Config` (and arg parser) in `train.py`

```python
tau_loss_type: str = "rel_l2"        # one of {"rel_l2", "huber"}
tau_huber_delta: float = 0.5
```

Wire CLI flags `--tau-loss-type {rel_l2,huber}` and `--tau-huber-delta FLOAT`. Use `python train.py --help` to confirm exact dash/underscore conventions used elsewhere in the file — match them.

### 4. Split surface loss in `train_loss()` (`train.py` lines 182-214)

Replace the single `surface_loss = masked_mse(...)` call with:

```python
if tau_loss_type == "huber":
    sp_loss = masked_mse(
        out["surface_preds"][..., 0:1],
        surface_target[..., 0:1],
        batch.surface_mask,
    )
    tau_loss = masked_huber(
        out["surface_preds"][..., 1:4],
        surface_target[..., 1:4],
        batch.surface_mask,
        delta=tau_huber_delta,
    )
    surface_loss = sp_loss + tau_loss
else:
    surface_loss = masked_mse(
        out["surface_preds"], surface_target, batch.surface_mask
    )
```

Pass the new config fields through `train_loss()`'s signature (currently uses keyword-only args for `surface_loss_weight`, `volume_loss_weight` — follow the same pattern).

**Volume loss is unchanged** — keep `masked_mse` for `out["volume_preds"]`.

### 5. Sanity check

Before kicking off the full run, verify with a 1-epoch dry run that `--tau-loss-type rel_l2` (default) produces identical loss values to the unmodified code and that `--tau-loss-type huber` produces a different (smaller, since clipped) loss number that decreases over the first few steps.

### 6. Run the experiment — single config, SOTA stack, --tau-loss-type huber, delta=0.5

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --tau-loss-type huber --tau-huber-delta 0.5 \
  --wandb_group askeladd-huber-tau
```

If you have GPU headroom in epoch budget after the primary delta=0.5 run, queue one secondary value of delta to characterize sensitivity — delta=1.0 is the natural second pick (closer to MSE; tells us whether the gain comes from clipping at all or from the specific bulk/tail balance). Use the same `--wandb_group askeladd-huber-tau`.

### What to report

- Per-axis val and test metrics from the **best-val-checkpoint** (test eval, not just terminal-epoch val).
- A single PR-body table with columns: SOTA #309 (val/test), this run (val/test), delta-pp.
- Best-val W&B run id and link.
- Loss-curve sanity-check note: confirm `surface_loss` value range stays comparable to baseline (Huber on tau will be slightly smaller numerically but should still dominate where the existing MSE dominated).

## Baseline (SOTA — PR #309 thorfinn grad-clip-norm=0.5)

W&B run `ztdhodw1` (https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ztdhodw1)

- **val_abupt = 9.0389% (ep11)** — merge bar
- test_abupt = 10.126%

Per-axis test:

| Metric | SOTA | AB-UPT | Gap |
|---|---:|---:|---:|
| abupt mean | 10.126 | — | — |
| surface_pressure | 5.395 | 3.82 | x1.41 |
| wall_shear | 9.883 | 7.29 | x1.36 |
| tau_x | 8.402 | 5.35 | x1.57 |
| tau_y | 11.941 | 3.65 | x3.27 |
| tau_z | 12.407 | 3.63 | x3.42 |
| volume_pressure | 12.484 | 6.08 | x2.05 |

**Reproduce SOTA:**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent <STUDENT> --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5
```

**Merge bar:** val_abupt < 9.0389%.
