### PR TITLE
thorfinn: asinh(tau/scale) target norm for tau_y/z dynamic range

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    asinh_tau_scale: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -616,6 +617,7 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        asinh_tau_scale: float = 0.0,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -633,6 +635,9 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        if asinh_tau_scale < 0.0:
+            raise ValueError("asinh_tau_scale must be >= 0")
+        self.asinh_tau_scale = float(asinh_tau_scale)
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -641,10 +646,22 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+        mean = self.surface_y_mean.to(y.device)
+        std = self.surface_y_std.to(y.device)
+        if self.asinh_tau_scale > 0:
+            cp_norm = (y[..., 0:1] - mean[0:1]) / std[0:1]
+            tau_norm = torch.asinh(y[..., 1:4] / self.asinh_tau_scale)
+            return torch.cat([cp_norm, tau_norm], dim=-1)
+        return (y - mean) / std
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        mean = self.surface_y_mean.to(y.device)
+        std = self.surface_y_std.to(y.device)
+        if self.asinh_tau_scale > 0:
+            cp_phys = y[..., 0:1] * std[0:1] + mean[0:1]
+            tau_phys = self.asinh_tau_scale * torch.sinh(y[..., 1:4])
+            return torch.cat([cp_phys, tau_phys], dim=-1)
+        return y * std + mean
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
         return (y - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)
@@ -1696,11 +1713,17 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Device: {device}" + (" [DEBUG]" if config.debug else ""))
 
     train_loader, val_loaders, test_loaders, stats = make_loaders(config)
+    if config.asinh_tau_scale > 0 and config.use_tangential_wallshear_loss:
+        raise ValueError(
+            "--asinh-tau-scale and --use-tangential-wallshear-loss are mutually "
+            "exclusive: tangential projection assumes physical-space wall-shear."
+        )
     transform = TargetTransform(
         surface_y_mean=stats["surface_y_mean"].to(device),
         surface_y_std=stats["surface_y_std"].to(device),
         volume_y_mean=stats["volume_y_mean"].to(device),
         volume_y_std=stats["volume_y_std"].to(device),
+        asinh_tau_scale=config.asinh_tau_scale,
     )
 
     model = build_model(config).to(device)


### PR DESCRIPTION
## Hypothesis

Wall-shear stresses tau_y and tau_z span a multi-decade dynamic range (GT |tau| can be as small as 0.05 and as large as 5+ Pa). MSE loss penalises absolute error — so the high-magnitude streamwise (tau_x) points dominate gradient signal and the small-magnitude cross-flow (tau_y, tau_z) components are systematically under-weighted.

**asinh(tau / scale) target normalization** compresses large values logarithmically while remaining linear near zero and differentiable everywhere:

```
f(x) = asinh(x / scale) = log(x/scale + sqrt((x/scale)^2 + 1))
```

For scale=0.1 (typical tau_y magnitude): a high-magnitude tau_x=3 maps to ~3.4, while a cross-flow tau_y=0.1 maps to ~0.88. Compare to raw: the ratio 3 vs 0.1 = 30× compressed to 3.4 vs 0.88 = 3.9×. This directly addresses the 4-decade dynamic range problem that causes tau_y/z loss to be numerically dominated by outlier high-shear points.

This is a standing Round-5 human-researcher directive (Issue #18) and directly targets our headline gap: tau_y 2.53× above AB-UPT, tau_z 2.88× above AB-UPT. It has never been tested on this stack.

No prior work on this repo has used asinh or log normalization on targets. All previous approaches (PR #66 loss upweighting, PR #316 GradNorm, PR #167 W_y=W_z=3.5) work at the loss-weight level — this works at the **target representation level**, which is orthogonal.

Reference: asinh normalization is widely used in competition-winning Kaggle tabular pipelines for multi-decade target distributions (NeurIPS tabular benchmarks, Jane Street, AmEx default prediction). Physical justification: aerodynamic pressure gradients often follow log-normal distributions.

## Instructions

Add an `--asinh-tau-scale` flag to `target/train.py`. The default should be `0.0` (disabled — no normalization). When set to a positive float, apply asinh normalization to **all wall-shear targets only** (tau_x, tau_y, tau_z) both in the loss and when decoding predictions back to physical units for metric computation.

### Implementation steps

**Step 1: Parse the flag**

In the `Config` dataclass (near the existing loss weight flags), add:
```python
asinh_tau_scale: float = 0.0  # 0 = disabled; positive = asinh(tau/scale) normalization
```

**Step 2: Apply normalization in the loss function**

In `train_loss()` (wherever wall-shear ground-truth and predictions are compared), if `cfg.asinh_tau_scale > 0`:
```python
import math
def _asinh_norm(x, scale):
    return torch.log(x / scale + torch.sqrt((x / scale)**2 + 1.0))

# Before computing wall-shear loss:
if cfg.asinh_tau_scale > 0:
    s = cfg.asinh_tau_scale
    wallshear_gt = _asinh_norm(wallshear_gt, s)
    wallshear_pred = _asinh_norm(wallshear_pred, s)
    # Note: gradients flow through inverse asinh at prediction side
```

**Step 3: Undo normalization before metric computation**

In `evaluate_split()` (wherever wall-shear predictions are evaluated against GT for val/test metrics), undo the transform before computing rel-L2:
```python
if cfg.asinh_tau_scale > 0:
    # inverse: x_phys = scale * sinh(x_norm)
    wallshear_pred = cfg.asinh_tau_scale * torch.sinh(wallshear_pred_norm)
    # GT is already in physical units from the dataset
```

This ensures val_primary metrics are always in physical units, comparable to baseline.

**Step 4: Run a 3-arm sweep on a single GPU**

Run all 3 arms simultaneously (3× single-GPU processes in background) with:
- `--wandb-group thorfinn-asinh-r25`
- Arm A: `--asinh-tau-scale 0.05` (aggressive compression for smallest-tau regime)
- Arm B: `--asinh-tau-scale 0.1` (moderate — matches typical tau_y/z magnitude ~0.1)
- Arm C: `--asinh-tau-scale 0.5` (mild — only weakly compresses the range)

Use the AdamW baseline config (single-GPU, since DDP is not yet stable on yi):
```bash
cd target/

# Arm A (GPU 0):
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent thorfinn \
  --optimizer adamw \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 1.0 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --asinh-tau-scale 0.05 \
  --wandb-group thorfinn-asinh-r25 \
  > logs/arm-a-asinh005.log 2>&1 &

# Arm B (GPU 1):
CUDA_VISIBLE_DEVICES=1 python train.py \
  ... (same flags, --asinh-tau-scale 0.1) \
  --wandb-group thorfinn-asinh-r25 \
  > logs/arm-b-asinh01.log 2>&1 &

# Arm C (GPU 2):
CUDA_VISIBLE_DEVICES=2 python train.py \
  ... (same flags, --asinh-tau-scale 0.5) \
  --wandb-group thorfinn-asinh-r25 \
  > logs/arm-c-asinh05.log 2>&1 &
```

Note: keep `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0` from the existing stack — asinh normalization is orthogonal to loss upweighting and they should compound.

**Step 5: Also run a 4th control arm on GPU 3** (no asinh, same config except `--asinh-tau-scale 0.0`) to verify reproducibility against the current baseline. Label it `arm-ctrl-no-asinh` in the W&B group.

### What to report

For each arm, report in the PR comment:
1. Terminal val_abupt, val_surface_pressure, val_volume_pressure, val_wall_shear, val_wall_shear_x, val_wall_shear_y, val_wall_shear_z (physical-unit metrics, not normalized)
2. Whether gradient norms remained healthy (no NaN/explosion at step 1)
3. Whether tau_y and tau_z error curves show faster early-epoch descent than control

If Arm B (scale=0.1) beats baseline val_abupt 7.546% OR shows a val_wall_shear_y improvement over control of ≥5% relative — report that as a strong signal and flag for 8-GPU DDP rerun.

## Baseline

Current best (PR #311, edward, STRING-separable position encoding — merged 2026-05-02):

| Metric | val | test | W&B run |
|---|---:|---:|---|
| `abupt_axis_mean_rel_l2_pct` | **7.546%** | 8.771% | `gcwx9yaa` |
| `surface_pressure_rel_l2_pct` | — | 4.485% | `gcwx9yaa` |
| `wall_shear_rel_l2_pct` | — | 8.227% | `gcwx9yaa` |
| `volume_pressure_rel_l2_pct` | — | 12.438% | `gcwx9yaa` |
| `wall_shear_x_rel_l2_pct` | — | 7.253% | `gcwx9yaa` |
| `wall_shear_y_rel_l2_pct` | — | 9.233% | `gcwx9yaa` |
| `wall_shear_z_rel_l2_pct` | — | 10.449% | `gcwx9yaa` |

**Merge bar: val_abupt < 7.546%**

AB-UPT reference targets (lower is better):
- surface_pressure: 3.82%
- wall_shear: 7.29%
- volume_pressure: 6.08%
- wall_shear_y: **3.65%** (our biggest gap at 2.53×)
- wall_shear_z: **3.63%** (our biggest gap at 2.88×)

Prior single-GPU AdamW runs for comparison (no STRING-sep PE):
- PR #222 fern (AdamW equivalent config): val_abupt ~9.291% after 9 epochs

Reproduce the baseline:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1
```
(8-GPU DDP requires emma's DDP infra fix from PR #355 — use single-GPU AdamW config above for this experiment)
