### PR TITLE
Mirror-aug + SW=2.0 on 5L/256d/4H + T_max=50 (port of #332 to current best architecture)

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from data import SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -117,6 +118,7 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    mirror_aug_prob: float = 0.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -157,6 +159,49 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_mirror_y_batch(batch: SurfaceBatch, prob: float) -> tuple[SurfaceBatch, float]:
+    """Per-sample independent y-mirror augmentation.
+
+    With probability `prob` per sample, reflect across the xz-plane:
+      surface_x[..., 1]  (y position)        -> negate
+      surface_x[..., 4]  (ny normal y)       -> negate
+      surface_y[..., 2]  (wsy = wall_shear_y) -> negate
+      volume_x[..., 1]   (y position)        -> negate
+    All other channels (x, z, nx, nz, area, cp, wsx, wsz, sdf, vol_p) are
+    sign-invariant under this reflection. Padded entries are 0 so the sign
+    multiply is a no-op there. Mask/metadata/case_ids untouched.
+
+    Returns the (possibly new) batch and the empirical fraction flipped.
+    """
+    if prob <= 0.0:
+        return batch, 0.0
+    bsz = batch.surface_x.shape[0]
+    flip = torch.rand(bsz, device=batch.surface_x.device) < prob
+    flip_frac = float(flip.float().mean().item())
+    if not bool(flip.any().item()):
+        return batch, flip_frac
+    sign_surf = (1.0 - 2.0 * flip.to(batch.surface_x.dtype)).view(bsz, 1)
+    sign_vol = (1.0 - 2.0 * flip.to(batch.volume_x.dtype)).view(bsz, 1)
+    sign_y = (1.0 - 2.0 * flip.to(batch.surface_y.dtype)).view(bsz, 1)
+    new_surface_x = batch.surface_x.clone()
+    new_surface_x[..., 1] = batch.surface_x[..., 1] * sign_surf
+    new_surface_x[..., 4] = batch.surface_x[..., 4] * sign_surf
+    new_surface_y = batch.surface_y.clone()
+    new_surface_y[..., 2] = batch.surface_y[..., 2] * sign_y
+    new_volume_x = batch.volume_x.clone()
+    new_volume_x[..., 1] = batch.volume_x[..., 1] * sign_vol
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=new_surface_x,
+        surface_y=new_surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=new_volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), flip_frac
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -167,8 +212,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     raw_rel_l2_weight: float = 0.0,
+    mirror_aug_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    batch, mirror_aug_frac = apply_mirror_y_batch(batch, mirror_aug_prob)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -210,6 +257,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "mirror_aug_frac": mirror_aug_frac,
         **aux_metrics,
     }
 
@@ -325,6 +373,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     raw_rel_l2_weight=config.raw_rel_l2_weight,
+                    mirror_aug_prob=config.mirror_aug_prob,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -360,6 +409,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/mirror_aug_frac": batch_loss_metrics["mirror_aug_frac"],
                         }
                     )
                     # Log per-channel raw relative L2 auxiliary metrics when enabled.


### PR DESCRIPTION
## Hypothesis

The mirror-aug + SW=2.0 stack is constructive at early gates (PR #332 ep5 beat haku-SW=2.0 reference by 0.41pp; ep11 beat gilbert-mirror reference by 0.99pp), but plateaued at 4L/256d ceiling (~7.82%). Port the same recipe onto the **5L/256d/4H + T_max=50** architecture (current best, alphonse PR #174, val_abupt=6.9549%) to test whether the early-gate gains stack with the +1L depth and longer cosine schedule.

## Instructions

Port your mirror-aug + SW=2.0 code change forward and run **one Trial A** on the new architecture.

**Code change** (re-apply your mirror-aug from the closed `tanjiro/mirror-aug-plus-sw-stack` branch):
- Implement mirror-augmentation with `p=0.5` flipping the y-axis (lateral car symmetry) on input coords AND on label fields wsy, wsz (wsy/wsz must be sign-flipped under y-mirror; wsx, sp, vp invariant). Apply at the dataloader / data augmentation level, only during training.
- Keep `--surface-loss-weight 2.0` as a CLI flag (already supported in train.py).
- All other changes stay scoped to the augmentation and CLI; do NOT modify the model.

**Reproduce command**:

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --lr-cosine-t-max 50 \
  --surface-loss-weight 2.0 \
  --grad-clip-norm 1.0 \
  --no-compile-model \
  --epochs 50 \
  --wandb-group bengio-wave14 \
  --wandb-name tanjiro-mirror-sw2-on-5l256d-tmax50
```

**Important**: do NOT add gc=0.5 (falsified by senku #325), do NOT add gilbert-style trunk FiLM (falsified by gilbert #346). Single hypothesis: mirror+SW=2.0 stack on the 5L/256d/T_max=50 base.

## Gates (kill if NOT below)

- **ep5**: val_primary/abupt_axis_mean_rel_l2_pct < 12.0% (your PR #332 ep5 was 11.13% on the 4L base — 5L should be at or below this)
- **ep10**: < 9.5% (PR #332 ep10 was 9.04% on 4L)
- **ep15**: < 8.5%
- **ep30**: < 7.5% (must beat your previous 4L plateau and approach baseline)
- **ep50** (final, full schedule): < 6.95% to beat current best

## Reporting

Post a final comment with:
1. Per-channel val metrics ep5/10/15/30/50 (abupt, sp, vp, wsy, wsz)
2. Best-checkpoint test metrics (test_primary/* for all 5 axes)
3. Best epoch and W&B run id

## Baseline (current best on bengio)

| Metric | Current Best (val) | AB-UPT Target |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** (alphonse PR #174) | 4.51 |
| `val_primary/surface_pressure_rel_l2_pct` | 4.5644 | 3.82 |
| `val_primary/volume_pressure_rel_l2_pct` | 3.9361 | 6.08 |
| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | 3.65 |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | 3.63 |

Reference (your PR #332 4L/256d trial A, run `w3thlivw`): val_abupt ep30 = 7.8243%, plateaued. The hypothesis here is the recipe was capacity-limited, not flawed.

## Constraints

- `--no-compile-model`: mandatory
- `--fourier-pe`: mandatory
- `--grad-clip-norm` (NOT `--grad-clip`)
- `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` are hard caps
- ACK within 30 min with W&B run id
