### PR TITLE
extended epoch training EP15 cosine on current SOTA stack

### DIFF
--- a/model.py
+++ b/model.py
@@ -90,14 +90,32 @@ class StringSeparableEncoding(nn.Module):
     the isotropic baseline.
     """
 
-    def __init__(self, in_dim: int, num_features: int = 32, sigma: float = 1.0):
+    def __init__(
+        self,
+        in_dim: int,
+        num_features: int = 32,
+        sigma: float = 1.0,
+        init_sigmas: list[float] | None = None,
+    ):
         super().__init__()
         self.in_dim = in_dim
         self.num_features = num_features
         # log_freq[d, f]: learnable log-frequency per axis per feature
-        self.log_freq = nn.Parameter(
-            torch.full((in_dim, num_features), math.log(sigma))
-        )
+        if init_sigmas is not None and len(init_sigmas) > 1:
+            # Multi-sigma init (PR #488): round-robin per-feature sigma so the
+            # encoding starts with broad spectral coverage across frequency
+            # octaves. Each axis shares the same per-feature sigma pattern;
+            # per-axis specialisation is acquired through gradient descent.
+            log_sigmas = torch.tensor(
+                [math.log(init_sigmas[f % len(init_sigmas)]) for f in range(num_features)],
+                dtype=torch.float32,
+            )
+            log_freq_init = log_sigmas.unsqueeze(0).expand(in_dim, num_features).clone()
+            self.log_freq = nn.Parameter(log_freq_init)
+        else:
+            self.log_freq = nn.Parameter(
+                torch.full((in_dim, num_features), math.log(sigma))
+            )
         # phase[d, f]: learnable phase per axis per feature
         self.phase = nn.Parameter(torch.zeros(in_dim, num_features))
 
@@ -321,6 +339,7 @@ class SurfaceTransolver(nn.Module):
         slice_num: int = 96,
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
+        rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
     ):
@@ -332,6 +351,7 @@ class SurfaceTransolver(nn.Module):
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
+        self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
@@ -343,10 +363,16 @@ class SurfaceTransolver(nn.Module):
             # num_features defaults to rff_num_features if provided, else 32.
             string_sep_features = rff_num_features if rff_num_features > 0 else 32
             self.surface_string_sep = StringSeparableEncoding(
-                in_dim=space_dim, num_features=string_sep_features, sigma=rff_sigma
+                in_dim=space_dim,
+                num_features=string_sep_features,
+                sigma=rff_sigma,
+                init_sigmas=self.rff_init_sigmas,
             )
             self.volume_string_sep = StringSeparableEncoding(
-                in_dim=space_dim, num_features=string_sep_features, sigma=rff_sigma
+                in_dim=space_dim,
+                num_features=string_sep_features,
+                sigma=rff_sigma,
+                init_sigmas=self.rff_init_sigmas,
             )
             string_sep_out_dim = self.surface_string_sep.output_dim  # 2 * space_dim * num_features
             self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)

--- a/train.py
+++ b/train.py
@@ -93,6 +93,7 @@ class Config:
     model_dropout: float = 0.0
     rff_num_features: int = 0
     rff_sigma: float = 1.0
+    rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     amp_mode: str = "bf16"
@@ -168,6 +169,31 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
 
 
+def parse_rff_init_sigmas(raw: str) -> list[float] | None:
+    if not raw:
+        return None
+    parsed = [float(x.strip()) for x in raw.split(",") if x.strip()]
+    return parsed or None
+
+
+def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for attr in ("surface_string_sep", "volume_string_sep"):
+        module = getattr(model, attr, None)
+        if module is None:
+            continue
+        log_freq = module.log_freq.detach().float()
+        prefix = f"string_sep/{attr}"
+        metrics[f"{prefix}/log_freq_mean"] = float(log_freq.mean().item())
+        metrics[f"{prefix}/log_freq_std"] = float(log_freq.std().item())
+        metrics[f"{prefix}/log_freq_min"] = float(log_freq.min().item())
+        metrics[f"{prefix}/log_freq_max"] = float(log_freq.max().item())
+        for axis in range(log_freq.shape[0]):
+            metrics[f"{prefix}/freq_axis_{axis}_mean"] = float(log_freq[axis].mean().item())
+            metrics[f"{prefix}/freq_axis_{axis}_std"] = float(log_freq[axis].std().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -178,6 +204,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         slice_num=config.model_slices,
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
     )
@@ -543,6 +570,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 log_metrics.update(primary_metric_log("val_primary", val_metrics["val_surface"]))
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
+                log_metrics.update(collect_string_sep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The validation curve in PR #488 (current SOTA, run `ki2q9ko9`) was **still descending at EP11** — the terminal epoch. This means the model had not converged and was leaving performance on the table. Extending the cosine LR schedule with `--lr-cosine-t-max 15` and training to EP15 should allow the model to find a lower minimum before LR decays to near-zero. This is a clean single-variable test: same architecture and all hyperparameters identical to SOTA, only the cosine decay length and epoch count change.

Historical context: PR #393 (edward) tried extended epochs on an older STRING-sep stack (no QK-norm, no multi-sigma init) and was closed. The current SOTA stack is substantially stronger — multi-sigma init dramatically changes the spectral coverage of the encoding — so the optimal epoch budget may have shifted.

Expected gain: if the val curve was still dropping at EP11 at the same rate as it descended from EP8→EP11, extending to EP15 could yield another 0.03–0.10pp improvement, which is meaningful at this precision level.

## Instructions

Run a single arm with the current SOTA config extended to 15 epochs, using a cosine schedule that extends proportionally:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --lr-cosine-t-max 15 \
  --epochs 15 \
  --wandb-group edward-extended-cosine --wandb-name edward-extended-ep15
```

**Important:** The multi-sigma STRING-sep init from PR #488 is not exposed as a CLI flag — it was implemented directly in model.py by alphonse. **You must obtain and apply the same multi-sigma init patch from alphonse's PR #488 student branch (branch `alphonse/multi-sigma-rff-init`) to your model.py before running.** This is critical — without the multi-sigma init you will not be building on the current SOTA.

If the 15-epoch run exceeds the time budget, try with `--epochs 13 --lr-cosine-t-max 13` as a fallback (this gives 2 extra epochs over the baseline without hitting the wall).

Report in a PR comment:
- Best `val_abupt` and the epoch at which it occurred
- Per-component val metrics at best epoch: `surface_pressure`, `wall_shear`, `volume_pressure`
- W&B run ID
- Whether the val curve was still descending at the final epoch

## Baseline

Current SOTA: alphonse PR #488 (`ki2q9ko9`), EP11 (val curve still descending)
- `val_abupt` = 7.3672%
- `surface_pressure` = 4.805%
- `wall_shear` = 8.347%
- `volume_pressure` = 4.357% (below AB-UPT ref 6.08% ✓)

Beat target: **val_abupt < 7.3672%**

SOTA reproduce command (baseline, EP11):
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16
```
(+ multi-sigma init patch from alphonse/multi-sigma-rff-init model.py)
