### PR TITLE
Learnable per-axis output scaling for surface predictions

### DIFF
--- a/model.py
+++ b/model.py
@@ -395,6 +395,7 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.surface_output_scale = nn.Parameter(torch.ones(self.surface_output_dim))
 
     def _encode_group(
         self,
@@ -482,7 +483,7 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden) * self.surface_output_scale * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -649,6 +649,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             global_step=global_step,
             total_minutes=total_minutes,
         )
+        if hasattr(base_model, "surface_output_scale"):
+            scale_values = base_model.surface_output_scale.detach().cpu().tolist()
+            scale_summary = {
+                f"surface_output_scale/ch{i}": float(v) for i, v in enumerate(scale_values)
+            }
+            print(f"Best-checkpoint surface_output_scale: {scale_values}")
+            wandb.summary.update(scale_summary)
         wandb.finish()
     finally:
         cleanup_distributed(state)


### PR DESCRIPTION
## Hypothesis

The current model uses a single `LinearProjection(n_hidden, 4)` output head that maps to all four surface channels simultaneously: `[cp, tau_x, tau_y, tau_z]`. The wall shear stress channels — especially tau_y (9.11% vs AB-UPT target 3.65%) and tau_z (10.27% vs 3.63%) — are roughly 2.5–3× above their AB-UPT reference targets, while surface pressure (4.44% vs 3.82%) is much closer.

We hypothesize that the per-channel scale of the output head's projection is miscalibrated: the linear head must simultaneously explain both the lower-magnitude surface pressure and the higher-variance shear stress components. Adding a learnable per-axis output scaling parameter (initialized to 1.0) gives the model a cheap additional degree of freedom to re-calibrate the relative output magnitudes during training, which may close the gap on the binding tau metrics.

This is analogous to feature-wise linear modulation (FiLM) applied at the final output layer, and adds essentially zero parameters (4 scalars).

## Instructions

### Code changes

**1. Add a learnable per-axis output scale parameter to `SurfaceTransolver` in `target/model.py`:**

In `SurfaceTransolver.__init__`, after line 397 (after `self.volume_out = LinearProjection(...)`), add:

```python
# Learnable per-channel output scale for surface predictions (init 1.0)
self.surface_output_scale = nn.Parameter(torch.ones(self.surface_output_dim))
```

**2. Apply the scale in `SurfaceTransolver.forward`, in `target/model.py`:**

Change line 485 from:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```
to:
```python
surface_preds = self.surface_out(surface_hidden) * self.surface_output_scale * surface_mask.unsqueeze(-1)
```

That's the complete change — 2 lines in `target/model.py`.

No changes to `train.py` or `trainer_runtime.py` are needed. The parameter is always active once added.

### Training command

Run the SOTA baseline config with the above model.py change applied. Use exactly the reproduce command from PR #387 (current SOTA):

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --wandb-group alphonse-per-axis-scale \
  --wandb-name alphonse/per-axis-output-scaling-pr$(gh pr list --head alphonse/per-axis-output-scaling --json number -q '.[0].number' 2>/dev/null || echo "new")
```

### What to report

After training, report:
- Best val_abupt (primary metric)
- Per-component test metrics: surface_pressure_rel_l2_pct, wall_shear_x/y/z_rel_l2_pct, volume_pressure_rel_l2_pct
- The learned `surface_output_scale` parameter values at the end of training (log with `model.surface_output_scale.data.tolist()`) — this tells us whether the model actually used the scaling and which channels were most affected
- W&B run ID

## Baseline

Current SOTA: PR #387 (alphonse), feat16 RFF + QK-norm + STRING-sep  
W&B run: `wj6mn6ve`  
Project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

| Metric | Baseline | AB-UPT Target | Gap |
|--------|----------|---------------|-----|
| val_abupt | 7.3816% | — | — |
| test_abupt | 8.5936% | — | — |
| surface_pressure | 4.4377% | 3.82% | 1.16× |
| wall_shear (total) | 7.9989% | 7.29% | 1.10× |
| tau_x | 6.9622% | 5.35% | 1.30× |
| **tau_y** | **9.1058%** | **3.65%** | **2.49×** |
| **tau_z** | **10.2736%** | **3.63%** | **2.83×** |
| volume_pressure | 12.1885% | 6.08% | 2.00× |

Reproduce command for baseline:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --wandb-group alphonse-rff-sweep \
  --wandb-name alphonse/feat16-qknorm-string-sep-pr387
```
