### PR TITLE
1-cycle LR schedule (OneCycleLR) vs cosine baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,10 @@ class Config:
     seed: int = -1
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
+    lr_schedule: str = "cosine"
+    onecycle_pct_start: float = 0.3
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1710,9 +1714,30 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    if config.lr_schedule not in ("cosine", "onecycle"):
+        raise ValueError(
+            f"Unknown lr_schedule '{config.lr_schedule}'. Must be 'cosine' or 'onecycle'."
+        )
+    if config.lr_schedule == "onecycle":
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.lr,
+            total_steps=total_estimated_steps,
+            pct_start=config.onecycle_pct_start,
+            div_factor=config.onecycle_div_factor,
+            final_div_factor=config.onecycle_final_div_factor,
+            anneal_strategy="cos",
+        )
+        print(
+            f"LR schedule: OneCycleLR(max_lr={config.lr}, total_steps={total_estimated_steps}, "
+            f"pct_start={config.onecycle_pct_start}, div_factor={config.onecycle_div_factor}, "
+            f"final_div_factor={config.onecycle_final_div_factor})"
+        )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+        print(f"LR schedule: CosineAnnealingLR(T_max={max_epochs})")
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -1872,7 +1897,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 global_step += 1
                 continue
-            if config.lr_warmup_steps > 0:
+            if config.lr_schedule != "onecycle" and config.lr_warmup_steps > 0:
                 if global_step < config.lr_warmup_steps:
                     warmup_lr = config.lr_warmup_start_lr + (
                         config.lr - config.lr_warmup_start_lr
@@ -1883,6 +1908,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for pg in optimizer.param_groups:
                         pg["lr"] = config.lr
             optimizer.step()
+            if config.lr_schedule == "onecycle":
+                scheduler.step()
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -1957,7 +1984,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if config.lr_schedule != "onecycle":
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

A **1-cycle learning rate schedule** (`torch.optim.lr_scheduler.OneCycleLR`) may improve convergence speed and final metric quality compared to the current plain cosine annealing (`CosineAnnealingLR`). This is Issue #18 directive from the human research team.

The 1-cycle schedule follows a warm-up phase where LR rises from `max_lr/div_factor` to `max_lr`, then a cosine annealing phase down to `max_lr/(div_factor * final_div_factor)`, with momentum cycling in the opposite direction (for Adam-family optimizers). Key advantages:

1. **Superconvergence**: Smith & Topin (2017) showed 1-cycle can match or exceed long cosine runs in far fewer epochs.
2. **Dynamic momentum**: The coupled LR+momentum schedule prevents the optimizer from getting stuck in flat regions.
3. **Built-in warmup**: Subsumes the current `--lr-warmup-epochs 1` effect and extends it more smoothly over `pct_start` fraction of total steps.

Reference: https://arxiv.org/abs/1708.07120 (Smith & Topin, "Super-Convergence: Very Fast Training of Neural Networks Using Large Learning Rates")

## Current Baseline

- **Merge bar**: `val_primary/abupt_axis_mean_rel_l2_pct = 7.546%` (PR #311 edward, W&B run `gcwx9yaa`)
- **Test metrics (PR #311)**:
  - `test_primary/surface_pressure_rel_l2_pct`: 4.485%
  - `test_primary/wall_shear_rel_l2_pct`: 8.227%
  - `test_primary/volume_pressure_rel_l2_pct`: 12.438%
  - `test_primary/abupt_axis_mean_rel_l2_pct`: 8.771%

## Instructions

Add a `--lr-schedule` flag to `target/train.py` that supports two values: `cosine` (current default, no behavior change) and `onecycle`.

### Step 1: Add the config field

In the `TrainConfig` dataclass (around line 598), add:

```python
lr_schedule: str = "cosine"  # choices: "cosine", "onecycle"
```

### Step 2: Add the CLI flag

In the argparse section, add:

```python
parser.add_argument("--lr-schedule", type=str, default="cosine",
                    choices=["cosine", "onecycle"],
                    help="LR schedule: cosine (default) or onecycle")
```

And map it to config: `config.lr_schedule = args.lr_schedule`

### Step 3: Replace the scheduler construction (around line 1713)

Replace:

```python
scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
```

With:

```python
if config.lr_schedule == "onecycle":
    scheduler = torch.optim.lr_scheduler.OneCycleLR(
        optimizer,
        max_lr=config.lr,
        total_steps=total_estimated_steps,
        pct_start=0.3,          # 30% of steps rising, 70% decaying
        div_factor=25.0,        # initial lr = max_lr / 25
        final_div_factor=1e4,   # final lr = max_lr / (25 * 1e4)
        anneal_strategy="cos",
    )
else:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
```

**Important:** `OneCycleLR` is a step-level scheduler — it must be stepped every batch (after `optimizer.step()`), not every epoch. The current `scheduler.step()` call that happens once per epoch needs to remain epoch-level for `cosine`, but for `onecycle` it must move to the per-batch location. The cleanest way to handle this:

Find the per-epoch `scheduler.step()` call (after the epoch training loop) and guard it:

```python
if config.lr_schedule != "onecycle":
    scheduler.step()
```

Then find the per-batch optimizer step (around line 1885) and add the onecycle step after it:

```python
optimizer.step()
if config.lr_schedule == "onecycle":
    scheduler.step()
```

**Important:** The existing `lr_warmup_steps` manual warmup loop (lines 1875-1884) must be **disabled** when `lr_schedule == "onecycle"` since OneCycleLR handles its own warmup. Guard it:

```python
if config.lr_schedule != "onecycle" and config.lr_warmup_steps > 0:
    # ... existing warmup logic
```

### Step 4: Log the LR for visibility

After the scheduler step in the per-batch section, add:

```python
wandb.log({"train/lr": optimizer.param_groups[0]["lr"], "global_step": global_step})
```

(Only needs to be done once — check if it's already logged; if so, skip.)

### Step 5: Run the experiment

Run **two arms** on a single GPU with AdamW as a fast screen:

**Arm A — Cosine baseline (control):**

```bash
python train.py \
  --agent frieren \
  --wandb-group frieren-r26-onecycle-lr-v1 \
  --wandb-name "frieren-r26-arm-a-cosine-ctrl" \
  --lr-schedule cosine \
  --optimizer adamw \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1
```

**Arm B — OneCycleLR (test):**

```bash
python train.py \
  --agent frieren \
  --wandb-group frieren-r26-onecycle-lr-v1 \
  --wandb-name "frieren-r26-arm-b-onecycle" \
  --lr-schedule onecycle \
  --optimizer adamw \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999
```

Note: Arm B does **not** pass `--lr-warmup-epochs 1` since `OneCycleLR` handles its own warm-up. Arm A retains it to match the current baseline config faithfully.

### Kill threshold

Use the standard kill threshold: `--kill-threshold "3000:val_primary/abupt_axis_mean_rel_l2_pct<25"` on both arms to avoid wasting GPU time on diverged runs.

### What to report

After training both arms, post a PR comment with:

1. W&B run IDs for both arms
2. Epoch-by-epoch `val_primary/abupt_axis_mean_rel_l2_pct` for both
3. LR curve shape from W&B (screenshot or description of `train/lr` trace)
4. Whether Arm B converges faster (same val loss at fewer steps)
5. Best val and test metrics for both arms at best-val checkpoint

The primary question is: does OneCycleLR reach a better `val_abupt` than cosine within the same epoch budget? Secondary: does it converge faster (lower loss at ep3-5)?
