### PR TITLE
tanjiro: log1p tau-norm v2 (fixed stats recompute)

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    compute_or_load_log1p_tau_stats,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -119,6 +120,7 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    log1p_tau_norm: bool = False
     debug: bool = False
 
 
@@ -237,12 +239,84 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
+
+        if config.log1p_tau_norm:
+            train_store = train_loader.dataset.store
+            log1p_tau_mean, log1p_tau_std = compute_or_load_log1p_tau_stats(
+                case_root=train_store.root,
+                train_case_ids=train_store.case_ids("train"),
+                distributed_state=state,
+            )
+            raw_tau_mean = stats["surface_y_mean"][1:4].clone()
+            raw_tau_std = stats["surface_y_std"][1:4].clone()
+            new_surface_mean = stats["surface_y_mean"].clone()
+            new_surface_std = stats["surface_y_std"].clone()
+            new_surface_mean[1:4] = log1p_tau_mean
+            new_surface_std[1:4] = log1p_tau_std
+            stats["surface_y_mean"] = new_surface_mean
+            stats["surface_y_std"] = new_surface_std
+            if state.is_main:
+                print(
+                    "[log1p_tau_norm] surface_y_mean (post-recompute): "
+                    f"{stats['surface_y_mean'].tolist()}"
+                )
+                print(
+                    "[log1p_tau_norm] surface_y_std  (post-recompute): "
+                    f"{stats['surface_y_std'].tolist()}"
+                )
+                print(
+                    "[log1p_tau_norm] raw tau mean was "
+                    f"{raw_tau_mean.tolist()}, raw tau std was {raw_tau_std.tolist()}"
+                )
+                print(
+                    "[log1p_tau_norm] log1p tau mean is "
+                    f"{log1p_tau_mean.tolist()}, log1p tau std is {log1p_tau_std.tolist()}"
+                )
+                if torch.allclose(log1p_tau_mean, raw_tau_mean) or torch.allclose(
+                    log1p_tau_std, raw_tau_std
+                ):
+                    raise RuntimeError(
+                        "log1p tau stats are equal to raw tau stats; recompute did not run correctly."
+                    )
+
         transform = TargetTransform(
             surface_y_mean=stats["surface_y_mean"].to(device),
             surface_y_std=stats["surface_y_std"].to(device),
             volume_y_mean=stats["volume_y_mean"].to(device),
             volume_y_std=stats["volume_y_std"].to(device),
+            log1p_tau_norm=config.log1p_tau_norm,
         )
+
+        if config.log1p_tau_norm and state.is_main:
+            try:
+                from data.loader import load_case as _load_case  # type: ignore
+
+                probe_case = _load_case(train_store.root, train_store.case_ids("train")[0])
+                probe_y = probe_case.surface_y.to(device)
+                with torch.no_grad():
+                    probe_norm = transform.apply_surface(probe_y)
+                per_chan_mean = probe_norm.mean(dim=0).tolist()
+                per_chan_std = probe_norm.std(dim=0).tolist()
+                print(
+                    "[log1p_tau_norm] post-transform per-channel mean (one train case): "
+                    f"{per_chan_mean}"
+                )
+                print(
+                    "[log1p_tau_norm] post-transform per-channel std  (one train case): "
+                    f"{per_chan_std}"
+                )
+                tau_mean_max = max(abs(m) for m in per_chan_mean[1:4])
+                tau_std_min = min(per_chan_std[1:4])
+                tau_std_max = max(per_chan_std[1:4])
+                if tau_mean_max > 0.2 or tau_std_min < 0.7 or tau_std_max > 1.4:
+                    raise RuntimeError(
+                        f"log1p_tau_norm post-transform tau stats out of expected band "
+                        f"(|mean|<=0.2, 0.7<=std<=1.4): mean={per_chan_mean[1:4]}, std={per_chan_std[1:4]}"
+                    )
+            except RuntimeError:
+                raise
+            except Exception as exc:
+                print(f"[log1p_tau_norm] post-transform probe skipped: {exc}")
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -6,15 +6,18 @@
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import re
 import subprocess
+import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -170,6 +173,7 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        log1p_tau_norm: bool = False,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -187,6 +191,7 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.log1p_tau_norm = log1p_tau_norm
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -195,16 +200,148 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
+        if self.log1p_tau_norm:
+            y = y.clone()
+            tau = y[..., 1:4]
+            y[..., 1:4] = tau.sign() * tau.abs().log1p()
         return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        y_out = y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        if self.log1p_tau_norm:
+            y_out = y_out.clone()
+            tau = y_out[..., 1:4]
+            y_out[..., 1:4] = tau.sign() * tau.abs().expm1()
+        return y_out
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
         return (y - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)
 
     def invert_volume(self, y: torch.Tensor) -> torch.Tensor:
         return y * self.volume_y_std.to(y.device) + self.volume_y_mean.to(y.device)
+
+
+_LOG1P_TAU_STATS_VERSION = "v1"
+
+
+def _compute_log1p_tau_stats_streaming(
+    case_root: Path,
+    train_case_ids: list[str],
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Stream training cases, apply sign-preserving log1p to tau, return per-channel mean/std.
+
+    Uses float64 accumulation of sum and sum of squares for numerical stability.
+    """
+    sum_per_chan = np.zeros(3, dtype=np.float64)
+    sum_sq_per_chan = np.zeros(3, dtype=np.float64)
+    total_count = 0
+    for idx, case_id in enumerate(train_case_ids):
+        path = Path(case_root) / case_id / "surface_wallshearstress.npy"
+        arr = np.load(path)
+        if arr.ndim != 2 or arr.shape[1] != 3:
+            raise ValueError(
+                f"Expected (N, 3) wall_shear array for case {case_id}, got shape {arr.shape}"
+            )
+        log1p_arr = (np.sign(arr) * np.log1p(np.abs(arr))).astype(np.float64)
+        sum_per_chan += log1p_arr.sum(axis=0)
+        sum_sq_per_chan += np.square(log1p_arr).sum(axis=0)
+        total_count += arr.shape[0]
+        if (idx + 1) % 50 == 0:
+            print(
+                f"[log1p_tau_stats] processed {idx + 1}/{len(train_case_ids)} cases, "
+                f"running n={total_count}"
+            )
+    if total_count == 0:
+        raise ValueError("No training samples to compute log1p tau stats from")
+    mean = sum_per_chan / total_count
+    var = sum_sq_per_chan / total_count - np.square(mean)
+    std = np.sqrt(np.clip(var, a_min=0.0, a_max=None))
+    return mean, std, total_count
+
+
+def compute_or_load_log1p_tau_stats(
+    case_root: Path | str,
+    train_case_ids: list[str],
+    distributed_state: DistributedState,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute (rank 0) or load (cached) per-channel mean/std of log1p-transformed tau channels.
+
+    Caches under <case_root>/log1p_tau_stats.json keyed by version + train-set fingerprint.
+    """
+    case_root = Path(case_root)
+    cache_path = case_root / "log1p_tau_stats.json"
+    fingerprint = {
+        "version": _LOG1P_TAU_STATS_VERSION,
+        "n_train_cases": len(train_case_ids),
+        "train_first": train_case_ids[0] if train_case_ids else None,
+        "train_last": train_case_ids[-1] if train_case_ids else None,
+    }
+
+    def _try_read_cache() -> dict | None:
+        if not cache_path.exists():
+            return None
+        try:
+            with cache_path.open() as f:
+                cached = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if cached.get("fingerprint") != fingerprint:
+            return None
+        return cached
+
+    mean_np: np.ndarray | None = None
+    std_np: np.ndarray | None = None
+
+    if distributed_state.is_main:
+        cached = _try_read_cache()
+        if cached is None:
+            print(
+                f"[log1p_tau_stats] computing from {len(train_case_ids)} train cases "
+                f"under {case_root}"
+            )
+            t0 = time.time()
+            mean_np, std_np, total_count = _compute_log1p_tau_stats_streaming(
+                case_root, train_case_ids
+            )
+            print(
+                f"[log1p_tau_stats] computed in {time.time() - t0:.1f}s "
+                f"(n={total_count}); mean={mean_np.tolist()}, std={std_np.tolist()}"
+            )
+            payload = {
+                "fingerprint": fingerprint,
+                "mean": mean_np.tolist(),
+                "std": std_np.tolist(),
+                "n_points": int(total_count),
+            }
+            try:
+                cache_path.write_text(json.dumps(payload, indent=2))
+                print(f"[log1p_tau_stats] cached to {cache_path}")
+            except OSError as exc:
+                print(f"[log1p_tau_stats] WARNING: failed to write cache {cache_path}: {exc}")
+        else:
+            mean_np = np.array(cached["mean"], dtype=np.float64)
+            std_np = np.array(cached["std"], dtype=np.float64)
+            print(
+                f"[log1p_tau_stats] loaded cached stats from {cache_path}: "
+                f"mean={mean_np.tolist()}, std={std_np.tolist()}"
+            )
+
+    distributed_barrier(distributed_state)
+
+    if not distributed_state.is_main:
+        cached = _try_read_cache()
+        if cached is None:
+            mean_np, std_np, _ = _compute_log1p_tau_stats_streaming(
+                case_root, train_case_ids
+            )
+        else:
+            mean_np = np.array(cached["mean"], dtype=np.float64)
+            std_np = np.array(cached["std"], dtype=np.float64)
+
+    assert mean_np is not None and std_np is not None
+    mean = torch.tensor(mean_np, dtype=torch.float32)
+    std = torch.tensor(std_np, dtype=torch.float32)
+    return mean, std
 
 
 def autocast_context(device: torch.device, amp_mode: str):


### PR DESCRIPTION
## Hypothesis

PR #470 v1 had a stats bug: log1p was applied to tau channels, but `surface_y_mean/std` were computed from raw (untransformed) tau values, so the network saw a non-zero-mean / non-unit-std distribution after z-scoring. The fundamental hypothesis stands: tau channels are heavy-tailed, and a sign-preserving log1p transform compresses dynamic range so optimization is not dominated by extreme-magnitude regions (separation lines, A/C-pillars, wheel arches). With stats correctly recomputed in the transformed space, this should give a real test of the idea.

## Instructions

Implement v2 of log1p tau normalization with corrected stats. Edit `target/trainer_runtime.py` and `target/train.py`.

1. **In `TargetTransform` (`trainer_runtime.py` ~line 163), add a `log1p_tau_norm: bool = False` flag:**
   ```python
   def __init__(self, ..., log1p_tau_norm: bool = False):
       self.log1p_tau_norm = log1p_tau_norm
   ```

2. **CRITICAL — recompute `surface_y_mean/std` from log1p-transformed tau values:** When `log1p_tau_norm=True`, the per-channel stats for tau channels (1:4) MUST be computed AFTER applying the log1p transform. Either:
   - (a) Add a one-time precomputation step at TargetTransform construction that loads the cached raw tau stats, applies log1p elementwise to the underlying samples used to fit them, and recomputes mean/std; OR
   - (b) Cache the log1p-tau stats alongside `normalizers.json` and load conditionally.
   - Confirm with a debug print: after init, with log1p_tau_norm=True, `surface_y_mean[1:4]` should NOT equal raw mean values (and `surface_y_std[1:4]` should be substantially smaller than raw std).

3. **`apply_surface` (forward, normalize):** apply log1p BEFORE z-scoring:
   ```python
   def apply_surface(self, y):
       if self.log1p_tau_norm:
           y = y.clone()
           tau = y[..., 1:4]
           y[..., 1:4] = tau.sign() * tau.abs().log1p()
       return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
   ```

4. **`invert_surface` (denormalize):** apply expm1 AFTER de-z-scoring:
   ```python
   def invert_surface(self, y):
       y_out = y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
       if self.log1p_tau_norm:
           y_out = y_out.clone()
           tau = y_out[..., 1:4]
           y_out[..., 1:4] = tau.sign() * tau.abs().expm1()
       return y_out
   ```

5. **Add `--log1p-tau-norm` CLI flag in `target/train.py`** and plumb to TargetTransform.

6. **Sanity check before main run:** print `surface_y_mean` and `surface_y_std` at startup; tau channels should be near-zero-mean and unit-std after the recompute.

**Reproduce command (DDP8, on SOTA stack):**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm --rff-num-features 16 \
  --log1p-tau-norm \
  --wandb-group tanjiro-log1p-tau-v2 \
  --wandb-name tanjiro/log1p-tau-norm-v2-fixed-stats
```

## Baseline

- SOTA to beat: PR #387 alphonse, **val_abupt=7.3816%** (EP11), test=8.5936%.
- Per-axis test gaps to attack: tau_y=9.1058% (AB-UPT 3.65%), tau_z=10.2736% (AB-UPT 3.63%).
- v1 (PR #470) was closed because of the stats bug — see #470 close-out comment.

This is the v2 promised in #470 close-out.
