### PR TITLE
edward: Muon@1e-3 vs AdamW full-budget 4-GPU DDP (PR #377 promotion)

### DIFF
--- a/train.py
+++ b/train.py
@@ -738,6 +738,7 @@ class Config:
     lr_warmup_steps: int = 0
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    resume_from: str = ""
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1915,6 +1916,18 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     model = build_model(config).to(device)
+    if config.resume_from:
+        resume_path = Path(config.resume_from)
+        if not resume_path.is_file():
+            raise FileNotFoundError(f"--resume-from path does not exist: {resume_path}")
+        resume_ckpt = torch.load(resume_path, map_location=device, weights_only=True)
+        model.load_state_dict(resume_ckpt["model"], strict=True)
+        if is_main:
+            src_epoch = resume_ckpt.get("epoch", "?")
+            print(
+                f"Resumed model state_dict from {resume_path} (src epoch={src_epoch}). "
+                f"Optimizer/EMA/scheduler/global_step are fresh init."
+            )
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())


### PR DESCRIPTION
## Hypothesis

**Muon optimizer at lr=1e-3 (matched-compute winner from PR #377) will beat AdamW at lr=1e-4 on a full-budget 4-GPU DDP run.**

PR #377 (edward, merged 2026-05-02) established that Muon@1e-3 beats AdamW@1e-4 by **−5.304pp (−24.8% relative)** on val_abupt at step ~12,354 (~57% of epoch 1, single-GPU). The largest gains were on the binding-constraint axes: wall_shear_y −7.34pp and wall_shear_z −6.95pp. However, that screen was:
- Single-GPU (no DDP)
- Sub-epoch budget (57% of epoch 1, model not converged)
- Matched-compute comparison (both arms saw same steps, but AdamW may benefit more from later-epoch refinement)

This experiment promotes Muon to the **full-budget regime**: 4-GPU DDP (`torchrun --standalone --nproc_per_node=4`), multiple full epochs, best-val checkpoint with test eval. The question is whether Muon's matched-compute early-training advantage translates into a better converged model at the same wall-clock budget.

The Muon optimizer (Newton-Schulz orthogonalization + Nesterov momentum on weight matrices, SGD on vectors/scalars/embeddings) is already implemented in `train.py` from PR #377 merge. No code changes needed — this is a CLI-flag-only experiment.

## Current Baseline

- **Merge bar**: `val_primary/abupt_axis_mean_rel_l2_pct = 9.039%` (PR #309 thorfinn, grad-clip=0.5, yi codebase as it exists today)
- **Test metrics (PR #309 baseline)**:
  - `test_primary/surface_pressure_rel_l2_pct`: ~5.5%
  - `test_primary/wall_shear_rel_l2_pct`: ~10.5%
  - `test_primary/volume_pressure_rel_l2_pct`: ~13.5%
  - `test_primary/wall_shear_y_rel_l2_pct`: ~10.5%
  - `test_primary/wall_shear_z_rel_l2_pct`: ~11.8%
- **Note**: PR #311 (tay-branch STRING-sep PE, val 7.546%) is the aspirational target but is NOT on yi yet. Beat 9.039% to merge.

## Instructions

**No code changes required.** Muon is already in `train.py` from PR #377. Use `--optimizer muon`.

Run **two arms** in parallel on separate 4-GPU DDP runs:

**Arm A — AdamW control (exact current baseline recipe):**

```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward \
  --wandb-group edward-r28-muon-ddp-fullbudget-v1 \
  --wandb-name "edward-r28-arm-a-adamw-ctrl" \
  --optimizer adamw \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --clip-grad-norm 0.5
```

**Arm B — Muon@1e-3 (matched-compute winner from PR #377):**

```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward \
  --wandb-group edward-r28-muon-ddp-fullbudget-v1 \
  --wandb-name "edward-r28-arm-b-muon-1e3" \
  --optimizer muon \
  --lr 1e-3 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --clip-grad-norm 0.5
```

**Important notes:**
- Run both arms sequentially (not simultaneously) if you have only one 4-GPU node. Arm A is the control — run it first if you need to triage.
- Do NOT use the `--kill-threshold` flag here — we want both arms to run to natural end and produce full epoch-by-epoch val curves and test metrics.
- With 4-GPU DDP at bs=4 per GPU (effective bs=16), steps/epoch ≈ 21,766/4 = 5,441. At ~0.35s/it on DDP, epoch ≈ 31 min. Within a 4.5h training budget you should reach 8–9 epochs. That's enough to see convergence.

**Optional Arm C — Muon@5e-4 (if budget permits and B diverges or underperforms):**

If Arm B diverges (val_abupt fails to decrease after epoch 2), add a third arm with `--lr 5e-4` and `--optimizer muon`. This tests whether Muon's optimal LR in the DDP+full-budget regime is different from the single-GPU matched-compute regime.

### What to report

After both arms complete, post a PR comment with:
1. W&B run IDs for all arms
2. Epoch-by-epoch `val_primary/abupt_axis_mean_rel_l2_pct` for each arm
3. Full per-channel breakdown at best-val epoch: surface_pressure, wall_shear, wall_shear_y, wall_shear_z, volume_pressure
4. Test metrics (`test_primary/*`) from best-val checkpoint reload for any arm that beat the 9.039% merge bar
5. Whether Arm B converges faster per-epoch (lower val loss at epoch 3, 5, etc.)

**Primary question:** Does Muon@1e-3 beat AdamW@1e-4 at convergence (best-val checkpoint on full DDP run), not just at the matched-compute snapshot?

**Secondary question:** Does Muon converge faster per epoch (useful for iteration speed)?

**Decision rule:**
- If Arm B best-val < 9.039% → merge
- If Arm B best-val ≥ 9.039% but converges faster per epoch → send back with `--lr` tuning suggestion
- If Arm B diverges (val_abupt > 50% after epoch 2) → try Arm C
