### PR TITLE
tanjiro: homoscedastic uncertainty-weighted multitask loss

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-03 (post W&B snapshot, Round 25 active — PR #489 assigned; 8 students active)
+- **Date:** 2026-05-03 (post W&B snapshot, late EP9 region — 8 students active, 0 idle)
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -22,73 +22,80 @@ W&B run `wj6mn6ve`, group `alphonse-rff-sweep`. All future PRs must beat val_abu
 
 ## Latest research direction from human researcher team
 
-No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-derived levers) plus organic vol_p / tau-axis attack.
+No new directives in last cycle. All 3 open human issues already responded to. Still working off Issue #252 (Modded-NanoGPT-derived levers) plus organic vol_p / tau-axis attack.
 
 ---
 
 ## Currently in-flight (8 active WIP PRs on tay, ZERO idle students)
 
-| PR | Student | Hypothesis | Run | Status (06:15 UTC) |
-|---|---|---|---|---|
-| **#489** | **thorfinn** | **Volume-points curriculum 16k→65k (4-stage ramp)** | pending | **JUST ASSIGNED** |
-| #471 | askeladd | Signed-log vol target transform (arm-a EP12 done; arm-b pending) | `a2skzz6m` / pending | Arm-a complete, arm-b launching |
-| #458 | nezuko | model-mlp-ratio=8 on SOTA stack | `he54fm6v` | In flight (EP2.4) |
-| #483 | edward | surface↔volume cross-attention bridge | `ok98szul` | In flight (EP3.3) |
-| #480 | fern | Cosine EMA ramp (fixed cosine span) | `2u6twuu4` | In flight (EP6.3) — **vol_p BREAKTHROUGH 5.30%** |
-| #481 | tanjiro | log1p tau-norm v2 (corrected stats) | `hnrpuptg` | In flight (EP6.0, gate waiver granted) |
-| #454 | frieren | tau_yz loss weight 1.5× | `l8nu1ajz` | In flight (EP5.2, gate pending) |
-| #488 | alphonse | Multi-sigma log_freq init for STRING-sep | `ki2q9ko9` (rank0) | In flight (EP0.7) |
+| PR | Student | Hypothesis | Run | Step / EP | val_abupt | Status |
+|---|---|---|---|---|---:|---|
+| **#480** | **fern** | **Cosine EMA ramp (12-ep span)** | `2u6twuu4` | 23171 / EP9.5 | **7.745%** | **PRIMARY SOTA CANDIDATE** — projected EP12 ~7.28% |
+| #481 | tanjiro | log1p tau-norm v2 | `hnrpuptg` | 22436 / EP9.2 | 8.064% | Descending, vol_p strong |
+| #454 | frieren | tau_yz loss weight 1.5× | `l8nu1ajz` | 20493 / EP8.4 | 8.248% | tau_yz weighting confirmed inert |
+| #483 | edward | surface↔vol cross-attn bridge | `ok98szul` | 14537 / EP6.0 | 8.969% (EP5.6) | EP5 gate borderline pass (waiver) |
+| #458 | nezuko | model-mlp-ratio=8 | `he54fm6v` | 12815 / EP5.3 | 9.805% (EP4.5) | EP5 slope-waiver granted (slope −1.377 pp/1k → proj 8.05%) |
+| #488 | alphonse | Multi-sigma log_freq init (STRING-sep) | `ki2q9ko9` | 9863 / EP4.1 | 13.99% | Pre-gate, slow-warmup expected |
+| #489 | thorfinn | Volume-points curriculum 16k→65k | (run pending) | 8617 / EP3.5 | (no val yet) | Pre-gate, first val at EP4 |
+| #471 | askeladd | Signed-log vol target (arm-b) | `wlb9zv1v` | 6207 / EP2.6 | 38.36% | Arm-a EP12 done (vol_p 4.62% record); arm-b early |
 
 ---
 
-## Latest signals (W&B snapshot — late EP7-8 region)
+## Latest signals (W&B snapshot — late EP7-9 region)
 
 ### Fern #480 — APPROACHING SOTA
-- W&B `2u6twuu4` step 21879: **val_abupt=7.745%** (only **+0.36pp above SOTA 7.3816%** — still descending)
-- vol_p=**4.688%** (well below AB-UPT 6.08%, improved from 5.30% at EP6)
-- surf_p=5.08% / wall_shear=8.67% / tau_x=7.43% / tau_y=9.98% / tau_z=11.54%
-- Strongest in-flight run on `tay`. Continue to EP12; **needs test metrics from best-val checkpoint** for SOTA decision
+- W&B `2u6twuu4` step 23171: **val_abupt=7.745%** (only +0.36pp above SOTA 7.3816%, descending)
+- vol_p=**4.688%** (well below AB-UPT 6.08%) — vol_p BREAKTHROUGH confirmed
+- tau_y=9.982%, tau_z=11.543% — best tau_y/z of any in-flight run
+- Slope: **−0.076 pp/1k steps** at EP9.5 — projected EP12 val ≈ **7.28%** (BELOW SOTA 7.3816%)
+- Trajectory log: EP1.1: 39.50% → EP3.4: 11.47% → EP5.6: 8.69% → EP7.8: 7.95% → EP9.0: 7.745%
+- **Strongest in-flight run on `tay`. Continue to EP12; needs test metrics from best-val checkpoint for SOTA decision.**
 
-### Tanjiro #481 — GATE WAIVER MET ✓
-- W&B `hnrpuptg` step 21300: **val_abupt=8.309%** (waiver required <8.5% by EP8 — MET)
-- vol_p=5.140% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
-- tau_y=10.71% / tau_z=12.32% — log1p has NOT yet shown clear tau-axis improvement vs fern/frieren
-- Continue to EP12; report best-val checkpoint val+test metrics
+### Tanjiro #481 — vol_p strong, tau-axis flat
+- W&B `hnrpuptg` step 22436: val_abupt=8.064% (+0.68pp above SOTA, descending)
+- vol_p=4.827% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
+- tau_y=10.71% / tau_z=12.32% — log1p NOT closing tau gap
 
-### Frieren #454 — GATE PASS
-- W&B `l8nu1ajz` step 19292: val_abupt=**8.248%** (well below 8.9% gate threshold)
+### Frieren #454 — confirms tau_yz weighting is inert
+- W&B `l8nu1ajz` step 20493: val_abupt=8.248% (descending)
 - vol_p=5.220% (below AB-UPT 6.08%)
-- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x not narrowing gap vs other runs
-- Continue to EP12
+- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x NOT narrowing the gap
+- Combined with #142 (w=2.0 NEG), #467 (per-axis scale NEG) → loss-weighting tau is exhausted; problem is upstream
 
-### Cross-cutting observation: vol_p victory, tau_y/z stagnation
-- All three late-epoch runs (fern/tanjiro/frieren) now beat AB-UPT vol_p benchmark (4.69%, 5.14%, 5.22% < 6.08%) — vol_p attack succeeding broadly
-- All three runs have tau_y ~10-11% and tau_z ~11.5-12.3% — none breaking through to AB-UPT 3.65/3.63%
-- Implication: log1p / loss-weight / EMA all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
+### Edward #483 — EP5 borderline gate pass
+- W&B `ok98szul` EP5.6: val_abupt=8.969% (+0.069pp above 8.9% gate — slope-waiver granted)
+- vol_p=5.457% (below AB-UPT 6.08%)
+- Slope: −0.469 pp/1k steps — healthy descent
+
+### Nezuko #458 — EP5 slope-waiver granted
+- W&B `he54fm6v` EP4.5: val_abupt=9.805%, vol_p=6.316%
+- Slope: **−1.377 pp/1k steps** (steepest in fleet) → projected EP5 ≈ 8.05% (clean gate pass)
+- mlp_ratio=8 is slow-converging — expected given param-count increase
+
+### Alphonse #488 — primary tau_y/z attack, pre-gate
+- W&B `ki2q9ko9` EP4.1: val_abupt=13.99% (early, descending)
+- Multi-sigma init [0.25, 0.5, 1.0, 2.0, 4.0] — slow-warmup expected; slope-waiver pre-approved
+- Most important final metrics: test tau_y, test tau_z
+
+### Thorfinn #489 — vol-curriculum, pre-first-val
+- step=8617 EP3.5, no val checkpoint yet — first val at EP4 completion
 
 ### Askeladd #471 — Arm-a complete, arm-b launched
-- Arm-a EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
-- Signed-log transform crushes vol_p but increases other axes → no headline win
-- Arm-b just launched at EP1 val_abupt=62.53% (early)
-- Candidate for composition with fern (cosine EMA) — both target vol_p
+- Arm-a (`a2skzz6m`) EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
+- Signed-log transform crushes vol_p but doesn't recover headline → composition target with fern (orthogonal vol_p levers)
+- Arm-b (`wlb9zv1v`) EP2.6 val_abupt=38.36% (early warmup)
 
-### Edward #483 — EP4, pre-gate
-- val_abupt ~10.24% — descending, on trajectory
-
-### Nezuko #458 (mlp_ratio=8) — EP4, pre-gate
-- val_abupt ~9.80% — descending
-
-### Alphonse #488 — EP3, pre-gate
-- val_abupt ~32.28% — early
-
-### Thorfinn #489 — vol-curriculum, just launched
+### Cross-cutting observation: vol_p victory broadly, tau_y/z stagnation
+- All four late-epoch runs (fern/tanjiro/frieren + askeladd arm-a) now beat AB-UPT vol_p benchmark (4.69% / 4.83% / 5.22% / 4.62% < 6.08%) — **vol_p attack succeeding broadly**
+- All four runs have tau_y ~9.98-10.71% and tau_z ~11.54-12.32% — none breaking through to AB-UPT 3.65/3.63%
+- Implication: log1p / loss-weight / EMA / signed-log all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
 
 ---
 
 ## Recent closeouts
 
-- **PR #482 thorfinn (TTA mirror-y) — CLOSED (EP5 gate fail).** EP6 val_abupt=10.989%, slope −1.03 pp/1k steps — training was worse than SOTA baseline despite TTA being inference-only. Likely TTA was applied to training path too, or unrelated regression. TTA can be tested post-hoc on frozen SOTA checkpoint.
-- **PR #467 alphonse (per-axis output scaling) — CLOSED-NEG.** val tie (−0.0022pp << noise), test regression +0.024pp. Key finding: tau_y/tau_z gap is upstream in spectral representation, NOT output head. Spawned PR #488.
+- **PR #482 thorfinn (TTA mirror-y) — CLOSED (EP5 gate fail).** EP6 val_abupt=10.989%; TTA must be inference-only.
+- **PR #467 alphonse (per-axis output scaling) — CLOSED-NEG.** Confirms tau_y/tau_z gap is upstream in spectral representation. Spawned PR #488.
 - **PR #142 frieren (tau_yz weight=2.0) — CLOSED-NEG.** w=1.5 follow-up in PR #454.
 - **PR #458 nezuko mlp6 (Run 1) — CLOSED-NEG.** mlp8 (Run 2) launched as `he54fm6v`.
 
@@ -96,23 +103,25 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 
 ## Current research focus and themes
 
-1. **Closing the volume_pressure gap (×2.0 vs AB-UPT)** — multi-pronged attack:
-   - **EMA dynamics:** PR #480 fern (cosine ramp) — val vol_p=5.30% BREAKTHROUGH at EP6; still descending
+1. **Closing the volume_pressure gap (×2.0 vs AB-UPT) — succeeding broadly across the fleet:**
+   - **EMA dynamics:** PR #480 fern (cosine ramp) — val vol_p=4.69% at EP9.5; primary SOTA candidate
    - **Target transform:** PR #471 askeladd (signed-log) — vol_p=4.62% best ever on arm-a
-   - **Cross-attn coupling:** PR #483 edward (surface↔volume bridge)
-   - **Data curriculum:** PR #489 thorfinn (16k→65k vol-points ramp — JUST ASSIGNED)
+   - **Cross-attn coupling:** PR #483 edward (surface↔volume bridge) — borderline gate pass
+   - **Data curriculum:** PR #489 thorfinn (16k→65k vol-points ramp)
+   - **log1p target:** PR #481 tanjiro — vol_p=4.83%
 
-2. **Closing the tau_y/tau_z gap (×2.5 / ×2.8 vs AB-UPT)**:
-   - **Distribution shape:** PR #481 tanjiro (log1p tau-norm v2, gate waiver granted)
-   - **Spectral representation:** PR #488 alphonse (multi-sigma STRING-sep init)
-   - **Loss weighting:** PR #454 frieren (tau_yz weight=1.5×)
+2. **Closing the tau_y/tau_z gap (×2.5 / ×2.8 vs AB-UPT) — needs upstream attacks:**
+   - **Spectral representation:** PR #488 alphonse (multi-sigma STRING-sep init) — most promising line
+   - **Distribution shape (likely insufficient):** PR #481 tanjiro (log1p tau-norm v2)
+   - **Loss weighting (confirmed inert):** PR #454 frieren — third NEG result for this lever family
 
-3. **Capacity scaling:** PR #458 nezuko (mlp_ratio=8, EP2.4)
+3. **Capacity scaling:** PR #458 nezuko (mlp_ratio=8, slow-warmup, slope-waiver granted)
 
 4. **Composition candidates (when winners land):**
-   - fern vol_p breakthrough (cosine EMA) + askeladd signed-log (vol_p 4.62%) = orthogonal composition
-   - tanjiro log1p + askeladd signed-log = both target vol_p representation (may conflict)
-   - thorfinn vol-curriculum + fern cosine EMA = orthogonal
+   - fern cosine EMA + askeladd signed-log = orthogonal vol_p attacks (data + optimization)
+   - thorfinn vol-curriculum + fern cosine EMA = orthogonal data + optimization
+   - edward cross-attn bridge + alphonse multi-sigma STRING = orthogonal coupling + spectral
+   - DO NOT compose: tanjiro log1p × askeladd signed-log (both target same vol target distribution)
 
 ---
 
@@ -132,20 +141,23 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 | dropout > 0 | Default 0.0 best |
 | 256d / 768d hidden | NEGATIVE on multiple stacks |
 | 6L / 8L depth | NEGATIVE |
-| Learnable per-axis output head scaling (#467) | NEGATIVE — test +0.024pp, uniform attenuation not recalibration; tau_y/tau_z gap is upstream |
-| TTA mirror-y in training loop (#482) | NEGATIVE — gate fail 10.99% at EP6, regression vs baseline; TTA must be inference-only |
+| Learnable per-axis output head scaling (#467) | NEGATIVE — tau_y/tau_z gap is upstream |
+| TTA mirror-y in training loop (#482) | NEGATIVE — TTA must be inference-only |
+| tau_yz loss-weight reweighting (#142, #454, #467) | EXHAUSTED — three NEG results, problem is upstream |
 
 ---
 
 ## Potential next research directions (when slots open / Round 26)
 
-1. **TTA post-hoc on frozen SOTA checkpoint** — apply mirror-y augmentation strictly at eval/test time on PR #387 checkpoint; near-zero compute, isolates TTA cleanly. Assign to thorfinn when #489 finishes.
-2. **Compose fern #480 (cosine EMA) with askeladd arm results** — if both win on vol_p, stack them.
-3. **GradNorm / uncertainty-weighted multitask loss** — addresses coupled-multitask redistribution confirmed across #142, #467; principled fix vs hand-tuned weights.
+1. **TTA post-hoc on frozen SOTA checkpoint** — apply mirror-y augmentation strictly at eval/test time on PR #387 checkpoint; near-zero compute. Assign to thorfinn after #489.
+2. **Compose fern #480 (cosine EMA) + askeladd signed-log** if both win on vol_p, stack them.
+3. **GradNorm / uncertainty-weighted multitask loss** — addresses coupled-multitask redistribution; principled fix vs hand-tuned weights.
 4. **Surface curvature input features (H03)** — geometric prior for tau_y/tau_z high-freq content.
-5. **Compose cross-attn bridge #483 with multi-sigma STRING init #488** — orthogonal coupling + spectral representation.
+5. **Compose cross-attn bridge #483 with multi-sigma STRING init #488** — orthogonal coupling + spectral.
 6. **Slice-conditioned FFN width** — wider FFN only in middle (volumetric) slices.
 7. **EMA model-soup average** — port from yi-track if it wins there.
 8. **Surface point density 2x** — confirmatory port of yi-track result.
 9. **Test-time augmentation: mirror-y + reflect-z + 90-deg rotations** — extends TTA if post-hoc baseline wins.
 10. **Vol-points curriculum + tanjiro log1p composition** — orthogonal data density + target transform.
+11. **Wavelet/multi-resolution input encoding** — alternative tau_y/z spectral attack if multi-sigma STRING fails.
+12. **Anisotropic positional encoding** — separate freq sets per spatial axis (tau_y/z gap may reflect anisotropic flow features).

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-03 06:15 UTC (Round 25 active — PR #489 assigned; 8 students active)
+- **Date:** 2026-05-03 (post W&B snapshot, Round 25 active — PR #489 assigned; 8 students active)
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -41,39 +41,47 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 
 ---
 
-## Latest signals (06:15 UTC snapshot)
+## Latest signals (W&B snapshot — late EP7-8 region)
 
-### Fern #480 — VOL_P BREAKTHROUGH
-- EP6.3: val_abupt=**8.687%** (gate PASS), vol_p=**5.299%** (beats AB-UPT 6.08% on val)
-- This is the first in-flight result to beat the AB-UPT vol_p benchmark
-- Cosine EMA ramp with fixed 12-epoch span is confirmed working; still descending
-- Continue to EP12; need test metrics from best-val checkpoint
+### Fern #480 — APPROACHING SOTA
+- W&B `2u6twuu4` step 21879: **val_abupt=7.745%** (only **+0.36pp above SOTA 7.3816%** — still descending)
+- vol_p=**4.688%** (well below AB-UPT 6.08%, improved from 5.30% at EP6)
+- surf_p=5.08% / wall_shear=8.67% / tau_x=7.43% / tau_y=9.98% / tau_z=11.54%
+- Strongest in-flight run on `tay`. Continue to EP12; **needs test metrics from best-val checkpoint** for SOTA decision
 
-### Tanjiro #481 — Gate waiver granted
-- EP5.8→EP6.0: 10.158%→9.090% (slope −1.07 pp in ~750 steps — 3-4× faster than fern)
-- vol_p already at 5.573% (below AB-UPT) — log1p compression working on vol target
-- Gate waiver: continue to EP12; must break 8.5% by EP8 or will close
-- tau_y=11.85% / tau_z=13.48% — watch for log1p improvement here
+### Tanjiro #481 — GATE WAIVER MET ✓
+- W&B `hnrpuptg` step 21300: **val_abupt=8.309%** (waiver required <8.5% by EP8 — MET)
+- vol_p=5.140% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
+- tau_y=10.71% / tau_z=12.32% — log1p has NOT yet shown clear tau-axis improvement vs fern/frieren
+- Continue to EP12; report best-val checkpoint val+test metrics
 
-### Askeladd #471 — Arm-a complete, arm-b pending
+### Frieren #454 — GATE PASS
+- W&B `l8nu1ajz` step 19292: val_abupt=**8.248%** (well below 8.9% gate threshold)
+- vol_p=5.220% (below AB-UPT 6.08%)
+- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x not narrowing gap vs other runs
+- Continue to EP12
+
+### Cross-cutting observation: vol_p victory, tau_y/z stagnation
+- All three late-epoch runs (fern/tanjiro/frieren) now beat AB-UPT vol_p benchmark (4.69%, 5.14%, 5.22% < 6.08%) — vol_p attack succeeding broadly
+- All three runs have tau_y ~10-11% and tau_z ~11.5-12.3% — none breaking through to AB-UPT 3.65/3.63%
+- Implication: log1p / loss-weight / EMA all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
+
+### Askeladd #471 — Arm-a complete, arm-b launched
 - Arm-a EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
 - Signed-log transform crushes vol_p but increases other axes → no headline win
-- Arm-b (variation of signed-log, presumably different scale) should be launching
-- Candidate for composition with cross-attn bridge (#483) or vol-curriculum (#489)
+- Arm-b just launched at EP1 val_abupt=62.53% (early)
+- Candidate for composition with fern (cosine EMA) — both target vol_p
 
-### Frieren #454 — Gate pending (next val at step ~13604, EP6.0)
-- EP4.8: val_abupt=10.285% (pre-gate, EP5 val not yet logged)
-- Slope: EP3.6→EP4.8 was −3.65 pp/1.2-epoch — similar trajectory to tanjiro
-- Similar slope to tanjiro suggests gate outcome will be borderline; watch EP6 reading
+### Edward #483 — EP4, pre-gate
+- val_abupt ~10.24% — descending, on trajectory
 
-### Edward #483 — EP3.3, pre-gate
-- EP3.3: val_abupt=29.6% (still very early — high-level descent expected)
+### Nezuko #458 (mlp_ratio=8) — EP4, pre-gate
+- val_abupt ~9.80% — descending
 
-### Nezuko #458 (mlp_ratio=8) — EP2.4, pre-gate
-- EP2.4: val_abupt=33.2% (still very early)
+### Alphonse #488 — EP3, pre-gate
+- val_abupt ~32.28% — early
 
-### Alphonse #488 — EP0.7, pre-gate
-- Multi-sigma STRING-sep init just launched, no val data yet
+### Thorfinn #489 — vol-curriculum, just launched
 
 ---
 

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Iterable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import wandb
 import yaml
@@ -119,6 +120,7 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    use_uncertainty_weighting: bool = False
     debug: bool = False
 
 
@@ -145,6 +147,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+UNCERTAINTY_TASK_NAMES: tuple[str, ...] = ("sp", "tau_x", "tau_y", "tau_z", "vol_p")
+UNCERTAINTY_LOG_SIGMA_CLAMP: tuple[float, float] = (-3.0, 3.0)
+# Lion's sign update would push log_sigma by ±lr each step regardless of grad
+# magnitude, capping drift at ±0.15 over a 12-epoch run. We instead optimize
+# log_sigma with a dedicated AdamW (adaptive step size, suitable for 5 scalars).
+UNCERTAINTY_LOG_SIGMA_LR: float = 1e-3
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -192,6 +202,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    log_sigma: nn.Parameter | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -203,19 +214,59 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
-        weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
-    return loss, {
-        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
-        "surface_loss": float(surface_loss.detach().cpu().item()),
-        "volume_loss": float(volume_loss.detach().cpu().item()),
-        "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
-        "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        if log_sigma is None:
+            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+            weighted_surface_loss = surface_loss_weight * surface_loss
+            weighted_volume_loss = volume_loss_weight * volume_loss
+            loss = weighted_surface_loss + weighted_volume_loss
+            base_mse_loss = surface_loss + volume_loss
+            return loss, {
+                "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
+                "surface_loss": float(surface_loss.detach().cpu().item()),
+                "volume_loss": float(volume_loss.detach().cpu().item()),
+                "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
+                "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+            }
+        # Homoscedastic uncertainty weighting (Kendall et al. 2018, arXiv:1705.07115)
+        # L = sum_i [ L_i / (2 * sigma_i^2) + log(sigma_i) ]
+        # = sum_i [ L_i * exp(-2 * log_sigma_i) / 2 + log_sigma_i ]
+        ch_losses = [
+            masked_mse(
+                out["surface_preds"][..., c : c + 1],
+                surface_target[..., c : c + 1],
+                batch.surface_mask,
+            )
+            for c in range(4)
+        ]
+        volume_loss_t = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # Cast to fp32 for numerical stability of exp(-2*log_sigma).
+        per_task_losses = torch.stack(ch_losses + [volume_loss_t]).float()
+        log_sigma_clamped = log_sigma.float().clamp(*UNCERTAINTY_LOG_SIGMA_CLAMP)
+        inv_var_weights = 0.5 * torch.exp(-2.0 * log_sigma_clamped)
+        weighted_per_task = per_task_losses * inv_var_weights
+        uncertainty_regularizer = log_sigma_clamped.sum()
+        loss = weighted_per_task.sum() + uncertainty_regularizer
+    surface_loss_mean = per_task_losses[:4].mean()
+    weighted_surface_loss_value = weighted_per_task[:4].sum()
+    weighted_volume_loss_value = weighted_per_task[4]
+    base_mse_loss_value = surface_loss_mean + per_task_losses[4]
+    metrics: dict[str, float] = {
+        "base_mse_loss": float(base_mse_loss_value.detach().cpu().item()),
+        "surface_loss": float(surface_loss_mean.detach().cpu().item()),
+        "volume_loss": float(per_task_losses[4].detach().cpu().item()),
+        "surface_loss_weighted": float(weighted_surface_loss_value.detach().cpu().item()),
+        "volume_loss_weighted": float(weighted_volume_loss_value.detach().cpu().item()),
+        "uncertainty_regularizer": float(uncertainty_regularizer.detach().cpu().item()),
     }
+    sigma_values = torch.exp(log_sigma_clamped)
+    for i, name in enumerate(UNCERTAINTY_TASK_NAMES):
+        metrics[f"uncertainty/raw_loss_{name}"] = float(per_task_losses[i].detach().cpu().item())
+        metrics[f"uncertainty/sigma_{name}"] = float(sigma_values[i].detach().cpu().item())
+        metrics[f"uncertainty/log_sigma_{name}"] = float(log_sigma_clamped[i].detach().cpu().item())
+        metrics[f"uncertainty/effective_weight_{name}"] = float(inv_var_weights[i].detach().cpu().item())
+        metrics[f"uncertainty/weighted_loss_{name}"] = float(weighted_per_task[i].detach().cpu().item())
+    return loss, metrics
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -245,6 +296,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         )
 
         model: nn.Module = build_model(config).to(device)
+        log_sigma: nn.Parameter | None = None
+        if config.use_uncertainty_weighting:
+            log_sigma = nn.Parameter(torch.zeros(len(UNCERTAINTY_TASK_NAMES), device=device))
+            if state.is_main:
+                print(
+                    "Uncertainty-weighted multitask loss enabled (Kendall et al. 2018): "
+                    f"5 learnable log_sigma scalars init=0 for tasks "
+                    f"{', '.join(UNCERTAINTY_TASK_NAMES)} (clamp={UNCERTAINTY_LOG_SIGMA_CLAMP})"
+                )
         n_params = sum(param.numel() for param in model.parameters())
         if config.compile_model:
             model = torch.compile(model)
@@ -258,6 +318,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
+        log_sigma_optimizer: torch.optim.Optimizer | None = None
+        if log_sigma is not None:
+            # Dedicated AdamW for log_sigma scalars: Lion's sign update is the wrong
+            # inductive bias for 5 adaptive task-uncertainty scalars (constant ±lr step).
+            log_sigma_optimizer = torch.optim.AdamW(
+                [log_sigma], lr=UNCERTAINTY_LOG_SIGMA_LR, weight_decay=0.0
+            )
+            if state.is_main:
+                print(
+                    f"log_sigma optimizer: AdamW(lr={UNCERTAINTY_LOG_SIGMA_LR}, wd=0.0) "
+                    f"[separate from {config.optimizer.lower()} backbone]"
+                )
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
@@ -328,8 +400,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    log_sigma=log_sigma,
                 )
                 optimizer.zero_grad(set_to_none=True)
+                if log_sigma_optimizer is not None:
+                    log_sigma_optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
                 loss_is_nonfinite = not bool(torch.isfinite(loss.detach()).item())
@@ -365,11 +440,29 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if log_sigma is not None:
+                        for key, value in batch_loss_metrics.items():
+                            if key.startswith("uncertainty/"):
+                                train_log[key] = value
+                        train_log["train/uncertainty_regularizer"] = batch_loss_metrics[
+                            "uncertainty_regularizer"
+                        ]
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
+                    if log_sigma_optimizer is not None:
+                        log_sigma_optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
+                    # log_sigma sits outside the DDP-wrapped model; manually all-reduce
+                    # its grad so every rank applies the same update.
+                    if (
+                        state.enabled
+                        and log_sigma is not None
+                        and log_sigma.grad is not None
+                    ):
+                        dist.all_reduce(log_sigma.grad, op=dist.ReduceOp.SUM)
+                        log_sigma.grad.div_(state.world_size)
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
                             base_model.parameters(),
@@ -403,8 +496,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                     if skip_step:
                         optimizer.zero_grad(set_to_none=True)
+                        if log_sigma_optimizer is not None:
+                            log_sigma_optimizer.zero_grad(set_to_none=True)
                     else:
                         optimizer.step()
+                        if log_sigma_optimizer is not None:
+                            log_sigma_optimizer.step()
                         if ema is not None:
                             ema.update(base_model)
                         weight_metrics = (
@@ -572,11 +669,27 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "val_metrics": val_metrics,
                             "checkpoint_source": best_checkpoint_source,
                             "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
+                            "log_sigma": (
+                                log_sigma.detach().cpu()
+                                if log_sigma is not None
+                                else None
+                            ),
+                            "uncertainty_task_names": (
+                                list(UNCERTAINTY_TASK_NAMES)
+                                if log_sigma is not None
+                                else None
+                            ),
                         },
                         model_path,
                     )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+                if log_sigma is not None:
+                    sigma_snapshot = torch.exp(
+                        log_sigma.detach().float().clamp(*UNCERTAINTY_LOG_SIGMA_CLAMP)
+                    ).cpu().tolist()
+                    for name, value in zip(UNCERTAINTY_TASK_NAMES, sigma_snapshot):
+                        log_metrics[f"uncertainty/sigma_{name}_epoch"] = float(value)
                 wandb.log(log_metrics)
                 tag = " *" if improved else ""
                 print(
@@ -584,6 +697,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"train_loss={epoch_train_loss:.5f} "
                     f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
                 )
+                if log_sigma is not None:
+                    sigma_str = " ".join(
+                        f"{name}={value:.4f}"
+                        for name, value in zip(UNCERTAINTY_TASK_NAMES, sigma_snapshot)
+                    )
+                    print(f"           sigma: {sigma_str}")
                 print_metrics("val_surface", val_metrics["val_surface"])
             else:
                 wandb.log(log_metrics)


### PR DESCRIPTION
## Hypothesis

The SOTA stack optimizes a flat equally-weighted sum of surface and volume MSE. With 5 output channels (surface_pressure, tau_x, tau_y, tau_z, volume_pressure) that have widely different loss magnitudes and gradient scales, the optimizer must spread capacity across tasks that compete. tau_y and tau_z trail AB-UPT by ×2.5–2.8×, suggesting insufficient optimization pressure on those channels. Static loss weights (already shown ineffective in PRs #142, #454, #467) fail because they require hand-tuning and cannot adapt to where the model's uncertainty actually lies.

**Homoscedastic uncertainty weighting** (Kendall et al., CVPR 2018: "Multi-Task Learning Using Uncertainty to Weigh Losses in Deep Neural Networks") provides a principled adaptive solution: each task gets a learnable log-variance parameter `log_sigma_i`, and the loss becomes:

```
L = sum_i [ L_i / (2 * sigma_i^2) + log(sigma_i) ]
```

This is equivalent to maximum likelihood under a Gaussian with per-task variance `sigma_i^2`. Tasks with inherently high uncertainty (like tau_y/tau_z, which are dominated by complex separated-flow regions) get learnable attenuation. The `log(sigma_i)` regularizer prevents the trivial solution of setting all `sigma_i → ∞`.

Key advantages over static weighting:
1. **Adaptive** — `sigma_i` learns the right effective weight per task during training, not via grid search.
2. **Theoretically grounded** — directly maximizes joint log-likelihood.
3. **Low complexity** — adds only 5 learnable scalars (`log_sigma` for [surface_pressure, tau_x, tau_y, tau_z, volume_pressure]) with near-zero compute overhead.
4. **Orthogonal to all prior attempts** — doesn't change target distribution (unlike PR #481 log1p), doesn't add parameters to the model backbone (unlike PR #467), and addresses the loss formulation rather than the optimizer state.

Reference: Kendall, A., Gal, Y., & Cipolla, R. (2018). Multi-Task Learning Using Uncertainty to Weigh Losses in Deep Neural Networks. CVPR. https://arxiv.org/abs/1705.07115

## Instructions

All changes go in `target/train.py`. The existing `compute_loss_for_batch` function computes surface_loss and volume_loss separately — you need to decompose surface_loss into its 4 channel contributions and apply per-channel uncertainty weighting.

### Step 1: Add CLI flag

In the `Config` dataclass or argparse block, add:

```python
use_uncertainty_weighting: bool = False  # --use-uncertainty-weighting flag
```

CLI flag: `--use-uncertainty-weighting` (boolean, default False).

### Step 2: Create uncertainty-weight parameters

When `use_uncertainty_weighting=True`, create 5 learnable `nn.Parameter` log-sigma scalars before the optimizer is constructed. These must be added to the optimizer parameter groups so they get updated during training.

```python
# After model is created, before optimizer construction:
if config.use_uncertainty_weighting:
    # One log_sigma per output channel: [sp, tau_x, tau_y, tau_z, vol_p]
    log_sigma = nn.Parameter(torch.zeros(5))  # init to log(1.0) = 0
    # Add to optimizer param groups (with same lr/wd as model params)
```

### Step 3: Decompose surface loss per channel

In `compute_loss_for_batch`, currently `surface_loss` is a single MSE over all 4 surface channels (shape: [B, N_surf, 4]). Decompose it:

```python
# surface_preds: [B, N_surf, 4] — channels [sp, tau_x, tau_y, tau_z]
# surface_target: [B, N_surf, 4]
# surface_mask: [B, N_surf] (bool)

if use_uncertainty_weighting:
    # Per-channel MSE (mean over valid surface points)
    ch_losses = []
    for c in range(4):
        ch_loss = masked_mse(
            surface_preds[..., c:c+1],
            surface_target[..., c:c+1],
            surface_mask
        )
        ch_losses.append(ch_loss)
    # vol loss is the 5th task
    vol_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)

    # Uncertainty-weighted combination (Kendall et al. eq. 4):
    # L = sum_i [ L_i / (2 * sigma_i^2) + log(sigma_i) ]
    # = sum_i [ L_i * exp(-2*log_sigma_i) / 2 + log_sigma_i ]
    losses_tensor = torch.stack(ch_losses + [vol_loss])  # shape [5]
    uncertainty_loss = (losses_tensor * torch.exp(-2 * log_sigma) / 2 + log_sigma).sum()
    loss = uncertainty_loss
    # log each sigma for monitoring
    for c, name in enumerate(["sp", "tau_x", "tau_y", "tau_z", "vol_p"]):
        log_metrics[f"uncertainty/sigma_{name}"] = float(torch.exp(log_sigma[c]).item())
else:
    # Original path (unchanged)
    surface_loss = masked_mse(...)
    volume_loss = masked_mse(...)
    loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
```

### Step 4: Log sigma values per step

Make sure `sigma_sp`, `sigma_tau_x`, `sigma_tau_y`, `sigma_tau_z`, `sigma_vol_p` are logged to W&B under the `uncertainty/` prefix so we can see how they evolve. At init (log_sigma=0), sigma=1 for all channels — any deviation during training indicates the model is adaptively reweighting.

### Step 5: Verify implementation

Check in the W&B logs after EP1 that:
- `uncertainty/sigma_tau_y` and `uncertainty/sigma_tau_z` are evolving (should increase or decrease relative to `sigma_sp` as the model adapts)
- Total loss is decreasing normally
- val_abupt at EP3 is in range 13–14% (same ballpark as SOTA EP3 ~13.1%)
- `train/nonfinite_count` stays at 0

## Baseline

Current SOTA: **PR #387 alphonse** (feat16 RFF + QK-norm + STRING-sep)
- **val_abupt: 7.3816%** (EP11, W&B run `wj6mn6ve`)
- **test_abupt: 8.5936%**

Per-axis test metrics (must beat):
| Metric | SOTA #387 | AB-UPT |
|---|---:|---:|
| surface_pressure | 4.4377% | 3.82% |
| wall_shear | 7.9989% | 7.29% |
| volume_pressure | 12.1885% | 6.08% |
| tau_x | 6.9622% | 5.35% |
| **tau_y** | **9.1058%** | **3.65%** ← primary gap |
| **tau_z** | **10.2736%** | **3.63%** ← primary gap |

**Merge bar: val_abupt < 7.3816%.**

### Reproduce command (full SOTA stack + uncertainty weighting):

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm --rff-num-features 16 \
  --use-uncertainty-weighting \
  --wandb-group tanjiro-uncertainty-loss \
  --wandb-name tanjiro/uncertainty-weighted-multitask-loss
```

### EP5 gate

Check val_abupt at EP5 ≤ 9.2% (same gate as standard SOTA stack runs). If above, report slope — an early slope of > −0.5 pp/1k steps may justify a waiver.

Report `uncertainty/sigma_*` values per epoch alongside val metrics so we can see whether the model is indeed reweighting toward tau_y/tau_z. The key hypothesis signal is: **do sigma_tau_y and sigma_tau_z evolve away from sigma_sp in a way consistent with harder task uncertainty?**
