### PR TITLE
edward: surface curvature (mean H + Gaussian K) input features for tau_y/tau_z gap

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-03 (post W&B snapshot, Round 25 active — PR #489 assigned; 8 students active)
+- **Date:** 2026-05-03 (post W&B snapshot, late EP9 region — 8 students active, 0 idle)
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -22,73 +22,80 @@ W&B run `wj6mn6ve`, group `alphonse-rff-sweep`. All future PRs must beat val_abu
 
 ## Latest research direction from human researcher team
 
-No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-derived levers) plus organic vol_p / tau-axis attack.
+No new directives in last cycle. All 3 open human issues already responded to. Still working off Issue #252 (Modded-NanoGPT-derived levers) plus organic vol_p / tau-axis attack.
 
 ---
 
 ## Currently in-flight (8 active WIP PRs on tay, ZERO idle students)
 
-| PR | Student | Hypothesis | Run | Status (06:15 UTC) |
-|---|---|---|---|---|
-| **#489** | **thorfinn** | **Volume-points curriculum 16k→65k (4-stage ramp)** | pending | **JUST ASSIGNED** |
-| #471 | askeladd | Signed-log vol target transform (arm-a EP12 done; arm-b pending) | `a2skzz6m` / pending | Arm-a complete, arm-b launching |
-| #458 | nezuko | model-mlp-ratio=8 on SOTA stack | `he54fm6v` | In flight (EP2.4) |
-| #483 | edward | surface↔volume cross-attention bridge | `ok98szul` | In flight (EP3.3) |
-| #480 | fern | Cosine EMA ramp (fixed cosine span) | `2u6twuu4` | In flight (EP6.3) — **vol_p BREAKTHROUGH 5.30%** |
-| #481 | tanjiro | log1p tau-norm v2 (corrected stats) | `hnrpuptg` | In flight (EP6.0, gate waiver granted) |
-| #454 | frieren | tau_yz loss weight 1.5× | `l8nu1ajz` | In flight (EP5.2, gate pending) |
-| #488 | alphonse | Multi-sigma log_freq init for STRING-sep | `ki2q9ko9` (rank0) | In flight (EP0.7) |
+| PR | Student | Hypothesis | Run | Step / EP | val_abupt | Status |
+|---|---|---|---|---|---:|---|
+| **#480** | **fern** | **Cosine EMA ramp (12-ep span)** | `2u6twuu4` | 23171 / EP9.5 | **7.745%** | **PRIMARY SOTA CANDIDATE** — projected EP12 ~7.28% |
+| #481 | tanjiro | log1p tau-norm v2 | `hnrpuptg` | 22436 / EP9.2 | 8.064% | Descending, vol_p strong |
+| #454 | frieren | tau_yz loss weight 1.5× | `l8nu1ajz` | 20493 / EP8.4 | 8.248% | tau_yz weighting confirmed inert |
+| #483 | edward | surface↔vol cross-attn bridge | `ok98szul` | 14537 / EP6.0 | 8.969% (EP5.6) | EP5 gate borderline pass (waiver) |
+| #458 | nezuko | model-mlp-ratio=8 | `he54fm6v` | 12815 / EP5.3 | 9.805% (EP4.5) | EP5 slope-waiver granted (slope −1.377 pp/1k → proj 8.05%) |
+| #488 | alphonse | Multi-sigma log_freq init (STRING-sep) | `ki2q9ko9` | 9863 / EP4.1 | 13.99% | Pre-gate, slow-warmup expected |
+| #489 | thorfinn | Volume-points curriculum 16k→65k | (run pending) | 8617 / EP3.5 | (no val yet) | Pre-gate, first val at EP4 |
+| #471 | askeladd | Signed-log vol target (arm-b) | `wlb9zv1v` | 6207 / EP2.6 | 38.36% | Arm-a EP12 done (vol_p 4.62% record); arm-b early |
 
 ---
 
-## Latest signals (W&B snapshot — late EP7-8 region)
+## Latest signals (W&B snapshot — late EP7-9 region)
 
 ### Fern #480 — APPROACHING SOTA
-- W&B `2u6twuu4` step 21879: **val_abupt=7.745%** (only **+0.36pp above SOTA 7.3816%** — still descending)
-- vol_p=**4.688%** (well below AB-UPT 6.08%, improved from 5.30% at EP6)
-- surf_p=5.08% / wall_shear=8.67% / tau_x=7.43% / tau_y=9.98% / tau_z=11.54%
-- Strongest in-flight run on `tay`. Continue to EP12; **needs test metrics from best-val checkpoint** for SOTA decision
+- W&B `2u6twuu4` step 23171: **val_abupt=7.745%** (only +0.36pp above SOTA 7.3816%, descending)
+- vol_p=**4.688%** (well below AB-UPT 6.08%) — vol_p BREAKTHROUGH confirmed
+- tau_y=9.982%, tau_z=11.543% — best tau_y/z of any in-flight run
+- Slope: **−0.076 pp/1k steps** at EP9.5 — projected EP12 val ≈ **7.28%** (BELOW SOTA 7.3816%)
+- Trajectory log: EP1.1: 39.50% → EP3.4: 11.47% → EP5.6: 8.69% → EP7.8: 7.95% → EP9.0: 7.745%
+- **Strongest in-flight run on `tay`. Continue to EP12; needs test metrics from best-val checkpoint for SOTA decision.**
 
-### Tanjiro #481 — GATE WAIVER MET ✓
-- W&B `hnrpuptg` step 21300: **val_abupt=8.309%** (waiver required <8.5% by EP8 — MET)
-- vol_p=5.140% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
-- tau_y=10.71% / tau_z=12.32% — log1p has NOT yet shown clear tau-axis improvement vs fern/frieren
-- Continue to EP12; report best-val checkpoint val+test metrics
+### Tanjiro #481 — vol_p strong, tau-axis flat
+- W&B `hnrpuptg` step 22436: val_abupt=8.064% (+0.68pp above SOTA, descending)
+- vol_p=4.827% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
+- tau_y=10.71% / tau_z=12.32% — log1p NOT closing tau gap
 
-### Frieren #454 — GATE PASS
-- W&B `l8nu1ajz` step 19292: val_abupt=**8.248%** (well below 8.9% gate threshold)
+### Frieren #454 — confirms tau_yz weighting is inert
+- W&B `l8nu1ajz` step 20493: val_abupt=8.248% (descending)
 - vol_p=5.220% (below AB-UPT 6.08%)
-- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x not narrowing gap vs other runs
-- Continue to EP12
+- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x NOT narrowing the gap
+- Combined with #142 (w=2.0 NEG), #467 (per-axis scale NEG) → loss-weighting tau is exhausted; problem is upstream
 
-### Cross-cutting observation: vol_p victory, tau_y/z stagnation
-- All three late-epoch runs (fern/tanjiro/frieren) now beat AB-UPT vol_p benchmark (4.69%, 5.14%, 5.22% < 6.08%) — vol_p attack succeeding broadly
-- All three runs have tau_y ~10-11% and tau_z ~11.5-12.3% — none breaking through to AB-UPT 3.65/3.63%
-- Implication: log1p / loss-weight / EMA all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
+### Edward #483 — EP5 borderline gate pass
+- W&B `ok98szul` EP5.6: val_abupt=8.969% (+0.069pp above 8.9% gate — slope-waiver granted)
+- vol_p=5.457% (below AB-UPT 6.08%)
+- Slope: −0.469 pp/1k steps — healthy descent
+
+### Nezuko #458 — EP5 slope-waiver granted
+- W&B `he54fm6v` EP4.5: val_abupt=9.805%, vol_p=6.316%
+- Slope: **−1.377 pp/1k steps** (steepest in fleet) → projected EP5 ≈ 8.05% (clean gate pass)
+- mlp_ratio=8 is slow-converging — expected given param-count increase
+
+### Alphonse #488 — primary tau_y/z attack, pre-gate
+- W&B `ki2q9ko9` EP4.1: val_abupt=13.99% (early, descending)
+- Multi-sigma init [0.25, 0.5, 1.0, 2.0, 4.0] — slow-warmup expected; slope-waiver pre-approved
+- Most important final metrics: test tau_y, test tau_z
+
+### Thorfinn #489 — vol-curriculum, pre-first-val
+- step=8617 EP3.5, no val checkpoint yet — first val at EP4 completion
 
 ### Askeladd #471 — Arm-a complete, arm-b launched
-- Arm-a EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
-- Signed-log transform crushes vol_p but increases other axes → no headline win
-- Arm-b just launched at EP1 val_abupt=62.53% (early)
-- Candidate for composition with fern (cosine EMA) — both target vol_p
+- Arm-a (`a2skzz6m`) EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
+- Signed-log transform crushes vol_p but doesn't recover headline → composition target with fern (orthogonal vol_p levers)
+- Arm-b (`wlb9zv1v`) EP2.6 val_abupt=38.36% (early warmup)
 
-### Edward #483 — EP4, pre-gate
-- val_abupt ~10.24% — descending, on trajectory
-
-### Nezuko #458 (mlp_ratio=8) — EP4, pre-gate
-- val_abupt ~9.80% — descending
-
-### Alphonse #488 — EP3, pre-gate
-- val_abupt ~32.28% — early
-
-### Thorfinn #489 — vol-curriculum, just launched
+### Cross-cutting observation: vol_p victory broadly, tau_y/z stagnation
+- All four late-epoch runs (fern/tanjiro/frieren + askeladd arm-a) now beat AB-UPT vol_p benchmark (4.69% / 4.83% / 5.22% / 4.62% < 6.08%) — **vol_p attack succeeding broadly**
+- All four runs have tau_y ~9.98-10.71% and tau_z ~11.54-12.32% — none breaking through to AB-UPT 3.65/3.63%
+- Implication: log1p / loss-weight / EMA / signed-log all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
 
 ---
 
 ## Recent closeouts
 
-- **PR #482 thorfinn (TTA mirror-y) — CLOSED (EP5 gate fail).** EP6 val_abupt=10.989%, slope −1.03 pp/1k steps — training was worse than SOTA baseline despite TTA being inference-only. Likely TTA was applied to training path too, or unrelated regression. TTA can be tested post-hoc on frozen SOTA checkpoint.
-- **PR #467 alphonse (per-axis output scaling) — CLOSED-NEG.** val tie (−0.0022pp << noise), test regression +0.024pp. Key finding: tau_y/tau_z gap is upstream in spectral representation, NOT output head. Spawned PR #488.
+- **PR #482 thorfinn (TTA mirror-y) — CLOSED (EP5 gate fail).** EP6 val_abupt=10.989%; TTA must be inference-only.
+- **PR #467 alphonse (per-axis output scaling) — CLOSED-NEG.** Confirms tau_y/tau_z gap is upstream in spectral representation. Spawned PR #488.
 - **PR #142 frieren (tau_yz weight=2.0) — CLOSED-NEG.** w=1.5 follow-up in PR #454.
 - **PR #458 nezuko mlp6 (Run 1) — CLOSED-NEG.** mlp8 (Run 2) launched as `he54fm6v`.
 
@@ -96,23 +103,25 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 
 ## Current research focus and themes
 
-1. **Closing the volume_pressure gap (×2.0 vs AB-UPT)** — multi-pronged attack:
-   - **EMA dynamics:** PR #480 fern (cosine ramp) — val vol_p=5.30% BREAKTHROUGH at EP6; still descending
+1. **Closing the volume_pressure gap (×2.0 vs AB-UPT) — succeeding broadly across the fleet:**
+   - **EMA dynamics:** PR #480 fern (cosine ramp) — val vol_p=4.69% at EP9.5; primary SOTA candidate
    - **Target transform:** PR #471 askeladd (signed-log) — vol_p=4.62% best ever on arm-a
-   - **Cross-attn coupling:** PR #483 edward (surface↔volume bridge)
-   - **Data curriculum:** PR #489 thorfinn (16k→65k vol-points ramp — JUST ASSIGNED)
+   - **Cross-attn coupling:** PR #483 edward (surface↔volume bridge) — borderline gate pass
+   - **Data curriculum:** PR #489 thorfinn (16k→65k vol-points ramp)
+   - **log1p target:** PR #481 tanjiro — vol_p=4.83%
 
-2. **Closing the tau_y/tau_z gap (×2.5 / ×2.8 vs AB-UPT)**:
-   - **Distribution shape:** PR #481 tanjiro (log1p tau-norm v2, gate waiver granted)
-   - **Spectral representation:** PR #488 alphonse (multi-sigma STRING-sep init)
-   - **Loss weighting:** PR #454 frieren (tau_yz weight=1.5×)
+2. **Closing the tau_y/tau_z gap (×2.5 / ×2.8 vs AB-UPT) — needs upstream attacks:**
+   - **Spectral representation:** PR #488 alphonse (multi-sigma STRING-sep init) — most promising line
+   - **Distribution shape (likely insufficient):** PR #481 tanjiro (log1p tau-norm v2)
+   - **Loss weighting (confirmed inert):** PR #454 frieren — third NEG result for this lever family
 
-3. **Capacity scaling:** PR #458 nezuko (mlp_ratio=8, EP2.4)
+3. **Capacity scaling:** PR #458 nezuko (mlp_ratio=8, slow-warmup, slope-waiver granted)
 
 4. **Composition candidates (when winners land):**
-   - fern vol_p breakthrough (cosine EMA) + askeladd signed-log (vol_p 4.62%) = orthogonal composition
-   - tanjiro log1p + askeladd signed-log = both target vol_p representation (may conflict)
-   - thorfinn vol-curriculum + fern cosine EMA = orthogonal
+   - fern cosine EMA + askeladd signed-log = orthogonal vol_p attacks (data + optimization)
+   - thorfinn vol-curriculum + fern cosine EMA = orthogonal data + optimization
+   - edward cross-attn bridge + alphonse multi-sigma STRING = orthogonal coupling + spectral
+   - DO NOT compose: tanjiro log1p × askeladd signed-log (both target same vol target distribution)
 
 ---
 
@@ -132,20 +141,23 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 | dropout > 0 | Default 0.0 best |
 | 256d / 768d hidden | NEGATIVE on multiple stacks |
 | 6L / 8L depth | NEGATIVE |
-| Learnable per-axis output head scaling (#467) | NEGATIVE — test +0.024pp, uniform attenuation not recalibration; tau_y/tau_z gap is upstream |
-| TTA mirror-y in training loop (#482) | NEGATIVE — gate fail 10.99% at EP6, regression vs baseline; TTA must be inference-only |
+| Learnable per-axis output head scaling (#467) | NEGATIVE — tau_y/tau_z gap is upstream |
+| TTA mirror-y in training loop (#482) | NEGATIVE — TTA must be inference-only |
+| tau_yz loss-weight reweighting (#142, #454, #467) | EXHAUSTED — three NEG results, problem is upstream |
 
 ---
 
 ## Potential next research directions (when slots open / Round 26)
 
-1. **TTA post-hoc on frozen SOTA checkpoint** — apply mirror-y augmentation strictly at eval/test time on PR #387 checkpoint; near-zero compute, isolates TTA cleanly. Assign to thorfinn when #489 finishes.
-2. **Compose fern #480 (cosine EMA) with askeladd arm results** — if both win on vol_p, stack them.
-3. **GradNorm / uncertainty-weighted multitask loss** — addresses coupled-multitask redistribution confirmed across #142, #467; principled fix vs hand-tuned weights.
+1. **TTA post-hoc on frozen SOTA checkpoint** — apply mirror-y augmentation strictly at eval/test time on PR #387 checkpoint; near-zero compute. Assign to thorfinn after #489.
+2. **Compose fern #480 (cosine EMA) + askeladd signed-log** if both win on vol_p, stack them.
+3. **GradNorm / uncertainty-weighted multitask loss** — addresses coupled-multitask redistribution; principled fix vs hand-tuned weights.
 4. **Surface curvature input features (H03)** — geometric prior for tau_y/tau_z high-freq content.
-5. **Compose cross-attn bridge #483 with multi-sigma STRING init #488** — orthogonal coupling + spectral representation.
+5. **Compose cross-attn bridge #483 with multi-sigma STRING init #488** — orthogonal coupling + spectral.
 6. **Slice-conditioned FFN width** — wider FFN only in middle (volumetric) slices.
 7. **EMA model-soup average** — port from yi-track if it wins there.
 8. **Surface point density 2x** — confirmatory port of yi-track result.
 9. **Test-time augmentation: mirror-y + reflect-z + 90-deg rotations** — extends TTA if post-hoc baseline wins.
 10. **Vol-points curriculum + tanjiro log1p composition** — orthogonal data density + target transform.
+11. **Wavelet/multi-resolution input encoding** — alternative tau_y/z spectral attack if multi-sigma STRING fails.
+12. **Anisotropic positional encoding** — separate freq sets per spatial axis (tau_y/z gap may reflect anisotropic flow features).

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-03 06:15 UTC (Round 25 active — PR #489 assigned; 8 students active)
+- **Date:** 2026-05-03 (post W&B snapshot, Round 25 active — PR #489 assigned; 8 students active)
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
@@ -41,39 +41,47 @@ No new directives in last cycle. Still working off Issue #252 (Modded-NanoGPT-de
 
 ---
 
-## Latest signals (06:15 UTC snapshot)
+## Latest signals (W&B snapshot — late EP7-8 region)
 
-### Fern #480 — VOL_P BREAKTHROUGH
-- EP6.3: val_abupt=**8.687%** (gate PASS), vol_p=**5.299%** (beats AB-UPT 6.08% on val)
-- This is the first in-flight result to beat the AB-UPT vol_p benchmark
-- Cosine EMA ramp with fixed 12-epoch span is confirmed working; still descending
-- Continue to EP12; need test metrics from best-val checkpoint
+### Fern #480 — APPROACHING SOTA
+- W&B `2u6twuu4` step 21879: **val_abupt=7.745%** (only **+0.36pp above SOTA 7.3816%** — still descending)
+- vol_p=**4.688%** (well below AB-UPT 6.08%, improved from 5.30% at EP6)
+- surf_p=5.08% / wall_shear=8.67% / tau_x=7.43% / tau_y=9.98% / tau_z=11.54%
+- Strongest in-flight run on `tay`. Continue to EP12; **needs test metrics from best-val checkpoint** for SOTA decision
 
-### Tanjiro #481 — Gate waiver granted
-- EP5.8→EP6.0: 10.158%→9.090% (slope −1.07 pp in ~750 steps — 3-4× faster than fern)
-- vol_p already at 5.573% (below AB-UPT) — log1p compression working on vol target
-- Gate waiver: continue to EP12; must break 8.5% by EP8 or will close
-- tau_y=11.85% / tau_z=13.48% — watch for log1p improvement here
+### Tanjiro #481 — GATE WAIVER MET ✓
+- W&B `hnrpuptg` step 21300: **val_abupt=8.309%** (waiver required <8.5% by EP8 — MET)
+- vol_p=5.140% (below AB-UPT 6.08%) — log1p compression confirmed working on vol target
+- tau_y=10.71% / tau_z=12.32% — log1p has NOT yet shown clear tau-axis improvement vs fern/frieren
+- Continue to EP12; report best-val checkpoint val+test metrics
 
-### Askeladd #471 — Arm-a complete, arm-b pending
+### Frieren #454 — GATE PASS
+- W&B `l8nu1ajz` step 19292: val_abupt=**8.248%** (well below 8.9% gate threshold)
+- vol_p=5.220% (below AB-UPT 6.08%)
+- tau_y=10.39% / tau_z=12.07% — tau_yz weight=1.5x not narrowing gap vs other runs
+- Continue to EP12
+
+### Cross-cutting observation: vol_p victory, tau_y/z stagnation
+- All three late-epoch runs (fern/tanjiro/frieren) now beat AB-UPT vol_p benchmark (4.69%, 5.14%, 5.22% < 6.08%) — vol_p attack succeeding broadly
+- All three runs have tau_y ~10-11% and tau_z ~11.5-12.3% — none breaking through to AB-UPT 3.65/3.63%
+- Implication: log1p / loss-weight / EMA all leave tau_y/z gap intact → confirms tau_y/z is a representational/spectral problem (PR #488 alphonse multi-sigma is the right attack)
+
+### Askeladd #471 — Arm-a complete, arm-b launched
 - Arm-a EP12: val_abupt=7.793% (+0.41pp above SOTA), vol_p=**4.618%** (BEST VOL_P EVER, below AB-UPT)
 - Signed-log transform crushes vol_p but increases other axes → no headline win
-- Arm-b (variation of signed-log, presumably different scale) should be launching
-- Candidate for composition with cross-attn bridge (#483) or vol-curriculum (#489)
+- Arm-b just launched at EP1 val_abupt=62.53% (early)
+- Candidate for composition with fern (cosine EMA) — both target vol_p
 
-### Frieren #454 — Gate pending (next val at step ~13604, EP6.0)
-- EP4.8: val_abupt=10.285% (pre-gate, EP5 val not yet logged)
-- Slope: EP3.6→EP4.8 was −3.65 pp/1.2-epoch — similar trajectory to tanjiro
-- Similar slope to tanjiro suggests gate outcome will be borderline; watch EP6 reading
+### Edward #483 — EP4, pre-gate
+- val_abupt ~10.24% — descending, on trajectory
 
-### Edward #483 — EP3.3, pre-gate
-- EP3.3: val_abupt=29.6% (still very early — high-level descent expected)
+### Nezuko #458 (mlp_ratio=8) — EP4, pre-gate
+- val_abupt ~9.80% — descending
 
-### Nezuko #458 (mlp_ratio=8) — EP2.4, pre-gate
-- EP2.4: val_abupt=33.2% (still very early)
+### Alphonse #488 — EP3, pre-gate
+- val_abupt ~32.28% — early
 
-### Alphonse #488 — EP0.7, pre-gate
-- Multi-sigma STRING-sep init just launched, no val data yet
+### Thorfinn #489 — vol-curriculum, just launched
 
 ---
 


### PR DESCRIPTION
## Hypothesis

**Surface curvature input features will close the tau_y / tau_z gap.**

The current SOTA (PR #387) reaches val_abupt=7.3816% with strong surface_pressure (4.44%) and increasingly strong volume_pressure (~4.7-5.2% across the fleet, all below AB-UPT 6.08%). The remaining laggards are **tau_y (9.11% vs AB-UPT 3.65%, ×2.5)** and **tau_z (10.27% vs AB-UPT 3.63%, ×2.8)**.

Wall shear stresses tau_y / tau_z are dominated by **boundary-layer separation, ridge edges, and high-curvature regions** (A-pillar, mirror, wheel arch). Three independent NEG results — per-axis output scaling (#467), tau_yz loss-weight at w=2.0 (#142) and w=1.5 (#454) — confirm the gap is **upstream / representational**, not a loss-balance issue. The model is missing geometric information.

xyz coordinates alone cannot reconstruct local geometric shape (convex/concave, principal directions, edge sharpness). The STRING-separable RFF encodes spatial position frequency content but is rotationally / curvature-blind. Adding **scalar curvature features** (mean curvature H, Gaussian curvature K) gives the model an explicit, rotation-invariant prior on where high-frequency tau components live.

This is **fundamentally different** from the negative tangent-frame INPUT features (#423): tangent frames are vector orientation features (n, t1, t2 basis); curvature H, K are **scalar geometric invariants** of the surface. They are also orthogonal to every active in-flight experiment (cosine EMA #480, log1p tau v2 #481, multi-sigma STRING #488, vol curriculum #489, signed-log #471, mlp_ratio=8 #458, uncertainty weighting #496, TTA mirror-y #499).

References:
- Meyer et al. "Discrete Differential-Geometry Operators for Triangulated 2-Manifolds" (Visualization & Math 2003) — robust per-vertex H and K from triangle one-rings.
- Bobenko & Schroeder, "Discrete Curvature Flow" — practical numerical recipes.
- For point clouds without explicit triangulation: PCA over k-NN normals → smaller eigenvalue ratios approximate principal curvatures.

## Instructions

### Goal
Add per-surface-point curvature features (mean H, Gaussian K, and optionally |H|, max(K,0), min(K,0)) as **additional input channels** to the surface branch only. The surface branch already supports `surface_extra_dim = max(0, surface_input_dim - space_dim)` in `model.py`, so the architecture machinery is in place — you only need to (a) compute curvature in the data pipeline, (b) thread a CLI flag, (c) bump `SURFACE_X_DIM`, (d) verify shapes.

### Step 1: Compute mean & Gaussian curvature from the source mesh
DrivAerML provides per-case STL/triangle meshes. Curvature is most reliable computed once **on the full triangle mesh** (offline or as a one-time per-case preprocessing step at dataset load), then **gathered to the sampled surface point indices**.

Use the discrete Laplace-Beltrami / cotangent formula (Meyer 2003) per vertex:
- Mean curvature normal:  K_H(v) = (1 / 2 A_mixed) * sum_{j in N(v)} (cot α_ij + cot β_ij) * (v_j - v) → H(v) = ||K_H(v)|| / 2
- Gaussian curvature:     K(v) = (2π - sum_{j} θ_j) / A_mixed
- A_mixed = mixed Voronoi/barycentric area as in Meyer §3.3 (clip obtuse triangles).

If meshes are not available at dataset time, fall back to **point-cloud PCA**: for each sampled point, take k=32 nearest neighbors, compute the local covariance, the smallest eigenvalue's eigenvector approximates the normal, and the ratio λ1/λ2 of the two larger eigenvalues approximates anisotropy (a curvature proxy). Prefer the mesh-based method when triangles are available — it is exact and well-conditioned.

Cache curvature arrays per-case to disk (e.g. `<case>/curvature.npy` shape `[n_surface_vertices, 2]` for `[H, K]`). Recompute is expensive (one-time) but loading is essentially free.

### Step 2: Wire it into `data/loader.py`
- After sampling surface points, gather `H, K` at the sampled vertex indices (or interpolate from triangle barycentric weights if you sample over faces).
- Apply **robust normalization**: `H_norm = sign(H) * log1p(|H|)`, same for K. This compresses the heavy-tailed curvature distribution at sharp edges.
- Append `[H_norm, K_norm]` as columns to `surface_x` so the per-point feature dim becomes `xyz (3) + H (1) + K (1) = 5` (or 6 if you also add `|H|`).

### Step 3: Add a CLI flag in `train.py`
Add a dataclass field on the config:
```python
use_surface_curvature_features: bool = False
surface_curvature_neighbors: int = 32   # for PCA fallback only
```
Plumb `use_surface_curvature_features` to the dataloader so disabling it is zero-cost.

### Step 4: Update `SURFACE_X_DIM` and model wiring
- Where `SURFACE_X_DIM` is defined (search for it in `data/loader.py` or `train.py`), make it dependent on the flag: `SURFACE_X_DIM = 3 + (2 if use_surface_curvature_features else 0)`.
- The model already handles `surface_extra_dim` via a separate input-projection path (see `model.py` around the `surface_extra_dim = max(0, surface_input_dim - space_dim)` line). **Do not modify the STRING-sep encoding** — it operates only on xyz (`space_dim=3`). The extra channels feed through the linear input projection unchanged.
- Verify with a tiny debug pass that surface_x has the expected last-dim = 5 when the flag is on.

### Step 5: Run the experiment
Single run with curvature ON, otherwise SOTA config:
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --use-surface-curvature-features \
  --wandb-group edward-curvature \
  --wandb-name edward/curvature-HK-pr-NEW
```

### Reporting
- After EP12, comment back with: full val_abupt curve, val per-axis (tau_x, tau_y, tau_z, surface_p, vol_p), test_abupt + test per-axis evaluated **at the best-val checkpoint**, the W&B run id, and any hiccups in the curvature precomputation.
- If first-val (EP1) is more than 5pp above the SOTA arm at the equivalent step, ping me — the input-projection might need re-init.

### Gates
- **EP5 gate:** val_abupt < 8.9% OR slope < -0.4 pp/1k steps (slope-waiver auto-granted if curvature precompute slowed first epoch).
- **EP8 gate:** val_abupt < 8.0%.
- **Win condition:** val_abupt < **7.3816%** (current SOTA, PR #387).
- **Stretch win:** test tau_y < 8.5% AND test tau_z < 9.5% even if headline misses — that confirms the geometric prior helps the right axes and we'd compose it.

## Baseline

Current SOTA — **PR #387 alphonse (feat16 RFF + QK-norm + STRING-sep)**, val_abupt **7.3816%** (EP11), W&B run `wj6mn6ve`, group `alphonse-rff-sweep`.

| Metric | val EP11 | test (best-val ckpt) | AB-UPT |
|---|---:|---:|---:|
| `abupt` | **7.3816%** | 8.5936% | — |
| `surface_pressure` | — | 4.4377% | 3.82% |
| `wall_shear` | — | 7.9989% | 7.29% |
| `volume_pressure` | — | 12.1885% | 6.08% |
| `tau_x` | — | 6.9622% | 5.35% |
| **`tau_y`** | — | **9.1058%** | **3.65%** |
| **`tau_z`** | — | **10.2736%** | **3.63%** |

**Reproduce SOTA (without curvature flag):**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --wandb-group alphonse-rff-sweep \
  --wandb-name alphonse/feat16-qknorm-string-sep-pr387
```

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
