### PR TITLE
gilbert: volume-pressure Huber loss for vol_p test gap (2.05× AB-UPT)

### DIFF
--- a/train.py
+++ b/train.py
@@ -694,6 +694,8 @@ class Config:
     validation_every: int = 10
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    volume_loss_type: str = "mse"
+    volume_huber_delta: float = 1.0
     aux_rel_l2_weight: float = 0.0
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
@@ -1411,6 +1413,45 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def masked_huber(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    beta: float,
+) -> torch.Tensor:
+    if bool(mask.any()):
+        return F.smooth_l1_loss(pred[mask], target[mask], beta=beta, reduction="mean")
+    return pred.sum() * 0.0
+
+
+_VOL_RESIDUAL_QUANTILES: tuple[float, ...] = (0.5, 0.75, 0.9, 0.95, 0.99)
+
+
+def volume_residual_percentiles(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> dict[str, float]:
+    if not bool(mask.any()):
+        return {}
+    diff = (pred[mask].detach().float() - target[mask].detach().float()).abs()
+    if diff.numel() == 0:
+        return {}
+    qs = torch.tensor(_VOL_RESIDUAL_QUANTILES, dtype=diff.dtype, device=diff.device)
+    # `torch.quantile` allocates O(N log N) for sort; subsample to keep cost bounded.
+    if diff.numel() > 200_000:
+        idx = torch.randperm(diff.numel(), device=diff.device)[:200_000]
+        diff_sample = diff[idx]
+    else:
+        diff_sample = diff
+    vals = torch.quantile(diff_sample, qs)
+    return {
+        f"vol_residual_p{int(q * 100):02d}": float(v.cpu().item())
+        for q, v in zip(_VOL_RESIDUAL_QUANTILES, vals)
+    }
+
+
 def weighted_masked_mse_per_channel(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -1497,6 +1538,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    volume_loss_type: str = "mse",
+    volume_huber_delta: float = 1.0,
     aux_rel_l2_weight: float = 0.0,
     use_tangential_wallshear_loss: bool = False,
     wallshear_y_weight: float = 1.0,
@@ -1548,8 +1591,24 @@ def train_loss(
             channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
             wallshear_huber_delta=wallshear_huber_delta,
         )
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_pred = out["volume_preds"]
+        if volume_loss_type == "huber":
+            volume_loss = masked_huber(
+                volume_pred,
+                volume_target,
+                batch.volume_mask,
+                beta=volume_huber_delta,
+            )
+        elif volume_loss_type == "mse":
+            volume_loss = masked_mse(volume_pred, volume_target, batch.volume_mask)
+        else:
+            raise ValueError(
+                f"Unknown volume_loss_type {volume_loss_type!r}; expected 'mse' or 'huber'."
+            )
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        vol_residual_metrics = volume_residual_percentiles(
+            volume_pred, volume_target, batch.volume_mask
+        )
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
             surf_pred_f = surface_pred_norm.float()
@@ -1568,6 +1627,7 @@ def train_loss(
         "loss_tau_y": per_axis_unweighted[2],
         "loss_tau_z": per_axis_unweighted[3],
     }
+    metrics.update(vol_residual_metrics)
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
@@ -1870,6 +1930,14 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    if config.volume_loss_type not in {"mse", "huber"}:
+        raise ValueError(
+            f"--volume-loss-type must be 'mse' or 'huber'; got {config.volume_loss_type!r}"
+        )
+    if config.volume_huber_delta <= 0:
+        raise ValueError(
+            f"--volume-huber-delta must be > 0; got {config.volume_huber_delta}"
+        )
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
     rank = int(os.environ.get("RANK", "0"))
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
@@ -2119,6 +2187,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 config.amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
+                volume_loss_type=config.volume_loss_type,
+                volume_huber_delta=config.volume_huber_delta,
                 aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
                 wallshear_y_weight=config.wallshear_y_weight,
@@ -2242,6 +2312,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
                 ]
+            for key, value in batch_loss_metrics.items():
+                if key.startswith("vol_residual_"):
+                    train_log[f"train/{key}"] = value
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():


### PR DESCRIPTION
## Hypothesis

Volume pressure has the **largest current gap** to AB-UPT (test 12.438% vs target 6.08%, ratio **2.05×**) — and it is the only major gap that is **completely unattended** by the active fleet (which is ~6 PRs deep on tau_y/z). Critically:

- val vol_pressure (PR #311 SOTA): ~5.88%
- test vol_pressure (PR #311 SOTA): 12.438%
- **2.1× val/test divergence on volume pressure only** — surface_pressure and wall_shear show ~1.2-1.4× val/test ratios

A 2× val/test divergence in CFD typically means **a small subset of test cases drives most of the test error** (heavy-tail distribution shift). MSE loss is L2 — gradients scale linearly with residual magnitude, so the model preferentially fits the easy cases and leaves the high-error cases poorly fit. **Huber loss** with a small δ caps the per-point gradient contribution, which:
1. Reduces the influence of large-residual outliers during training
2. Forces the model to spread capacity across cases more uniformly
3. Should reduce val/test divergence specifically on the heavy-tail target

This is the same robust-loss family violet PR #317 is testing on wall-shear — but applied to a **completely orthogonal target** (volume pressure, not tau). Both can land independently if both win.

**Why this is high-leverage right now:**
- Volume pressure regression is the largest remaining gap (2.05× vs 1.13-1.36× elsewhere).
- Nobody on yi is currently working on volume pressure.
- One CLI flag, one config sweep — minimum scope for maximum coverage.
- The val numbers say the model *can* learn volume pressure well; it just doesn't generalize. Robust loss is a textbook fix for this exact pattern.

## Instructions

### Step 1: Add volume-pressure Huber loss option

Add two new CLI flags to `target/train.py`:
- `--volume-loss-type` with choices `{"mse", "huber"}` (default `"mse"`)
- `--volume-huber-delta DELTA` (default 1.0, only used when type=huber)

Apply only to the volume_pressure prediction loss, NOT to surface losses (surface should remain MSE).

In the loss computation function:

```python
if args.volume_loss_type == "huber":
    vol_loss = F.smooth_l1_loss(vol_pred, vol_target, beta=args.volume_huber_delta, reduction="mean")
else:
    vol_loss = F.mse_loss(vol_pred, vol_target, reduction="mean")
```

(`smooth_l1_loss` with `beta=δ` is exactly Huber loss in PyTorch's parameterization — quadratic for |r|<δ, linear for |r|>δ.)

**Important:** the per-target normalization (the relative-L2 metric you log to W&B) must remain **unchanged**. Huber is a training-loss replacement only. The W&B metric `val_primary/volume_pressure_rel_l2_pct` and `test_primary/volume_pressure_rel_l2_pct` must be computed identically to the current implementation so the result is comparable to PR #311's 12.438% test number.

### Step 2: Calibrate δ before the sweep

Before launching the full sweep, run a tiny diagnostic to print the distribution of `(vol_pred - vol_target)` residuals on a few train batches at initialization and at ep1. The right δ is roughly the value that splits the residual distribution at the 75–90th percentile (so most points get quadratic gradient, the heavy tail gets linear).

Reasonable candidates:
- If residuals are O(1): use δ ∈ {0.25, 0.5, 1.0} for Arms A/B/C
- If residuals are O(0.1): use δ ∈ {0.05, 0.1, 0.25} for Arms A/B/C

**Calibrate δ from data, not from defaults.** Post a histogram or percentile table in your launch comment.

### Step 3: 4-arm sweep (single-GPU AdamW screening)

Same screening recipe as your PR #334 (4L/256d/4h/96sl, AdamW lr=1e-4, bs=8, single-GPU per arm via `CUDA_VISIBLE_DEVICES`):

| GPU | Arm | volume_loss_type | δ |
|-----|-----|------------------|----|
| 0 | Control | mse | — |
| 1 | A | huber | δ_low |
| 2 | B | huber | δ_mid |
| 3 | C | huber | δ_high |

Carry forward standard tau_y/z weights: `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`.

```bash
# Arm Control (MSE, baseline)
CUDA_VISIBLE_DEVICES=0 python train.py --agent gilbert --lr 1e-4 --weight-decay 5e-4 --batch-size 8 \
  --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 96 \
  --ema-decay 0.999 --lr-warmup-steps 1000 --validation-every 1 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --epochs 9 \
  --volume-loss-type mse \
  --wandb-group gilbert-vol-huber-sweep --wandb-name gilbert/vol-huber-control

# Arms A/B/C: same as control with --volume-loss-type huber --volume-huber-delta {δ_low, δ_mid, δ_high}
# and CUDA_VISIBLE_DEVICES=1/2/3
```

### Step 4: Report

For each arm, report:
- **ep1 and ep-best val_primary**: `val_abupt`, `val_volume_pressure`, `val_surface_pressure`, `val_wall_shear` (and per-axis tau_x/y/z)
- **test_primary at best-val checkpoint**: same metrics
- **val/test divergence ratio for volume_pressure** specifically — this is what Huber is supposed to reduce
- W&B run IDs and group: `gilbert-vol-huber-sweep`

The win condition for promotion to a 4L/512d Lion DDP final run:
- (a) Δval_volume_pressure < −0.5pp vs control (better val), OR
- (b) val/test divergence ratio reduced from ~2.1× to <1.6× even if val is ~flat (Huber may not help val but should help test specifically)
- (c) AND no regression in val_abupt or val_wall_shear > +0.3pp

If neither (a) nor (b) holds, clean negative result → close.

## Baseline

Current best: **PR #311 (edward, STRING-separable PE)** — val_abupt **7.546%** / test_abupt **8.771%**

Distance from AB-UPT (test):
| Metric | yi best test | AB-UPT | Ratio |
|---|---:|---:|---:|
| abupt_axis_mean | 8.771% | — | — |
| surface_pressure | 4.485% | 3.82% | 1.17× |
| wall_shear | 8.227% | 7.29% | 1.13× |
| **volume_pressure** | **12.438%** | **6.08%** | **2.05× ← TARGET** |
| wall_shear_x | 7.253% | 5.35% | 1.36× |
| wall_shear_y | 9.233% | 3.65% | 2.53× |
| wall_shear_z | 10.449% | 3.63% | 2.88× |

Merge bar: **val_abupt 7.546%** (screening won't reach this — compare within-experiment delta vs control, exactly as in PR #334).
