### PR TITLE
chihiro: per-step cosine LR schedule (fix epoch-step LR decay)

### DIFF
--- a/train.py
+++ b/train.py
@@ -764,6 +764,7 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     lr_schedule_steps: bool = False
+    lr_schedule_cosine_t_max_override: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2045,7 +2046,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
         effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
     if config.lr_schedule_steps:
-        cosine_steps = max(1, total_estimated_steps - effective_warmup_steps)
+        if config.lr_schedule_cosine_t_max_override > 0:
+            cosine_steps = config.lr_schedule_cosine_t_max_override
+        else:
+            cosine_steps = max(1, total_estimated_steps - effective_warmup_steps)
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
             optimizer, T_max=cosine_steps, eta_min=0.0
         )
@@ -2053,7 +2057,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(
                 f"LR schedule: per-step cosine, T_max={cosine_steps} "
                 f"(total_estimated_steps={total_estimated_steps}, "
-                f"effective_warmup_steps={effective_warmup_steps})"
+                f"effective_warmup_steps={effective_warmup_steps}, "
+                f"override={config.lr_schedule_cosine_t_max_override})"
             )
     else:
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
@@ -2090,8 +2095,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             "lr_warmup_steps_effective": effective_warmup_steps,
             **resume_info,
             "lr_schedule_mode": "step" if config.lr_schedule_steps else "epoch",
-            "lr_schedule_cosine_t_max": (
-                max(1, total_estimated_steps - effective_warmup_steps)
+            "lr_schedule_cosine_t_max_effective": (
+                (
+                    config.lr_schedule_cosine_t_max_override
+                    if config.lr_schedule_cosine_t_max_override > 0
+                    else max(1, total_estimated_steps - effective_warmup_steps)
+                )
                 if config.lr_schedule_steps
                 else max_epochs
             ),

--- a/train.py
+++ b/train.py
@@ -763,6 +763,7 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    lr_schedule_steps: bool = False
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2039,12 +2040,24 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"lr={config.lr} wd={config.weight_decay}"
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
     effective_warmup_steps = config.lr_warmup_steps
     if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
         effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+    if config.lr_schedule_steps:
+        cosine_steps = max(1, total_estimated_steps - effective_warmup_steps)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=cosine_steps, eta_min=0.0
+        )
+        if is_main:
+            print(
+                f"LR schedule: per-step cosine, T_max={cosine_steps} "
+                f"(total_estimated_steps={total_estimated_steps}, "
+                f"effective_warmup_steps={effective_warmup_steps})"
+            )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if is_main and effective_warmup_steps > 0:
         print(
             f"LR warmup: {effective_warmup_steps} steps "
@@ -2076,6 +2089,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_batch_size": config.batch_size * world_size,
             "lr_warmup_steps_effective": effective_warmup_steps,
             **resume_info,
+            "lr_schedule_mode": "step" if config.lr_schedule_steps else "epoch",
+            "lr_schedule_cosine_t_max": (
+                max(1, total_estimated_steps - effective_warmup_steps)
+                if config.lr_schedule_steps
+                else max_epochs
+            ),
         },
         mode=(
             os.environ.get("WANDB_MODE", "online") if is_main else "disabled"
@@ -2246,6 +2265,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 elif global_step == effective_warmup_steps:
                     for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
                         pg["lr"] = base_lr
+            if (
+                config.lr_schedule_steps
+                and global_step > effective_warmup_steps
+                and scheduler.last_epoch < scheduler.T_max
+            ):
+                scheduler.step()
             optimizer.step()
             ema_decay_now: float | None = None
             if ema is not None:
@@ -2321,7 +2346,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not config.lr_schedule_steps:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0

--- a/train.py
+++ b/train.py
@@ -765,6 +765,7 @@ class Config:
     resume_from: str = ""
     lr_schedule_steps: bool = False
     lr_schedule_cosine_t_max_override: int = 0
+    lr_schedule_eta_min: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2051,17 +2052,20 @@ def main(argv: Iterable[str] | None = None) -> None:
         else:
             cosine_steps = max(1, total_estimated_steps - effective_warmup_steps)
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-            optimizer, T_max=cosine_steps, eta_min=0.0
+            optimizer, T_max=cosine_steps, eta_min=config.lr_schedule_eta_min
         )
         if is_main:
             print(
                 f"LR schedule: per-step cosine, T_max={cosine_steps} "
+                f"eta_min={config.lr_schedule_eta_min} "
                 f"(total_estimated_steps={total_estimated_steps}, "
                 f"effective_warmup_steps={effective_warmup_steps}, "
                 f"override={config.lr_schedule_cosine_t_max_override})"
             )
     else:
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=max_epochs, eta_min=config.lr_schedule_eta_min
+        )
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if is_main and effective_warmup_steps > 0:
         print(


### PR DESCRIPTION
## Hypothesis

The current `yi` training loop uses `CosineAnnealingLR(T_max=max_epochs)` stepped **once per epoch** (see `train.py:1995` and `train.py:2276`). However `max_epochs` defaults to 50 while we typically run only 9–10 epochs — meaning the cosine only moves through ~18% of its period. The LR is effectively **constant** throughout training once warmup ends.

Switching to a **per-step cosine schedule** with `T_max = total_optimizer_steps - warmup_steps` will:
1. Actually decay LR from peak → ~0 over the full training run
2. Provide the final-epoch "super-convergence" effect (heavily decayed LR at end = fine-tuning regime)
3. Remove the accidental constant-LR bias in all prior runs (this is a genuine fix, not a tune)

Per-step LR scheduling is standard in modern language model training (GPT, LLaMA, etc.) and is known to improve convergence in transformer-style architectures.

**Secondary hypothesis**: Compare two variants to understand the effect of the decay speed:
- Arm A: current epoch-step cosine with `T_max=max_epochs` (control — current behavior)
- Arm B: per-step cosine with `T_max=total_steps` (proper full-budget decay)

## Instructions

**Arm A (control — no code change, just run the current baseline config):**
```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent chihiro \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r29-per-step-cosine
```

**Arm B (per-step cosine — code change required):**

Add a `--lr-schedule-steps` flag (default False / not set) to `train.py`. When enabled, replace the epoch-step cosine scheduler with a per-step one:

**Code change in `train.py`** — add a CLI flag (in the argparse/Config section):
```python
# In Config dataclass or argparse args, add:
lr_schedule_steps: bool = False  # If True, step scheduler per optimizer step, not per epoch
```

**In the training loop, replace the scheduler creation (line ~1995):**
```python
# BEFORE (current):
scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)

# AFTER (when --lr-schedule-steps is set):
if config.lr_schedule_steps:
    # total_estimated_steps and effective_warmup_steps are computed at line ~1997
    cosine_steps = max(1, total_estimated_steps - effective_warmup_steps)
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer, T_max=cosine_steps, eta_min=0.0
    )
else:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
```

**Move the scheduler step from per-epoch to per-step** (line ~2276). The warmup already runs per-step. Add the per-step cosine step inside the inner training loop, after the warmup block. The existing `scheduler.step()` at the end of the epoch loop should be conditioned:

In the inner step loop (after the warmup LR application):
```python
if config.lr_schedule_steps and global_step > effective_warmup_steps:
    scheduler.step()
```

In the epoch-end block (line ~2276):
```python
if not config.lr_schedule_steps:
    scheduler.step()
```

Make sure to log the per-step LR to W&B when `lr_schedule_steps=True`:
```python
# In the per-step wandb.log call inside the inner loop, add:
"train/lr": current_lr  # where current_lr = optimizer.param_groups[0]["lr"]
```

Then run Arm B with `--lr-schedule-steps`:
```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent chihiro \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --lr-schedule-steps \
  --wandb-group yi-r29-per-step-cosine
```

**Important implementation notes:**
- The warmup LR ramp already runs per-step (lines ~2002–2005 logic gates on `global_step`). The per-step cosine needs to start exactly where warmup ends — do not double-step.
- Both arms must run with `--seed 42` to remove seed-noise from the comparison.
- Run Arm A first to confirm baseline reproducibility, then Arm B. Both arms 4-GPU DDP.
- Budget: ~31 min/epoch at 4-GPU DDP × 9 epochs + 1 warmup ep = ~310 min. Should fit in SENPAI_TIMEOUT_MINUTES.

## Baseline

**Yi active merge bar: val_abupt < 9.039%** (PR #309 thorfinn, run `328dffb`)

| Metric | Yi baseline (PR #309) | AB-UPT target |
|---|---:|---:|
| val_abupt (primary) | **9.039%** | — |
| surface_pressure | ~5.5% | 3.82% |
| wall_shear | ~10.5% | 7.29% |
| wall_shear_y | ~10.5% | 3.65% |
| wall_shear_z | ~11.8% | 3.63% |
| volume_pressure | ~13.5% | 6.08% |

**Win condition:** Arm B val_abupt < Arm A val_abupt (confirms per-step cosine helps). Merge condition: either arm achieves val_abupt < 9.039%.

**When reporting results, include:**
- Per-epoch val_abupt curve for both arms (to show LR schedule effect over training)
- Final per-channel decomposition (surface_pressure, wall_shear_y, wall_shear_z, volume_pressure)
- Per-step LR trajectory from W&B (to confirm the schedule shape is correct)
- W&B run IDs for both arms
