### PR TITLE
Sign-preserving log1p normalization for tau targets

### DIFF
--- a/train.py
+++ b/train.py
@@ -95,6 +95,7 @@ class Config:
     rff_sigma: float = 1.0
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    log1p_tau_norm: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -242,6 +243,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             surface_y_std=stats["surface_y_std"].to(device),
             volume_y_mean=stats["volume_y_mean"].to(device),
             volume_y_std=stats["volume_y_std"].to(device),
+            log1p_tau_norm=config.log1p_tau_norm,
         )
 
         model: nn.Module = build_model(config).to(device)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -170,6 +170,7 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        log1p_tau_norm: bool = False,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -187,6 +188,7 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.log1p_tau_norm = log1p_tau_norm
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -195,10 +197,19 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
+        if self.log1p_tau_norm:
+            y = y.clone()
+            tau = y[..., 1:4]
+            y[..., 1:4] = tau.sign() * tau.abs().log1p()
         return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        y_out = y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        if self.log1p_tau_norm:
+            y_out = y_out.clone()
+            tau = y_out[..., 1:4]
+            y_out[..., 1:4] = tau.sign() * tau.abs().expm1()
+        return y_out
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
         return (y - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)


### PR DESCRIPTION
## Hypothesis

The wall shear stress channels (tau_y: 9.11%, tau_z: 10.27%) are 2.5–3× above the AB-UPT reference targets (3.65%, 3.63%). The standard z-score normalization treats all surface channels symmetrically. However, wall shear stress is physically heavy-tailed: most vehicle surfaces have near-zero tau, but boundary layer separation zones and sharp edges produce large spike values that dominate the MSE loss without contributing proportionally to the relative-L2 metric.

We hypothesize that a **sign-preserving log1p transform applied to the tau channels** before normalization — and inverted after — will improve optimization by compressing the heavy tail, making the loss landscape more Gaussian-like. This is a well-established trick in Kaggle competitions for heavy-tailed regression targets (e.g., price prediction, count data).

The transform: `tau_norm = sign(tau) * log(1 + |tau|)`, with inverse `sign(y) * (exp(|y|) - 1)`. This is applied after z-score normalization and the inverse is applied before metric evaluation.

## Instructions

### Code changes

All changes go in `target/trainer_runtime.py`. No changes to `model.py` or `train.py` needed.

**1. Add a `log1p_tau_norm` flag to `TargetTransform.__init__`:**

```python
class TargetTransform:
    def __init__(
        self,
        *,
        surface_y_mean: torch.Tensor | None = None,
        surface_y_std: torch.Tensor | None = None,
        volume_y_mean: torch.Tensor | None = None,
        volume_y_std: torch.Tensor | None = None,
        y_mean: torch.Tensor | None = None,
        y_std: torch.Tensor | None = None,
        log1p_tau_norm: bool = False,   # <-- ADD THIS
    ):
        # ... existing init code ...
        self.log1p_tau_norm = log1p_tau_norm   # <-- ADD THIS
```

**2. Override `apply_surface` to apply sign-preserving log1p to tau channels (indices 1, 2, 3) before z-score normalization:**

Replace the existing `apply_surface` method:
```python
def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
    if self.log1p_tau_norm:
        y = y.clone()
        tau = y[..., 1:4]
        y[..., 1:4] = tau.sign() * tau.abs().log1p()
    return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
```

**3. Override `invert_surface` to invert the log1p transform after z-score inversion:**

Replace the existing `invert_surface` method:
```python
def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
    y_out = y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
    if self.log1p_tau_norm:
        y_out = y_out.clone()
        tau = y_out[..., 1:4]
        y_out[..., 1:4] = tau.sign() * tau.abs().expm1()
    return y_out
```

**Important note**: The `surface_y_mean` and `surface_y_std` statistics are computed from the dataset's raw tau values. With log1p, you should re-compute the stats from the log1p-transformed values so that the z-score is applied in the transformed space. To do this cleanly, the simplest approach is to pre-apply the log1p transform to the raw tau channels when computing stats, and store those stats. However, for a first experiment, it is acceptable to use the raw stats with log1p — the network will adapt. If the first trial shows promise, a follow-up can recompute stats.

**4. Add `--log1p-tau-norm` CLI flag to `target/train.py`:**

In the `TrainingConfig` dataclass (or wherever CLI args are parsed), add:
```python
log1p_tau_norm: bool = False
```

Add the corresponding argparse argument (look for where `--use-qk-norm` is defined for the pattern):
```python
parser.add_argument("--log1p-tau-norm", action="store_true", default=False,
                    help="Apply sign-preserving log1p normalization to tau channels")
```

**5. Pass the flag when constructing `TargetTransform` in `train.py`:**

Change:
```python
transform = TargetTransform(
    surface_y_mean=stats["surface_y_mean"].to(device),
    surface_y_std=stats["surface_y_std"].to(device),
    volume_y_mean=stats["volume_y_mean"].to(device),
    volume_y_std=stats["volume_y_std"].to(device),
)
```
to:
```python
transform = TargetTransform(
    surface_y_mean=stats["surface_y_mean"].to(device),
    surface_y_std=stats["surface_y_std"].to(device),
    volume_y_mean=stats["volume_y_mean"].to(device),
    volume_y_std=stats["volume_y_std"].to(device),
    log1p_tau_norm=config.log1p_tau_norm,
)
```

Also check if `TargetTransform` is constructed elsewhere in `trainer_runtime.py` (e.g., for evaluation-only paths) and pass the flag there too.

### Training command

Run the SOTA baseline config with `--log1p-tau-norm` added:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --log1p-tau-norm \
  --wandb-group tanjiro-log1p-tau \
  --wandb-name tanjiro/log1p-tau-norm-pr468
```

### What to report

After training, report:
- Best val_abupt (primary metric)
- Per-component test metrics: surface_pressure_rel_l2_pct, wall_shear_x/y/z_rel_l2_pct, volume_pressure_rel_l2_pct
- W&B run ID
- Whether the training loss curve looked healthy (no spikes, smooth convergence)

## Baseline

Current SOTA: PR #387 (alphonse), feat16 RFF + QK-norm + STRING-sep  
W&B run: `wj6mn6ve`  
Project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

| Metric | Baseline | AB-UPT Target | Gap |
|--------|----------|---------------|-----|
| val_abupt | 7.3816% | — | — |
| test_abupt | 8.5936% | — | — |
| surface_pressure | 4.4377% | 3.82% | 1.16× |
| wall_shear (total) | 7.9989% | 7.29% | 1.10× |
| tau_x | 6.9622% | 5.35% | 1.30× |
| **tau_y** | **9.1058%** | **3.65%** | **2.49×** |
| **tau_z** | **10.2736%** | **3.63%** | **2.83×** |
| volume_pressure | 12.1885% | 6.08% | 2.00× |

Reproduce command for baseline:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --wandb-group alphonse-rff-sweep \
  --wandb-name alphonse/feat16-qknorm-string-sep-pr387
```
