### PR TITLE
edward: surface<->volume cross-attention bridge on SOTA stack

### DIFF
--- a/model.py
+++ b/model.py
@@ -302,6 +302,180 @@ class Transformer(nn.Module):
         return x
 
 
+class SurfaceVolumeCrossAttn(nn.Module):
+    """Bidirectional slice-level cross-attention bridge between surface and volume tokens.
+
+    Surface points query volume slice tokens; volume points query surface slice tokens.
+    Each modality builds its own ``num_slices`` Physics-Attention-style soft pool, so
+    cross-attention is ``S x S`` (default 128 x 128) per head rather than the full
+    65k x 65k point-level matrix. A per-head tanh gate initialised at zero keeps the
+    bridge as identity at training start, so the model begins exactly at the SOTA
+    baseline and only deviates if the cross-coupling actually helps validation loss.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        dropout: float = 0.0,
+        gate_init: float = 0.0,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.dim_head = hidden_dim // num_heads
+        self.num_slices = num_slices
+        self.dropout = dropout
+
+        self.norm_s = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_v = nn.LayerNorm(hidden_dim, eps=1e-6)
+
+        # Surface slice creator (Physics-Attention-style soft pool per modality).
+        self.surface_temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
+        self.surface_in_x = LinearProjection(hidden_dim, hidden_dim)
+        self.surface_in_fx = LinearProjection(hidden_dim, hidden_dim)
+        self.surface_in_slice = LinearProjection(self.dim_head, num_slices)
+        # Volume slice creator
+        self.volume_temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
+        self.volume_in_x = LinearProjection(hidden_dim, hidden_dim)
+        self.volume_in_fx = LinearProjection(hidden_dim, hidden_dim)
+        self.volume_in_slice = LinearProjection(self.dim_head, num_slices)
+
+        # K, V projections from per-head slice tokens (B, H, S, dim_head).
+        self.surface_kv = LinearProjection(self.dim_head, self.dim_head * 2, bias=False)
+        self.volume_kv = LinearProjection(self.dim_head, self.dim_head * 2, bias=False)
+
+        # Q projections from each modality's unpooled point tokens (B, N, hidden_dim).
+        self.surface_q = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.volume_q = LinearProjection(hidden_dim, hidden_dim, bias=False)
+
+        # Per-direction output projections.
+        self.proj_s = LinearProjection(hidden_dim, hidden_dim)
+        self.proj_v = LinearProjection(hidden_dim, hidden_dim)
+        self.proj_dropout = nn.Dropout(dropout)
+
+        # Per-head Flamingo-style tanh gates, init=0 -> identity at start.
+        self.gate_s = nn.Parameter(torch.full((num_heads,), float(gate_init)))
+        self.gate_v = nn.Parameter(torch.full((num_heads,), float(gate_init)))
+
+    def _create_slices(
+        self,
+        x_norm: torch.Tensor,
+        mask: torch.Tensor | None,
+        in_x: nn.Module,
+        in_fx: nn.Module,
+        in_slice: nn.Module,
+        temperature: nn.Parameter,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch, num_tokens, _ = x_norm.shape
+        fx_mid = (
+            in_fx(x_norm).view(batch, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        )
+        x_mid = (
+            in_x(x_norm).view(batch, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        )
+        slice_logits = in_slice(x_mid) / temperature
+        slice_weights = F.softmax(slice_logits, dim=-1)
+        if mask is not None:
+            slice_weights = slice_weights * mask[:, None, :, None].to(
+                device=slice_weights.device,
+                dtype=slice_weights.dtype,
+            )
+        slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
+        slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
+        return slice_tokens, slice_norm
+
+    @staticmethod
+    def _slice_attn_mask(slice_norm: torch.Tensor, dtype: torch.dtype, eps: float = 1e-5) -> torch.Tensor:
+        # slice_norm: (B, H, S, 1) -> attn_mask: (B, H, 1, S) for SDPA broadcasting.
+        slice_valid = slice_norm.squeeze(-1) > eps
+        attn_mask = torch.zeros(slice_valid.shape, dtype=dtype, device=slice_valid.device)
+        attn_mask = attn_mask.masked_fill(~slice_valid, torch.finfo(dtype).min)
+        return attn_mask.unsqueeze(2)
+
+    def forward(
+        self,
+        x_s: torch.Tensor,
+        x_v: torch.Tensor,
+        mask_s: torch.Tensor | None = None,
+        mask_v: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch, num_surface, _ = x_s.shape
+        num_volume = x_v.shape[1]
+        if num_surface == 0 or num_volume == 0:
+            return x_s, x_v
+
+        x_s_norm = self.norm_s(x_s)
+        x_v_norm = self.norm_v(x_v)
+
+        slice_s, slice_norm_s = self._create_slices(
+            x_s_norm,
+            mask_s,
+            self.surface_in_x,
+            self.surface_in_fx,
+            self.surface_in_slice,
+            self.surface_temperature,
+        )
+        slice_v, slice_norm_v = self._create_slices(
+            x_v_norm,
+            mask_v,
+            self.volume_in_x,
+            self.volume_in_fx,
+            self.volume_in_slice,
+            self.volume_temperature,
+        )
+
+        K_s, V_s = self.surface_kv(slice_s).chunk(2, dim=-1)
+        K_v, V_v = self.volume_kv(slice_v).chunk(2, dim=-1)
+
+        Q_s = (
+            self.surface_q(x_s_norm)
+            .view(batch, num_surface, self.num_heads, self.dim_head)
+            .permute(0, 2, 1, 3)
+        )
+        Q_v = (
+            self.volume_q(x_v_norm)
+            .view(batch, num_volume, self.num_heads, self.dim_head)
+            .permute(0, 2, 1, 3)
+        )
+
+        attn_mask_s = self._slice_attn_mask(slice_norm_s, dtype=Q_s.dtype)
+        attn_mask_v = self._slice_attn_mask(slice_norm_v, dtype=Q_v.dtype)
+
+        out_s = F.scaled_dot_product_attention(
+            Q_s,
+            K_v,
+            V_v,
+            attn_mask=attn_mask_v,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        out_v = F.scaled_dot_product_attention(
+            Q_v,
+            K_s,
+            V_s,
+            attn_mask=attn_mask_s,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+
+        gate_s = self.gate_s.view(1, self.num_heads, 1, 1).tanh().to(out_s.dtype)
+        gate_v = self.gate_v.view(1, self.num_heads, 1, 1).tanh().to(out_v.dtype)
+        out_s = out_s * gate_s
+        out_v = out_v * gate_v
+
+        out_s = out_s.permute(0, 2, 1, 3).contiguous().view(batch, num_surface, self.hidden_dim)
+        out_v = out_v.permute(0, 2, 1, 3).contiguous().view(batch, num_volume, self.hidden_dim)
+        out_s = self.proj_dropout(self.proj_s(out_s))
+        out_v = self.proj_dropout(self.proj_v(out_v))
+
+        out_s = _apply_token_mask(out_s, mask_s)
+        out_v = _apply_token_mask(out_v, mask_v)
+
+        return x_s + out_s, x_v + out_v
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -323,6 +497,8 @@ class SurfaceTransolver(nn.Module):
         rff_sigma: float = 1.0,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_cross_attn_bridge: bool = False,
+        cross_attn_position: str = "pre_heads",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -334,6 +510,12 @@ class SurfaceTransolver(nn.Module):
         self.rff_sigma = rff_sigma
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_cross_attn_bridge = use_cross_attn_bridge
+        if cross_attn_position not in ("pre_heads", "mid_trunk"):
+            raise ValueError(
+                f"cross_attn_position must be 'pre_heads' or 'mid_trunk', got {cross_attn_position!r}"
+            )
+        self.cross_attn_position = cross_attn_position
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -395,6 +577,16 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        if use_cross_attn_bridge:
+            self.cross_attn_bridge = SurfaceVolumeCrossAttn(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                num_slices=slice_num,
+                dropout=dropout,
+            )
+        else:
+            self.cross_attn_bridge = None
 
     def _encode_group(
         self,
@@ -472,7 +664,28 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        bridge_active = (
+            self.use_cross_attn_bridge
+            and self.cross_attn_bridge is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        )
+        if bridge_active and self.cross_attn_position == "mid_trunk":
+            half = len(self.backbone.blocks) // 2
+            for block in self.backbone.blocks[:half]:
+                hidden = block(hidden, attn_mask=attn_mask)
+            x_s_mid = hidden[:, :surface_tokens]
+            x_v_mid = hidden[:, surface_tokens : surface_tokens + volume_tokens]
+            x_s_mid, x_v_mid = self.cross_attn_bridge(
+                x_s_mid, x_v_mid, surface_mask, volume_mask
+            )
+            hidden = _apply_token_mask(torch.cat([x_s_mid, x_v_mid], dim=1), attn_mask)
+            for block in self.backbone.blocks[half:]:
+                hidden = block(hidden, attn_mask=attn_mask)
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
+
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -480,6 +693,13 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if bridge_active and self.cross_attn_position == "pre_heads":
+            surface_hidden, volume_hidden = self.cross_attn_bridge(
+                surface_hidden, volume_hidden, surface_mask, volume_mask
+            )
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -95,6 +95,8 @@ class Config:
     rff_sigma: float = 1.0
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_cross_attn_bridge: bool = False
+    cross_attn_position: str = "pre_heads"
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -180,6 +182,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_sigma=config.rff_sigma,
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_cross_attn_bridge=config.use_cross_attn_bridge,
+        cross_attn_position=config.cross_attn_position,
     )
 
 
@@ -252,6 +256,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            if config.use_cross_attn_bridge:
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
@@ -577,6 +583,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+                if (
+                    getattr(base_model, "use_cross_attn_bridge", False)
+                    and getattr(base_model, "cross_attn_bridge", None) is not None
+                ):
+                    bridge = base_model.cross_attn_bridge
+                    gate_s_tanh = bridge.gate_s.detach().tanh()
+                    gate_v_tanh = bridge.gate_v.detach().tanh()
+                    log_metrics["bridge/gate_s_tanh_mean"] = float(gate_s_tanh.mean().item())
+                    log_metrics["bridge/gate_v_tanh_mean"] = float(gate_v_tanh.mean().item())
+                    log_metrics["bridge/gate_s_tanh_max_abs"] = float(gate_s_tanh.abs().max().item())
+                    log_metrics["bridge/gate_v_tanh_max_abs"] = float(gate_v_tanh.abs().max().item())
+                    for head_idx in range(bridge.num_heads):
+                        log_metrics[f"bridge/gate_s_tanh_h{head_idx}"] = float(gate_s_tanh[head_idx].item())
+                        log_metrics[f"bridge/gate_v_tanh_h{head_idx}"] = float(gate_v_tanh[head_idx].item())
                 wandb.log(log_metrics)
                 tag = " *" if improved else ""
                 print(


### PR DESCRIPTION
## Hypothesis

The current Transolver architecture handles surface and volume tokens via *grouped* attention with separate heads, but does not have an **explicit cross-attention bridge** between the two modalities. Surface boundary layer behavior should propagate signal into nearby volume points (and vice versa) — physically, surface flow gradients drive the near-wall volume pressure field. An explicit surface↔volume cross-attention block in the trunk would expose this coupling directly to the model rather than relying on it being learned implicitly via shared backbone features.

This attacks the **#1 laggard (volume_pressure: 12.19% test, ×2.0 vs AB-UPT 6.08%)** by giving volume tokens direct access to surface representations. PR #452 (separate vol decoder) attacked from the *capacity* side and revealed val→test overfitting on vol_p — extra capacity alone isn't the answer. This attacks from the *coupling* side: better volume representations from a stronger surface→volume signal pathway.

## Instructions

Add a single cross-attention block to the Transolver trunk (or just before the heads), in `target/model.py`.

1. **Locate the trunk**: after the grouped attention layers, both surface and volume tokens are available as `(B, N_s, D)` and `(B, N_v, D)`.

2. **Add a `--use-cross-attn-bridge` CLI flag** (default False) and a `--cross-attn-position {pre_heads, mid_trunk}` flag. Start with `pre_heads`.

3. **Implement a single bidirectional cross-attention block**:
   ```python
   # Pseudo-code
   class SurfaceVolumeCrossAttn(nn.Module):
       def __init__(self, dim, heads):
           self.s2v = MultiheadAttention(dim, heads)  # volume queries, surface kv
           self.v2s = MultiheadAttention(dim, heads)  # surface queries, volume kv
           self.gate_s = nn.Parameter(torch.zeros(1))  # init 0 → identity at start
           self.gate_v = nn.Parameter(torch.zeros(1))

       def forward(self, surface, volume, surface_mask, volume_mask):
           v_new = self.s2v(volume, surface, surface, key_padding_mask=~surface_mask)
           s_new = self.v2s(surface, volume, volume, key_padding_mask=~volume_mask)
           return surface + self.gate_s.tanh() * s_new, volume + self.gate_v.tanh() * v_new
   ```

4. **Critical: gate init = 0.0**. The cross-attention starts as identity (no effect at init), so the model begins exactly at the SOTA baseline. The gates `tanh(g)` start at 0 and grow if the cross-coupling helps.

5. **Mask handling**: respect surface_mask and volume_mask carefully — DDP batch padding will cause silent NaN issues otherwise. Use `key_padding_mask` in nn.MultiheadAttention or its functional form.

6. **Memory check**: surface ~65k points and volume ~65k points → s2v cross-attn matrix is 65k × 65k tokens per sample. **Use the existing slice-based attention pattern from Physics-Attention** rather than full quadratic — limit cross-attn to the slice level (128 slices × 128 slices = 16k pairs) by using slice-level KV summaries instead of point-level. This keeps memory in line with the rest of the trunk.

**Reproduce command (DDP8, on SOTA stack):**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm --rff-num-features 16 \
  --use-cross-attn-bridge --cross-attn-position pre_heads \
  --wandb-group edward-surf-vol-xattn \
  --wandb-name edward/surface-volume-cross-attn-bridge
```

## Baseline

- SOTA to beat: PR #387 alphonse, **val_abupt=7.3816%** (EP11), test=8.5936%.
- #1 axis to attack: test_volume_pressure=12.1885% (AB-UPT 6.08%, gap ×2.0).
- Note PR #452 separate vol decoder finished best=7.9028% with val_vp=4.80% but test_vp=12.38% — capacity alone overfits. This experiment tests whether *coupling* is the better lever.
- Reference: ABLator (Cao et al. 2023) and most multi-modal transformers use cross-attention bridges between modalities; this is the natural Transolver analogue.

If gate values stay near 0 throughout training, that's a clean diagnostic that the surface↔volume coupling isn't a binding constraint — informative null result.
