### PR TITLE
[alphonse] Multi-scale STRING-sep PE: k=1/4/8 learnable freqs per axis

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,6 +124,43 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class StringMultiScaleEncoding(nn.Module):
+    """STRING-separable multi-scale position encoding.
+
+    Per-axis learnable log-frequencies and phases. With ``num_freqs=1`` this
+    matches the STRING-separable design from PR #311; ``num_freqs > 1`` stacks
+    multiple per-axis frequencies before a linear projection so the model can
+    attend to global and near-wall scales simultaneously.
+    """
+
+    def __init__(self, hidden_dim: int, space_dim: int, num_freqs: int = 4):
+        super().__init__()
+        if num_freqs < 1:
+            raise ValueError("num_freqs must be >= 1")
+        self.hidden_dim = hidden_dim
+        self.space_dim = space_dim
+        self.num_freqs = num_freqs
+        self.log_freq = nn.Parameter(torch.zeros(space_dim, num_freqs))
+        self.phase = nn.Parameter(torch.zeros(space_dim, num_freqs))
+        self.proj = nn.Linear(2 * space_dim * num_freqs, hidden_dim, bias=True)
+        _init_linear(self.proj)
+        with torch.no_grad():
+            if num_freqs > 1:
+                init_range = torch.linspace(-6.9, 0.0, num_freqs)
+            else:
+                init_range = torch.zeros(1)
+            for ax in range(space_dim):
+                self.log_freq[ax] = init_range
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        freq = torch.exp(self.log_freq)
+        angles = coords.unsqueeze(-1) * freq + self.phase
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -350,6 +387,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        string_num_freqs: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,12 +400,20 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.string_num_freqs = string_num_freqs
 
-        self.pos_embed = ContinuousSincosEmbed(
-            hidden_dim=n_hidden,
-            input_dim=space_dim,
-            max_wavelength=pos_max_wavelength,
-        )
+        if string_num_freqs > 0:
+            self.pos_embed = StringMultiScaleEncoding(
+                hidden_dim=n_hidden,
+                space_dim=space_dim,
+                num_freqs=string_num_freqs,
+            )
+        else:
+            self.pos_embed = ContinuousSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -579,6 +625,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    string_num_freqs: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -664,6 +711,11 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
         ),
+        "string_num_freqs": (
+            "If >0, replace ContinuousSincosEmbed with StringMultiScaleEncoding "
+            "(per-axis learnable log-frequencies). num_freqs=1 reproduces "
+            "STRING-separable PE; num_freqs>1 stacks multiple frequencies."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -745,6 +797,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        string_num_freqs=config.string_num_freqs,
     )
 
 
@@ -1763,6 +1816,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("model/string/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
@@ -2041,6 +2095,24 @@ def main(argv: Iterable[str] | None = None) -> None:
         )
         if early_stop_reason is not None:
             log_metrics["early_stop/triggered"] = 1.0
+        base_model_for_log = getattr(model, "_orig_mod", model)
+        pos_embed_log = getattr(base_model_for_log, "pos_embed", None)
+        if isinstance(pos_embed_log, StringMultiScaleEncoding):
+            with torch.no_grad():
+                lf = pos_embed_log.log_freq.detach().float().cpu()
+                ph = pos_embed_log.phase.detach().float().cpu()
+                fr = lf.exp()
+                axis_names = ("x", "y", "z")
+                for ax in range(lf.shape[0]):
+                    ax_name = axis_names[ax] if ax < len(axis_names) else f"a{ax}"
+                    log_metrics[f"model/string/{ax_name}/freq_min"] = float(fr[ax].min())
+                    log_metrics[f"model/string/{ax_name}/freq_max"] = float(fr[ax].max())
+                    log_metrics[f"model/string/{ax_name}/log_freq_mean"] = float(lf[ax].mean())
+                    if lf.shape[1] > 1:
+                        log_metrics[f"model/string/{ax_name}/log_freq_std"] = float(lf[ax].std())
+                    log_metrics[f"model/string/{ax_name}/phase_mean"] = float(ph[ax].mean())
+                    for fi in range(lf.shape[1]):
+                        log_metrics[f"model/string/{ax_name}/freq_{fi}"] = float(fr[ax, fi])
         wandb.log(log_metrics)
 
         primary_val_is_valid = math.isfinite(primary_val) and primary_val > 0.0


### PR DESCRIPTION
## Hypothesis

The STRING-separable position encoding (PR #311, val_abupt 9.039% → **7.546%**, a 16.5% improvement) replaced the fixed sincos omega-bank with per-axis learnable `log_freq` and `phase` parameters. This was the single largest architectural win in many rounds.

The current implementation uses `k=1` learnable frequency per axis. We hypothesise that extending to `k=4` or `k=8` learnable frequencies per axis (multi-scale STRING-sep) will provide a richer spectral basis, better capturing the high-frequency cross-flow boundary gradients responsible for the dominant remaining errors:

- **wall_shear_y**: 9.233% vs AB-UPT 3.65 (2.53×)
- **wall_shear_z**: 10.449% vs AB-UPT 3.63 (2.88×)
- **volume_pressure**: 12.438% vs AB-UPT 6.08 (2.05×)

At PR #311 terminal epoch, all val slopes were still negative — the model had not converged — suggesting that more expressive position encoding can continue to drive improvement. Multiple per-axis frequencies give the model access to both long-range global structure (low freq) and fine near-wall boundary-layer gradients (high freq) simultaneously.

This sweep runs 3 arms: Arm A (`k=1`, re-baseline), Arm B (`k=4`), Arm C (`k=8`).

## Instructions

### 1. Add `StringMultiScaleEncoding` class to `target/train.py`

Insert the following new class after the `ContinuousSincosEmbed` class (around line 124):

```python
class StringMultiScaleEncoding(nn.Module):
    """STRING-separable multi-scale position encoding.

    Axis-aligned learnable frequencies — extends PR #311 STRING-sep (k=1)
    to k>1 frequencies per axis for a richer spectral basis.

    Args:
        hidden_dim:  output embedding dimension (must equal model n_hidden)
        space_dim:   number of coordinate axes (3 for XYZ)
        num_freqs:   number of learnable frequencies per axis (k)
    """
    def __init__(self, hidden_dim: int, space_dim: int, num_freqs: int = 4):
        super().__init__()
        self.hidden_dim = hidden_dim
        self.space_dim = space_dim
        self.num_freqs = num_freqs
        # Per-axis learnable log-frequencies and phases
        self.log_freq = nn.Parameter(torch.zeros(space_dim, num_freqs))
        self.phase    = nn.Parameter(torch.zeros(space_dim, num_freqs))
        # Project 2*space_dim*num_freqs sincos features → hidden_dim
        self.proj = nn.Linear(2 * space_dim * num_freqs, hidden_dim, bias=True)
        # Initialise log_freq with log of a geometric sequence so freqs span
        # a wide range from ~1/(2π*1000) to ~1/(2π*1) by default
        with torch.no_grad():
            for ax in range(space_dim):
                self.log_freq[ax] = torch.linspace(
                    -6.9,   # log(1/1000)
                     0.0,   # log(1)
                    num_freqs
                )

    def forward(self, coords: torch.Tensor) -> torch.Tensor:
        # coords: [B, N, space_dim]
        coords = coords.float()
        freq = torch.exp(self.log_freq)                      # [space_dim, k]
        # [B, N, space_dim, 1] * [space_dim, k] + [space_dim, k]
        angles = coords.unsqueeze(-1) * freq + self.phase    # [B, N, space_dim, k]
        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)  # [B, N, space_dim, 2k]
        emb = emb.flatten(start_dim=-2)                      # [B, N, 2*space_dim*k]
        return self.proj(emb)                                # [B, N, hidden_dim]
```

### 2. Add `--string-num-freqs` CLI flag to `Config`

In the `Config` dataclass, add:
```python
string_num_freqs: int = 0  # 0 = use ContinuousSincosEmbed; >0 = StringMultiScaleEncoding
```

Wire up the CLI argument (in the `add_argument` block):
```python
parser.add_argument("--string-num-freqs", type=int, default=0,
                    help="Number of learnable STRING-sep freqs per axis (0=use sincos omega-bank)")
```
And set `config.string_num_freqs = args.string_num_freqs`.

### 3. Swap the positional embedding in `SurfaceTransolver.__init__`

Find the line that instantiates `self.pos_embed = ContinuousSincosEmbed(...)` and replace it with:

```python
if config.string_num_freqs > 0:
    self.pos_embed = StringMultiScaleEncoding(
        hidden_dim=n_hidden,
        space_dim=space_dim,
        num_freqs=config.string_num_freqs,
    )
else:
    self.pos_embed = ContinuousSincosEmbed(
        hidden_dim=n_hidden,
        input_dim=space_dim,
        max_wavelength=pos_max_wavelength,
    )
```

Note: `StringMultiScaleEncoding.forward` already returns `[B, N, hidden_dim]` so the downstream `_encode_group` code needs no changes.

### 4. Kill threshold and W&B group

Use `--kill-metric val_primary/abupt_axis_mean_rel_l2_pct --kill-threshold 25` and
`--wandb-group alphonse-r25-multiscale-string-sweep` so all 3 arms are grouped in W&B.

### 5. Run all three arms (sequential, same 8 GPUs)

**Arm A — k=1 (STRING-sep re-baseline, confirms the flag plumbing is correct)**
```bash
cd /path/to/DrivAerML
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent alphonse \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 0.5 \
  --string-num-freqs 1 \
  --wandb-group alphonse-r25-multiscale-string-sweep
```

**Arm B — k=4 (primary test arm)**
```bash
cd /path/to/DrivAerML
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent alphonse \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 0.5 \
  --string-num-freqs 4 \
  --wandb-group alphonse-r25-multiscale-string-sweep
```

**Arm C — k=8 (high-frequency-rich arm)**
```bash
cd /path/to/DrivAerML
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent alphonse \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 500 \
  --clip-grad-norm 0.5 \
  --string-num-freqs 8 \
  --wandb-group alphonse-r25-multiscale-string-sweep
```

## Baseline

Current SOTA (PR #311, edward, STRING-sep PE, W&B run `gcwx9yaa`):

| Metric | val | test |
|--------|-----|------|
| `abupt_axis_mean_rel_l2_pct` | **7.546%** | **8.771%** |
| `surface_pressure_rel_l2_pct` | — | 4.485% |
| `wall_shear_rel_l2_pct` | — | 8.227% |
| `volume_pressure_rel_l2_pct` | — | 12.438% |
| `wall_shear_x_rel_l2_pct` | — | 7.253% |
| `wall_shear_y_rel_l2_pct` | — | 9.233% |
| `wall_shear_z_rel_l2_pct` | — | 10.449% |

**Merge bar: val_abupt < 7.546% (must beat this to merge)**

AB-UPT reference targets: surface_pressure 3.82, wall_shear 7.29, volume_pressure 6.08, wall_shear_x 5.35, wall_shear_y 3.65, wall_shear_z 3.63.

## Expected results

- Arm A (`k=1`) should reproduce ~7.5% val_abupt confirming correct implementation
- Arm B (`k=4`) is the primary bet — richer spectral basis expected to push val_abupt toward 7.0–7.2%
- Arm C (`k=8`) may help or plateau; will tell us if more freqs keep helping

Report `val_primary/abupt_axis_mean_rel_l2_pct` and `test_primary/*` for all 3 arms in your PR comment. Best arm's W&B run ID is the key result.
