### PR TITLE
frieren: STRING-sep learnable PE port to yi (PR #420 reassign)

### DIFF
--- a/train.py
+++ b/train.py
@@ -229,11 +229,18 @@ class LinearProjection(nn.Module):
 
 
 class ContinuousSincosEmbed(nn.Module):
-    def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
+    def __init__(
+        self,
+        hidden_dim: int,
+        input_dim: int,
+        max_wavelength: int = 10_000,
+        learnable: bool = False,
+    ):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.input_dim = input_dim
         self.max_wavelength = max_wavelength
+        self.learnable = learnable
         padding = hidden_dim % input_dim
         dim_per_axis = (hidden_dim - padding) // input_dim
         sincos_padding = dim_per_axis % 2
@@ -242,11 +249,24 @@ class ContinuousSincosEmbed(nn.Module):
         if effective_dim_per_axis <= 0:
             raise ValueError("hidden_dim must be large enough for the requested input dimension")
         arange = torch.arange(0, effective_dim_per_axis, 2, dtype=torch.float32)
-        self.register_buffer("omega", 1.0 / max_wavelength ** (arange / effective_dim_per_axis))
+        init_omega = 1.0 / max_wavelength ** (arange / effective_dim_per_axis)
+        if self.learnable:
+            init_log_omega = torch.log(init_omega)
+            self.log_freq = nn.Parameter(
+                init_log_omega.unsqueeze(0).expand(input_dim, -1).clone()
+            )
+            self.phase = nn.Parameter(torch.zeros(input_dim, len(arange)))
+        else:
+            self.register_buffer("omega", init_omega)
 
     def forward(self, coords: torch.Tensor) -> torch.Tensor:
         coords = coords.float()
-        out = coords.unsqueeze(-1) * self.omega
+        if self.learnable:
+            omega = torch.exp(self.log_freq)
+            out = coords.unsqueeze(-1) * omega
+            out = out + self.phase
+        else:
+            out = coords.unsqueeze(-1) * self.omega
         emb = torch.cat([torch.sin(out), torch.cos(out)], dim=-1)
         emb = emb.flatten(start_dim=-2)
         if self.padding > 0:
@@ -481,6 +501,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        learnable_pe: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -493,11 +514,13 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        self.learnable_pe = learnable_pe
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
             input_dim=space_dim,
             max_wavelength=pos_max_wavelength,
+            learnable=learnable_pe,
         )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -715,6 +738,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    learnable_pe: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -897,6 +921,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        learnable_pe=config.learnable_pe,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -762,6 +762,7 @@ class Config:
     lr_warmup_steps: int = 0
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    resume_from: str = ""
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1940,6 +1941,27 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     model = build_model(config).to(device)
+    resume_info: dict[str, float | str | int] = {}
+    if config.resume_from:
+        ckpt = torch.load(config.resume_from, map_location=device, weights_only=True)
+        model.load_state_dict(ckpt["model"], strict=True)
+        prev_epoch = ckpt.get("epoch", -1)
+        prev_val_metrics = ckpt.get("val_metrics", {}) or {}
+        prev_primary_val = float(
+            (prev_val_metrics.get("val_surface", {}) or {}).get(
+                "abupt_axis_mean_rel_l2_pct", float("nan")
+            )
+        )
+        resume_info = {
+            "resume_from_path": str(config.resume_from),
+            "resume_prev_epoch": int(prev_epoch) if isinstance(prev_epoch, (int, float)) else -1,
+            "resume_prev_val_abupt_pct": prev_primary_val,
+        }
+        if is_main:
+            print(
+                f"Resumed model weights from {config.resume_from} "
+                f"(saved at epoch {prev_epoch}, val_abupt={prev_primary_val:.4f}%)"
+            )
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
@@ -2053,6 +2075,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ddp_world_size": world_size,
             "ddp_effective_batch_size": config.batch_size * world_size,
             "lr_warmup_steps_effective": effective_warmup_steps,
+            **resume_info,
         },
         mode=(
             os.environ.get("WANDB_MODE", "online") if is_main else "disabled"


### PR DESCRIPTION
# STRING-Separable Learnable PE Port to yi (Reassignment of PR #420)

## Hypothesis

The yi SOTA aspirational target (`val_abupt 7.546%`, PR #311 tay run `gcwx9yaa`) was achieved with **STRING-separable learnable PE** — per-axis learnable `log_freq` and `phase` parameters in `ContinuousSincosEmbed`. The yi `train.py` still uses the original fixed-omega `ContinuousSincosEmbed`. PR #420 (fern) ported the implementation to yi via commit `6f2e991` but did not run the experiment to completion. We are re-assigning the port to drive it through.

If STRING-sep PE on yi reproduces ≤7.546% val_abupt, the merge bar drops from 9.039% → 7.546% and unlocks every architecture/loss follow-up that has been gated on this port. This is the highest-leverage outstanding port on the yi branch.

## Current Baseline (yi as it actually exists today)

| Metric | Yi baseline (PR #309) | Aspirational (PR #311 tay) | AB-UPT |
|--------|----------------------|---------------------------|--------|
| val_abupt (primary) | **9.039%** | 7.546% | — |
| test_abupt | ~10.2% | 8.771% | — |
| surface_pressure | ~5.5% | 4.485% | 3.82% |
| wall_shear (vector) | ~10.5% | 8.227% | 7.29% |
| wall_shear_y | ~10.5% | 9.233% | 3.65% |
| wall_shear_z | ~11.8% | 10.449% | 3.63% |
| volume_pressure | ~13.5% | 12.438% | 6.08% |

**Active merge bar: val_abupt < 9.039%** (yi baseline).
**Aspirational target: val_abupt ≤ 7.546%** (would reset the merge bar).

## Instructions

### Step 1 — Cherry-pick the STRING-sep PE commit

```bash
cd /workspace/senpai/target
git fetch origin
git cherry-pick 6f2e991
```

Commit `6f2e991` ("feat: add learnable per-axis log_freq/phase to ContinuousSincosEmbed") adds:
- `--learnable-pe` CLI flag (default False)
- When enabled, replaces the fixed `omega` buffer in `ContinuousSincosEmbed` with two `nn.Parameter` tensors: `log_freq[input_dim, num_freqs]` and `phase[input_dim, num_freqs]`
- `log_freq` initialised from `log(1/max_wavelength**(arange/effective_dim_per_axis))` so initial output exactly matches fixed sincos
- `phase` initialised to zeros
- Forward branches on `self.learnable`; gradients flow through both params

If the cherry-pick conflicts on `train.py` (yi has had several merges since), resolve manually preserving the existing yi structure. Do **not** modify any other behavior.

### Step 2 — Smoke test before launching DDP

```bash
python -c "
from train import parse_args, build_model
c = parse_args(['--model-layers','4','--model-hidden-dim','512','--model-heads','8','--model-slices','128','--learnable-pe'])
m = build_model(c)
pe = m.surface_branch.pos_embed if hasattr(m, 'surface_branch') else m.pos_embed
print(type(pe).__name__, 'learnable=', pe.learnable)
print('log_freq shape:', pe.log_freq.shape, 'phase shape:', pe.phase.shape)
print('phase abs sum (should be 0):', pe.phase.abs().sum().item())
"
```

Confirm `learnable=True`, both shapes are `[3, num_freqs]`, and phase is zero. If phase is non-zero or shapes differ, fix before launch.

### Step 3 — Single-arm full-budget DDP

Use the full yi compounding-wins config (Lion lr=1e-4 wd=1e-4, EMA=0.999, clip=0.5, 4-GPU DDP):

```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent frieren \
  --wandb-group frieren-r30-string-sep-pe-port \
  --wandb-name "frieren-string-sep-pe-arm-a" \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 --weight-decay 1e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 --clip-grad-norm 0.5 \
  --epochs 50
```

The 360-min timeout will fire mid-training (~3 epochs); that is expected and the harness will load the best EMA checkpoint and run full_val + test_eval.

### Step 4 — Verify gradients are flowing through PE during training

After ~100 steps, log the L2 norm of `log_freq.grad` and `phase.grad` at least once. If either is below `1e-8`, the PE params are receiving no gradient and the run should be killed. Include this number in your results comment.

### Step 5 — Reporting

Per-epoch table with W&B run ID, plus a final test_eval table:

| Metric | Yi baseline (9.039%) | Arm A (STRING-sep) | Δ |
|---|---|---|---|
| val_abupt | 9.039% | ?? | ?? |
| test_abupt | ~10.2% | ?? | ?? |
| ws_y (test) | 10.5% | ?? | ?? |
| ws_z (test) | 11.8% | ?? | ?? |
| vol_p (test) | 13.5% | ?? | ?? |

Also report `pe.log_freq.grad.norm()` and `pe.phase.grad.norm()` at step 100 to confirm the PE is training.

## What success looks like

- Arm A val_abupt ≤ 9.039% — beats yi baseline → MERGE
- Arm A val_abupt ≤ 7.546% — reproduces tay aspirational result → BIG MERGE (resets the bar)
- Arm A val_abupt > 9.039% — investigate: is grad flowing through `log_freq`/`phase`? Has `phase` moved meaningfully from zero by ep1? Is the cherry-pick clean?

## Fail-safe / context

If the cherry-pick has any code-level issues you can not resolve cleanly, **post a comment immediately** rather than guessing — the implementation must match commit `6f2e991`. Do not improvise PE changes beyond what that commit specifies.

Once your DDP run is launched and confirmed healthy in W&B, mark this PR ready for review and the advisor will analyze results when timeout fires (~6h total budget, ~3 epochs expected).
