### PR TITLE
frieren: per-axis tau_y/z loss weights 2x on SOTA stack

### DIFF
--- a/train.py
+++ b/train.py
@@ -61,6 +61,33 @@ from trainer_runtime import (
 )
 
 
+# Per-axis surface loss weights, ordered to match data/loader.py
+# SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z").
+# tau_y/tau_z are the worst test metrics (×2.5–2.9 gap to AB-UPT) so we double their gradient signal.
+SURFACE_COMPONENT_WEIGHTS = (1.0, 1.0, 2.0, 2.0)
+SURFACE_COMPONENT_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")
+
+
+def _masked_per_component_mse(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Per-component masked MSE over a [B, N, C] tensor; returns shape [C].
+
+    With uniform weights, ``_masked_per_component_mse(...).mean()`` equals
+    ``masked_mse(...)`` exactly: both reduce to (sum mask*diff^2) / (C * sum mask).
+    """
+    diff_sq = (pred - target).square()
+    if diff_sq.numel() == 0:
+        return diff_sq.sum(dim=tuple(range(diff_sq.ndim - 1))) * 0.0
+    expanded_mask = mask.to(device=diff_sq.device, dtype=diff_sq.dtype)
+    while expanded_mask.ndim < diff_sq.ndim:
+        expanded_mask = expanded_mask.unsqueeze(-1)
+    point_count = expanded_mask.expand(*diff_sq.shape[:-1], 1).sum()
+    weighted_diff = diff_sq * expanded_mask
+    reduce_dims = tuple(range(diff_sq.ndim - 1))
+    return weighted_diff.sum(dim=reduce_dims) / point_count.clamp_min(1.0)
+
+
 # ---------------------------------------------------------------------------
 # Training helpers
 # ---------------------------------------------------------------------------
@@ -203,18 +230,34 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_component_mse = _masked_per_component_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )
+        component_weights = torch.as_tensor(
+            SURFACE_COMPONENT_WEIGHTS,
+            device=surface_component_mse.device,
+            dtype=surface_component_mse.dtype,
+        )
+        surface_loss = (surface_component_mse * component_weights).mean()
+        surface_loss_unweighted = surface_component_mse.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
+        base_mse_loss = surface_loss_unweighted + volume_loss
+    component_mse_cpu = surface_component_mse.detach().float().cpu().tolist()
+    component_metrics = {
+        f"surface_component_mse/{name}": value
+        for name, value in zip(SURFACE_COMPONENT_NAMES, component_mse_cpu)
+    }
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_loss_unweighted": float(surface_loss_unweighted.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **component_metrics,
     }
 
 
@@ -277,6 +320,14 @@ def main(argv: Iterable[str] | None = None) -> None:
             max_epochs=max_epochs,
             train_timeout_minutes=train_timeout_minutes,
             val_budget_minutes=val_budget_minutes,
+        )
+        wandb.config.update(
+            {
+                "surface_component_weights": dict(
+                    zip(SURFACE_COMPONENT_NAMES, SURFACE_COMPONENT_WEIGHTS)
+                ),
+            },
+            allow_val_change=True,
         )
 
         output_dir = Path(config.output_dir) / f"run-{run.id}"
@@ -360,11 +411,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/loss": float(loss.detach().cpu().item()),
                             "train/base_mse_loss": batch_loss_metrics["base_mse_loss"],
                             "train/surface_loss": batch_loss_metrics["surface_loss"],
+                            "train/surface_loss_unweighted": batch_loss_metrics["surface_loss_unweighted"],
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    for component_name in SURFACE_COMPONENT_NAMES:
+                        key = f"surface_component_mse/{component_name}"
+                        if key in batch_loss_metrics:
+                            train_log[f"train/{key}"] = batch_loss_metrics[key]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/train.py
+++ b/train.py
@@ -63,8 +63,10 @@ from trainer_runtime import (
 
 # Per-axis surface loss weights, ordered to match data/loader.py
 # SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z").
-# tau_y/tau_z are the worst test metrics (×2.5–2.9 gap to AB-UPT) so we double their gradient signal.
-SURFACE_COMPONENT_WEIGHTS = (1.0, 1.0, 2.0, 2.0)
+# tau_y/tau_z are the worst test metrics (×2.5–2.9 gap to AB-UPT). 1.5× boost is a softer
+# variant of the 2.0× run (PR #454, val 7.3848%), aiming to keep the tau_y/z gain without
+# regressing surface_pressure / volume_pressure as much.
+SURFACE_COMPONENT_WEIGHTS = (1.0, 1.0, 1.5, 1.5)
 SURFACE_COMPONENT_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")
 
 


### PR DESCRIPTION
## Hypothesis

Our three worst test metrics are all tau (wall-shear) components on axes that our loss doesn't distinguish:

| Axis | Test result | AB-UPT target | Gap ratio |
|------|------------|---------------|-----------|
| tau_y | 9.233% | 3.65% | **×2.53** |
| tau_z | 10.449% | 3.63% | **×2.88** |
| tau_x | 7.253% | 5.35% | ×1.36 |

The current loss treats all surface prediction components equally. But tau_y and tau_z have more than 2.5× larger gaps to target than tau_x, while tau_x is already much closer. Upweighting tau_y and tau_z in the loss should force the model to reduce errors on the components it's most struggling with, at a modest cost to the already-adequate tau_x.

This requires a small code change to `train.py` to apply per-axis weights to the surface loss components. No new CLI flags needed — hardcode the weights in the loss function.

**Expected mechanism**: tau_y and tau_z represent lateral and vertical shear stress. On a car body, these components depend on complex flow separation patterns and are harder to learn than streamwise (tau_x) shear. Boosting their loss signal should increase gradient flow to the representations most predictive of these physically challenging components.

## Instructions

**Change: Add per-component loss weights to the surface loss in `train.py`**

1. **Locate the surface loss computation** in `train.py`. The surface prediction `out["surface_preds"]` has shape `[B, N_surface, 4]` where the 4 components are `[surface_pressure, tau_x, tau_y, tau_z]` (confirm the exact channel ordering by checking the data loader or training code).

2. **Apply per-axis weights** to the per-component loss before averaging:

```python
# Per-axis surface loss weights: [surface_pressure, tau_x, tau_y, tau_z]
# Upweight tau_y (idx 2) and tau_z (idx 3) by 2x, keep others at 1.0
SURFACE_COMPONENT_WEIGHTS = torch.tensor([1.0, 1.0, 2.0, 2.0], 
                                          device=preds.device, dtype=preds.dtype)

# Apply before reducing: multiply per-component losses by weights
# If loss is computed as: component_losses = (preds - targets).pow(2).mean(dim=[0,1])  # shape [4]
# Then: weighted_loss = (component_losses * SURFACE_COMPONENT_WEIGHTS).mean()
```

The exact implementation depends on how the surface loss is currently structured. Adapt the above pattern to match the existing code — the key requirement is that tau_y and tau_z receive 2× the gradient signal compared to tau_x and surface_pressure.

3. **Confirm channel ordering**: Before running, add a brief comment or print statement in your PR to confirm which channel index corresponds to tau_y and tau_z. Getting this wrong would train the wrong components.

4. **No other changes**: Keep all hyperparameters, optimizer, and architecture identical to SOTA.

Run command:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --wandb-group frieren-tau-axis-loss-weights \
  --wandb-name frieren/tau-yz-weight2x-string-qknorm
```

**If the mean `abupt_axis_mean_rel_l2_pct` improves, also try weights `[1.0, 1.0, 3.0, 3.0]`** (tau_y/z at 3×) in a second run under the same group to explore the tradeoff.

Report per-axis val metrics each epoch: `val/surface_pressure_rel_l2_pct`, `val/tau_x_rel_l2_pct`, `val/tau_y_rel_l2_pct`, `val/tau_z_rel_l2_pct`, `val/volume_pressure_rel_l2_pct`, and `val/abupt_axis_mean_rel_l2_pct`.

## Baseline

Current SOTA: PR #358 (thorfinn, STRING-sep + QK-norm, W&B run `tkiigfmc`)

| Metric | Val (EP11) | Test |
|--------|-----------|------|
| `abupt_axis_mean_rel_l2_pct` | **7.3921%** | 8.625% |
| surface_pressure | — | 4.462% |
| tau_x | — | 7.253% |
| tau_y | — | 9.233% ← 2.53× gap |
| tau_z | — | 10.449% ← 2.88× gap |
| volume_pressure | — | 12.434% |

**Merge bar: val `abupt_axis_mean_rel_l2_pct` < 7.3921%**

AB-UPT targets: surface_p 3.82%, tau_x 5.35%, **tau_y 3.65%**, **tau_z 3.63%**, volume_p 6.08%.

Baseline W&B run: [tkiigfmc](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/tkiigfmc)
