### PR TITLE
STRING-sep: sweep num_features (16 / 32 / 64) for optimal spectral resolution

### DIFF
--- a/model.py
+++ b/model.py
@@ -171,7 +171,14 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_qk_norm: bool = False,
+    ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -180,6 +187,7 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.use_qk_norm = use_qk_norm
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -188,6 +196,12 @@ class TransolverAttention(nn.Module):
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
+        if use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+        else:
+            self.q_norm = None
+            self.k_norm = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -208,6 +222,9 @@ class TransolverAttention(nn.Module):
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        if self.q_norm is not None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -229,6 +246,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -238,6 +256,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            use_qk_norm=use_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -260,6 +279,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -270,6 +290,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    use_qk_norm=use_qk_norm,
                 )
                 for _ in range(depth)
             ]
@@ -301,6 +322,7 @@ class SurfaceTransolver(nn.Module):
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
         pos_encoding_mode: str = "sincos",
+        use_qk_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -311,6 +333,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
         self.pos_encoding_mode = pos_encoding_mode
+        self.use_qk_norm = use_qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -367,6 +390,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -94,6 +94,7 @@ class Config:
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     pos_encoding_mode: str = "sincos"
+    use_qk_norm: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -178,6 +179,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
         pos_encoding_mode=config.pos_encoding_mode,
+        use_qk_norm=config.use_qk_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

STRING-separable positional encoding uses `num_features` learnable frequency/phase pairs per spatial axis. The current SOTA (PR #311) uses the default of 32 features (output dim = 6×32 = 192). This count is untested — it may be suboptimal in either direction:

- **64 features** (output dim 384): double the spectral expressivity; may better capture the fine-grained anisotropic aerodynamic structure in streamwise/spanwise/vertical axes
- **16 features** (output dim 96): tests whether the learned spectral structure is sparse; halved encoding may suffice and reduce overfitting on the 400-car dataset

The key question: what is the right spectral resolution for DrivAerML's 3D coordinate space?

## Instructions

Run 3 arms sequentially (one per run), grouped in W&B under `alphonse-string-sep-features`. All other hyperparameters identical to SOTA (PR #311).

**Arm A — 16 features (sparse):**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --wandb-group alphonse-string-sep-features --wandb-run-name string-sep-feat16
```

**Arm B — 32 features (SOTA default / control):**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable --rff-num-features 32 \
  --wandb-group alphonse-string-sep-features --wandb-run-name string-sep-feat32
```

**Arm C — 64 features (dense):**
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --pos-encoding-mode string_separable --rff-num-features 64 \
  --wandb-group alphonse-string-sep-features --wandb-run-name string-sep-feat64
```

Report the best `val_primary/abupt_axis_mean_rel_l2_pct` for each arm at the end. If Arm C beats Arm B by ≥0.3pp, also report all `test_primary/*` metrics from summary.

## What to watch for

- If 64 > 32 > 16: more spectral resolution helps — consider 128 as a follow-up
- If 32 ≈ 64 but >> 16: current default is already near-optimal; sparse encoding doesn't suffice
- If 16 ≈ 32 ≈ 64: feature count is not a sensitive dimension; report all are within 0.2pp of each other

## Baseline (merge bar)

| Metric | PR #311 SOTA |
|---|---:|
| **val_abupt** | **7.546%** |
| test_abupt | 8.771% |
| test surface_pressure | 4.485% |
| test wall_shear | 8.227% |
| test volume_pressure | 12.438% |
| test tau_x | 7.253% |
| test tau_y | 9.233% |
| test tau_z | 10.449% |

W&B run: `gcwx9yaa` (project `senpai-v1-drivaerml-ddp8`)

Beat val_abupt < **7.546%** to merge.
