### PR TITLE
thorfinn: local tangent-frame input features (tau_y/tau_z context)

### DIFF
--- a/model.py
+++ b/model.py
@@ -323,10 +323,10 @@ class SurfaceTransolver(nn.Module):
         rff_sigma: float = 1.0,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_tangent_frame_features: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
-        self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
@@ -334,6 +334,13 @@ class SurfaceTransolver(nn.Module):
         self.rff_sigma = rff_sigma
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_tangent_frame_features = use_tangent_frame_features
+        # When tangent-frame features are enabled, the model augments surface
+        # inputs internally with [t1x, t1y, t1z, t2x, t2y, t2z] (6 extra dims).
+        # Volume inputs stay at their original dim — separate projections.
+        if use_tangent_frame_features:
+            surface_input_dim = surface_input_dim + 6
+        self.surface_input_dim = surface_input_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -396,6 +403,32 @@ class SurfaceTransolver(nn.Module):
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
+    @staticmethod
+    def _compute_tangent_frame(normals: torch.Tensor) -> torch.Tensor:
+        """Build a deterministic local tangent frame (t1, t2) from unit normals.
+
+        Returns a [..., 6] tensor [t1x, t1y, t1z, t2x, t2y, t2z]. Points whose
+        normal magnitude is below 1e-6 (e.g. padded slots) are returned as
+        zeros so they do not poison the projection.
+        """
+        eps_norm = 1e-6
+        eps_axis = 1e-3
+        ref_z = normals.new_tensor([0.0, 0.0, 1.0]).expand_as(normals)
+        ref_x = normals.new_tensor([1.0, 0.0, 0.0]).expand_as(normals)
+        cross_z = torch.cross(normals, ref_z, dim=-1)
+        cross_x = torch.cross(normals, ref_x, dim=-1)
+        norm_z = cross_z.norm(dim=-1, keepdim=True)
+        # Fall back to cross with x when n is nearly parallel to z
+        t1_raw = torch.where(norm_z > eps_axis, cross_z, cross_x)
+        t1 = F.normalize(t1_raw, dim=-1, eps=eps_norm)
+        t2 = torch.cross(normals, t1, dim=-1)
+        normal_mag = normals.norm(dim=-1, keepdim=True)
+        valid = normal_mag > eps_norm
+        zeros = torch.zeros_like(t1)
+        t1 = torch.where(valid, t1, zeros)
+        t2 = torch.where(valid, t2, zeros)
+        return torch.cat([t1, t2], dim=-1)
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -443,6 +476,12 @@ class SurfaceTransolver(nn.Module):
         volume_tokens = 0
 
         if surface_x is not None:
+            if self.use_tangent_frame_features:
+                # surface_x layout: [x, y, z, nx, ny, nz, area]; append the
+                # local tangent frame [t1, t2] computed from the normals.
+                normals = surface_x[..., 3:6]
+                tangent_features = self._compute_tangent_frame(normals)
+                surface_x = torch.cat([surface_x, tangent_features], dim=-1)
             surface_tokens = surface_x.shape[1]
             tokens.append(
                 self._encode_group(

--- a/train.py
+++ b/train.py
@@ -95,6 +95,7 @@ class Config:
     rff_sigma: float = 1.0
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_tangent_frame_features: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -180,6 +181,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_sigma=config.rff_sigma,
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_tangent_frame_features=config.use_tangent_frame_features,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Wall shear stress tau_y and tau_z are defined in the global Cartesian frame, but wall shear stress physics lives in the **local surface tangent frame**. The model currently receives `[x, y, z, nx, ny, nz, area]` as input and must implicitly learn the relationship between the global normal `n` and the local tangent axes `(t1, t2)` through the loss gradient. This is feasible but wasteful — the tangent frame can be **computed deterministically** from the normal and added as explicit input features.

Adding precomputed unit tangent vectors `[t1x, t1y, t1z, t2x, t2y, t2z]` gives the model the coordinate basis in which `tau_y ≈ dot(tau_vec, t1)` and `tau_z ≈ dot(tau_vec, t2)`. This targets the two largest remaining gaps: **tau_y (×2.53)** and **tau_z (×2.88)** vs AB-UPT.

**Mechanism:** Transolver's slice attention aggregates information across surface points, but the input features must encode the local geometry explicitly. The tangent frame tells the model "here is the surface's local coordinate system" — directly reducing the implicit geometric reasoning burden. FIGConvNet (NVIDIA, NeurIPS ML4PS 2025) uses local surface frame features on the same DrivAerML dataset and shows improvement on tau.

**Tangent frame construction** (stable for all normals):
```python
def compute_tangent_frame(n):  # n: [B, N, 3], unit normal
    e_z = torch.tensor([0,0,1.], device=n.device).expand_as(n)
    e_x = torch.tensor([1,0,0.], device=n.device).expand_as(n)
    # Cross with e_z; fall back to e_x for nearly vertical normals
    cross_z = torch.cross(n, e_z, dim=-1)
    cross_x = torch.cross(n, e_x, dim=-1)
    norm_z = cross_z.norm(dim=-1, keepdim=True)
    t1 = torch.where(norm_z > 1e-3, cross_z, cross_x)
    t1 = F.normalize(t1, dim=-1)
    t2 = torch.cross(n, t1, dim=-1)
    return t1, t2  # both [B, N, 3]
```

## Instructions

### Implementation

The change is in **`target/model.py`** (or wherever input features are assembled before Transolver):

1. Locate where surface features `[x, y, z, nx, ny, nz, area]` are concatenated into the input tensor `x` (look for `surface_x` or similar in the forward pass or dataset preprocessing).

2. Compute `t1, t2` from the normal columns using the function above. This is a pure compute step — no parameters added.

3. Concatenate `t1` and `t2` to the surface input features: input becomes 13-dim instead of 7-dim (`[x, y, z, nx, ny, nz, area, t1x, t1y, t1z, t2x, t2y, t2z]`).

4. **For volume points**, pad with zeros on the 6 tangent channels (volume points have no surface normal/tangent meaning). Or use a learned embedding if you find a cleaner implementation.

5. The input projection layer `Linear(7, hidden_dim)` becomes `Linear(13, hidden_dim)` — this is automatic if you resize the input.

6. Add a config flag `--use-tangent-frame-features` (bool, default `False`) to toggle this. Add to Config dataclass in train.py and pass to the model.

**IMPORTANT:** Volume points currently have normals [0,0,0] or similar. When computing tangent frame for volume points, short-circuit to zeros rather than applying the cross-product formula (which would produce NaN for zero normals). Use a surface mask or the `area > 0` indicator to separate surface vs volume.

**Verify** correct computation: for a flat horizontal surface with n=[0,0,1]:
- t1 = normalize(cross([0,0,1], [0,0,1])) → undefined → use cross with [1,0,0] fallback → t1=[0,1,0]
- t2 = cross([0,0,1], [0,1,0]) = [1,0,0]
- tau_y (spanwise) should project onto t1, tau_z (vertical-tangential) onto t2

### Launch command

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --use-tangent-frame-features \
  --wandb-group tay-thorfinn-tangent-frame \
  --wandb-name thorfinn/local-tangent-frame-pr
```

## Expected behaviour

- Input projection is wider (7→13 dim input) but all else unchanged
- Ep1-3: similar convergence to SOTA (tangent frame is a pure input feature — no architecture change)
- Diagnostic to watch: val_primary/wall_shear_y_rel_l2_pct and val_primary/wall_shear_z_rel_l2_pct — these should improve disproportionately if the tangent frame helps
- If tau_y/tau_z don't improve despite tangent frame being available, it rules out "missing geometric context" as the bottleneck → we look elsewhere (loss form, capacity)

## Baseline (PR #358, run `tkiigfmc`, EP10)

| Metric | val | notes |
|---|---:|---|
| **val_abupt** | **7.4648%** | ← merge bar |
| surface_pressure | 4.9919% | |
| volume_pressure | 4.5871% | |
| wall_shear | 8.4538% | |

Merge bar: val_abupt < **7.4648%**

AB-UPT targets (test): tau_y 3.65%, tau_z 3.63% (current ×2.53/×2.88 gaps)

Post rank-0 W&B run ID once ep1 completes.
