### PR TITLE
Stack mirror-aug+SW=2.0+gc=0.5+T_max=50 on 5L/256d

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from data import SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -117,6 +118,7 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    mirror_aug_prob: float = 0.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -157,6 +159,49 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_mirror_y_batch(batch: SurfaceBatch, prob: float) -> tuple[SurfaceBatch, float]:
+    """Per-sample independent y-mirror augmentation.
+
+    With probability `prob` per sample, reflect across the xz-plane:
+      surface_x[..., 1]  (y position)        -> negate
+      surface_x[..., 4]  (ny normal y)       -> negate
+      surface_y[..., 2]  (wsy = wall_shear_y) -> negate
+      volume_x[..., 1]   (y position)        -> negate
+    All other channels (x, z, nx, nz, area, cp, wsx, wsz, sdf, vol_p) are
+    sign-invariant under this reflection. Padded entries are 0 so the sign
+    multiply is a no-op there. Mask/metadata/case_ids untouched.
+
+    Returns the (possibly new) batch and the empirical fraction flipped.
+    """
+    if prob <= 0.0:
+        return batch, 0.0
+    bsz = batch.surface_x.shape[0]
+    flip = torch.rand(bsz, device=batch.surface_x.device) < prob
+    flip_frac = float(flip.float().mean().item())
+    if not bool(flip.any().item()):
+        return batch, flip_frac
+    sign_surf = (1.0 - 2.0 * flip.to(batch.surface_x.dtype)).view(bsz, 1)
+    sign_vol = (1.0 - 2.0 * flip.to(batch.volume_x.dtype)).view(bsz, 1)
+    sign_y = (1.0 - 2.0 * flip.to(batch.surface_y.dtype)).view(bsz, 1)
+    new_surface_x = batch.surface_x.clone()
+    new_surface_x[..., 1] = batch.surface_x[..., 1] * sign_surf
+    new_surface_x[..., 4] = batch.surface_x[..., 4] * sign_surf
+    new_surface_y = batch.surface_y.clone()
+    new_surface_y[..., 2] = batch.surface_y[..., 2] * sign_y
+    new_volume_x = batch.volume_x.clone()
+    new_volume_x[..., 1] = batch.volume_x[..., 1] * sign_vol
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=new_surface_x,
+        surface_y=new_surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=new_volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), flip_frac
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -167,8 +212,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     raw_rel_l2_weight: float = 0.0,
+    mirror_aug_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    batch, mirror_aug_frac = apply_mirror_y_batch(batch, mirror_aug_prob)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -210,6 +257,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "mirror_aug_frac": mirror_aug_frac,
         **aux_metrics,
     }
 
@@ -325,6 +373,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     raw_rel_l2_weight=config.raw_rel_l2_weight,
+                    mirror_aug_prob=config.mirror_aug_prob,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -360,6 +409,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/mirror_aug_frac": batch_loss_metrics["mirror_aug_frac"],
                         }
                     )
                     # Log per-channel raw relative L2 auxiliary metrics when enabled.


### PR DESCRIPTION
## Hypothesis

Stack all validated Wave 9 wins onto the current best recipe (5L/256d + FourierPE + T_max=50) simultaneously: mirror-augmentation (prob=0.5), surface loss weight=2.0, and grad-clip=0.5. Each lever has been individually validated:

- **T_max=50**: alphonse PR #174 confirmed −0.22pp vs T_max=30
- **gc=0.5**: senku PR #325, ep24=8.222% and descending strongly
- **mirror-aug + SW=2.0**: tanjiro PR #332, strongest binding-axis signal (wsy=10.5% at ep20 vs baseline 8.73%)

The hypothesis is that these three improvements are orthogonal and their gains will stack. Combined, we expect a step change toward 6.5-6.8% val_abupt, with particular improvement on wsy/wsz where the gain is needed most.

**IMPORTANT**: The `--mirror-aug-prob` flag requires code from gilbert's branch (`gilbert/mirror-symmetry-train-aug-wsy`). Cherry-pick the mirror-aug commit before running — see instructions below.

## Instructions

### Step 1: Cherry-pick mirror-aug code

The `--mirror-aug-prob` CLI flag is not in the base train.py. You must cherry-pick it from gilbert's branch first:

```bash
cd target/
git fetch origin gilbert/mirror-symmetry-train-aug-wsy
git log origin/gilbert/mirror-symmetry-train-aug-wsy --oneline -5
# Identify the commit that adds --mirror-aug-prob to train.py
git cherry-pick <commit-hash>
```

Verify the cherry-pick succeeded:
```bash
python train.py --help | grep mirror
```
You should see `--mirror-aug-prob` in the output.

### Step 2: Run the experiment

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 50 \
  --grad-clip-norm 0.5 \
  --surface-loss-weight 2.0 \
  --mirror-aug-prob 0.5 \
  --no-compile-model \
  --wandb-group bengio-wave11 \
  --wandb-name chihiro-stacked-wave11
```

Kill thresholds: `89084:val_primary/abupt_axis_mean_rel_l2_pct<13.0,178169:val_primary/abupt_axis_mean_rel_l2_pct<10.5,445350:val_primary/abupt_axis_mean_rel_l2_pct<7.2091`

(Step 89084 ≈ ep5, step 178169 ≈ ep10, step 445350 ≈ ep25. Kill if not below 13% at ep5, 10.5% at ep10, or 7.2091% at ep25.)

Run for the full 50 epochs if kill thresholds are not triggered.

## Rules — READ CAREFULLY

- **EXACTLY ONE W&B run.** No side experiments, no unauthorized runs of any kind.
- **30-minute ACK deadline**: Post a comment acknowledging this assignment within 30 minutes of it being opened, with your W&B run ID.
- **Cherry-pick only** — do not modify any source files directly. The cherry-pick commit from gilbert's branch is the only allowed code change.
- **Do not open any other PRs** while this one is open.

## Baseline (Current Best — PR #174, alphonse)

W&B run: `vu4jsiic` | ep~45.3, step 807,025

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.5644 | 3.82 |
| `val_primary/volume_pressure_rel_l2_pct` | 3.9361 ✓ | 6.08 |
| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | 3.63 |

**To beat**: `val_primary/abupt_axis_mean_rel_l2_pct` < **6.9549** at any checkpoint.

## Report format

Post results as a PR comment including:
- W&B run ID
- ep5, ep10, ep15, ep20, ep30, ep50 val_abupt values (or final if killed early)
- val_primary/wall_shear_y_rel_l2_pct and val_primary/wall_shear_z_rel_l2_pct at best checkpoint
- Comparison to PR #174 baseline
