### PR TITLE
askeladd: signed-log transform on volume_pressure target channel

### DIFF
--- a/train.py
+++ b/train.py
@@ -119,6 +119,8 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    vol_signed_log: bool = False
+    vol_signed_log_c: float = 1.0
     debug: bool = False
 
 
@@ -145,6 +147,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+class VolumeSignedLogTransform(TargetTransform):
+    """TargetTransform variant that replaces volume mean/std with signed-log compression.
+
+    Forward: y' = sign(y) * log1p(|y| / c)
+    Inverse: y = sign(y') * c * (exp(|y'|) - 1)
+    Surface targets are unchanged from the base TargetTransform.
+    """
+
+    def __init__(self, *args, signed_log_c: float = 1.0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vol_signed_log_c = float(signed_log_c)
+
+    def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
+        c = self.vol_signed_log_c
+        return torch.sign(y) * torch.log1p(torch.abs(y) / c)
+
+    def invert_volume(self, y: torch.Tensor) -> torch.Tensor:
+        c = self.vol_signed_log_c
+        return torch.sign(y) * c * torch.expm1(torch.abs(y))
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -237,12 +260,26 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
-        transform = TargetTransform(
-            surface_y_mean=stats["surface_y_mean"].to(device),
-            surface_y_std=stats["surface_y_std"].to(device),
-            volume_y_mean=stats["volume_y_mean"].to(device),
-            volume_y_std=stats["volume_y_std"].to(device),
-        )
+        if config.vol_signed_log:
+            transform = VolumeSignedLogTransform(
+                surface_y_mean=stats["surface_y_mean"].to(device),
+                surface_y_std=stats["surface_y_std"].to(device),
+                volume_y_mean=stats["volume_y_mean"].to(device),
+                volume_y_std=stats["volume_y_std"].to(device),
+                signed_log_c=config.vol_signed_log_c,
+            )
+            if state.is_main:
+                print(
+                    f"Volume target: signed-log transform with c={config.vol_signed_log_c} "
+                    f"(replaces volume mean/std normalization)."
+                )
+        else:
+            transform = TargetTransform(
+                surface_y_mean=stats["surface_y_mean"].to(device),
+                surface_y_std=stats["surface_y_std"].to(device),
+                volume_y_mean=stats["volume_y_mean"].to(device),
+                volume_y_std=stats["volume_y_std"].to(device),
+            )
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())


### PR DESCRIPTION
## Hypothesis

Volume pressure is the primary laggard at **test=12.1885% vs AB-UPT 6.08% (×2.0 gap)**. Two orthogonal attacks have already failed:
- PR #366 Huber loss on vol_p — no signal
- PR #451 volume-loss-weight=3.0 — EP6=9.272%, closed negative

Both are loss/optimization levers. The next clean orthogonal attack is on the **target representation**.

Volume pressure has a heavy-tailed amplitude distribution: front-stagnation, body wake, and recirculation zones span multiple decades. The standard L2 loss disproportionately amplifies errors on the tail of the distribution. A signed-log transform compresses this dynamic range so the network distributes representation capacity evenly across magnitudes, improving accuracy in the low-amplitude regime (body/wake) without sacrificing high-amplitude fidelity.

**Transform:** `y' = sign(y) · log1p(|y| / c)` (forward) / `y = sign(y') · c · (exp(|y'|) − 1)` (inverse), with scale `c=1.0`.

This is intentionally orthogonal to PR #452 (separate volume decoder head, currently at EP6.7 best=8.934%) — if both win, they can be stacked. If #452 merges as new SOTA first, this experiment should be re-tested on that stack.

## Instructions

1. In `target/train.py`, add a `--vol-signed-log` boolean flag (default `False`) and a `--vol-signed-log-c` float flag (default `1.0`). These are your only code changes — **no other hyperparameter or config changes**.

2. Apply the transform **only to the volume_pressure target channel**, in whatever preprocessing / target-normalization pipeline is cleanest:
   - Forward (train target): `y_t = torch.sign(y) * torch.log1p(torch.abs(y) / c)`
   - Inverse (before eval metric): `y = torch.sign(y_t) * c * (torch.exp(torch.abs(y_t)) - 1)`
   - All other targets (surface_pressure, tau_x, tau_y, tau_z) stay untransformed.
   - The transform must be symmetric: loss is in transformed space; `val_primary/volume_pressure_rel_l2_pct` and all other reported metrics are computed after inverse-transform, so they remain directly comparable to baseline.

3. Run a **2-arm DDP8 sweep** head-to-head:
   - **Arm A (control):** verbatim SOTA reproduce command (see below), `--agent askeladd`, no signed-log flag
   - **Arm B (treat):** same command + `--vol-signed-log --vol-signed-log-c 1.0`
   - Run both simultaneously (arm A on GPUs 0–3 rank-local, arm B on GPUs 4–7, OR as two separate DDP8 runs if that's easier with the harness — student's call)
   - `--wandb-group askeladd-vol-signedlog-r23`

4. Use `python train.py --help` to confirm exact flag spellings before running.

5. Report per-epoch val_abupt AND val_volume_pressure for both arms at EP1, EP3, EP5, EP7.

## Reproduce Command (SOTA baseline — Arm A)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --wandb-group askeladd-vol-signedlog-r23 \
  --wandb-name askeladd/vol-signedlog-arm-a-control
```

Arm B adds: `--vol-signed-log --vol-signed-log-c 1.0 --wandb-name askeladd/vol-signedlog-arm-b-treat`

## Baseline Metrics (PR #387 alphonse, run `wj6mn6ve`, EP11)

| Metric | Val/Test | PR #387 (SOTA) | AB-UPT target |
|---|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | val | **7.3816%** | — |
| `test_primary/abupt_axis_mean_rel_l2_pct` | test | 8.5936% | — |
| `test_primary/surface_pressure_rel_l2_pct` | test | 4.4377% | 3.82% |
| `test_primary/wall_shear_rel_l2_pct` | test | 7.9989% | 7.29% |
| **`test_primary/volume_pressure_rel_l2_pct`** | test | **12.1885%** | **6.08% (×2.0 gap)** |

**Merge bar:** val_abupt < 7.3816% AND vol_p materially improves over baseline 12.1885%.

**Gates:** EP5 ≤8.9%, EP7 ≤8.5% for val_abupt.
