### PR TITLE
OHEM spatial hard-mining (top-50%) for wall-shear on 5L/256d

### DIFF
--- a/train.py
+++ b/train.py
@@ -49,6 +49,7 @@ from trainer_runtime import (
     init_wandb_run,
     is_valid_primary_metric,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     squared_relative_l2_loss,
@@ -117,6 +118,9 @@ class Config:
     raw_rel_l2_weight: float = 0.0
     fourier_pe: bool = False
     fourier_pe_num_freqs: int = 8
+    ohem_surface_ratio: float = 1.0
+    ohem_warmup_epochs: int = 0
+    ohem_min_k: int = 100
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -167,10 +171,13 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     raw_rel_l2_weight: float = 0.0,
+    ohem_surface_ratio: float = 1.0,
+    ohem_min_k: int = 100,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    ohem_metrics: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -178,7 +185,55 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        N_surface = out["surface_preds"].shape[1]
+        ohem_active = ohem_surface_ratio < 1.0 and N_surface > 0
+        if ohem_active:
+            # OHEM: compute per-point squared error [B, N, C], rank points by mean
+            # across channels, keep the top-K% hardest per sample, then reduce.
+            surface_sq = (out["surface_preds"] - surface_target).square()  # [B, N, C]
+            mask_bool = batch.surface_mask.to(torch.bool)                  # [B, N]
+            mask_float = mask_bool.to(dtype=surface_sq.dtype)
+            # fp32 ranking signal: bf16 ties produce noisy topk indices
+            per_point_loss = (surface_sq.float().mean(dim=-1)) * mask_float.float()  # [B, N]
+            # Use mean valid count across batch so all samples get ~ratio fraction.
+            n_valid = mask_float.sum(dim=1).clamp_min(1.0)                  # [B]
+            mean_n_valid = float(n_valid.mean().item())
+            k = int(round(ohem_surface_ratio * mean_n_valid))
+            k = max(int(ohem_min_k), k)
+            k = min(N_surface, k)
+            _, hard_idx = per_point_loss.topk(k, dim=1)                    # [B, k]
+            hard_sq = surface_sq.gather(
+                1,
+                hard_idx.unsqueeze(-1).expand(-1, -1, surface_sq.shape[-1]),
+            )                                                                # [B, k, C]
+            hard_mask = mask_bool.gather(1, hard_idx)                       # [B, k]
+            surface_loss = masked_mean(hard_sq, hard_mask)
+            with torch.no_grad():
+                hard_per_pt_loss = per_point_loss.gather(1, hard_idx)       # [B, k]
+                threshold_loss = float(
+                    hard_per_pt_loss.amin(dim=1).mean().detach().cpu().item()
+                )
+                full_per_pt = per_point_loss[mask_bool]
+                mean_full_loss = float(full_per_pt.mean().detach().cpu().item()) if full_per_pt.numel() else 0.0
+                hard_mean_loss = float(hard_per_pt_loss.mean().detach().cpu().item())
+                # Easy = remaining fraction by removing the hard ones; estimate via
+                # difference using the global mean weighted by counts.
+                total_valid = float(mask_float.sum().detach().cpu().item())
+                hard_count = float(hard_mask.to(mask_float.dtype).sum().detach().cpu().item())
+                easy_count = max(total_valid - hard_count, 1.0)
+                easy_mean_loss = (
+                    (mean_full_loss * total_valid - hard_mean_loss * hard_count) / easy_count
+                ) if total_valid > 0 else 0.0
+                ohem_metrics["ohem/active"] = 1.0
+                ohem_metrics["ohem/k_selected"] = float(k)
+                ohem_metrics["ohem/k_fraction"] = float(k) / max(mean_n_valid, 1.0)
+                ohem_metrics["ohem/threshold_loss"] = threshold_loss
+                ohem_metrics["ohem/hard_mean_loss"] = hard_mean_loss
+                ohem_metrics["ohem/easy_mean_loss"] = easy_mean_loss
+                ohem_metrics["ohem/full_mean_loss"] = mean_full_loss
+        else:
+            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            ohem_metrics["ohem/active"] = 0.0
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -211,6 +266,7 @@ def train_loss(
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
         **aux_metrics,
+        **ohem_metrics,
     }
 
 
@@ -310,6 +366,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_loss_sum = 0.0
             n_batches = 0
 
+            in_ohem_warmup = epoch < config.ohem_warmup_epochs
+            effective_ohem_ratio = 1.0 if in_ohem_warmup else config.ohem_surface_ratio
             for batch in tqdm(
                 train_loader,
                 desc=f"Epoch {epoch + 1}/{max_epochs}",
@@ -325,6 +383,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
                     raw_rel_l2_weight=config.raw_rel_l2_weight,
+                    ohem_surface_ratio=effective_ohem_ratio,
+                    ohem_min_k=config.ohem_min_k,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -350,6 +410,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "lr": current_lr,
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/ohem_surface_ratio": config.ohem_surface_ratio,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(
@@ -368,6 +429,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                                      "raw_rel_l2/vol_pressure"):
                         if _aux_key in batch_loss_metrics:
                             train_log[f"train/{_aux_key}"] = batch_loss_metrics[_aux_key]
+                    # Log OHEM diagnostics whenever they were emitted by train_loss.
+                    for _ohem_key in (
+                        "ohem/active",
+                        "ohem/k_selected",
+                        "ohem/k_fraction",
+                        "ohem/threshold_loss",
+                        "ohem/hard_mean_loss",
+                        "ohem/easy_mean_loss",
+                        "ohem/full_mean_loss",
+                    ):
+                        if _ohem_key in batch_loss_metrics:
+                            train_log[f"train/{_ohem_key}"] = batch_loss_metrics[_ohem_key]
+                    train_log["train/ohem/in_warmup"] = 1.0 if in_ohem_warmup else 0.0
+                    train_log["train/ohem/configured_ratio"] = float(config.ohem_surface_ratio)
+                    train_log["train/ohem/effective_ratio"] = float(effective_ohem_ratio)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

**Online Hard Example Mining (OHEM) applied to surface point-level wall-shear loss will force the model to focus gradient budget on spatially-hard regions, reducing wsy/wsz error.**

The current wall-shear loss averages point-level L2 error uniformly across all surface points. However, wall-shear stress on automotive geometries is spatially highly non-uniform — the most challenging points are concentrated in regions of flow separation (A-pillars, wheel arches, rear wake), which account for ~10–20% of the surface but dominate the overall metric error. Uniform averaging means the model receives relatively weak gradient signal from these hard regions because they are outnumbered by easier laminar-regime points.

**OHEM approach:** At each training step, compute per-point wall-shear L2 errors, select the top-K% hardest points (largest error), and backpropagate only through those points' losses. This is inspired by Shrivastava et al. (2016) "Training Region-based Object Detectors with Online Hard Example Mining" — adapted from detection to regression on point clouds.

**Target top-K = 50%:** Retain the 50% hardest surface points per sample per batch. This is aggressive enough to concentrate gradient signal on hard regions without completely ignoring easy points (which provide stable training signal).

## Instructions

Base config: **5L/256d/4H + FourierPE + T_max=50 + no-EMA + lr=3e-4** (the current best recipe from PR #174).

Add a `--ohem-surface-ratio` argument to `train.py` (float, default=1.0 = no OHEM, disabled). When < 1.0, apply OHEM to the surface loss by selecting only the top `ohem_surface_ratio` fraction of per-point surface losses (by magnitude) before computing the mean.

**Implementation sketch for the surface loss computation:**

```python
# In the surface loss computation, after computing per-point L2 errors:
# surface_losses shape: [B, N_surface, C]  (C channels: sp, wsx, wsy, wsz)

if ohem_surface_ratio < 1.0:
    # Compute per-point total loss across all channels
    per_point_loss = surface_losses.mean(dim=-1)  # [B, N_surface]
    k = max(1, int(ohem_surface_ratio * per_point_loss.shape[1]))
    # Select top-k hardest points per sample
    _, hard_indices = per_point_loss.topk(k, dim=1)  # [B, k]
    # Gather hard points for loss computation
    hard_losses = surface_losses.gather(
        1, hard_indices.unsqueeze(-1).expand(-1, -1, surface_losses.shape[-1])
    )  # [B, k, C]
    surface_loss = hard_losses.mean()
else:
    surface_loss = surface_losses.mean()
```

Adapt this to the actual loss structure in `train.py` — the exact tensor shapes and variable names may differ.

**Run the experiment:**

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --fourier-pe \
  --no-use-ema \
  --lr 3e-4 \
  --epochs 50 \
  --lr-cosine-t-max 50 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 3 \
  --ohem-surface-ratio 0.5 \
  --no-compile-model \
  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb-group bengio-wave12-ohem \
  --wandb-name norman/ohem-wall-shear-ratio-0.5 \
  --agent norman
```

**Kill threshold:** if val_abupt > 10% at step 100k, kill and report. If abupt at ep25 is tracking above 9.0% (worse than baseline), kill and report without completing the full 50 epochs.

**Note on implementation:** Read `train.py` carefully before implementing to understand the existing loss computation structure. If there is already a per-point loss tensor computed before the mean reduction, simply gate it with the top-K mask. Do not restructure the training loop beyond adding this mask.

## Baseline

Current best (PR #174, W&B run `vu4jsiic`, ep~45.3, step 807,025):

| Metric | Best val |
|--------|---------|
| `abupt_axis_mean_rel_l2_pct` | **6.9549** |
| `surface_pressure_rel_l2_pct` | 4.5644 |
| `wall_shear_y_rel_l2_pct` | 8.7345 |
| `wall_shear_z_rel_l2_pct` | 10.5766 |
| `volume_pressure_rel_l2_pct` | 3.9361 |

Target to beat: **val abupt < 6.9549%**

Reproduce baseline:
```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 --model-hidden-dim 256 --model-heads 4 \
  --fourier-pe --no-use-ema --lr 3e-4 --lr-cosine-t-max 50 \
  --no-compile-model --wandb-group bengio-wave9
```

## Expected outcome

If OHEM works, we expect:
- wsy and wsz to improve significantly (the hard-region signal is amplified)
- surface_pressure may stay flat or slightly degrade (easier points are downweighted)
- Net effect on abupt should be positive given wsy/wsz dominate the gap

A skeptical outcome: OHEM may cause training instability or harm convergence if too many easy points are dropped. The 50% ratio is conservative enough to avoid this but monitor train/loss for spikes in the first 5 epochs.

## Reporting

After each epoch, report the full `val_primary` breakdown (abupt, sp, vp, wsy, wsz). Include the W&B run ID in your first update comment. If you observe training loss spikes or instability in ep1–5, report immediately — do not wait for ep10.
