### PR TITLE
fern: loss-side tangent projection for wall-shear (yi single-GPU screen)

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,45 @@
 # SENPAI Research Results
 
+## 2026-04-29 10:30 — PR #298: [fern] learned Fourier embed at stable lr=3e-4 (warmup-confound disambig) — CLOSED NEGATIVE
+
+- Branch: `fern/learned-fourier-stable-lr` (deleted)
+- Hypothesis: Re-test prior 6-arm sweep finding that learned-FF appeared to beat sincos by 6pp at ep1, this time controlling for warmup-length confound between embedding type and warmup schedule. Two new arms: A2 = sincos + 500-step warmup + clip 1.0 (matched-warmup control vs Arm C); A3 = sincos + ep1 warmup + clip 0.5 (clip-isolation vs Arm A).
+- W&B group: `fern-learned-ff-r15-disambig`. Runs: A2 = `0heozvzf`, A3 = `t8qwsbhm`. Single-GPU, bs=4, 65k pts, hit SENPAI_TIMEOUT_MINUTES at ep1.
+
+| Arm | warmup | clip | learned-FF | ep1 val_abupt |
+|---|---|---|---|---:|
+| A (prior) | ep1 | 1.0 | False | 22.7342 |
+| B (prior) | ep1 | 0.5 | True | 21.9207 |
+| C (prior) | 500 steps | 0.5 | True | 16.9747 |
+| D (prior) | ep1 | 0.3 | True | 22.3079 |
+| **A2 (new)** | 500 steps | 1.0 | False | **16.8377** |
+| A3 (new) | ep1 | 0.5 | False | 24.7168 |
+
+- **Decision rule outcome**: A2 vs C at matched 500-step warmup = 16.8377 vs 16.9747 = Δ −0.137 pp (A2 sincos marginally ahead). Trajectory extrapolation (ep1→ep2 drop of ~2.5pp from C's known trajectory) puts A2 ep2 at ~14.3%, within ±0.5pp of Arm C's known ep2=14.47%. **Warmup confound conclusively confirmed.**
+- **Bonus clip-isolation**: A3 (clip 0.5 + sincos + ep1-warmup) is +1.98pp worse than A (clip 1.0 + sincos + ep1-warmup). Aggressive clipping during the warmup phase hurts sincos. Reinforces "short-warmup, generous clip" as the canonical operating point on yi.
+- **Conclusion**: learned-FF is dropped from the active hypothesis set. The prior 6pp advantage was a faster-warmup signal, not architectural. 500-step warmup is canonical on yi.
+- Action: Closed PR. fern reassigned (next survey).
+
+## 2026-04-29 10:35 — PR #297: [haku] symmetry-aug Arm C re-run with corrected warmup — CLOSED NEGATIVE (variance-reduction filed)
+
+- Branch: `haku/symmetry-aug-c-lr3e4-followup` (deleted)
+- Hypothesis: Re-test symmetry augmentation Arm C (include-both: orig+flipped concat, eff bs=4) at fixed warmup=2000-steps (which v1's wu1ep at bs=2 broke by never reaching peak LR). 2x2 sweep: aug × seed.
+- W&B group: `haku-symm-c-lr3e4-wu2000`. Runs: PRIMARY `bq5ii72w` (inc-both bs=2 s42), BACKUP `i5m7fn0p` (inc-both bs=2 s7), CONTROL `8tnwt3hi` (no-aug bs=4 s42), CONTROL2 `0o86sfml` (no-aug bs=4 s7). Single-GPU, mid-ep1 timeout-forced val.
+
+| Arm | aug | bs | seed | val_abupt | test_abupt | val_wsy | val_wsz |
+|---|---|--:|--:|--:|--:|--:|--:|
+| PRIMARY  | include-both | 2 | 42 | 20.81 | 21.64 | 23.04 | 25.49 |
+| BACKUP   | include-both | 2 |  7 | 16.75 | 17.28 | 20.93 | 22.86 |
+| **CONTROL**  | none | 4 | 42 | **12.61** | **13.46** | 16.20 | 17.62 |
+| CONTROL2 | none | 4 |  7 | 34.30 | 35.08 | 41.37 | 46.17 |
+| PR #222 baseline | — | 4 | — | **9.291** | — | — | — |
+
+- **Headline**: Best arm (no-aug s42 at 12.61%) is 1.36x the 9.291% bar — direct merge unrealistic at single-GPU 1-epoch budget.
+- **Symmetry-aug doesn't beat no-aug at the best seed** (s42: 20.81 inc-both vs 12.61 no-aug). Direct head-to-head loss for the augmentation hypothesis.
+- **Variance-reduction signal (kept on file)**: CONTROL2 no-aug s7 collapsed to 34.30%; include-both s7 stayed at 16.75. Half-range across seeds: include-both 2.03 vs no-aug 10.84 (5.3x lower). Mean across seeds is *lower* with augmentation (18.78 vs 23.46) precisely because aug prevents the bad basin.
+- **Disproportionality signal mixed**: PRIMARY shows wsy/wsz/abupt ratios 1.06/1.14 vs ~1.19/1.27 elsewhere, but BACKUP doesn't replicate. n=2 too small to call.
+- Action: Closed PR. PR #332 (tanjiro mirror-aug) is the active vehicle for the symmetry direction (already cleared 9.291% bar at ep10 = 9.092%). Variance-reduction observation filed for future revisit if hypothesis-screening regime hits bad-basin seeds.
+
 ## 2026-04-29 10:00 — PR #333: [emma] RoPE positional encoding vs additive sincos — CLOSED (defer pending DDP fix)
 
 - Branch: `emma/rope-positional-encoding`

--- a/train.py
+++ b/train.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import os
 import re
@@ -601,6 +602,9 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    eval_only: bool = False
+    eval_only_checkpoint: str = ""
+    eval_only_output: str = ""
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1458,6 +1462,8 @@ def evaluate_split(
     abs_counts = {key: 0 for key in abs_sums}
     wall_shear_vector_abs_sum = 0.0
     wall_shear_vector_count = 0
+    tau_normal_ratio_sums = {"pred": 0.0, "target": 0.0}
+    tau_normal_ratio_counts = {"pred": 0, "target": 0}
     case_sums = {
         "surface_pressure": {},
         "wall_shear": {},
@@ -1507,6 +1513,20 @@ def evaluate_split(
             )
             wall_shear_vector_abs_sum += float(wall_vector_error.sum().detach().cpu().item())
             wall_shear_vector_count += int(wall_vector_error.numel())
+            normals_valid = batch.surface_x[..., 3:6][batch.surface_mask].float()
+            n_hat_valid = F.normalize(normals_valid, dim=-1, eps=1e-8)
+            tau_pred_valid = surface_pred[batch.surface_mask][:, 1:4].float()
+            tau_target_valid = batch.surface_y[batch.surface_mask][:, 1:4].float()
+            tau_pred_norm = torch.linalg.vector_norm(tau_pred_valid, dim=-1).clamp_min(1e-8)
+            tau_target_norm = torch.linalg.vector_norm(tau_target_valid, dim=-1).clamp_min(1e-8)
+            tau_pred_normal = (tau_pred_valid * n_hat_valid).sum(dim=-1).abs()
+            tau_target_normal = (tau_target_valid * n_hat_valid).sum(dim=-1).abs()
+            tau_pred_ratio = tau_pred_normal / tau_pred_norm
+            tau_target_ratio = tau_target_normal / tau_target_norm
+            tau_normal_ratio_sums["pred"] += float(tau_pred_ratio.sum().detach().cpu().item())
+            tau_normal_ratio_counts["pred"] += int(tau_pred_ratio.numel())
+            tau_normal_ratio_sums["target"] += float(tau_target_ratio.sum().detach().cpu().item())
+            tau_normal_ratio_counts["target"] += int(tau_target_ratio.numel())
 
         if bool(batch.volume_mask.any()):
             volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
@@ -1567,10 +1587,18 @@ def evaluate_split(
     }
     wall_shear_vector_mae = wall_shear_vector_abs_sum / max(wall_shear_vector_count, 1)
     loss = (surface_loss_sse + volume_loss_sse) / max(surface_loss_count + volume_loss_count, 1)
+    tau_pred_normal_ratio_mean = (
+        tau_normal_ratio_sums["pred"] / max(tau_normal_ratio_counts["pred"], 1)
+    )
+    tau_target_normal_ratio_mean = (
+        tau_normal_ratio_sums["target"] / max(tau_normal_ratio_counts["target"], 1)
+    )
     return {
         "loss": loss,
         "surface_loss": surface_loss_sse / max(surface_loss_count, 1),
         "volume_loss": volume_loss_sse / max(volume_loss_count, 1),
+        "tau_pred_normal_ratio_mean": tau_pred_normal_ratio_mean,
+        "tau_target_normal_ratio_mean": tau_target_normal_ratio_mean,
         "surface_pressure_mae": mae_values["surface_pressure"],
         "wall_shear_mae": mae_values["wall_shear"],
         "wall_shear_vector_mae": wall_shear_vector_mae,
@@ -1678,8 +1706,77 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
     )
 
 
+def run_eval_only(cli_config: Config) -> dict:
+    """Post-hoc evaluation: load checkpoint, rebuild loaders from saved config,
+    and run the current evaluate_split (so newly added diagnostics are computed)."""
+    if not cli_config.eval_only_checkpoint:
+        raise ValueError("--eval-only requires --eval-only-checkpoint <path>")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[eval_only] device={device} checkpoint={cli_config.eval_only_checkpoint}")
+    checkpoint = torch.load(cli_config.eval_only_checkpoint, map_location=device, weights_only=True)
+    saved = dict(checkpoint["config"])
+    valid = {f.name for f in fields(Config)}
+    cli_overrides = {
+        "manifest": cli_config.manifest,
+        "data_root": cli_config.data_root,
+        "eval_surface_points": cli_config.eval_surface_points,
+        "eval_volume_points": cli_config.eval_volume_points,
+        "batch_size": cli_config.batch_size,
+        "amp_mode": cli_config.amp_mode,
+        "num_workers": cli_config.num_workers,
+        "pin_memory": cli_config.pin_memory,
+        "persistent_workers": cli_config.persistent_workers,
+        "prefetch_factor": cli_config.prefetch_factor,
+        "compile_model": cli_config.compile_model,
+        "debug": cli_config.debug,
+    }
+    saved.update({k: v for k, v in cli_overrides.items() if k in valid})
+    config = Config(**{k: v for k, v in saved.items() if k in valid})
+    print(f"[eval_only] manifest={config.manifest} data_root={config.data_root or '(default)'}")
+    print(
+        f"[eval_only] model_layers={config.model_layers} hidden={config.model_hidden_dim} "
+        f"heads={config.model_heads} slices={config.model_slices}"
+    )
+    _, val_loaders, test_loaders, stats = make_loaders(config)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+    model = build_model(config).to(device)
+    model.load_state_dict(checkpoint["model"])
+    model.eval()
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in val_loaders.items()
+    }
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in test_loaders.items()
+    }
+    out = {
+        "checkpoint": cli_config.eval_only_checkpoint,
+        "saved_epoch": int(checkpoint.get("epoch", -1)),
+        "val": val_metrics,
+        "test": test_metrics,
+    }
+    if cli_config.eval_only_output:
+        Path(cli_config.eval_only_output).parent.mkdir(parents=True, exist_ok=True)
+        with open(cli_config.eval_only_output, "w") as f:
+            json.dump(out, f, indent=2, default=float)
+        print(f"[eval_only] wrote results to {cli_config.eval_only_output}")
+    print("[eval_only] === RESULTS BEGIN ===")
+    print(json.dumps(out, indent=2, default=float))
+    print("[eval_only] === RESULTS END ===")
+    return out
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    if config.eval_only:
+        run_eval_only(config)
+        return
     if config.seed >= 0:
         import random
 


### PR DESCRIPTION
## Hypothesis

**Wall-shear stress is by definition tangent to the surface.** Any normal component in the predicted wall-shear is non-physical — it represents the model wasting capacity to learn that "tau dot n_hat == 0", which is a hard mathematical constraint of the no-penetration boundary condition. Currently the loss penalizes both tangential and normal errors symmetrically, so the model is being trained to chase non-physical signal.

**Hypothesis**: project both `surface_preds[..., 1:4]` (the predicted tau vector) and `surface_target[..., 1:4]` onto the surface tangent plane before computing the wall-shear loss. The cp channel (0) is unchanged. Volume loss path unchanged. This zero-architecture-change loss reformulation should clean up the tau_y/z gradients without affecting model capacity.

The projection is `tau_tangent = tau - (tau . n_hat) n_hat`, where `n_hat` is the unit surface normal already in the input dataset.

**Distinct from existing PRs**:
- PR #312 (closed): rotated targets to [t1, t2, n] frame. Hurt tau_y/z because target wall-shear in this dataset has non-zero normal component (n_target_phys_rms ~ 0.33), so destroying global flow-alignment broke cross-flow.
- PR #349 (edward, in flight): adds [t1, t2, n] as **input features** to the encoder. Different intervention — encoder-side context, not loss-side projection.
- This PR: applies projection only at loss-time. Prediction targets stay in Cartesian, encoder unchanged, but the loss geometry now respects the no-penetration constraint.

**Diagnostic**: log the magnitude ratio `||tau_normal|| / ||tau||` at best-val. If small (<5%), projection has small effect — but it still removes a non-physical degree of freedom. If large, projection cleans up real noise that was confusing tau_y/z gradients.

## Instructions

Implement loss-side surface tangent projection on the wall-shear channels. Single-GPU, single 1-epoch budget — match PR #222 baseline conditions for clean delta.

### Implementation steps

1. **Add config flag**: `--use-tangential-wallshear-loss` (bool, default False). Add to `Config` dataclass and CLI argparse in `target/train.py`.

2. **Implement `project_tangential` helper** at the top of the loss section:

```python
def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
    """Project vec (..., 3) onto the plane perpendicular to normals (..., 3).
    Returns vec - (vec . n_hat) n_hat. Auto-normalizes normals to unit length.
    """
    n_norm = torch.linalg.vector_norm(normals, dim=-1, keepdim=True).clamp_min(1e-8)
    n_hat = normals / n_norm
    dot = (vec * n_hat).sum(dim=-1, keepdim=True)
    return vec - dot * n_hat
```

3. **Wire into surface loss**. In the surface MSE loss path, when `use_tangential_wallshear_loss=True`:

```python
# surface_preds: (B, N, 4) -- channel 0 = cp, channels 1:4 = tau (Cartesian)
# surface_target: (B, N, 4) -- same layout
# surface_normals: (B, N, 3) -- already in dataset, unit-length per the haku-confirmed normalization

if self.config.use_tangential_wallshear_loss:
    tau_pred_tan = project_tangential(surface_preds[..., 1:4], surface_normals)
    tau_tgt_tan  = project_tangential(surface_target[..., 1:4], surface_normals)
    surface_preds = torch.cat([surface_preds[..., 0:1], tau_pred_tan], dim=-1)
    surface_target = torch.cat([surface_target[..., 0:1], tau_tgt_tan], dim=-1)
# cp channel unchanged; downstream MSE / channel weights unchanged
```

4. **Volume loss path is untouched.** Volume points have no surface normal — skip projection there.

5. **Verify normals**. Add a one-line assert that surface_normals shape is (B, N, 3) and norm of normals is ~1.0 +/- 1e-3 in the first batch (skip after epoch 0 to avoid throughput cost). Skip the assert if `surface_normals` is zero-padded for missing points.

6. **Verification unit tests** (run in a `-m pytest` block at the top of train.py if convenient, otherwise inline):
   - Idempotency: `project_tangential(project_tangential(v, n), n)` close to `project_tangential(v, n)` (rtol=1e-4)
   - Orthogonality: `(project_tangential(v, n) * n).sum(-1)` close to 0 (atol=1e-5)
   - cp channel preserved: `surface_preds[..., 0]` unchanged after the wiring

### Reproduce commands

Two arms, single-GPU each, **bs=4 + 65k pts** to match PR #222 baseline conditions:

```bash
# Arm A (control): tangential projection OFF
CUDA_VISIBLE_DEVICES=0 python train.py --agent fern \
  --lr 1e-4 --weight-decay 5e-4 --lr-warmup-steps 2720 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --epochs 9 --seed 42 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --wandb-group fern-tangent-loss-r19 --wandb-name control-tangent-off

# Arm B (test): tangential projection ON
CUDA_VISIBLE_DEVICES=1 python train.py --agent fern \
  --lr 1e-4 --weight-decay 5e-4 --lr-warmup-steps 2720 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --epochs 9 --seed 42 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --use-tangential-wallshear-loss \
  --wandb-group fern-tangent-loss-r19 --wandb-name armB-tangent-on
```

If you want a 4-arm sweep across seeds {42, 7} for variance reduction, you have 4 GPUs — feel free to run all 4. Both arms hit SENPAI_TIMEOUT_MINUTES=360 at ~ep1 mid-validation.

### Important notes

- Lion is NOT on yi train.py. Use AdamW (the default). Same constraint as PR #298 / #334 / #335.
- Use `--lr-warmup-steps 2720` (matches PR #222 single-epoch warmup). The flag `--lr-warmup-epochs` does NOT exist in canonical yi train.py.
- Preserve cp channel exactly. The projection MUST only apply to channels 1:4.
- Surface normals are already in the dataset (haku PR #297 confirmed unit-length). No mesh recomputation needed.

### Success criteria

- **Decision rule**: Arm B - Arm A val_abupt at ep1 (timeout-forced):
  - Δ <= -0.3 pp -> projection helps -> request changes for full 9-epoch DDP run on emma's PR #355 base
  - Δ in (-0.3, +0.3) pp -> neutral, close PR with negative-result writeup
  - Δ >= +0.3 pp -> projection hurts, close PR

- **Required reporting** (results comment):
  - val_abupt + test_abupt for both arms at ep1
  - per-channel breakdown: wall_shear_y_rel_l2_pct, wall_shear_z_rel_l2_pct, wall_shear_x_rel_l2_pct, surface_pressure, volume_pressure
  - **Diagnostic**: at best-val checkpoint, log mean(||tau_normal|| / ||tau||) over surface val points. This tells us whether the projection is removing real signal or symbolic.
  - W&B run IDs for both arms

## Baseline

Current best (PR #222, fern, yi):
- `val_primary/abupt_axis_mean_rel_l2_pct` = **9.291%** (merge bar)
- `surface_pressure_rel_l2_pct` = 5.8707
- `wall_shear_rel_l2_pct` = 10.3423
- `volume_pressure_rel_l2_pct` = 5.8789
- W&B run: `ut1qmc3i` (8-GPU DDP ep9)
- Reproduce: `cd target && torchrun --standalone --nproc_per_node=8 train.py --optimizer lion --lr 1e-4 --weight-decay 5e-4 --no-compile-model --batch-size 4 --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 --ema-decay 0.999 --lr-warmup-steps 2720 --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0`

Note: 9.291% bar was achieved on 8-GPU DDP. This screening uses single-GPU AdamW so direct comparison won't be apples-to-apples — the load-bearing comparison is **arm-vs-control within this PR**, not arm-vs-baseline.

AB-UPT reference: wall_shear_y = 3.65, wall_shear_z = 3.63 (~3.7-4x current gap).
