### PR TITLE
senku: 5L/512d depth on STRING-sep SOTA (stack test)

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,6 +124,47 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class StringSepEmbed(nn.Module):
+    """STRING-separable axis-aligned learnable position encoding.
+
+    Drop-in replacement for ContinuousSincosEmbed: outputs the same hidden_dim
+    shape, padding, and sin/cos layout, but per-axis log-frequencies and
+    phase shifts are learnable parameters initialized from the sincos
+    omega-bank. Replicates PR #311's STRING-sep arm on the yi sincos+omega base.
+    """
+
+    def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.max_wavelength = max_wavelength
+        padding = hidden_dim % input_dim
+        dim_per_axis = (hidden_dim - padding) // input_dim
+        sincos_padding = dim_per_axis % 2
+        self.padding = padding + sincos_padding * input_dim
+        effective_dim_per_axis = (hidden_dim - self.padding) // input_dim
+        if effective_dim_per_axis <= 0:
+            raise ValueError("hidden_dim must be large enough for the requested input dimension")
+        n_features_per_axis = effective_dim_per_axis // 2
+        self.n_features_per_axis = n_features_per_axis
+        arange = torch.arange(0, effective_dim_per_axis, 2, dtype=torch.float32)
+        omega_init = 1.0 / max_wavelength ** (arange / effective_dim_per_axis)  # [F]
+        log_freq_init = torch.log(omega_init).unsqueeze(0).repeat(input_dim, 1)  # [in_dim, F]
+        self.log_freq = nn.Parameter(log_freq_init)
+        self.phase = nn.Parameter(torch.zeros(input_dim, n_features_per_axis))
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        freq = self.log_freq.exp()  # [in_dim, F]
+        proj = coords.unsqueeze(-1) * freq + self.phase  # [..., in_dim, F]
+        emb = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # [..., in_dim, 2*F]
+        emb = emb.flatten(start_dim=-2)  # [..., in_dim*2*F]
+        if self.padding > 0:
+            padding = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
+            emb = torch.cat([emb, padding], dim=-1)
+        return emb
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -350,6 +391,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        pos_encoding_mode: str = "sincos",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,12 +404,22 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.pos_encoding_mode = pos_encoding_mode
 
-        self.pos_embed = ContinuousSincosEmbed(
-            hidden_dim=n_hidden,
-            input_dim=space_dim,
-            max_wavelength=pos_max_wavelength,
-        )
+        if pos_encoding_mode == "sincos":
+            self.pos_embed = ContinuousSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
+        elif pos_encoding_mode == "string":
+            self.pos_embed = StringSepEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
+        else:
+            raise ValueError(f"Unknown pos_encoding_mode: {pos_encoding_mode!r}; expected 'sincos' or 'string'")
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -579,6 +631,8 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    pos_encoding_mode: str = "sincos"
+    max_steps_per_epoch: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -745,6 +799,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        pos_encoding_mode=config.pos_encoding_mode,
     )
 
 
@@ -1797,7 +1852,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        epoch_step_limit = config.max_steps_per_epoch if config.max_steps_per_epoch > 0 else None
+        epoch_step_idx = 0
         for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+            if epoch_step_limit is not None and epoch_step_idx >= epoch_step_limit:
+                break
+            epoch_step_idx += 1
             loss, batch_loss_metrics = train_loss(
                 model,
                 batch,


### PR DESCRIPTION
## Hypothesis

Stacking depth (5L) on top of the current STRING-separable position encoding SOTA (PR #311) may compound the gains from both changes. Evidence from two prior experiments:

1. **PR #283 (nezuko, tay branch)**: 5L cleanly beat the old 4L SOTA on every test axis — abupt 10.0426% vs 10.190%, tau_y 11.70% vs 11.95%, tau_z 12.23% vs 12.45%. All deltas consistent and monotone.
2. **PR #311 (edward, STRING-sep)**: Replaced position encoding with axis-aligned learnable STRING-sep frequencies, cutting val_abupt from 9.039% → **7.546%** — the first new-architecture win in many rounds.

These two changes are **orthogonal**: STRING-sep affects positional representation; depth scaling affects model capacity. A 5L/512d model with STRING-sep has neither been attempted nor ruled out. If they compound (even partially), the combined val_abupt could approach or beat 7.0%.

**Risk:** PR #283 showed that depth=5 with Lion is less stable than depth=4 — two divergence events (ep10 spike, ep14 terminal). Mitigations available: grad-clip=0.5 (from PR #309), lower lr (8e-5 instead of 1e-4), or a longer warmup. The current STRING-sep base already uses STRING-sep position encoding and we don't yet know if depth=5 changes its stability profile.

This is the natural architecture-level follow-up to both PR #283's depth finding and PR #311's encoding win.

## Instructions

Add `--model-layers 5` to the standard config. Run a **2-arm stability sweep** on a single GPU:

- **Arm A (GPU 0)**: `--model-layers 5` with baseline lr=5e-4, grad-clip=1.0 (test whether depth=5 is stable at standard hyperparameters on STRING-sep base)
- **Arm B (GPU 1)**: `--model-layers 5` with lr=3e-4, grad-clip=0.5 (conservative stability-first config — mitigations from PR #283's divergence events)

Run both arms to the same step budget as the single-GPU protocol (9 epochs, max-steps-per-epoch scaled to your GPU). Use `--wandb-group senku-depth5-r25`.

### Arm A command (GPU 0):
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent senku \
  --wandb-group senku-depth5-r25 \
  --wandb-name arm-a-5l-lr5e4 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --optimizer adamw \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 1.0 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --ema-decay 0.999 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  > logs/arm-a-5l-lr5e4.log 2>&1 &
```

### Arm B command (GPU 1):
```bash
CUDA_VISIBLE_DEVICES=1 python train.py \
  --agent senku \
  --wandb-group senku-depth5-r25 \
  --wandb-name arm-b-5l-lr3e4-clip05 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --optimizer adamw \
  --lr 3e-4 \
  --weight-decay 1e-4 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --ema-decay 0.999 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  > logs/arm-b-5l-lr3e4-clip05.log 2>&1 &
```

**Note**: This experiment tests whether the current `yi` branch `train.py` already includes STRING-separable position encoding (from PR #311). Check the code first — if `--pos-encoding string-sep` or similar is the default, no flag is needed. If it's behind a flag, add it to both arms.

Also optionally run a **control arm (GPU 2)**: `--model-layers 4` with `--lr 5e-4` (the 4L baseline at this same protocol) so the depth=5 gain is measured head-to-head rather than against the PR #311 8-GPU run.

### What to report

1. Per-epoch val_abupt trajectory for both arms (table format)
2. Whether either arm NaN'd / spiked and at which epoch
3. Final val_abupt and test_abupt from best-val checkpoint
4. Per-axis test breakdown: surface_pressure, wall_shear, volume_pressure, tau_x, tau_y, tau_z
5. Gradient norm trajectory (from W&B `train/grad_norm`) — flag if gnorm > 200 or spikes

**Merge signal**: If either arm reaches val_abupt < 7.546% → flag as winner; we will scale to 8-GPU DDP immediately once PR #355 (emma DDP fix) lands.
**Kill signal**: If Arm A NaN's early (before ep5) → close Arm A, continue Arm B. If both NaN → close PR and advisor will redesign with even lower lr.

## Baseline

Current best (PR #311, edward, STRING-separable position encoding — merged 2026-05-02):

| Metric | val | test | W&B run |
|---|---:|---:|---|
| `abupt_axis_mean_rel_l2_pct` | **7.546%** | 8.771% | `gcwx9yaa` |
| `surface_pressure_rel_l2_pct` | — | 4.485% | `gcwx9yaa` |
| `wall_shear_rel_l2_pct` | — | 8.227% | `gcwx9yaa` |
| `volume_pressure_rel_l2_pct` | — | 12.438% | `gcwx9yaa` |
| `wall_shear_x_rel_l2_pct` | — | 7.253% | `gcwx9yaa` |
| `wall_shear_y_rel_l2_pct` | — | 9.233% | `gcwx9yaa` |
| `wall_shear_z_rel_l2_pct` | — | 10.449% | `gcwx9yaa` |

**Merge bar: val_abupt < 7.546%**

Architecture (locked from PRs #315 + #339): `layers=4→5, hidden_dim=512, heads=8, slices=128, mlp_ratio=8`

Prior 5L reference (PR #283, nezuko, **OLD tay stack, NOT STRING-sep base**):
- val_abupt best: 8.9938% (ep12), test_abupt: 10.0426%
- This was on a different stack WITHOUT STRING-sep encoding — not directly comparable to the current baseline

Prior 4L STRING-sep reference (PR #311, Arm A control, RFF-32):
- val_abupt: 9.710% — so STRING-sep alone gives 4L STRING-sep 7.546% vs 4L RFF-32 9.710%

The key question: does 5L+STRING-sep beat 4L+STRING-sep 7.546%?
