### PR TITLE
Theta-conditioned wall-shear loss weight for cross-flow error

### DIFF
--- a/train.py
+++ b/train.py
@@ -566,6 +566,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    wallshear_theta_alpha: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1286,6 +1287,7 @@ def weighted_masked_mse_per_channel(
     *,
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
+    wallshear_point_weight: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, list[float]]:
     """Per-channel weighted masked loss for surface predictions.
 
@@ -1338,6 +1340,12 @@ def weighted_masked_mse_per_channel(
         loss_elem = diff_sq
 
     weighted_diff = loss_elem * weights.view(1, 1, -1)
+    if wallshear_point_weight is not None and n_channels >= 4:
+        # Apply per-point weight to the tau channels (1:4). Keep cp (channel 0)
+        # and any extra channels (4:) at unity.
+        pw_full = weighted_diff.new_ones(weighted_diff.shape)
+        pw_full[..., 1:4] = wallshear_point_weight.unsqueeze(-1).expand_as(weighted_diff[..., 1:4]).to(weighted_diff.dtype)
+        weighted_diff = weighted_diff * pw_full
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
     per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
@@ -1370,6 +1378,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    wallshear_theta_alpha: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1409,12 +1418,33 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
+        theta_weight: torch.Tensor | None = None
+        theta_weight_mean: float | None = None
+        if wallshear_theta_alpha > 0.0:
+            # Per-point theta-conditioned wall-shear weight.
+            # theta_i = angle between GT wall-shear vector and global-x (streamwise) axis.
+            # w_i = 1 + alpha * sin(theta_i)  — up-weights cross-flow-dominant points.
+            ws_std_t  = transform.surface_y_std[1:4].to(device)
+            ws_mean_t = transform.surface_y_mean[1:4].to(device)
+            ws_true_norm_t = surface_target[..., 1:4]                 # [B, N, 3] normalised
+            ws_true_phys_t = ws_true_norm_t * ws_std_t + ws_mean_t    # physical space
+            tau_mag = ws_true_phys_t.norm(dim=-1, keepdim=False).clamp_min(1e-8)  # [B, N]
+            tau_x_abs = ws_true_phys_t[..., 0].abs()                              # [B, N]
+            cos_theta = (tau_x_abs / tau_mag).clamp(0.0, 1.0)
+            sin_theta = (1.0 - cos_theta.pow(2)).clamp_min(0.0).sqrt()
+            theta_weight = 1.0 + wallshear_theta_alpha * sin_theta                # [B, N]
+            mask_bool = batch.surface_mask
+            if bool(mask_bool.any()):
+                theta_weight_mean = float(
+                    theta_weight[mask_bool].detach().float().mean().cpu().item()
+                )
         surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
             surface_pred_used,
             surface_target_used,
             batch.surface_mask,
             channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
             wallshear_huber_delta=wallshear_huber_delta,
+            wallshear_point_weight=theta_weight,
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -1438,6 +1468,8 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if theta_weight_mean is not None:
+        metrics["wallshear_theta_weight_mean"] = theta_weight_mean
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -1951,6 +1983,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                wallshear_theta_alpha=config.wallshear_theta_alpha,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2062,6 +2095,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "wallshear_theta_weight_mean" in batch_loss_metrics:
+                train_log["train/wallshear_theta_weight_mean"] = batch_loss_metrics[
+                    "wallshear_theta_weight_mean"
                 ]
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[


### PR DESCRIPTION
## Hypothesis

PR #363 diagnostic found that **cross-flow-aligned surface points (theta≈90°) produce 2.21× higher wall-shear error** than streamwise-aligned points (theta≈4°), where theta is the angle between the GT wall-shear vector and the local streamwise axis. The model systematically under-predicts small-magnitude cross-flow content (GT |tau|=0.54 vs predicted 2.20 at streamwise bias). Spatial errors are clustered (Moran's I significant in all 34 val cases).

The current loss treats all surface points equally. A **per-point theta-conditioned weight** that up-weights cross-flow-dominant points during training should force the model to attend to this underserved regime. Weight formula:

```
theta_i = arccos(|tau_x_i| / (|tau_i| + eps))     # angle from streamwise, in [0, pi/2]
w_i     = 1 + alpha * sin(theta_i)                  # max weight at theta=90°
```

where GT wall shear in physical space is used (computed from the normalised targets using the transform). This is a smooth, physically motivated attention signal — no hard thresholds.

**Screen:** alpha=0.0 (control), alpha=1.0 (max 2×), alpha=2.0 (max 3×, within the W<3.0 stability ceiling from PR #66).

## Instructions

All three arms use **the same base config as PR #311 (current SOTA)**:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent haku \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --use-tangential-wallshear-loss \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0
```

(STRING-separable position encoding is already the default on `yi` after PR #311 merge.)

### Code changes required in `target/train.py`

**Step 1: Add `--wallshear-theta-alpha` CLI flag**

Find where `--wallshear-y-weight` and `--wallshear-z-weight` are added to `argparse` (search for `wallshear_y_weight`) and add immediately after:

```python
parser.add_argument("--wallshear-theta-alpha", type=float, default=0.0,
                    help="Alpha for per-point theta-conditioned wall-shear weight. "
                         "w_i = 1 + alpha*sin(theta_i) where theta is angle from streamwise. "
                         "0 = no conditioning (default). Try 1.0 or 2.0.")
```

**Step 2: Thread `wallshear_theta_alpha` into `train_loss()`**

Add the parameter to the `train_loss()` signature (alongside `wallshear_y_weight`, `wallshear_z_weight`):

```python
def train_loss(
    model, batch, transform, device, amp_mode, *,
    surface_loss_weight=1.0, volume_loss_weight=1.0,
    aux_rel_l2_weight=0.0,
    use_tangential_wallshear_loss=False,
    wallshear_y_weight=1.0, wallshear_z_weight=1.0,
    wallshear_theta_alpha: float = 0.0,   # <-- ADD THIS
) -> tuple[torch.Tensor, dict[str, float]]:
```

Also thread it through in the call site (wherever `train_loss` is called with `wallshear_y_weight=...`):

```python
wallshear_theta_alpha=args.wallshear_theta_alpha,
```

**Step 3: Compute and apply the per-point theta weight inside `train_loss()`**

Inside `train_loss()`, **after** the existing code that denormalises GT wall shear to physical space (the block that computes `ws_true_phys` — same pattern used by `use_tangential_wallshear_loss`), add:

```python
if wallshear_theta_alpha > 0.0:
    # GT wall shear in physical space: shape [B, N, 3] (tau_x, tau_y, tau_z)
    ws_std  = transform.surface_y_std[1:4].to(device)
    ws_mean = transform.surface_y_mean[1:4].to(device)
    ws_true_norm = surface_target[..., 1:4]            # [B, N, 3]
    ws_true_phys = ws_true_norm * ws_std + ws_mean     # physical space

    tau_norm = ws_true_phys.norm(dim=-1, keepdim=False).clamp_min(1e-8)   # [B, N]
    tau_x_abs = ws_true_phys[..., 0].abs()                                  # [B, N]
    cos_theta = (tau_x_abs / tau_norm).clamp(0.0, 1.0)
    sin_theta = (1.0 - cos_theta.pow(2)).clamp_min(0.0).sqrt()
    theta_weight = 1.0 + wallshear_theta_alpha * sin_theta                   # [B, N]
```

Then, in the surface loss computation block, apply this weight to the wall-shear channels only. **Replace** the call to `weighted_masked_mse_per_channel` with a version that applies `theta_weight` to the squared differences for channels 1:4 (tau_x, tau_y, tau_z) before the mean:

```python
if wallshear_theta_alpha > 0.0:
    # Apply per-point theta weight to wall-shear channels
    diff_sq = (surface_pred_used - surface_target_used).pow(2)  # [B, N, C]
    mask_f  = batch.surface_mask.unsqueeze(-1).to(diff_sq.dtype)
    valid   = mask_f.sum().clamp_min(1)
    n_ch    = diff_sq.shape[-1]

    tw = theta_weight                                    # [B, N]
    # expand to [B, N, 3] for tau channels
    tw_exp = tw.unsqueeze(-1).expand_as(diff_sq[..., 1:4])
    diff_sq = diff_sq.clone()
    diff_sq[..., 1:4] = diff_sq[..., 1:4] * tw_exp

    ch_w = torch.tensor(
        [1.0, 1.0, wallshear_y_weight, wallshear_z_weight],
        device=diff_sq.device, dtype=diff_sq.dtype
    )
    weighted_diff = diff_sq * ch_w.view(1, 1, -1)
    surface_loss  = (weighted_diff * mask_f).sum() / valid / n_ch

    per_axis_sum  = ((surface_pred_used - surface_target_used).pow(2) * mask_f).sum(dim=(0,1)).detach().float()
    per_axis_unweighted = (per_axis_sum / valid.detach().float()).cpu().tolist()
else:
    surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
        surface_pred_used, surface_target_used, batch.surface_mask,
        channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
    )
```

> **Note:** `per_axis_unweighted` is intentionally computed from the unweighted squared differences so that logged per-axis metrics remain comparable across arms.

> **Tip:** If `use_tangential_wallshear_loss` is True, `ws_true_phys` may already be in scope. Avoid recomputing it — check the existing code and reuse the variable if possible.

### Three-arm run commands

Use `--wandb_group haku-theta-wallshear-screen` so all three runs appear together in W&B.

**Arm A — control (alpha=0.0):**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent haku --wandb_group haku-theta-wallshear-screen \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --use-tangential-wallshear-loss \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --wallshear-theta-alpha 0.0
```

**Arm B — alpha=1.0 (max weight 2×):**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent haku --wandb_group haku-theta-wallshear-screen \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --use-tangential-wallshear-loss \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --wallshear-theta-alpha 1.0
```

**Arm C — alpha=2.0 (max weight 3×):**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent haku --wandb_group haku-theta-wallshear-screen \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --use-tangential-wallshear-loss \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --wallshear-theta-alpha 2.0
```

### Reporting

Report per-arm results in a table:

| Arm | alpha | val_abupt | wall_shear_y | wall_shear_z | W&B run |
|-----|-------|-----------|--------------|--------------|---------|
| A   | 0.0   |           |              |              |         |
| B   | 1.0   |           |              |              |         |
| C   | 2.0   |           |              |              |         |

Also note the **best val_abupt epoch** per arm and whether loss curves are stable.

Key diagnostic: does `wall_shear_y` and `wall_shear_z` improve with alpha>0 relative to control? If `val_abupt` also improves, that's a merge candidate.

## Baseline

Current SOTA from PR #311 (edward, STRING-separable learnable position encoding, W&B run `gcwx9yaa`):

| Metric | val | test |
|--------|-----|------|
| `abupt_axis_mean_rel_l2_pct` | **7.546%** | **8.771%** |
| `surface_pressure_rel_l2_pct` | — | 4.485% |
| `wall_shear_rel_l2_pct` | — | 8.227% |
| `wall_shear_y_rel_l2_pct` | — | 9.233% |
| `wall_shear_z_rel_l2_pct` | — | 10.449% |
| `volume_pressure_rel_l2_pct` | — | 12.438% |

**Merge bar: val_abupt < 7.546%**

Note: `wall_shear_y` (9.233%) and `wall_shear_z` (10.449%) are 2.53× and 2.88× the AB-UPT reference targets (3.65% and 3.63%) — these are the dominant remaining gaps.

## Context

- PR #363 diagnostic run: identified 2.21× cross-flow error concentration (theta-split analysis across all 34 val geometries), significant spatial clustering (Moran's I), and run_228/run_324 as systematic outliers.
- `surface_x` layout: `[x, y, z, nx, ny, nz, area]` (normals at indices 3:6)
- `surface_y` layout: `[cp, tau_x, tau_y, tau_z]` (GT wall shear at indices 1:4)
- `project_tangential()` and `weighted_masked_mse_per_channel()` already exist in train.py
- `--use-tangential-wallshear-loss` already handles denorm of GT wall shear (reuse that pattern)
