### PR TITLE
feat: STRING-separable learnable positional encoding on yi branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch>=0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -25,11 +25,13 @@ from pathlib import Path
 from typing import Iterable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import wandb
 import yaml
-from torch.utils.data import DataLoader
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
 
 from data import (
@@ -600,7 +602,9 @@ class Config:
     debug: bool = False
     seed: int = -1
     lr_warmup_steps: int = 0
+    lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    optimizer: str = "adamw"
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -697,6 +701,10 @@ def resolve_num_workers(config: Config) -> int:
 
 def make_loaders(
     config: Config,
+    *,
+    is_distributed: bool = False,
+    world_size: int = 1,
+    rank: int = 0,
 ) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
     train_ds, val_splits, test_splits, stats = load_data(
         manifest_path=config.manifest,
@@ -716,12 +724,23 @@ def make_loaders(
     if num_workers > 0:
         loader_kwargs["persistent_workers"] = config.persistent_workers
         loader_kwargs["prefetch_factor"] = config.prefetch_factor
-    train_loader = DataLoader(
-        train_ds,
-        batch_size=config.batch_size,
-        shuffle=True,
-        **loader_kwargs,
-    )
+    if is_distributed:
+        train_sampler = DistributedSampler(
+            train_ds, num_replicas=world_size, rank=rank, shuffle=True, drop_last=False
+        )
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=config.batch_size,
+            sampler=train_sampler,
+            **loader_kwargs,
+        )
+    else:
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=config.batch_size,
+            shuffle=True,
+            **loader_kwargs,
+        )
     val_loaders = {
         name: DataLoader(ds, batch_size=config.batch_size, shuffle=False, **loader_kwargs)
         for name, ds in val_splits.items()
@@ -1680,22 +1699,43 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
 
 def main(argv: Iterable[str] | None = None) -> None:
     config = parse_args(argv)
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    rank = int(os.environ.get("RANK", "0"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_distributed = world_size > 1
+    is_main = rank == 0
+    if is_distributed:
+        dist.init_process_group(backend="nccl")
+        torch.cuda.set_device(local_rank)
     if config.seed >= 0:
         import random
 
         import numpy as np
 
-        random.seed(config.seed)
-        np.random.seed(config.seed)
-        torch.manual_seed(config.seed)
-        torch.cuda.manual_seed_all(config.seed)
+        random.seed(config.seed + rank)
+        np.random.seed(config.seed + rank)
+        torch.manual_seed(config.seed + rank)
+        torch.cuda.manual_seed_all(config.seed + rank)
     kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
     max_epochs = min(config.epochs, 3) if config.debug else config.epochs
     timeout_minutes = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30"))
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Device: {device}" + (" [DEBUG]" if config.debug else ""))
+    if is_distributed:
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if is_main:
+        print(
+            f"Device: {device}"
+            + (" [DEBUG]" if config.debug else "")
+            + (f" [DDP world_size={world_size}]" if is_distributed else "")
+        )
 
-    train_loader, val_loaders, test_loaders, stats = make_loaders(config)
+    train_loader, val_loaders, test_loaders, stats = make_loaders(
+        config,
+        is_distributed=is_distributed,
+        world_size=world_size,
+        rank=rank,
+    )
     transform = TargetTransform(
         surface_y_mean=stats["surface_y_mean"].to(device),
         surface_y_std=stats["surface_y_std"].to(device),
@@ -1707,13 +1747,51 @@ def main(argv: Iterable[str] | None = None) -> None:
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
-    print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+    if is_main:
+        print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+    if is_distributed:
+        train_model = DistributedDataParallel(
+            model,
+            device_ids=[local_rank],
+            output_device=local_rank,
+            find_unused_parameters=False,
+        )
+    else:
+        train_model = model
+
+    optimizer_name = config.optimizer.lower()
+    if optimizer_name == "adamw":
+        optimizer = torch.optim.AdamW(
+            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+        )
+    elif optimizer_name == "lion":
+        from lion_pytorch import Lion
+
+        optimizer = Lion(
+            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+        )
+    else:
+        raise ValueError(
+            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion'."
+        )
+    if is_main:
+        print(
+            f"Optimizer: {optimizer.__class__.__name__} "
+            f"lr={config.lr} wd={config.weight_decay}"
+        )
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
-    if kill_thresholds:
+    effective_warmup_steps = config.lr_warmup_steps
+    if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
+        effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+    if is_main and effective_warmup_steps > 0:
+        print(
+            f"LR warmup: {effective_warmup_steps} steps "
+            f"(start_lr={config.lr_warmup_start_lr} -> peak_lr={config.lr})"
+        )
+    if is_main and kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
     val_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1735,8 +1813,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             "surface_targets": SURFACE_TARGET_NAMES,
             "volume_targets": VOLUME_TARGET_NAMES,
             "total_estimated_steps": total_estimated_steps,
+            "ddp_world_size": world_size,
+            "ddp_effective_batch_size": config.batch_size * world_size,
+            "lr_warmup_steps_effective": effective_warmup_steps,
         },
-        mode=os.environ.get("WANDB_MODE", "online"),
+        mode=(
+            os.environ.get("WANDB_MODE", "online") if is_main else "disabled"
+        ),
     )
     wandb.define_metric("global_step")
     wandb.define_metric("train/*", step_metric="global_step")
@@ -1769,11 +1852,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
     output_dir = Path(config.output_dir) / f"run-{run.id}"
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if is_main:
+        output_dir.mkdir(parents=True, exist_ok=True)
     model_path = output_dir / "checkpoint.pt"
     config_path = output_dir / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.safe_dump(asdict(config), f)
+    if is_main:
+        with config_path.open("w") as f:
+            yaml.safe_dump(asdict(config), f)
+    if is_distributed:
+        dist.barrier()
 
     best_val = float("inf")
     best_metrics: dict[str, float] = {}
@@ -1787,19 +1874,27 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
-            print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
+            if is_main:
+                print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
             break
 
+        if is_distributed and isinstance(train_loader.sampler, DistributedSampler):
+            train_loader.sampler.set_epoch(epoch)
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()
         t0 = time.time()
-        model.train()
+        train_model.train()
         train_loss_sum = 0.0
         n_batches = 0
 
-        for batch in tqdm(train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False):
+        train_iter = train_loader
+        if is_main:
+            train_iter = tqdm(
+                train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
+            )
+        for batch in train_iter:
             loss, batch_loss_metrics = train_loss(
-                model,
+                train_model,
                 batch,
                 transform,
                 device,
@@ -1872,14 +1967,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 global_step += 1
                 continue
-            if config.lr_warmup_steps > 0:
-                if global_step < config.lr_warmup_steps:
+            if effective_warmup_steps > 0:
+                if global_step < effective_warmup_steps:
                     warmup_lr = config.lr_warmup_start_lr + (
                         config.lr - config.lr_warmup_start_lr
-                    ) * (global_step / config.lr_warmup_steps)
+                    ) * (global_step / effective_warmup_steps)
                     for pg in optimizer.param_groups:
                         pg["lr"] = warmup_lr
-                elif global_step == config.lr_warmup_steps:
+                elif global_step == effective_warmup_steps:
                     for pg in optimizer.param_groups:
                         pg["lr"] = config.lr
             optimizer.step()
@@ -1988,12 +2083,14 @@ def main(argv: Iterable[str] | None = None) -> None:
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
             wandb.log(log_metrics)
-            print(
-                f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
-                f"train_loss={epoch_train_loss:.5f}"
-            )
+            if is_main:
+                print(
+                    f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                    f"train_loss={epoch_train_loss:.5f}"
+                )
+                if early_stop_reason is not None:
+                    print(early_stop_reason)
             if early_stop_reason is not None:
-                print(early_stop_reason)
                 break
             continue
 
@@ -2048,38 +2145,42 @@ def main(argv: Iterable[str] | None = None) -> None:
         if improved:
             best_val = primary_val
             best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}
-            save_model = model
-            if ema is not None:
-                ema.store(model)
-                ema.copy_to(model)
-                save_model = model
-            torch.save(
-                {
-                    "model": save_model.state_dict(),
-                    "config": asdict(config),
-                    "epoch": epoch + 1,
-                    "val_metrics": val_metrics,
-                },
-                model_path,
-            )
-            if ema is not None:
-                ema.restore(model)
+            if is_main:
+                if ema is not None:
+                    ema.store(model)
+                    ema.copy_to(model)
+                torch.save(
+                    {
+                        "model": model.state_dict(),
+                        "config": asdict(config),
+                        "epoch": epoch + 1,
+                        "val_metrics": val_metrics,
+                    },
+                    model_path,
+                )
+                if ema is not None:
+                    ema.restore(model)
+        if is_distributed:
+            dist.barrier()
 
         tag = " *" if improved else ""
-        print(
-            f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
-            f"train_loss={epoch_train_loss:.5f} "
-            f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
-        )
-        print_metrics("val_surface", val_metrics["val_surface"])
+        if is_main:
+            print(
+                f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                f"train_loss={epoch_train_loss:.5f} "
+                f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
+            )
+            print_metrics("val_surface", val_metrics["val_surface"])
+            if early_stop_reason is not None:
+                print(early_stop_reason)
         if early_stop_reason is not None:
-            print(early_stop_reason)
             break
         if timeout_hit:
             break
 
     total_minutes = (time.time() - train_start) / 60.0
-    print(f"\nTraining done in {total_minutes:.1f} min")
+    if is_main:
+        print(f"\nTraining done in {total_minutes:.1f} min")
 
     if early_stop_reason is not None:
         wandb.summary.update(
@@ -2091,19 +2192,27 @@ def main(argv: Iterable[str] | None = None) -> None:
             }
         )
         wandb.finish()
+        if is_distributed:
+            dist.destroy_process_group()
         return
 
     if not best_metrics:
-        print("No validation checkpoint was saved.")
+        if is_main:
+            print("No validation checkpoint was saved.")
         wandb.finish()
+        if is_distributed:
+            dist.destroy_process_group()
         return
 
+    if is_distributed:
+        dist.barrier()
     checkpoint = torch.load(model_path, map_location=device, weights_only=True)
     model.load_state_dict(checkpoint["model"])
-    print(
-        f"Best val: epoch {int(best_metrics['epoch'])}, "
-        f"abupt_axis_mean_rel_l2_pct={best_metrics['abupt_axis_mean_rel_l2_pct']:.4f}"
-    )
+    if is_main:
+        print(
+            f"Best val: epoch {int(best_metrics['epoch'])}, "
+            f"abupt_axis_mean_rel_l2_pct={best_metrics['abupt_axis_mean_rel_l2_pct']:.4f}"
+        )
     wandb.summary.update(
         {
             "best_epoch": int(best_metrics["epoch"]),
@@ -2147,7 +2256,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     wandb.log(full_val_log)
     wandb.summary.update(_numeric_metric_items(full_val_log))
-    print_metrics("full_val", full_val_metrics["val_surface"])
+    if is_main:
+        print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
         name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
@@ -2181,18 +2291,22 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     wandb.log(test_log)
     wandb.summary.update(_numeric_metric_items(test_log))
-    print_metrics("test_surface", test_metrics["test_surface"])
+    if is_main:
+        print_metrics("test_surface", test_metrics["test_surface"])
 
-    log_model_artifact(
-        run=run,
-        model_path=model_path,
-        config_path=config_path,
-        config=config,
-        best_metrics=best_metrics,
-        test_metrics=test_metrics,
-        n_params=n_params,
-    )
+    if is_main:
+        log_model_artifact(
+            run=run,
+            model_path=model_path,
+            config_path=config_path,
+            config=config,
+            best_metrics=best_metrics,
+            test_metrics=test_metrics,
+            n_params=n_params,
+        )
     wandb.finish()
+    if is_distributed:
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -1851,7 +1851,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
-    output_dir = Path(config.output_dir) / f"run-{run.id}"
+    if is_distributed:
+        run_id_holder = [run.id if is_main else None]
+        dist.broadcast_object_list(run_id_holder, src=0)
+        shared_run_id = run_id_holder[0]
+    else:
+        shared_run_id = run.id
+    output_dir = Path(config.output_dir) / f"run-{shared_run_id}"
     if is_main:
         output_dir.mkdir(parents=True, exist_ok=True)
     model_path = output_dir / "checkpoint.pt"

--- a/train.py
+++ b/train.py
@@ -100,11 +100,18 @@ class LinearProjection(nn.Module):
 
 
 class ContinuousSincosEmbed(nn.Module):
-    def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
+    def __init__(
+        self,
+        hidden_dim: int,
+        input_dim: int,
+        max_wavelength: int = 10_000,
+        learnable: bool = False,
+    ):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
         self.max_wavelength = max_wavelength
+        self.learnable = learnable
         padding = hidden_dim % input_dim
         dim_per_axis = (hidden_dim - padding) // input_dim
         sincos_padding = dim_per_axis % 2
@@ -113,11 +120,24 @@ class ContinuousSincosEmbed(nn.Module):
         if effective_dim_per_axis <= 0:
             raise ValueError("hidden_dim must be large enough for the requested input dimension")
         arange = torch.arange(0, effective_dim_per_axis, 2, dtype=torch.float32)
-        self.register_buffer("omega", 1.0 / max_wavelength ** (arange / effective_dim_per_axis))
+        init_omega = 1.0 / max_wavelength ** (arange / effective_dim_per_axis)
+        if self.learnable:
+            init_log_omega = torch.log(init_omega)
+            self.log_freq = nn.Parameter(
+                init_log_omega.unsqueeze(0).expand(input_dim, -1).clone()
+            )
+            self.phase = nn.Parameter(torch.zeros(input_dim, len(arange)))
+        else:
+            self.register_buffer("omega", init_omega)
 
     def forward(self, coords: torch.Tensor) -> torch.Tensor:
         coords = coords.float()
-        out = coords.unsqueeze(-1) * self.omega
+        if self.learnable:
+            omega = torch.exp(self.log_freq)
+            out = coords.unsqueeze(-1) * omega
+            out = out + self.phase
+        else:
+            out = coords.unsqueeze(-1) * self.omega
         emb = torch.cat([torch.sin(out), torch.cos(out)], dim=-1)
         emb = emb.flatten(start_dim=-2)
         if self.padding > 0:
@@ -352,6 +372,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        learnable_pe: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -364,11 +385,13 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.learnable_pe = learnable_pe
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
             input_dim=space_dim,
             max_wavelength=pos_max_wavelength,
+            learnable=learnable_pe,
         )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -581,6 +604,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    learnable_pe: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -764,6 +788,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        learnable_pe=config.learnable_pe,
     )
 
 


### PR DESCRIPTION
# STRING-Separable Learnable Positional Encoding on Yi Branch

## Hypothesis

The current yi SOTA (`val_abupt 7.546%`, PR #311, `gcwx9yaa`) was achieved by replacing
the fixed sincos position encoding with a **STRING-separable learnable PE** — per-axis
frequencies with learnable `log_freq` and `phase` parameters. However, PR #311 was
implemented and merged into the **`tay` branch**, not `yi`. The `yi` branch still uses
the original `ContinuousSincosEmbed` with a fixed `omega` buffer.

**Root cause of the gap:** The fixed sincos PE uses a single shared frequency sweep
across all three spatial axes. Aerodynamic point clouds have highly anisotropic structure:
the streamwise (x) dimension spans the full car length while the cross-section (y, z)
dimensions are much smaller. Fixed isotropic frequencies are a mismatch — the model
cannot independently tune how it resolves each axis.

**Fix:** Replace the fixed `omega` buffer with learnable `nn.Parameter` `log_freq` and
`phase` tensors — one scalar per frequency bin per axis. The model then auto-adjusts the
frequency spectrum for each axis during training, attending differently to streamwise vs.
cross-flow spatial scales. This is the known-best architectural improvement from the tay
research track.

**What to implement:** Modify `ContinuousSincosEmbed` in `train.py` to add an optional
`learnable=True` mode. When enabled, replace:
```python
self.register_buffer("omega", 1.0 / max_wavelength ** (arange / effective_dim_per_axis))
```
with:
```python
self.log_freq = nn.Parameter(
    torch.log(1.0 / max_wavelength ** (arange / effective_dim_per_axis))
    .unsqueeze(0).expand(input_dim, -1).clone()
)  # shape: [input_dim, num_freqs]
self.phase = nn.Parameter(torch.zeros(input_dim, len(arange)))  # shape: [input_dim, num_freqs]
```

And in `forward`, replace the fixed omega multiplication with per-axis learnable:
```python
def forward(self, coords: torch.Tensor) -> torch.Tensor:
    coords = coords.float()  # [..., input_dim]
    if self.learnable:
        omega = torch.exp(self.log_freq)  # [input_dim, num_freqs]
        # coords: [..., input_dim], omega: [input_dim, num_freqs]
        out = coords.unsqueeze(-1) * omega  # [..., input_dim, num_freqs]
        out = out + self.phase  # add per-axis phase offset
    else:
        out = coords.unsqueeze(-1) * self.omega  # original fixed path
    emb = torch.cat([torch.sin(out), torch.cos(out)], dim=-1)
    emb = emb.flatten(start_dim=-2)
    if self.padding > 0:
        padding = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
        emb = torch.cat([emb, padding], dim=-1)
    return emb
```

Add a CLI flag `--learnable-pe` (boolean, default=False) that sets `learnable=True`
on the `ContinuousSincosEmbed` constructor.

**Two arms:**
- **Arm A (control):** Fixed sincos PE, `pos-max-wavelength=1000` (yi current best from PR #183) — confirms yi reproducibility
- **Arm B (STRING-sep):** Learnable PE via `--learnable-pe`, same `pos-max-wavelength=1000`

## Current Baseline

| Metric | Baseline (PR #311, tay) | AB-UPT Target | Gap |
|--------|------------------------|---------------|-----|
| val_abupt (primary) | **7.546%** | — | merge bar |
| test_abupt | 8.771% | — | — |
| surface_pressure_rel_l2_pct | 4.485% | 3.82% | 1.17× |
| wall_shear_rel_l2_pct | 8.227% | 7.29% | 1.13× |
| wall_shear_y_rel_l2_pct | 9.233% | 3.65% | 2.53× |
| wall_shear_z_rel_l2_pct | 10.449% | 3.63% | 2.88× |
| volume_pressure_rel_l2_pct | 12.438% | 6.08% | 2.05× |

Baseline W&B run: `gcwx9yaa` (PR #311, edward, tay branch)

## Implementation Instructions

### Step 1: Modify `ContinuousSincosEmbed` in `train.py`

Add `learnable: bool = False` to the `__init__` signature. When `learnable=True`:
1. Store `self.learnable = learnable` and `self.input_dim = input_dim`.
2. Compute `arange` and `effective_dim_per_axis` as before (same padding logic).
3. Instead of `register_buffer("omega", ...)`, register two learnable parameters:
   ```python
   init_log_omega = torch.log(1.0 / max_wavelength ** (arange / effective_dim_per_axis))
   # init_log_omega shape: [num_freqs]  — same as fixed omega, just logged
   self.log_freq = nn.Parameter(
       init_log_omega.unsqueeze(0).expand(input_dim, -1).clone()
   )  # [input_dim, num_freqs]
   self.phase = nn.Parameter(torch.zeros(input_dim, len(arange)))  # [input_dim, num_freqs]
   ```
4. When `learnable=False`, keep the original fixed buffer path unchanged.

In `forward`, branch on `self.learnable`:
```python
def forward(self, coords: torch.Tensor) -> torch.Tensor:
    coords = coords.float()
    if self.learnable:
        omega = torch.exp(self.log_freq)         # [input_dim, num_freqs]
        out = coords.unsqueeze(-1) * omega        # [..., input_dim, num_freqs]
        out = out + self.phase                    # phase shift per axis/freq
    else:
        out = coords.unsqueeze(-1) * self.omega   # original fixed path
    emb = torch.cat([torch.sin(out), torch.cos(out)], dim=-1)  # [..., input_dim, 2*num_freqs]
    emb = emb.flatten(start_dim=-2)
    if self.padding > 0:
        padding = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
        emb = torch.cat([emb, padding], dim=-1)
    return emb
```

### Step 2: Add `--learnable-pe` CLI flag to `train.py`

In the argument parser section, add:
```python
parser.add_argument("--learnable-pe", action="store_true", default=False,
                    help="Use learnable per-axis log_freq and phase in positional encoding (STRING-sep)")
```

Pass `learnable=config.learnable_pe` when constructing `ContinuousSincosEmbed`.

### Step 3: Training configuration

Both arms use the same yi base config (4L/512d/8h/128sl). No Lion optimizer in yi —
use AdamW (hardcoded in train.py). The `--lr-warmup-steps 100` option sets a linear
warmup from `lr-warmup-start-lr` to `lr` over the first 100 steps.

```bash
# Arm A: fixed sincos PE (control — confirm yi reproducibility)
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --pos-max-wavelength 1000 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --wandb-group string-sep-pe-yi \
  --wandb-name arm-a-fixed-sincos-control \
  --seed 42

# Arm B: STRING-separable learnable PE
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --pos-max-wavelength 1000 \
  --learnable-pe \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --wandb-group string-sep-pe-yi \
  --wandb-name arm-b-string-sep-learnable-pe \
  --seed 42
```

**Note on wallshear weights:** Using `--wallshear-y-weight 2.0 --wallshear-z-weight 2.0`
from PR #66 as the base upweighting — these are already in the yi merge history.

**Note on `--clip-grad-norm 0.5`:** From PR #309 (thorfinn) which is part of the yi
compounding wins leading to the current baseline.

### Step 4: Reporting

For each arm, report a per-epoch table:
- `val_abupt` (primary — must beat **7.546%** to merge)
- `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct`
- `surface_pressure_rel_l2_pct`
- `volume_pressure_rel_l2_pct`
- W&B run ID

Also check whether `learned log_freq` and `phase` parameters have moved meaningfully
from their initialisation — if `log_freq.grad.norm()` is near zero, the gradients
aren't flowing through the PE, which would indicate a bug.

If val_abupt is diverging or stuck above 20% by epoch 2, kill the run and report.

After finding the best val checkpoint, run `--eval-only` to get test metrics.

## What success looks like

Arm B beats Arm A by at least 0.5pp on val_abupt, consistent with the tay result
where STRING-sep PE yielded −2.16pp vs fixed sincos. If Arm B also beats the PR #311
SOTA (7.546%), that means STRING-sep PE + yi-specific compounding wins (grad-clip,
wallshear upweighting) together produce a new best.

## Suggested follow-ups

If Arm B beats baseline, try also initialising `phase` from a random uniform U(0, 2π)
rather than zeros — this may help with symmetry breaking during the initial training steps.
