### PR TITLE
alphonse: per-axis coordinate normalization to fix PE anisotropy

### DIFF
--- a/train.py
+++ b/train.py
@@ -481,6 +481,8 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        coord_normalize: str = "none",
+        coord_axis_scale: tuple[float, float, float] = (1.4, 0.7, 0.4),
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -493,6 +495,17 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        if coord_normalize not in ("none", "axis", "l2"):
+            raise ValueError(
+                f"coord_normalize must be one of 'none'|'axis'|'l2', got '{coord_normalize}'"
+            )
+        self.coord_normalize = coord_normalize
+        self.register_buffer(
+            "coord_axis_scale",
+            torch.tensor(list(coord_axis_scale), dtype=torch.float32),
+            persistent=False,
+        )
+        self._coord_stats_logged = False
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -528,6 +541,16 @@ class SurfaceTransolver(nn.Module):
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
+    def _normalize_pos(self, pos: torch.Tensor) -> torch.Tensor:
+        if self.coord_normalize == "none":
+            return pos
+        if self.coord_normalize == "axis":
+            return pos / self.coord_axis_scale.to(device=pos.device, dtype=pos.dtype)
+        if self.coord_normalize == "l2":
+            norm = pos.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+            return pos / norm
+        return pos
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -537,6 +560,7 @@ class SurfaceTransolver(nn.Module):
         placeholder: torch.Tensor,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
+        pos = self._normalize_pos(pos)
         hidden = self.pos_embed(pos)
         if project_features is not None and x.shape[-1] > self.space_dim:
             hidden = hidden + project_features(x[:, :, self.space_dim :])
@@ -715,6 +739,10 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    coord_normalize: str = "none"  # "none" | "axis" | "l2"
+    coord_axis_scale_x: float = 1.4
+    coord_axis_scale_y: float = 0.7
+    coord_axis_scale_z: float = 0.4
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -897,6 +925,12 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        coord_normalize=config.coord_normalize,
+        coord_axis_scale=(
+            config.coord_axis_scale_x,
+            config.coord_axis_scale_y,
+            config.coord_axis_scale_z,
+        ),
     )
 
 
@@ -2111,6 +2145,72 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            if epoch == 0 and n_batches == 0 and is_main:
+                surf_xyz_b = batch.surface_x[..., :3]
+                vol_xyz_b = batch.volume_x[..., :3]
+                surf_mask_b = batch.surface_mask.bool()
+                vol_mask_b = batch.volume_mask.bool()
+                surf_valid = surf_xyz_b[surf_mask_b]
+                vol_valid = vol_xyz_b[vol_mask_b]
+                base_model = getattr(model, "_orig_mod", model)
+                norm_surf = base_model._normalize_pos(surf_valid.to(device))
+                norm_vol = base_model._normalize_pos(vol_valid.to(device))
+                coord_log = {
+                    "coord/raw_surf_min_x": float(surf_valid[:, 0].min()),
+                    "coord/raw_surf_min_y": float(surf_valid[:, 1].min()),
+                    "coord/raw_surf_min_z": float(surf_valid[:, 2].min()),
+                    "coord/raw_surf_max_x": float(surf_valid[:, 0].max()),
+                    "coord/raw_surf_max_y": float(surf_valid[:, 1].max()),
+                    "coord/raw_surf_max_z": float(surf_valid[:, 2].max()),
+                    "coord/raw_surf_std_x": float(surf_valid[:, 0].std()),
+                    "coord/raw_surf_std_y": float(surf_valid[:, 1].std()),
+                    "coord/raw_surf_std_z": float(surf_valid[:, 2].std()),
+                    "coord/raw_vol_min_x": float(vol_valid[:, 0].min()),
+                    "coord/raw_vol_min_y": float(vol_valid[:, 1].min()),
+                    "coord/raw_vol_min_z": float(vol_valid[:, 2].min()),
+                    "coord/raw_vol_max_x": float(vol_valid[:, 0].max()),
+                    "coord/raw_vol_max_y": float(vol_valid[:, 1].max()),
+                    "coord/raw_vol_max_z": float(vol_valid[:, 2].max()),
+                    "coord/raw_vol_std_x": float(vol_valid[:, 0].std()),
+                    "coord/raw_vol_std_y": float(vol_valid[:, 1].std()),
+                    "coord/raw_vol_std_z": float(vol_valid[:, 2].std()),
+                    "coord/normed_surf_min_x": float(norm_surf[:, 0].min()),
+                    "coord/normed_surf_min_y": float(norm_surf[:, 1].min()),
+                    "coord/normed_surf_min_z": float(norm_surf[:, 2].min()),
+                    "coord/normed_surf_max_x": float(norm_surf[:, 0].max()),
+                    "coord/normed_surf_max_y": float(norm_surf[:, 1].max()),
+                    "coord/normed_surf_max_z": float(norm_surf[:, 2].max()),
+                    "coord/normed_surf_std_x": float(norm_surf[:, 0].std()),
+                    "coord/normed_surf_std_y": float(norm_surf[:, 1].std()),
+                    "coord/normed_surf_std_z": float(norm_surf[:, 2].std()),
+                    "coord/normed_vol_std_x": float(norm_vol[:, 0].std()),
+                    "coord/normed_vol_std_y": float(norm_vol[:, 1].std()),
+                    "coord/normed_vol_std_z": float(norm_vol[:, 2].std()),
+                    "global_step": global_step,
+                }
+                wandb.log(coord_log)
+                print(
+                    f"[coord-norm={config.coord_normalize}] surface raw "
+                    f"min={surf_valid.min(0).values.tolist()} "
+                    f"max={surf_valid.max(0).values.tolist()} "
+                    f"std={surf_valid.std(0).tolist()}"
+                )
+                print(
+                    f"[coord-norm={config.coord_normalize}] surface normed "
+                    f"min={norm_surf.min(0).values.tolist()} "
+                    f"max={norm_surf.max(0).values.tolist()} "
+                    f"std={norm_surf.std(0).tolist()}"
+                )
+                print(
+                    f"[coord-norm={config.coord_normalize}] volume raw "
+                    f"min={vol_valid.min(0).values.tolist()} "
+                    f"max={vol_valid.max(0).values.tolist()} "
+                    f"std={vol_valid.std(0).tolist()}"
+                )
+                print(
+                    f"[coord-norm={config.coord_normalize}] volume normed "
+                    f"std={norm_vol.std(0).tolist()}"
+                )
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,

--- a/train.py
+++ b/train.py
@@ -482,7 +482,7 @@ class SurfaceTransolver(nn.Module):
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
         coord_normalize: str = "none",
-        coord_axis_scale: tuple[float, float, float] = (1.4, 0.7, 0.4),
+        coord_axis_scale: tuple[float, float, float] = (2.5, 1.1, 0.75),
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -740,9 +740,9 @@ class Config:
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
     coord_normalize: str = "none"  # "none" | "axis" | "l2"
-    coord_axis_scale_x: float = 1.4
-    coord_axis_scale_y: float = 0.7
-    coord_axis_scale_z: float = 0.4
+    coord_axis_scale_x: float = 2.5
+    coord_axis_scale_y: float = 1.1
+    coord_axis_scale_z: float = 0.75
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True


### PR DESCRIPTION
## Hypothesis

**Rotating the input xyz coordinates into a car-aligned streamwise/lateral/vertical frame before the positional encoding will reduce the wall_shear_y/z (tau_y/z) gap by giving the PE a physics-meaningful decomposition instead of an arbitrary world-frame one.**

The root cause of the tau_y/z gap (currently 2.53× and 2.88× the AB-UPT benchmark) has been identified as **coordinate anisotropy**: the car geometry spans x∈[−2,2] (streamwise), but y and z only span ≈[−0.5,0.5]. The raw xyz world frame mixes aerodynamically meaningful directions with arbitrary world-frame orientation.

A physics-motivated coordinate rotation:
- **x′ = streamwise** (car longitudinal axis, main flow direction)  
- **y′ = lateral** (cross-car, left-right)  
- **z′ = vertical** (ground-normal, up-down)

This frame is the natural basis for CFD wall-shear: tau_y lives in the lateral-shear plane and tau_z in the ground-normal-shear plane. Forcing the PE to operate in this frame means the model learns PE frequencies aligned with how the physics actually varies.

This is **distinct from but complementary to** STRING-sep PE (PR #420): STRING-sep learns per-axis frequencies after the fact; this hypothesis says rotating the coordinate frame *before* any PE (fixed or learnable) will already put the right structure in front of the model.

**Implementation:** Pre-rotate all surface and volume point coordinates by a fixed rotation matrix (aligning car x-axis to world x-axis, which in DrivAerML is already approximately aligned). The minimal version is simply **normalizing each axis independently by its range** (de-anisotropizing without rotation), since in DrivAerML the car is already aligned with world axes. Concretely:
- `x_norm = x / 2.0`  (maps [−2,2] → [−1,1])
- `y_norm = y / 0.5`  (maps [−0.5,0.5] → [−1,1])
- `z_norm = z / 0.5`  (maps [−0.5,0.5] → [−1,1])

This gives each axis equal "PE bandwidth" while preserving the physical coordinate frame. It is the simplest possible version and requires only 3 lines of code — a good control before trying full rotation.

A second arm tests **isotropic L2-norm normalization**: `xyz_norm = xyz / ||xyz||_2_per_point` (normalize each point's coordinate vector to the unit sphere). This removes absolute position but preserves directional structure — a contrastive to axis-wise normalization.

## Current Baseline

- **Merge bar**: `val_primary/abupt_axis_mean_rel_l2_pct = 9.039%` (PR #309 thorfinn, yi codebase today)
- **Key gap targets**:
  - `wall_shear_y_rel_l2_pct`: ~10.5% vs AB-UPT 3.65 (2.87×)
  - `wall_shear_z_rel_l2_pct`: ~11.8% vs AB-UPT 3.63 (3.25×)
  - `volume_pressure_rel_l2_pct`: ~13.5% vs AB-UPT 6.08 (2.22×)
  - `surface_pressure_rel_l2_pct`: ~5.5% vs AB-UPT 3.82 (1.44×)

## Instructions

The coordinate normalization must happen at the **point-cloud input stage**, before the positional encoding is applied. Find where the surface and volume point coordinates (`surf_xyz`, `vol_xyz`) are passed into the model and insert the normalization there.

### Step 1: Find the coordinate input path

In `train.py`, look for where `surf_xyz` and `vol_xyz` tensors are constructed or passed to the model (approximately around the data loading and forward pass sections). The normalization should be applied to both surface AND volume coordinates consistently.

### Step 2: Add a `--coord-normalize` flag

Add a config field and CLI flag:

```python
# In TrainConfig dataclass:
coord_normalize: str = "none"  # choices: "none", "axis", "l2"

# In argparse:
parser.add_argument("--coord-normalize", type=str, default="none",
                    choices=["none", "axis", "l2"],
                    help="Pre-PE coordinate normalization: none|axis (per-axis range)|l2 (unit sphere)")
```

### Step 3: Add the normalization function

Immediately before the coordinates are fed to the PE or model:

```python
def normalize_coords(xyz, mode):
    """Pre-PE coordinate normalization.
    xyz: [..., 3] tensor in world-frame (x=streamwise, y=lateral, z=vertical)
    """
    if mode == "none":
        return xyz
    elif mode == "axis":
        # Per-axis range normalization: x/2.0, y/0.5, z/0.5
        # Maps DrivAerML coordinate ranges to [-1,1] each axis
        scale = xyz.new_tensor([2.0, 0.5, 0.5])  # approximate half-ranges
        return xyz / scale
    elif mode == "l2":
        # Isotropic unit-sphere normalization per point
        norm = xyz.norm(dim=-1, keepdim=True).clamp(min=1e-6)
        return xyz / norm
    return xyz
```

Apply this to BOTH `surf_xyz` and `vol_xyz` before any PE call. Make sure the same scale is applied consistently between training and validation/test.

**Important:** The normalization scale values `[2.0, 0.5, 0.5]` for axis mode are approximate. Check the actual coordinate ranges in the DrivAerML dataset by inspecting `surf_xyz.min(dim=0)` and `surf_xyz.max(dim=0)` in your first batch — log these to W&B for verification and adjust the scale if the true ranges differ significantly.

### Step 4: Run three arms

**Arm A — No normalization (control, exact current baseline config):**

```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent alphonse \
  --wandb-group alphonse-r28-coord-normalize-v1 \
  --wandb-name "alphonse-r28-arm-a-none-ctrl" \
  --coord-normalize none \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --clip-grad-norm 0.5
```

**Arm B — Axis normalization (x/2.0, y/0.5, z/0.5):**

Same as Arm A but `--coord-normalize axis`.

**Arm C — L2 normalization (unit sphere per point):**

Same as Arm A but `--coord-normalize l2`.

Run arms sequentially (A then B then C) on the 4-GPU node. If budget is tight, run A and B in parallel and skip C if B fails.

### Step 5: Verify normalization is applied correctly

In your first batch, log the following to W&B or print to confirm:
```python
print(f"surf_xyz range before norm: {surf_xyz.min(0).values} to {surf_xyz.max(0).values}")
print(f"surf_xyz range after norm: {surf_xyz_normed.min(0).values} to {surf_xyz_normed.max(0).values}")
```
Include these in your results comment.

### What to report

After all arms complete, post a PR comment with:
1. W&B run IDs for all arms
2. The actual coordinate ranges observed (min/max per axis) in the first batch
3. Epoch-by-epoch `val_primary/abupt_axis_mean_rel_l2_pct` for each arm
4. Full per-channel val table at best-val epoch: surface_pressure, wall_shear, wall_shear_y, wall_shear_z, volume_pressure
5. Test metrics from best-val checkpoint reload for any arm beating 9.039%
6. Whether wall_shear_y/z improved disproportionately (the key diagnostic for the anisotropy hypothesis)

**Primary question:** Does axis normalization reduce the tau_y/z gap specifically (not just improve abupt equally across channels)?

**Decision rule:**
- Best arm val_abupt < 9.039% → merge
- If tau_y/z improve but overall abupt misses bar → send back for tuning (different scale, or apply only to surface coords)
- If all arms worse → close, anisotropy hypothesis disproved at this level of normalization
