### PR TITLE
fern: cosine EMA ramp 0.99->0.9999 with FIXED total-epochs span

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    cosine_ema_decay,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -103,6 +104,9 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_start: float = 0.0
+    ema_decay_end: float = 0.9999
+    ema_cosine_total_epochs: int = 0
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
@@ -294,9 +298,21 @@ def main(argv: Iterable[str] | None = None) -> None:
         timeout_hit = False
         train_start = time.time()
 
+        cosine_ema_active = config.ema_decay_start > 0.0 and ema is not None
+        cosine_ema_total_epochs = (
+            config.ema_cosine_total_epochs if config.ema_cosine_total_epochs > 0 else max_epochs
+        )
         for epoch in range(max_epochs):
             if isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
+            if cosine_ema_active:
+                current_ema_decay = cosine_ema_decay(
+                    epoch=epoch,
+                    total_epochs=cosine_ema_total_epochs,
+                    decay_start=config.ema_decay_start,
+                    decay_end=config.ema_decay_end,
+                )
+                ema.set_decay(current_ema_decay)
             timeout_hit = distributed_any(
                 state,
                 (time.time() - train_start) / 60.0 >= timeout_minutes,
@@ -475,6 +491,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }
+            if ema is not None:
+                log_metrics["train/ema_decay"] = float(ema.decay)
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
                 wandb.log(log_metrics)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -45,6 +45,9 @@ class EMA:
         }
         self.backup: dict[str, torch.Tensor] | None = None
 
+    def set_decay(self, new_decay: float) -> None:
+        self.decay = float(new_decay)
+
     @torch.no_grad()
     def update(self, model: nn.Module) -> None:
         self.step_counter += 1
@@ -76,6 +79,19 @@ class EMA:
             if param.requires_grad and name in self.backup:
                 param.data.copy_(self.backup[name])
         self.backup = None
+
+
+def cosine_ema_decay(
+    epoch: int,
+    total_epochs: int,
+    decay_start: float = 0.99,
+    decay_end: float = 0.9999,
+) -> float:
+    """Cosine ramp from decay_start at epoch 0 to decay_end at epoch total_epochs - 1."""
+    progress = epoch / max(total_epochs - 1, 1)
+    progress = min(max(progress, 0.0), 1.0)
+    cosine_factor = (1.0 - math.cos(math.pi * progress)) / 2.0
+    return decay_start + cosine_factor * (decay_end - decay_start)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Hypothesis

The original cosine EMA ramp 0.99→0.9999 (PR #453) was inadvertently neutralized by a config bug: `epochs=50`, `max_epochs_effective=50` made the cosine span 50 epochs while training only ran ~12 epochs. As a result, EMA decay only reached ~0.9908 at training end (not the intended 0.9999). The hypothesis "progressive ramp helps" was therefore not actually tested. Even so, fern #453 vp=4.80% (val) was AB-UPT-class — best-yet for that axis. With the cosine span correctly bounded to the actual training horizon, the model should benefit from low-decay (0.99) early-epoch responsiveness AND high-decay (0.9999) late-epoch averaging.

## Instructions

Re-run the cosine EMA ramp with a properly bounded cosine span. Two changes in `target/train.py` and `target/trainer_runtime.py`:

1. **Add CLI flag `--ema-cosine-total-epochs N`** in `target/train.py` (default = `epochs`). When set, the EMA decay scheduler uses N as the cosine span instead of the nominal `epochs` config.

2. **Plumb the value through to the EMA scheduler** in `trainer_runtime.py`. Locate the EMA decay scheduling code that consumes `ema_decay_start`, `ema_decay_end`, and currently uses `max_epochs_effective` (or equivalent) as the cosine span. Replace that with `ema_cosine_total_epochs` so the cosine half-period is `--ema-cosine-total-epochs / 2` epochs.

3. Verify by logging `ema_decay` per epoch — at training-end (~EP12), `ema_decay` should be ~0.9999, not ~0.9908.

**Reproduce command (DDP8, on the SOTA stack):**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm --rff-num-features 16 \
  --ema-decay 0.999 --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --ema-cosine-total-epochs 12 \
  --wandb-group fern-progressive-ema-fixed \
  --wandb-name fern/progressive-ema-cosine-fixed
```

## Baseline

- Current SOTA: PR #387 alphonse, **val_abupt=7.3816%** (EP11), test_abupt=8.5936% — beat this.
- fern #453 (buggy span, EP10): 7.7247% — what we got with effectively-fixed-0.99 EMA.
- AB-UPT vp target 6.08%; fern #453 hit val_vp=4.80% (already AB-UPT-class). Test vp likely still ~12% due to known dataset val→test gap.

Reference fern #453 close-out comment for the bug analysis.
