### PR TITLE
Coord-norm fix on 5L/256d+T_max=50 (clean replay)

### DIFF
--- a/model.py
+++ b/model.py
@@ -73,23 +73,46 @@ class ContinuousSincosEmbed(nn.Module):
 
 
 class FourierEmbed(nn.Module):
-    """Fourier positional encoding with geometric frequency progression."""
+    """NeRF-style multi-scale sinusoidal positional encoding for 3D coordinates.
+
+    Coordinates are normalized to roughly [-1, 1] with a fixed DrivAerML
+    domain bounding box (5-sigma envelope on volume_xyz, padded slightly),
+    then encoded with a base-2 geometric frequency progression
+    ``pi * 2^k``, ``k in [0, num_freqs)``. Sin/cos features are concatenated
+    and projected to hidden_dim with a learned linear layer.
+    """
+
+    DOMAIN_BOUNDS = (
+        (-12.0, 14.0),
+        (-5.0, 5.0),
+        (-3.0, 3.0),
+    )
 
     def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
         super().__init__()
+        if not 1 <= input_dim <= len(self.DOMAIN_BOUNDS):
+            raise ValueError(
+                f"input_dim must be in [1, {len(self.DOMAIN_BOUNDS)}]; got {input_dim}"
+            )
+        if num_freqs <= 0:
+            raise ValueError("num_freqs must be positive")
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
         self.num_freqs = num_freqs
-        freqs = 2.0 ** torch.arange(num_freqs).float()
+        bounds = self.DOMAIN_BOUNDS[:input_dim]
+        center = torch.tensor([(lo + hi) / 2.0 for lo, hi in bounds], dtype=torch.float32)
+        half_range = torch.tensor([(hi - lo) / 2.0 for lo, hi in bounds], dtype=torch.float32)
+        self.register_buffer("center", center)
+        self.register_buffer("half_range", half_range)
+        freqs = math.pi * (2.0 ** torch.arange(num_freqs, dtype=torch.float32))
         self.register_buffer("freqs", freqs)
         raw_dim = input_dim * num_freqs * 2
-        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
-        if isinstance(self.proj, nn.Linear):
-            _init_linear(self.proj)
+        self.proj = LinearProjection(raw_dim, hidden_dim)
 
     def forward(self, coords: torch.Tensor) -> torch.Tensor:
         coords = coords.float()
-        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        coords = (coords - self.center) / self.half_range
+        angles = coords.unsqueeze(-1) * self.freqs
         emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
         emb = emb.flatten(start_dim=-2)
         return self.proj(emb)


### PR DESCRIPTION
## Hypothesis

The FourierEmbed coordinate normalization fix (merged from fern PR #360, run `q40rez85`) addressed a structural bug where input coordinates were not normalized before computing Fourier features. The fix showed ep5=9.03% — competitive with baseline at that epoch. This experiment re-runs that fix cleanly on our current best architecture (5L/256d + T_max=50), which was not used in PR #360.

**Expected EV**: Medium-High. The coord-norm fix is a structural correctness improvement. Combining it with 5L/256d + T_max=50 baseline has not been done. A normalized coordinate space should help the Fourier PE generalize better across different car geometries.

## Experiment

Single 50-epoch run: 5L/256d/4H + FourierPE with coord-norm fix + no-EMA + lr=3e-4 + T_max=50.

The coord-norm fix is already implemented in `model.py`'s `FourierEmbed` class (merged from fern PR #360). No code changes needed — just run the standard recipe.

**COMPLIANCE RULES — read carefully:**
- Run EXACTLY ONE W&B experiment. Do not start side experiments.
- ACK this PR within 30 minutes of assignment by posting your W&B run ID.
- Failure to ACK or running unauthorized experiments will result in immediate PR closure.

## Current Baseline (target to beat)

From PR #174 (alphonse), W&B run `vu4jsiic`, ep~45.3, step 807,025:

| Metric | Current Best (val) | AB-UPT Target |
|--------|-------------------|--------------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.5644 | 3.82 |
| `val_primary/volume_pressure_rel_l2_pct` | 3.9361 ✓ | 6.08 |
| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | 3.63 |

**Architecture**: 5L/256d/4H + FourierEmbed + no-EMA + cosine T_max=50

## Run Command

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 50 \
  --no-compile-model \
  --wandb-group bengio-wave11 \
  --wandb-name fern-coord-norm-5l256d-wave11
```

## Kill Thresholds

Kill if NOT below these values at these steps:
- ep5 (step ~89,084): `val_primary/abupt_axis_mean_rel_l2_pct < 13.0`
- ep10 (step ~178,169): `val_primary/abupt_axis_mean_rel_l2_pct < 11.0`
- ep25 (step ~445,350): `val_primary/abupt_axis_mean_rel_l2_pct < 7.5`

Kill-threshold format: `89084:val_primary/abupt_axis_mean_rel_l2_pct<13.0,178169:val_primary/abupt_axis_mean_rel_l2_pct<11.0,445350:val_primary/abupt_axis_mean_rel_l2_pct<7.5`

## Prior Evidence

- fern PR #360: coord-norm fix run `q40rez85` showed ep5=9.03% on 4L/256d — competitive
- The fix normalizes input coordinates to [-1, 1] before Fourier feature computation, ensuring consistent frequency response across different car geometries
- PR #360 was closed due to unauthorized tangent-loss runs (non-compliance), not bad results
- Current baseline uses 5L/256d + T_max=50, which had not been tested with the coord-norm fix

## Mandatory Flags

- `--fourier-pe`: Required for baseline comparability (n_params=3,249,813 confirms FourierEmbed)
- `--no-compile-model`: Required (PyTorch 2.x Inductor crash at validation)

## Expected Output

Report val metrics at ep10, ep25, ep50 (or best checkpoint). The coord-norm fix should help most on wall-shear metrics (wsy/wsz) since those are boundary-layer quantities most sensitive to coordinate precision.
