### PR TITLE
feat: surface-tangent frame vectors as input features (tau_y/z gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -352,9 +352,15 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        use_tangent_frame: bool = False,
+        predict_tau_local_frame: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
+        self.use_tangent_frame = use_tangent_frame
+        self.predict_tau_local_frame = predict_tau_local_frame
+        if use_tangent_frame:
+            surface_input_dim = surface_input_dim + 6  # +t1(3) +t2(3)
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
@@ -433,6 +439,14 @@ class SurfaceTransolver(nn.Module):
         surface_tokens = 0
         volume_tokens = 0
 
+        n_hat: torch.Tensor | None = None
+        t1: torch.Tensor | None = None
+        t2: torch.Tensor | None = None
+        if surface_x is not None and self.use_tangent_frame:
+            normals = surface_x[..., 3:6]
+            n_hat, t1, t2 = compute_tangent_frame(normals)
+            surface_x = torch.cat([surface_x, t1, t2], dim=-1)
+
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
             tokens.append(
@@ -472,7 +486,29 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            if (
+                self.predict_tau_local_frame
+                and n_hat is not None
+                and t1 is not None
+                and t2 is not None
+            ):
+                # Output channels 1-3 are interpreted as (tau_t1, tau_t2, tau_n) in
+                # the local frame; rotate back to global Cartesian (tau_x, tau_y, tau_z).
+                # Channel 0 (surface_pressure) is left untouched.
+                cp_pred = surface_preds[..., 0:1]
+                tau_local = surface_preds[..., 1:4]
+                tau_t1 = tau_local[..., 0:1]
+                tau_t2 = tau_local[..., 1:2]
+                tau_n = tau_local[..., 2:3]
+                tau_global = (
+                    tau_t1 * t1.to(tau_local.dtype)
+                    + tau_t2 * t2.to(tau_local.dtype)
+                    + tau_n * n_hat.to(tau_local.dtype)
+                )
+                extra = surface_preds[..., 4:]  # in case output_dim > 4
+                surface_preds = torch.cat([cp_pred, tau_global, extra], dim=-1)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -582,6 +618,8 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    use_tangent_frame: bool = False
+    predict_tau_local_frame: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -765,6 +803,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        use_tangent_frame=config.use_tangent_frame,
+        predict_tau_local_frame=config.predict_tau_local_frame,
     )
 
 
@@ -1354,6 +1394,31 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
     dot = (vec_f * n_hat).sum(dim=-1, keepdim=True)
     return (vec_f - dot * n_hat).to(vec.dtype)
+
+
+def compute_tangent_frame(
+    normals: torch.Tensor, near_parallel_dot: float = 0.9
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a deterministic orthonormal tangent frame (n, t1, t2) from per-point normals.
+
+    Uses the standard Gram-Schmidt construction `t1 = normalize(n x ref)` with
+    `ref = [0, 1, 0]`, falling back to `[1, 0, 0]` where n is near-parallel to
+    the reference (|n.ref| > 0.9) to avoid degenerate crosses. fp32 internally
+    for bf16 stability. Returns (n_hat, t1, t2) all matching the input dtype.
+    """
+    normals_f = normals.float()
+    n_hat = F.normalize(normals_f, dim=-1, eps=1e-8)
+    primary = torch.zeros_like(n_hat)
+    primary[..., 1] = 1.0  # [0, 1, 0]
+    fallback = torch.zeros_like(n_hat)
+    fallback[..., 0] = 1.0  # [1, 0, 0]
+    dot = (n_hat * primary).sum(dim=-1, keepdim=True).abs()
+    ref = torch.where(dot > near_parallel_dot, fallback, primary)
+    t1 = torch.linalg.cross(n_hat, ref)
+    t1 = t1 / (t1.norm(dim=-1, keepdim=True) + 1e-8)
+    t2 = torch.linalg.cross(n_hat, t1)
+    t2 = t2 / (t2.norm(dim=-1, keepdim=True) + 1e-8)
+    return n_hat.to(normals.dtype), t1.to(normals.dtype), t2.to(normals.dtype)
 
 
 def train_loss(


### PR DESCRIPTION
# Surface-Tangent Frame Vectors as Input Features (tau_y/z Gap Fix)

## Hypothesis

The dominant failure mode of the current SOTA is cross-flow wall shear: `wall_shear_y` is 2.53× above the AB-UPT target and `wall_shear_z` is 2.88× above. A diagnostic run (PR #363) confirmed that surface points with theta~86° (nearly horizontal surfaces facing the cross-flow direction) produce errors 2.21× higher on tau_y compared to other orientations.

**Root cause:** When predicting tau in global Cartesian coordinates, the model must resolve near-zero cross-flow shear components from a mix of x/y/z signals — a low signal-to-noise problem. The geometry is always available (normal vector already in input), but the model cannot easily decompose the prediction into flow-parallel and cross-flow components without explicit guidance.

**Fix:** Compute two orthonormal tangent vectors `t1`, `t2` for each surface point from the existing surface normal `n`, and append them as 6 additional input features. This gives the model an explicit local coordinate frame: it can learn to attend to the t1/t2 directions when predicting tau_y/z, dramatically reducing the ambiguity.

Two arms:
- **Arm A**: Tangent vectors as extra input features only (no output rotation) — simplest change, tests whether the coordinate hint alone is sufficient
- **Arm B**: Tangent vectors as input features + predict tau in the local frame (tau_t1, tau_t2, tau_n) and rotate back to global at output — closes the loop for equivariance

## Current Baseline

| Metric | Baseline (PR #311) | AB-UPT Target | Gap |
|--------|-------------------|---------------|-----|
| val_abupt (primary) | **7.546%** | — | merge bar |
| test_abupt | 8.771% | — | — |
| surface_pressure_rel_l2_pct | 4.485% | 3.82% | 1.17× |
| wall_shear_rel_l2_pct | 8.227% | 7.29% | 1.13× |
| wall_shear_y_rel_l2_pct | 9.233% | 3.65% | **2.53×** |
| wall_shear_z_rel_l2_pct | 10.449% | 3.63% | **2.88×** |
| volume_pressure_rel_l2_pct | 12.438% | 6.08% | 2.05× |

Baseline W&B run: `gcwx9yaa` (PR #311, edward, STRING-separable PE)

## Implementation Instructions

### Step 1: Add tangent vector computation to the dataset loader

In `data/loader.py`, after the surface normals are loaded into `surface_x`, compute tangent vectors and append them. The `surface_x` tensor has shape `[N, 7]` (xyz + normals + area). You will augment it to shape `[N, 13]` (xyz + normals + area + t1_xyz + t2_xyz).

Add a function to compute the tangent frame:

```python
def compute_tangent_frame(normals: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
    """
    Compute two orthonormal tangent vectors for each surface point.
    normals: [N, 3] unit normal vectors
    Returns: t1 [N, 3], t2 [N, 3]
    """
    # Use [0, 1, 0] as the reference vector; fall back to [1, 0, 0] for degenerate cases
    ref = torch.zeros_like(normals)
    ref[:, 1] = 1.0  # [0, 1, 0]
    
    # Detect near-parallel cases: |dot(n, ref)| > 0.9
    dot = (normals * ref).sum(dim=-1, keepdim=True).abs()
    fallback = torch.zeros_like(normals)
    fallback[:, 0] = 1.0  # [1, 0, 0]
    ref = torch.where(dot > 0.9, fallback, ref)
    
    # t1 = normalize(n x ref)
    t1 = torch.linalg.cross(normals, ref)
    t1 = t1 / (t1.norm(dim=-1, keepdim=True) + 1e-8)
    
    # t2 = n x t1  (already unit length since n and t1 are orthonormal)
    t2 = torch.linalg.cross(normals, t1)
    t2 = t2 / (t2.norm(dim=-1, keepdim=True) + 1e-8)
    
    return t1, t2
```

Then in the data loading path where `surface_x` is assembled, call this function on the normals slice and concatenate:

```python
# After surface_x is loaded (shape [N, 7])
normals = surface_x[:, 3:6]  # columns 3,4,5 are nx, ny, nz
t1, t2 = compute_tangent_frame(normals)
surface_x = torch.cat([surface_x, t1, t2], dim=-1)  # now [N, 13]
```

Update the constant at the top of `loader.py`:
```python
SURFACE_X_DIM = 13  # xyz(3) + normals(3) + panel area(1) + t1(3) + t2(3)
```

### Step 2: Arm B — Local frame output prediction (optional second arm)

For Arm B, add a flag `--predict-tau-local-frame` to `train.py`. When enabled:

1. **Output head**: predict 3 components in local frame: `(tau_t1, tau_t2, tau_n)` instead of `(tau_x, tau_y, tau_z)`.

2. **Rotation back to global**: During forward pass on surface points, after the output head, rotate local predictions back to global Cartesian:
   ```python
   # t1, t2, n are [B, N, 3] tensors (from surface_x columns 7-9, 10-12, 3-5)
   tau_global = tau_t1.unsqueeze(-1) * t1 + tau_t2.unsqueeze(-1) * t2 + tau_n.unsqueeze(-1) * n
   ```
   where `tau_t1`, `tau_t2`, `tau_n` are the 3 output channels.

3. The loss is computed against the global-frame ground truth as normal (no change to loss function).

**Note:** If implementing Arm B significantly complicates the code, skip it and report only Arm A results. The tangent input features alone may be sufficient.

### Step 3: Training configuration

Use the STRING-separable PE baseline config (from PR #311). Both arms should use identical hyperparameters:

```bash
# Arm A: tangent vectors as input features only
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --wandb-group surface-tangent-wallshear-head \
  --wandb-name arm-a-tangent-input-only \
  --seed 42

# Arm B: tangent vectors as input + local-frame output rotation
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --predict-tau-local-frame \
  --wandb-group surface-tangent-wallshear-head \
  --wandb-name arm-b-tangent-input-localframe \
  --seed 42
```

**Note on STRING-separable PE flags:** Check whether PR #311's flags (per-axis `log_freq` and `phase` parameters) are already in the `yi` base branch — they should be since that PR was merged. If the flags are `--use-string-pe` or similar, add them to both commands. Check `python train.py --help` for the exact flags.

Also check if Lion optimizer flags are available (`--optimizer lion` etc.) — if so, add `--optimizer lion --lr 1e-4` (Lion trains best at lower lr than AdamW).

## What to Report

For each arm, report per-epoch (in a table):
- `val_abupt` (primary metric — must beat **7.546%** to merge)
- `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` (the target gap)
- `surface_pressure_rel_l2_pct` (regression check)
- `volume_pressure_rel_l2_pct`
- W&B run ID

Also report the best epoch test metrics using `--eval-only` on the best val checkpoint.

If val_abupt is diverging or stuck above 20% by epoch 2, kill the run and report.

## Suggested follow-ups (if time permits)

If Arm A works (beats baseline), try adding the tangent vectors to the **positional encoding** as well, not just as MLP features.

If neither arm beats baseline but tau_y/z errors decrease meaningfully (~20%+), consider combining with `--use-tangential-wallshear-loss` flag already in the codebase.
