### PR TITLE
frieren: anisotropic per-axis STRING freq priors (sigma_x/y/z) for tau_y/z gap

### DIFF
--- a/model.py
+++ b/model.py
@@ -88,6 +88,13 @@ class StringSeparableEncoding(nn.Module):
     Parameters are initialised so that ``exp(log_freq)`` starts near the fixed
     RFF sigma (i.e. ``log_freq = log(sigma)``), providing a warm-start from
     the isotropic baseline.
+
+    When ``axis_init_sigmas`` is provided (per-axis list of sigma lists, one
+    list per spatial axis), the init switches to anisotropic round-robin
+    multi-sigma: ``log_freq[d, f] = log(axis_init_sigmas[d][f % len_d])``.
+    This generalises both PR #488 (axis-shared multi-sigma) and PR #501 Arm A
+    (per-axis single-sigma) by letting each axis claim its own log-spaced
+    octave bank.
     """
 
     def __init__(
@@ -96,12 +103,31 @@ class StringSeparableEncoding(nn.Module):
         num_features: int = 32,
         sigma: float = 1.0,
         init_sigmas: list[float] | None = None,
+        axis_init_sigmas: list[list[float]] | None = None,
     ):
         super().__init__()
         self.in_dim = in_dim
         self.num_features = num_features
         # log_freq[d, f]: learnable log-frequency per axis per feature
-        if init_sigmas is not None and len(init_sigmas) > 1:
+        if axis_init_sigmas is not None:
+            # Per-axis multi-sigma (PR #501 v2): each axis ``d`` gets its own
+            # log-spaced sigma list; round-robin maps feature index ``f`` to
+            # that axis's sigma list. Lets x have one octave bank (e.g. low
+            # freq for streamwise smoothness) while y/z claim a different,
+            # higher-freq bank (lateral/vertical detail).
+            if len(axis_init_sigmas) != in_dim:
+                raise ValueError(
+                    f"axis_init_sigmas has {len(axis_init_sigmas)} axes, expected in_dim={in_dim}"
+                )
+            log_freq_init = torch.empty(in_dim, num_features, dtype=torch.float32)
+            for d, sigmas_d in enumerate(axis_init_sigmas):
+                if not sigmas_d:
+                    raise ValueError(f"axis_init_sigmas[{d}] is empty")
+                for f in range(num_features):
+                    log_freq_init[d, f] = math.log(float(sigmas_d[f % len(sigmas_d)]))
+            self.log_freq = nn.Parameter(log_freq_init)
+            self.axis_init_sigmas = [list(map(float, sigmas_d)) for sigmas_d in axis_init_sigmas]
+        elif init_sigmas is not None and len(init_sigmas) > 1:
             # Multi-sigma init (PR #488): round-robin per-feature sigma so the
             # encoding starts with broad spectral coverage across frequency
             # octaves. Each axis shares the same per-feature sigma pattern;
@@ -112,10 +138,12 @@ class StringSeparableEncoding(nn.Module):
             )
             log_freq_init = log_sigmas.unsqueeze(0).expand(in_dim, num_features).clone()
             self.log_freq = nn.Parameter(log_freq_init)
+            self.axis_init_sigmas = None
         else:
             self.log_freq = nn.Parameter(
                 torch.full((in_dim, num_features), math.log(sigma))
             )
+            self.axis_init_sigmas = None
         # phase[d, f]: learnable phase per axis per feature
         self.phase = nn.Parameter(torch.zeros(in_dim, num_features))
 
@@ -340,6 +368,7 @@ class SurfaceTransolver(nn.Module):
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
         rff_init_sigmas: list[float] | None = None,
+        rff_axis_init_sigmas: list[list[float]] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
     ):
@@ -352,6 +381,11 @@ class SurfaceTransolver(nn.Module):
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
+        self.rff_axis_init_sigmas = (
+            [list(map(float, sigmas_d)) for sigmas_d in rff_axis_init_sigmas]
+            if rff_axis_init_sigmas
+            else None
+        )
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
@@ -367,12 +401,14 @@ class SurfaceTransolver(nn.Module):
                 num_features=string_sep_features,
                 sigma=rff_sigma,
                 init_sigmas=self.rff_init_sigmas,
+                axis_init_sigmas=self.rff_axis_init_sigmas,
             )
             self.volume_string_sep = StringSeparableEncoding(
                 in_dim=space_dim,
                 num_features=string_sep_features,
                 sigma=rff_sigma,
                 init_sigmas=self.rff_init_sigmas,
+                axis_init_sigmas=self.rff_axis_init_sigmas,
             )
             string_sep_out_dim = self.surface_string_sep.output_dim  # 2 * space_dim * num_features
             self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)

--- a/train.py
+++ b/train.py
@@ -97,6 +97,9 @@ class Config:
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     rff_init_sigmas: str = ""
+    rff_init_sigmas_x: str = ""
+    rff_init_sigmas_y: str = ""
+    rff_init_sigmas_z: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     amp_mode: str = "bf16"
@@ -189,6 +192,31 @@ def parse_rff_init_sigmas(raw: str) -> list[float] | None:
     return parsed or None
 
 
+def parse_rff_axis_init_sigmas(
+    sx: str, sy: str, sz: str
+) -> list[list[float]] | None:
+    """Parse per-axis multi-sigma flags into a list[list[float]] of length 3.
+
+    All three axis flags must be set together; if any is empty, returns None
+    (falls through to the axis-shared multi-sigma or single-sigma init).
+    """
+    raw = (sx, sy, sz)
+    set_count = sum(1 for r in raw if r)
+    if set_count == 0:
+        return None
+    if set_count != 3:
+        raise ValueError(
+            "rff_init_sigmas_{x,y,z} must all be set together; got "
+            f"x={sx!r}, y={sy!r}, z={sz!r}"
+        )
+    parsed = [parse_rff_init_sigmas(r) for r in raw]
+    if any(p is None or len(p) == 0 for p in parsed):
+        raise ValueError(
+            "rff_init_sigmas_{x,y,z} must each contain at least one positive float"
+        )
+    return parsed  # type: ignore[return-value]
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -218,6 +246,11 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
+        rff_axis_init_sigmas=parse_rff_axis_init_sigmas(
+            config.rff_init_sigmas_x,
+            config.rff_init_sigmas_y,
+            config.rff_init_sigmas_z,
+        ),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
     )


### PR DESCRIPTION
## Hypothesis

**Per-axis multi-sigma STRING-separable initialization will narrow the tau_y / tau_z gap by giving each spatial axis its own log-spaced octave bank.**

This generalises two prior wins:
- **PR #488 (alphonse)** — axis-shared multi-sigma init, log_freq[d, f] = log(sigmas[f % len]). Same sigma list across all axes.
- **PR #501 Arm A (frieren, this PR)** — per-axis single-sigma random init (sigma_x=1, sigma_y=2, sigma_z=2). Confirmed test_tau_y −0.22pp / test_tau_z −0.24pp vs PR #387.

The new design — per-axis multi-sigma — gives each axis ``d`` its own log-spaced sigma list. log_freq[d, f] = log(axis_sigmas[d][f % len_d]). This lets x have a low-frequency-biased octave bank (long-wavelength pressure recovery, wake) while y/z claim higher-frequency banks (mirror separation, wheel-arch detail, body-side ridges, A-pillars).

**Why now:** Prior single-sigma anisotropic Arm A reached val_abupt 7.27%, ~0.10pp short of PR #511 SOTA 7.0134%. Composing single-sigma anisotropic with vol-curriculum (run `i5fgc06e`) tracked SOTA #489 trajectory but does not stack on PR #511 (extended cosine, no curriculum). Per-axis multi-sigma is orthogonal to extended cosine and preserves the alphonse octave-coverage gain that vp benefited from.

References:
- Tancik et al. 2020 (arXiv:2006.10739) — Fourier features bandwidth selection.
- Mildenhall NeRF (arXiv:2003.08934) — log-spaced (octave) frequency basis.
- F-FNO (arXiv:2111.13802) — per-axis spectral factorisation for 3D PDEs.
- AFPE (arXiv:2509.02488) — anisotropic per-axis Fourier priors for volumetric data.
- Learnable Fourier Features (arXiv:2106.02795) — closest direct precedent for per-axis frequency banks.

## Research

Researcher pass on per-axis multi-sigma init prior to launch. Key findings:

- **Round-robin (`f % len`) over log-spaced (octaves) sigmas is canonical for structured coordinate inputs** (NeRF, Mip-NeRF, F-FNO, FourCastNet). Random sampling has high variance at small F; round-robin guarantees uniform log-spectrum coverage.
- **Coordinate normalization audit:** DrivAerML xyz coords are in unit-normalised meters with x range 4.70, y range 2.02, z range 1.51. With sigma=16 and z=1.5, peak frequency ≈ 3.8 cycles/domain — well below Nyquist for 65k-point sampling. No aliasing concern.
- **Failure modes to monitor:** (1) highest-sigma channels can be gradient-starved / noisy at init; logging `string_sep/*/log_freq_*` per-axis statistics tracks this. (2) Tancik 2020 shows overshoot worse than undershoot — Run B (sigma_z up to 16) is the riskier arm.
- **Matched-mean design:** Run A's geometric-mean sigmas (x=0.5, y=2.0, z=2.0) shift x slightly lower than Arm A's 1.0 — preserves anisotropy direction and adds spread. Run B (x=1.0 isotropic-control, y/z=4.0) is the aggressive arm that doubles the y/z mean-frequency.

## Implementation

`StringSeparableEncoding.__init__` extended with `axis_init_sigmas: list[list[float]] | None`. When provided:
```python
log_freq[d, f] = log(axis_init_sigmas[d][f % len(axis_init_sigmas[d])])
```
Backward compatible: if not provided, falls through to PR #488 axis-shared `init_sigmas` or single-sigma. Surface and volume STRING-sep modules share the same per-axis sigmas (matching SOTA #511 design).

`train.py` adds three CLI flags: `--rff-init-sigmas-x`, `--rff-init-sigmas-y`, `--rff-init-sigmas-z`. All three required together; per-axis precedence over `--rff-init-sigmas`. Existing `collect_string_sep_metrics` already logs per-axis `log_freq` mean/std/min/max — no extra logging needed.

Smoke-tested: per-axis init produces correct round-robin pattern, backward compat preserved, forward pass shape correct, full debug train.py launches cleanly.

## Sweep design

Two arms (advisor-requested), W&B group `frieren-aniso-string-vs511`:

| Arm | sigma_x list | sigma_y list | sigma_z list | geom mean (x/y/z) |
|---|---|---|---|---|
| **A (primary)** | `0.125,0.25,0.5,1.0,2.0` | `0.5,1.0,2.0,4.0,8.0` | `0.5,1.0,2.0,4.0,8.0` | 0.5 / 2.0 / 2.0 |
| **B (aggressive)** | `0.25,0.5,1.0,2.0,4.0` | `1.0,2.0,4.0,8.0,16.0` | `1.0,2.0,4.0,8.0,16.0` | 1.0 / 4.0 / 4.0 |

Run A first (8 GPUs, ~5.7h on 13 epochs). Submit Run B sequentially after.

## Run command (Arm A)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas-x "0.125,0.25,0.5,1.0,2.0" \
  --rff-init-sigmas-y "0.5,1.0,2.0,4.0,8.0" \
  --rff-init-sigmas-z "0.5,1.0,2.0,4.0,8.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --wandb-group frieren-aniso-string-vs511 \
  --wandb-name frieren/aniso-A-perAxis-multi-sigma
```

## Reporting

EP3, EP5, EP8, EP13 (final). Per-channel rel_l2 breakdown — val_abupt, surface_pressure, wall_shear, volume_pressure, tau_x/y/z. Test metrics from best-val ckpt at completion.

## Gates

- **EP3 gate:** val_abupt < 14.5% (PR #511 reference EP3 = 14.15%; per-axis multi-sigma should track this trajectory)
- **EP5 gate:** val_abupt < 9.0%
- **EP8 gate:** val_abupt < 7.7%
- **Win condition:** val_abupt < **7.0063%** (PR #510 SOTA)
- **Stretch / partial:** test_tau_y < 8.6452% AND test_tau_z < 9.8066% (improving on PR #510 test) even if headline misses by <0.2pp

## Baseline

Current SOTA — **PR #510 alphonse (slw=2.0 + axis-shared multi-sigma + extended cosine EP13)**, val_abupt **7.0063%** (EP13), W&B run `qqtdnlwq`, group `alphonse-slw-sweep`.

| Metric | val EP13 | test (best-val ckpt) | AB-UPT |
|---|---:|---:|---:|
| `abupt` | **7.0063%** | **8.2921%** | — |
| `surface_pressure` | 4.5994% | 4.2381% | 3.82% |
| `wall_shear` | 7.8939% | 7.6341% | 7.29% |
| `volume_pressure` | 4.1643% | 12.1047% | 6.08% |
| `tau_x` | 6.8150% | 6.6657% | 5.35% |
| **`tau_y`** | **8.9515%** | **8.6452%** | **3.65%** |
| **`tau_z`** | **10.5010%** | **9.8066%** | **3.63%** |

Prior reference — PR #511 edward (extended cosine EP13 + axis-shared multi-sigma), val 7.0134% / test 8.3130%, run `5o7jc7wi`. PR #510 supersedes via surface-loss-weight tilt.

**Reproduce SOTA #510 stack (replace `--rff-init-sigmas` with axis-shared list):**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13
```

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

