### PR TITLE
emma: DDP infrastructure fix — restore 8-GPU torchrun on yi/train.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch>=0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -25,11 +25,13 @@ from pathlib import Path
 from typing import Iterable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import wandb
 import yaml
-from torch.utils.data import DataLoader
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
 
 from data import (
@@ -600,7 +602,9 @@ class Config:
     debug: bool = False
     seed: int = -1
     lr_warmup_steps: int = 0
+    lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    optimizer: str = "adamw"
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -697,6 +701,10 @@ def resolve_num_workers(config: Config) -> int:
 
 def make_loaders(
     config: Config,
+    *,
+    is_distributed: bool = False,
+    world_size: int = 1,
+    rank: int = 0,
 ) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
     train_ds, val_splits, test_splits, stats = load_data(
         manifest_path=config.manifest,
@@ -716,12 +724,23 @@ def make_loaders(
     if num_workers > 0:
         loader_kwargs["persistent_workers"] = config.persistent_workers
         loader_kwargs["prefetch_factor"] = config.prefetch_factor
-    train_loader = DataLoader(
-        train_ds,
-        batch_size=config.batch_size,
-        shuffle=True,
-        **loader_kwargs,
-    )
+    if is_distributed:
+        train_sampler = DistributedSampler(
+            train_ds, num_replicas=world_size, rank=rank, shuffle=True, drop_last=False
+        )
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=config.batch_size,
+            sampler=train_sampler,
+            **loader_kwargs,
+        )
+    else:
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=config.batch_size,
+            shuffle=True,
+            **loader_kwargs,
+        )
     val_loaders = {
         name: DataLoader(ds, batch_size=config.batch_size, shuffle=False, **loader_kwargs)
         for name, ds in val_splits.items()
@@ -1680,22 +1699,43 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    rank = int(os.environ.get("RANK", "0"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_distributed = world_size > 1
+    is_main = rank == 0
+    if is_distributed:
+        dist.init_process_group(backend="nccl")
+        torch.cuda.set_device(local_rank)
     if config.seed >= 0:
         import random
 
         import numpy as np
 
-        random.seed(config.seed)
-        np.random.seed(config.seed)
-        torch.manual_seed(config.seed)
-        torch.cuda.manual_seed_all(config.seed)
+        random.seed(config.seed + rank)
+        np.random.seed(config.seed + rank)
+        torch.manual_seed(config.seed + rank)
+        torch.cuda.manual_seed_all(config.seed + rank)
     kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
     max_epochs = min(config.epochs, 3) if config.debug else config.epochs
     timeout_minutes = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30"))
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Device: {device}" + (" [DEBUG]" if config.debug else ""))
+    if is_distributed:
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if is_main:
+        print(
+            f"Device: {device}"
+            + (" [DEBUG]" if config.debug else "")
+            + (f" [DDP world_size={world_size}]" if is_distributed else "")
+        )
 
-    train_loader, val_loaders, test_loaders, stats = make_loaders(config)
+    train_loader, val_loaders, test_loaders, stats = make_loaders(
+        config,
+        is_distributed=is_distributed,
+        world_size=world_size,
+        rank=rank,
+    )
     transform = TargetTransform(
         surface_y_mean=stats["surface_y_mean"].to(device),
         surface_y_std=stats["surface_y_std"].to(device),
@@ -1707,13 +1747,51 @@ def main(argv: Iterable[str] | None = None) -> None:
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
-    print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+    if is_main:
+        print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+    if is_distributed:
+        train_model = DistributedDataParallel(
+            model,
+            device_ids=[local_rank],
+            output_device=local_rank,
+            find_unused_parameters=False,
+        )
+    else:
+        train_model = model
+
+    optimizer_name = config.optimizer.lower()
+    if optimizer_name == "adamw":
+        optimizer = torch.optim.AdamW(
+            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+        )
+    elif optimizer_name == "lion":
+        from lion_pytorch import Lion
+
+        optimizer = Lion(
+            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+        )
+    else:
+        raise ValueError(
+            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion'."
+        )
+    if is_main:
+        print(
+            f"Optimizer: {optimizer.__class__.__name__} "
+            f"lr={config.lr} wd={config.weight_decay}"
+        )
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
-    if kill_thresholds:
+    effective_warmup_steps = config.lr_warmup_steps
+    if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
+        effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+    if is_main and effective_warmup_steps > 0:
+        print(
+            f"LR warmup: {effective_warmup_steps} steps "
+            f"(start_lr={config.lr_warmup_start_lr} -> peak_lr={config.lr})"
+        )
+    if is_main and kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
     val_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1735,8 +1813,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             "surface_targets": SURFACE_TARGET_NAMES,
             "volume_targets": VOLUME_TARGET_NAMES,
             "total_estimated_steps": total_estimated_steps,
+            "ddp_world_size": world_size,
+            "ddp_effective_batch_size": config.batch_size * world_size,
+            "lr_warmup_steps_effective": effective_warmup_steps,
         },
-        mode=os.environ.get("WANDB_MODE", "online"),
+        mode=(
+            os.environ.get("WANDB_MODE", "online") if is_main else "disabled"
+        ),
     )
     wandb.define_metric("global_step")
     wandb.define_metric("train/*", step_metric="global_step")
@@ -1769,11 +1852,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if is_main:
+        output_dir.mkdir(parents=True, exist_ok=True)
     model_path = output_dir / "checkpoint.pt"
     config_path = output_dir / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.safe_dump(asdict(config), f)
+    if is_main:
+        with config_path.open("w") as f:
+            yaml.safe_dump(asdict(config), f)
+    if is_distributed:
+        dist.barrier()
 
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
@@ -1787,19 +1874,27 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
-            print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
+            if is_main:
+                print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
             break
 
+        if is_distributed and isinstance(train_loader.sampler, DistributedSampler):
+            train_loader.sampler.set_epoch(epoch)
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()
         t0 = time.time()
-        model.train()
+        train_model.train()
         train_loss_sum = 0.0
         n_batches = 0
 
-        for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+        train_iter = train_loader
+        if is_main:
+            train_iter = tqdm(
+                train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
+            )
+        for batch in train_iter:
             loss, batch_loss_metrics = train_loss(
-                model,
+                train_model,
                 batch,
                 transform,
                 device,
@@ -1872,14 +1967,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 global_step += 1
                 continue
-            if config.lr_warmup_steps > 0:
-                if global_step < config.lr_warmup_steps:
+            if effective_warmup_steps > 0:
+                if global_step < effective_warmup_steps:
                     warmup_lr = config.lr_warmup_start_lr + (
                         config.lr - config.lr_warmup_start_lr
-                    ) * (global_step / config.lr_warmup_steps)
+                    ) * (global_step / effective_warmup_steps)
                     for pg in optimizer.param_groups:
                         pg["lr"] = warmup_lr
-                elif global_step == config.lr_warmup_steps:
+                elif global_step == effective_warmup_steps:
                     for pg in optimizer.param_groups:
                         pg["lr"] = config.lr
             optimizer.step()
@@ -1988,12 +2083,14 @@ def main(argv: Iterable[str] | None = None) -> None:
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
             wandb.log(log_metrics)
-            print(
-                f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
-                f"train_loss={epoch_train_loss:.5f}"
-            )
+            if is_main:
+                print(
+                    f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                    f"train_loss={epoch_train_loss:.5f}"
+                )
+                if early_stop_reason is not None:
+                    print(early_stop_reason)
             if early_stop_reason is not None:
-                print(early_stop_reason)
                 break
             continue
 
@@ -2048,38 +2145,42 @@ def main(argv: Iterable[str] | None = None) -> None:
         if improved:
             best_val = primary_val
             best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}
-            save_model = model
-            if ema is not None:
-                ema.store(model)
-                ema.copy_to(model)
-                save_model = model
-            torch.save(
-                {
-                    "model": save_model.state_dict(),
-                    "config": asdict(config),
-                    "epoch": epoch + 1,
-                    "val_metrics": val_metrics,
-                },
-                model_path,
-            )
-            if ema is not None:
-                ema.restore(model)
+            if is_main:
+                if ema is not None:
+                    ema.store(model)
+                    ema.copy_to(model)
+                torch.save(
+                    {
+                        "model": model.state_dict(),
+                        "config": asdict(config),
+                        "epoch": epoch + 1,
+                        "val_metrics": val_metrics,
+                    },
+                    model_path,
+                )
+                if ema is not None:
+                    ema.restore(model)
+        if is_distributed:
+            dist.barrier()
 
         tag = " *" if improved else ""
-        print(
-            f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
-            f"train_loss={epoch_train_loss:.5f} "
-            f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
-        )
-        print_metrics("val_surface", val_metrics["val_surface"])
+        if is_main:
+            print(
+                f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                f"train_loss={epoch_train_loss:.5f} "
+                f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
+            )
+            print_metrics("val_surface", val_metrics["val_surface"])
+            if early_stop_reason is not None:
+                print(early_stop_reason)
         if early_stop_reason is not None:
-            print(early_stop_reason)
             break
         if timeout_hit:
             break
 
     total_minutes = (time.time() - train_start) / 60.0
-    print(f"\nTraining done in {total_minutes:.1f} min")
+    if is_main:
+        print(f"\nTraining done in {total_minutes:.1f} min")
 
     if early_stop_reason is not None:
         wandb.summary.update(
@@ -2091,19 +2192,27 @@ def main(argv: Iterable[str] | None = None) -> None:
             }
         )
         wandb.finish()
+        if is_distributed:
+            dist.destroy_process_group()
         return
 
     if not best_metrics:
-        print("No validation checkpoint was saved.")
+        if is_main:
+            print("No validation checkpoint was saved.")
         wandb.finish()
+        if is_distributed:
+            dist.destroy_process_group()
         return
 
+    if is_distributed:
+        dist.barrier()
     checkpoint = torch.load(model_path, map_location=device, weights_only=True)
     model.load_state_dict(checkpoint["model"])
-    print(
-        f"Best val: epoch {int(best_metrics['epoch'])}, "
-        f"abupt_axis_mean_rel_l2_pct={best_metrics['abupt_axis_mean_rel_l2_pct']:.4f}"
-    )
+    if is_main:
+        print(
+            f"Best val: epoch {int(best_metrics['epoch'])}, "
+            f"abupt_axis_mean_rel_l2_pct={best_metrics['abupt_axis_mean_rel_l2_pct']:.4f}"
+        )
     wandb.summary.update(
         {
             "best_epoch": int(best_metrics["epoch"]),
@@ -2147,7 +2256,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     wandb.log(full_val_log)
     wandb.summary.update(_numeric_metric_items(full_val_log))
-    print_metrics("full_val", full_val_metrics["val_surface"])
+    if is_main:
+        print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
         name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
@@ -2181,18 +2291,22 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     wandb.log(test_log)
     wandb.summary.update(_numeric_metric_items(test_log))
-    print_metrics("test_surface", test_metrics["test_surface"])
+    if is_main:
+        print_metrics("test_surface", test_metrics["test_surface"])
 
-    log_model_artifact(
-        run=run,
-        model_path=model_path,
-        config_path=config_path,
-        config=config,
-        best_metrics=best_metrics,
-        test_metrics=test_metrics,
-        n_params=n_params,
-    )
+    if is_main:
+        log_model_artifact(
+            run=run,
+            model_path=model_path,
+            config_path=config_path,
+            config=config,
+            best_metrics=best_metrics,
+            test_metrics=test_metrics,
+            n_params=n_params,
+        )
     wandb.finish()
+    if is_distributed:
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -1851,7 +1851,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
-    output_dir = Path(config.output_dir) / f"run-{run.id}"
+    if is_distributed:
+        run_id_holder = [run.id if is_main else None]
+        dist.broadcast_object_list(run_id_holder, src=0)
+        shared_run_id = run_id_holder[0]
+    else:
+        shared_run_id = run.id
+    output_dir = Path(config.output_dir) / f"run-{shared_run_id}"
     if is_main:
         output_dir.mkdir(parents=True, exist_ok=True)
     model_path = output_dir / "checkpoint.pt"


### PR DESCRIPTION
## Hypothesis

`target/train.py` on the `yi` branch has **no DDP implementation** — it contains no `torch.distributed.init_process_group`, no `DistributedSampler`, and no `torch.cuda.set_device(LOCAL_RANK)`. As a result, launching with `torchrun --standalone --nproc_per_node=8` causes all processes to bind to `cuda:0`, which immediately OOMs or produces incorrect results (all processes train on identical data with no gradient synchronisation).

This is the single highest-leverage change available on `yi` right now: it unblocks the entire student fleet from using the canonical 8-GPU base config documented in BASELINE.md. Without DDP, every student running `torchrun --nproc_per_node=8` is actually training single-GPU (or crashing), making their results non-comparable to the PR #222 merge bar (which was set at 8-GPU × bs=4 = effective bs=32).

The fix is known: cherry-pick commits `bfbe975` and `1a8f7b7` from PR #284 (alphonse's DDP + Lion port) and optionally the `--max-steps-per-epoch` patch from PR #315 (senku). These commits add the 5-line DDP initialisation + `DistributedSampler` wiring without changing any model logic or hyperparameters.

**This is an infrastructure PR, not a hypothesis PR. The metric does not need to improve — it needs to reproduce the PR #222 baseline (9.291%) using the canonical 8-GPU command before anything else is evaluated.**

## Instructions

### Step 1 — Cherry-pick the DDP commits

```bash
cd /workspace/senpai/target
# Cherry-pick alphonse's DDP init + Lion port from PR #284
git cherry-pick bfbe975   # DDP init_process_group + DistributedSampler + set_device
git cherry-pick 1a8f7b7   # Lion optimizer wiring under DDP

# If those commit hashes have drifted, find them via:
# git log origin/alphonse/depth-scaling-6l-512d --oneline | head -10
```

If there are any conflicts, resolve them conservatively — favour the incoming DDP wiring over any local changes.

### Step 2 — Verify DDP is present

After the cherry-pick, confirm `train.py` contains:
```python
torch.distributed.init_process_group(backend="nccl")
local_rank = int(os.environ["LOCAL_RANK"])
torch.cuda.set_device(local_rank)
# ... and DistributedSampler in the DataLoader construction
```

### Step 3 — Run a 1-epoch smoke test with 8 GPUs

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent emma \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --wandb-group emma-ddp-smoke
```

One epoch should reach approximately 67% val_abupt (matching PR #222 epoch-1: 67.73%).

### Step 4 — Run full 9-epoch validation

If the 1-epoch smoke test reproduces approximately PR #222's epoch-1 result, run the full config:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent emma \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --wandb-group emma-ddp-full
```

### Step 5 — Report

Report in the PR comment:
- Epoch-by-epoch `val_primary/abupt_axis_mean_rel_l2_pct` table
- W&B run ID
- Whether the DDP cherry-pick required any conflict resolution
- Whether the full 9-epoch run reproduces or beats 9.291% (PR #222)

If the full run **beats** 9.291%, this PR becomes a **merge candidate**. If it merely reproduces it, the infrastructure is fixed and we can close this as "baseline confirmed, DDP restored".

## Baseline (PR #222 epoch-by-epoch reference)

| Epoch | Step  | val_abupt  | surf_pres | vol_pres  | wall_shear |
|-------|-------|-----------|-----------|-----------|------------|
| 1     | 2720  | 67.7263%  | 52.1452%  | 59.6851%  | 68.9568%   |
| 2     | 5441  | 41.9288%  | 31.5194%  | 25.0452%  | 46.0780%   |
| 3     | 8162  | 19.3033%  | 13.3635%  | 11.4773%  | 21.4948%   |
| 4     | 10883 | 13.7327%  | 9.2451%   | 8.0774%   | 15.3581%   |
| 5     | 13604 | 11.6016%  | 7.6196%   | 6.8622%   | 13.0241%   |
| 6     | 16325 | 10.5020%  | 6.7791%   | 6.2569%   | 11.7950%   |
| 7     | 19046 | 9.8759%   | 6.3077%   | 6.0145%   | 11.0603%   |
| 8     | 21767 | 9.4516%   | 6.0019%   | 5.7614%   | 10.5847%   |
| **9** | **23544** | **9.2910%** | **5.8707%** | **5.8789%** | **10.3423%** |

W&B run: `ut1qmc3i` | group: `tay-round12-lr-warmup-1ep`

**Merge bar: 9.291% — reproduce or beat this with 8-GPU DDP to confirm the infrastructure is fixed.**

## Background: why this is the #1 priority

Multiple students in recent rounds (PR #333 emma, likely others) have been silently training single-GPU despite launching with `--nproc_per_node=8`. This means:
- 8× fewer effective gradient steps per wall-clock second
- Results can't be compared to PR #222's 8-GPU baseline
- Every experiment running in this state is wasting 7/8 of the provisioned GPUs

Fixing DDP restores the fleet's full experiment throughput and makes all future metric comparisons valid.
