### PR TITLE
norman: surface-only point masking sweep (--surface-mask-ratio)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,6 +65,23 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+def apply_surface_mask(surface_mask: torch.Tensor, mask_ratio: float) -> torch.Tensor:
+    """Bernoulli-drop currently-valid surface positions for MAE-style point masking.
+
+    Each True position in `surface_mask` is independently kept with probability
+    (1 - mask_ratio). Already-invalid (False) positions remain False.
+    Returns the input mask unchanged when mask_ratio <= 0.0. Volume mask is
+    intentionally left untouched by callers — this helper operates only on the
+    surface mask.
+    """
+    if mask_ratio <= 0.0:
+        return surface_mask
+    if mask_ratio >= 1.0:
+        raise ValueError(f"surface_mask_ratio must be < 1.0, got {mask_ratio}")
+    keep = torch.rand(surface_mask.shape, device=surface_mask.device, dtype=torch.float32) >= mask_ratio
+    return surface_mask & keep
+
+
 class DropPath(nn.Module):
     """Stochastic depth: drop entire residual branch with probability `drop_prob`."""
 
@@ -606,6 +623,7 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     optimizer: str = "adamw"
+    surface_mask_ratio: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1788,6 +1806,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     n_params = sum(param.numel() for param in model.parameters())
     if is_main:
         print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+        print(
+            f"[surface_mask] config.surface_mask_ratio={config.surface_mask_ratio:.3f} "
+            f"(applied to surface_mask only in train loop; volume_mask is never modified)",
+            flush=True,
+        )
 
     if is_distributed:
         train_model = DistributedDataParallel(
@@ -1916,6 +1939,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     train_start = time.time()
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
+    surface_mask_logged = False
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
@@ -1938,6 +1962,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            if config.surface_mask_ratio > 0.0:
+                surface_valid_before = int(batch.surface_mask.sum().item())
+                batch.surface_mask = apply_surface_mask(batch.surface_mask, config.surface_mask_ratio)
+                if is_main and not surface_mask_logged:
+                    surface_valid_after = int(batch.surface_mask.sum().item())
+                    surface_dropped = surface_valid_before - surface_valid_after
+                    surface_realized = surface_dropped / max(surface_valid_before, 1)
+                    print(
+                        f"[surface_mask] ratio={config.surface_mask_ratio:.3f} "
+                        f"surface dropped={surface_dropped}/{surface_valid_before} "
+                        f"({surface_realized:.4f}) "
+                        f"volume_mask UNTOUCHED",
+                        flush=True,
+                    )
+                    surface_mask_logged = True
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,


### PR DESCRIPTION
## Hypothesis

Uniform Bernoulli masking in PR #350 hurt `volume_pressure` (+0.77pp at p=0.30) because it indiscriminately dropped interior volume points from the loss, degrading the already-2.05× volume-pressure gap. However, the p=0.30 arm showed a consistent tau_y/tau_z improvement (Δτy −0.318pp, Δτz −0.738pp test vs control). The volume regression is an artifact of the mask design, not the masking concept itself.

**New hypothesis:** If we restrict masking to *surface* query points only (leaving all volume points unmasked), the tau_y/z regularisation benefit should survive while volume_pressure is fully protected. This is a cleaner test of MAE-style masking as a surface-specific regulariser.

Mechanistic rationale: randomly removing surface query points from slice-attention input forces the model to predict tau_y/z from global context rather than local neighbourhood interpolation — this is precisely the generalisation pressure needed for cross-flow-dominant surface patches (theta~86°, 2.21× worse per PR #363 diagnostic).

## Instructions

Your implementation from PR #350 is already correct and committed on `yi`. The only change is to add a separate `--surface-mask-ratio` flag that applies masking **only to the surface mask** (`surface_mask`), leaving `volume_mask` untouched.

### Step 1 — Add `--surface-mask-ratio` flag

In `target/train.py`, add a new CLI argument:
```
--surface-mask-ratio FLOAT  (default 0.0, no-op)
```

The new `apply_surface_mask(surface_mask, ratio)` helper should be structurally identical to your `apply_point_mask()` from PR #350, but only operate on `surface_mask`. Do NOT touch `volume_mask`.

Apply it in the training loop only (not in `evaluate_split`), immediately before `train_loss()` — same position as before.

### Step 2 — Run a 3-arm sweep (single GPU each, 4 GPUs total, 3 active + 1 for the existing AdamW control)

| Arm | surface_mask_ratio | W&B run name | CUDA |
|---|---|---|---|
| A (control) | 0.00 | `norman/surf-mask-ctrl` | 0 |
| B | 0.20 | `norman/surf-mask-020` | 1 |
| C | 0.30 | `norman/surf-mask-030` | 2 |
| D | 0.40 | `norman/surf-mask-040` | 3 |

Arm A is a matched control under identical single-GPU AdamW setup.

### Step 3 — Config flags (yi-compatible)

```bash
CUDA_VISIBLE_DEVICES=<N> python target/train.py \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 2000 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --surface-mask-ratio <VALUE> \
  --wandb_group norman-surface-only-mask
```

Launch all 4 arms simultaneously with `&` and `wait`.

### Merge bar

**val_abupt < 7.546%** (PR #311, edward, STRING-sep PE). Note: single-GPU AdamW will not reach this absolute level. **The relevant comparison is Arms B/C/D vs Arm A** (matched control). A win is any arm that beats Arm A on val_abupt without hurting volume_pressure.

### Reporting format

Post results as a PR comment when complete:
- Best val_abupt per arm + epoch at which it occurred
- val_abupt and test_abupt for all arms at best validation epoch
- Per-axis tau_y / tau_z / vol_pressure / surface_pressure at best epoch
- Confirm `volume_mask` was NOT touched (verify from `[point_mask]` or absence of log line for volume)

## Baseline

**Current SOTA: PR #311 (edward, STRING-separable position encoding)**
- val_primary/abupt_axis_mean_rel_l2_pct: **7.546%** (W&B run `gcwx9yaa`)
- test_primary/abupt_axis_mean_rel_l2_pct: **8.771%**
- test surface_pressure_rel_l2_pct: 4.485%
- test wall_shear_rel_l2_pct: 8.227%
- test volume_pressure_rel_l2_pct: 12.438%
- test wall_shear_y_rel_l2_pct: 9.233%
- test wall_shear_z_rel_l2_pct: 10.449%

**PR #350 matched control (Arm A=p=0.0, single-GPU AdamW, ~11k steps):**
- val_abupt: 25.0436% (W&B run `9axjku8c`) — this is the relevant single-GPU baseline

**Merge bar: val_abupt < 7.546%.** For the single-GPU sweep, beat the matched Arm A (25.04%) without volume_pressure regression.

**Reproduce command (ARM A baseline):**
```bash
cd target/ && CUDA_VISIBLE_DEVICES=0 python train.py \
  --lr 1e-4 --weight-decay 5e-4 --batch-size 4 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-steps 2000 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-mask-ratio 0.0 \
  --wandb_group norman-surface-only-mask
```
