### PR TITLE
asinh wall-shear target normalization to compress 4-decade tau range

### DIFF
--- a/train.py
+++ b/train.py
@@ -699,6 +699,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    asinh_wallshear_scale: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -753,6 +754,7 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        asinh_wallshear_scale: float = 0.0,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -770,6 +772,27 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.asinh_wallshear_scale = float(asinh_wallshear_scale)
+
+        # Pre-compute asinh-space mean/std for wall-shear channels (indices 1–3).
+        # We approximate by sampling from the raw N(μ, σ²) distribution using a
+        # fixed grid of 10001 quantile points for fast, deterministic moment estimation.
+        if self.asinh_wallshear_scale > 0.0:
+            ws_raw_mean = surface_y_mean[1:4].float().cpu()
+            ws_raw_std = surface_y_std.clamp(min=1e-6)[1:4].float().cpu()
+            n_samples = 10_001
+            quantiles = torch.linspace(1e-4, 1 - 1e-4, n_samples)
+            # icdf of standard normal: approximate via erfinv
+            z = torch.erfinv(2.0 * quantiles - 1.0) * (2.0 ** 0.5)  # shape (n_samples,)
+            # shape: (n_samples, 3) — compute on CPU, then move to same device as stats
+            samples = ws_raw_mean.unsqueeze(0) + ws_raw_std.unsqueeze(0) * z.unsqueeze(1)
+            asinh_samples = torch.asinh(samples / self.asinh_wallshear_scale)
+            target_device = surface_y_mean.device
+            self.asinh_ws_mean = asinh_samples.mean(dim=0).to(target_device)  # shape (3,)
+            self.asinh_ws_std = asinh_samples.std(dim=0).clamp(min=1e-6).to(target_device)  # shape (3,)
+        else:
+            self.asinh_ws_mean = None
+            self.asinh_ws_std = None
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -778,10 +801,51 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
+        if self.asinh_wallshear_scale > 0.0:
+            # Channel 0 (cp): standard z-score with raw mean/std
+            cp = (y[..., :1] - self.surface_y_mean[:1].to(y.device)) / self.surface_y_std[:1].to(y.device)
+            # Channels 1–3 (wall-shear): asinh pre-transform then z-score with asinh-space stats
+            ws = y[..., 1:4]
+            ws_asinh = torch.asinh(ws / self.asinh_wallshear_scale)
+            ws_norm = (ws_asinh - self.asinh_ws_mean.to(y.device)) / self.asinh_ws_std.to(y.device)
+            return torch.cat([cp, ws_norm], dim=-1)
         return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
+        if self.asinh_wallshear_scale > 0.0:
+            # Channel 0 (cp): standard un-z-score
+            cp = y[..., :1] * self.surface_y_std[:1].to(y.device) + self.surface_y_mean[:1].to(y.device)
+            # Channels 1–3 (wall-shear): un-z-score then inverse asinh (sinh * scale)
+            ws_norm = y[..., 1:4]
+            ws_asinh = ws_norm * self.asinh_ws_std.to(y.device) + self.asinh_ws_mean.to(y.device)
+            ws = torch.sinh(ws_asinh) * self.asinh_wallshear_scale
+            return torch.cat([cp, ws], dim=-1)
         return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+
+    def invert_wallshear(self, ws_norm: torch.Tensor) -> torch.Tensor:
+        """Invert normalization for wall-shear channels only (shape: [..., 3]).
+
+        When asinh is enabled, applies un-z-score then sinh * scale.
+        Otherwise, applies the standard linear un-z-score using raw mean/std.
+        Used by the tangential wall-shear loss to convert between normalized and
+        physical space without touching the cp channel.
+        """
+        if self.asinh_wallshear_scale > 0.0:
+            ws_asinh = ws_norm * self.asinh_ws_std.to(ws_norm.device) + self.asinh_ws_mean.to(ws_norm.device)
+            return torch.sinh(ws_asinh) * self.asinh_wallshear_scale
+        return ws_norm * self.surface_y_std[1:4].to(ws_norm.device) + self.surface_y_mean[1:4].to(ws_norm.device)
+
+    def apply_wallshear(self, ws_phys: torch.Tensor) -> torch.Tensor:
+        """Apply normalization to wall-shear channels only (shape: [..., 3]).
+
+        When asinh is enabled, applies asinh / scale then z-score with asinh-space stats.
+        Otherwise, applies the standard linear z-score using raw mean/std.
+        Used by the tangential wall-shear loss to re-normalize after physical projection.
+        """
+        if self.asinh_wallshear_scale > 0.0:
+            ws_asinh = torch.asinh(ws_phys / self.asinh_wallshear_scale)
+            return (ws_asinh - self.asinh_ws_mean.to(ws_phys.device)) / self.asinh_ws_std.to(ws_phys.device)
+        return (ws_phys - self.surface_y_mean[1:4].to(ws_phys.device)) / self.surface_y_std[1:4].to(ws_phys.device)
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
         return (y - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)
@@ -1520,16 +1584,14 @@ def train_loss(
             # in normalized space does not equal physical-space tangent projection.
             # Denormalize -> project in physical space -> renormalize.
             normals = batch.surface_x[..., 3:6]
-            ws_std = transform.surface_y_std[1:4]
-            ws_mean = transform.surface_y_mean[1:4]
             ws_pred_norm = surface_pred_norm[..., 1:4]
             ws_true_norm = surface_target[..., 1:4]
-            ws_pred_phys = ws_pred_norm * ws_std + ws_mean
-            ws_true_phys = ws_true_norm * ws_std + ws_mean
+            ws_pred_phys = transform.invert_wallshear(ws_pred_norm)
+            ws_true_phys = transform.invert_wallshear(ws_true_norm)
             ws_pred_tan = project_tangential(ws_pred_phys, normals)
             ws_true_tan = project_tangential(ws_true_phys, normals)
-            ws_pred_tan_norm = (ws_pred_tan - ws_mean) / ws_std
-            ws_true_tan_norm = (ws_true_tan - ws_mean) / ws_std
+            ws_pred_tan_norm = transform.apply_wallshear(ws_pred_tan)
+            ws_true_tan_norm = transform.apply_wallshear(ws_true_tan)
             surface_pred_used = torch.cat([surface_pred_norm[..., :1], ws_pred_tan_norm], dim=-1)
             surface_target_used = torch.cat([surface_target[..., :1], ws_true_tan_norm], dim=-1)
             if bool(batch.surface_mask.any()):
@@ -1912,6 +1974,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         surface_y_std=stats["surface_y_std"].to(device),
         volume_y_mean=stats["volume_y_mean"].to(device),
         volume_y_std=stats["volume_y_std"].to(device),
+        asinh_wallshear_scale=config.asinh_wallshear_scale,
     )
 
     model = build_model(config).to(device)


### PR DESCRIPTION
## Hypothesis

Wall-shear targets span a ~4-decade magnitude range (tau_x can exceed 1000× tau_y in cross-flow regions). Standard MSE with linear normalisation treats a residual on a high-magnitude point identically to a residual on a low-magnitude point, which means the loss is dominated by streamwise shear and effectively ignores cross-flow tau_y/tau_z — the channels where we are furthest from AB-UPT (2.53× and 2.88× respectively on the test set).

`asinh(tau / scale)` maps the 4-decade range onto a compact symmetric interval: large magnitudes are log-compressed, small-magnitude cross-flow shear is linear near zero. This should rebalance the optimisation gradient towards tau_y/tau_z without changing architecture, optimizer, or the loss weight hyperparameters.

The hypothesis is that replacing the current linear normalization of wall-shear targets with `asinh(tau / scale)` will reduce val_abupt below the yi merge bar of 9.039% and produce **disproportionate** tau_y and tau_z improvements.

Reference: asinh normalization for skewed-range regression targets is standard in meteorological forecasting (precipitation) and financial ML. The approach is scale-sensitive: `scale` controls the crossover from linear (|tau| ≪ scale) to log (|tau| ≫ scale).

## Instructions

**Add `--asinh-wallshear-scale SCALE` to `train.py`.**

The change is a data-transform only — no architecture, optimizer, or loss-weight changes. All wall-shear target normalization/denormalization in the dataset pipeline needs to be updated to use `asinh(tau / scale)` instead of the current linear standardization, and predictions must be back-transformed via `scale * sinh(pred)` before metric computation.

Concretely:

1. **Add the CLI flag** `--asinh-wallshear-scale` (type=float, default=0.0 — zero means disabled, preserve exact current behaviour with no behaviour change when the flag is absent or zero).

2. **In the dataset / normalization code**, when `asinh_wallshear_scale > 0`:
   - Forward transform: `tau_normalized = asinh(tau_raw / asinh_wallshear_scale)` applied to the 3 wall-shear channels before feeding into the model.
   - The asinh output is then further standardized to zero-mean/unit-std (subtract mean of asinh-transformed training data, divide by std) so the model still sees zero-centered inputs.
   - Inverse transform (for metric computation and W&B logging): `tau_raw = asinh_wallshear_scale * sinh(tau_model_output * std + mean)` — exactly reverse the chain.

3. **Surface pressure and volume pressure targets** are **not** changed by this flag. Only the 3 wall-shear channels (tau_x, tau_y, tau_z) are affected.

4. **Run a 3-arm single-GPU screen** to find the best scale, using the PR #309 yi base config (NOT PR #311 tay, which is not on yi):
   - Arm A: `--asinh-wallshear-scale 0.05` (very tight, compresses even small tau heavily)
   - Arm B: `--asinh-wallshear-scale 0.1` (moderate compression, cross-over at ~0.1 Pa)
   - Arm C: `--asinh-wallshear-scale 0.5` (mild compression, cross-over at ~0.5 Pa)
   
   Each arm: 1-GPU single-seed, SENPAI default epoch budget. Use `--wandb-group yi-r30-kohaku-asinh-wallshear` so all arms appear in one W&B group.

5. **If any arm beats the single-GPU yi baseline by ≥ 0.3pp on val_abupt**, promote the best arm to **8-GPU DDP** for a full-budget confirmation run.

**Base config for all arms (yi PR #309 SOTA):**

```bash
torchrun --standalone --nproc_per_node=1 train.py \
  --agent kohaku \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --clip-grad-norm 0.5 \
  --use-tangential-wallshear-loss \
  --wallshear-y-weight 2.0 \
  --wallshear-z-weight 2.0 \
  --asinh-wallshear-scale <SCALE> \
  --wandb-group yi-r30-kohaku-asinh-wallshear
```

Replace `<SCALE>` with 0.05, 0.1, or 0.5 per arm.

**DDP promotion config (if triggered):**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  [same flags as above, best --asinh-wallshear-scale value] \
  --batch-size 4 \
  --wandb-group yi-r30-kohaku-asinh-wallshear-ddp
```

## Win criterion

- **Merge:** Any arm (screen or DDP) achieves `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (current yi merge bar).
- **Bonus signal:** tau_y and tau_z show disproportionately large improvement vs tau_x and surface_pressure — this confirms the asinh compression is doing what the hypothesis predicts (rebalancing gradient toward cross-flow channels).
- **Send back:** If screening arms don't beat baseline but show tau_y/tau_z improving, report the per-channel deltas — the hypothesis may hold but need a different scale range.

## Baseline

Current yi merge bar: **val_abupt 9.039%** (PR #309 thorfinn, `--clip-grad-norm 0.5`)

| Metric (test, PR #309) | yi best |
|---|---:|
| `abupt_axis_mean_rel_l2_pct` | — (merge bar is val 9.039%) |
| `surface_pressure_rel_l2_pct` | ~5.87% |
| `wall_shear_rel_l2_pct` | ~10.34% |
| `volume_pressure_rel_l2_pct` | ~5.88% |
| `wall_shear_y_rel_l2_pct` | largest gap vs AB-UPT (AB-UPT: 3.65%) |
| `wall_shear_z_rel_l2_pct` | largest gap vs AB-UPT (AB-UPT: 3.63%) |

Best full-campaign test result (PR #311 on tay branch, NOT on yi yet):

| Metric (test, PR #311 tay) | tay best | AB-UPT |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | 8.771% | — |
| `surface_pressure_rel_l2_pct` | 4.485% | 3.82% |
| `wall_shear_rel_l2_pct` | 8.227% | 7.29% |
| `volume_pressure_rel_l2_pct` | 12.438% | 6.08% |
| `wall_shear_y_rel_l2_pct` | 9.233% | 3.65% |
| `wall_shear_z_rel_l2_pct` | 10.449% | 3.63% |

Your experiment runs on the **yi codebase** — compare against the yi merge bar (9.039% val), not the tay result.

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml`

When done, report val_abupt and per-channel test metrics for each arm in a comment on this PR.
