### PR TITLE
senku: 5L+STRING-sep full-budget 8-GPU DDP escalation (PR #375 Arm A)

### DIFF
--- a/train.py
+++ b/train.py
@@ -636,6 +636,7 @@ class Config:
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
     pos_encoding_mode: str = "sincos"
+    max_steps_per_epoch: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -1954,7 +1955,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_iter = tqdm(
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
+        epoch_step_limit = config.max_steps_per_epoch if config.max_steps_per_epoch > 0 else None
+        epoch_step_idx = 0
         for batch in train_iter:
+            if epoch_step_limit is not None and epoch_step_idx >= epoch_step_limit:
+                break
+            epoch_step_idx += 1
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,

--- a/train.py
+++ b/train.py
@@ -126,6 +126,47 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class StringSepEmbed(nn.Module):
+    """STRING-separable axis-aligned learnable position encoding.
+
+    Drop-in replacement for ContinuousSincosEmbed: outputs the same hidden_dim
+    shape, padding, and sin/cos layout, but per-axis log-frequencies and
+    phase shifts are learnable parameters initialised from the sincos
+    omega-bank. Replicates PR #311's STRING-sep arm on the yi sincos+omega base.
+    """
+
+    def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.max_wavelength = max_wavelength
+        padding = hidden_dim % input_dim
+        dim_per_axis = (hidden_dim - padding) // input_dim
+        sincos_padding = dim_per_axis % 2
+        self.padding = padding + sincos_padding * input_dim
+        effective_dim_per_axis = (hidden_dim - self.padding) // input_dim
+        if effective_dim_per_axis <= 0:
+            raise ValueError("hidden_dim must be large enough for the requested input dimension")
+        n_features_per_axis = effective_dim_per_axis // 2
+        self.n_features_per_axis = n_features_per_axis
+        arange = torch.arange(0, effective_dim_per_axis, 2, dtype=torch.float32)
+        omega_init = 1.0 / max_wavelength ** (arange / effective_dim_per_axis)  # [F]
+        log_freq_init = torch.log(omega_init).unsqueeze(0).repeat(input_dim, 1)  # [in_dim, F]
+        self.log_freq = nn.Parameter(log_freq_init)
+        self.phase = nn.Parameter(torch.zeros(input_dim, n_features_per_axis))
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        freq = self.log_freq.exp()  # [in_dim, F]
+        proj = coords.unsqueeze(-1) * freq + self.phase  # [..., in_dim, F]
+        emb = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # [..., in_dim, 2*F]
+        emb = emb.flatten(start_dim=-2)
+        if self.padding > 0:
+            padding = torch.zeros(*emb.shape[:-1], self.padding, device=emb.device, dtype=emb.dtype)
+            emb = torch.cat([emb, padding], dim=-1)
+        return emb
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -352,6 +393,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        pos_encoding_mode: str = "sincos",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -364,12 +406,24 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.pos_encoding_mode = pos_encoding_mode
 
-        self.pos_embed = ContinuousSincosEmbed(
-            hidden_dim=n_hidden,
-            input_dim=space_dim,
-            max_wavelength=pos_max_wavelength,
-        )
+        if pos_encoding_mode == "sincos":
+            self.pos_embed = ContinuousSincosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
+        elif pos_encoding_mode == "string":
+            self.pos_embed = StringSepEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                max_wavelength=pos_max_wavelength,
+            )
+        else:
+            raise ValueError(
+                f"Unknown pos_encoding_mode: {pos_encoding_mode!r}; expected 'sincos' or 'string'"
+            )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
@@ -581,6 +635,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    pos_encoding_mode: str = "sincos"
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -764,6 +819,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        pos_encoding_mode=config.pos_encoding_mode,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Your PR #375 produced a clean causal chain: STRING-separable position encoding adds −0.66pp (4L D→C) and depth=5 adds another −0.59pp on top (C→A), totalling −1.25pp compounding improvement over the 4L/sincos control. Both effects cleared the ≥0.3pp escalation bar.

The val_abupt at 17.78% in that run was not a signal of model weakness — it was 4× undertrained: `max_steps_per_epoch=700` forced by 4-way parallel contention on a single GPU, with no 8-GPU DDP. All curves were still steeply descending (1.4pp/epoch at the last step).

PR #355 (emma) has just merged — yi now has working 8-GPU DDP. This PR escalates your best single-arm configuration (Arm A: 5L, STRING-sep, lr=5e-4, clip=1.0) to a full-budget 8-GPU DDP run against the current baseline of **7.546%** (PR #311 edward, STRING-sep on 4L/512d).

## Merge bar

- **val_primary/abupt_axis_mean_rel_l2_pct < 7.546%** (PR #311 best val)
- **test_primary/abupt_axis_mean_rel_l2_pct < 8.771%** (PR #311 best test)

## Instructions

**Step 1: Get the STRING-sep code**

Your PR #375 branch was deleted. The STRING-sep implementation you wrote (512-dim drop-in, 85 features/axis) is the right one to use here. Two options:

a) Copy your implementation from the history in your local git: `git log --all | grep 375` then cherry-pick the diff onto a fresh yi base.

b) Reference PR #420 (fern, branch `fern/string-sep-pe-yi`): fern has implemented STRING-separable PE on yi as well. Cherry-pick their STRING-sep commit, or read their diff and apply the same changes to `train.py`. The critical code is the `ContinuousSincosEmbed` modification with per-axis learnable `log_freq` and `phase` parameters.

Either implementation is fine — the key is that STRING-sep must be active (axis-aligned learnable log_freq + phase, not isotropic sincos).

**Step 2: Run the single-arm escalation**

One arm only — no screening sweep. This is a direct escalation of the confirmed hypothesis to full budget.

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent senku \
  --optimizer lion \
  --lr 5e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 1.0 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.9995 \
  --lr-warmup-epochs 1 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --kill-thresholds '3000:val_primary/abupt_axis_mean_rel_l2_pct<25' \
  --wandb-group senku-5L-string-ddp-r26
```

Note: `--ema-decay 0.9995` (not the baseline 0.999) — this was in your PR #375 config and is the correct value for the 5L+STRING-sep model. Also `--weight-decay 5e-4` (the merged baseline uses 5e-4, not yi default 1e-4).

**Step 3: Report results**

After all 9 epochs complete, report:
- `val_primary/abupt_axis_mean_rel_l2_pct` at every epoch (table format)
- `test_primary/abupt_axis_mean_rel_l2_pct` at best val epoch
- Per-axis test metrics: `surface_pressure_rel_l2_pct`, `wall_shear_rel_l2_pct`, `volume_pressure_rel_l2_pct`, `wall_shear_x/y/z_rel_l2_pct`
- W&B run ID and final training step
- Whether the curve was still descending or plateaued at epoch 9

## Baseline metrics (PR #311 edward, W&B run `gcwx9yaa`)

| Metric | val | test |
|---|---:|---:|
| abupt_axis_mean | **7.546%** | **8.771%** |
| surface_pressure | — | 4.485% |
| wall_shear | — | 8.227% |
| volume_pressure | — | 12.438% |
| wall_shear_x | — | 7.253% |
| wall_shear_y | — | 9.233% |
| wall_shear_z | — | 10.449% |

## Prior screening results (PR #375, single-GPU 700 steps/epoch)

| Arm | val_abupt | test_abupt | run_id |
|---|---:|---:|---|
| D (4L sincos control) | 19.032 | 20.046 | 75ax2spv |
| C (4L STRING-sep) | 18.368 | 19.267 | 0rtank8m |
| **A (5L STRING-sep, lr=5e-4)** | **17.783** | **18.795** | **3sz9t11z** |

All curves still descending at final step (17.78 → ? with more budget). This is the arm to escalate.

## AB-UPT reference targets (lower is better)

| Target | AB-UPT |
|---|---:|
| surface_pressure | 3.82% |
| wall_shear | 7.29% |
| volume_pressure | 6.08% |
| wall_shear_x | 5.35% |
| wall_shear_y | 3.65% |
| wall_shear_z | 3.63% |
