### PR TITLE
tanjiro: cross-flow exposure index as 8th surface input feature

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,6 +65,16 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+def maybe_append_cross_flow_index(surface_x: torch.Tensor, use_cfi: bool) -> torch.Tensor:
+    if not use_cfi:
+        return surface_x
+    # surface_x columns: [x, y, z, n_x, n_y, n_z, area]; cfi = sqrt(n_y^2+n_z^2).
+    ny = surface_x[..., 4:5]
+    nz = surface_x[..., 5:6]
+    cfi = torch.sqrt(ny * ny + nz * nz)
+    return torch.cat([surface_x, cfi], dim=-1)
+
+
 class DropPath(nn.Module):
     """Stochastic depth: drop entire residual branch with probability `drop_prob`."""
 
@@ -582,6 +592,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    use_cross_flow_index: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -754,7 +765,9 @@ def make_loaders(
 
 
 def build_model(config: Config) -> SurfaceTransolver:
+    surface_input_dim = SURFACE_X_DIM + (1 if config.use_cross_flow_index else 0)
     return SurfaceTransolver(
+        surface_input_dim=surface_input_dim,
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
         dropout=config.model_dropout,
@@ -1370,13 +1383,15 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    use_cross_flow_index: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    surface_x_in = maybe_append_cross_flow_index(batch.surface_x, use_cross_flow_index)
     with autocast_context(device, amp_mode):
         out = model(
-            surface_x=batch.surface_x,
+            surface_x=surface_x_in,
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
@@ -1499,6 +1514,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    use_cross_flow_index: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -1529,9 +1545,10 @@ def evaluate_split(
         batch = batch.to(device)
         surface_target_norm = transform.apply_surface(batch.surface_y)
         volume_target_norm = transform.apply_volume(batch.volume_y)
+        surface_x_in = maybe_append_cross_flow_index(batch.surface_x, use_cross_flow_index)
         with autocast_context(device, amp_mode):
             out = model(
-                surface_x=batch.surface_x,
+                surface_x=surface_x_in,
                 surface_mask=batch.surface_mask,
                 volume_x=batch.volume_x,
                 volume_mask=batch.volume_mask,
@@ -1951,6 +1968,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                use_cross_flow_index=config.use_cross_flow_index,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2144,7 +2162,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_cross_flow_index=config.use_cross_flow_index)
             for name, loader in val_loaders.items()
         }
         if ema is not None:
@@ -2271,7 +2289,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_cross_flow_index=config.use_cross_flow_index)
         for name, loader in val_loaders.items()
     }
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -2306,7 +2324,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_cross_flow_index=config.use_cross_flow_index)
         for name, loader in test_loaders.items()
     }
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]


### PR DESCRIPTION
## Hypothesis

The model's surface input is a 7-dimensional vector: `(x, y, z, n_x, n_y, n_z, area)`. The extra features `(n_x, n_y, n_z, area)` are projected to hidden_dim via a single **LinearProjection(4 → n_hidden)**. A linear layer can compute linear combinations of inputs, but **cannot** compute `sqrt(n_y^2 + n_z^2)` — the cross-flow exposure index. This means the model cannot extract "how cross-flow-dominant is this surface point" in a single linear step.

PR #363 (haku diagnostic, 2026-05-02) confirmed that cross-flow alignment is the dominant tau_y/z error signal: surface points with theta ~86° (shear nearly perpendicular to global x) are **2.21× worse** on tau_y than streamwise points (theta ~4°). The surface normal direction is the best available proxy for cross-flow exposure: points with normals nearly perpendicular to x (side windows, doors, roof panels facing sideways) tend to have cross-flow-dominant shear.

**Hypothesis:** Explicitly pre-computing the cross-flow exposure index `cfi = sqrt(n_y^2 + n_z^2)` (= sine of the angle between the surface normal and global x-axis) as an 8th input feature gives the model a direct scalar representation of cross-flow exposure that it cannot derive from the current linear projection of (n_x, n_y, n_z, area). This is the minimal, lossless change that directly encodes the haku diagnostic finding as an input feature.

**Why this is different from PR #349 (edward, tangent-frame encoder inputs):** PR #349 changes the coordinate frame for ALL model inputs (rotates to a local surface-tangent frame per point). This PR adds a single derived scalar to the existing global-frame representation. The interventions are orthogonal and should be additive if both work.

**Why this can't already be redundant:** The model currently has `(n_x, n_y, n_z)` as inputs — but `cfi = sqrt(n_y^2+n_z^2)` is a non-linear function. A 1-layer LinearProjection cannot express it. The model's subsequent MLP (surface_bias) could in principle learn it, but the signal has to compete with n_hidden other dimensions and must first be disentangled from the linear mixing of all 4 extra features. Providing it explicitly is free and direct.

## Instructions

### Step 1 — Add `--use-cross-flow-index` flag

In `train.py` parser:
```python
parser.add_argument(
    "--use-cross-flow-index",
    action="store_true",
    default=False,
    help="Append cross-flow exposure index sqrt(n_y^2+n_z^2) as an 8th surface input feature.",
)
```

### Step 2 — Append the CFI in the training loop

After collating each batch (so you don't need to change the data loader interface), compute and append CFI:

```python
# In the training loop / eval loop, after batch collation, before passing to model:
if config.use_cross_flow_index:
    # surface_x: [B, N, 7] — columns 3,4,5 are n_x, n_y, n_z
    nx = surface_x[:, :, 3:4]  # n_x
    ny = surface_x[:, :, 4:5]  # n_y
    nz = surface_x[:, :, 5:6]  # n_z
    cfi = torch.sqrt(ny**2 + nz**2)  # [B, N, 1], range [0, 1]
    surface_x = torch.cat([surface_x, cfi], dim=-1)  # [B, N, 8]
```

Verify the column layout by printing `surface_x[0, :5, :]` on the first batch and confirming columns 3-5 look like unit normals (magnitudes ≈ 1.0 after normalization, or check loader.py to see if normals are normalizer-transformed).

Note: if the normalizers transform normals (subtract mean, divide by std), the above computation should still work since `sqrt(ny^2 + nz^2)` on normalized normals gives a signal that correlates with the original cfi. However, you may want to check if using the raw (pre-normalization) normals gives a cleaner cfi. The simplest approach: don't worry about it, use whatever is in `surface_x[:, :, 3:6]`, and report the first-batch range of the cfi column so we can verify it's non-degenerate.

### Step 3 — Update model construction

In `build_model(config)`:
```python
surface_input_dim = SURFACE_X_DIM + (1 if config.use_cross_flow_index else 0)
# pass surface_input_dim=surface_input_dim to SurfaceTransolver(...)
```

The model's `surface_extra_dim = surface_input_dim - space_dim` (space_dim=3) automatically adjusts the `project_surface_features` linear layer to accept 4 (baseline) or 5 (with CFI) extra channels. No other model change needed.

### Step 4 — Run control vs treatment

Two arms in parallel on 2 GPUs, same 4L/512d AdamW base:

**Arm A — Control:**
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --lr 5e-4 --weight-decay 1e-4 --batch-size 4 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-steps 500 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --validation-every 1 --epochs 3 \
  --wandb-group tanjiro-cfi-input-r0 --wandb-name tanjiro/cfi-A-control \
  --kill-thresholds "3000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --agent tanjiro &
```

**Arm B — With cross-flow index:**
```bash
CUDA_VISIBLE_DEVICES=1 python train.py \
  --lr 5e-4 --weight-decay 1e-4 --batch-size 4 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-steps 500 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 --volume-loss-weight 2.0 \
  --use-cross-flow-index \
  --validation-every 1 --epochs 3 \
  --wandb-group tanjiro-cfi-input-r0 --wandb-name tanjiro/cfi-B-cfi \
  --kill-thresholds "3000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --agent tanjiro &
```

### Step 5 — Reporting

Report per-epoch val metrics for both arms, especially:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary merge metric)
- `val_primary/wall_shear_y_rel_l2_pct` and `val_primary/wall_shear_z_rel_l2_pct` (hypothesis test — the cross-flow channels)
- `val_primary/wall_shear_x_rel_l2_pct` (sanity — should be unaffected)
- `val_primary/surface_pressure_rel_l2_pct` (sanity — should be unaffected)

**Decision criteria:**
- Arm B val_abupt < Arm A at ep2+ AND wall_shear_y/z improves ≥0.3pp → promising, launch full 8-GPU Lion run
- Arm B diverges → close
- Arm B matches or worse than Arm A → close as negative

## Baseline

Current best: PR #311 (edward, STRING-separable learnable PE), W&B run `gcwx9yaa`

| Metric | val | test | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **7.546** | **8.771** | — |
| `surface_pressure_rel_l2_pct` | — | 4.485 | 3.82 |
| `wall_shear_rel_l2_pct` | — | 8.227 | 7.29 |
| `volume_pressure_rel_l2_pct` | — | 12.438 | 6.08 |
| `wall_shear_x_rel_l2_pct` | — | 7.253 | 5.35 |
| `wall_shear_y_rel_l2_pct` | — | 9.233 | 3.65 |
| `wall_shear_z_rel_l2_pct` | — | 10.449 | 3.63 |

**Merge bar: val_abupt < 7.546%** (only achievable via full 8-GPU Lion run after a positive single-GPU screen).

**Physical motivation (haku diagnostic, PR #363):** cross-flow points (theta~86°) are 2.21× worse on tau_y than streamwise points (theta~4°). The cross-flow exposure index `cfi = sqrt(n_y^2+n_z^2)` is the geometric feature that separates these two populations. Giving the model direct access to this scalar at input time is the minimal, lossless intervention that directly addresses the diagnostic root cause.
