### PR TITLE
nezuko: model-layers=5 + STRING-sep PE on new SOTA stack

### DIFF
--- a/model.py
+++ b/model.py
@@ -70,6 +70,113 @@ class RFFEncoding(nn.Module):
         proj = 2.0 * math.pi * (x @ self.B.to(dtype=x.dtype))
         return torch.cat([proj.sin(), proj.cos()], dim=-1)
 
+    @torch.no_grad()
+    def diagnostics(self) -> dict[str, float]:
+        B = self.B.float()
+        return {"B_norm": float(B.norm().item()), "B_abs_mean": float(B.abs().mean().item())}
+
+
+class StringEncoding(nn.Module):
+    """Separable axis-aligned learnable frequency encoding (STRING-inspired).
+
+    Each of the ``in_dim`` axes gets ``num_features_per_axis`` independent learnable
+    frequencies parameterised as (log-amplitude, phase). The output dimension is
+    ``in_dim * num_features_per_axis * 2``.
+    """
+
+    def __init__(self, in_dim: int, num_features_per_axis: int = 11, sigma: float = 1.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features_per_axis = num_features_per_axis
+        # Initialise log-frequencies near log(sigma); small noise avoids symmetry
+        self.log_freq = nn.Parameter(
+            torch.randn(in_dim, num_features_per_axis) * 0.1 + math.log(sigma)
+        )
+        self.phase = nn.Parameter(torch.zeros(in_dim, num_features_per_axis))
+
+    @property
+    def output_dim(self) -> int:
+        return self.in_dim * self.num_features_per_axis * 2
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        freq = self.log_freq.exp()  # [in_dim, F]
+        # x: [..., in_dim]  ->  [..., in_dim, F]
+        proj = x.unsqueeze(-1) * freq + self.phase
+        proj = 2.0 * math.pi * proj
+        # sin/cos then flatten last two dims: [..., in_dim*F*2]
+        return torch.cat([proj.sin(), proj.cos()], dim=-1).flatten(start_dim=-2)
+
+    @torch.no_grad()
+    def diagnostics(self) -> dict[str, float]:
+        log_freq = self.log_freq.detach().float()
+        freq = log_freq.exp()
+        phase = self.phase.detach().float()
+        out = {
+            "log_freq_mean": float(log_freq.mean().item()),
+            "log_freq_std": float(log_freq.std().item()),
+            "freq_min": float(freq.min().item()),
+            "freq_max": float(freq.max().item()),
+            "phase_std": float(phase.std().item()),
+            "phase_abs_max": float(phase.abs().max().item()),
+        }
+        # Per-axis frequency spread reveals whether axes have specialized
+        for axis in range(self.in_dim):
+            out[f"freq_axis{axis}_mean"] = float(freq[axis].mean().item())
+            out[f"freq_axis{axis}_std"] = float(freq[axis].std().item())
+        return out
+
+
+class GrapeEncoding(nn.Module):
+    """Minimal GRAPE-M: learnable spectral projection planes (Knigge et al. 2024).
+
+    Identical in structure to :class:`RFFEncoding` but the projection matrix ``B``
+    is an ``nn.Parameter`` trained end-to-end rather than a fixed buffer.
+    Output dim = ``2 * num_features``.
+    """
+
+    def __init__(self, in_dim: int, num_features: int = 32, sigma: float = 1.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        init = torch.randn(in_dim, num_features) * sigma
+        self.B = nn.Parameter(init.clone())
+        # B_init kept as buffer (non-trainable, DDP-broadcast) so we can measure
+        # how far the learned planes drift from initialization.
+        self.register_buffer("B_init", init.clone())
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        proj = 2.0 * math.pi * (x @ self.B.to(dtype=x.dtype))
+        return torch.cat([proj.sin(), proj.cos()], dim=-1)
+
+    @torch.no_grad()
+    def diagnostics(self) -> dict[str, float]:
+        B = self.B.detach().float()
+        B_init = self.B_init.detach().float()
+        delta = B - B_init
+        init_norm = float(B_init.norm().item())
+        cur_norm = float(B.norm().item())
+        delta_norm = float(delta.norm().item())
+        # Per-row (per learned-plane) drift, useful for spotting dead rows
+        delta_row = delta.norm(dim=1)  # [in_dim]
+        out = {
+            "B_norm": cur_norm,
+            "B_abs_mean": float(B.abs().mean().item()),
+            "B_init_norm": init_norm,
+            "B_delta_norm": delta_norm,
+            "B_relative_drift": delta_norm / max(init_norm, 1e-12),
+            "B_max_row_drift": float(delta_row.max().item()),
+            "B_min_row_drift": float(delta_row.min().item()),
+        }
+        # Per-axis row drift reveals anisotropic learning
+        for axis in range(self.in_dim):
+            out[f"B_axis{axis}_row_drift"] = float(delta_row[axis].item())
+            out[f"B_axis{axis}_norm"] = float(B[axis].norm().item())
+        return out
+
 
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
@@ -237,6 +344,8 @@ class Transformer(nn.Module):
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
+    _ENCODING_MODES = ("rff", "string", "grape")
+
     def __init__(
         self,
         *,
@@ -253,8 +362,13 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        pos_encoding_mode: str = "rff",
     ):
         super().__init__()
+        if pos_encoding_mode not in self._ENCODING_MODES:
+            raise ValueError(
+                f"pos_encoding_mode must be one of {self._ENCODING_MODES}, got {pos_encoding_mode!r}"
+            )
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
@@ -262,6 +376,7 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
+        self.pos_encoding_mode = pos_encoding_mode
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -269,21 +384,29 @@ class SurfaceTransolver(nn.Module):
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
 
-        if rff_num_features > 0:
-            self.surface_rff = RFFEncoding(
+        def _make_encoding() -> nn.Module | None:
+            if rff_num_features <= 0:
+                return None
+            if pos_encoding_mode == "string":
+                # STRING: per-axis features; use rff_num_features as features-per-axis
+                return StringEncoding(
+                    in_dim=space_dim, num_features_per_axis=rff_num_features, sigma=rff_sigma
+                )
+            if pos_encoding_mode == "grape":
+                return GrapeEncoding(
+                    in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
+                )
+            # default: rff
+            return RFFEncoding(
                 in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
             )
-            self.volume_rff = RFFEncoding(
-                in_dim=space_dim, num_features=rff_num_features, sigma=rff_sigma
-            )
-            rff_out_dim = 2 * rff_num_features
-        else:
-            self.surface_rff = None
-            self.volume_rff = None
-            rff_out_dim = 0
 
-        surface_proj_in = surface_extra_dim + rff_out_dim
-        volume_proj_in = volume_extra_dim + rff_out_dim
+        self.surface_rff = _make_encoding()
+        self.volume_rff = _make_encoding()
+        enc_out_dim = self.surface_rff.output_dim if self.surface_rff is not None else 0
+
+        surface_proj_in = surface_extra_dim + enc_out_dim
+        volume_proj_in = volume_extra_dim + enc_out_dim
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )

--- a/train.py
+++ b/train.py
@@ -93,6 +93,7 @@ class Config:
     model_dropout: float = 0.0
     rff_num_features: int = 0
     rff_sigma: float = 1.0
+    pos_encoding_mode: str = "rff"
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -176,6 +177,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        pos_encoding_mode=config.pos_encoding_mode,
     )
 
 
@@ -573,6 +575,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+                # Encoding diagnostics: tell us whether learnable encodings (STRING/GRAPE)
+                # are actually moving from init or stuck — answers "is the learnable
+                # advantage real" question that motivates the ablation.
+                for tag, enc in (("surface", base_model.surface_rff), ("volume", base_model.volume_rff)):
+                    if enc is not None and hasattr(enc, "diagnostics"):
+                        for k, v in enc.diagnostics().items():
+                            log_metrics[f"train/encoding/{tag}/{k}"] = v
                 wandb.log(log_metrics)
                 tag = " *" if improved else ""
                 print(


### PR DESCRIPTION
## Hypothesis

Deeper model (5 transformer layers instead of 4) stacked on top of the current STRING-separable positional encoding SOTA may further reduce error by giving the model more capacity to encode complex aerodynamic feature interactions. PR #283 showed that model-layers=5 on the pre-STRING-sep SOTA reached val~8.99% — promising depth signal. Now that STRING-sep has unlocked a much richer positional representation, a 5-layer model should be able to exploit that richer geometry signal more effectively than the current 4-layer baseline (7.546% val / 8.771% test).

The rationale: STRING-sep learned anisotropic per-axis spectral emphasis that dramatically improved geometric representation. More transformer depth allows the model to compose those richer features hierarchically, which is beneficial for automotive aerodynamics where flow features span multiple scales (near-wall boundary layer, wake, roof vortex).

Note: 5-layer models are ~25% slower per epoch than 4-layer. With 8×DDP and the 270-min budget this should still allow 10-12 epochs. Keep batch-size=4.

## Instructions

Start from the full SOTA config (PR #311 STRING-sep stack). The **only** change from baseline is `--model-layers 5` (instead of 4). Everything else stays identical.

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable \
  --wandb_group tay-nezuko-layers5-string-sep
```

Key changes vs baseline SOTA reproduce command:
- `--model-layers 5` (was 4)
- `--wandb_group tay-nezuko-layers5-string-sep`

Everything else is **identical** to the SOTA config. Do NOT change any other hyperparameter.

After training completes, report:
1. Best val_abupt (epoch it occurred)
2. Terminal val_abupt (final epoch)
3. test_primary/abupt_axis_mean_rel_l2_pct from best-val checkpoint
4. All per-axis test metrics: surface_pressure, wall_shear, volume_pressure, tau_x, tau_y, tau_z
5. W&B run ID and approximate runtime

## Baseline

Current SOTA — PR #311 edward (STRING-separable positional encoding):

| Metric | PR #311 (SOTA) | AB-UPT target |
|--------|---------------|---------------|
| val_abupt | **7.546%** | — |
| test_abupt | **8.771%** | — |
| surface_pressure | **4.485%** | 3.82% |
| wall_shear | **8.227%** | 7.29% |
| volume_pressure | **12.438%** | 6.08% |
| tau_x | **7.253%** | 5.35% |
| tau_y | **9.233%** | 3.65% |
| tau_z | **10.449%** | 3.63% |

**W&B run:** `gcwx9yaa` — group `tay-round18-grape-ablation`

**Target to beat:** val_abupt < 7.546% AND test_abupt < 8.771%

### Reproduce SOTA (for reference — your run adds only `--model-layers 5`)

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent <STUDENT> --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable
```
