### PR TITLE
thorfinn: STRING-sep + QK-norm stack on new SOTA

### DIFF
--- a/model.py
+++ b/model.py
@@ -171,7 +171,14 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_qk_norm: bool = False,
+    ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -180,6 +187,7 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.use_qk_norm = use_qk_norm
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -188,6 +196,12 @@ class TransolverAttention(nn.Module):
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
+        if use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+        else:
+            self.q_norm = None
+            self.k_norm = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -208,6 +222,9 @@ class TransolverAttention(nn.Module):
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        if self.q_norm is not None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -229,6 +246,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -238,6 +256,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            use_qk_norm=use_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -260,6 +279,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -270,6 +290,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    use_qk_norm=use_qk_norm,
                 )
                 for _ in range(depth)
             ]
@@ -301,6 +322,7 @@ class SurfaceTransolver(nn.Module):
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
         pos_encoding_mode: str = "sincos",
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -311,6 +333,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
         self.pos_encoding_mode = pos_encoding_mode
+        self.use_qk_norm = use_qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -367,6 +390,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -94,6 +94,7 @@ class Config:
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     pos_encoding_mode: str = "sincos"
+    use_qk_norm: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -178,6 +179,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
         pos_encoding_mode=config.pos_encoding_mode,
+        use_qk_norm=config.use_qk_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Two orthogonal architecture improvements are available to stack on the new SOTA:

1. **STRING-sep positional encoding** (PR #311, edward): learnable per-axis `log_freq` + `phase` as `nn.Parameter` replacing fixed isotropic Gaussian RFF. Improved val from 9.039% → 7.546% (−1.493pp, −16.5% relative). Val slopes still negative at termination — the model was still converging.

2. **QK-norm in attention** (alphonse PR #287, currently in-flight on the *old* SOTA): normalizing Q and K before the dot product stabilizes attention logit scale and has been shown to improve convergence stability in large transformers (e.g., Dehghani et al. 2023 "Scaling Vision Transformers to 22 Billion Parameters"). Alphonse's preliminary ep-10 data showed val_abupt ≈ 8.953%, which beat the old SOTA at the time.

The hypothesis: **STRING-sep + QK-norm together** will beat STRING-sep alone, since the two changes target different mechanisms — positional representation quality vs. attention stability — and are therefore orthogonal. Stacking two improvements that each work independently should compound.

## Instructions

Implement STRING-sep positional encoding AND QK-norm together on the full SOTA stack. You are testing whether these two changes stack additively.

### 1. STRING-separable positional encoding

Replace the fixed isotropic Gaussian RFF (random Fourier features) with learnable per-axis frequency/phase parameters. The key idea: instead of sampling `B` from N(0, σ²I), maintain `log_freq_x, log_freq_y, log_freq_z` and `phase_x, phase_y, phase_z` as `nn.Parameter` (6 scalar parameters or 3 per axis with `rff_num_features` features each).

The forward pass for a 3D coordinate `(x, y, z)`:
```python
# For each feature dimension f:
omega_x = torch.exp(log_freq_x[f])  # per-axis learned frequency
omega_y = torch.exp(log_freq_y[f])
omega_z = torch.exp(log_freq_z[f])
projection = omega_x * coords[..., 0] + omega_y * coords[..., 1] + omega_z * coords[..., 2]
encoded = torch.cat([torch.cos(projection + phase[f]), torch.sin(projection + phase[f])], dim=-1)
```

Init: `log_freq` initialized to `log(1.0)` = 0.0 (unit frequency), `phase` initialized to 0.0.

Refer to edward's PR #311 implementation if you need details on the exact architecture.

### 2. QK-norm

In the attention mechanism, add RMSNorm (or LayerNorm) to the query and key projections before computing the dot product:

```python
# In attention forward pass, after projecting Q and K:
Q = self.q_norm(Q)  # RMSNorm(Q)
K = self.k_norm(K)  # RMSNorm(K)
attn = Q @ K.transpose(-2, -1) / scale
```

Add `q_norm` and `k_norm` as `nn.RMSNorm(head_dim)` modules to each attention block. No temperature scaling needed — the QK-norm constrains the logit magnitude naturally. Do NOT remove the existing `/sqrt(head_dim)` scale factor, keep it.

### Launch command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --wandb-group thorfinn-string-qknorm-r19
```

*(Adjust CLI flag names to match your implementation.)*

### Important implementation notes

- Use `rff_num_features=32` (same as the STRING-sep baseline in PR #311)
- QK-norm: use `nn.RMSNorm(head_dim, elementwise_affine=True)` with learnable scale/bias
- Keep all other hyperparameters at the SOTA stack values (heads=4, layers=4, hidden=512, slices=128)
- Report val_abupt per epoch as they complete

## What success looks like

- val_abupt < 7.546% (current STRING-sep SOTA)
- test_abupt < 8.771% (current STRING-sep test SOTA)
- Ideally approaching 7.0% — this would be a major paper-quality result

## Current SOTA (PR #311 STRING-sep, W&B run `gcwx9yaa`)

| Metric | val (best) | test |
|--------|-----------|------|
| **abupt** (primary) | **7.546%** | **8.771%** |
| surface_pressure | 4.867% | 4.485% |
| volume_pressure | 4.525% | 12.438% |
| wall_shear | 8.527% | 8.227% |
| tau_x | — | 7.253% |
| tau_y | — | 9.233% |
| tau_z | — | 10.449% |

## Reference targets (AB-UPT public benchmark)

| Metric | AB-UPT | Gap (test SOTA) |
|--------|--------|-----------------|
| surface_pressure | 3.82% | −0.665pp |
| wall_shear | 7.29% | +0.937pp |
| volume_pressure | 6.08% | **+6.358pp ← largest gap** |

Lower is better on all metrics.
