### PR TITLE
edward: separate 2-layer MLP volume decoder head in model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -394,7 +394,18 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
-        self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        # Dedicated 2-layer MLP volume decoder head.
+        # Why: volume pressure (3D, Laplace-like, global flow topology) and
+        # surface fields (boundary-layer physics, local geometry) have different
+        # inductive biases; a deeper decoder lets the volume branch specialize
+        # without competing with surface for a single linear projection.
+        volume_decoder_hidden = n_hidden // 2
+        self.volume_out = nn.Sequential(
+            nn.Linear(n_hidden, volume_decoder_hidden),
+            nn.GELU(),
+            nn.Linear(volume_decoder_hidden, self.volume_output_dim),
+        )
+        self.volume_out.apply(_init_linear)
 
     def _encode_group(
         self,


### PR DESCRIPTION
## Hypothesis

Volume pressure is our primary laggard: **12.434% test vs AB-UPT target 6.08%** — essentially unchanged despite 16 rounds of improvements to surface metrics. The root cause hypothesis: the current Transolver architecture uses a **shared decoder** that must simultaneously represent surface fields (pressure + 3 wall-shear components, boundary layer physics) and interior volume fields (3D pressure, governed by Laplace-like equations). These have fundamentally different inductive biases. Surface fields correlate strongly with local geometry; volume fields depend on global flow topology.

**Proposed fix:** Give the volume branch its own 2-layer MLP decoder head in `model.py`. The surface branch keeps the existing decoder; the volume branch gets a dedicated MLP with its own learned projection. This allows the model to specialize representations for each regime without interference.

This is a minimal, targeted architectural change — not a full model redesign. It isolates the volume-specific representation learning from the surface decoder, which may be actively competing for the same linear projection weights.

Prior art: PointNet++ and similar works show that separate task heads for different physical regimes significantly improve multi-task regression. The 3D pressure field is a fundamentally different regression target than surface boundary conditions.

## Instructions

**Change: Add a separate 2-layer MLP volume decoder in `model.py`**

In `model.py`, find the decoder section where `out["volume_preds"]` is produced. Currently, volume predictions likely share the same linear projection as surface predictions (or use a single MLP). Add a dedicated separate 2-layer MLP for volume:

1. **Add a separate volume MLP in the `__init__`** of the model class. It should project from `hidden_dim` → `hidden_dim//2` → `1` (volume predicts a single scalar: pressure). Use `nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 1))`. Do NOT share weights with the surface decoder.

2. **Wire up the new volume decoder**: In the `forward` method, use the new MLP exclusively for `out["volume_preds"]` instead of the shared projection. The surface predictions (`out["surface_preds"]`, shape `[B, N_surface, 4]`) should continue to use the existing decoder unchanged.

3. **No other changes**: Keep all training hyperparameters, optimizer, and loss weighting identical to the current SOTA. No changes to `train.py` or `trainer_runtime.py`.

Run command (no CLI changes needed — the architecture change is internal to `model.py`):

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --wandb-group edward-separate-volume-decoder \
  --wandb-name edward/sep-vol-decoder-2layer-mlp
```

**Important:** Before running, carefully inspect `model.py` to understand the exact decoder structure — the implementation depends on how the current shared head is structured. If volume and surface already share a common trunk before splitting, add the new MLP head at that split point. Report the exact code changes made in your PR comment.

Report per-axis val metrics each epoch: `val/surface_pressure_rel_l2_pct`, `val/tau_x_rel_l2_pct`, `val/tau_y_rel_l2_pct`, `val/tau_z_rel_l2_pct`, `val/volume_pressure_rel_l2_pct`, and `val/abupt_axis_mean_rel_l2_pct`.

## Baseline

Current SOTA: PR #358 (thorfinn, STRING-sep + QK-norm, W&B run `tkiigfmc`)

| Metric | Val (EP11) | Test |
|--------|-----------|------|
| `abupt_axis_mean_rel_l2_pct` | **7.3921%** | 8.625% |
| surface_pressure | — | 4.462% |
| wall_shear (mean tau) | — | 7.965% |
| volume_pressure | — | **12.434%** ← primary laggard |
| tau_x | — | 7.253% |
| tau_y | — | 9.233% |
| tau_z | — | 10.449% |

**Merge bar: val `abupt_axis_mean_rel_l2_pct` < 7.3921%**

AB-UPT targets: surface_p 3.82%, tau_x 5.35%, tau_y 3.65%, tau_z 3.63%, volume_p **6.08%**.

Baseline W&B run: [tkiigfmc](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/tkiigfmc)
