### PR TITLE
feat: Dual-stream Transformer with cross-attention bridge on yi

### DIFF
--- a/train.py
+++ b/train.py
@@ -235,41 +235,154 @@ class TransformerBlock(nn.Module):
         return x
 
 
-class CrossAttentionBlock(nn.Module):
-    """Lightweight cross-attention bridge between surface and volume streams.
+class CrossAttentionBridge(nn.Module):
+    """One-directional cross-stream attention via a register-token bottleneck.
 
-    Each stream uses standard multi-head attention to read from the other
-    stream's hidden states. Output is gated by a learnable `tanh(g)` scalar
-    initialised at 0 so cross-stream contribution starts at zero and the
-    gradient signal can gradually open the bridge.
+    Two-pass design (Perceiver / Set Transformer / DINOv3 registers):
+      Pass 1: K learned register tokens attend to source tokens
+              (registers=Q, source=K/V) -> registers summarise the source.
+      Pass 2: target tokens attend to the summarised registers
+              (target=Q, registers=K/V) -> per-token cross-stream delta.
+
+    Complexity is O((N_source + N_target) * K), avoiding O(N^2) over raw
+    65k-token streams. Output is gated by `tanh(gate)` initialised at 0, so
+    the bridge contributes nothing at init and gradient on the gate gradually
+    opens it.
     """
 
-    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_registers: int = 128,
+        dropout: float = 0.0,
+    ):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.num_heads = num_heads
-        self.norm_surf_q = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.norm_vol_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.surf_to_vol = nn.MultiheadAttention(
+        self.num_registers = int(num_registers)
+        # Learnable register tokens, shaped [1, K, D].
+        self.registers = nn.Parameter(
+            torch.randn(1, self.num_registers, hidden_dim) * 0.02
+        )
+        # Pass 1: registers (Q) attend to source (K/V).
+        self.norm_reg_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_src_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.attn_reg_from_src = nn.MultiheadAttention(
             embed_dim=hidden_dim,
             num_heads=num_heads,
             dropout=dropout,
             batch_first=True,
         )
-        self.norm_vol_q = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.norm_surf_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.vol_to_surf = nn.MultiheadAttention(
+        # Pass 2: target (Q) attends to registers (K/V).
+        self.norm_tgt_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_reg_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.attn_tgt_from_reg = nn.MultiheadAttention(
             embed_dim=hidden_dim,
             num_heads=num_heads,
             dropout=dropout,
             batch_first=True,
         )
-        # Zero-init residual gates -> tanh(0)=0 -> cross-attn contributes 0 at init.
-        self.surf_gate = nn.Parameter(torch.zeros(1))
-        self.vol_gate = nn.Parameter(torch.zeros(1))
+        # Zero-init residual gate -> bridge contributes 0 at init.
+        self.gate = nn.Parameter(torch.zeros(1))
 
-    def _has_tokens(self, mask: torch.Tensor) -> bool:
-        return mask.shape[1] > 0 and bool(mask.any())
+    def forward(
+        self,
+        source: torch.Tensor,        # [B, N_src, D]
+        target: torch.Tensor,        # [B, N_tgt, D]
+        source_mask: torch.Tensor,   # [B, N_src] 1=valid
+        target_mask: torch.Tensor,   # [B, N_tgt] 1=valid
+    ) -> torch.Tensor:
+        batch_size = source.shape[0]
+        registers = self.registers.expand(batch_size, -1, -1).contiguous()
+
+        # Pass 1: registers attend to source tokens.
+        # nn.MultiheadAttention key_padding_mask: True = ignore.
+        src_key_pad = ~source_mask.bool()
+        # Guard rows where every source token is padding -- MHA returns NaN if
+        # a query attends to a fully-masked KV. Disable padding for those rows;
+        # the gate is zero-init so any noise is multiplied to ~0 anyway.
+        all_pad_rows = src_key_pad.all(dim=-1)
+        if bool(all_pad_rows.any()):
+            src_key_pad = src_key_pad.clone()
+            src_key_pad[all_pad_rows] = False
+
+        reg_q = self.norm_reg_q(registers)
+        src_kv = self.norm_src_kv(source)
+        reg_summary, _ = self.attn_reg_from_src(
+            reg_q, src_kv, src_kv,
+            key_padding_mask=src_key_pad,
+            need_weights=False,
+        )
+        registers = registers + reg_summary  # residual on registers
+
+        # Pass 2: target attends to registers (always valid -- no padding mask).
+        tgt_q = self.norm_tgt_q(target)
+        reg_kv = self.norm_reg_kv(registers)
+        tgt_delta, _ = self.attn_tgt_from_reg(
+            tgt_q, reg_kv, reg_kv,
+            need_weights=False,
+        )
+        target = target + self.gate.tanh() * tgt_delta
+        target = _apply_token_mask(target, target_mask)
+        return target
+
+
+class CrossAttentionBlock(nn.Module):
+    """Bi-directional register-token cross-attention bridge.
+
+    Holds two `CrossAttentionBridge` modules: one for surface<-volume and one
+    for volume<-surface. Each direction owns its own learned register tokens,
+    so the two streams' summaries do not have to share a representation space.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_registers: int = 128,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.num_registers = int(num_registers)
+        # surface receives information from volume
+        self.vol_to_surf = CrossAttentionBridge(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_registers=num_registers,
+            dropout=dropout,
+        )
+        # volume receives information from (post-update) surface
+        self.surf_to_vol = CrossAttentionBridge(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_registers=num_registers,
+            dropout=dropout,
+        )
+
+    @property
+    def surf_gate(self) -> torch.Tensor:
+        return self.vol_to_surf.gate
+
+    @property
+    def vol_gate(self) -> torch.Tensor:
+        return self.surf_to_vol.gate
+
+    def _touch_all_params(self) -> torch.Tensor:
+        """DDP-safe no-op: 0-valued tensor with grad path through every parameter.
+
+        Needed because some DrivAerML batches have surface_views < volume_views
+        (or vice-versa), so a batch can arrive with N_surface=0 or N_volume=0.
+        In that case MHA cannot run; we skip the bridge but must still register
+        each parameter as "used" or DDP find_unused_parameters=False will error.
+        """
+        accum = None
+        for p in self.parameters():
+            term = p.sum()
+            accum = term if accum is None else accum + term
+        return accum * 0.0 if accum is not None else torch.zeros((), device=next(self.parameters()).device)
 
     def forward(
         self,
@@ -278,69 +391,26 @@ class CrossAttentionBlock(nn.Module):
         surf_mask: torch.Tensor,
         vol_mask: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        surf_has = self._has_tokens(surf_mask)
-        vol_has = self._has_tokens(vol_mask)
-
-        # Without keys/values on one side, attention is undefined — skip the
-        # bridge. We still touch all parameters via a 0-multiplied dummy pass
-        # so DDP / autograd see every gate even when this batch happens to be
-        # surface-only or volume-only.
-        if not (surf_has and vol_has):
-            zero = (
-                self.surf_gate.sum() * 0.0
-                + self.vol_gate.sum() * 0.0
-            )
+        # Empty-stream guard: if either modality has 0 tokens (e.g. a view-count
+        # mismatch in the DrivAerML loader), MHA cannot run on a 0-length axis.
+        if surf.shape[1] == 0 or vol.shape[1] == 0:
+            zero = self._touch_all_params()
             return surf + zero, vol + zero
 
-        # nn.MultiheadAttention key_padding_mask convention: True = ignore.
-        surf_key_pad = ~surf_mask.bool()
-        vol_key_pad = ~vol_mask.bool()
-        # Guard fully-padded query rows: nn.MultiheadAttention returns NaN when
-        # a query attends to a fully-masked key set. Disable padding for any
-        # row that has no valid keys (the corresponding query rows are
-        # themselves padding and will be re-zeroed by the post-call mask
-        # multiplication).
-        if bool(vol_key_pad.all(dim=-1).any()):
-            all_pad_rows = vol_key_pad.all(dim=-1)
-            vol_key_pad = vol_key_pad.clone()
-            vol_key_pad[all_pad_rows] = False
-        if bool(surf_key_pad.all(dim=-1).any()):
-            all_pad_rows = surf_key_pad.all(dim=-1)
-            surf_key_pad = surf_key_pad.clone()
-            surf_key_pad[all_pad_rows] = False
-
-        surf_q = self.norm_surf_q(surf)
-        vol_kv = self.norm_vol_kv(vol)
-        # nn.MultiheadAttention does not support bf16 autocast on all paths;
-        # cast to fp32 internally to avoid silent NaNs and let DropPath/EMA see
-        # finite values in the residual.
-        surf_q_f = surf_q.float()
-        vol_kv_f = vol_kv.float()
-        surf_delta, _ = self.surf_to_vol(
-            surf_q_f, vol_kv_f, vol_kv_f,
-            key_padding_mask=vol_key_pad,
-            need_weights=False,
+        # Surface pulls a summary of the volume stream.
+        surf = self.vol_to_surf(
+            source=vol,
+            target=surf,
+            source_mask=vol_mask,
+            target_mask=surf_mask,
         )
-        surf_delta = surf_delta.to(surf.dtype)
-        surf = surf + self.surf_gate.tanh() * surf_delta
-        surf = _apply_token_mask(surf, surf_mask)
-
-        vol_q = self.norm_vol_q(vol)
-        # use the *updated* surf as the KV source for vol_to_surf — this matches
-        # the deterministic ordering described in the PR (surface receives,
-        # then volume reads from the post-update surface).
-        surf_kv = self.norm_surf_kv(surf)
-        vol_q_f = vol_q.float()
-        surf_kv_f = surf_kv.float()
-        vol_delta, _ = self.vol_to_surf(
-            vol_q_f, surf_kv_f, surf_kv_f,
-            key_padding_mask=surf_key_pad,
-            need_weights=False,
+        # Volume pulls a summary of the (just-updated) surface stream.
+        vol = self.surf_to_vol(
+            source=surf,
+            target=vol,
+            source_mask=surf_mask,
+            target_mask=vol_mask,
         )
-        vol_delta = vol_delta.to(vol.dtype)
-        vol = vol + self.vol_gate.tanh() * vol_delta
-        vol = _apply_token_mask(vol, vol_mask)
-
         return surf, vol
 
 
@@ -458,6 +528,7 @@ class DualStreamTransformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         cross_attn_every: int = 2,
+        cross_attn_registers: int = 128,
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
     ):
@@ -470,6 +541,7 @@ class DualStreamTransformer(nn.Module):
             ]
         self.depth = depth
         self.cross_attn_every = max(1, int(cross_attn_every))
+        self.cross_attn_registers = int(cross_attn_registers)
 
         self.surface_blocks = nn.ModuleList(
             [
@@ -503,6 +575,7 @@ class DualStreamTransformer(nn.Module):
                 CrossAttentionBlock(
                     hidden_dim=hidden_dim,
                     num_heads=num_heads,
+                    num_registers=self.cross_attn_registers,
                     dropout=dropout,
                 )
                 for _ in range(num_bridges)
@@ -551,6 +624,7 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         use_dual_stream: bool = False,
         cross_attn_every: int = 2,
+        cross_attn_registers: int = 128,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -565,6 +639,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_max_wavelength = pos_max_wavelength
         self.use_dual_stream = bool(use_dual_stream)
         self.cross_attn_every = int(cross_attn_every)
+        self.cross_attn_registers = int(cross_attn_registers)
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -599,6 +674,7 @@ class SurfaceTransolver(nn.Module):
                 mlp_expansion_factor=mlp_ratio,
                 num_slices=slice_num,
                 cross_attn_every=self.cross_attn_every,
+                cross_attn_registers=self.cross_attn_registers,
                 dropout=dropout,
                 stochastic_depth_prob=stochastic_depth_prob,
             )
@@ -859,6 +935,7 @@ class Config:
     pos_max_wavelength: int = 1000
     use_dual_stream: bool = False
     cross_attn_every: int = 2
+    cross_attn_registers: int = 128
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -1044,6 +1121,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_max_wavelength=config.pos_max_wavelength,
         use_dual_stream=config.use_dual_stream,
         cross_attn_every=config.cross_attn_every,
+        cross_attn_registers=config.cross_attn_registers,
     )
 
 
@@ -1400,6 +1478,35 @@ def slope_source_metrics(metrics: dict[str, object]) -> dict[str, float]:
     )
     numeric = _numeric_metric_items(metrics)
     return {key: value for key, value in numeric.items() if any(word in key for word in keywords)}
+
+
+def collect_cross_attn_gate_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-bridge tanh(gate) magnitudes — sanity check that bridges open over time."""
+
+    base_model = getattr(model, "_orig_mod", model)
+    backbone = getattr(base_model, "backbone", None)
+    bridges = getattr(backbone, "cross_attn_bridges", None)
+    if bridges is None:
+        return {}
+    metrics: dict[str, float] = {}
+    abs_values: list[float] = []
+    for idx, bridge in enumerate(bridges):
+        for name, mod in (
+            ("vol_to_surf", getattr(bridge, "vol_to_surf", None)),
+            ("surf_to_vol", getattr(bridge, "surf_to_vol", None)),
+        ):
+            if mod is None:
+                continue
+            gate = getattr(mod, "gate", None)
+            if gate is None:
+                continue
+            value = float(gate.detach().tanh().item())
+            metrics[f"train/cross_attn/bridge_{idx}/{name}/tanh_gate"] = value
+            abs_values.append(abs(value))
+    if abs_values:
+        metrics["train/cross_attn/tanh_gate_abs_mean"] = sum(abs_values) / len(abs_values)
+        metrics["train/cross_attn/tanh_gate_abs_max"] = max(abs_values)
+    return metrics
 
 
 class MetricSlopeTracker:
@@ -2324,6 +2431,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_loss_sum += float(loss.detach().cpu().item())
             n_batches += 1
             global_step += 1
+            cross_attn_gate_metrics = (
+                collect_cross_attn_gate_metrics(model)
+                if config.use_dual_stream and should_log_weights
+                else {}
+            )
             train_log: dict[str, object] = {
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
@@ -2337,6 +2449,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
+                **cross_attn_gate_metrics,
             }
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[

--- a/train.py
+++ b/train.py
@@ -806,11 +806,11 @@ class SurfaceTransolver(nn.Module):
             surface_tokens = surf_h.shape[1] if surf_h is not None else 0
             volume_tokens = vol_h.shape[1] if vol_h is not None else 0
             surface_hidden = (
-                hidden_norm[:, :surface_tokens] if surface_tokens > 0 else None
+                hidden_norm[:, :surface_tokens] if surf_h is not None else None
             )
             volume_hidden = (
                 hidden_norm[:, surface_tokens : surface_tokens + volume_tokens]
-                if volume_tokens > 0
+                if vol_h is not None
                 else None
             )
 

--- a/train.py
+++ b/train.py
@@ -233,6 +233,115 @@ class TransformerBlock(nn.Module):
         return x
 
 
+class CrossAttentionBlock(nn.Module):
+    """Lightweight cross-attention bridge between surface and volume streams.
+
+    Each stream uses standard multi-head attention to read from the other
+    stream's hidden states. Output is gated by a learnable `tanh(g)` scalar
+    initialised at 0 so cross-stream contribution starts at zero and the
+    gradient signal can gradually open the bridge.
+    """
+
+    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.0):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.norm_surf_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_vol_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.surf_to_vol = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.norm_vol_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_surf_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.vol_to_surf = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+        # Zero-init residual gates -> tanh(0)=0 -> cross-attn contributes 0 at init.
+        self.surf_gate = nn.Parameter(torch.zeros(1))
+        self.vol_gate = nn.Parameter(torch.zeros(1))
+
+    def _has_tokens(self, mask: torch.Tensor) -> bool:
+        return mask.shape[1] > 0 and bool(mask.any())
+
+    def forward(
+        self,
+        surf: torch.Tensor,
+        vol: torch.Tensor,
+        surf_mask: torch.Tensor,
+        vol_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        surf_has = self._has_tokens(surf_mask)
+        vol_has = self._has_tokens(vol_mask)
+
+        # Without keys/values on one side, attention is undefined — skip the
+        # bridge. We still touch all parameters via a 0-multiplied dummy pass
+        # so DDP / autograd see every gate even when this batch happens to be
+        # surface-only or volume-only.
+        if not (surf_has and vol_has):
+            zero = (
+                self.surf_gate.sum() * 0.0
+                + self.vol_gate.sum() * 0.0
+            )
+            return surf + zero, vol + zero
+
+        # nn.MultiheadAttention key_padding_mask convention: True = ignore.
+        surf_key_pad = ~surf_mask.bool()
+        vol_key_pad = ~vol_mask.bool()
+        # Guard fully-padded query rows: nn.MultiheadAttention returns NaN when
+        # a query attends to a fully-masked key set. Disable padding for any
+        # row that has no valid keys (the corresponding query rows are
+        # themselves padding and will be re-zeroed by the post-call mask
+        # multiplication).
+        if bool(vol_key_pad.all(dim=-1).any()):
+            all_pad_rows = vol_key_pad.all(dim=-1)
+            vol_key_pad = vol_key_pad.clone()
+            vol_key_pad[all_pad_rows] = False
+        if bool(surf_key_pad.all(dim=-1).any()):
+            all_pad_rows = surf_key_pad.all(dim=-1)
+            surf_key_pad = surf_key_pad.clone()
+            surf_key_pad[all_pad_rows] = False
+
+        surf_q = self.norm_surf_q(surf)
+        vol_kv = self.norm_vol_kv(vol)
+        # nn.MultiheadAttention does not support bf16 autocast on all paths;
+        # cast to fp32 internally to avoid silent NaNs and let DropPath/EMA see
+        # finite values in the residual.
+        surf_q_f = surf_q.float()
+        vol_kv_f = vol_kv.float()
+        surf_delta, _ = self.surf_to_vol(
+            surf_q_f, vol_kv_f, vol_kv_f,
+            key_padding_mask=vol_key_pad,
+            need_weights=False,
+        )
+        surf_delta = surf_delta.to(surf.dtype)
+        surf = surf + self.surf_gate.tanh() * surf_delta
+        surf = _apply_token_mask(surf, surf_mask)
+
+        vol_q = self.norm_vol_q(vol)
+        # use the *updated* surf as the KV source for vol_to_surf — this matches
+        # the deterministic ordering described in the PR (surface receives,
+        # then volume reads from the post-update surface).
+        surf_kv = self.norm_surf_kv(surf)
+        vol_q_f = vol_q.float()
+        surf_kv_f = surf_kv.float()
+        vol_delta, _ = self.vol_to_surf(
+            vol_q_f, surf_kv_f, surf_kv_f,
+            key_padding_mask=surf_key_pad,
+            need_weights=False,
+        )
+        vol_delta = vol_delta.to(vol.dtype)
+        vol = vol + self.vol_gate.tanh() * vol_delta
+        vol = _apply_token_mask(vol, vol_mask)
+
+        return surf, vol
+
+
 class GeomEncoder(nn.Module):
     """Mean-pooled MLP encoder over surface points to a per-case geometry token."""
 
@@ -329,6 +438,94 @@ class Transformer(nn.Module):
         return x
 
 
+class DualStreamTransformer(nn.Module):
+    """Two parallel Transformer stacks (surface + volume) with cross-attention bridges.
+
+    Each stream owns its own per-layer TransformerBlock list (independent
+    Transolver slice budgets, independent MLPs, independent LayerNorms).
+    A `CrossAttentionBlock` is inserted after every `cross_attn_every`
+    Transformer blocks so the two streams can exchange information without
+    contaminating their own slice representations.
+    """
+
+    def __init__(
+        self,
+        depth: int,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        num_slices: int,
+        cross_attn_every: int = 2,
+        dropout: float = 0.0,
+        stochastic_depth_prob: float = 0.0,
+    ):
+        super().__init__()
+        if depth <= 1:
+            drop_path_rates = [stochastic_depth_prob] * depth
+        else:
+            drop_path_rates = [
+                stochastic_depth_prob * i / (depth - 1) for i in range(depth)
+            ]
+        self.depth = depth
+        self.cross_attn_every = max(1, int(cross_attn_every))
+
+        self.surface_blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    mlp_expansion_factor=mlp_expansion_factor,
+                    num_slices=num_slices,
+                    dropout=dropout,
+                    drop_path_prob=drop_path_rates[i],
+                )
+                for i in range(depth)
+            ]
+        )
+        self.volume_blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    mlp_expansion_factor=mlp_expansion_factor,
+                    num_slices=num_slices,
+                    dropout=dropout,
+                    drop_path_prob=drop_path_rates[i],
+                )
+                for i in range(depth)
+            ]
+        )
+        num_bridges = depth // self.cross_attn_every
+        self.cross_attn_bridges = nn.ModuleList(
+            [
+                CrossAttentionBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    dropout=dropout,
+                )
+                for _ in range(num_bridges)
+            ]
+        )
+
+    def forward(
+        self,
+        surf: torch.Tensor,
+        vol: torch.Tensor,
+        surf_mask: torch.Tensor,
+        vol_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        bridge_idx = 0
+        for i in range(self.depth):
+            surf = self.surface_blocks[i](surf, attn_mask=surf_mask)
+            vol = self.volume_blocks[i](vol, attn_mask=vol_mask)
+            if (i + 1) % self.cross_attn_every == 0 and bridge_idx < len(self.cross_attn_bridges):
+                surf, vol = self.cross_attn_bridges[bridge_idx](
+                    surf, vol, surf_mask, vol_mask
+                )
+                bridge_idx += 1
+        return surf, vol
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -350,6 +547,8 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        use_dual_stream: bool = False,
+        cross_attn_every: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,6 +561,8 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.use_dual_stream = bool(use_dual_stream)
+        self.cross_attn_every = int(cross_attn_every)
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -383,17 +584,39 @@ class SurfaceTransolver(nn.Module):
             if use_film
             else None
         )
-        self.backbone = Transformer(
-            depth=n_layers,
-            hidden_dim=n_hidden,
-            num_heads=n_head,
-            mlp_expansion_factor=mlp_ratio,
-            num_slices=slice_num,
-            dropout=dropout,
-            stochastic_depth_prob=stochastic_depth_prob,
-            film_geom_dim=film_encoder_dim if use_film else 0,
-        )
-        self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        if self.use_dual_stream:
+            if use_film:
+                raise ValueError(
+                    "use_dual_stream and use_film are not currently compatible "
+                    "(dual stream backbone does not consume FiLM tokens)."
+                )
+            self.backbone = DualStreamTransformer(
+                depth=n_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                cross_attn_every=self.cross_attn_every,
+                dropout=dropout,
+                stochastic_depth_prob=stochastic_depth_prob,
+            )
+            self.surface_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.volume_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.norm = None
+        else:
+            self.backbone = Transformer(
+                depth=n_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                stochastic_depth_prob=stochastic_depth_prob,
+                film_geom_dim=film_encoder_dim if use_film else 0,
+            )
+            self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.surface_norm = None
+            self.volume_norm = None
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
@@ -426,67 +649,119 @@ class SurfaceTransolver(nn.Module):
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
 
-        tokens: list[torch.Tensor] = []
-        masks: list[torch.Tensor] = []
-        surface_tokens = 0
-        volume_tokens = 0
-
+        surf_h: torch.Tensor | None = None
+        vol_h: torch.Tensor | None = None
         if surface_x is not None:
-            surface_tokens = surface_x.shape[1]
-            tokens.append(
+            surf_h = _apply_token_mask(
                 self._encode_group(
                     surface_x,
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
-                )
+                ),
+                surface_mask,
             )
-            masks.append(surface_mask)
-
         if volume_x is not None:
-            volume_tokens = volume_x.shape[1]
-            tokens.append(
+            vol_h = _apply_token_mask(
                 self._encode_group(
                     volume_x,
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
-                )
+                ),
+                volume_mask,
             )
-            masks.append(volume_mask)
 
-        attn_mask = torch.cat(masks, dim=1)
-        hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
         geom_token: torch.Tensor | None = None
         if self.use_film and self.geom_encoder is not None and surface_x is not None:
             geom_token = self.geom_encoder(surface_x, surface_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask, geom_token=geom_token)
-        hidden = _apply_token_mask(hidden, attn_mask)
-        hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
-        cursor = 0
-        surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
-        cursor += surface_tokens
-        volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+        if self.use_dual_stream:
+            if surface_x is not None and volume_x is not None:
+                surf_out, vol_out = self.backbone(
+                    surf_h, vol_h, surface_mask, volume_mask
+                )
+            elif surface_x is not None:
+                surf_out = surf_h
+                for blk in self.backbone.surface_blocks:
+                    surf_out = blk(surf_out, attn_mask=surface_mask)
+                vol_out = None
+            else:
+                vol_out = vol_h
+                for blk in self.backbone.volume_blocks:
+                    vol_out = blk(vol_out, attn_mask=volume_mask)
+                surf_out = None
 
-        if surface_x is not None:
+            surface_hidden = (
+                _apply_token_mask(self.surface_norm(surf_out), surface_mask)
+                if surf_out is not None
+                else None
+            )
+            volume_hidden = (
+                _apply_token_mask(self.volume_norm(vol_out), volume_mask)
+                if vol_out is not None
+                else None
+            )
+            # Reconstruct a concatenated hidden for downstream consumers
+            # (loss/metrics only read surface_preds / volume_preds, but we
+            # preserve the dict-shape contract from the single-stream path).
+            hidden_chunks: list[torch.Tensor] = []
+            if surface_hidden is not None:
+                hidden_chunks.append(surface_hidden)
+            if volume_hidden is not None:
+                hidden_chunks.append(volume_hidden)
+            hidden_norm = torch.cat(hidden_chunks, dim=1) if hidden_chunks else surf_h
+        else:
+            tokens: list[torch.Tensor] = []
+            masks: list[torch.Tensor] = []
+            if surf_h is not None:
+                tokens.append(surf_h)
+                masks.append(surface_mask)
+            if vol_h is not None:
+                tokens.append(vol_h)
+                masks.append(volume_mask)
+            attn_mask = torch.cat(masks, dim=1)
+            hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
+            hidden = self.backbone(hidden, attn_mask=attn_mask, geom_token=geom_token)
+            hidden = _apply_token_mask(hidden, attn_mask)
+            hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
+            surface_tokens = surf_h.shape[1] if surf_h is not None else 0
+            volume_tokens = vol_h.shape[1] if vol_h is not None else 0
+            surface_hidden = (
+                hidden_norm[:, :surface_tokens] if surface_tokens > 0 else None
+            )
+            volume_hidden = (
+                hidden_norm[:, surface_tokens : surface_tokens + volume_tokens]
+                if volume_tokens > 0
+                else None
+            )
+
+        if surface_hidden is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
-            surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+            surface_preds = (
+                volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+                if volume_hidden is not None
+                else hidden_norm.new_zeros(batch_size, 0, self.surface_output_dim)
+            )
 
-        if volume_x is not None:
+        if volume_hidden is not None:
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
-            volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+            volume_preds = (
+                surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+                if surface_hidden is not None
+                else hidden_norm.new_zeros(batch_size, 0, self.volume_output_dim)
+            )
 
         result = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
-            "hidden": hidden,
-            "surface_hidden": surface_hidden,
-            "volume_hidden": volume_hidden,
+            "hidden": hidden_norm,
+            "surface_hidden": surface_hidden if surface_hidden is not None else hidden_norm.new_zeros(0),
+            "volume_hidden": volume_hidden if volume_hidden is not None else hidden_norm.new_zeros(0),
         }
         if geom_token is not None:
             result["geom_token"] = geom_token
@@ -579,6 +854,8 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    use_dual_stream: bool = False
+    cross_attn_every: int = 2
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -745,6 +1022,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        use_dual_stream=config.use_dual_stream,
+        cross_attn_every=config.cross_attn_every,
     )
 
 


### PR DESCRIPTION
# Dual-Stream Transformer with Cross-Attention Bridge

## Hypothesis

The current `SurfaceTransolver` concatenates surface and volume tokens into a single
sequence and passes them through one shared Transformer backbone. With 4 layers and
128 slices, the slice assignments (physics tokens) must simultaneously serve two
very different physical regimes: boundary-layer surface aerodynamics and far-field
volume pressure. The surface branch's wall shear predictions (tau_y/z at 2.53× and
2.88× above target) are the dominant failure mode.

**Root cause:** When surface and volume tokens share a single Transformer, they
compete for the same physics-token (slice) budget. The `TransolverAttention` learns
a soft assignment of tokens to slices, but a slice cannot simultaneously represent
fine-grained near-wall boundary layer variation AND coarse far-field pressure
gradients. The surface tokens get "diluted" by the volume tokens, preventing the
model from developing specialized surface representations.

**Fix:** Replace the single shared backbone with two separate `Transformer` stacks
(surface stream and volume stream) with a **cross-attention bridge** inserted between
them every `--cross-attn-every` layers. The cross-attention allows each stream to
condition on the other's hidden states without contaminating its own slice
representations.

The architecture is:
```
surface_tokens → [SurfaceTransformer layers] ← cross-attn from volume
volume_tokens  → [VolumeTransformer layers]  ← cross-attn from surface
```

Each domain keeps its own slice budget. Cross-attention is lightweight (standard
multi-head attention, not Transolver-style slicing).

This is directly analogous to the dual-encoder architecture that won the SE(2)-
equivariant geometry experiment in the wandb/senpai noam/radford track — separate
encoders with cross-domain communication proved superior to a single shared encoder.

## Current Baseline

| Metric | Baseline (PR #311) | AB-UPT Target | Gap |
|--------|-------------------|---------------|-----|
| val_abupt (primary) | **7.546%** | — | merge bar |
| test_abupt | 8.771% | — | — |
| surface_pressure_rel_l2_pct | 4.485% | 3.82% | 1.17× |
| wall_shear_rel_l2_pct | 8.227% | 7.29% | 1.13× |
| wall_shear_y_rel_l2_pct | 9.233% | 3.65% | **2.53×** |
| wall_shear_z_rel_l2_pct | 10.449% | 3.63% | **2.88×** |
| volume_pressure_rel_l2_pct | 12.438% | 6.08% | 2.05× |

Baseline W&B run: `gcwx9yaa` (PR #311, edward, STRING-sep PE + yi compounding wins)

## Implementation Instructions

### Step 1: Add `CrossAttention` module to `train.py`

After the `TransformerBlock` class (around line 233), add a new module:

```python
class CrossAttentionBlock(nn.Module):
    """Lightweight cross-attention between surface and volume streams.
    
    Each stream attends to the other as key-value source.
    Uses standard multi-head attention (not Transolver slicing).
    """
    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.0):
        super().__init__()
        self.hidden_dim = hidden_dim
        self.num_heads = num_heads
        # Surface attends to volume
        self.norm_surf_q = nn.LayerNorm(hidden_dim, eps=1e-6)
        self.norm_vol_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
        self.surf_to_vol = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            dropout=dropout,
            batch_first=True,
        )
        # Volume attends to surface
        self.norm_vol_q = nn.LayerNorm(hidden_dim, eps=1e-6)
        self.norm_surf_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
        self.vol_to_surf = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            dropout=dropout,
            batch_first=True,
        )
        # Scale cross-attention contribution — residual gating
        self.surf_gate = nn.Parameter(torch.zeros(1))
        self.vol_gate = nn.Parameter(torch.zeros(1))

    def forward(
        self,
        surf: torch.Tensor,       # [B, Ns, D]
        vol: torch.Tensor,        # [B, Nv, D]
        surf_mask: torch.Tensor,  # [B, Ns] 1=valid
        vol_mask: torch.Tensor,   # [B, Nv] 1=valid
    ) -> tuple[torch.Tensor, torch.Tensor]:
        # Build key padding masks for nn.MultiheadAttention
        # (True means IGNORE — opposite of our convention)
        surf_key_pad = ~surf_mask.bool()  # [B, Ns]
        vol_key_pad = ~vol_mask.bool()    # [B, Nv]

        # Surface queries → volume keys/values
        surf_q = self.norm_surf_q(surf)
        vol_kv = self.norm_vol_kv(vol)
        surf_delta, _ = self.surf_to_vol(
            surf_q, vol_kv, vol_kv,
            key_padding_mask=vol_key_pad,
        )
        surf = surf + self.surf_gate.tanh() * surf_delta

        # Volume queries → surface keys/values
        vol_q = self.norm_vol_q(vol)
        surf_kv = self.norm_surf_kv(surf)
        vol_delta, _ = self.vol_to_surf(
            vol_q, surf_kv, surf_kv,
            key_padding_mask=surf_key_pad,
        )
        vol = vol + self.vol_gate.tanh() * vol_delta

        return surf, vol
```

**Key design choices:**
- Zero-initialized gates (`surf_gate`, `vol_gate`) → tanh(0)=0 → cross-attention is
  zero at init. Training gradually opens the gates, providing a stable residual path.
- Separate layer norms for query and key/value of each direction — prevents scale
  mismatch between streams.
- Standard `nn.MultiheadAttention` (not Transolver slicing) — cross-stream
  communication should be dense/global, not physics-token-based.

### Step 2: Add `DualStreamTransformer` class to `train.py`

After the `Transformer` class (around line 330), add:

```python
class DualStreamTransformer(nn.Module):
    """Two separate Transformer streams (surface + volume) with cross-attention bridges.
    
    Args:
        depth: number of Transformer blocks per stream
        hidden_dim: token dimension
        num_heads: attention heads (both self-attention and cross-attention)
        mlp_expansion_factor: MLP hidden = hidden_dim * factor
        num_slices: slice count for TransolverAttention
        cross_attn_every: insert cross-attention bridge every N layers (default 2)
        dropout: dropout probability
        stochastic_depth_prob: max stochastic depth drop rate
    """
    def __init__(
        self,
        depth: int,
        hidden_dim: int,
        num_heads: int,
        mlp_expansion_factor: int | float,
        num_slices: int,
        cross_attn_every: int = 2,
        dropout: float = 0.0,
        stochastic_depth_prob: float = 0.0,
    ):
        super().__init__()
        if depth <= 1:
            drop_path_rates = [stochastic_depth_prob] * depth
        else:
            drop_path_rates = [
                stochastic_depth_prob * i / (depth - 1) for i in range(depth)
            ]
        self.depth = depth
        self.cross_attn_every = cross_attn_every

        self.surface_blocks = nn.ModuleList([
            TransformerBlock(
                hidden_dim=hidden_dim,
                num_heads=num_heads,
                mlp_expansion_factor=mlp_expansion_factor,
                num_slices=num_slices,
                dropout=dropout,
                drop_path_prob=drop_path_rates[i],
            )
            for i in range(depth)
        ])
        self.volume_blocks = nn.ModuleList([
            TransformerBlock(
                hidden_dim=hidden_dim,
                num_heads=num_heads,
                mlp_expansion_factor=mlp_expansion_factor,
                num_slices=num_slices,
                dropout=dropout,
                drop_path_prob=drop_path_rates[i],
            )
            for i in range(depth)
        ])
        # Cross-attention bridges: one after every `cross_attn_every` layers
        num_bridges = depth // cross_attn_every
        self.cross_attn_bridges = nn.ModuleList([
            CrossAttentionBlock(hidden_dim=hidden_dim, num_heads=num_heads, dropout=dropout)
            for _ in range(num_bridges)
        ])

    def forward(
        self,
        surf: torch.Tensor,       # [B, Ns, D]
        vol: torch.Tensor,        # [B, Nv, D]
        surf_mask: torch.Tensor,  # [B, Ns]
        vol_mask: torch.Tensor,   # [B, Nv]
    ) -> tuple[torch.Tensor, torch.Tensor]:
        bridge_idx = 0
        for i in range(self.depth):
            surf = self.surface_blocks[i](surf, attn_mask=surf_mask)
            vol = self.volume_blocks[i](vol, attn_mask=vol_mask)
            # Apply cross-attention bridge every `cross_attn_every` layers
            if (i + 1) % self.cross_attn_every == 0 and bridge_idx < len(self.cross_attn_bridges):
                surf, vol = self.cross_attn_bridges[bridge_idx](surf, vol, surf_mask, vol_mask)
                bridge_idx += 1
        return surf, vol
```

### Step 3: Add `--use-dual-stream` and `--cross-attn-every` flags to `Config`

In the `Config` dataclass (around line 549), add:
```python
use_dual_stream: bool = False
cross_attn_every: int = 2
```

These auto-generate CLI flags `--use-dual-stream` and `--cross-attn-every N`.

### Step 4: Modify `SurfaceTransolver.__init__` to support dual-stream mode

In `SurfaceTransolver.__init__`, replace the single `self.backbone = Transformer(...)` with:

```python
if getattr(config, 'use_dual_stream', False):
    # This branch won't be used here — instead pass use_dual_stream as a param
    pass
```

Actually, add `use_dual_stream: bool = False` and `cross_attn_every: int = 2` to
`SurfaceTransolver.__init__`'s signature, then:

```python
if use_dual_stream:
    self.backbone = DualStreamTransformer(
        depth=n_layers,
        hidden_dim=n_hidden,
        num_heads=n_head,
        mlp_expansion_factor=mlp_ratio,
        num_slices=slice_num,
        cross_attn_every=cross_attn_every,
        dropout=dropout,
        stochastic_depth_prob=stochastic_depth_prob,
    )
else:
    self.backbone = Transformer(
        depth=n_layers,
        hidden_dim=n_hidden,
        num_heads=n_head,
        mlp_expansion_factor=mlp_ratio,
        num_slices=slice_num,
        dropout=dropout,
        stochastic_depth_prob=stochastic_depth_prob,
        film_geom_dim=film_encoder_dim if use_film else 0,
    )
self.use_dual_stream = use_dual_stream
```

Also add two separate `nn.LayerNorm` heads for dual stream (the shared `self.norm` won't work when processing streams separately):

```python
if use_dual_stream:
    self.surface_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    self.volume_norm = nn.LayerNorm(n_hidden, eps=1e-6)
```

### Step 5: Modify `SurfaceTransolver.forward` for dual-stream path

In `SurfaceTransolver.forward`, after encoding surface and volume tokens separately
(already done in `_encode_group`), add a branch:

```python
if self.use_dual_stream:
    # Run dual-stream transformer
    # Handle cases where one modality is absent (rare in practice)
    if surface_x is not None and volume_x is not None:
        surf_hidden, vol_hidden = self.backbone(
            surf_h, vol_h, surface_mask, volume_mask
        )
        surf_hidden = _apply_token_mask(self.surface_norm(surf_hidden), surface_mask)
        vol_hidden = _apply_token_mask(self.volume_norm(vol_hidden), volume_mask)
    elif surface_x is not None:
        # Volume absent — fall back to surface-only single-stream
        surf_hidden = surf_h
        for blk, xblk in zip(self.backbone.surface_blocks, self.backbone.volume_blocks):
            surf_hidden = blk(surf_hidden, attn_mask=surface_mask)
        surf_hidden = _apply_token_mask(self.surface_norm(surf_hidden), surface_mask)
        vol_hidden = surf_hidden.new_zeros(surf_hidden.shape[0], 0, surf_hidden.shape[-1])
    else:
        # Surface absent — volume only
        vol_hidden = vol_h
        for blk in self.backbone.volume_blocks:
            vol_hidden = blk(vol_hidden, attn_mask=volume_mask)
        vol_hidden = _apply_token_mask(self.volume_norm(vol_hidden), volume_mask)
        surf_hidden = vol_hidden.new_zeros(vol_hidden.shape[0], 0, vol_hidden.shape[-1])
    # surface_preds and volume_preds output remain the same
    ...
else:
    # Original single-stream path (unchanged)
    ...
```

**Tip:** Restructure the forward to separate the encoding step from the backbone
step. Store `surf_h` and `vol_h` as local variables before the backbone call so
both modes can reuse them.

The key is: in the dual-stream mode, `surface_tokens` and `volume_tokens` are now
processed by `DualStreamTransformer`, which returns them as separate tensors rather
than a single concatenated tensor. The output heads (`surface_out`, `volume_out`)
remain unchanged.

### Step 6: Update `build_model` to pass new config flags

```python
def build_model(config: Config) -> SurfaceTransolver:
    return SurfaceTransolver(
        n_layers=config.model_layers,
        n_hidden=config.model_hidden_dim,
        dropout=config.model_dropout,
        n_head=config.model_heads,
        mlp_ratio=config.model_mlp_ratio,
        slice_num=config.model_slices,
        stochastic_depth_prob=config.stochastic_depth_prob,
        use_film=config.use_film,
        film_encoder_dim=config.film_encoder_dim,
        pos_max_wavelength=config.pos_max_wavelength,
        use_dual_stream=config.use_dual_stream,
        cross_attn_every=config.cross_attn_every,
    )
```

## Parameter Budget

With `--use-dual-stream`, the model has:
- 2× single-stream TransformerBlocks (one per domain) → ~2× backbone parameters
- Cross-attention bridges: each `CrossAttentionBlock` adds ~4 * D² parameters
  (2 MHA modules with D=512, 8 heads → ~2M params per bridge for 4 layers, 2 bridges)
- Total increase: ~1.5× baseline params (backbone dominates)

To maintain a comparable parameter count with baseline, reduce `--model-layers` from 4
to 3 when using `--use-dual-stream`. At 3 layers dual-stream, the total params should
be close to 4-layer single-stream.

Alternatively, keep 4 layers and let the model be larger — the VRAM budget (4×96GB)
is not the bottleneck at 512d.

## Training Configuration

**Arm A: Control (single-stream baseline, reproducibility check)**
```bash
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --pos-max-wavelength 1000 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --wandb-group dual-stream-cross-attn-yi \
  --wandb-name arm-a-single-stream-control \
  --seed 42
```

**Arm B: Dual-stream, 4 layers, cross-attn every 2 layers (2 bridges)**
```bash
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --use-dual-stream \
  --cross-attn-every 2 \
  --pos-max-wavelength 1000 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --wandb-group dual-stream-cross-attn-yi \
  --wandb-name arm-b-dual-stream-4l-xattn-every2 \
  --seed 42
```

**Arm C (optional, if time allows): Dual-stream with reduced depth to match params**
```bash
torchrun --nproc_per_node=4 train.py \
  --epochs 10 \
  --lr 5e-4 \
  --weight-decay 1e-4 \
  --batch-size 4 \
  --model-layers 3 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --use-dual-stream \
  --cross-attn-every 1 \
  --pos-max-wavelength 1000 \
  --ema-decay 0.999 \
  --lr-warmup-steps 100 \
  --lr-warmup-start-lr 1e-6 \
  --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --wandb-group dual-stream-cross-attn-yi \
  --wandb-name arm-c-dual-stream-3l-xattn-every1 \
  --seed 42
```

Run Arm A and Arm B in parallel first. If both complete without divergence, add
Arm C to explore cross-attn frequency. Arm B is the primary test.

## Reporting

For each arm, per-epoch table:
- `val_abupt` (primary — must beat **7.546%** to merge)
- `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` (gap targets)
- `surface_pressure_rel_l2_pct`
- `volume_pressure_rel_l2_pct`
- W&B run ID

Also report:
- **Gate values**: After training, log the values of `surf_gate` and `vol_gate`
  for each cross-attention bridge. If they remain near zero, the gradients aren't
  flowing through the cross-stream path — check whether the `tanh()` activation
  provides enough gradient signal. If gates stay at 0, try initializing them at
  0.1 instead of 0.0.
- **Per-domain slice analysis**: If W&B gradient histograms show surface and volume
  blocks developing different gradient norms, that confirms domain specialization
  is happening.

If val_abupt is diverging or stuck above 20% by epoch 2, kill and report.

After finding the best val checkpoint, run `--eval-only` to get test metrics.

## What Success Looks Like

Arm B beats Arm A by ≥0.5pp on val_abupt, and specifically the
`wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` metrics decrease more than
proportionately (relative to total val_abupt improvement). This would confirm that
domain separation + cross-attention communication is the right inductive bias for
this problem.

If the cross-attention gates open significantly (|tanh(gate)| > 0.1), it confirms
that cross-domain information is actively being used, which validates the hypothesis
that the shared-backbone architecture was creating a cross-contamination bottleneck.

## Suggested Follow-ups

If Arm B beats baseline:
1. Try a **directional cross-attention** variant: surface attends to volume but
   volume does NOT attend to surface (one-directional bridge). This tests whether
   the benefit comes from the surface branch getting global pressure context, or
   from both directions.
2. Combine with **learnable PE** (PR #420, `--learnable-pe`) to stack the gains.
3. Try deeper dual-stream with `--model-layers 6` — if the parameter count concern
   is resolved, deeper domain-specific stacks may improve further.
