### PR TITLE
[fern] Fix FourierEmbed coordinate normalization (restores alphonse baseline)

### DIFF
--- a/model.py
+++ b/model.py
@@ -73,23 +73,46 @@ class ContinuousSincosEmbed(nn.Module):
 
 
 class FourierEmbed(nn.Module):
-    """Fourier positional encoding with geometric frequency progression."""
+    """NeRF-style multi-scale sinusoidal positional encoding for 3D coordinates.
+
+    Coordinates are normalized to roughly [-1, 1] with a fixed DrivAerML
+    domain bounding box (5-sigma envelope on volume_xyz, padded slightly),
+    then encoded with a base-2 geometric frequency progression
+    ``pi * 2^k``, ``k in [0, num_freqs)``. Sin/cos features are concatenated
+    and projected to hidden_dim with a learned linear layer.
+    """
+
+    DOMAIN_BOUNDS = (
+        (-12.0, 14.0),
+        (-5.0, 5.0),
+        (-3.0, 3.0),
+    )
 
     def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
         super().__init__()
+        if not 1 <= input_dim <= len(self.DOMAIN_BOUNDS):
+            raise ValueError(
+                f"input_dim must be in [1, {len(self.DOMAIN_BOUNDS)}]; got {input_dim}"
+            )
+        if num_freqs <= 0:
+            raise ValueError("num_freqs must be positive")
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
         self.num_freqs = num_freqs
-        freqs = 2.0 ** torch.arange(num_freqs).float()
+        bounds = self.DOMAIN_BOUNDS[:input_dim]
+        center = torch.tensor([(lo + hi) / 2.0 for lo, hi in bounds], dtype=torch.float32)
+        half_range = torch.tensor([(hi - lo) / 2.0 for lo, hi in bounds], dtype=torch.float32)
+        self.register_buffer("center", center)
+        self.register_buffer("half_range", half_range)
+        freqs = math.pi * (2.0 ** torch.arange(num_freqs, dtype=torch.float32))
         self.register_buffer("freqs", freqs)
         raw_dim = input_dim * num_freqs * 2
-        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
-        if isinstance(self.proj, nn.Linear):
-            _init_linear(self.proj)
+        self.proj = LinearProjection(raw_dim, hidden_dim)
 
     def forward(self, coords: torch.Tensor) -> torch.Tensor:
         coords = coords.float()
-        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        coords = (coords - self.center) / self.half_range
+        angles = coords.unsqueeze(-1) * self.freqs
         emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
         emb = emb.flatten(start_dim=-2)
         return self.proj(emb)


### PR DESCRIPTION
## Hypothesis

The +1pp structural regression vs alphonse `m9775k1v` (val_abupt=7.2091%) has been diagnosed by your previous PR #354. The root cause is missing coordinate normalization in `model.py:FourierEmbed`. **This single fix will unblock the entire research programme.**

**Root cause (from PR #354 diagnosis):**
- alphonse's pod trained with uncommitted local edits to `model.py` that included coordinate normalization in `FourierEmbed.forward()`
- chihiro PR #176 re-implemented FourierEmbed but silently dropped the normalization step
- DrivAerML coordinates are NOT in [-1, 1]: x ≈ [-10, 14], y ≈ [-4.3, 4.2], z ≈ [-2.5, 2.7]
- Without normalization, the highest-frequency sinusoid (freq = 2^7 * π ≈ 402 rad) produces severe aliasing at x=14 → 5,628 rad → pure noise
- With normalization, the same frequency sweeps through ~128π over [-1, 1] → sensible NeRF-style encoding the model can learn from

**Current model.py FourierEmbed (BROKEN):**
```python
def forward(self, coords: torch.Tensor) -> torch.Tensor:
    coords = coords.float()
    angles = coords.unsqueeze(-1) * self.freqs * math.pi  # NO normalization → aliasing
    emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
    emb = emb.flatten(start_dim=-2)
    return self.proj(emb)
```

**Required fix (alphonse's actual implementation from W&B diff.patch):**
```python
DOMAIN_BOUNDS = (
    (-12.0, 14.0),
    (-5.0, 5.0),
    (-3.0, 3.0),
)
```
Added to the `__init__`:
```python
bounds = self.DOMAIN_BOUNDS[:input_dim]
center = torch.tensor([(lo + hi) / 2.0 for lo, hi in bounds], dtype=torch.float32)
half_range = torch.tensor([(hi - lo) / 2.0 for lo, hi in bounds], dtype=torch.float32)
self.register_buffer("center", center)
self.register_buffer("half_range", half_range)
freqs = math.pi * (2.0 ** torch.arange(num_freqs, dtype=torch.float32))
self.register_buffer("freqs", freqs)
```
And in `forward`:
```python
def forward(self, coords: torch.Tensor) -> torch.Tensor:
    coords = coords.float()
    coords = (coords - self.center) / self.half_range  # Normalize to [-1, 1]
    angles = coords.unsqueeze(-1) * self.freqs
    emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
    emb = emb.flatten(start_dim=-2)
    return self.proj(emb)
```

## Instructions

**Step 1: Apply the FourierEmbed coordinate normalization fix to `target/model.py`**

The class currently starts at line 75. You need to:

1. Add `DOMAIN_BOUNDS` as a class-level constant to `FourierEmbed`:
   ```python
   DOMAIN_BOUNDS = (
       (-12.0, 14.0),  # x: 5-sigma envelope from normalizers.json
       (-5.0, 5.0),    # y
       (-3.0, 3.0),    # z
   )
   ```

2. Update `__init__` to register `center` and `half_range` buffers, AND change the freqs calculation from `2.0 ** torch.arange(num_freqs)` to `math.pi * (2.0 ** torch.arange(num_freqs))`:
   ```python
   def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
       super().__init__()
       self.hidden_dim = hidden_dim
       self.input_dim = input_dim
       self.num_freqs = num_freqs
       bounds = self.DOMAIN_BOUNDS[:input_dim]
       center = torch.tensor([(lo + hi) / 2.0 for lo, hi in bounds], dtype=torch.float32)
       half_range = torch.tensor([(hi - lo) / 2.0 for lo, hi in bounds], dtype=torch.float32)
       self.register_buffer("center", center)
       self.register_buffer("half_range", half_range)
       freqs = math.pi * (2.0 ** torch.arange(num_freqs, dtype=torch.float32))
       self.register_buffer("freqs", freqs)
       raw_dim = input_dim * num_freqs * 2
       self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
       if isinstance(self.proj, nn.Linear):
           _init_linear(self.proj)
   ```

3. Update `forward` to normalize coordinates before encoding:
   ```python
   def forward(self, coords: torch.Tensor) -> torch.Tensor:
       coords = coords.float()
       coords = (coords - self.center) / self.half_range  # Normalize to approx [-1, 1]
       angles = coords.unsqueeze(-1) * self.freqs
       emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
       emb = emb.flatten(start_dim=-2)
       return self.proj(emb)
   ```

**Step 2: Commit this change and validate with a 10-epoch baseline run**

```bash
torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 30 \
  --no-compile-model \
  --epochs 10 \
  --wandb-group bengio-fouriembed-fix
```

**Validation gate**: At ep5 the run must show `val_primary/abupt_axis_mean_rel_l2_pct < 10.5%`. The current broken implementation reaches ~13.3% at ep5.

Expected trajectory with fix (alphonse m9775k1v reference):
- ep5: ~11.5%
- ep10: ~9.5%
- ep20: ~8.2%
- ep30: ~7.2%

**Step 3: Post results**

Report W&B run ID, ep10 abupt, and commit SHA in a PR comment.

## Baseline

Current best (val, with BROKEN FourierEmbed):

| Metric | Baseline (broken) | AB-UPT Target |
|--------|------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | 7.2091% (m9775k1v, but was trained with normalized FourierEmbed!) | 4.51% |
| `val_primary/surface_pressure_rel_l2_pct` | 4.802% | 3.82% |
| `val_primary/wall_shear_rel_l2_pct` | 8.160% | 7.29% |
| `val_primary/volume_pressure_rel_l2_pct` | 4.166% | 6.08% |
| `val_primary/wall_shear_y_rel_l2_pct` | 9.100% | 3.65% |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.869% | 3.63% |

All Wave 5–8 experiments are affected by the regression. This fix should recover ~1pp across all metrics for all in-flight runs once applied.

W&B baseline run: `m9775k1v` (https://wandb.ai/morganmcg1/DrivAerML/runs/m9775k1v) — trained with the CORRECT normalized FourierEmbed (confirmed via W&B diff.patch in PR #354).
