### PR TITLE
edward: Muon optimizer on current SOTA (AdamW vs Muon 2-arm)

### DIFF
--- a/train.py
+++ b/train.py
@@ -30,6 +30,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import wandb
 import yaml
+from torch import Tensor
 from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
@@ -45,6 +46,134 @@ from data import (
     load_data,
     pad_collate,
 )
+
+
+# ---------------------------------------------------------------------------
+# Muon optimizer (Newton-Schulz orthogonalized momentum)
+# Reference: https://github.com/KellerJordan/Muon  (Keller Jordan, 2024)
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5) -> Tensor:
+    """Quintic Newton-Schulz iteration that drives singular values toward 1.
+
+    Casts to fp32 for the iteration to avoid bf16 Gram-matrix instabilities
+    flagged in the Newton-Muon literature; casts back at the end.
+    """
+    assert G.ndim == 2
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.float()
+    transposed = G.size(-2) > G.size(-1)
+    if transposed:
+        X = X.T
+    X = X / (X.norm() + 1e-7)
+    for _ in range(steps):
+        A = X @ X.T
+        X = a * X + b * (A @ X) + c * (A @ A @ X)
+    if transposed:
+        X = X.T
+    return X.to(G.dtype)
+
+
+class Muon(torch.optim.Optimizer):
+    """Muon: Newton-Schulz orthogonalized SGD-momentum on 2-D weights, AdamW fallback elsewhere.
+
+    Per parameter group:
+      - ``mode == "muon"``: 2-D matmul weights are updated via Nesterov momentum +
+        Newton-Schulz orthogonalization, scaled by ``sqrt(max(rows, cols))``.
+      - ``mode == "adamw"``: all other tensors (1-D biases, layernorm scales, 0-D scalars,
+        3-D/4-D tensors) use a self-contained AdamW update inside this optimizer.
+
+    Both modes read ``group["lr"]`` directly so external warmup / cosine schedulers
+    affect both groups proportionally.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 2e-2,
+        momentum: float = 0.95,
+        ns_steps: int = 5,
+        betas: tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+        weight_decay: float = 0.0,
+        mode: str = "muon",
+    ):
+        if lr <= 0.0:
+            raise ValueError(f"Muon lr must be > 0, got {lr}")
+        if mode not in ("muon", "adamw"):
+            raise ValueError(f"Muon group mode must be 'muon' or 'adamw', got {mode!r}")
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            ns_steps=ns_steps,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            mode=mode,
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            mode = group["mode"]
+
+            if mode == "muon":
+                momentum = group["momentum"]
+                ns_steps = group["ns_steps"]
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    g = p.grad
+                    if g.ndim != 2:
+                        raise RuntimeError(
+                            f"Muon mode='muon' got param of ndim {g.ndim}; route non-2-D "
+                            f"params to a mode='adamw' group."
+                        )
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    g_nesterov = g.add(buf, alpha=momentum)
+                    g_ortho = zeropower_via_newtonschulz5(g_nesterov, steps=ns_steps)
+                    scale = max(g.size(-2), g.size(-1)) ** 0.5
+                    p.data.add_(g_ortho, alpha=-lr * scale)
+            else:
+                beta1, beta2 = group["betas"]
+                eps = group["eps"]
+                wd = group["weight_decay"]
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    g = p.grad
+                    state = self.state[p]
+                    if "exp_avg" not in state:
+                        state["exp_avg"] = torch.zeros_like(p)
+                        state["exp_avg_sq"] = torch.zeros_like(p)
+                        state["step"] = 0
+                    state["step"] += 1
+                    exp_avg = state["exp_avg"]
+                    exp_avg_sq = state["exp_avg_sq"]
+                    exp_avg.mul_(beta1).add_(g, alpha=1.0 - beta1)
+                    exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
+                    step = state["step"]
+                    bias_corr1 = 1.0 - beta1 ** step
+                    bias_corr2 = 1.0 - beta2 ** step
+                    step_size = lr / bias_corr1
+                    denom = (exp_avg_sq.sqrt() / (bias_corr2 ** 0.5)).add_(eps)
+                    p.data.addcdiv_(exp_avg, denom, value=-step_size)
+                    if wd > 0:
+                        p.data.mul_(1.0 - lr * wd)
+        return loss
 
 
 # ---------------------------------------------------------------------------
@@ -552,6 +681,10 @@ class EMA:
 class Config:
     lr: float = 3e-4
     weight_decay: float = 1e-4
+    optimizer: str = "adamw"  # "adamw" or "muon"
+    muon_momentum: float = 0.95
+    muon_ns_steps: int = 5
+    muon_adamw_lr_scale: float = 0.1  # adamw fallback LR = lr * this
     batch_size: int = 2
     epochs: int = 50
     train_surface_points: int = 40_000
@@ -605,7 +738,6 @@ class Config:
     lr_warmup_steps: int = 0
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
-    optimizer: str = "adamw"
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1810,15 +1942,56 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = Lion(
             model.parameters(), lr=config.lr, weight_decay=config.weight_decay
         )
+    elif optimizer_name == "muon":
+        muon_2d_params = [p for p in model.parameters() if p.requires_grad and p.ndim == 2]
+        muon_other_params = [p for p in model.parameters() if p.requires_grad and p.ndim != 2]
+        n_muon_2d = sum(p.numel() for p in muon_2d_params)
+        n_muon_other = sum(p.numel() for p in muon_other_params)
+        adamw_fallback_lr = config.lr * config.muon_adamw_lr_scale
+        if is_main:
+            print(
+                f"Optimizer: Muon (lr={config.lr}, momentum={config.muon_momentum}, "
+                f"ns_steps={config.muon_ns_steps}); 2-D params {n_muon_2d / 1e6:.2f}M -> Muon, "
+                f"other params {n_muon_other / 1e6:.2f}M -> AdamW fallback "
+                f"(lr={adamw_fallback_lr}, wd={config.weight_decay})"
+            )
+        optimizer = Muon(
+            [
+                {
+                    "params": muon_2d_params,
+                    "mode": "muon",
+                    "lr": config.lr,
+                    "momentum": config.muon_momentum,
+                    "ns_steps": config.muon_ns_steps,
+                    "weight_decay": 0.0,
+                },
+                {
+                    "params": muon_other_params,
+                    "mode": "adamw",
+                    "lr": adamw_fallback_lr,
+                    "betas": (0.9, 0.999),
+                    "eps": 1e-8,
+                    "weight_decay": config.weight_decay,
+                },
+            ],
+            lr=config.lr,
+            momentum=config.muon_momentum,
+            ns_steps=config.muon_ns_steps,
+            betas=(0.9, 0.999),
+            eps=1e-8,
+            weight_decay=config.weight_decay,
+            mode="muon",
+        )
     else:
         raise ValueError(
-            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion'."
+            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion', 'muon'."
         )
-    if is_main:
+    if is_main and optimizer_name != "muon":
         print(
             f"Optimizer: {optimizer.__class__.__name__} "
             f"lr={config.lr} wd={config.weight_decay}"
         )
+    initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
@@ -2015,14 +2188,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 continue
             if effective_warmup_steps > 0:
                 if global_step < effective_warmup_steps:
-                    warmup_lr = config.lr_warmup_start_lr + (
-                        config.lr - config.lr_warmup_start_lr
-                    ) * (global_step / effective_warmup_steps)
-                    for pg in optimizer.param_groups:
-                        pg["lr"] = warmup_lr
+                    progress = global_step / effective_warmup_steps
+                    start_ratio = (
+                        config.lr_warmup_start_lr / max(config.lr, 1e-12)
+                    )
+                    warmup_ratio = start_ratio + (1.0 - start_ratio) * progress
+                    for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
+                        pg["lr"] = base_lr * warmup_ratio
                 elif global_step == effective_warmup_steps:
-                    for pg in optimizer.param_groups:
-                        pg["lr"] = config.lr
+                    for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
+                        pg["lr"] = base_lr
             optimizer.step()
             ema_decay_now: float | None = None
             if ema is not None:


### PR DESCRIPTION
## Hypothesis

The **Muon optimizer** (from Modded-NanoGPT by Keller Jordan, 2024) applies Newton-Schulz orthogonalization to gradient matrices before the Adam-style update. For transformer weight matrices (which are rank-deficient after training), this produces better-conditioned updates than standard Adam or Lion. The orthogonalization step enforces spectral norm ~1 on the effective weight updates, preventing feature-space collapse and improving gradient signal for the high-variance tau_y/tau_z outputs.

Reference: https://github.com/KellerJordan/modded-nanogpt — Muon is used as the default optimizer in Modded-NanoGPT and shows significant gains over AdamW on language modeling. The core insight is that gradient matrices for matmul weights benefit from the Nesterov-momentum + NS-orthogonalization treatment; embedding parameters and biases use standard Adam.

Our current largest remaining gaps vs AB-UPT targets are wall_shear_y (9.233% vs 3.65%, 2.53×) and wall_shear_z (10.449% vs 3.63%, 2.88×). These are the hardest axes to predict — they correspond to crossflow and yaw-direction shear, which are dominated by fine-scale turbulent structures. Better optimizer conditioning may help the model learn these more reliably.

**Muon algorithm summary:**
```
# For each linear weight matrix W:
G = gradient(W)                            # standard gradient
G = nesterov_momentum(G, mu=0.95)          # momentum buffer
G = newton_schulz_orth(G, steps=5)         # orthogonalize: G -> U where U^T U ~ I
W -= lr * G                                # SGD-like update with ortho gradient

# Embeddings, biases, scalars: use standard AdamW
```

## Instructions

Implement Muon optimizer support in `target/train.py`. This requires:

### 1. Add `--optimizer` CLI flag

In the argument-parser section of `train.py`, add:
```python
parser.add_argument("--optimizer", type=str, default="adamw",
                    choices=["adamw", "muon"],
                    help="Optimizer: adamw (default) or muon (Newton-Schulz ortho)")
```
Also add `config.optimizer` to the config dataclass or equivalent storage.

### 2. Implement the Muon optimizer class

Add this class to `train.py` (after imports, before training code). This is the minimal Muon implementation from Modded-NanoGPT:

```python
import torch
from torch import Tensor


def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5) -> Tensor:
    """Newton-Schulz iteration to compute G / ||G||_spec (approximately)."""
    assert G.ndim >= 2
    a, b, c = (3.4445, -4.7750, 2.0315)
    X = G.bfloat16()
    if G.size(-2) > G.size(-1):
        X = X.T
    # Ensure spectral norm <= 1 before iteration
    X = X / (X.norm() + 1e-7)
    for _ in range(steps):
        A = X @ X.T
        X = a * X + b * A @ X + c * A @ A @ X
    if G.size(-2) > G.size(-1):
        X = X.T
    return X.to(G.dtype)


class Muon(torch.optim.Optimizer):
    """
    Muon — Momentum + Newton-Schulz orthogonalization for weight matrices.
    Embeddings, biases, and 1-D params use AdamW fallback.

    Args:
        params:     parameter groups (or list of params)
        lr:         learning rate for Muon update (default 2e-2 — Muon uses
                    higher LR than Adam due to ortho normalization)
        momentum:   Nesterov momentum (default 0.95)
        ns_steps:   Newton-Schulz iterations (default 5)
        adamw_lr:   LR for AdamW fallback params
        adamw_wd:   weight decay for AdamW fallback
    """
    def __init__(self, params, lr=2e-2, momentum=0.95, ns_steps=5,
                 adamw_lr=3e-4, adamw_wd=0.0):
        defaults = dict(lr=lr, momentum=momentum, ns_steps=ns_steps,
                        adamw_lr=adamw_lr, adamw_wd=adamw_wd)
        super().__init__(params, defaults)

    def step(self, closure=None):
        loss = None
        if closure is not None:
            loss = closure()

        for group in self.param_groups:
            lr = group["lr"]
            momentum = group["momentum"]
            ns_steps = group["ns_steps"]
            adamw_lr = group["adamw_lr"]
            adamw_wd = group["adamw_wd"]

            for p in group["params"]:
                if p.grad is None:
                    continue
                g = p.grad
                state = self.state[p]

                # Use Muon only for ≥2-D weight matrices (not embeddings/biases)
                if g.ndim >= 2:
                    if "momentum_buffer" not in state:
                        state["momentum_buffer"] = torch.zeros_like(g)
                    buf = state["momentum_buffer"]
                    buf.mul_(momentum).add_(g)
                    # Nesterov: g + momentum * buf
                    g_nesterov = g.add(buf, alpha=momentum)
                    # Orthogonalize
                    g_ortho = zeropower_via_newtonschulz5(g_nesterov, steps=ns_steps)
                    # SGD-like update; scale by sqrt(max(n_rows, n_cols)) for uniform LR
                    scale = max(g.size(-2), g.size(-1)) ** 0.5
                    p.data.add_(g_ortho, alpha=-lr * scale)
                else:
                    # AdamW fallback for 1-D params (biases, layernorm scales, etc.)
                    if "exp_avg" not in state:
                        state["exp_avg"] = torch.zeros_like(p)
                        state["exp_avg_sq"] = torch.zeros_like(p)
                        state["step"] = 0
                    state["step"] += 1
                    exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
                    beta1, beta2 = 0.9, 0.999
                    exp_avg.mul_(beta1).add_(g, alpha=1 - beta1)
                    exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1 - beta2)
                    step = state["step"]
                    bias_corr1 = 1 - beta1 ** step
                    bias_corr2 = 1 - beta2 ** step
                    step_size = adamw_lr / bias_corr1
                    denom = (exp_avg_sq.sqrt() / bias_corr2 ** 0.5).add_(1e-8)
                    p.data.addcdiv_(exp_avg, denom, value=-step_size)
                    if adamw_wd > 0:
                        p.data.mul_(1 - adamw_lr * adamw_wd)
        return loss
```

### 3. Wire up the optimizer selection

Replace the current optimizer setup (around line 1712):
```python
# Current:
optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)

# Replace with:
if getattr(config, "optimizer", "adamw") == "muon":
    # For Muon: separate weight matrices (2D+) from biases/norms (1D)
    params_2d = [p for p in model.parameters() if p.requires_grad and p.ndim >= 2]
    params_1d = [p for p in model.parameters() if p.requires_grad and p.ndim < 2]
    optimizer = Muon(
        [{"params": params_2d}, {"params": params_1d}],
        lr=config.lr,           # Muon LR — user passes via --lr
        momentum=0.95,
        ns_steps=5,
        adamw_lr=config.lr * 0.1,   # 1D params use 10% of main LR
        adamw_wd=config.weight_decay,
    )
else:
    optimizer = torch.optim.AdamW(
        model.parameters(), lr=config.lr, weight_decay=config.weight_decay
    )
```

### 4. Gradient clipping compatibility

Muon performs its own gradient normalization internally (the NS orthogonalization replaces the role of gradient clipping for 2D weights). However, keep `--clip-grad-norm` active — it will clip the raw gradients before Muon processes them. This is fine and matches Modded-NanoGPT practice.

### 5. Run 2-arm comparison

**Arm A (baseline/control) — confirm yi SOTA with AdamW:**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer adamw \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 2720 \
  --clip-grad-norm 0.5 \
  --pos-max-wavelength 1000 \
  --wandb-group edward-r25-muon-vs-adamw
```

**Arm B (hypothesis) — Muon optimizer:**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer muon \
  --lr 2e-2 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 2720 \
  --clip-grad-norm 0.5 \
  --pos-max-wavelength 1000 \
  --wandb-group edward-r25-muon-vs-adamw
```

Note: Muon uses `--lr 2e-2` (higher than Adam/Lion because the orthogonalization normalizes the update). The `adamw_lr` for 1D fallback params is set internally to `config.lr * 0.1 = 2e-3`. This matches Modded-NanoGPT defaults.

If Arm B shows convergence issues at `2e-2`, try `1e-2` or `3e-2` as a quick follow-up before reporting back.

## Baseline

Current best on `yi` (PR #311, edward STRING-separable PE, W&B run `gcwx9yaa`):

| Metric | val | test | AB-UPT target | Gap |
|--------|-----|------|---------------|-----|
| abupt_axis_mean_rel_l2_pct | **7.546%** | **8.771%** | — | — |
| surface_pressure_rel_l2_pct | — | 4.485% | 3.82 | 1.17× |
| wall_shear_rel_l2_pct | — | 8.227% | 7.29 | 1.13× |
| volume_pressure_rel_l2_pct | — | 12.438% | 6.08 | 2.05× |
| wall_shear_x_rel_l2_pct | — | 7.253% | 5.35 | 1.36× |
| wall_shear_y_rel_l2_pct | — | 9.233% | 3.65 | **2.53×** |
| wall_shear_z_rel_l2_pct | — | 10.449% | 3.63 | **2.88×** |

**Merge bar: val_abupt < 7.546% required to beat current SOTA.**

The dominant open gaps are tau_y (2.53×) and tau_z (2.88×) — crossflow shear axes. Improved optimizer conditioning is hypothesized to reduce these.

## Expected outcome

Muon's orthogonalized updates should produce better-conditioned transformer weight matrices, leading to:
- Improved convergence speed (fewer epochs to reach same val loss)
- Better generalization on the hardest axes (tau_y/z) where AdamW/Lion show largest gaps
- Potentially lower val_abupt than 7.546% at terminal epoch

Please report per-axis metrics (tau_x, tau_y, tau_z) and volume_pressure separately in addition to the headline abupt metric. Also note whether training loss was smoother or rougher than AdamW.
