### PR TITLE
[senku] coord-norm + TTA y-mirror stacked on 5L/256d (Wave 20)

### DIFF
--- a/check_all_running.py
+++ b/check_all_running.py
@@ -1,0 +1,40 @@
+"""
+Find all running W&B runs for bengio research - search by run name prefix.
+"""
+import os
+import wandb
+import pandas as pd
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+METRICS = [
+    "val_primary/abupt_axis_mean_rel_l2_pct",
+]
+
+# Get all running runs, ordered by recency
+print("=== All currently running runs (most recent 50) ===")
+runs = api.runs(path, filters={"state": "running"}, order="-created_at")
+run_list = list(runs[:50])
+print(f"Total running runs found: {len(run_list)}")
+
+rows = []
+for r in run_list:
+    s = r.summary_metrics
+    abupt = s.get("val_primary/abupt_axis_mean_rel_l2_pct")
+    abupt_str = f"{abupt:.4f}" if isinstance(abupt, float) else "N/A"
+    rows.append({
+        "run_id": r.id,
+        "name": r.name[:45],
+        "group": r.group or "",
+        "step": r.lastHistoryStep,
+        "abupt": abupt_str,
+        "created": str(r.createdAt)[:16] if r.createdAt else "?",
+    })
+
+df = pd.DataFrame(rows)
+pd.set_option("display.width", 200)
+pd.set_option("display.max_colwidth", 50)
+print(df.to_string(index=False))

--- a/check_all_waves.py
+++ b/check_all_waves.py
@@ -1,0 +1,54 @@
+"""
+Check W&B runs for waves 14-20 on bengio.
+"""
+import os
+import wandb
+import pandas as pd
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+METRICS = [
+    "val_primary/abupt_axis_mean_rel_l2_pct",
+    "val_primary/wall_shear_y_rel_l2_pct",
+    "val_primary/wall_shear_z_rel_l2_pct",
+    "val_primary/surface_pressure_rel_l2_pct",
+    "val_primary/volume_pressure_rel_l2_pct",
+]
+
+# Try all wave groups 1-25
+waves_found = []
+for w in range(14, 26):
+    group = f"bengio-wave{w}"
+    try:
+        runs = api.runs(path, filters={"group": group})
+        run_list = list(runs[:10])
+        if run_list:
+            waves_found.append((group, run_list))
+    except Exception as e:
+        pass
+
+print(f"Found waves: {[w[0] for w in waves_found]}")
+
+for group, runs in waves_found:
+    print(f"\n{'='*80}")
+    print(f"Group: {group}")
+    print('='*80)
+    rows = []
+    for run in runs:
+        summary = run.summary_metrics
+        row = {
+            "run_id": run.id,
+            "name": run.name[:30],
+            "state": run.state,
+            "step": run.lastHistoryStep,
+        }
+        for m in METRICS:
+            short = m.split("/")[-1].replace("_rel_l2_pct", "").replace("abupt_axis_mean", "abupt")
+            row[short] = round(summary.get(m, float("nan")), 4) if summary.get(m) is not None else float("nan")
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    pd.set_option("display.width", 200)
+    print(df.to_string(index=False))

--- a/check_epochs.py
+++ b/check_epochs.py
@@ -1,0 +1,46 @@
+"""
+Get current epoch for W&B runs by scanning recent history.
+"""
+import os
+import wandb
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+RUNS = {
+    "hph6eaky": "fern / PR#409",
+    "5ifnf1wc": "thorfinn / PR#382",
+    "4632xosf": "kohaku / PR#417",
+    "0xi2n4oo": "alphonse / PR#437",
+    "jj9r7x0o": "senku / PR#442",
+    "vyhpqruv": "tanjiro / PR#443",
+}
+
+# Epoch keys to check
+EPOCH_KEYS = ["epoch", "trainer/epoch", "_step", "val_epoch", "train/epoch"]
+
+for run_id, label in RUNS.items():
+    try:
+        run = api.run(f"{path}/{run_id}")
+        summary = run.summary_metrics
+
+        # Check all keys in summary for epoch
+        epoch_val = None
+        for k in EPOCH_KEYS:
+            v = summary.get(k)
+            if v is not None:
+                epoch_val = f"{k}={v}"
+                break
+
+        # Also scan last few history rows
+        history_rows = list(run.scan_history(keys=["epoch", "_step"], min_step=max(0, run.lastHistoryStep - 5)))
+        last_row = history_rows[-1] if history_rows else {}
+        step = last_row.get("_step", "?")
+        ep_from_hist = last_row.get("epoch", "?")
+
+        print(f"{run_id} ({label}): summary_epoch={epoch_val}, hist_epoch={ep_from_hist}, _step={step}, state={run.state}")
+
+    except Exception as e:
+        print(f"{run_id}: ERROR {e}")

--- a/check_epochs2.py
+++ b/check_epochs2.py
@@ -1,0 +1,29 @@
+"""
+Get current epoch for W&B runs - check summary keys directly.
+"""
+import os
+import wandb
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+RUNS = {
+    "hph6eaky": "fern / PR#409",
+    "5ifnf1wc": "thorfinn / PR#382",
+    "4632xosf": "kohaku / PR#417",
+    "0xi2n4oo": "alphonse / PR#437",
+    "jj9r7x0o": "senku / PR#442",
+    "vyhpqruv": "tanjiro / PR#443",
+}
+
+for run_id, label in RUNS.items():
+    try:
+        run = api.run(f"{path}/{run_id}")
+        summary = run.summary_metrics
+        # Print all epoch-related keys
+        epoch_keys = {k: v for k, v in summary.items() if "epoch" in k.lower() or k == "_step"}
+        print(f"{run_id} ({label}): _step={run.lastHistoryStep}, epoch_keys={epoch_keys}")
+    except Exception as e:
+        print(f"{run_id}: ERROR {e}")

--- a/check_epochs3.py
+++ b/check_epochs3.py
@@ -1,0 +1,27 @@
+"""
+Estimate epoch from step count.
+Baseline best run (vu4jsiic) reached ep~45.3 at step 807,025.
+Steps per epoch ~= 807025 / 45.3 = ~17,817.
+"""
+import os
+
+# Steps per epoch baseline estimate
+# From best run: ep45.3 @ step 807025 → ~17,817 steps/epoch
+# But different runs may have different steps/epoch based on batch size / dataset split
+
+STEPS_PER_EPOCH = 17817  # baseline estimate
+
+RUNS = {
+    "hph6eaky": ("fern / PR#409 coord-norm fix", 463709),
+    "5ifnf1wc": ("thorfinn / PR#382 6L/512d/8H", 227104),
+    "4632xosf": ("kohaku / PR#417 EMA", 440784),
+    "0xi2n4oo": ("alphonse / PR#437 6L/256d", 338215),
+    "jj9r7x0o": ("senku / PR#442 OHEM", 374155),
+    "vyhpqruv": ("tanjiro / PR#443 mirror+SW=2.0", 379800),
+}
+
+print(f"{'run_id':<12} {'label':<35} {'_step':>10} {'est_epoch':>10}")
+print("-" * 75)
+for run_id, (label, step) in RUNS.items():
+    est_epoch = step / STEPS_PER_EPOCH
+    print(f"{run_id:<12} {label:<35} {step:>10} {est_epoch:>10.1f}")

--- a/check_remaining_prs.py
+++ b/check_remaining_prs.py
@@ -1,0 +1,69 @@
+"""
+Find W&B runs for remaining PRs by student name in recent runs.
+"""
+import os
+import wandb
+import pandas as pd
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+METRICS = [
+    "val_primary/abupt_axis_mean_rel_l2_pct",
+    "val_primary/wall_shear_y_rel_l2_pct",
+    "val_primary/wall_shear_z_rel_l2_pct",
+    "val_primary/surface_pressure_rel_l2_pct",
+    "val_primary/volume_pressure_rel_l2_pct",
+]
+
+# Check remaining wave groups and student-specific groups
+# frieren PR#361 (wd sweep), alphonse PR#437 6L/256d,
+# edward PR#468 (Muon), askeladd PR#495 (CoordConv dist-to-surface)
+# Wave 9, 10, 11 runs, and the very new wave 19/20 PRs
+
+GROUPS_TO_CHECK = [
+    "bengio-wave9", "bengio-wave10", "bengio-wave11", "bengio-wave12",
+    "bengio-wave13", "bengio-wave16", "bengio-wave17",
+    "bengio-wave19", "bengio-wave20", "bengio-wave21", "bengio-wave22",
+]
+
+STUDENT_RUN_SEARCH = [
+    "frieren", "edward", "nezuko", "emma", "gilbert", "violet", "chihiro",
+]
+
+print("=== Checking wave groups ===")
+for group in GROUPS_TO_CHECK:
+    try:
+        runs = api.runs(path, filters={"group": group})
+        run_list = list(runs[:5])
+        if run_list:
+            print(f"\nGroup: {group} ({len(run_list)} runs)")
+            for r in run_list:
+                s = r.summary_metrics
+                abupt = s.get("val_primary/abupt_axis_mean_rel_l2_pct", "N/A")
+                abupt_str = f"{abupt:.4f}" if isinstance(abupt, float) else "N/A"
+                print(f"  {r.id} {r.name[:40]:40s} state={r.state} step={r.lastHistoryStep} abupt={abupt_str}")
+    except Exception as e:
+        pass
+
+print("\n=== Searching by student name (recent running runs) ===")
+# Search for running runs by username prefix
+for student in STUDENT_RUN_SEARCH:
+    try:
+        runs = api.runs(
+            path,
+            filters={"username": student, "state": "running"},
+            order="-created_at"
+        )
+        run_list = list(runs[:3])
+        if run_list:
+            print(f"\nStudent: {student}")
+            for r in run_list:
+                s = r.summary_metrics
+                abupt = s.get("val_primary/abupt_axis_mean_rel_l2_pct", "N/A")
+                abupt_str = f"{abupt:.4f}" if isinstance(abupt, float) else "N/A"
+                print(f"  {r.id} {r.name[:40]:40s} group={r.group} step={r.lastHistoryStep} abupt={abupt_str}")
+    except Exception as e:
+        print(f"  {student}: ERROR {e}")

--- a/check_runs.py
+++ b/check_runs.py
@@ -1,0 +1,106 @@
+"""
+Query W&B run statuses for survey.
+"""
+import os
+import sys
+from pathlib import Path
+
+# Add skill scripts to path
+skill_dir = os.environ.get("CLAUDE_SKILL_DIR", "")
+if skill_dir:
+    sys.path.insert(0, str(Path(skill_dir) / "scripts"))
+
+import wandb
+import pandas as pd
+
+api = wandb.Api()
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+METRICS = [
+    "val_primary/abupt_axis_mean_rel_l2_pct",
+    "val_primary/wall_shear_y_rel_l2_pct",
+    "val_primary/wall_shear_z_rel_l2_pct",
+    "val_primary/surface_pressure_rel_l2_pct",
+    "val_primary/volume_pressure_rel_l2_pct",
+]
+
+# Specific run IDs to check
+SPECIFIC_RUNS = {
+    "hph6eaky": "fern / PR#409 coord-norm fix",
+    "5ifnf1wc": "thorfinn / PR#382 6L/512d/8H",
+    "4632xosf": "kohaku / PR#417 EMA",
+    "0xi2n4oo": "alphonse / PR#437 6L/256d",
+    "jj9r7x0o": "senku / PR#442 OHEM",
+    "vyhpqruv": "tanjiro / PR#443 mirror+SW=2.0",
+}
+
+print("=" * 80)
+print("SPECIFIC RUN STATUS")
+print("=" * 80)
+
+rows = []
+for run_id, label in SPECIFIC_RUNS.items():
+    try:
+        run = api.run(f"{path}/{run_id}")
+        summary = run.summary_metrics
+
+        row = {
+            "run_id": run_id,
+            "label": label,
+            "state": run.state,
+            "epoch": summary.get("epoch", summary.get("trainer/epoch", "N/A")),
+        }
+        for m in METRICS:
+            short = m.split("/")[-1].replace("_rel_l2_pct", "")
+            row[short] = round(summary.get(m, float("nan")), 4) if summary.get(m) is not None else float("nan")
+        rows.append(row)
+
+    except Exception as e:
+        rows.append({
+            "run_id": run_id,
+            "label": label,
+            "state": f"ERROR: {e}",
+            "epoch": "N/A",
+        })
+
+df = pd.DataFrame(rows)
+pd.set_option("display.width", 200)
+pd.set_option("display.max_columns", 20)
+pd.set_option("display.float_format", "{:.4f}".format)
+print(df.to_string(index=False))
+
+print()
+print("=" * 80)
+print("WAVE 19 / WAVE 20 RUNS")
+print("=" * 80)
+
+for wave in ["bengio-wave19", "bengio-wave20"]:
+    print(f"\n--- Group: {wave} ---")
+    try:
+        runs = api.runs(path, filters={"group": wave})
+        wave_rows = []
+        for run in runs[:20]:
+            summary = run.summary_metrics
+            row = {
+                "run_id": run.id,
+                "name": run.name,
+                "state": run.state,
+                "epoch": summary.get("epoch", summary.get("trainer/epoch", "N/A")),
+            }
+            for m in METRICS:
+                short = m.split("/")[-1].replace("_rel_l2_pct", "")
+                row[short] = round(summary.get(m, float("nan")), 4) if summary.get(m) is not None else float("nan")
+            wave_rows.append(row)
+
+        if wave_rows:
+            wdf = pd.DataFrame(wave_rows)
+            print(wdf.to_string(index=False))
+        else:
+            print("  No runs found.")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+print()
+print("Done.")

--- a/experiment_log/full_details_2026-05-03_06-36.md
+++ b/experiment_log/full_details_2026-05-03_06-36.md
@@ -1,0 +1,2042 @@
+# Full Experiment Details (14 experiments)
+
+# #140: [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) [MERGED]
+
+## Hypothesis
+
+**Curriculum (easy-first) case sampling via per-case gradient-norm difficulty proxy will improve convergence speed and final `abupt_axis_mean_rel_l2_pct`.**
+
+In Wave 1, all 16 runs used uniform random case sampling throughout training. However, DrivAerML cases vary substantially in aerodynamic complexity — some vehicles produce nearly laminar flow while others have strong separation and recirculation. Standard sampling presents hard and easy cases with equal frequency from epoch 0, potentially causing early gradient conflict and slowing the model's ability to build robust representations.
+
+The hypothesis: **training on "easy" (low gradient-norm) cases first and gradually introducing harder cases** mirrors classical curriculum learning findings and should help the model establish stable surface pressure and wall-shear representations before being overwhelmed by aerodynamically complex geometries. Once the model has a stable foundation (epochs 1–10), switching to uniform sampling ensures full coverage of the training distribution.
+
+This experiment uses the **alphonse Wave 1 leader recipe** (4L/256d/4H + Fourier PE + T_max=30 + no-EMA) as the base — the strongest known DDP4 configuration.
+
+---
+
+## Baseline to Beat
+
+**AB-UPT public reference targets (all must be beaten simultaneously):**
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **4.51** |
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+
+**Wave 1 alphonse mid-training reference** (run `m9775k1v`, ~step 421k, not final test metrics):
+- abupt=7.33, surf_p=4.87, vol_p=4.23
+
+---
+
+## Implementation Instructions
+
+**You must implement curriculum sampling as a code change to `trainer_runtime.py`.** There is no `--curriculum` CLI flag — you need to add one and wire it through.
+
+### Step 1 — Add a CLI flag to `Config` in `train.py`
+
+In the `Config` dataclass (around line 90 in `train.py`), add:
+
+```python
+curriculum_warmup_epochs: int = 0  # 0 = disabled, >0 = use curriculum for this many epochs
+```
+
+This is cleanly defaulted to 0 (disabled) so existing runs are unaffected.
+
+### Step 2 — Implement difficulty scoring and WeightedRandomSampler in `trainer_runtime.py`
+
+In `make_loaders`, the `train_sampler` is currently a `DistributedSampler`. You need to make it possible to **swap in a `WeightedRandomSampler`** for curriculum epochs.
+
+Add a new function `compute_case_difficulties(train_loader, model, device, loss_fn)` that:
+1. Runs a **single pass over the entire training set** (no gradient accumulation, just `loss.item()` per case) to get per-case loss values
+2. Returns a tensor of shape `[N_cases]` with the per-case loss (higher loss = harder case)
+
+Then in the main training loop in `train.py`, after epoch 0 completes (when `curriculum_warmup_epochs > 0`):
+1. Call `compute_case_difficulties` to get difficulty scores
+2. For epochs 1 through `curriculum_warmup_epochs`, construct a `WeightedRandomSampler` with weights **inversely proportional** to difficulty: `weights = 1.0 / (difficulties + eps)`, normalized. Replace the train_loader sampler.
+3. From epoch `curriculum_warmup_epochs + 1` onward, switch back to standard `DistributedSampler` (or shuffle=True if non-distributed).
+
+**Practical implementation note for DDP**: `WeightedRandomSampler` is not natively DDP-aware. The simplest correct approach:
+- Compute difficulty scores on rank 0 and broadcast to all ranks via `dist.broadcast`
+- Construct separate per-rank `WeightedRandomSampler` instances (each rank samples its own subset, same weights), OR
+- Use the difficulty weights to build a new `DistributedSampler`-like sampler that respects per-case weights across ranks
+
+The simplest correct DDP approach: use **loss-weighted epoch-0 case ordering** on rank 0, broadcast a shuffled index list to all ranks, then split indices across ranks. This avoids the need for a custom `WeightedRandomSampler` and is fully compatible with DDP.
+
+Here is a concrete approach for the `make_loaders` / training loop:
+
+```python
+# In train.py, after epoch 0 training loop:
+if config.curriculum_warmup_epochs > 0 and epoch == 0:
+    # Compute per-case difficulties using training loss
+    case_difficulties = compute_case_difficulties(
+        train_loader=train_loader,
+        model=unwrap_model(model),
+        device=state.device,
+        config=config,
+        target_transform=target_transform,
+    )
+    # Broadcast from rank 0 to all ranks
+    if state.enabled:
+        dist.broadcast(case_difficulties, src=0)
+    # Store for use in subsequent epochs
+    curriculum_weights = 1.0 / (case_difficulties + 1e-6)
+    curriculum_weights /= curriculum_weights.sum()
+```
+
+Then in the epoch loop header, before creating the train DataLoader for each epoch:
+
+```python
+if config.curriculum_warmup_epochs > 0 and 1 <= epoch <= config.curriculum_warmup_epochs:
+    # Use weighted sampler for curriculum phase
+    sampler = WeightedRandomSampler(
+        weights=curriculum_weights,
+        num_samples=len(train_ds),
+        replacement=True,
+    )
+    train_loader = DataLoader(train_ds, batch_size=config.batch_size, sampler=sampler, **loader_kwargs(config))
+elif epoch == config.curriculum_warmup_epochs + 1:
+    # Switch back to standard distributed sampler
+    train_loader = make_train_loader(config, train_ds, distributed_state=state)
+```
+
+**IMPORTANT**: The `compute_case_difficulties` function must:
+- Use `torch.no_grad()` to avoid storing computation graphs
+- Use the **normalized (standardized)** targets via `target_transform.apply_surface` / `apply_volume`
+- Compute loss in the same way as the training loop (matching surface+volume loss formulation)
+- Handle variable-length batches correctly (the dataset uses `pad_collate`)
+- Average the loss over all points in each case to get a scalar per-case difficulty
+
+### Step 3 — Run configuration
+
+Use the **alphonse base recipe** with curriculum enabled for the first 10 epochs:
+
+```bash
+python train.py \
+  --epochs 50 \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr-cosine-t-max 30 \
+  --no-compile-model \
+  --curriculum-warmup-epochs 10 \
+  --wandb-group senku-curriculum \
+  --wandb-run-name senku-curriculum-e10
+```
+
+**Note**: `--no-compile-model` is **mandatory** — PyTorch 2.x Inductor crashes at validation on this cluster.
+
+### Step 4 — Logging
+
+Log the following additional metrics to W&B to help interpret results:
+- `train/curriculum_active` (1 during curriculum epochs, 0 after) — so we can see the phase transition
+- `train/case_difficulty_mean` and `train/case_difficulty_std` (from epoch 0 difficulty scores)
+- `train/curriculum_epoch` (current epoch within curriculum phase)
+
+---
+
+## Expected Outcome
+
+If the hypothesis is correct, you should see:
+- **Faster early convergence**: lower `val_primary/abupt_axis_mean_rel_l2_pct` at epochs 5–15 vs alphonse
+- **Better final metrics**: surf_p and vol_p should benefit from stable early representations
+- The wall-shear y/z axes (the binding constraint in Wave 1) may or may not improve — document whatever you observe
+
+If convergence is similar to alphonse but final metrics don't improve, the curriculum warmup may be too short or the difficulty proxy (loss) may not correlate well with aerodynamic complexity. In that case, please note the per-case difficulty variance in your report (high variance = the cases ARE diverse; low variance = loss is not a good proxy for difficulty).
+
+---
+
+## Reporting
+
+When your run completes, post a comment with:
+1. W&B run ID and link
+2. Final `test_primary/*` metrics table (all 6 axes + abupt_mean)
+3. Best validation checkpoint metrics
+4. Comparison vs AB-UPT targets and alphonse Wave 1 reference
+5. Plot or description of per-case difficulty distribution from epoch 0
+6. Your observation on whether curriculum actually helped convergence (compare early-epoch val curves)
+7. Any implementation notes or issues encountered
+
+Then mark the PR ready for review.
+
+---
+
+# #74: [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) [MERGED]
+
+## Hypothesis
+
+**Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseline**
+
+The strongest known DrivAerML result from the radford branch (PR #2593) used a specific recipe:
+- 4 transformer layers, 256 hidden dim (vs default 3L/192d)
+- No EMA (EMA was found to hurt on DrivAerML)
+- Fourier/sinusoidal positional encoding replacing the default ContinuousSincosEmbed
+- Cosine LR schedule with T_max=30
+- lr=3e-4, weight_decay=1e-4, batch_size=2
+
+This experiment replicates that recipe on the bengio branch to establish a confirmed baseline. Without this replication we are building on unconfirmed assumptions.
+
+**Source:** radford PR #2593, ~12.96% abupt_axis_mean_rel_l2_pct on the test set.
+
+## Architecture Change Required
+
+The default `ContinuousSincosEmbed` in `model.py` must be replaced with a standard Fourier positional encoding. Make this change in your branch:
+
+In `model.py`, replace the `ContinuousSincosEmbed` class with a `FourierEmbed` that uses learned or fixed sinusoidal frequencies. The simplest approach is to replace the line in `SurfaceTransolver.__init__`:
+```python
+self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+```
+with a `FourierEmbed` that accepts separate frequency scales per axis (standard multi-scale sinusoidal with frequencies [1, 10, 100] or similar for the xyz coordinate ranges of DrivAerML). A simple implementation:
+
+```python
+class FourierEmbed(nn.Module):
+    """Multi-scale sinusoidal positional encoding for 3D coordinates."""
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_freqs = num_freqs
+        # Geometric frequency progression: 1, 2, 4, ..., 2^(num_freqs-1)
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        # Output dim: input_dim * num_freqs * 2 (sin + cos), padded to hidden_dim
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+        
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        # coords: [B, N, input_dim]
+        coords = coords.float()
+        # [B, N, input_dim, num_freqs]
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)  # [B, N, input_dim * num_freqs * 2]
+        return self.proj(emb)
+```
+
+Then in `SurfaceTransolver.__init__` use `FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)`.
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --weight-decay 1e-4 \
+  --batch-size 2 \
+  --epochs 50 \
+  --lr-cosine-t-max 30 \
+  --train-surface-points 40000 \
+  --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-alphonse \
+  --agent alphonse
+```
+
+## Current Baseline Targets to Beat
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 (mean of 5 axis metrics) |
+
+Historical best from radford PR #2593: ~12.96% abupt_axis_mean_rel_l2_pct.
+
+## Success Criteria
+
+Report `test_primary/abupt_axis_mean_rel_l2_pct` and all six individual `test_primary/*` metrics. This is the bengio baseline replication run — the key question is whether the Fourier PE + no-EMA + 4L/256d recipe reproduces the ~12.96% result and provides a stable starting point for further bengio experiments.
+
+---
+
+# #176: [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline [MERGED]
+
+## Hypothesis
+
+Wave 1 winner used lr=3e-4 (default). However, 3e-4 may be suboptimal for the Fourier PE baseline — the Fourier features expand the input space significantly and a slightly higher or lower lr may train more efficiently. This experiment sweeps two lr values (1e-4 and 5e-4) on the exact Wave 1 winner config to find the optimal lr for the Fourier PE regime. Run both as sequential trials.
+
+**Target gap:** val_abupt from 7.21% → below 6.8%.
+
+## Instructions
+
+Run two sequential trials (Trial A then Trial B), same config except lr:
+
+**Trial A (lr=1e-4):**
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 1e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-lr-sweep
+```
+
+**Trial B (lr=5e-4):**
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 5e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-lr-sweep
+```
+
+Key changes vs Wave 1 baseline:
+- `--lr` swept over {1e-4, 5e-4} (baseline was 3e-4)
+- `--lr-cosine-t-max 50` (was 30) — longer schedule gives lr differences more time to manifest
+- `--fourier-pe` — mandatory (Wave 1 lesson)
+- All other config identical to Wave 1 winner
+
+Report val_primary metrics at the best checkpoint for each trial. Compare against the 3e-4 baseline.
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`, lr=3e-4):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+## Results
+
+### Trial A (lr=1e-4)
+- **Run 1 (`ro7ocwte`)**: killed at end of ep1 by val_primary kill threshold (abupt=40.97% at step 17,816 vs threshold <25). Cause: with lr-warmup-epochs=3, lr at end of ep1 was ~3.3e-5, three times lower than alphonse's lr at the same step.
+- **Run 2 (`lle5ylae`, kill threshold relaxed to step >= 100k)**: killed at advisor's request (abupt=40.5% at step 22,043 / step 100k+ assessed too late). lr=1e-4 is too low for AB-UPT under T_max=50 — model was severely under-trained and would not catch up before the cosine valley.
+
+**Conclusion:** lr=1e-4 is non-competitive with the FourierEmbed swap.
+
+### Trial B (lr=5e-4) — `ld3ff1gs`
+
+Per-epoch val_primary trajectory:
+
+| Epoch | step | abupt | surface_p | wall_shear | volume_p |
+|-------|------|-------|-----------|------------|----------|
+| 1 | 17,816 | 30.17 | 23.24 | 31.66 | 22.34 |
+| 2 | 35,633 | 14.98 | 10.34 | 16.03 | 11.01 |
+| 3 | 53,450 | 12.51 | 8.52 | 13.46 | 9.09 |
+| 4 | 71,267 | 11.41 | 7.65 | 12.28 | 8.33 |
+| 5 | 89,084 | 11.05 | 7.34 | 11.75 | 8.72 |
+| 6 | 106,901 | 10.34 | 6.83 | 11.21 | 7.41 |
+| 7 | 124,718 | 9.61 | 6.37 | 10.39 | 6.97 |
+| 8 | 142,535 | 9.37 | 6.23 | 10.17 | 6.76 |
+| 9 | 160,352 | 9.71 | 6.48 | 10.50 | 7.09 |
+| 10 | 178,169 | 9.21 | 6.09 | 10.00 | 6.62 |
+| **11 (best)** | **195,986** | **9.122** | **6.041** | **9.910** | **6.522** |
+| 12 | 213,803 | 10.44 | 7.09 | 11.16 | 7.95 |
+
+**Best so far (ep11):**
+
+| Metric | ep11 best | Baseline (alphonse, lr=3e-4) | Δ vs baseline |
+|--------|-----------|------------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.122** | 7.209 | **+1.91% (worse)** |
+| `val_primary/surface_pressure_rel_l2_pct` | 6.041 | 4.802 | +1.24% (worse) |
+| `val_primary/wall_shear_rel_l2_pct` | 9.910 | 8.160 | +1.75% (worse) |
+| `val_primary/volume_pressure_rel_l2_pct` | 6.522 | 4.166 | +2.36% (worse) |
+
+ep12 regression: all four primary metrics jumped together (+1.32% on abupt) with two large train/loss spikes (steps 199,522 and 211,125 at ~0.51 vs ~0.01 baseline) — destabilization signal, not noise.
+
+**Conclusion:** lr=5e-4 with `--lr-cosine-t-max 50` + Fourier PE is non-competitive vs alphonse's lr=3e-4 (T_max=30). Even at ep11-best, model is ~1.9% worse on abupt with declining slope and a paired-channel destabilization at ep12. Not worth running to ep31 valley.
+
+**Final command used (Trial B):**
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema \
+  --lr 5e-4 --epochs 50 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb-group bengio-wave2-lr-sweep --wandb-name chihiro/lr-sweep-5e-4 \
+  --agent chihiro
+```
+
+W&B run IDs (rank-0): Trial A v1 `ro7ocwte`, Trial A v2 `lle5ylae`, Trial B `ld3ff1gs` (group: `bengio-wave2-lr-sweep`).
+
+Peak GPU memory: ~10.85 GB / GPU (4× A100), all four GPUs ~90-95% util throughout.
+
+---
+
+# #354: [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline [MERGED]
+
+## Hypothesis
+
+A systematic +1.0–1.5 pp structural gap has been observed between every recent `fourier-pe nf=8` baseline-config run and the alphonse `m9775k1v` baseline (ep30, `val_abupt=7.2091%`). All the data points:
+
+| Run ID | Config | Best abupt |
+|--------|--------|-----------|
+| `m9775k1v` | alphonse baseline PR #74 (ep30 best) | **7.2091%** |
+| `67u9bilg` | haku surface-weight 2.0 (identical arch, 50ep) | 8.168% |
+| `kuz4na0j` | trial-B wsy/wsz 0.5 | 8.895% |
+| `w3thlivw` | mirror0.5 + sw2.0 | 8.919% |
+| `31s1j3a0` | gc=0.5 (grad clip) | 9.215% |
+| `0fhryk4r` | fern SWA-last5 (fourier-pe confirmed, ep10) | 9.270% |
+
+**Architecture-identical runs (3,249,813 params, FourierEmbed, lr=3e-4, cosine_t_max=30, no-EMA) still land ~1pp above alphonse.** This cannot be explained by hyperparameter difference — it is a codebase, data, or environment change between the alphonse merge (PR #74) and current HEAD.
+
+This affects every in-flight Wave 5–8 PR. Finding and fixing this regression is the highest-leverage action in the entire research programme right now.
+
+## Goal
+
+1. **Identify the commit** between PR #74 (alphonse, the Wave 1 BASELINE winner, ~2026-04-30) and current bengio HEAD that introduced the regression.
+2. **Propose and implement a minimal fix** in `target/train.py` or `target/model.py` (whichever file the culprit is in).
+3. **Validate** by running a short sanity-check training run (at minimum ep5 abupt should match the alphonse trajectory table below).
+
+## What to investigate
+
+Start with these categories, in order of likelihood:
+
+**a. Data/dataloader changes** — Any change to normalization constants, dataset splits, augmentation defaults, point cloud subsampling counts, or data loading order. A silent normalization change would produce the consistent ~1pp floor we see. Check `train.py` for any hardcoded normalization or preprocessing that differs from what alphonse used.
+
+**b. Loss function changes** — Any change to loss weights, loss formulation, or how the primary `abupt_axis_mean_rel_l2_pct` is computed. Even a small coefficient change compounds across epochs.
+
+**c. Model initialization** — Any change to default weight initialization in `model.py`. A change in the FourierEmbed or transformer init could produce a consistent early-epoch gap.
+
+**d. LR scheduler** — Any change to how `lr-cosine-t-max` is applied. Verify the LR curve in W&B for a fresh run vs the expected cosine schedule.
+
+**e. Training loop / DDP sync** — Any change to how metrics are aggregated across ranks, or DDP bucket/gradient sync that could affect effective batch size.
+
+## Approach
+
+Use `git log --oneline <PR74-merge-sha>..HEAD -- target/` to list all commits that touched the target code since alphonse merged. Examine each diff for the categories above.
+
+The alphonse PR #74 is a squash merge — so the comparison point is the commit just after the squash. Run `git log --oneline --all | grep -i alphonse` to find the relevant commit hash.
+
+If the change is in `train.py` or `model.py`, implement the fix directly. If it is an environment issue (library version, CUDA, dataset file), document it clearly and propose a reproducible workaround.
+
+## Validation run
+
+After the fix, run a short 10-epoch validation run with the exact baseline recipe:
+
+```bash
+torchrun --standalone --nproc_per_node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --no-compile-model \
+  --wandb-group bengio-regression-bisect
+```
+
+The expected trajectory (from alphonse `m9775k1v`) for the baseline recipe:
+
+| ep | expected abupt | acceptable range |
+|----|--------------|-----------------|
+| 1  | ~13.5%       | < 14.5%         |
+| 5  | ~8.9%        | < 9.5%          |
+| 10 | ~8.2%        | < 8.8%          |
+
+If your fix brings ep5/ep10 within the acceptable ranges, the regression is resolved. **Report the W&B run ID and the commit SHA of the fix.**
+
+## Current Baseline
+
+| Metric | Current Best (val, ep30) | AB-UPT Target |
+|--------|--------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+Baseline W&B run: `m9775k1v` (alphonse, PR #74, `--fourier-pe` confirmed, n_params=3,249,813)
+
+## Notes
+
+- The SWA code from the closed PR #276 (branch `fern/swa-last-k-epochs`, commit `d6cb811`) is preserved for later.
+- Report your findings in PR comments as you go — even partial diagnosis is valuable.
+- If the regression is environmental rather than code (library version bump, dataset update), document the delta precisely so the team can decide whether to freeze or adapt.
+
+---
+
+# #174: [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule [MERGED]
+
+## Hypothesis
+
+Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. That config likely underfits given the short cosine schedule (30 epochs). Adding a 5th layer increases model capacity; pairing it with a longer T_max=50 schedule gives the deeper model sufficient time to converge. Wave 1 5L run (gilbert, #76) reached val_abupt=7.47% at ep30 — but was run WITHOUT Fourier PE and without the longer schedule. This run isolates depth+PE+schedule together.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+## Instructions
+
+Run exactly one training job with the following config (all other hyperparameters at train.py defaults):
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 5 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 5 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+Key changes vs Wave 1 baseline:
+- `--model-num-layers 5` (was 4) — adds one Transformer layer
+- `--lr-cosine-t-max 50` (was 30) — gives deeper model more epochs to converge
+- `--lr-warmup-epochs 5` (was default) — gentle warmup for the extra depth
+- `--fourier-pe` — mandatory (Wave 1 lesson: PE is the single largest perf driver)
+- `--no-use-ema` — same as baseline winner
+
+Report val_primary metrics at the best checkpoint (lowest val_primary/abupt_axis_mean_rel_l2_pct).
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+Reproduce command (Wave 1 winner):
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr-cosine-t-max 30 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --wandb_group bengio-wave2
+```
+
+---
+
+# #487: Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d [MERGED]
+
+## Hypothesis
+
+The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num-freqs` = 8 (default in the codebase). The Fourier positional embedding maps 3D coordinates through sin/cos of 8 frequency bands, producing a 48-dim input (3 coords × 8 freqs × 2 = 48) before a linear projection to hidden_dim=256. Increasing the number of Fourier frequency bands to 16 (96-dim input) gives the model more high-frequency positional resolution, potentially capturing the fine-scale geometry variation in boundary-layer regions that drive wsy/wsz errors. Conversely, 4 bands (24-dim input) would test whether the current 8 bands are over-specified. The cost of more frequencies is only a larger input projection — the rest of the model is unchanged.
+
+This is a single architectural knob targeting positional encoding expressiveness.
+
+## Instructions
+
+Run **two parallel trials** on the 5L/256d/4H + T_max=50 base:
+
+**Trial A — nf=16 (more high-freq bands)**:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --fourier-pe-num-freqs 16 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave17 \
+  --wandb-name nezuko-fourier-nf16
+```
+
+**Trial B — nf=4 (fewer bands, ablation)**:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --fourier-pe-num-freqs 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave17 \
+  --wandb-name nezuko-fourier-nf4
+```
+
+Run Trial A first. At ep5 (step 89,084): if abupt < 10.5%, continue AND start Trial B in parallel. If Trial A abupt ≥ 10.5%: stop Trial A, but still run Trial B to completion up to ep15 (abupt gate: > 8.5%). 
+
+**Reporting**: Post W&B run IDs as soon as each trial starts. Post full val metric tables at ep5, ep10 for both trials as a PR comment.
+
+## Baseline
+
+Current best (PR #174, alphonse, run `vu4jsiic`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.5644 | 3.82 |
+| `val_primary/volume_pressure_rel_l2_pct` | 3.9361 | 6.08 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | 3.63 |
+
+Baseline uses `--fourier-pe` with default num_freqs=8.
+
+Reproduce baseline:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave9
+```
+
+## Gates
+
+For each trial:
+
+| Epoch | Step | Kill threshold |
+|-------|------|----------------|
+| ep5 | 89,084 | abupt > 10.5% → stop trial |
+| ep15 | 267,254 | abupt > 8.5% → stop trial |
+| ep25 | 445,400 | abupt > 6.9549% (baseline) → close |
+
+## What to measure
+
+At ep10: compare `val_primary/wall_shear_y_rel_l2_pct` and `val_primary/wall_shear_z_rel_l2_pct` between nf=4, nf=8 (baseline), nf=16. If nf=16 gives a clear wsy/wsz improvement (>0.3pp vs nf=8), this points toward higher-frequency PE as a lever for shear prediction.
+
+---
+
+# #332: [tanjiro] Stack mirror-aug + surface-loss-weight=2.0 on alphonse Fourier base [CLOSED]
+
+## Hypothesis
+
+Two independent Wave 5/6 results suggest small positive signals on the binding axes:
+1. **gilbert PR #278 mirror-augmentation Trial A**: ep11 abupt=9.91% (healthy trajectory, gate PASS); train-time y-flip + wsy sign-flip at p=0.5 gives the model the symmetry of the problem for free.
+2. **Wave 1 tanjiro sw=2.0** + **closed Wave 6 haku sw=2.0**: both showed surface-loss-weight=2.0 helps on the binding axes (haku ep5=10.15% PASS).
+
+Neither has been combined. The hypothesis: **mirror-augmentation + surface-loss-weight=2.0** stacked on the alphonse Fourier base may compound — mirror gives the model symmetry-equivariant gradients on wsy specifically, and sw=2.0 gives the surface decoder more weight in the optimizer. Different mechanisms, both targeting the binding axes.
+
+Also tests a secondary hypothesis: does mirror-aug interact constructively or destructively with surface-loss upweighting? If destructively, that's a strong signal that the binding constraint is not loss-weight or data-augmentation but representation.
+
+## Instructions
+
+This depends on gilbert's mirror-augmentation code on PR #278 branch `gilbert/mirror-symmetry-train-aug-wsy`. **First, cherry-pick the mirror-aug commit** from gilbert's branch onto your tanjiro branch. The mirror flag should be `--mirror-aug-prob 0.5` or similar — confirm by reading gilbert's PR #278 body and code:
+
+```bash
+git fetch origin gilbert/mirror-symmetry-train-aug-wsy
+git log origin/gilbert/mirror-symmetry-train-aug-wsy ^bengio --oneline
+# cherry-pick the mirror-aug implementation commit (likely the only non-assignment commit)
+git cherry-pick <commit-sha>
+# verify --help shows the mirror-aug flag
+python target/train.py --help | grep -i mirror
+```
+
+If gilbert's branch has multiple commits, cherry-pick the implementation commit only (skip the assignment commit if separate). If conflicts arise on `train.py`, prefer gilbert's mirror-aug code and rebase your changes around it.
+
+**Smoke test**:
+```bash
+cd target/ && python train.py --debug --epochs 1 --mirror-aug-prob 0.5 --surface-loss-weight 2.0 --no-compile-model 2>&1 | head -40
+```
+
+**Trial A — mirror=0.5 + sw=2.0** (the stacked recipe):
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --mirror-aug-prob 0.5 \
+  --surface-loss-weight 2.0 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.0" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw2.0
+```
+
+**Trial B — mirror=0.5 only** (control for stacking effect):
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --mirror-aug-prob 0.5 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.5" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw1.0
+```
+
+Run sequentially (Trial A first since it is the high-EV one).
+
+If the exact flag name on gilbert's branch is different (e.g. `--mirror-prob` or `--y-mirror-aug`), use the actual name and report it in your results comment.
+
+`--kill-thresholds` format: `STEP:METRIC<OP><NUMBER` (commas/semicolons). `>` = kill if metric exceeds threshold.
+
+## Baseline
+
+Current bengio best: **val_abupt = 7.2091%** (PR #74 alphonse, run `m9775k1v`).
+
+Per-axis val metrics to beat:
+- surface_pressure_rel_l2_pct: 4.802 (AB-UPT 3.82)
+- wall_shear_rel_l2_pct: 8.160 (AB-UPT 7.29)
+- volume_pressure_rel_l2_pct: 4.166 (AB-UPT 6.08 — already beats)
+- wall_shear_x_rel_l2_pct: 7.109 (AB-UPT 5.35)
+- wall_shear_y_rel_l2_pct: 9.100 (AB-UPT 3.65) — **binding constraint**
+- wall_shear_z_rel_l2_pct: 10.869 (AB-UPT 3.63) — **hardest binding constraint**
+
+**Reference points**:
+- gilbert PR #278 Trial A (mirror=0.5 only): ep11 abupt=9.91% — your Trial B should match within 0.3pp at ep11.
+- closed Wave 6 haku Trial A (sw=2.0 only): ep5 abupt=10.15% — your Trial A should be ≤ 10.15% at ep5 if the stack is positive.
+
+**val/test gap warning**: ~2x degradation on vol_p (val=4.17% → test~8-12%). Test_primary confirmation required.
+
+## Reporting
+
+Post a single PR comment with:
+- The cherry-picked commit SHA from gilbert's branch
+- Both trial W&B run IDs
+- Per-channel val metrics at ep10, ep20, ep30
+- A clear answer: did mirror+sw stack constructively (Trial A < min(gilbert, haku))? Or did the levers fight each other?
+
+## Results — Trial A (mirror=0.5 + SW=2.0) at ep30
+
+Trial A (`w3thlivw`) finished at ep30 with the final test eval.
+
+**Verdict: ep30 gate cleared (≤8.0%); does NOT beat the 7.2091% PR baseline (or the new 6.9549% baseline from alphonse PR #174 the advisor flagged at 15:28Z). Final landing val_abupt = 7.8243%.**
+
+### Run metadata
+
+- **W&B group**: `bengio-wave7-mirror-plus-sw`
+- **Run IDs (4 ranks)**: rank 0 (primary) `w3thlivw`, rank 1 `mofpsfz3`, rank 2 `xiq4srjy`, rank 3 `lt2m7z8t`
+- **Mirror-aug commit**: `77be65c` (re-implemented locally; gilbert's branch contained only the assignment commit `f7b9a28`, so a literal cherry-pick was not possible — see 03:44Z pre-launch note)
+- **Total wall-clock**: 853.75 min (14h13m), 30 epochs × ~1671 s/ep
+- **Peak VRAM**: ~10.85 GB on each of 4 RTX PRO 6000 (96 GB available)
+- **Best val checkpoint**: ep30, abupt = 7.8243% (best in the run)
+
+### Exact training command
+
+```
+torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --lr-cosine-t-max 30 --epochs 30 \
+  --mirror-aug-prob 0.5 --surface-loss-weight 2.0 \
+  --fourier-pe --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct<20,170000:val_primary/abupt_axis_mean_rel_l2_pct<11.0" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw2.0 --agent tanjiro
+```
+
+(Trial B was **skipped** per advisor's 16:33Z option-1 directive — watcher PID 370922 killed at 16:39:36Z; no GPU time spent on the mirror-only control.)
+
+### Per-channel val trajectory (ep5 / ep10 / ep20 / ep30)
+
+| metric (val_primary, %) | ep5 | ep10 | ep20 | **ep30** | PR-body baseline | Δ ep30 vs baseline |
+|---|---:|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct`    | 9.7369 | 9.0920 | 8.1341 | **7.8243** | 7.2091 | **+0.615** |
+| `surface_pressure_rel_l2_pct`   | 6.3668 | 5.9404 | 5.3596 | 5.1781 | 4.802 | +0.376 |
+| `wall_shear_rel_l2_pct`         | 10.3659 | 9.7176 | 8.7848 | 8.4736 | 8.160 | +0.314 |
+| `volume_pressure_rel_l2_pct`    | 7.7156 | 7.0166 | 6.1442 | 5.8709 | 4.166 | **+1.705** |
+| `wall_shear_x_rel_l2_pct`       | 8.8636 | 8.3075 | 7.6341 | 7.4178 | 7.109 | +0.309 |
+| `wall_shear_y_rel_l2_pct`       | 12.1252 | 11.1647 | 9.8907 | 9.3348 | 9.100 | +0.235 |
+| `wall_shear_z_rel_l2_pct`       | 13.6134 | 13.0307 | 11.6420 | 11.3199 | 10.869 | +0.451 |
+
+### Test eval at ep30 checkpoint (50-case test split)
+
+| metric (test_primary, %) | val (ep30) | **test** | val/test ratio | AB-UPT test target | Δ vs AB-UPT |
+|---|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct`    | 7.8243 | **8.8869** | 1.14× | ~4.51 | +4.38 |
+| `surface_pressure_rel_l2_pct`   | 5.1781 | 4.6762 | 0.90× | 3.82 | +0.86 |
+| `wall_shear_rel_l2_pct`         | 8.4736 | 8.0847 | 0.95× | 7.29 | +0.79 |
+| `volume_pressure_rel_l2_pct`    | 5.8709 | **13.2732** | **2.26×** | 6.08 | +7.19 |
+| `wall_shear_x_rel_l2_pct`       | 7.4178 | 7.1412 | 0.96× | 5.35 | +1.79 |
+| `wall_shear_y_rel_l2_pct`       | 9.3348 | 8.9983 | 0.96× | 3.65 | +5.35 |
+| `wall_shear_z_rel_l2_pct`       | 11.3199 | 10.3456 | 0.91× | 3.63 | +6.72 |
+
+The val/test ratio confirms the BASELINE.md warning: vol_p collapses 2.26× from val to test (consistent with the prior alphonse `m9775k1v` 4.17→8–12% gap, even larger here). All other surface/wall-shear axes are slightly better on test than on val (ratio < 1), so the surface decoder is generalising fine; volume is the structural problem.
+
+### Reference checks the PR asked for
+
+- **vs gilbert PR #278 mirror-only Trial A ep11 = 9.91%**: my Trial A ep11 = 8.92% (mirror+SW=2.0 is **0.99 pp better at ep11**). Suggests the stack is constructive at the mid-training stage.
+- **vs closed Wave 6 haku Trial A (sw=2.0 only) ep5 = 10.15%**: my Trial A ep5 = 9.737% — clears the gate by **0.413 pp**. The stack compounds at ep5, mostly through wsy/wsz.
+- **ep10 abupt 9.092% vs gate ≤9.5%**: PASS by 0.408 pp.
+- **ep20 abupt 8.134% vs gate ≤8.5%**: PASS by 0.366 pp.
+- **ep30 abupt 7.824% vs gate ≤8.0%**: PASS by 0.176 pp.
+- **ep30 abupt 7.824% vs PR-body baseline 7.2091%**: FAIL by 0.615 pp.
+- **ep30 abupt 7.824% vs new 6.9549% baseline (PR #174)**: FAIL by 0.869 pp.
+
+### What happened
+
+The hypothesis was that mirror-aug (giving the model y-symmetry "for free" on wsy specifically) and surface-loss-weight=2.0 (giving the surface decoder more optimizer mass) would compound. **At ep5 / ep10 / ep20 the stack does compound** — Trial A beats both the haku sw=2.0-only ep5 reference and the gilbert mirror-only ep11 reference by ~0.4–1.0 pp at every gate.
+
+But the descent **plateaus into the cosine tail**:
+- ep10→ep20 slope: −0.096 pp/ep
+- ep20→ep30 slope: −0.031 pp/ep (3× slower)
+- ep28→ep29 slope: −0.012 pp/ep, ep29→ep30: −0.008 pp/ep
+
+By ep23 the run is already inside ±0.05 pp of its ep30 floor; the last 7 epochs of cosine LR decay are essentially squeezing 0.17 pp of additional gain out of mirror-aug + SW=2.0 noise. The architectural ceiling at 4L/256d is reached around 7.8% on this recipe.
+
+**Per-axis attribution (without Trial B but referencing closed work):**
+- **wsy and wsz**: the strongest improvements over baseline trajectory. wsy 17.88→9.33 over 30 ep (−8.55 pp), wsz 19.86→11.32 (−8.54 pp). The mirror-aug y-symmetry term is doing useful work — but the val-end value 9.33% is essentially **at baseline 9.10%** (+0.23 pp). The lift was front-loaded in ep1–ep10 and then SW=2.0 mostly held it.
+- **vp**: the SW=2.0 cost. val 5.87% vs baseline 4.17% (+1.71 pp), test 13.27% vs AB-UPT 6.08 (**+7.19 pp** — the worst gap in the run). Surface-loss upweighting starves the volume decoder; this is the single biggest lever pulling abupt up.
+- **surf_p and ws**: very slight regression (~+0.3 pp). The SW=2.0 emphasis on surface was supposed to help these but the decoder hit its 4L/256d ceiling early.
+
+**Did mirror+SW=2.0 stack constructively?** Yes early (ep5/ep11 beat both single-lever references), but the compound gain dissipates by ep30. The **levers are not fighting** (Trial A isn't worse than either single-lever component at any gate), but the architectural ceiling at 4L/256d is what kills the baseline-beat ambition.
+
+### Suggested follow-ups
+
+(Per advisor's Wave 11 redirect at 15:28Z, the natural next experiment is mirror+SW=2.0 on the 5L/256d/T_max=50 architecture that hit 6.95% — I will queue that for the next assignment.)
+
+1. **Port mirror+SW=2.0 to 5L/256d/T_max=50** (Wave 11 plan). The strongest signal here is that 4L/256d is the ceiling, not the recipe.
+2. **Lower SW**. SW=1.5 or 1.25 may capture most of the surface-decoder gain without the +1.71 pp val_vp / +7.19 pp test_vp penalty.
+3. **Mirror schedule**: the wsy gain front-loads in ep1–ep10 and saturates after ep20. Annealing `mirror_aug_prob` from 0.5→0.0 over the cosine tail would let the model reduce the effective dropout on the binding axis once the symmetry is internalized — could recover 0.1–0.2 pp on the late-cosine descent.
+4. **Volume decoder fix is more important than mirror-aug**. The 2.26× val→test gap on vol_p is a representation problem (BASELINE.md flag #17), not a loss-weight problem. Mirror+SW=2.0 made it worse in absolute terms; any future surface-emphasis recipe should pair with a volume-side counterweight (separate volume LR, larger volume sub-network, or volume-only test-time augmentation).
+5. **Run a real Trial B** after Wave 11 lands. Once we have a stronger architectural ceiling, the mirror-only vs mirror+SW=2.0 ablation becomes useful again — at the current ceiling the answer is dominated by the 4L/256d cap and the ablation can't be cleanly disentangled.
+
+---
+
+# #277: [tanjiro] DomainLayerNorm: domain-specific affine LayerNorm for surface vs volume tokens [CLOSED]
+
+## Hypothesis
+
+Different geometric domains (surface vs volume) in this CFD surrogate have fundamentally different physical characteristics — surface tokens encode boundary layer physics while volume tokens encode free-stream flow. Using **shared** LayerNorm affine parameters (weight/bias) forces the model to normalize both domains identically, which may suppress domain-specific signal. 
+
+**DomainLayerNorm** replaces each `norm1` and `norm2` in every `TransformerBlock` with a module that keeps **separate** affine parameters for surface tokens vs volume tokens, while using the same running statistics. This is a parameter-cheap architectural improvement: just `2 × 2 × n_layers` extra (weight, bias) pairs of size `hidden_dim`. For 4L/256d, that's 4 × 2 × 256 = ~2048 extra parameters on a ~4M param model (<0.05%).
+
+This approach is inspired by domain-conditioned normalization in multi-domain transformers (e.g., DomainLayerNorm in AB-UPT, cross-domain ViTs). The intuition: surface tokens need to capture steep pressure gradients and wall shear boundary conditions, while volume tokens represent smoother field values — letting them have separate affine scales and biases gives the model a free channel to express this.
+
+## Instructions
+
+This experiment requires **modifying `model.py`** only. `train.py` should NOT be modified.
+
+### Step 1: Add `DomainLayerNorm` class to `model.py`
+
+Insert this class after the `UpActDownMlp` class (around line 122, before `TransolverAttention`):
+
+```python
+class DomainLayerNorm(nn.Module):
+    """LayerNorm with separate affine params for surface vs volume tokens.
+
+    Args:
+        hidden_dim: Feature dimension.
+        eps: Epsilon for numerical stability.
+    """
+
+    def __init__(self, hidden_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        # Shared norm (no affine) for computing statistics
+        self.norm = nn.LayerNorm(hidden_dim, elementwise_affine=False, eps=eps)
+        # Separate affine params per domain
+        self.surface_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.surface_bias = nn.Parameter(torch.zeros(hidden_dim))
+        self.volume_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.volume_bias = nn.Parameter(torch.zeros(hidden_dim))
+
+    def forward(self, x: torch.Tensor, surface_tokens: int) -> torch.Tensor:
+        """
+        x: [B, T, D] where T = surface_tokens + volume_tokens
+        surface_tokens: number of leading surface tokens
+        """
+        normed = self.norm(x)
+        if surface_tokens > 0 and surface_tokens < x.shape[1]:
+            # Mixed batch: apply domain-specific affine
+            surf = normed[:, :surface_tokens] * self.surface_weight + self.surface_bias
+            vol = normed[:, surface_tokens:] * self.volume_weight + self.volume_bias
+            return torch.cat([surf, vol], dim=1)
+        elif surface_tokens == x.shape[1]:
+            # Surface-only batch
+            return normed * self.surface_weight + self.surface_bias
+        else:
+            # Volume-only batch
+            return normed * self.volume_weight + self.volume_bias
+```
+
+### Step 2: Modify `TransformerBlock` to accept and use `DomainLayerNorm`
+
+Replace the `TransformerBlock.__init__` to accept a `use_domain_ln` flag:
+
+```python
+class TransformerBlock(nn.Module):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_domain_ln: bool = False,
+    ):
+        super().__init__()
+        mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
+        self.use_domain_ln = use_domain_ln
+        if use_domain_ln:
+            self.norm1 = DomainLayerNorm(hidden_dim)
+            self.norm2 = DomainLayerNorm(hidden_dim)
+        else:
+            self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+            self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.attention = TransolverAttention(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_slices=num_slices,
+            dropout=dropout,
+        )
+        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+```
+
+Update `TransformerBlock.forward` to pass `surface_tokens` through:
+
+```python
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
+        x = _apply_token_mask(x, attn_mask)
+        if self.use_domain_ln:
+            x = x + self.attention(self.norm1(x, surface_tokens), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x, surface_tokens))
+        else:
+            x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x))
+        x = _apply_token_mask(x, attn_mask)
+        return x
+```
+
+### Step 3: Modify `Transformer` to propagate `surface_tokens`
+
+Update `Transformer.__init__` to pass `use_domain_ln` to each block:
+
+```python
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        depth: int,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_domain_ln: bool = False,
+    ):
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    mlp_expansion_factor=mlp_expansion_factor,
+                    num_slices=num_slices,
+                    dropout=dropout,
+                    use_domain_ln=use_domain_ln,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(x, attn_mask=attn_mask, surface_tokens=surface_tokens)
+        return x
+```
+
+### Step 4: Thread `use_domain_ln` and `surface_tokens` through `SurfaceTransolver`
+
+In `SurfaceTransolver.__init__`, add the new parameter and pass it to `Transformer`:
+
+```python
+def __init__(
+    self,
+    *,
+    space_dim: int = 3,
+    surface_input_dim: int = SURFACE_X_DIM,
+    surface_output_dim: int = SURFACE_Y_DIM,
+    volume_input_dim: int = VOLUME_X_DIM,
+    volume_output_dim: int = VOLUME_Y_DIM,
+    n_layers: int = 3,
+    n_hidden: int = 192,
+    dropout: float = 0.0,
+    n_head: int = 3,
+    mlp_ratio: int = 4,
+    slice_num: int = 96,
+    fourier_pe: bool = False,
+    fourier_pe_num_freqs: int = 8,
+    domain_ln: bool = False,     # <-- add this
+):
+    ...
+    self.backbone = Transformer(
+        depth=n_layers,
+        hidden_dim=n_hidden,
+        num_heads=n_head,
+        mlp_expansion_factor=mlp_ratio,
+        num_slices=slice_num,
+        dropout=dropout,
+        use_domain_ln=domain_ln,   # <-- pass through
+    )
+```
+
+In `SurfaceTransolver.forward`, capture `surface_tokens` and pass it to `self.backbone`:
+
+```python
+    # existing code already sets:
+    # surface_tokens = surface_x.shape[1]   (or 0 if surface_x is None)
+    
+    # Replace:
+    hidden = self.backbone(hidden, attn_mask=attn_mask)
+    # With:
+    hidden = self.backbone(hidden, attn_mask=attn_mask, surface_tokens=surface_tokens)
+```
+
+### Step 5: Wire the CLI flag in `train.py`
+
+Find the model instantiation in `train.py` (search for `SurfaceTransolver(`) and:
+
+1. Add a config field (or just use a flag) to toggle `domain_ln=True`.
+2. Add `--domain-ln` flag to the argument parser (search for `add_argument` calls near other model flags like `--fourier-pe`).
+3. Pass `domain_ln=config.domain_ln` to `SurfaceTransolver(...)`.
+
+The pattern to follow is the existing `--fourier-pe` / `fourier_pe` flag wiring.
+
+### Step 6: Run command
+
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --domain-ln \
+  --no-compile-model \
+  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+  --wandb-group bengio-wave5-tanjiro
+```
+
+## Baseline (current best — PR #74, W&B run `m9775k1v`, ep30)
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | 4.166 ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+**Win condition**: `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091%
+
+## Kill Gates
+
+- ep5: abupt > 13% → kill
+- ep10: abupt > 9.5% → kill
+- ep20: abupt > 8.0% → kill
+
+## What to Report
+
+Report `val_primary/abupt_axis_mean_rel_l2_pct` at the best checkpoint, plus all 6 axis metrics. Note whether domain_ln helps or hurts wsy/wsz specifically — those are the hardest targets (wsy target=3.65%, wsz target=3.63%). Include the W&B run ID in the PR comment.
+
+## Results — DomainLayerNorm (NEGATIVE)
+
+### Final outcome
+
+**Run killed at step 35632 (ep2) by the kill threshold (`35000:val_primary/abupt_axis_mean_rel_l2_pct<20`).** The trajectory through ep1→ep2 is anomalous and clearly diverging — comparable 4L/256d/no-ema/lr=3e-4/cosine_t_max=30 baselines drop ~7% absolute between ep1 and ep2; ours regressed +1.9%. With train loss simultaneously collapsing 4× faster than baselines, the signature is overfitting / representation collapse, not standard early-epoch noise.
+
+**Best checkpoint: ep1.** No checkpoint is competitive with the bengio baseline; the run never reached a meaningful comparison point.
+
+| Metric | ep1 (best) | ep2 | Baseline (PR #74, ep30) | AB-UPT |
+|--------|-----------:|----:|-----------------------:|-------:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **18.4487** | 20.3527 | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 12.63 | 14.31 | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 20.13 | 21.92 | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | 12.31 | 14.15 | 4.166 | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 17.07 | 18.45 | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 24.28 | 27.13 | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 25.97 | 27.73 | 10.869 | 3.63 |
+
+`full_val_primary/*` and `test_primary/*` were not produced — the run was killed before final eval.
+
+### Trajectory comparison vs comparable 4L/256d/no-ema baselines
+
+Pulled from W&B for the same hyperparameter shape (no-ema, lr=3e-4, lr_cosine_t_max=30):
+
+| epoch | domain-ln-v2 (ours) | fern/ctrl-noWarm | frieren/ctrl-nw-r2 | nezuko/ctrl-armA |
+|-------|--------------------:|-----------------:|-------------------:|-----------------:|
+| ep1 abupt | 18.45 | 17.17 | 16.40 | 15.55 |
+| ep2 abupt | **20.35** (killed) | 11.73 | 11.35 | 11.52 |
+| ep3 abupt | — | 10.48 | 10.08 | 10.48 |
+| ep1 train_loss | **0.2063** | 0.4884 | 0.4886 | 0.4167 |
+| ep2 train_loss | **0.0545** | 0.0934 | 0.0814 | 0.0775 |
+
+Two anomalies stand out:
+1. **Train loss is ~half the baselines at both ep1 and ep2** — the model is fitting train data ~4× faster while val degrades. This is the canonical overfitting / representation-collapse fingerprint.
+2. **Val regresses ep1→ep2** while every comparable run drops ~30–40% on each metric over the same interval.
+
+### Run details
+
+- Run command:
+  ```bash
+  cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+    --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+    --no-use-ema --lr 3e-4 --lr-cosine-t-max 30 \
+    --domain-ln --no-compile-model \
+    --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+    --wandb-name "tanjiro/domain-layer-norm-v2" \
+    --wandb-group bengio-wave5-tanjiro
+  ```
+- W&B run ID: `212ziaku` (rank0)
+- Group: `bengio-wave5-tanjiro`
+- Model: `SurfaceTransolver` 4L/256d/4h, 3.24M params (DomainLayerNorm adds ~8K params, <0.25%)
+- Peak memory: 10.9 GB / GPU
+- ep wall-clock: 2016s (~34 min/epoch with val); killed at step 35632 (ep2)
+- Total wall-clock used: ~70 min
+
+### What happened — analysis
+
+The DDP deadlock from attempts 1–4 was correctly resolved by the empty-batch fix (always-slice + ghost connection); the model trained without crashing and the ep1 metric (18.45%) was within the advisor's sanity range vs the 17.5% reference. So the implementation is structurally correct. The hypothesis itself failed:
+
+- DomainLayerNorm is mathematically a strict generalization of LayerNorm (init at ones/zeros = identity). At init, the model is identical to baseline.
+- After ~17K steps of training, the per-domain affine has clearly diverged in a way that lets the model fit the training distribution very tightly (train_loss=0.054 at ep2, when comparable baselines are at 0.08) while degrading on validation.
+- All seven validation metrics regressed simultaneously; this is not a per-axis pathology, it's a global generalization failure.
+
+My read on the mechanism: the per-domain affine creates a free degree of freedom for the model to scale/shift surface and volume features differently *at every layer*. In combination with `TransolverAttention`'s slice formation (softmax over slice dim using shared `in_project_slice`), differential scaling of surface vs volume features biases the slice tokens toward whichever domain has larger affine norm, which can collapse the slice attention into a degenerate form. The model can drive train loss down by exploiting this shortcut without learning generalizable structure. This is consistent with both the train/val divergence and the simultaneous regression across all targets.
+
+The placeholder embeddings (`surface_placeholder`, `volume_placeholder`) already give surface and volume tokens distinct domain identity at the input. DomainLayerNorm at every block is apparently too much additional differentiation for this architecture/data scale to absorb without overfitting.
+
+### Suggested follow-ups
+
+If you want to give this idea another shot, the most likely productive variants (smallest first):
+
+1. **DomainLayerNorm only on `norm1` (pre-attention)**, keep `norm2` shared. Rationale: post-attention, surface tokens already contain volume info and vice versa — applying domain-specific affine to "mixed" tokens may be the part of the change that breaks it. Pre-attention norm operates on still-domain-pure tokens.
+2. **DomainLayerNorm only on the first 1–2 blocks**, shared LN deeper. Rationale: domain identity matters most at the input where the features are still raw; deep layers compute mixed representations where domain-specific scale is less meaningful.
+3. **Domain-specific bias only (not weight)**: `surface_bias` and `volume_bias` separately, share `weight`. Rationale: bias is a domain prior (offset), weight is a per-feature scale that should arguably be shared because the *features* are shared across domains after concatenation.
+4. **DomainLayerNorm + dropout 0.05**: regularize the new capacity to prevent the shortcut. Cheapest knob, but doesn't address the root cause.
+5. Drop this hypothesis. Given how clean the train/val divergence is, I'd lean toward (5) unless there's a specific reason to think one of (1)–(3) fixes the shortcut.
+
+### Bug fixes / observations during this experiment
+
+- **Empty-surface-batch DDP deadlock fix** (already in this PR): `DomainLayerNorm` now always slices both `surf` and `vol` and adds a `0.0 * (sum_of_all_4_affine_params)` ghost connection so all four affine parameters appear in every rank's autograd graph, regardless of whether `surface_tokens` is 0 or equal to total. This is the canonical fix for the `find_unused_parameters=False` deadlock and is preferable to flipping that flag (which has per-step cost).
+- **38% empty-surface batches** in the train sampler at batch_size=1, ~14% at per-rank batch_size=2. Worth surfacing to other students — any code that adds a surface-specific path under DDP without ghost-connecting its params will hit the same deadlock.
+
+---
+
+# #218: [frieren] SO(3)-equivariant tangent-frame wall shear head [CLOSED]
+
+## Hypothesis
+
+Wall shear stress is a vector field tangent to the surface. The current model predicts all 3 shear channels (τ_x, τ_y, τ_z) with a shared MLP head — losing the geometric constraint that shear must lie in the tangent plane. An **SO(3)-equivariant** approach for the wall shear output can enforce this constraint structurally.
+
+**Method**: Replace the flat 3-channel shear output head with a frame-relative decomposition:
+1. At each surface point, compute the local tangent frame (e_t1, e_t2, n) from the surface normals [nx, ny, nz] and a tangent direction (e.g., cross-product with x-axis, gram-schmidt normalized).
+2. Predict 2 scalars per point: (α, β) = shear magnitude components in e_t1 and e_t2 directions.
+3. Reconstruct: τ = α * e_t1 + β * e_t2. This lives in the tangent plane by construction.
+4. Compare to ground truth in the same frame: loss is computed in frame-relative coords, then transformed back.
+
+This is the "tangent frame" approach mentioned in stark's Wave 3 direction but frieren takes it further by enforcing it through the SO(3) equivariance structure of the head, not just as a loss regularizer.
+
+## Instructions
+
+Base recipe: 4L/256d, no EMA, Fourier PE, T_max=30, lr=5e-4, surface_weight=2.0, 64 slices.
+
+### Changes to model.py
+
+The surface point features include [x, y, z, nx, ny, nz, area] as input. The model needs access to surface normals in the output head.
+
+1. Add a `TangentFrameHead` module:
+   ```python
+   class TangentFrameHead(nn.Module):
+       def __init__(self, d_model):
+           super().__init__()
+           self.pressure_head = nn.Linear(d_model, 1)   # surface pressure (scalar, frame-invariant)
+           self.shear_head = nn.Linear(d_model, 2)       # (alpha, beta) in tangent frame
+   
+       def forward(self, features, normals):
+           # features: [B, N, D]
+           # normals: [B, N, 3] — unit surface normals
+           pressure = self.pressure_head(features)  # [B, N, 1]
+   
+           # Build tangent frame
+           n = F.normalize(normals, dim=-1)  # [B, N, 3]
+           # e_t1: perpendicular to n, in x-direction if possible
+           ref = torch.zeros_like(n); ref[..., 0] = 1.0
+           # Handle near-parallel case
+           parallel = (torch.abs((n * ref).sum(-1, keepdim=True)) > 0.9)
+           ref2 = torch.zeros_like(n); ref2[..., 1] = 1.0
+           ref = torch.where(parallel, ref2, ref)
+           e_t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1)
+           e_t2 = torch.cross(n, e_t1, dim=-1)
+   
+           # Predict frame-relative shear
+           ab = self.shear_head(features)  # [B, N, 2]
+           tau = ab[..., :1] * e_t1 + ab[..., 1:] * e_t2  # [B, N, 3]
+   
+           return torch.cat([pressure, tau], dim=-1)  # [B, N, 4]
+   ```
+
+2. Pass surface normals (first 6 input features: [x, y, z, nx, ny, nz]) to the output head.
+
+3. Compute loss in Cartesian space (compare predicted τ to ground truth τ directly) — the equivariance is structural, not a loss term.
+
+### train.py changes
+
+- Add `--tangent-frame-head` flag (default False).
+
+### Run
+
+```bash
+cd target/ && python train.py \
+  --epochs 30 --lr 5e-4 --depth 4 --hidden-dim 256 --num-slices 64 \
+  --surface-weight 2.0 --fourier-pe --no-ema \
+  --train-surface-points 32768 --train-volume-points 32768 \
+  --tangent-frame-head \
+  --wandb-project DrivAerML --wandb-group frieren-so3-tangent-frame \
+  --kill-thresholds "3000:val_primary/abupt_axis_mean_rel_l2_pct<=25"
+```
+
+## W&B run IDs
+
+DDP run launched 2026-05-01 15:22 UTC, 4×H100 (`torchrun --nproc_per_node 4`), `wandb-applied-ai-team/senpai-v1-drivaerml`:
+
+- **Rank 0 (primary):** [`lpnr8zhi`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/lpnr8zhi) — `frieren/so3-tangent-frame-head-rank0`
+- **Rank 1:** [`dwl5oi97`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/dwl5oi97)
+- **Rank 2:** [`d4cvbt1p`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/d4cvbt1p)
+- **Rank 3:** [`i3lx54ou`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/i3lx54ou)
+
+Group: `frieren-so3-tangent-frame`. Final reported metrics will come from rank 0 (`lpnr8zhi`).
+
+## Baseline
+
+alphonse Wave 1 run `m9775k1v`: abupt=7.209%, surf_p=4.802%, vol_p=4.166%✓, wsx=7.109%, wsy=9.100%←BINDING, wsz=10.869%←HARDEST
+
+AB-UPT targets (all must be beaten simultaneously):
+- surf_p: 3.82%
+- vol_p: 6.08% ✓ (already beaten)
+- wsx: 5.35%
+- wsy: 3.65%
+- wsz: 3.63%
+
+## Expected outcome
+
+By construction, predicted shear lies in the tangent plane — eliminating the structural prediction error from a flat head that can predict non-physical normal-direction shear components. This should particularly help τ_y and τ_z on complex curved surfaces.
+
+## Results — KILLED at advisor's request
+
+Killed run `lpnr8zhi` (and DDP siblings `dwl5oi97`, `d4cvbt1p`, `i3lx54ou`) at advisor's instruction. Final captured state: global_step=215,018, ~ep11.0 of 30. The run had ~5 hours wall-clock left to ep30, but the projected ep15 abupt of 9.5–11.0% (vs <9.0% gate) made continuation a poor use of GPU.
+
+### Final metrics (val_primary, rank0 lpnr8zhi @ step 214,801)
+
+| Metric | Final | Baseline (m9775k1v) | AB-UPT Target | Reference |
+|--------|-------|---------------------|---------------|-----------|
+| **abupt** | **13.195%** | 7.209% | — | gap +5.99pp |
+| surface_pressure | 6.288% | 4.802% | <3.82% | gap +1.49pp |
+| volume_pressure | 5.868% | 4.166% | <6.08% ✓ | already under target |
+| wall_shear_x | 13.057% | 7.109% | <5.35% | gap +5.95pp |
+| wall_shear_y | 19.379% | 9.100% | <3.65% | gap +10.28pp ←worst |
+| wall_shear_z | 21.380% | 10.869% | <3.63% | gap +10.51pp ←worst |
+
+### Trajectory (val_primary/abupt across all 9 vals)
+
+| step | epoch | abupt | wsy | wsz |
+|------|-------|-------|-----|-----|
+| 21,742 | 1 | 18.675 | 26.07 | 28.27 |
+| 43,485 | 2 | 17.133 | 23.58 | 26.15 |
+| 65,228 | 3 | 15.480 | 22.35 | 24.13 |
+| 86,971 | 4 | 14.969 | 21.81 | 23.72 |
+| 108,714 | 5 | 14.919 | 21.10 | 22.98 |
+| 130,457 | 6 | 14.088 | 20.70 | 22.58 |
+| 152,200 | 7 | 13.710 | 20.32 | 21.85 |
+| 173,943 | 8 | 13.657 | 20.12 | 22.03 |
+| 195,686 | 9 | **13.195** | 19.38 | 21.38 |
+
+Slope decelerated from -0.0383%/1k (vals 1→6) to -0.0137%/1k (vals 7→9). Convergence had effectively flatlined.
+
+### Command
+
+```bash
+cd target/ && torchrun --nproc_per_node 4 train.py \
+  --epochs 30 --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 64 \
+  --surface-loss-weight 2.0 --no-use-ema --lr-cosine-t-max 30 --lr 5e-4 \
+  --train-surface-points 32768 --train-volume-points 32768 --no-compile-model \
+  --tangent-frame-head --agent frieren \
+  --wandb-group frieren-so3-tangent-frame --wandb-name frieren/so3-tangent-frame-head \
+  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20"
+```
+
+### Peak memory
+
+~32 GB / 80 GB per H100 (4× DDP, no compile). Plenty of headroom — memory was not a binding constraint.
+
+### W&B run IDs
+
+- Rank 0 (primary): [`lpnr8zhi`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/lpnr8zhi)
+- Rank 1: [`dwl5oi97`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/dwl5oi97)
+- Rank 2: [`d4cvbt1p`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/d4cvbt1p)
+- Rank 3: [`i3lx54ou`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/i3lx54ou)
+
+Group: `frieren-so3-tangent-frame`.
+
+### What happened
+
+**Negative result.** The SO(3)-equivariant TangentFrameHead implementation was correct (verified `τ·n ≈ 0` to ~1e-6 in normalised loss space, Frisvad–Duff basis orthonormal to fp32 precision including at hood/roof poles). The structural geometric constraint was being enforced as designed.
+
+The failure mode is **optimization, not modelling**:
+
+1. **Slow early convergence.** Across 9 validations the run dropped abupt from 18.7% → 13.2% (5.5pp over 11 epochs) versus the baseline trajectory which lands ~7% in 30 epochs. Per-axis, the picture is worst on the very axes the SO(3) head was supposed to help: wsy/wsz are at 19.4% / 21.4% — over 2× the baseline. This is the opposite of the predicted outcome.
+
+2. **The Frisvad–Duff basis is geometrically stable but kinematically arbitrary.** The basis is determined entirely by the surface normal, with no relationship to the dominant flow direction. So the model still has to learn an implicit per-point rotation from the canonical tangent basis to the local "flow-aligned" frame in which shear is sparse — an extra learning burden on top of fitting the magnitudes (α, β). The structural constraint `τ⊥n` removes 1 of 3 degrees of freedom, but the remaining 2 DOF live in a basis that is *less* aligned with the data's principal directions than the global Cartesian basis used by the baseline 3-channel head.
+
+3. **Loss curvature.** Reconstructing `τ = α·e_t1 + β·e_t2` and then renormalising introduces a non-linear, normal-dependent transformation between the predicted scalars and the loss space. Gradient flow back through this transformation is per-point anisotropic — at hood/roof points (n≈ẑ) gradients flow only into x/y components; at side panels (n≈±ŷ) into x/z; etc. The optimizer effectively sees a different conditioning at every surface point, which the un-modified lr=5e-4 + T_max=30 schedule does not accommodate.
+
+The hypothesis that the original head was "wasting capacity learning the τ⊥n constraint implicitly" appears wrong on this dataset. The flat 3-channel head learns a near-tangential τ trivially because the Cartesian basis is well-conditioned; the SO(3) head trades that easy optimization for a structural guarantee that the data didn't really need.
+
+### Suggested follow-ups
+
+Per advisor's note, archived for Wave 5+:
+
+1. **Lower head-only LR.** The TangentFrameHead has 1.7K params but lives downstream of an anisotropic per-point transform. Try `lr_head = 1e-4` or `5e-5` while keeping backbone at `5e-4`. The simplest implementation is a parameter group.
+
+2. **Backbone pre-train, then tangent fine-tune.** Train the baseline 3-channel head to convergence, then warm-start a TangentFrameHead by initializing `α = (τ·e_t1)`, `β = (τ·e_t2)` predictions from the baseline outputs. This moves the SO(3) head into a regime where it only needs to refine, not re-learn from scratch.
+
+3. **Flow-aligned tangent basis.** Replace Frisvad–Duff with a basis derived from the *predicted* shear direction at the previous training step (or from a learnable per-point rotation initialised to identity). This is the principled fix to point #2 above — the basis itself becomes learnable so the model stops fighting it.
+
+4. **Hybrid head.** Keep the 3-channel Cartesian shear head as-is, and add a small auxiliary loss `λ · |(τ·n)|²` instead of enforcing the constraint structurally. This was the "simple" version of the hypothesis frieren took further by full equivariance — going back to the simpler version may capture most of the geometric prior without the optimization penalty.
+
+5. **Re-test on a smaller variant where convergence is fast** (e.g. 2L/128d or fewer training points) to isolate whether the issue is fundamental or just a "needs longer + retuned schedule" problem.
+
+---
+
+# #182: [violet] Volume loss downweight {0.5, 0.25} on Fourier PE baseline [CLOSED]
+
+## Hypothesis
+
+Volume pressure already **beats** the AB-UPT target (4.166% vs. 6.08% — best-in-class). The current loss recipe spends fixed capacity / gradient bandwidth on the volume-pressure objective when that head is already converged well below target. Reducing the volume loss weight should redirect the optimizer's attention to the still-failing surface metrics, especially `wall_shear_y` (9.10% vs. 3.65% target — 5.45pp gap) and `wall_shear_z` (10.87% vs. 3.63% target — 7.24pp gap).
+
+This is a complementary direction to frieren's #177 (which upweights `--surface-loss-weight`): violet downweights `--volume-loss-weight` so the relative balance shifts toward the surface fields without inflating absolute gradient norms (which would otherwise destabilize training and require re-tuning LR / clip).
+
+Test two downweight values bracketing the regime where vol_p stays at-target while shear improves.
+
+## Wave 1 Baseline (PR #74 — alphonse)
+
+| Metric | Wave 1 best (val) | AB-UPT target |
+|---|---:|---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+
+## Reproduce commands
+
+Two sequential trials sharing W&B group `bengio-wave2-vol-downweight`. Run Trial A first; once it is past epoch 10 with healthy curves, launch Trial B.
+
+### Trial A — `volume-loss-weight = 0.5`
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.5 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-vol-downweight
+```
+
+### Trial B — `volume-loss-weight = 0.25`
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.25 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-vol-downweight
+```
+
+## Decision Criteria
+
+- **Merge** the better trial if `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091, **and** vol_p stays under the AB-UPT target (6.08%).
+- **Discuss** if abupt is roughly flat (7.0–7.5%) but `wall_shear_y/z` improve materially — that signals the rebalance worked but a different LR or a longer schedule may close the rest. Also good signal if vol_p drifts above 5% (still under target) while shear improves.
+- **Close** if both trials > 8.0, or if vol_p degrades past 6.08% (lost the target advantage) without commensurate shear gains.
+
+## Notes
+
+- Default volume_loss_weight in train.py is 1.0 — verify with `python train.py --help`.
+- Watch vol_p in early epochs: if it rises past 5.5% by epoch 10 in Trial B, the downweight is too aggressive — kill and report.
+- Report best val metrics for both trials, the W&B run IDs, and the best-checkpoint epoch for each.
+- Track per-axis `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` separately in your report — those are the metrics this hypothesis is most directly trying to move.
+
+## Results (negative — killed early)
+
+| Metric | Wave 1 baseline (val) | AB-UPT target | **vol-downweight 0.5 @ ep2** | vs baseline |
+|---|---:|---:|---:|---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | 7.209 | 4.51 | **24.879** | 3.45× worse |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 | 17.666 | 3.68× worse |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 | 27.369 | 3.35× worse |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 | 23.528 | 3.31× worse |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 | 32.797 | 3.60× worse |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 | 34.596 | 3.18× worse |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 | 15.808 | **lost target** |
+
+**W&B group:** `bengio-wave2-vol-downweight`
+**Run IDs (rank0..3):** `tnpb1777`, `y4bfvygm`, `avc3ic2e`, `o40i85ua`
+**Best epoch reached:** epoch 2 of 50 (only 2 validations completed before kill at step 45,388)
+**Peak step:** 45,388 (~ep2.5)
+**Trial B (`vol-downweight-0.25`):** never launched (advisor killed Trial A before the ep10 health gate).
+
+### Exact command used
+
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.5 \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+  --wandb-group bengio-wave2-vol-downweight \
+  --wandb-name "violet/vol-downweight-0.5" \
+  --agent violet
+```
+
+**Peak memory:** not finalized (run killed mid-epoch 3); single-GPU memory was nominal during the active phase.
+
+---
+
+# #178: [kohaku] 6L/256d + Fourier PE + T_max=60 depth scaling [CLOSED]
+
+## Hypothesis
+
+Wave 1 showed 4L → 5L (gilbert #76, no PE) improved from ~8.78% to ~7.47%. With Fourier PE, alphonse's 4L is at 7.21%. The question: does pushing depth to 6L with Fourier PE continue the improvement trend? The 2.7pp gap to AB-UPT is substantial; more depth may be needed to capture the full aerodynamic complexity. We double-check by testing 6L directly, skipping 5L (which alphonse is running) to cover the search space efficiently.
+
+Reference: AB-UPT uses a deep transformer stack; we are likely capacity-limited at 4-5 layers for wall shear in particular.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+## Instructions
+
+Run exactly one training job:
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 6 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 60 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 5 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+Key changes vs Wave 1 baseline:
+- `--model-num-layers 6` (was 4) — two additional Transformer layers
+- `--lr-cosine-t-max 60` (was 30) — even longer schedule for deeper model (empirical: deeper models need proportionally more epochs)
+- `--lr-warmup-epochs 5` — important: longer warmup prevents early instability in deep models
+- `--fourier-pe` — mandatory (Wave 1 lesson)
+- `--no-use-ema` — same as baseline winner
+
+Report val_primary metrics at the best checkpoint (lowest val_primary/abupt_axis_mean_rel_l2_pct).
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+## Results
+
+Acknowledging the advisor's EP50 assessment on run `h7ve1hmb` (kohaku/6l-256d-fourier-pe-deeper). The 6L/256d depth-scaling experiment with Fourier PE and T_max=60 ran to completion (~ep50) and **does not beat the alphonse 4L baseline**.
+
+### Best checkpoint (step 570,143, ~ep32)
+
+| Metric | Best val | Baseline (alphonse 4L) | Δ |
+|--------|:---:|:---:|:---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.834%** | 7.209% | +0.625pp ❌ |
+| `val_primary/surface_pressure_rel_l2_pct` | 5.235% | 4.802% | +0.43pp ❌ |
+| `val_primary/volume_pressure_rel_l2_pct` | 5.569% | 4.166% | +1.40pp ❌ (still beats AB-UPT 6.08% ✓) |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.465% | 9.100% | +0.37pp ❌ |
+| `val_primary/wall_shear_z_rel_l2_pct` | 11.420% | 10.869% | +0.55pp ❌ |
+
+**Command used** (per PR instructions):
+```bash
+cd target/ && python train.py \
+  --model-num-layers 6 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 60 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+W&B run: `h7ve1hmb`
+
+### What happened
+
+Depth scaling 4L → 6L in isolation (with Fourier PE, T_max=60, warmup=5) does **not** continue the Wave 1 trend. The peak val_abupt of 7.834% at ep32 is worse than alphonse's 4L Fourier PE baseline (7.209% at ep30). Combined with the 8L alphonse run (Wave 2) at 11.334%, this confirms the advisor's hypothesis that **the 4L/256d Fourier PE configuration is a sharp optimum** on this dataset/budget, and depth scaling alone is not the right axis.
+
+Volume pressure remains robustly under AB-UPT target (5.569% vs 6.08% target).
+
+### Suggested follow-ups
+
+- Wall shear axis decomposition (wsy=9.47%, wsz=11.42%) remains the dominant gap to AB-UPT target. Future runs should probably target axis-specific loss reweighting or rotation/symmetry-aware architectures rather than raw capacity scaling.
+- If depth is to be revisited, pair it with width or token-budget changes (capacity-balanced sweeps) instead of depth-only.
+
+Closing per advisor directive.
+
+---
+
+# #84: [edward] DrivAerML Dynamic Uncertainty Loss Weighting [CLOSED]
+
+# [edward] DrivAerML Dynamic Uncertainty Loss Weighting (Homoscedastic)
+
+## Hypothesis
+
+The current model uses fixed loss weights for the different output modalities (surface pressure, wall shear x/y/z, volume pressure). Homoscedastic uncertainty weighting (Kendall & Gal 2018, "Multi-Task Learning Using Uncertainty to Weigh Losses for Scene Geometry and Semantics") automatically learns per-task loss weights by treating the weight for each task as a learnable log-variance parameter. Tasks where the model is less certain get lower effective weight, preventing high-variance tasks from dominating training.
+
+**Mathematically:** For each task i with prediction σ_i (learnable), the loss becomes:
+```
+L_total = Σ_i (L_i / (2 * σ_i²)) + log(σ_i)
+```
+The `log(σ_i)` term regularizes σ_i from growing unbounded. This is equivalent to learning the optimal fixed weights but adapting them during training.
+
+**Prediction:** Dynamic uncertainty weighting will improve `abupt_axis_mean_rel_l2_pct` by automatically discovering the optimal balance between surface_pressure, wall_shear_x/y/z, and volume_pressure losses, especially since these tasks have very different error magnitudes.
+
+## Implementation Instructions
+
+In `train.py` or `model.py`, add learnable log-variance parameters for each task:
+
+```python
+import torch
+import torch.nn as nn
+
+class UncertaintyWeightedLoss(nn.Module):
+    """
+    Homoscedastic uncertainty multi-task loss weighting.
+    Reference: Kendall & Gal (2018) - Multi-Task Learning Using Uncertainty
+    """
+    def __init__(self, n_tasks: int = 5):
+        super().__init__()
+        # Initialize log(sigma^2) = 0 → sigma^2 = 1 → equal initial weights
+        self.log_vars = nn.Parameter(torch.zeros(n_tasks))
+
+    def forward(self, losses: list[torch.Tensor]) -> torch.Tensor:
+        """
+        losses: list of per-task losses [surface_pressure, wall_shear_x, wall_shear_y, 
+                                         wall_shear_z, volume_pressure]
+        """
+        total = 0.0
+        for i, loss in enumerate(losses):
+            # 1/(2*sigma^2) * loss + log(sigma)
+            precision = torch.exp(-self.log_vars[i])
+            total = total + 0.5 * precision * loss + 0.5 * self.log_vars[i]
+        return total
+```
+
+**Integration steps:**
+1. Instantiate `UncertaintyWeightedLoss(n_tasks=5)` and add it to the optimizer parameters
+2. Compute per-task losses separately before combining
+3. Log the learned `log_vars` values to W&B to see how they evolve (add to the W&B log dict)
+4. At inference time, no change needed — predictions use the raw model output
+
+**Tasks to weight:** Map the 5 DrivAerML targets:
+- Task 0: surface_pressure (cp)
+- Task 1: wall_shear_x (tau_x)
+- Task 2: wall_shear_y (tau_y)
+- Task 3: wall_shear_z (tau_z)
+- Task 4: volume_pressure
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream2-edward --agent edward
+```
+
+**Note:** Add a CLI flag (e.g. `--uncertainty-weighting`) to toggle this feature on/off.
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report the final learned `log_vars` values (what did the model learn to weight each task?)
+- Report all `test_primary/*` metrics
+- Compare convergence speed vs. fixed weights (did uncertainty weighting converge faster?)
+- Note any training instability (if log_vars diverge, reduce lr for the uncertainty parameters)
+
+## Results — Final test_primary on epoch-16 best checkpoint (UW with clamp=[-5, 5])
+
+Training was stopped at epoch 20/50 per advisor approval after the run destabilized post-epoch 16 (clamp-induced runaway precision; see prior comment for full diagnostic). Best checkpoint (epoch 16) was preserved on disk and post-hoc evaluated end-to-end on the full val and test splits via a new `train.py --eval-only` flag that resumes the same W&B run id.
+
+**W&B run id:** [3gfy3fi7](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/3gfy3fi7) — `edward/uw-fixed-kill`, group `bengio-stream2-edward` (rank 0; the rank 1/2/3 runs `izw183ei`, `6ec0jven`, `er6k2hvz` carry the per-rank training telemetry).
+
+### test_primary/* on the held-out 50-case test split
+
+| Target | This run | AB-UPT ref | Δ |
+|---|---:|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **9.99** | 4.51 | +5.48 |
+| `test_primary/surface_pressure_rel_l2_pct` | **5.23** | 3.82 | +1.41 |
+| `test_primary/wall_shear_rel_l2_pct` (vector `tau`) | **9.63** | 7.29 | +2.34 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **7.99** | 5.35 | +2.64 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **11.88** | 3.65 | +8.23 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **12.34** | 3.63 | +8.71 |
+| `test_primary/volume_pressure_rel_l2_pct` | **12.51** | 6.08 | +6.43 |
+
+`test_primary/{surface,wall_shear,volume}_pressure_mae`: 0.0146, 0.0861, 28.19.
+
+### full_val/* (best checkpoint reload) — for sanity vs. the per-epoch val table I posted earlier
+
+| Metric | full_val | Best val (epoch 16, the same checkpoint at training time) |
+|---|---:|---:|
+| `full_val_primary/abupt_axis_mean_rel_l2_pct` | 8.87 | 8.87 |
+| `full_val_primary/surface_pressure_rel_l2_pct` | 5.47 | 5.47 |
+| `full_val_primary/wall_shear_rel_l2_pct` | 9.81 | 9.81 |
+| `full_val_primary/wall_shear_x_rel_l2_pct` | 8.14 | 8.14 |
+| `full_val_primary/wall_shear_y_rel_l2_pct` | 12.04 | 12.04 |
+| `full_val_primary/wall_shear_z_rel_l2_pct` | 12.86 | 12.86 |
+| `full_val_primary/volume_pressure_rel_l2_pct` | 5.83 | 5.83 |
+
+(`full_val` matches end-of-epoch-16 val exactly, confirming the eval-only flag faithfully reloads the saved best checkpoint.)
+
+### Final learned `log_vars` (from the last train step, just before SIGTERM in epoch ~20)
+
+| task | log_var | precision (1/σ²) | effective weight (0.5/σ²) |
+|---|---:|---:|---:|
+| surface_pressure | **-5.00 (clamped)** | 148.4 | 74.2 |
+| wall_shear_x | **-5.00 (clamped)** | 148.4 | 74.2 |
+| wall_shear_y | -4.10 | 60.3 | 30.2 |
+| wall_shear_z | -4.08 | 59.1 | 29.6 |
+| volume_pressure | -4.68 | 107.8 | 53.9 |
+
+All five were drifting toward the lower clamp, with surface_pressure and wall_shear_x reaching it first. The relative ordering UW discovered (`surf > ws_x > vol > ws_y ≈ ws_z`) is plausible — the lowest-loss task gets the highest precision — but the math wanted clamp=[-10, 10] (or unclamped) so log_vars could equilibrate. The destabilization at epoch 17+ is exactly the failure mode predicted by that analysis.
+
+### Convergence speed vs. fixed weights
+
+The cohort's other 4L/256d/no-EMA runs at this same recipe sit in the 8.3–9.1% val range at epoch ~19–24. UW reached `best_val=8.87` at epoch 16, then regressed; without UW we'd expect a similar val number at this depth/width but without the late-stage destabilization risk. UW did **not** converge faster in any meaningful sense for this problem.
+
+### Train command
+
+```bash
+torchrun --nproc_per_node=4 train.py --uncertainty-weighting --no-compile-model \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --no-use-ema \
+  --lr 3e-4 --weight-decay 1e-4 --batch-size 2 --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/base_mse_loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream2-edward --agent edward --wandb-name edward/uw-fixed-kill
+```
+
+(SIGTERM'd cleanly at epoch 20; best checkpoint preserved at `outputs/drivaerml/run-3gfy3fi7/checkpoint.pt`.)
+
+### Eval-only command (post-hoc test_primary on the saved best checkpoint)
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python train.py --eval-only --eval-only-run-id 3gfy3fi7 \
+  --no-compile-model --no-use-ema \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --batch-size 2 \
+  --eval-surface-points 40000 --eval-volume-points 40000 \
+  --wandb-group bengio-stream2-edward --agent edward --wandb-name edward/uw-fixed-kill
+```
+
+The new `--eval-only --eval-only-run-id <id>` path skips training, builds the model + loaders + transform on a single rank, loads `outputs/drivaerml/run-{id}/checkpoint.pt`, resumes the original W&B run, and calls the existing `run_final_evaluation` helper. Resulting `full_val_primary/*` and `test_primary/*` are appended to the same W&B run that produced the checkpoint.
+
+### Peak memory
+
+**9.6 GB / GPU** during training (4× H100 DDP, batch_size=2/rank, 40k surface + 40k volume points). Eval-only on a single GPU peaked at ~4.4 GB.
+
+### What happened
+
+The hypothesis that homoscedastic UW would auto-balance the per-task losses and improve `abupt_axis_mean_rel_l2_pct` did **not pay off in practice** for this clamp setting. Two failure modes compounded:
+
+1. **Clamp-induced rectified equilibrium.** Per-task MSEs after target normalization are very small (0.003–0.02), so the analytic optimum `s* = log(L)` lands at `-3.9` to `-5.7`. With the spec's clamp at `[-5, 5]`, two tasks (surface_pressure, wall_shear_x) saturated at the lower bound. Effective weight `0.5·exp(-(-5))=74.2` for those tasks dwarfed the others, breaking the auto-balancing intent.
+2. **Late-stage destabilization.** Once two log_vars saturated, the global gradient norm exploded from ~10 (early/mid training) to ~140 (post-epoch 16) under the `--grad-clip-norm 1.0` setting; every step was clipped by ~140×, leaving the optimizer chasing the clamped tasks at the expense of `ws_y/z/vol`. Per-task losses for those started climbing (`ws_z` doubled from 0.010 to 0.022 in 4 epochs), and val abupt regressed from 8.87 (epoch 16) → 14.29 (epoch 20).
+
+Net result on test_primary: the run trails the AB-UPT reference everywhere by 1.4–8.7 percentage points, and trails the cohort's fixed-weight 4L/256d/no-EMA runs (e.g. tanjiro 8.98 val, frieren w/ volume_pressure already below 6.08 ref). **The hypothesis is not validated for this problem at this configuration**; UW with `clamp=[-5, 5]` is strictly worse than the cohort's fixed-weight recipe.
+
+The volume_pressure test/val gap (5.83 → 12.51) is striking and is the dominant component of the abupt-mean degradation on test. This is consistent with UW under-weighting `volume_pressure` on val (its log_var was the third-highest precision) but the under-weighting hurt generalization to test cases. Surface pressure and wall_shear (vector) test numbers are within ~0.2 pct of val, so the generalization story is volume-specific.
+
+### Suggested follow-ups
+
+1. **Wider clamp UW (`clamp=[-10, 10]` or unclamped).** This was option 2 in my pre-stop comment and is the natural next experiment if UW is to be revisited. Math says log_vars want to land at ~-4 to -6 here; giving them the room to equilibrate is necessary to actually measure the *idea* of UW rather than a rectified version. Note for the advisor's idea queue (you've already noted this in your last reply).
+2. **UW without the +0.5·log_var regularizer.** The regularizer is what drives log_vars toward the per-task loss magnitude (i.e. toward the lower clamp here when losses are small). Removing it and using an explicit per-task scale schedule (e.g. cosine ramp from `s_init` to `s_final` per task) decouples weighting dynamics from per-task loss magnitude. This is the cleanest way to isolate "is dynamic weighting useful?" from "is the K&G formula well-conditioned for this loss-scale regime?"
+3. **Loss-scale-aware initialization.** If we want to keep K&G's formula, initialize `log_var_i = log(L_i_at_step_500)` (one short pre-pass to estimate per-task losses, then init log_vars there). That avoids the long warm-in where log_vars drift from 0 to -4-ish, during which UW is just reproducing the equal-weights baseline noisily. Could plausibly halve the time-to-best.
+4. **Use a higher effective floor for `--grad-clip-norm`.** The 1.0 clip with UW makes the optimizer step direction extremely sensitive to the clamped tasks. A 10–50 clip would let the unclamped tasks contribute more even when the clamped tasks dominate the raw norm. (Diagnostic: pre-clip norm went from ~10 → 140 over the run; the clip is what's distorting the step direction.)
+5. **Decoupled per-task LRs instead of dynamic weights.** A simpler alternative: keep fixed equal weights but use task-conditioned LR scales applied to head parameters (one head per task). This achieves the "balance task contributions" goal without the K&G regularizer pathology.
+
+Items 1–2 directly answer the advisor's note about the "math says we want clamp=[-10,10]" follow-up; items 3–5 are independent ideas that came out of staring at the diagnostic table.
+
+---
+
+# #80: [tanjiro] DrivAerML Surface Loss Weight Sweep [CLOSED]
+
+# [tanjiro] DrivAerML Surface Loss Weight Tuning: surface_weight=2.0 + 4L/256d
+
+## Hypothesis
+
+The default training uses equal loss weights for surface and volume predictions. Surface metrics (surface_pressure, wall_shear) are the most physically critical for aerodynamic drag and lift coefficient estimation. Upweighting the surface loss by 2x should push the model to prioritize surface accuracy, potentially reducing `surface_pressure_rel_l2_pct` and `wall_shear_*` metrics at the cost of slightly worse `volume_pressure_rel_l2_pct`.
+
+**Prediction:** `surface_pressure_rel_l2_pct` and `wall_shear_*` will improve, `volume_pressure_rel_l2_pct` may slightly worsen. The overall `abupt_axis_mean_rel_l2_pct` (which includes both) should net improve since wall shear contributes 3 of the 5 axis metrics.
+
+**Note:** This experiment does NOT use Fourier PE to isolate the surface weight effect. Using the standard recipe (4L/256d, no-EMA, T_max=30) with surface_weight=2.0.
+
+## No Model Architecture Change Required
+
+This experiment uses the default `ContinuousSincosEmbed` positional encoding. No changes to `model.py` are needed.
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --surface-loss-weight 2.0 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-tanjiro --agent tanjiro
+```
+
+**Bonus trial (if time allows):** Try `--surface-loss-weight 3.0` in the same wandb group:
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --surface-loss-weight 3.0 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-tanjiro --agent tanjiro
+```
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report final `val_primary/abupt_axis_mean_rel_l2_pct` for weight=2.0 (and weight=3.0 if run)
+- Report all `test_primary/*` metrics — especially compare surface vs volume tradeoff
+- Note the training loss breakdown (surface vs volume component) if visible in W&B logs
+
+## Results
+
+### Best-val checkpoint metrics (ep31)
+
+**val_primary (re-eval at best ckpt):**
+| Metric | SW=2.0 | AB-UPT target | Δ vs target |
+|---|---|---|---|
+| `abupt_axis_mean_rel_l2_pct` | **8.436** | 4.51 | +87% |
+| `surface_pressure_rel_l2_pct` | 5.455 | 3.82 | +43% |
+| `wall_shear_rel_l2_pct` | 9.456 | 7.29 | +30% |
+| `volume_pressure_rel_l2_pct` | **5.186** | 6.08 | **−15% (beats target)** |
+| `wall_shear_x_rel_l2_pct` | 8.076 | 5.35 | +51% |
+| `wall_shear_y_rel_l2_pct` | 11.119 | 3.65 | +205% |
+| `wall_shear_z_rel_l2_pct` | 12.344 | 3.63 | +240% |
+
+**test_primary (best ckpt → held-out test set):**
+| Metric | SW=2.0 | AB-UPT target | Δ vs target |
+|---|---|---|---|
+| `abupt_axis_mean_rel_l2_pct` | **9.697** | 4.51 | +115% |
+| `surface_pressure_rel_l2_pct` | 5.078 | 3.82 | +33% |
+| `wall_shear_rel_l2_pct` | 9.242 | 7.29 | +27% |
+| `volume_pressure_rel_l2_pct` | 12.897 | 6.08 | +112% |
+| `wall_shear_x_rel_l2_pct` | 7.953 | 5.35 | +49% |
+| `wall_shear_y_rel_l2_pct` | 10.895 | 3.65 | +198% |
+| `wall_shear_z_rel_l2_pct` | 11.664 | 3.63 | +221% |
+
+### Comparison vs alphonse (Fourier-PE, same recipe sans surface weighting)
+
+| Metric (test_primary) | tanjiro SW=2.0 | alphonse Fourier-PE | Winner |
+|---|---|---|---|
+| abupt_axis_mean | 9.697 | 8.480 | alphonse |
+| surface_pressure | 5.078 | 4.405 | alphonse |
+| wall_shear | 9.242 | 7.871 | alphonse |
+| volume_pressure | 12.897 | 12.175 | alphonse |
+| wall_shear_x | 7.953 | 6.926 | alphonse |
+| wall_shear_y | 10.895 | 8.778 | alphonse |
+| wall_shear_z | 11.664 | 10.116 | alphonse |
+
+**SW=2.0 does NOT beat alphonse on the primary metric** (9.70 vs 8.48 test abupt). Per advisor's plan, proceeding with the Trial B1/B2/B3 matrix without an early merge.
+
+### Validation trajectory (val_primary/abupt_axis_mean_rel_l2_pct)
+
+- ep11: 9.55, ep17: 9.03, ep18: 8.98, ep23: 8.86, ep26: 8.60, ep28: 8.51, **ep31 best: 8.436**
+- ep38: 8.65, ep41: 8.76, ep43: 9.08 → ep50 finished
+- Cosine warm-restart bounce after ep31 confirms advisor's read; best-checkpoint reload was correctly used for test eval.
+
+### Run details
+
+- **W&B (rank0):** https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/846uciam
+- **W&B group:** `bengio-stream1-tanjiro`
+- **Best epoch:** 31 / 50
+- **Total train time:** 1430.85 min (~23.8 h)
+- **Peak memory:** ~11 GiB / 97 GiB per GPU (4 GPUs, plenty of headroom)
+- **Command:**
+  ```bash
+  torchrun --nproc_per_node=4 train.py \
+    --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+    --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+    --epochs 50 --lr-cosine-t-max 30 \
+    --surface-loss-weight 2.0 \
+    --train-surface-points 40000 --train-volume-points 40000 \
+    --no-compile-model \
+    --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+    --wandb-group bengio-stream1-tanjiro --agent tanjiro \
+    --wandb-name tanjiro/surface-weight-2.0
+  ```
+
+### What happened
+
+1. **Surface weighting did NOT improve surface metrics relative to alphonse.** Alphonse's Fourier-PE delivered better surface_pressure (4.41 vs 5.08), better wall_shear (7.87 vs 9.24), and better volume_pressure (12.18 vs 12.90). The Fourier positional encoding is a much stronger lever than reweighting the loss.
+2. **The hypothesis "upweight surface, push surface metrics down" partially held vs no-Fourier baseline**, but Fourier-PE is a confounder: alphonse hits *all* metrics better with weight=1.0 + Fourier than tanjiro hits with weight=2.0 + standard PE.
+3. **Volume pressure prediction works on val but generalises poorly to test** (5.19 → 12.90 — a >2x degradation on a distribution-shifted held-out set; also seen on alphonse 4.17 → 12.18). This is consistent across both runs and suggests a dataset-level issue (volume points sampled differently in train/val vs test split), not a hypothesis-specific failure.
+4. **wsy/wsz remain the worst components** at 10.9 and 11.7 (test) — surface weighting did not specifically improve them. They are likely under-resolved by the architecture rather than under-weighted by the loss.
+5. **Cosine T_max=30 produces a measurable bounce** (best ep31, ep50 abupt has risen ~0.7pp). For the next matrix, comparing T_max=30 vs T_max=50 will isolate whether the bounce or the warmth at end is the bigger lever.
+
+### Suggested follow-ups (per advisor's matrix)
+
+- **Trial B1:** SW=2.0, T_max=50, 50 epochs (monotone-decay control of current best)
+- **Trial B2:** SW=3.0, T_max=30, 50 epochs (original SW=3.0 idea)
+- **Trial B3:** SW=3.0, T_max=50, 50 epochs (most aggressive combination)
+- Each ~13h on 4xH100 → ~39h total. Will queue with sequential auto-launcher and report each as it completes.
+
+---
+
+# #79: [emma] DrivAerML 60k Points + Fourier PE [CLOSED]
+
+# [emma] DrivAerML More Training Points: 60k Surface/Volume + 4L/256d + no-EMA + Fourier
+
+## Hypothesis
+
+The default training setup uses 40k surface points and 40k volume points per sample. DrivAerML contains dense CFD meshes with ~300k+ surface points per geometry. Increasing the sampled point count to 60k gives the model more spatial context per training step, potentially capturing finer geometric details and flow features that are missed with sparser sampling.
+
+**Prediction:** 60k points will improve especially `surface_pressure_rel_l2_pct` and `wall_shear_*` metrics since more surface sample coverage reduces sampling bias on complex vehicle geometry regions (wheel arches, underbody, rear diffuser).
+
+**Trade-off:** Each step will be ~1.5x slower. With 50 epochs the wall-clock time will increase, but the quality improvement should outweigh the cost.
+
+## Model Architecture Change (Required)
+
+Replace `ContinuousSincosEmbed` with `FourierEmbed` in `model.py`. Add the following class **before** the `SurfaceTransolver` class:
+
+```python
+import math
+
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression."""
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+```
+
+In `SurfaceTransolver.__init__`, replace:
+```python
+self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+```
+with:
+```python
+self.pos_embed = FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)
+```
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+**If batch-size 2 with 60k points causes OOM, fall back to:**
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 1 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report final `val_primary/abupt_axis_mean_rel_l2_pct` compared to alphonse (40k points)
+- Report all `test_primary/*` metrics
+- Report whether batch_size=2 was feasible or if you had to fall back to batch_size=1
+- Report training wall-clock time per epoch to quantify the compute overhead
+
+## Results — Trial A (60k Points + Fourier PE, T_max=30)
+
+**Trial A complete.** Total runtime 23h08m (1389 min). Best validation at **epoch 32**, terminal at epoch 50 was +0.58pp worse due to the cosine warm-restart bounce as predicted.
+
+### Best-val checkpoint metrics (epoch 32)
+
+| Metric | val (best ckpt) | full_val (best ckpt) | **test_primary** | AB-UPT Target |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **8.214** | 8.214 | **9.329** | ~4.51 |
+| `surface_pressure_rel_l2_pct` | — | 5.528 | **5.187** | 3.82 |
+| `wall_shear_rel_l2_pct` | — | 8.973 | **8.733** | 7.29 |
+| `volume_pressure_rel_l2_pct` | — | 5.909 | **12.890** | 6.08 |
+| `wall_shear_x_rel_l2_pct` | — | 7.902 | **7.730** | 5.35 |
+| `wall_shear_y_rel_l2_pct` | — | 9.904 | **9.717** | 3.65 |
+| `wall_shear_z_rel_l2_pct` | — | 11.828 | **11.123** | 3.63 |
+
+### val_primary trajectory (cosine T_max=30 with warm-restart bounce)
+
+| Epoch | val_abupt% | LR phase |
+|---|---:|---|
+| 5 | 10.42 | warmup-ramp |
+| 10 | 9.42 | descending |
+| 15 | 8.90 | descending |
+| 20 | 8.54 | descending |
+| 25 | 8.33 | mid-decay |
+| 30 | 8.216 | reached η_min |
+| **32** | **8.214** | **best** (rising LR) |
+| 35 | 8.277 | bounce |
+| 40 | 8.437 | bounce |
+| 45 | 8.593 | bounce |
+| 50 | 8.794 | terminal |
+
+### Setup confirmed
+
+- **Batch size:** 2 (no OOM at 60k points; peak 14.3GB/GPU)
+- **Wall-clock per epoch:** ~27 min (target promise met; 1.5x the 40k budget)
+- **Total wall-clock:** 23h08m for 50 epochs
+- **DDP:** 4 GPUs, no torch.compile (`--no-compile-model` per advisor warning)
+- **Notable:** test_primary/volume_pressure_rel_l2_pct = 12.89% vs full_val 5.91% — large train/test split gap on volume; the dataset's volume pressure scale on heldout test is harder than val.
+
+### Train command used
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+- **Peak memory:** 14.3 GB/GPU
+- **W&B run ID:** kuk0oy8g
+- **W&B group:** bengio-stream1-emma
+
+### What happened
+
+60k point sampling at batch_size=2 trained cleanly throughout. Fourier PE (8 freqs, geometric base-2 progression) substituted for ContinuousSincosEmbed without crashing or stalling. Convergence trajectory was monotone and healthy through epoch 30. The cosine schedule with `T_max=30 < epochs=50` triggered the warm-restart at ep30, after which val degraded steadily by +0.58pp (8.214 → 8.794) — exactly the secondary-cycle pathology the advisor warned of.
+
+**test_primary/abupt = 9.329%** (best-val ckpt at ep32) is +1.12pp worse than the val number, which is consistent with the test split's harder volume_pressure region (12.89% vs 5.91% val). Per-channel test errors are otherwise close to val. The result is **not under the 8.0% threshold the advisor set for an immediate-merge winner**, so launching Trial B (T_max=50, monotone decay) per the authorization.
+
+### Suggested follow-ups
+
+- **Trial B (already authorized):** Same recipe with `--lr-cosine-t-max 50` so the LR decays monotonically through the full schedule. Launching immediately.
+- The val/test gap on `volume_pressure_rel_l2_pct` (5.91 → 12.89) is striking. Worth a separate investigation into whether the volume sampling distribution differs systematically between val and test (e.g., extreme drag cars over-represented in test).
+- `wall_shear_y/z` are the largest weakness vs AB-UPT (~3x worse) — these are the narrow-band lateral and vertical shear components. Consider directional loss weighting in a follow-up if Trial B doesn't close the gap.
+
+---
+

--- a/experiment_log/full_details_2026-05-03_07-16.md
+++ b/experiment_log/full_details_2026-05-03_07-16.md
@@ -1,0 +1,2163 @@
+# Full Experiment Details (15 experiments)
+
+# #140: [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) [MERGED]
+
+## Hypothesis
+
+**Curriculum (easy-first) case sampling via per-case gradient-norm difficulty proxy will improve convergence speed and final `abupt_axis_mean_rel_l2_pct`.**
+
+In Wave 1, all 16 runs used uniform random case sampling throughout training. However, DrivAerML cases vary substantially in aerodynamic complexity — some vehicles produce nearly laminar flow while others have strong separation and recirculation. Standard sampling presents hard and easy cases with equal frequency from epoch 0, potentially causing early gradient conflict and slowing the model's ability to build robust representations.
+
+The hypothesis: **training on "easy" (low gradient-norm) cases first and gradually introducing harder cases** mirrors classical curriculum learning findings and should help the model establish stable surface pressure and wall-shear representations before being overwhelmed by aerodynamically complex geometries. Once the model has a stable foundation (epochs 1–10), switching to uniform sampling ensures full coverage of the training distribution.
+
+This experiment uses the **alphonse Wave 1 leader recipe** (4L/256d/4H + Fourier PE + T_max=30 + no-EMA) as the base — the strongest known DDP4 configuration.
+
+---
+
+## Baseline to Beat
+
+**AB-UPT public reference targets (all must be beaten simultaneously):**
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **4.51** |
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+
+**Wave 1 alphonse mid-training reference** (run `m9775k1v`, ~step 421k, not final test metrics):
+- abupt=7.33, surf_p=4.87, vol_p=4.23
+
+---
+
+## Implementation Instructions
+
+**You must implement curriculum sampling as a code change to `trainer_runtime.py`.** There is no `--curriculum` CLI flag — you need to add one and wire it through.
+
+### Step 1 — Add a CLI flag to `Config` in `train.py`
+
+In the `Config` dataclass (around line 90 in `train.py`), add:
+
+```python
+curriculum_warmup_epochs: int = 0  # 0 = disabled, >0 = use curriculum for this many epochs
+```
+
+This is cleanly defaulted to 0 (disabled) so existing runs are unaffected.
+
+### Step 2 — Implement difficulty scoring and WeightedRandomSampler in `trainer_runtime.py`
+
+In `make_loaders`, the `train_sampler` is currently a `DistributedSampler`. You need to make it possible to **swap in a `WeightedRandomSampler`** for curriculum epochs.
+
+Add a new function `compute_case_difficulties(train_loader, model, device, loss_fn)` that:
+1. Runs a **single pass over the entire training set** (no gradient accumulation, just `loss.item()` per case) to get per-case loss values
+2. Returns a tensor of shape `[N_cases]` with the per-case loss (higher loss = harder case)
+
+Then in the main training loop in `train.py`, after epoch 0 completes (when `curriculum_warmup_epochs > 0`):
+1. Call `compute_case_difficulties` to get difficulty scores
+2. For epochs 1 through `curriculum_warmup_epochs`, construct a `WeightedRandomSampler` with weights **inversely proportional** to difficulty: `weights = 1.0 / (difficulties + eps)`, normalized. Replace the train_loader sampler.
+3. From epoch `curriculum_warmup_epochs + 1` onward, switch back to standard `DistributedSampler` (or shuffle=True if non-distributed).
+
+**Practical implementation note for DDP**: `WeightedRandomSampler` is not natively DDP-aware. The simplest correct approach:
+- Compute difficulty scores on rank 0 and broadcast to all ranks via `dist.broadcast`
+- Construct separate per-rank `WeightedRandomSampler` instances (each rank samples its own subset, same weights), OR
+- Use the difficulty weights to build a new `DistributedSampler`-like sampler that respects per-case weights across ranks
+
+The simplest correct DDP approach: use **loss-weighted epoch-0 case ordering** on rank 0, broadcast a shuffled index list to all ranks, then split indices across ranks. This avoids the need for a custom `WeightedRandomSampler` and is fully compatible with DDP.
+
+Here is a concrete approach for the `make_loaders` / training loop:
+
+```python
+# In train.py, after epoch 0 training loop:
+if config.curriculum_warmup_epochs > 0 and epoch == 0:
+    # Compute per-case difficulties using training loss
+    case_difficulties = compute_case_difficulties(
+        train_loader=train_loader,
+        model=unwrap_model(model),
+        device=state.device,
+        config=config,
+        target_transform=target_transform,
+    )
+    # Broadcast from rank 0 to all ranks
+    if state.enabled:
+        dist.broadcast(case_difficulties, src=0)
+    # Store for use in subsequent epochs
+    curriculum_weights = 1.0 / (case_difficulties + 1e-6)
+    curriculum_weights /= curriculum_weights.sum()
+```
+
+Then in the epoch loop header, before creating the train DataLoader for each epoch:
+
+```python
+if config.curriculum_warmup_epochs > 0 and 1 <= epoch <= config.curriculum_warmup_epochs:
+    # Use weighted sampler for curriculum phase
+    sampler = WeightedRandomSampler(
+        weights=curriculum_weights,
+        num_samples=len(train_ds),
+        replacement=True,
+    )
+    train_loader = DataLoader(train_ds, batch_size=config.batch_size, sampler=sampler, **loader_kwargs(config))
+elif epoch == config.curriculum_warmup_epochs + 1:
+    # Switch back to standard distributed sampler
+    train_loader = make_train_loader(config, train_ds, distributed_state=state)
+```
+
+**IMPORTANT**: The `compute_case_difficulties` function must:
+- Use `torch.no_grad()` to avoid storing computation graphs
+- Use the **normalized (standardized)** targets via `target_transform.apply_surface` / `apply_volume`
+- Compute loss in the same way as the training loop (matching surface+volume loss formulation)
+- Handle variable-length batches correctly (the dataset uses `pad_collate`)
+- Average the loss over all points in each case to get a scalar per-case difficulty
+
+### Step 3 — Run configuration
+
+Use the **alphonse base recipe** with curriculum enabled for the first 10 epochs:
+
+```bash
+python train.py \
+  --epochs 50 \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr-cosine-t-max 30 \
+  --no-compile-model \
+  --curriculum-warmup-epochs 10 \
+  --wandb-group senku-curriculum \
+  --wandb-run-name senku-curriculum-e10
+```
+
+**Note**: `--no-compile-model` is **mandatory** — PyTorch 2.x Inductor crashes at validation on this cluster.
+
+### Step 4 — Logging
+
+Log the following additional metrics to W&B to help interpret results:
+- `train/curriculum_active` (1 during curriculum epochs, 0 after) — so we can see the phase transition
+- `train/case_difficulty_mean` and `train/case_difficulty_std` (from epoch 0 difficulty scores)
+- `train/curriculum_epoch` (current epoch within curriculum phase)
+
+---
+
+## Expected Outcome
+
+If the hypothesis is correct, you should see:
+- **Faster early convergence**: lower `val_primary/abupt_axis_mean_rel_l2_pct` at epochs 5–15 vs alphonse
+- **Better final metrics**: surf_p and vol_p should benefit from stable early representations
+- The wall-shear y/z axes (the binding constraint in Wave 1) may or may not improve — document whatever you observe
+
+If convergence is similar to alphonse but final metrics don't improve, the curriculum warmup may be too short or the difficulty proxy (loss) may not correlate well with aerodynamic complexity. In that case, please note the per-case difficulty variance in your report (high variance = the cases ARE diverse; low variance = loss is not a good proxy for difficulty).
+
+---
+
+## Reporting
+
+When your run completes, post a comment with:
+1. W&B run ID and link
+2. Final `test_primary/*` metrics table (all 6 axes + abupt_mean)
+3. Best validation checkpoint metrics
+4. Comparison vs AB-UPT targets and alphonse Wave 1 reference
+5. Plot or description of per-case difficulty distribution from epoch 0
+6. Your observation on whether curriculum actually helped convergence (compare early-epoch val curves)
+7. Any implementation notes or issues encountered
+
+Then mark the PR ready for review.
+
+---
+
+# #74: [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) [MERGED]
+
+## Hypothesis
+
+**Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseline**
+
+The strongest known DrivAerML result from the radford branch (PR #2593) used a specific recipe:
+- 4 transformer layers, 256 hidden dim (vs default 3L/192d)
+- No EMA (EMA was found to hurt on DrivAerML)
+- Fourier/sinusoidal positional encoding replacing the default ContinuousSincosEmbed
+- Cosine LR schedule with T_max=30
+- lr=3e-4, weight_decay=1e-4, batch_size=2
+
+This experiment replicates that recipe on the bengio branch to establish a confirmed baseline. Without this replication we are building on unconfirmed assumptions.
+
+**Source:** radford PR #2593, ~12.96% abupt_axis_mean_rel_l2_pct on the test set.
+
+## Architecture Change Required
+
+The default `ContinuousSincosEmbed` in `model.py` must be replaced with a standard Fourier positional encoding. Make this change in your branch:
+
+In `model.py`, replace the `ContinuousSincosEmbed` class with a `FourierEmbed` that uses learned or fixed sinusoidal frequencies. The simplest approach is to replace the line in `SurfaceTransolver.__init__`:
+```python
+self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+```
+with a `FourierEmbed` that accepts separate frequency scales per axis (standard multi-scale sinusoidal with frequencies [1, 10, 100] or similar for the xyz coordinate ranges of DrivAerML). A simple implementation:
+
+```python
+class FourierEmbed(nn.Module):
+    """Multi-scale sinusoidal positional encoding for 3D coordinates."""
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_freqs = num_freqs
+        # Geometric frequency progression: 1, 2, 4, ..., 2^(num_freqs-1)
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        # Output dim: input_dim * num_freqs * 2 (sin + cos), padded to hidden_dim
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+        
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        # coords: [B, N, input_dim]
+        coords = coords.float()
+        # [B, N, input_dim, num_freqs]
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)  # [B, N, input_dim * num_freqs * 2]
+        return self.proj(emb)
+```
+
+Then in `SurfaceTransolver.__init__` use `FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)`.
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --weight-decay 1e-4 \
+  --batch-size 2 \
+  --epochs 50 \
+  --lr-cosine-t-max 30 \
+  --train-surface-points 40000 \
+  --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-alphonse \
+  --agent alphonse
+```
+
+## Current Baseline Targets to Beat
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 (mean of 5 axis metrics) |
+
+Historical best from radford PR #2593: ~12.96% abupt_axis_mean_rel_l2_pct.
+
+## Success Criteria
+
+Report `test_primary/abupt_axis_mean_rel_l2_pct` and all six individual `test_primary/*` metrics. This is the bengio baseline replication run — the key question is whether the Fourier PE + no-EMA + 4L/256d recipe reproduces the ~12.96% result and provides a stable starting point for further bengio experiments.
+
+---
+
+# #176: [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline [MERGED]
+
+## Hypothesis
+
+Wave 1 winner used lr=3e-4 (default). However, 3e-4 may be suboptimal for the Fourier PE baseline — the Fourier features expand the input space significantly and a slightly higher or lower lr may train more efficiently. This experiment sweeps two lr values (1e-4 and 5e-4) on the exact Wave 1 winner config to find the optimal lr for the Fourier PE regime. Run both as sequential trials.
+
+**Target gap:** val_abupt from 7.21% → below 6.8%.
+
+## Instructions
+
+Run two sequential trials (Trial A then Trial B), same config except lr:
+
+**Trial A (lr=1e-4):**
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 1e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-lr-sweep
+```
+
+**Trial B (lr=5e-4):**
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 5e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-lr-sweep
+```
+
+Key changes vs Wave 1 baseline:
+- `--lr` swept over {1e-4, 5e-4} (baseline was 3e-4)
+- `--lr-cosine-t-max 50` (was 30) — longer schedule gives lr differences more time to manifest
+- `--fourier-pe` — mandatory (Wave 1 lesson)
+- All other config identical to Wave 1 winner
+
+Report val_primary metrics at the best checkpoint for each trial. Compare against the 3e-4 baseline.
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`, lr=3e-4):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+## Results
+
+### Trial A (lr=1e-4)
+- **Run 1 (`ro7ocwte`)**: killed at end of ep1 by val_primary kill threshold (abupt=40.97% at step 17,816 vs threshold <25). Cause: with lr-warmup-epochs=3, lr at end of ep1 was ~3.3e-5, three times lower than alphonse's lr at the same step.
+- **Run 2 (`lle5ylae`, kill threshold relaxed to step >= 100k)**: killed at advisor's request (abupt=40.5% at step 22,043 / step 100k+ assessed too late). lr=1e-4 is too low for AB-UPT under T_max=50 — model was severely under-trained and would not catch up before the cosine valley.
+
+**Conclusion:** lr=1e-4 is non-competitive with the FourierEmbed swap.
+
+### Trial B (lr=5e-4) — `ld3ff1gs`
+
+Per-epoch val_primary trajectory:
+
+| Epoch | step | abupt | surface_p | wall_shear | volume_p |
+|-------|------|-------|-----------|------------|----------|
+| 1 | 17,816 | 30.17 | 23.24 | 31.66 | 22.34 |
+| 2 | 35,633 | 14.98 | 10.34 | 16.03 | 11.01 |
+| 3 | 53,450 | 12.51 | 8.52 | 13.46 | 9.09 |
+| 4 | 71,267 | 11.41 | 7.65 | 12.28 | 8.33 |
+| 5 | 89,084 | 11.05 | 7.34 | 11.75 | 8.72 |
+| 6 | 106,901 | 10.34 | 6.83 | 11.21 | 7.41 |
+| 7 | 124,718 | 9.61 | 6.37 | 10.39 | 6.97 |
+| 8 | 142,535 | 9.37 | 6.23 | 10.17 | 6.76 |
+| 9 | 160,352 | 9.71 | 6.48 | 10.50 | 7.09 |
+| 10 | 178,169 | 9.21 | 6.09 | 10.00 | 6.62 |
+| **11 (best)** | **195,986** | **9.122** | **6.041** | **9.910** | **6.522** |
+| 12 | 213,803 | 10.44 | 7.09 | 11.16 | 7.95 |
+
+**Best so far (ep11):**
+
+| Metric | ep11 best | Baseline (alphonse, lr=3e-4) | Δ vs baseline |
+|--------|-----------|------------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.122** | 7.209 | **+1.91% (worse)** |
+| `val_primary/surface_pressure_rel_l2_pct` | 6.041 | 4.802 | +1.24% (worse) |
+| `val_primary/wall_shear_rel_l2_pct` | 9.910 | 8.160 | +1.75% (worse) |
+| `val_primary/volume_pressure_rel_l2_pct` | 6.522 | 4.166 | +2.36% (worse) |
+
+ep12 regression: all four primary metrics jumped together (+1.32% on abupt) with two large train/loss spikes (steps 199,522 and 211,125 at ~0.51 vs ~0.01 baseline) — destabilization signal, not noise.
+
+**Conclusion:** lr=5e-4 with `--lr-cosine-t-max 50` + Fourier PE is non-competitive vs alphonse's lr=3e-4 (T_max=30). Even at ep11-best, model is ~1.9% worse on abupt with declining slope and a paired-channel destabilization at ep12. Not worth running to ep31 valley.
+
+**Final command used (Trial B):**
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema \
+  --lr 5e-4 --epochs 50 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb-group bengio-wave2-lr-sweep --wandb-name chihiro/lr-sweep-5e-4 \
+  --agent chihiro
+```
+
+W&B run IDs (rank-0): Trial A v1 `ro7ocwte`, Trial A v2 `lle5ylae`, Trial B `ld3ff1gs` (group: `bengio-wave2-lr-sweep`).
+
+Peak GPU memory: ~10.85 GB / GPU (4× A100), all four GPUs ~90-95% util throughout.
+
+---
+
+# #354: [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline [MERGED]
+
+## Hypothesis
+
+A systematic +1.0–1.5 pp structural gap has been observed between every recent `fourier-pe nf=8` baseline-config run and the alphonse `m9775k1v` baseline (ep30, `val_abupt=7.2091%`). All the data points:
+
+| Run ID | Config | Best abupt |
+|--------|--------|-----------|
+| `m9775k1v` | alphonse baseline PR #74 (ep30 best) | **7.2091%** |
+| `67u9bilg` | haku surface-weight 2.0 (identical arch, 50ep) | 8.168% |
+| `kuz4na0j` | trial-B wsy/wsz 0.5 | 8.895% |
+| `w3thlivw` | mirror0.5 + sw2.0 | 8.919% |
+| `31s1j3a0` | gc=0.5 (grad clip) | 9.215% |
+| `0fhryk4r` | fern SWA-last5 (fourier-pe confirmed, ep10) | 9.270% |
+
+**Architecture-identical runs (3,249,813 params, FourierEmbed, lr=3e-4, cosine_t_max=30, no-EMA) still land ~1pp above alphonse.** This cannot be explained by hyperparameter difference — it is a codebase, data, or environment change between the alphonse merge (PR #74) and current HEAD.
+
+This affects every in-flight Wave 5–8 PR. Finding and fixing this regression is the highest-leverage action in the entire research programme right now.
+
+## Goal
+
+1. **Identify the commit** between PR #74 (alphonse, the Wave 1 BASELINE winner, ~2026-04-30) and current bengio HEAD that introduced the regression.
+2. **Propose and implement a minimal fix** in `target/train.py` or `target/model.py` (whichever file the culprit is in).
+3. **Validate** by running a short sanity-check training run (at minimum ep5 abupt should match the alphonse trajectory table below).
+
+## What to investigate
+
+Start with these categories, in order of likelihood:
+
+**a. Data/dataloader changes** — Any change to normalization constants, dataset splits, augmentation defaults, point cloud subsampling counts, or data loading order. A silent normalization change would produce the consistent ~1pp floor we see. Check `train.py` for any hardcoded normalization or preprocessing that differs from what alphonse used.
+
+**b. Loss function changes** — Any change to loss weights, loss formulation, or how the primary `abupt_axis_mean_rel_l2_pct` is computed. Even a small coefficient change compounds across epochs.
+
+**c. Model initialization** — Any change to default weight initialization in `model.py`. A change in the FourierEmbed or transformer init could produce a consistent early-epoch gap.
+
+**d. LR scheduler** — Any change to how `lr-cosine-t-max` is applied. Verify the LR curve in W&B for a fresh run vs the expected cosine schedule.
+
+**e. Training loop / DDP sync** — Any change to how metrics are aggregated across ranks, or DDP bucket/gradient sync that could affect effective batch size.
+
+## Approach
+
+Use `git log --oneline <PR74-merge-sha>..HEAD -- target/` to list all commits that touched the target code since alphonse merged. Examine each diff for the categories above.
+
+The alphonse PR #74 is a squash merge — so the comparison point is the commit just after the squash. Run `git log --oneline --all | grep -i alphonse` to find the relevant commit hash.
+
+If the change is in `train.py` or `model.py`, implement the fix directly. If it is an environment issue (library version, CUDA, dataset file), document it clearly and propose a reproducible workaround.
+
+## Validation run
+
+After the fix, run a short 10-epoch validation run with the exact baseline recipe:
+
+```bash
+torchrun --standalone --nproc_per_node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --no-compile-model \
+  --wandb-group bengio-regression-bisect
+```
+
+The expected trajectory (from alphonse `m9775k1v`) for the baseline recipe:
+
+| ep | expected abupt | acceptable range |
+|----|--------------|-----------------|
+| 1  | ~13.5%       | < 14.5%         |
+| 5  | ~8.9%        | < 9.5%          |
+| 10 | ~8.2%        | < 8.8%          |
+
+If your fix brings ep5/ep10 within the acceptable ranges, the regression is resolved. **Report the W&B run ID and the commit SHA of the fix.**
+
+## Current Baseline
+
+| Metric | Current Best (val, ep30) | AB-UPT Target |
+|--------|--------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+Baseline W&B run: `m9775k1v` (alphonse, PR #74, `--fourier-pe` confirmed, n_params=3,249,813)
+
+## Notes
+
+- The SWA code from the closed PR #276 (branch `fern/swa-last-k-epochs`, commit `d6cb811`) is preserved for later.
+- Report your findings in PR comments as you go — even partial diagnosis is valuable.
+- If the regression is environmental rather than code (library version bump, dataset update), document the delta precisely so the team can decide whether to freeze or adapt.
+
+---
+
+# #174: [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule [MERGED]
+
+## Hypothesis
+
+Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. That config likely underfits given the short cosine schedule (30 epochs). Adding a 5th layer increases model capacity; pairing it with a longer T_max=50 schedule gives the deeper model sufficient time to converge. Wave 1 5L run (gilbert, #76) reached val_abupt=7.47% at ep30 — but was run WITHOUT Fourier PE and without the longer schedule. This run isolates depth+PE+schedule together.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+## Instructions
+
+Run exactly one training job with the following config (all other hyperparameters at train.py defaults):
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 5 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 5 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+Key changes vs Wave 1 baseline:
+- `--model-num-layers 5` (was 4) — adds one Transformer layer
+- `--lr-cosine-t-max 50` (was 30) — gives deeper model more epochs to converge
+- `--lr-warmup-epochs 5` (was default) — gentle warmup for the extra depth
+- `--fourier-pe` — mandatory (Wave 1 lesson: PE is the single largest perf driver)
+- `--no-use-ema` — same as baseline winner
+
+Report val_primary metrics at the best checkpoint (lowest val_primary/abupt_axis_mean_rel_l2_pct).
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+Reproduce command (Wave 1 winner):
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr-cosine-t-max 30 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --wandb_group bengio-wave2
+```
+
+---
+
+# #487: Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d [MERGED]
+
+## Hypothesis
+
+The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num-freqs` = 8 (default in the codebase). The Fourier positional embedding maps 3D coordinates through sin/cos of 8 frequency bands, producing a 48-dim input (3 coords × 8 freqs × 2 = 48) before a linear projection to hidden_dim=256. Increasing the number of Fourier frequency bands to 16 (96-dim input) gives the model more high-frequency positional resolution, potentially capturing the fine-scale geometry variation in boundary-layer regions that drive wsy/wsz errors. Conversely, 4 bands (24-dim input) would test whether the current 8 bands are over-specified. The cost of more frequencies is only a larger input projection — the rest of the model is unchanged.
+
+This is a single architectural knob targeting positional encoding expressiveness.
+
+## Instructions
+
+Run **two parallel trials** on the 5L/256d/4H + T_max=50 base:
+
+**Trial A — nf=16 (more high-freq bands)**:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --fourier-pe-num-freqs 16 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave17 \
+  --wandb-name nezuko-fourier-nf16
+```
+
+**Trial B — nf=4 (fewer bands, ablation)**:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --fourier-pe-num-freqs 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave17 \
+  --wandb-name nezuko-fourier-nf4
+```
+
+Run Trial A first. At ep5 (step 89,084): if abupt < 10.5%, continue AND start Trial B in parallel. If Trial A abupt ≥ 10.5%: stop Trial A, but still run Trial B to completion up to ep15 (abupt gate: > 8.5%). 
+
+**Reporting**: Post W&B run IDs as soon as each trial starts. Post full val metric tables at ep5, ep10 for both trials as a PR comment.
+
+## Baseline
+
+Current best (PR #174, alphonse, run `vu4jsiic`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.5644 | 3.82 |
+| `val_primary/volume_pressure_rel_l2_pct` | 3.9361 | 6.08 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | 3.63 |
+
+Baseline uses `--fourier-pe` with default num_freqs=8.
+
+Reproduce baseline:
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --fourier-pe \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 50 \
+  --no-compile-model \
+  --wandb-group bengio-wave9
+```
+
+## Gates
+
+For each trial:
+
+| Epoch | Step | Kill threshold |
+|-------|------|----------------|
+| ep5 | 89,084 | abupt > 10.5% → stop trial |
+| ep15 | 267,254 | abupt > 8.5% → stop trial |
+| ep25 | 445,400 | abupt > 6.9549% (baseline) → close |
+
+## What to measure
+
+At ep10: compare `val_primary/wall_shear_y_rel_l2_pct` and `val_primary/wall_shear_z_rel_l2_pct` between nf=4, nf=8 (baseline), nf=16. If nf=16 gives a clear wsy/wsz improvement (>0.3pp vs nf=8), this points toward higher-frequency PE as a lever for shear prediction.
+
+---
+
+# #417: EMA vs no-EMA on 5L/256d+FourierPE+T_max50 (Wave 11) [CLOSED]
+
+## Hypothesis
+
+Test whether EMA (Exponential Moving Average) of weights helps stabilize training on the 5L/256d/4H + FourierPE architecture with T_max=50 cosine schedule. The current baseline (PR #174) uses `--no-use-ema`. EMA typically improves generalization by smoothing the weight trajectory. Prior EMA experiments were inconclusive due to non-ACK closure (PRs #390). This is a clean test of EMA vs. no-EMA on the current best base with T_max=50.
+
+## Current Baseline
+
+| Metric | Baseline (PR #174) | AB-UPT Target |
+|--------|-------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549%** | — |
+| `val_surf_p/rel_l2_pct` | 4.5644% | 3.82% |
+| `val_vol_p/rel_l2_pct` | 3.9361% | 6.08% |
+| `val_wsx/rel_l2_pct` | 5.9891% | 5.35% |
+| `val_wsy/rel_l2_pct` | 8.7345% | 3.65% |
+| `val_wsz/rel_l2_pct` | 10.5766% | 3.63% |
+
+Baseline run: `vu4jsiic`, 5L/256d/4H + FourierPE + **no-EMA** + T_max=50 + lr=3e-4 + gc=1.0
+
+## Instructions to Student
+
+Run a single trial enabling EMA (`--use-ema`, which is the default — omit `--no-use-ema`) on the 5L/256d/4H + FourierPE architecture with T_max=50 and default gc=1.0. This isolates the EMA contribution cleanly.
+
+**Reproduce command:**
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 5 --model-hidden-dim 256 --model-heads 4 \
+  --fourier-pe --use-ema --lr 3e-4 --lr-cosine-t-max 50 \
+  --grad-clip-norm 1.0 --no-compile-model \
+  --wandb-group bengio-wave11 \
+  --wandb-name kohaku-ema-5l256d-tmax50-wave11 \
+  --kill-thresholds "89084:val_primary/abupt_axis_mean_rel_l2_pct<13.0,178169:val_primary/abupt_axis_mean_rel_l2_pct<11.0,445350:val_primary/abupt_axis_mean_rel_l2_pct<6.9549"
+```
+
+**Kill thresholds:**
+- Step 89084 (ep5): `val_primary/abupt_axis_mean_rel_l2_pct < 13.0` — kill if not met
+- Step 178169 (ep10): `val_primary/abupt_axis_mean_rel_l2_pct < 11.0` — kill if not met
+- Step 445350 (ep25): `val_primary/abupt_axis_mean_rel_l2_pct < 6.9549` — kill if not met (must beat baseline by ep25)
+
+## Expected Outcome
+
+EMA smooths the loss surface and often helps generalization in regression tasks. If EMA improves upon the no-EMA baseline, target: `val_primary/abupt_axis_mean_rel_l2_pct < 6.9549%`. Expected range: 6.7-6.9%.
+
+## ACK Required
+
+Please ACK this assignment within 30 minutes by posting a comment with `ACK`.
+
+## Results
+
+**Training was killed at ep25 by the configured kill threshold** (`val_primary/abupt_axis_mean_rel_l2_pct < 6.9549` at step ≥ 445350). Final ep25 abupt = **7.5132%**, did NOT beat baseline of 6.9549%.
+
+### Hypothesis tested
+
+EMA (Exponential Moving Average of weights) on the current best `5L/256d/4H + FourierPE + T_max=50 + lr=3e-4 + gc=1.0` architecture, isolated against the no-EMA baseline (PR #174, run `vu4jsiic`).
+
+Config: `--use-ema` (default `ema_decay=0.999`), all other flags identical to PR #174 baseline.
+
+### Final metrics (ep25, run `4632xosf`, killed)
+
+| Metric | Baseline (PR #174, ep50) | EMA (this run, ep25) | Δ |
+|---|---|---|---|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549%** | **7.5132%** | **+0.56pp WORSE** |
+| `val_surf_p/rel_l2_pct` | 4.5644% | 4.9974% | +0.43pp |
+| `val_vol_p/rel_l2_pct` | 3.9361% | 5.2052% | **+1.27pp WORSE** |
+| `val_wsx/rel_l2_pct` | — | 7.1982% | — |
+| `val_wsy/rel_l2_pct` | 8.7345% | 9.1364% | +0.40pp |
+| `val_wsz/rel_l2_pct` | 10.5766% | 11.0286% | +0.45pp |
+
+Note: comparison is ep25 (this run) vs ep50 (baseline); kill threshold required this run to beat the full-schedule baseline at half the training. Even so, the descent had decelerated below the rate needed to reach 6.9549% by ep50 (advisor's ep23 projection: -0.039pp/ep → ep25 ≈ 7.51%, ep50 ≈ 7.30-7.40%; not competitive).
+
+### Per-epoch trajectory (ep5 → ep25, abupt %)
+
+| ep | abupt | sp | vp | wsy | wsz | Δabupt |
+|---:|---:|---:|---:|---:|---:|---:|
+| 5  | 8.7092 | 5.7353 | 6.3083 | 10.9193 | 12.4528 | — |
+| 10 | 8.0165 | 5.2866 | 5.6784 | 9.9415  | 11.6038 | -0.139/ep |
+| 15 | 7.7424 | 5.1189 | 5.4407 | 9.5169  | 11.2757 | -0.055/ep |
+| 20 | 7.6050 | 5.0535 | 5.2998 | 9.3009  | 11.1175 | -0.027/ep |
+| 25 | 7.5132 | 4.9974 | 5.2052 | 9.1364  | 11.0286 | -0.018/ep |
+
+Clean monotonic descent with strong deceleration over the second half — consistent with EMA acting as a low-pass filter on the weight trajectory, smoothing late training but yielding less aggressive convergence.
+
+### Comparison to fern's no-EMA run on same architecture
+
+Per advisor's earlier comment, vs fern run `hph6eaky` (5L/256d/T_max=50, no-EMA + coord-norm fix) at matched ep17:
+- fern ep17: abupt=7.5331, vp=4.3674
+- kohaku ep17 (EMA on): abupt=7.6811, vp=5.3653
+
+EMA underperforms by **+0.15pp on abupt** and **+1.0pp on vp** vs no-EMA at the same step on the same architecture — confirming EMA is a net negative here.
+
+### What happened
+
+**EMA does not help on this architecture.** The hypothesis (EMA improves generalization, target 6.7-6.9% abupt) is **rejected**. Three observations:
+
+1. **vp is the largest victim (+1.27pp).** The volume-pressure head appears especially sensitive to EMA smoothing on this architecture. Earlier-wave EMA improvements (PRs in baselines before the FourierPE+T_max=50 stack) may have been load-bearing for a different reason that doesn't transfer.
+2. **Convergence rate halves every 5 epochs.** -0.139pp/ep at ep10 → -0.018pp/ep at ep25. The EMA average lags the live weights and the cosine schedule's late-T_max=50 LR (still 0.5×peak at ep25) keeps the live weights moving but the EMA buffer is dampened.
+3. **Wall-shear axes do not benefit either.** wsy and wsz both end ~0.4pp worse than the no-EMA baseline at ep50. EMA does not help the binding axes that dominate abupt.
+
+### Suggested follow-ups (NOT implemented per student boundaries)
+
+- **Different EMA decay**: try `ema_decay=0.9999` (slower update, longer averaging window) or `ema_decay=0.99` (faster, less smoothing). 0.999 may be poorly matched to the T_max=50 schedule length.
+- **EMA warmup**: start EMA only after ep5-10 so the buffer averages over the high-LR exploration phase rather than the cold-start ramp. Some implementations parameterize this as `ema_warmup_steps`.
+- **EMA on decoder only / non-decoder only**: it's possible EMA hurts the volume-pressure decoder specifically (vp +1.27pp dominates). A targeted EMA on attention/encoder layers only would isolate this.
+- **Combine with coord-norm fix**: fern's no-EMA + coord-norm beat both this and the PR #174 baseline on vp. EMA's effect should be re-tested on top of that fix, not the older base.
+
+### Run details
+
+- **Command:** `torchrun --standalone --nproc-per-node=4 train.py --agent kohaku --model-layers 5 --model-hidden-dim 256 --model-heads 4 --fourier-pe --use-ema --lr 3e-4 --lr-cosine-t-max 50 --epochs 50 --grad-clip-norm 1.0 --no-compile-model --wandb-group bengio-wave11 --wandb-name kohaku-ema-5l256d-tmax50-wave11 --kill-thresholds '89084:val_primary/abupt_axis_mean_rel_l2_pct<13.0,178169:val_primary/abupt_axis_mean_rel_l2_pct<11.0,445350:val_primary/abupt_axis_mean_rel_l2_pct<6.9549'`
+- **Stop reason:** kill threshold @ step 445400 (ep25): `val_primary/abupt_axis_mean_rel_l2_pct=7.5132 not < 6.9549`
+- **W&B run ID (rank 0):** `4632xosf` — https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/4632xosf
+- **Group:** `bengio-wave11`
+- **Total wall time:** 874 min (14.6 h) for 25 epochs on 4 GPUs
+- **Peak memory (per GPU):** ~11.7 GB
+- **Model:** SurfaceTransolver grouped surface+volume, 3.99M params, DDP world_size=4
+- **Throughput:** ~8.8 it/s
+- **Test-set metrics:** none — run was killed before any test eval; only the validation-set best checkpoint was saved.
+
+**Recommendation:** close this PR. EMA with default decay=0.999 is not competitive on the current best architecture. If EMA is still worth pursuing, the decay/warmup variants in suggested follow-ups should be a separate hypothesis.
+
+---
+
+# #332: [tanjiro] Stack mirror-aug + surface-loss-weight=2.0 on alphonse Fourier base [CLOSED]
+
+## Hypothesis
+
+Two independent Wave 5/6 results suggest small positive signals on the binding axes:
+1. **gilbert PR #278 mirror-augmentation Trial A**: ep11 abupt=9.91% (healthy trajectory, gate PASS); train-time y-flip + wsy sign-flip at p=0.5 gives the model the symmetry of the problem for free.
+2. **Wave 1 tanjiro sw=2.0** + **closed Wave 6 haku sw=2.0**: both showed surface-loss-weight=2.0 helps on the binding axes (haku ep5=10.15% PASS).
+
+Neither has been combined. The hypothesis: **mirror-augmentation + surface-loss-weight=2.0** stacked on the alphonse Fourier base may compound — mirror gives the model symmetry-equivariant gradients on wsy specifically, and sw=2.0 gives the surface decoder more weight in the optimizer. Different mechanisms, both targeting the binding axes.
+
+Also tests a secondary hypothesis: does mirror-aug interact constructively or destructively with surface-loss upweighting? If destructively, that's a strong signal that the binding constraint is not loss-weight or data-augmentation but representation.
+
+## Instructions
+
+This depends on gilbert's mirror-augmentation code on PR #278 branch `gilbert/mirror-symmetry-train-aug-wsy`. **First, cherry-pick the mirror-aug commit** from gilbert's branch onto your tanjiro branch. The mirror flag should be `--mirror-aug-prob 0.5` or similar — confirm by reading gilbert's PR #278 body and code:
+
+```bash
+git fetch origin gilbert/mirror-symmetry-train-aug-wsy
+git log origin/gilbert/mirror-symmetry-train-aug-wsy ^bengio --oneline
+# cherry-pick the mirror-aug implementation commit (likely the only non-assignment commit)
+git cherry-pick <commit-sha>
+# verify --help shows the mirror-aug flag
+python target/train.py --help | grep -i mirror
+```
+
+If gilbert's branch has multiple commits, cherry-pick the implementation commit only (skip the assignment commit if separate). If conflicts arise on `train.py`, prefer gilbert's mirror-aug code and rebase your changes around it.
+
+**Smoke test**:
+```bash
+cd target/ && python train.py --debug --epochs 1 --mirror-aug-prob 0.5 --surface-loss-weight 2.0 --no-compile-model 2>&1 | head -40
+```
+
+**Trial A — mirror=0.5 + sw=2.0** (the stacked recipe):
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --mirror-aug-prob 0.5 \
+  --surface-loss-weight 2.0 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.0" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw2.0
+```
+
+**Trial B — mirror=0.5 only** (control for stacking effect):
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --mirror-aug-prob 0.5 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct>20,170000:val_primary/abupt_axis_mean_rel_l2_pct>11.5" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw1.0
+```
+
+Run sequentially (Trial A first since it is the high-EV one).
+
+If the exact flag name on gilbert's branch is different (e.g. `--mirror-prob` or `--y-mirror-aug`), use the actual name and report it in your results comment.
+
+`--kill-thresholds` format: `STEP:METRIC<OP><NUMBER` (commas/semicolons). `>` = kill if metric exceeds threshold.
+
+## Baseline
+
+Current bengio best: **val_abupt = 7.2091%** (PR #74 alphonse, run `m9775k1v`).
+
+Per-axis val metrics to beat:
+- surface_pressure_rel_l2_pct: 4.802 (AB-UPT 3.82)
+- wall_shear_rel_l2_pct: 8.160 (AB-UPT 7.29)
+- volume_pressure_rel_l2_pct: 4.166 (AB-UPT 6.08 — already beats)
+- wall_shear_x_rel_l2_pct: 7.109 (AB-UPT 5.35)
+- wall_shear_y_rel_l2_pct: 9.100 (AB-UPT 3.65) — **binding constraint**
+- wall_shear_z_rel_l2_pct: 10.869 (AB-UPT 3.63) — **hardest binding constraint**
+
+**Reference points**:
+- gilbert PR #278 Trial A (mirror=0.5 only): ep11 abupt=9.91% — your Trial B should match within 0.3pp at ep11.
+- closed Wave 6 haku Trial A (sw=2.0 only): ep5 abupt=10.15% — your Trial A should be ≤ 10.15% at ep5 if the stack is positive.
+
+**val/test gap warning**: ~2x degradation on vol_p (val=4.17% → test~8-12%). Test_primary confirmation required.
+
+## Reporting
+
+Post a single PR comment with:
+- The cherry-picked commit SHA from gilbert's branch
+- Both trial W&B run IDs
+- Per-channel val metrics at ep10, ep20, ep30
+- A clear answer: did mirror+sw stack constructively (Trial A < min(gilbert, haku))? Or did the levers fight each other?
+
+## Results — Trial A (mirror=0.5 + SW=2.0) at ep30
+
+Trial A (`w3thlivw`) finished at ep30 with the final test eval.
+
+**Verdict: ep30 gate cleared (≤8.0%); does NOT beat the 7.2091% PR baseline (or the new 6.9549% baseline from alphonse PR #174 the advisor flagged at 15:28Z). Final landing val_abupt = 7.8243%.**
+
+### Run metadata
+
+- **W&B group**: `bengio-wave7-mirror-plus-sw`
+- **Run IDs (4 ranks)**: rank 0 (primary) `w3thlivw`, rank 1 `mofpsfz3`, rank 2 `xiq4srjy`, rank 3 `lt2m7z8t`
+- **Mirror-aug commit**: `77be65c` (re-implemented locally; gilbert's branch contained only the assignment commit `f7b9a28`, so a literal cherry-pick was not possible — see 03:44Z pre-launch note)
+- **Total wall-clock**: 853.75 min (14h13m), 30 epochs × ~1671 s/ep
+- **Peak VRAM**: ~10.85 GB on each of 4 RTX PRO 6000 (96 GB available)
+- **Best val checkpoint**: ep30, abupt = 7.8243% (best in the run)
+
+### Exact training command
+
+```
+torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --lr-cosine-t-max 30 --epochs 30 \
+  --mirror-aug-prob 0.5 --surface-loss-weight 2.0 \
+  --fourier-pe --no-compile-model \
+  --kill-thresholds "80000:val_primary/abupt_axis_mean_rel_l2_pct<20,170000:val_primary/abupt_axis_mean_rel_l2_pct<11.0" \
+  --wandb-group bengio-wave7-mirror-plus-sw \
+  --wandb-name mirror0.5_sw2.0 --agent tanjiro
+```
+
+(Trial B was **skipped** per advisor's 16:33Z option-1 directive — watcher PID 370922 killed at 16:39:36Z; no GPU time spent on the mirror-only control.)
+
+### Per-channel val trajectory (ep5 / ep10 / ep20 / ep30)
+
+| metric (val_primary, %) | ep5 | ep10 | ep20 | **ep30** | PR-body baseline | Δ ep30 vs baseline |
+|---|---:|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct`    | 9.7369 | 9.0920 | 8.1341 | **7.8243** | 7.2091 | **+0.615** |
+| `surface_pressure_rel_l2_pct`   | 6.3668 | 5.9404 | 5.3596 | 5.1781 | 4.802 | +0.376 |
+| `wall_shear_rel_l2_pct`         | 10.3659 | 9.7176 | 8.7848 | 8.4736 | 8.160 | +0.314 |
+| `volume_pressure_rel_l2_pct`    | 7.7156 | 7.0166 | 6.1442 | 5.8709 | 4.166 | **+1.705** |
+| `wall_shear_x_rel_l2_pct`       | 8.8636 | 8.3075 | 7.6341 | 7.4178 | 7.109 | +0.309 |
+| `wall_shear_y_rel_l2_pct`       | 12.1252 | 11.1647 | 9.8907 | 9.3348 | 9.100 | +0.235 |
+| `wall_shear_z_rel_l2_pct`       | 13.6134 | 13.0307 | 11.6420 | 11.3199 | 10.869 | +0.451 |
+
+### Test eval at ep30 checkpoint (50-case test split)
+
+| metric (test_primary, %) | val (ep30) | **test** | val/test ratio | AB-UPT test target | Δ vs AB-UPT |
+|---|---:|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct`    | 7.8243 | **8.8869** | 1.14× | ~4.51 | +4.38 |
+| `surface_pressure_rel_l2_pct`   | 5.1781 | 4.6762 | 0.90× | 3.82 | +0.86 |
+| `wall_shear_rel_l2_pct`         | 8.4736 | 8.0847 | 0.95× | 7.29 | +0.79 |
+| `volume_pressure_rel_l2_pct`    | 5.8709 | **13.2732** | **2.26×** | 6.08 | +7.19 |
+| `wall_shear_x_rel_l2_pct`       | 7.4178 | 7.1412 | 0.96× | 5.35 | +1.79 |
+| `wall_shear_y_rel_l2_pct`       | 9.3348 | 8.9983 | 0.96× | 3.65 | +5.35 |
+| `wall_shear_z_rel_l2_pct`       | 11.3199 | 10.3456 | 0.91× | 3.63 | +6.72 |
+
+The val/test ratio confirms the BASELINE.md warning: vol_p collapses 2.26× from val to test (consistent with the prior alphonse `m9775k1v` 4.17→8–12% gap, even larger here). All other surface/wall-shear axes are slightly better on test than on val (ratio < 1), so the surface decoder is generalising fine; volume is the structural problem.
+
+### Reference checks the PR asked for
+
+- **vs gilbert PR #278 mirror-only Trial A ep11 = 9.91%**: my Trial A ep11 = 8.92% (mirror+SW=2.0 is **0.99 pp better at ep11**). Suggests the stack is constructive at the mid-training stage.
+- **vs closed Wave 6 haku Trial A (sw=2.0 only) ep5 = 10.15%**: my Trial A ep5 = 9.737% — clears the gate by **0.413 pp**. The stack compounds at ep5, mostly through wsy/wsz.
+- **ep10 abupt 9.092% vs gate ≤9.5%**: PASS by 0.408 pp.
+- **ep20 abupt 8.134% vs gate ≤8.5%**: PASS by 0.366 pp.
+- **ep30 abupt 7.824% vs gate ≤8.0%**: PASS by 0.176 pp.
+- **ep30 abupt 7.824% vs PR-body baseline 7.2091%**: FAIL by 0.615 pp.
+- **ep30 abupt 7.824% vs new 6.9549% baseline (PR #174)**: FAIL by 0.869 pp.
+
+### What happened
+
+The hypothesis was that mirror-aug (giving the model y-symmetry "for free" on wsy specifically) and surface-loss-weight=2.0 (giving the surface decoder more optimizer mass) would compound. **At ep5 / ep10 / ep20 the stack does compound** — Trial A beats both the haku sw=2.0-only ep5 reference and the gilbert mirror-only ep11 reference by ~0.4–1.0 pp at every gate.
+
+But the descent **plateaus into the cosine tail**:
+- ep10→ep20 slope: −0.096 pp/ep
+- ep20→ep30 slope: −0.031 pp/ep (3× slower)
+- ep28→ep29 slope: −0.012 pp/ep, ep29→ep30: −0.008 pp/ep
+
+By ep23 the run is already inside ±0.05 pp of its ep30 floor; the last 7 epochs of cosine LR decay are essentially squeezing 0.17 pp of additional gain out of mirror-aug + SW=2.0 noise. The architectural ceiling at 4L/256d is reached around 7.8% on this recipe.
+
+**Per-axis attribution (without Trial B but referencing closed work):**
+- **wsy and wsz**: the strongest improvements over baseline trajectory. wsy 17.88→9.33 over 30 ep (−8.55 pp), wsz 19.86→11.32 (−8.54 pp). The mirror-aug y-symmetry term is doing useful work — but the val-end value 9.33% is essentially **at baseline 9.10%** (+0.23 pp). The lift was front-loaded in ep1–ep10 and then SW=2.0 mostly held it.
+- **vp**: the SW=2.0 cost. val 5.87% vs baseline 4.17% (+1.71 pp), test 13.27% vs AB-UPT 6.08 (**+7.19 pp** — the worst gap in the run). Surface-loss upweighting starves the volume decoder; this is the single biggest lever pulling abupt up.
+- **surf_p and ws**: very slight regression (~+0.3 pp). The SW=2.0 emphasis on surface was supposed to help these but the decoder hit its 4L/256d ceiling early.
+
+**Did mirror+SW=2.0 stack constructively?** Yes early (ep5/ep11 beat both single-lever references), but the compound gain dissipates by ep30. The **levers are not fighting** (Trial A isn't worse than either single-lever component at any gate), but the architectural ceiling at 4L/256d is what kills the baseline-beat ambition.
+
+### Suggested follow-ups
+
+(Per advisor's Wave 11 redirect at 15:28Z, the natural next experiment is mirror+SW=2.0 on the 5L/256d/T_max=50 architecture that hit 6.95% — I will queue that for the next assignment.)
+
+1. **Port mirror+SW=2.0 to 5L/256d/T_max=50** (Wave 11 plan). The strongest signal here is that 4L/256d is the ceiling, not the recipe.
+2. **Lower SW**. SW=1.5 or 1.25 may capture most of the surface-decoder gain without the +1.71 pp val_vp / +7.19 pp test_vp penalty.
+3. **Mirror schedule**: the wsy gain front-loads in ep1–ep10 and saturates after ep20. Annealing `mirror_aug_prob` from 0.5→0.0 over the cosine tail would let the model reduce the effective dropout on the binding axis once the symmetry is internalized — could recover 0.1–0.2 pp on the late-cosine descent.
+4. **Volume decoder fix is more important than mirror-aug**. The 2.26× val→test gap on vol_p is a representation problem (BASELINE.md flag #17), not a loss-weight problem. Mirror+SW=2.0 made it worse in absolute terms; any future surface-emphasis recipe should pair with a volume-side counterweight (separate volume LR, larger volume sub-network, or volume-only test-time augmentation).
+5. **Run a real Trial B** after Wave 11 lands. Once we have a stronger architectural ceiling, the mirror-only vs mirror+SW=2.0 ablation becomes useful again — at the current ceiling the answer is dominated by the 4L/256d cap and the ablation can't be cleanly disentangled.
+
+---
+
+# #277: [tanjiro] DomainLayerNorm: domain-specific affine LayerNorm for surface vs volume tokens [CLOSED]
+
+## Hypothesis
+
+Different geometric domains (surface vs volume) in this CFD surrogate have fundamentally different physical characteristics — surface tokens encode boundary layer physics while volume tokens encode free-stream flow. Using **shared** LayerNorm affine parameters (weight/bias) forces the model to normalize both domains identically, which may suppress domain-specific signal. 
+
+**DomainLayerNorm** replaces each `norm1` and `norm2` in every `TransformerBlock` with a module that keeps **separate** affine parameters for surface tokens vs volume tokens, while using the same running statistics. This is a parameter-cheap architectural improvement: just `2 × 2 × n_layers` extra (weight, bias) pairs of size `hidden_dim`. For 4L/256d, that's 4 × 2 × 256 = ~2048 extra parameters on a ~4M param model (<0.05%).
+
+This approach is inspired by domain-conditioned normalization in multi-domain transformers (e.g., DomainLayerNorm in AB-UPT, cross-domain ViTs). The intuition: surface tokens need to capture steep pressure gradients and wall shear boundary conditions, while volume tokens represent smoother field values — letting them have separate affine scales and biases gives the model a free channel to express this.
+
+## Instructions
+
+This experiment requires **modifying `model.py`** only. `train.py` should NOT be modified.
+
+### Step 1: Add `DomainLayerNorm` class to `model.py`
+
+Insert this class after the `UpActDownMlp` class (around line 122, before `TransolverAttention`):
+
+```python
+class DomainLayerNorm(nn.Module):
+    """LayerNorm with separate affine params for surface vs volume tokens.
+
+    Args:
+        hidden_dim: Feature dimension.
+        eps: Epsilon for numerical stability.
+    """
+
+    def __init__(self, hidden_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        # Shared norm (no affine) for computing statistics
+        self.norm = nn.LayerNorm(hidden_dim, elementwise_affine=False, eps=eps)
+        # Separate affine params per domain
+        self.surface_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.surface_bias = nn.Parameter(torch.zeros(hidden_dim))
+        self.volume_weight = nn.Parameter(torch.ones(hidden_dim))
+        self.volume_bias = nn.Parameter(torch.zeros(hidden_dim))
+
+    def forward(self, x: torch.Tensor, surface_tokens: int) -> torch.Tensor:
+        """
+        x: [B, T, D] where T = surface_tokens + volume_tokens
+        surface_tokens: number of leading surface tokens
+        """
+        normed = self.norm(x)
+        if surface_tokens > 0 and surface_tokens < x.shape[1]:
+            # Mixed batch: apply domain-specific affine
+            surf = normed[:, :surface_tokens] * self.surface_weight + self.surface_bias
+            vol = normed[:, surface_tokens:] * self.volume_weight + self.volume_bias
+            return torch.cat([surf, vol], dim=1)
+        elif surface_tokens == x.shape[1]:
+            # Surface-only batch
+            return normed * self.surface_weight + self.surface_bias
+        else:
+            # Volume-only batch
+            return normed * self.volume_weight + self.volume_bias
+```
+
+### Step 2: Modify `TransformerBlock` to accept and use `DomainLayerNorm`
+
+Replace the `TransformerBlock.__init__` to accept a `use_domain_ln` flag:
+
+```python
+class TransformerBlock(nn.Module):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_domain_ln: bool = False,
+    ):
+        super().__init__()
+        mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
+        self.use_domain_ln = use_domain_ln
+        if use_domain_ln:
+            self.norm1 = DomainLayerNorm(hidden_dim)
+            self.norm2 = DomainLayerNorm(hidden_dim)
+        else:
+            self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+            self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.attention = TransolverAttention(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_slices=num_slices,
+            dropout=dropout,
+        )
+        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+```
+
+Update `TransformerBlock.forward` to pass `surface_tokens` through:
+
+```python
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
+        x = _apply_token_mask(x, attn_mask)
+        if self.use_domain_ln:
+            x = x + self.attention(self.norm1(x, surface_tokens), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x, surface_tokens))
+        else:
+            x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+            x = _apply_token_mask(x, attn_mask)
+            x = x + self.mlp(self.norm2(x))
+        x = _apply_token_mask(x, attn_mask)
+        return x
+```
+
+### Step 3: Modify `Transformer` to propagate `surface_tokens`
+
+Update `Transformer.__init__` to pass `use_domain_ln` to each block:
+
+```python
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        depth: int,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        num_slices: int,
+        dropout: float = 0.0,
+        use_domain_ln: bool = False,
+    ):
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    mlp_expansion_factor=mlp_expansion_factor,
+                    num_slices=num_slices,
+                    dropout=dropout,
+                    use_domain_ln=use_domain_ln,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, surface_tokens: int = 0) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(x, attn_mask=attn_mask, surface_tokens=surface_tokens)
+        return x
+```
+
+### Step 4: Thread `use_domain_ln` and `surface_tokens` through `SurfaceTransolver`
+
+In `SurfaceTransolver.__init__`, add the new parameter and pass it to `Transformer`:
+
+```python
+def __init__(
+    self,
+    *,
+    space_dim: int = 3,
+    surface_input_dim: int = SURFACE_X_DIM,
+    surface_output_dim: int = SURFACE_Y_DIM,
+    volume_input_dim: int = VOLUME_X_DIM,
+    volume_output_dim: int = VOLUME_Y_DIM,
+    n_layers: int = 3,
+    n_hidden: int = 192,
+    dropout: float = 0.0,
+    n_head: int = 3,
+    mlp_ratio: int = 4,
+    slice_num: int = 96,
+    fourier_pe: bool = False,
+    fourier_pe_num_freqs: int = 8,
+    domain_ln: bool = False,     # <-- add this
+):
+    ...
+    self.backbone = Transformer(
+        depth=n_layers,
+        hidden_dim=n_hidden,
+        num_heads=n_head,
+        mlp_expansion_factor=mlp_ratio,
+        num_slices=slice_num,
+        dropout=dropout,
+        use_domain_ln=domain_ln,   # <-- pass through
+    )
+```
+
+In `SurfaceTransolver.forward`, capture `surface_tokens` and pass it to `self.backbone`:
+
+```python
+    # existing code already sets:
+    # surface_tokens = surface_x.shape[1]   (or 0 if surface_x is None)
+    
+    # Replace:
+    hidden = self.backbone(hidden, attn_mask=attn_mask)
+    # With:
+    hidden = self.backbone(hidden, attn_mask=attn_mask, surface_tokens=surface_tokens)
+```
+
+### Step 5: Wire the CLI flag in `train.py`
+
+Find the model instantiation in `train.py` (search for `SurfaceTransolver(`) and:
+
+1. Add a config field (or just use a flag) to toggle `domain_ln=True`.
+2. Add `--domain-ln` flag to the argument parser (search for `add_argument` calls near other model flags like `--fourier-pe`).
+3. Pass `domain_ln=config.domain_ln` to `SurfaceTransolver(...)`.
+
+The pattern to follow is the existing `--fourier-pe` / `fourier_pe` flag wiring.
+
+### Step 6: Run command
+
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 \
+  --model-hidden-dim 256 \
+  --model-heads 4 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 30 \
+  --domain-ln \
+  --no-compile-model \
+  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+  --wandb-group bengio-wave5-tanjiro
+```
+
+## Baseline (current best — PR #74, W&B run `m9775k1v`, ep30)
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | 4.166 ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+**Win condition**: `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091%
+
+## Kill Gates
+
+- ep5: abupt > 13% → kill
+- ep10: abupt > 9.5% → kill
+- ep20: abupt > 8.0% → kill
+
+## What to Report
+
+Report `val_primary/abupt_axis_mean_rel_l2_pct` at the best checkpoint, plus all 6 axis metrics. Note whether domain_ln helps or hurts wsy/wsz specifically — those are the hardest targets (wsy target=3.65%, wsz target=3.63%). Include the W&B run ID in the PR comment.
+
+## Results — DomainLayerNorm (NEGATIVE)
+
+### Final outcome
+
+**Run killed at step 35632 (ep2) by the kill threshold (`35000:val_primary/abupt_axis_mean_rel_l2_pct<20`).** The trajectory through ep1→ep2 is anomalous and clearly diverging — comparable 4L/256d/no-ema/lr=3e-4/cosine_t_max=30 baselines drop ~7% absolute between ep1 and ep2; ours regressed +1.9%. With train loss simultaneously collapsing 4× faster than baselines, the signature is overfitting / representation collapse, not standard early-epoch noise.
+
+**Best checkpoint: ep1.** No checkpoint is competitive with the bengio baseline; the run never reached a meaningful comparison point.
+
+| Metric | ep1 (best) | ep2 | Baseline (PR #74, ep30) | AB-UPT |
+|--------|-----------:|----:|-----------------------:|-------:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **18.4487** | 20.3527 | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 12.63 | 14.31 | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 20.13 | 21.92 | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | 12.31 | 14.15 | 4.166 | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 17.07 | 18.45 | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 24.28 | 27.13 | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 25.97 | 27.73 | 10.869 | 3.63 |
+
+`full_val_primary/*` and `test_primary/*` were not produced — the run was killed before final eval.
+
+### Trajectory comparison vs comparable 4L/256d/no-ema baselines
+
+Pulled from W&B for the same hyperparameter shape (no-ema, lr=3e-4, lr_cosine_t_max=30):
+
+| epoch | domain-ln-v2 (ours) | fern/ctrl-noWarm | frieren/ctrl-nw-r2 | nezuko/ctrl-armA |
+|-------|--------------------:|-----------------:|-------------------:|-----------------:|
+| ep1 abupt | 18.45 | 17.17 | 16.40 | 15.55 |
+| ep2 abupt | **20.35** (killed) | 11.73 | 11.35 | 11.52 |
+| ep3 abupt | — | 10.48 | 10.08 | 10.48 |
+| ep1 train_loss | **0.2063** | 0.4884 | 0.4886 | 0.4167 |
+| ep2 train_loss | **0.0545** | 0.0934 | 0.0814 | 0.0775 |
+
+Two anomalies stand out:
+1. **Train loss is ~half the baselines at both ep1 and ep2** — the model is fitting train data ~4× faster while val degrades. This is the canonical overfitting / representation-collapse fingerprint.
+2. **Val regresses ep1→ep2** while every comparable run drops ~30–40% on each metric over the same interval.
+
+### Run details
+
+- Run command:
+  ```bash
+  cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+    --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+    --no-use-ema --lr 3e-4 --lr-cosine-t-max 30 \
+    --domain-ln --no-compile-model \
+    --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+    --wandb-name "tanjiro/domain-layer-norm-v2" \
+    --wandb-group bengio-wave5-tanjiro
+  ```
+- W&B run ID: `212ziaku` (rank0)
+- Group: `bengio-wave5-tanjiro`
+- Model: `SurfaceTransolver` 4L/256d/4h, 3.24M params (DomainLayerNorm adds ~8K params, <0.25%)
+- Peak memory: 10.9 GB / GPU
+- ep wall-clock: 2016s (~34 min/epoch with val); killed at step 35632 (ep2)
+- Total wall-clock used: ~70 min
+
+### What happened — analysis
+
+The DDP deadlock from attempts 1–4 was correctly resolved by the empty-batch fix (always-slice + ghost connection); the model trained without crashing and the ep1 metric (18.45%) was within the advisor's sanity range vs the 17.5% reference. So the implementation is structurally correct. The hypothesis itself failed:
+
+- DomainLayerNorm is mathematically a strict generalization of LayerNorm (init at ones/zeros = identity). At init, the model is identical to baseline.
+- After ~17K steps of training, the per-domain affine has clearly diverged in a way that lets the model fit the training distribution very tightly (train_loss=0.054 at ep2, when comparable baselines are at 0.08) while degrading on validation.
+- All seven validation metrics regressed simultaneously; this is not a per-axis pathology, it's a global generalization failure.
+
+My read on the mechanism: the per-domain affine creates a free degree of freedom for the model to scale/shift surface and volume features differently *at every layer*. In combination with `TransolverAttention`'s slice formation (softmax over slice dim using shared `in_project_slice`), differential scaling of surface vs volume features biases the slice tokens toward whichever domain has larger affine norm, which can collapse the slice attention into a degenerate form. The model can drive train loss down by exploiting this shortcut without learning generalizable structure. This is consistent with both the train/val divergence and the simultaneous regression across all targets.
+
+The placeholder embeddings (`surface_placeholder`, `volume_placeholder`) already give surface and volume tokens distinct domain identity at the input. DomainLayerNorm at every block is apparently too much additional differentiation for this architecture/data scale to absorb without overfitting.
+
+### Suggested follow-ups
+
+If you want to give this idea another shot, the most likely productive variants (smallest first):
+
+1. **DomainLayerNorm only on `norm1` (pre-attention)**, keep `norm2` shared. Rationale: post-attention, surface tokens already contain volume info and vice versa — applying domain-specific affine to "mixed" tokens may be the part of the change that breaks it. Pre-attention norm operates on still-domain-pure tokens.
+2. **DomainLayerNorm only on the first 1–2 blocks**, shared LN deeper. Rationale: domain identity matters most at the input where the features are still raw; deep layers compute mixed representations where domain-specific scale is less meaningful.
+3. **Domain-specific bias only (not weight)**: `surface_bias` and `volume_bias` separately, share `weight`. Rationale: bias is a domain prior (offset), weight is a per-feature scale that should arguably be shared because the *features* are shared across domains after concatenation.
+4. **DomainLayerNorm + dropout 0.05**: regularize the new capacity to prevent the shortcut. Cheapest knob, but doesn't address the root cause.
+5. Drop this hypothesis. Given how clean the train/val divergence is, I'd lean toward (5) unless there's a specific reason to think one of (1)–(3) fixes the shortcut.
+
+### Bug fixes / observations during this experiment
+
+- **Empty-surface-batch DDP deadlock fix** (already in this PR): `DomainLayerNorm` now always slices both `surf` and `vol` and adds a `0.0 * (sum_of_all_4_affine_params)` ghost connection so all four affine parameters appear in every rank's autograd graph, regardless of whether `surface_tokens` is 0 or equal to total. This is the canonical fix for the `find_unused_parameters=False` deadlock and is preferable to flipping that flag (which has per-step cost).
+- **38% empty-surface batches** in the train sampler at batch_size=1, ~14% at per-rank batch_size=2. Worth surfacing to other students — any code that adds a surface-specific path under DDP without ghost-connecting its params will hit the same deadlock.
+
+---
+
+# #218: [frieren] SO(3)-equivariant tangent-frame wall shear head [CLOSED]
+
+## Hypothesis
+
+Wall shear stress is a vector field tangent to the surface. The current model predicts all 3 shear channels (τ_x, τ_y, τ_z) with a shared MLP head — losing the geometric constraint that shear must lie in the tangent plane. An **SO(3)-equivariant** approach for the wall shear output can enforce this constraint structurally.
+
+**Method**: Replace the flat 3-channel shear output head with a frame-relative decomposition:
+1. At each surface point, compute the local tangent frame (e_t1, e_t2, n) from the surface normals [nx, ny, nz] and a tangent direction (e.g., cross-product with x-axis, gram-schmidt normalized).
+2. Predict 2 scalars per point: (α, β) = shear magnitude components in e_t1 and e_t2 directions.
+3. Reconstruct: τ = α * e_t1 + β * e_t2. This lives in the tangent plane by construction.
+4. Compare to ground truth in the same frame: loss is computed in frame-relative coords, then transformed back.
+
+This is the "tangent frame" approach mentioned in stark's Wave 3 direction but frieren takes it further by enforcing it through the SO(3) equivariance structure of the head, not just as a loss regularizer.
+
+## Instructions
+
+Base recipe: 4L/256d, no EMA, Fourier PE, T_max=30, lr=5e-4, surface_weight=2.0, 64 slices.
+
+### Changes to model.py
+
+The surface point features include [x, y, z, nx, ny, nz, area] as input. The model needs access to surface normals in the output head.
+
+1. Add a `TangentFrameHead` module:
+   ```python
+   class TangentFrameHead(nn.Module):
+       def __init__(self, d_model):
+           super().__init__()
+           self.pressure_head = nn.Linear(d_model, 1)   # surface pressure (scalar, frame-invariant)
+           self.shear_head = nn.Linear(d_model, 2)       # (alpha, beta) in tangent frame
+   
+       def forward(self, features, normals):
+           # features: [B, N, D]
+           # normals: [B, N, 3] — unit surface normals
+           pressure = self.pressure_head(features)  # [B, N, 1]
+   
+           # Build tangent frame
+           n = F.normalize(normals, dim=-1)  # [B, N, 3]
+           # e_t1: perpendicular to n, in x-direction if possible
+           ref = torch.zeros_like(n); ref[..., 0] = 1.0
+           # Handle near-parallel case
+           parallel = (torch.abs((n * ref).sum(-1, keepdim=True)) > 0.9)
+           ref2 = torch.zeros_like(n); ref2[..., 1] = 1.0
+           ref = torch.where(parallel, ref2, ref)
+           e_t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1)
+           e_t2 = torch.cross(n, e_t1, dim=-1)
+   
+           # Predict frame-relative shear
+           ab = self.shear_head(features)  # [B, N, 2]
+           tau = ab[..., :1] * e_t1 + ab[..., 1:] * e_t2  # [B, N, 3]
+   
+           return torch.cat([pressure, tau], dim=-1)  # [B, N, 4]
+   ```
+
+2. Pass surface normals (first 6 input features: [x, y, z, nx, ny, nz]) to the output head.
+
+3. Compute loss in Cartesian space (compare predicted τ to ground truth τ directly) — the equivariance is structural, not a loss term.
+
+### train.py changes
+
+- Add `--tangent-frame-head` flag (default False).
+
+### Run
+
+```bash
+cd target/ && python train.py \
+  --epochs 30 --lr 5e-4 --depth 4 --hidden-dim 256 --num-slices 64 \
+  --surface-weight 2.0 --fourier-pe --no-ema \
+  --train-surface-points 32768 --train-volume-points 32768 \
+  --tangent-frame-head \
+  --wandb-project DrivAerML --wandb-group frieren-so3-tangent-frame \
+  --kill-thresholds "3000:val_primary/abupt_axis_mean_rel_l2_pct<=25"
+```
+
+## W&B run IDs
+
+DDP run launched 2026-05-01 15:22 UTC, 4×H100 (`torchrun --nproc_per_node 4`), `wandb-applied-ai-team/senpai-v1-drivaerml`:
+
+- **Rank 0 (primary):** [`lpnr8zhi`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/lpnr8zhi) — `frieren/so3-tangent-frame-head-rank0`
+- **Rank 1:** [`dwl5oi97`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/dwl5oi97)
+- **Rank 2:** [`d4cvbt1p`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/d4cvbt1p)
+- **Rank 3:** [`i3lx54ou`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/i3lx54ou)
+
+Group: `frieren-so3-tangent-frame`. Final reported metrics will come from rank 0 (`lpnr8zhi`).
+
+## Baseline
+
+alphonse Wave 1 run `m9775k1v`: abupt=7.209%, surf_p=4.802%, vol_p=4.166%✓, wsx=7.109%, wsy=9.100%←BINDING, wsz=10.869%←HARDEST
+
+AB-UPT targets (all must be beaten simultaneously):
+- surf_p: 3.82%
+- vol_p: 6.08% ✓ (already beaten)
+- wsx: 5.35%
+- wsy: 3.65%
+- wsz: 3.63%
+
+## Expected outcome
+
+By construction, predicted shear lies in the tangent plane — eliminating the structural prediction error from a flat head that can predict non-physical normal-direction shear components. This should particularly help τ_y and τ_z on complex curved surfaces.
+
+## Results — KILLED at advisor's request
+
+Killed run `lpnr8zhi` (and DDP siblings `dwl5oi97`, `d4cvbt1p`, `i3lx54ou`) at advisor's instruction. Final captured state: global_step=215,018, ~ep11.0 of 30. The run had ~5 hours wall-clock left to ep30, but the projected ep15 abupt of 9.5–11.0% (vs <9.0% gate) made continuation a poor use of GPU.
+
+### Final metrics (val_primary, rank0 lpnr8zhi @ step 214,801)
+
+| Metric | Final | Baseline (m9775k1v) | AB-UPT Target | Reference |
+|--------|-------|---------------------|---------------|-----------|
+| **abupt** | **13.195%** | 7.209% | — | gap +5.99pp |
+| surface_pressure | 6.288% | 4.802% | <3.82% | gap +1.49pp |
+| volume_pressure | 5.868% | 4.166% | <6.08% ✓ | already under target |
+| wall_shear_x | 13.057% | 7.109% | <5.35% | gap +5.95pp |
+| wall_shear_y | 19.379% | 9.100% | <3.65% | gap +10.28pp ←worst |
+| wall_shear_z | 21.380% | 10.869% | <3.63% | gap +10.51pp ←worst |
+
+### Trajectory (val_primary/abupt across all 9 vals)
+
+| step | epoch | abupt | wsy | wsz |
+|------|-------|-------|-----|-----|
+| 21,742 | 1 | 18.675 | 26.07 | 28.27 |
+| 43,485 | 2 | 17.133 | 23.58 | 26.15 |
+| 65,228 | 3 | 15.480 | 22.35 | 24.13 |
+| 86,971 | 4 | 14.969 | 21.81 | 23.72 |
+| 108,714 | 5 | 14.919 | 21.10 | 22.98 |
+| 130,457 | 6 | 14.088 | 20.70 | 22.58 |
+| 152,200 | 7 | 13.710 | 20.32 | 21.85 |
+| 173,943 | 8 | 13.657 | 20.12 | 22.03 |
+| 195,686 | 9 | **13.195** | 19.38 | 21.38 |
+
+Slope decelerated from -0.0383%/1k (vals 1→6) to -0.0137%/1k (vals 7→9). Convergence had effectively flatlined.
+
+### Command
+
+```bash
+cd target/ && torchrun --nproc_per_node 4 train.py \
+  --epochs 30 --model-layers 4 --model-hidden-dim 256 --model-heads 4 --model-slices 64 \
+  --surface-loss-weight 2.0 --no-use-ema --lr-cosine-t-max 30 --lr 5e-4 \
+  --train-surface-points 32768 --train-volume-points 32768 --no-compile-model \
+  --tangent-frame-head --agent frieren \
+  --wandb-group frieren-so3-tangent-frame --wandb-name frieren/so3-tangent-frame-head \
+  --kill-thresholds "35000:val_primary/abupt_axis_mean_rel_l2_pct<20"
+```
+
+### Peak memory
+
+~32 GB / 80 GB per H100 (4× DDP, no compile). Plenty of headroom — memory was not a binding constraint.
+
+### W&B run IDs
+
+- Rank 0 (primary): [`lpnr8zhi`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/lpnr8zhi)
+- Rank 1: [`dwl5oi97`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/dwl5oi97)
+- Rank 2: [`d4cvbt1p`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/d4cvbt1p)
+- Rank 3: [`i3lx54ou`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/i3lx54ou)
+
+Group: `frieren-so3-tangent-frame`.
+
+### What happened
+
+**Negative result.** The SO(3)-equivariant TangentFrameHead implementation was correct (verified `τ·n ≈ 0` to ~1e-6 in normalised loss space, Frisvad–Duff basis orthonormal to fp32 precision including at hood/roof poles). The structural geometric constraint was being enforced as designed.
+
+The failure mode is **optimization, not modelling**:
+
+1. **Slow early convergence.** Across 9 validations the run dropped abupt from 18.7% → 13.2% (5.5pp over 11 epochs) versus the baseline trajectory which lands ~7% in 30 epochs. Per-axis, the picture is worst on the very axes the SO(3) head was supposed to help: wsy/wsz are at 19.4% / 21.4% — over 2× the baseline. This is the opposite of the predicted outcome.
+
+2. **The Frisvad–Duff basis is geometrically stable but kinematically arbitrary.** The basis is determined entirely by the surface normal, with no relationship to the dominant flow direction. So the model still has to learn an implicit per-point rotation from the canonical tangent basis to the local "flow-aligned" frame in which shear is sparse — an extra learning burden on top of fitting the magnitudes (α, β). The structural constraint `τ⊥n` removes 1 of 3 degrees of freedom, but the remaining 2 DOF live in a basis that is *less* aligned with the data's principal directions than the global Cartesian basis used by the baseline 3-channel head.
+
+3. **Loss curvature.** Reconstructing `τ = α·e_t1 + β·e_t2` and then renormalising introduces a non-linear, normal-dependent transformation between the predicted scalars and the loss space. Gradient flow back through this transformation is per-point anisotropic — at hood/roof points (n≈ẑ) gradients flow only into x/y components; at side panels (n≈±ŷ) into x/z; etc. The optimizer effectively sees a different conditioning at every surface point, which the un-modified lr=5e-4 + T_max=30 schedule does not accommodate.
+
+The hypothesis that the original head was "wasting capacity learning the τ⊥n constraint implicitly" appears wrong on this dataset. The flat 3-channel head learns a near-tangential τ trivially because the Cartesian basis is well-conditioned; the SO(3) head trades that easy optimization for a structural guarantee that the data didn't really need.
+
+### Suggested follow-ups
+
+Per advisor's note, archived for Wave 5+:
+
+1. **Lower head-only LR.** The TangentFrameHead has 1.7K params but lives downstream of an anisotropic per-point transform. Try `lr_head = 1e-4` or `5e-5` while keeping backbone at `5e-4`. The simplest implementation is a parameter group.
+
+2. **Backbone pre-train, then tangent fine-tune.** Train the baseline 3-channel head to convergence, then warm-start a TangentFrameHead by initializing `α = (τ·e_t1)`, `β = (τ·e_t2)` predictions from the baseline outputs. This moves the SO(3) head into a regime where it only needs to refine, not re-learn from scratch.
+
+3. **Flow-aligned tangent basis.** Replace Frisvad–Duff with a basis derived from the *predicted* shear direction at the previous training step (or from a learnable per-point rotation initialised to identity). This is the principled fix to point #2 above — the basis itself becomes learnable so the model stops fighting it.
+
+4. **Hybrid head.** Keep the 3-channel Cartesian shear head as-is, and add a small auxiliary loss `λ · |(τ·n)|²` instead of enforcing the constraint structurally. This was the "simple" version of the hypothesis frieren took further by full equivariance — going back to the simpler version may capture most of the geometric prior without the optimization penalty.
+
+5. **Re-test on a smaller variant where convergence is fast** (e.g. 2L/128d or fewer training points) to isolate whether the issue is fundamental or just a "needs longer + retuned schedule" problem.
+
+---
+
+# #182: [violet] Volume loss downweight {0.5, 0.25} on Fourier PE baseline [CLOSED]
+
+## Hypothesis
+
+Volume pressure already **beats** the AB-UPT target (4.166% vs. 6.08% — best-in-class). The current loss recipe spends fixed capacity / gradient bandwidth on the volume-pressure objective when that head is already converged well below target. Reducing the volume loss weight should redirect the optimizer's attention to the still-failing surface metrics, especially `wall_shear_y` (9.10% vs. 3.65% target — 5.45pp gap) and `wall_shear_z` (10.87% vs. 3.63% target — 7.24pp gap).
+
+This is a complementary direction to frieren's #177 (which upweights `--surface-loss-weight`): violet downweights `--volume-loss-weight` so the relative balance shifts toward the surface fields without inflating absolute gradient norms (which would otherwise destabilize training and require re-tuning LR / clip).
+
+Test two downweight values bracketing the regime where vol_p stays at-target while shear improves.
+
+## Wave 1 Baseline (PR #74 — alphonse)
+
+| Metric | Wave 1 best (val) | AB-UPT target |
+|---|---:|---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+
+## Reproduce commands
+
+Two sequential trials sharing W&B group `bengio-wave2-vol-downweight`. Run Trial A first; once it is past epoch 10 with healthy curves, launch Trial B.
+
+### Trial A — `volume-loss-weight = 0.5`
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.5 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-vol-downweight
+```
+
+### Trial B — `volume-loss-weight = 0.25`
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 4 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.25 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2-vol-downweight
+```
+
+## Decision Criteria
+
+- **Merge** the better trial if `val_primary/abupt_axis_mean_rel_l2_pct` < 7.2091, **and** vol_p stays under the AB-UPT target (6.08%).
+- **Discuss** if abupt is roughly flat (7.0–7.5%) but `wall_shear_y/z` improve materially — that signals the rebalance worked but a different LR or a longer schedule may close the rest. Also good signal if vol_p drifts above 5% (still under target) while shear improves.
+- **Close** if both trials > 8.0, or if vol_p degrades past 6.08% (lost the target advantage) without commensurate shear gains.
+
+## Notes
+
+- Default volume_loss_weight in train.py is 1.0 — verify with `python train.py --help`.
+- Watch vol_p in early epochs: if it rises past 5.5% by epoch 10 in Trial B, the downweight is too aggressive — kill and report.
+- Report best val metrics for both trials, the W&B run IDs, and the best-checkpoint epoch for each.
+- Track per-axis `wall_shear_y_rel_l2_pct` and `wall_shear_z_rel_l2_pct` separately in your report — those are the metrics this hypothesis is most directly trying to move.
+
+## Results (negative — killed early)
+
+| Metric | Wave 1 baseline (val) | AB-UPT target | **vol-downweight 0.5 @ ep2** | vs baseline |
+|---|---:|---:|---:|---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | 7.209 | 4.51 | **24.879** | 3.45× worse |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 | 17.666 | 3.68× worse |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 | 27.369 | 3.35× worse |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 | 23.528 | 3.31× worse |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 | 32.797 | 3.60× worse |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 | 34.596 | 3.18× worse |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 | 15.808 | **lost target** |
+
+**W&B group:** `bengio-wave2-vol-downweight`
+**Run IDs (rank0..3):** `tnpb1777`, `y4bfvygm`, `avc3ic2e`, `o40i85ua`
+**Best epoch reached:** epoch 2 of 50 (only 2 validations completed before kill at step 45,388)
+**Peak step:** 45,388 (~ep2.5)
+**Trial B (`vol-downweight-0.25`):** never launched (advisor killed Trial A before the ep10 health gate).
+
+### Exact command used
+
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --volume-loss-weight 0.5 \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<20" \
+  --wandb-group bengio-wave2-vol-downweight \
+  --wandb-name "violet/vol-downweight-0.5" \
+  --agent violet
+```
+
+**Peak memory:** not finalized (run killed mid-epoch 3); single-GPU memory was nominal during the active phase.
+
+---
+
+# #178: [kohaku] 6L/256d + Fourier PE + T_max=60 depth scaling [CLOSED]
+
+## Hypothesis
+
+Wave 1 showed 4L → 5L (gilbert #76, no PE) improved from ~8.78% to ~7.47%. With Fourier PE, alphonse's 4L is at 7.21%. The question: does pushing depth to 6L with Fourier PE continue the improvement trend? The 2.7pp gap to AB-UPT is substantial; more depth may be needed to capture the full aerodynamic complexity. We double-check by testing 6L directly, skipping 5L (which alphonse is running) to cover the search space efficiently.
+
+Reference: AB-UPT uses a deep transformer stack; we are likely capacity-limited at 4-5 layers for wall shear in particular.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+## Instructions
+
+Run exactly one training job:
+
+```bash
+cd target/ && python train.py \
+  --model-num-layers 6 \
+  --model-hidden-dim 256 \
+  --no-use-ema \
+  --lr 3e-4 \
+  --lr-cosine-t-max 60 \
+  --lr-min 1e-6 \
+  --lr-warmup-epochs 5 \
+  --fourier-pe \
+  --no-compile-model \
+  --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+Key changes vs Wave 1 baseline:
+- `--model-num-layers 6` (was 4) — two additional Transformer layers
+- `--lr-cosine-t-max 60` (was 30) — even longer schedule for deeper model (empirical: deeper models need proportionally more epochs)
+- `--lr-warmup-epochs 5` — important: longer warmup prevents early instability in deep models
+- `--fourier-pe` — mandatory (Wave 1 lesson)
+- `--no-use-ema` — same as baseline winner
+
+Report val_primary metrics at the best checkpoint (lowest val_primary/abupt_axis_mean_rel_l2_pct).
+
+## Baseline
+
+Current best (PR #74, alphonse, Wave 1, W&B run `m9775k1v`):
+
+| Metric | Current Best (val) | AB-UPT Target |
+|--------|-------------------|--------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.2091** | 4.51 |
+| `val_primary/surface_pressure_rel_l2_pct` | 4.802 | 3.82 |
+| `val_primary/wall_shear_rel_l2_pct` | 8.160 | 7.29 |
+| `val_primary/volume_pressure_rel_l2_pct` | **4.166** ✓ | 6.08 |
+| `val_primary/wall_shear_x_rel_l2_pct` | 7.109 | 5.35 |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.100 | 3.65 |
+| `val_primary/wall_shear_z_rel_l2_pct` | 10.869 | 3.63 |
+
+## Results
+
+Acknowledging the advisor's EP50 assessment on run `h7ve1hmb` (kohaku/6l-256d-fourier-pe-deeper). The 6L/256d depth-scaling experiment with Fourier PE and T_max=60 ran to completion (~ep50) and **does not beat the alphonse 4L baseline**.
+
+### Best checkpoint (step 570,143, ~ep32)
+
+| Metric | Best val | Baseline (alphonse 4L) | Δ |
+|--------|:---:|:---:|:---:|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **7.834%** | 7.209% | +0.625pp ❌ |
+| `val_primary/surface_pressure_rel_l2_pct` | 5.235% | 4.802% | +0.43pp ❌ |
+| `val_primary/volume_pressure_rel_l2_pct` | 5.569% | 4.166% | +1.40pp ❌ (still beats AB-UPT 6.08% ✓) |
+| `val_primary/wall_shear_y_rel_l2_pct` | 9.465% | 9.100% | +0.37pp ❌ |
+| `val_primary/wall_shear_z_rel_l2_pct` | 11.420% | 10.869% | +0.55pp ❌ |
+
+**Command used** (per PR instructions):
+```bash
+cd target/ && python train.py \
+  --model-num-layers 6 --model-hidden-dim 256 --no-use-ema \
+  --lr 3e-4 --lr-cosine-t-max 60 --lr-min 1e-6 --lr-warmup-epochs 5 \
+  --fourier-pe --no-compile-model --nproc_per_node 4 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb_group bengio-wave2
+```
+
+W&B run: `h7ve1hmb`
+
+### What happened
+
+Depth scaling 4L → 6L in isolation (with Fourier PE, T_max=60, warmup=5) does **not** continue the Wave 1 trend. The peak val_abupt of 7.834% at ep32 is worse than alphonse's 4L Fourier PE baseline (7.209% at ep30). Combined with the 8L alphonse run (Wave 2) at 11.334%, this confirms the advisor's hypothesis that **the 4L/256d Fourier PE configuration is a sharp optimum** on this dataset/budget, and depth scaling alone is not the right axis.
+
+Volume pressure remains robustly under AB-UPT target (5.569% vs 6.08% target).
+
+### Suggested follow-ups
+
+- Wall shear axis decomposition (wsy=9.47%, wsz=11.42%) remains the dominant gap to AB-UPT target. Future runs should probably target axis-specific loss reweighting or rotation/symmetry-aware architectures rather than raw capacity scaling.
+- If depth is to be revisited, pair it with width or token-budget changes (capacity-balanced sweeps) instead of depth-only.
+
+Closing per advisor directive.
+
+---
+
+# #84: [edward] DrivAerML Dynamic Uncertainty Loss Weighting [CLOSED]
+
+# [edward] DrivAerML Dynamic Uncertainty Loss Weighting (Homoscedastic)
+
+## Hypothesis
+
+The current model uses fixed loss weights for the different output modalities (surface pressure, wall shear x/y/z, volume pressure). Homoscedastic uncertainty weighting (Kendall & Gal 2018, "Multi-Task Learning Using Uncertainty to Weigh Losses for Scene Geometry and Semantics") automatically learns per-task loss weights by treating the weight for each task as a learnable log-variance parameter. Tasks where the model is less certain get lower effective weight, preventing high-variance tasks from dominating training.
+
+**Mathematically:** For each task i with prediction σ_i (learnable), the loss becomes:
+```
+L_total = Σ_i (L_i / (2 * σ_i²)) + log(σ_i)
+```
+The `log(σ_i)` term regularizes σ_i from growing unbounded. This is equivalent to learning the optimal fixed weights but adapting them during training.
+
+**Prediction:** Dynamic uncertainty weighting will improve `abupt_axis_mean_rel_l2_pct` by automatically discovering the optimal balance between surface_pressure, wall_shear_x/y/z, and volume_pressure losses, especially since these tasks have very different error magnitudes.
+
+## Implementation Instructions
+
+In `train.py` or `model.py`, add learnable log-variance parameters for each task:
+
+```python
+import torch
+import torch.nn as nn
+
+class UncertaintyWeightedLoss(nn.Module):
+    """
+    Homoscedastic uncertainty multi-task loss weighting.
+    Reference: Kendall & Gal (2018) - Multi-Task Learning Using Uncertainty
+    """
+    def __init__(self, n_tasks: int = 5):
+        super().__init__()
+        # Initialize log(sigma^2) = 0 → sigma^2 = 1 → equal initial weights
+        self.log_vars = nn.Parameter(torch.zeros(n_tasks))
+
+    def forward(self, losses: list[torch.Tensor]) -> torch.Tensor:
+        """
+        losses: list of per-task losses [surface_pressure, wall_shear_x, wall_shear_y, 
+                                         wall_shear_z, volume_pressure]
+        """
+        total = 0.0
+        for i, loss in enumerate(losses):
+            # 1/(2*sigma^2) * loss + log(sigma)
+            precision = torch.exp(-self.log_vars[i])
+            total = total + 0.5 * precision * loss + 0.5 * self.log_vars[i]
+        return total
+```
+
+**Integration steps:**
+1. Instantiate `UncertaintyWeightedLoss(n_tasks=5)` and add it to the optimizer parameters
+2. Compute per-task losses separately before combining
+3. Log the learned `log_vars` values to W&B to see how they evolve (add to the W&B log dict)
+4. At inference time, no change needed — predictions use the raw model output
+
+**Tasks to weight:** Map the 5 DrivAerML targets:
+- Task 0: surface_pressure (cp)
+- Task 1: wall_shear_x (tau_x)
+- Task 2: wall_shear_y (tau_y)
+- Task 3: wall_shear_z (tau_z)
+- Task 4: volume_pressure
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream2-edward --agent edward
+```
+
+**Note:** Add a CLI flag (e.g. `--uncertainty-weighting`) to toggle this feature on/off.
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report the final learned `log_vars` values (what did the model learn to weight each task?)
+- Report all `test_primary/*` metrics
+- Compare convergence speed vs. fixed weights (did uncertainty weighting converge faster?)
+- Note any training instability (if log_vars diverge, reduce lr for the uncertainty parameters)
+
+## Results — Final test_primary on epoch-16 best checkpoint (UW with clamp=[-5, 5])
+
+Training was stopped at epoch 20/50 per advisor approval after the run destabilized post-epoch 16 (clamp-induced runaway precision; see prior comment for full diagnostic). Best checkpoint (epoch 16) was preserved on disk and post-hoc evaluated end-to-end on the full val and test splits via a new `train.py --eval-only` flag that resumes the same W&B run id.
+
+**W&B run id:** [3gfy3fi7](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/3gfy3fi7) — `edward/uw-fixed-kill`, group `bengio-stream2-edward` (rank 0; the rank 1/2/3 runs `izw183ei`, `6ec0jven`, `er6k2hvz` carry the per-rank training telemetry).
+
+### test_primary/* on the held-out 50-case test split
+
+| Target | This run | AB-UPT ref | Δ |
+|---|---:|---:|---:|
+| `test_primary/abupt_axis_mean_rel_l2_pct` | **9.99** | 4.51 | +5.48 |
+| `test_primary/surface_pressure_rel_l2_pct` | **5.23** | 3.82 | +1.41 |
+| `test_primary/wall_shear_rel_l2_pct` (vector `tau`) | **9.63** | 7.29 | +2.34 |
+| `test_primary/wall_shear_x_rel_l2_pct` | **7.99** | 5.35 | +2.64 |
+| `test_primary/wall_shear_y_rel_l2_pct` | **11.88** | 3.65 | +8.23 |
+| `test_primary/wall_shear_z_rel_l2_pct` | **12.34** | 3.63 | +8.71 |
+| `test_primary/volume_pressure_rel_l2_pct` | **12.51** | 6.08 | +6.43 |
+
+`test_primary/{surface,wall_shear,volume}_pressure_mae`: 0.0146, 0.0861, 28.19.
+
+### full_val/* (best checkpoint reload) — for sanity vs. the per-epoch val table I posted earlier
+
+| Metric | full_val | Best val (epoch 16, the same checkpoint at training time) |
+|---|---:|---:|
+| `full_val_primary/abupt_axis_mean_rel_l2_pct` | 8.87 | 8.87 |
+| `full_val_primary/surface_pressure_rel_l2_pct` | 5.47 | 5.47 |
+| `full_val_primary/wall_shear_rel_l2_pct` | 9.81 | 9.81 |
+| `full_val_primary/wall_shear_x_rel_l2_pct` | 8.14 | 8.14 |
+| `full_val_primary/wall_shear_y_rel_l2_pct` | 12.04 | 12.04 |
+| `full_val_primary/wall_shear_z_rel_l2_pct` | 12.86 | 12.86 |
+| `full_val_primary/volume_pressure_rel_l2_pct` | 5.83 | 5.83 |
+
+(`full_val` matches end-of-epoch-16 val exactly, confirming the eval-only flag faithfully reloads the saved best checkpoint.)
+
+### Final learned `log_vars` (from the last train step, just before SIGTERM in epoch ~20)
+
+| task | log_var | precision (1/σ²) | effective weight (0.5/σ²) |
+|---|---:|---:|---:|
+| surface_pressure | **-5.00 (clamped)** | 148.4 | 74.2 |
+| wall_shear_x | **-5.00 (clamped)** | 148.4 | 74.2 |
+| wall_shear_y | -4.10 | 60.3 | 30.2 |
+| wall_shear_z | -4.08 | 59.1 | 29.6 |
+| volume_pressure | -4.68 | 107.8 | 53.9 |
+
+All five were drifting toward the lower clamp, with surface_pressure and wall_shear_x reaching it first. The relative ordering UW discovered (`surf > ws_x > vol > ws_y ≈ ws_z`) is plausible — the lowest-loss task gets the highest precision — but the math wanted clamp=[-10, 10] (or unclamped) so log_vars could equilibrate. The destabilization at epoch 17+ is exactly the failure mode predicted by that analysis.
+
+### Convergence speed vs. fixed weights
+
+The cohort's other 4L/256d/no-EMA runs at this same recipe sit in the 8.3–9.1% val range at epoch ~19–24. UW reached `best_val=8.87` at epoch 16, then regressed; without UW we'd expect a similar val number at this depth/width but without the late-stage destabilization risk. UW did **not** converge faster in any meaningful sense for this problem.
+
+### Train command
+
+```bash
+torchrun --nproc_per_node=4 train.py --uncertainty-weighting --no-compile-model \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --no-use-ema \
+  --lr 3e-4 --weight-decay 1e-4 --batch-size 2 --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/base_mse_loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream2-edward --agent edward --wandb-name edward/uw-fixed-kill
+```
+
+(SIGTERM'd cleanly at epoch 20; best checkpoint preserved at `outputs/drivaerml/run-3gfy3fi7/checkpoint.pt`.)
+
+### Eval-only command (post-hoc test_primary on the saved best checkpoint)
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python train.py --eval-only --eval-only-run-id 3gfy3fi7 \
+  --no-compile-model --no-use-ema \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 --batch-size 2 \
+  --eval-surface-points 40000 --eval-volume-points 40000 \
+  --wandb-group bengio-stream2-edward --agent edward --wandb-name edward/uw-fixed-kill
+```
+
+The new `--eval-only --eval-only-run-id <id>` path skips training, builds the model + loaders + transform on a single rank, loads `outputs/drivaerml/run-{id}/checkpoint.pt`, resumes the original W&B run, and calls the existing `run_final_evaluation` helper. Resulting `full_val_primary/*` and `test_primary/*` are appended to the same W&B run that produced the checkpoint.
+
+### Peak memory
+
+**9.6 GB / GPU** during training (4× H100 DDP, batch_size=2/rank, 40k surface + 40k volume points). Eval-only on a single GPU peaked at ~4.4 GB.
+
+### What happened
+
+The hypothesis that homoscedastic UW would auto-balance the per-task losses and improve `abupt_axis_mean_rel_l2_pct` did **not pay off in practice** for this clamp setting. Two failure modes compounded:
+
+1. **Clamp-induced rectified equilibrium.** Per-task MSEs after target normalization are very small (0.003–0.02), so the analytic optimum `s* = log(L)` lands at `-3.9` to `-5.7`. With the spec's clamp at `[-5, 5]`, two tasks (surface_pressure, wall_shear_x) saturated at the lower bound. Effective weight `0.5·exp(-(-5))=74.2` for those tasks dwarfed the others, breaking the auto-balancing intent.
+2. **Late-stage destabilization.** Once two log_vars saturated, the global gradient norm exploded from ~10 (early/mid training) to ~140 (post-epoch 16) under the `--grad-clip-norm 1.0` setting; every step was clipped by ~140×, leaving the optimizer chasing the clamped tasks at the expense of `ws_y/z/vol`. Per-task losses for those started climbing (`ws_z` doubled from 0.010 to 0.022 in 4 epochs), and val abupt regressed from 8.87 (epoch 16) → 14.29 (epoch 20).
+
+Net result on test_primary: the run trails the AB-UPT reference everywhere by 1.4–8.7 percentage points, and trails the cohort's fixed-weight 4L/256d/no-EMA runs (e.g. tanjiro 8.98 val, frieren w/ volume_pressure already below 6.08 ref). **The hypothesis is not validated for this problem at this configuration**; UW with `clamp=[-5, 5]` is strictly worse than the cohort's fixed-weight recipe.
+
+The volume_pressure test/val gap (5.83 → 12.51) is striking and is the dominant component of the abupt-mean degradation on test. This is consistent with UW under-weighting `volume_pressure` on val (its log_var was the third-highest precision) but the under-weighting hurt generalization to test cases. Surface pressure and wall_shear (vector) test numbers are within ~0.2 pct of val, so the generalization story is volume-specific.
+
+### Suggested follow-ups
+
+1. **Wider clamp UW (`clamp=[-10, 10]` or unclamped).** This was option 2 in my pre-stop comment and is the natural next experiment if UW is to be revisited. Math says log_vars want to land at ~-4 to -6 here; giving them the room to equilibrate is necessary to actually measure the *idea* of UW rather than a rectified version. Note for the advisor's idea queue (you've already noted this in your last reply).
+2. **UW without the +0.5·log_var regularizer.** The regularizer is what drives log_vars toward the per-task loss magnitude (i.e. toward the lower clamp here when losses are small). Removing it and using an explicit per-task scale schedule (e.g. cosine ramp from `s_init` to `s_final` per task) decouples weighting dynamics from per-task loss magnitude. This is the cleanest way to isolate "is dynamic weighting useful?" from "is the K&G formula well-conditioned for this loss-scale regime?"
+3. **Loss-scale-aware initialization.** If we want to keep K&G's formula, initialize `log_var_i = log(L_i_at_step_500)` (one short pre-pass to estimate per-task losses, then init log_vars there). That avoids the long warm-in where log_vars drift from 0 to -4-ish, during which UW is just reproducing the equal-weights baseline noisily. Could plausibly halve the time-to-best.
+4. **Use a higher effective floor for `--grad-clip-norm`.** The 1.0 clip with UW makes the optimizer step direction extremely sensitive to the clamped tasks. A 10–50 clip would let the unclamped tasks contribute more even when the clamped tasks dominate the raw norm. (Diagnostic: pre-clip norm went from ~10 → 140 over the run; the clip is what's distorting the step direction.)
+5. **Decoupled per-task LRs instead of dynamic weights.** A simpler alternative: keep fixed equal weights but use task-conditioned LR scales applied to head parameters (one head per task). This achieves the "balance task contributions" goal without the K&G regularizer pathology.
+
+Items 1–2 directly answer the advisor's note about the "math says we want clamp=[-10,10]" follow-up; items 3–5 are independent ideas that came out of staring at the diagnostic table.
+
+---
+
+# #80: [tanjiro] DrivAerML Surface Loss Weight Sweep [CLOSED]
+
+# [tanjiro] DrivAerML Surface Loss Weight Tuning: surface_weight=2.0 + 4L/256d
+
+## Hypothesis
+
+The default training uses equal loss weights for surface and volume predictions. Surface metrics (surface_pressure, wall_shear) are the most physically critical for aerodynamic drag and lift coefficient estimation. Upweighting the surface loss by 2x should push the model to prioritize surface accuracy, potentially reducing `surface_pressure_rel_l2_pct` and `wall_shear_*` metrics at the cost of slightly worse `volume_pressure_rel_l2_pct`.
+
+**Prediction:** `surface_pressure_rel_l2_pct` and `wall_shear_*` will improve, `volume_pressure_rel_l2_pct` may slightly worsen. The overall `abupt_axis_mean_rel_l2_pct` (which includes both) should net improve since wall shear contributes 3 of the 5 axis metrics.
+
+**Note:** This experiment does NOT use Fourier PE to isolate the surface weight effect. Using the standard recipe (4L/256d, no-EMA, T_max=30) with surface_weight=2.0.
+
+## No Model Architecture Change Required
+
+This experiment uses the default `ContinuousSincosEmbed` positional encoding. No changes to `model.py` are needed.
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --surface-loss-weight 2.0 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-tanjiro --agent tanjiro
+```
+
+**Bonus trial (if time allows):** Try `--surface-loss-weight 3.0` in the same wandb group:
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --surface-loss-weight 3.0 \
+  --train-surface-points 40000 --train-volume-points 40000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-tanjiro --agent tanjiro
+```
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report final `val_primary/abupt_axis_mean_rel_l2_pct` for weight=2.0 (and weight=3.0 if run)
+- Report all `test_primary/*` metrics — especially compare surface vs volume tradeoff
+- Note the training loss breakdown (surface vs volume component) if visible in W&B logs
+
+## Results
+
+### Best-val checkpoint metrics (ep31)
+
+**val_primary (re-eval at best ckpt):**
+| Metric | SW=2.0 | AB-UPT target | Δ vs target |
+|---|---|---|---|
+| `abupt_axis_mean_rel_l2_pct` | **8.436** | 4.51 | +87% |
+| `surface_pressure_rel_l2_pct` | 5.455 | 3.82 | +43% |
+| `wall_shear_rel_l2_pct` | 9.456 | 7.29 | +30% |
+| `volume_pressure_rel_l2_pct` | **5.186** | 6.08 | **−15% (beats target)** |
+| `wall_shear_x_rel_l2_pct` | 8.076 | 5.35 | +51% |
+| `wall_shear_y_rel_l2_pct` | 11.119 | 3.65 | +205% |
+| `wall_shear_z_rel_l2_pct` | 12.344 | 3.63 | +240% |
+
+**test_primary (best ckpt → held-out test set):**
+| Metric | SW=2.0 | AB-UPT target | Δ vs target |
+|---|---|---|---|
+| `abupt_axis_mean_rel_l2_pct` | **9.697** | 4.51 | +115% |
+| `surface_pressure_rel_l2_pct` | 5.078 | 3.82 | +33% |
+| `wall_shear_rel_l2_pct` | 9.242 | 7.29 | +27% |
+| `volume_pressure_rel_l2_pct` | 12.897 | 6.08 | +112% |
+| `wall_shear_x_rel_l2_pct` | 7.953 | 5.35 | +49% |
+| `wall_shear_y_rel_l2_pct` | 10.895 | 3.65 | +198% |
+| `wall_shear_z_rel_l2_pct` | 11.664 | 3.63 | +221% |
+
+### Comparison vs alphonse (Fourier-PE, same recipe sans surface weighting)
+
+| Metric (test_primary) | tanjiro SW=2.0 | alphonse Fourier-PE | Winner |
+|---|---|---|---|
+| abupt_axis_mean | 9.697 | 8.480 | alphonse |
+| surface_pressure | 5.078 | 4.405 | alphonse |
+| wall_shear | 9.242 | 7.871 | alphonse |
+| volume_pressure | 12.897 | 12.175 | alphonse |
+| wall_shear_x | 7.953 | 6.926 | alphonse |
+| wall_shear_y | 10.895 | 8.778 | alphonse |
+| wall_shear_z | 11.664 | 10.116 | alphonse |
+
+**SW=2.0 does NOT beat alphonse on the primary metric** (9.70 vs 8.48 test abupt). Per advisor's plan, proceeding with the Trial B1/B2/B3 matrix without an early merge.
+
+### Validation trajectory (val_primary/abupt_axis_mean_rel_l2_pct)
+
+- ep11: 9.55, ep17: 9.03, ep18: 8.98, ep23: 8.86, ep26: 8.60, ep28: 8.51, **ep31 best: 8.436**
+- ep38: 8.65, ep41: 8.76, ep43: 9.08 → ep50 finished
+- Cosine warm-restart bounce after ep31 confirms advisor's read; best-checkpoint reload was correctly used for test eval.
+
+### Run details
+
+- **W&B (rank0):** https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/846uciam
+- **W&B group:** `bengio-stream1-tanjiro`
+- **Best epoch:** 31 / 50
+- **Total train time:** 1430.85 min (~23.8 h)
+- **Peak memory:** ~11 GiB / 97 GiB per GPU (4 GPUs, plenty of headroom)
+- **Command:**
+  ```bash
+  torchrun --nproc_per_node=4 train.py \
+    --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+    --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+    --epochs 50 --lr-cosine-t-max 30 \
+    --surface-loss-weight 2.0 \
+    --train-surface-points 40000 --train-volume-points 40000 \
+    --no-compile-model \
+    --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+    --wandb-group bengio-stream1-tanjiro --agent tanjiro \
+    --wandb-name tanjiro/surface-weight-2.0
+  ```
+
+### What happened
+
+1. **Surface weighting did NOT improve surface metrics relative to alphonse.** Alphonse's Fourier-PE delivered better surface_pressure (4.41 vs 5.08), better wall_shear (7.87 vs 9.24), and better volume_pressure (12.18 vs 12.90). The Fourier positional encoding is a much stronger lever than reweighting the loss.
+2. **The hypothesis "upweight surface, push surface metrics down" partially held vs no-Fourier baseline**, but Fourier-PE is a confounder: alphonse hits *all* metrics better with weight=1.0 + Fourier than tanjiro hits with weight=2.0 + standard PE.
+3. **Volume pressure prediction works on val but generalises poorly to test** (5.19 → 12.90 — a >2x degradation on a distribution-shifted held-out set; also seen on alphonse 4.17 → 12.18). This is consistent across both runs and suggests a dataset-level issue (volume points sampled differently in train/val vs test split), not a hypothesis-specific failure.
+4. **wsy/wsz remain the worst components** at 10.9 and 11.7 (test) — surface weighting did not specifically improve them. They are likely under-resolved by the architecture rather than under-weighted by the loss.
+5. **Cosine T_max=30 produces a measurable bounce** (best ep31, ep50 abupt has risen ~0.7pp). For the next matrix, comparing T_max=30 vs T_max=50 will isolate whether the bounce or the warmth at end is the bigger lever.
+
+### Suggested follow-ups (per advisor's matrix)
+
+- **Trial B1:** SW=2.0, T_max=50, 50 epochs (monotone-decay control of current best)
+- **Trial B2:** SW=3.0, T_max=30, 50 epochs (original SW=3.0 idea)
+- **Trial B3:** SW=3.0, T_max=50, 50 epochs (most aggressive combination)
+- Each ~13h on 4xH100 → ~39h total. Will queue with sequential auto-launcher and report each as it completes.
+
+---
+
+# #79: [emma] DrivAerML 60k Points + Fourier PE [CLOSED]
+
+# [emma] DrivAerML More Training Points: 60k Surface/Volume + 4L/256d + no-EMA + Fourier
+
+## Hypothesis
+
+The default training setup uses 40k surface points and 40k volume points per sample. DrivAerML contains dense CFD meshes with ~300k+ surface points per geometry. Increasing the sampled point count to 60k gives the model more spatial context per training step, potentially capturing finer geometric details and flow features that are missed with sparser sampling.
+
+**Prediction:** 60k points will improve especially `surface_pressure_rel_l2_pct` and `wall_shear_*` metrics since more surface sample coverage reduces sampling bias on complex vehicle geometry regions (wheel arches, underbody, rear diffuser).
+
+**Trade-off:** Each step will be ~1.5x slower. With 50 epochs the wall-clock time will increase, but the quality improvement should outweigh the cost.
+
+## Model Architecture Change (Required)
+
+Replace `ContinuousSincosEmbed` with `FourierEmbed` in `model.py`. Add the following class **before** the `SurfaceTransolver` class:
+
+```python
+import math
+
+class FourierEmbed(nn.Module):
+    """Fourier positional encoding with geometric frequency progression."""
+    def __init__(self, hidden_dim: int, input_dim: int = 3, num_freqs: int = 8):
+        super().__init__()
+        freqs = 2.0 ** torch.arange(num_freqs).float()
+        self.register_buffer("freqs", freqs)
+        raw_dim = input_dim * num_freqs * 2
+        self.proj = nn.Linear(raw_dim, hidden_dim) if raw_dim != hidden_dim else nn.Identity()
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords = coords.float()
+        angles = coords.unsqueeze(-1) * self.freqs * math.pi
+        emb = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        emb = emb.flatten(start_dim=-2)
+        return self.proj(emb)
+```
+
+In `SurfaceTransolver.__init__`, replace:
+```python
+self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+```
+with:
+```python
+self.pos_embed = FourierEmbed(hidden_dim=n_hidden, input_dim=space_dim, num_freqs=8)
+```
+
+## Training Command
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+**If batch-size 2 with 60k points causes OOM, fall back to:**
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 1 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+## Baseline Targets to Beat (AB-UPT Reference)
+
+| Metric | AB-UPT Target |
+|--------|--------------|
+| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
+| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
+| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
+| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
+| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
+| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |
+| `test_primary/abupt_axis_mean_rel_l2_pct` | ~4.51 |
+
+**Primary checkpoint metric:** `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better)
+
+## Success Criteria
+
+- Report final `val_primary/abupt_axis_mean_rel_l2_pct` compared to alphonse (40k points)
+- Report all `test_primary/*` metrics
+- Report whether batch_size=2 was feasible or if you had to fall back to batch_size=1
+- Report training wall-clock time per epoch to quantify the compute overhead
+
+## Results — Trial A (60k Points + Fourier PE, T_max=30)
+
+**Trial A complete.** Total runtime 23h08m (1389 min). Best validation at **epoch 32**, terminal at epoch 50 was +0.58pp worse due to the cosine warm-restart bounce as predicted.
+
+### Best-val checkpoint metrics (epoch 32)
+
+| Metric | val (best ckpt) | full_val (best ckpt) | **test_primary** | AB-UPT Target |
+|---|---:|---:|---:|---:|
+| `abupt_axis_mean_rel_l2_pct` | **8.214** | 8.214 | **9.329** | ~4.51 |
+| `surface_pressure_rel_l2_pct` | — | 5.528 | **5.187** | 3.82 |
+| `wall_shear_rel_l2_pct` | — | 8.973 | **8.733** | 7.29 |
+| `volume_pressure_rel_l2_pct` | — | 5.909 | **12.890** | 6.08 |
+| `wall_shear_x_rel_l2_pct` | — | 7.902 | **7.730** | 5.35 |
+| `wall_shear_y_rel_l2_pct` | — | 9.904 | **9.717** | 3.65 |
+| `wall_shear_z_rel_l2_pct` | — | 11.828 | **11.123** | 3.63 |
+
+### val_primary trajectory (cosine T_max=30 with warm-restart bounce)
+
+| Epoch | val_abupt% | LR phase |
+|---|---:|---|
+| 5 | 10.42 | warmup-ramp |
+| 10 | 9.42 | descending |
+| 15 | 8.90 | descending |
+| 20 | 8.54 | descending |
+| 25 | 8.33 | mid-decay |
+| 30 | 8.216 | reached η_min |
+| **32** | **8.214** | **best** (rising LR) |
+| 35 | 8.277 | bounce |
+| 40 | 8.437 | bounce |
+| 45 | 8.593 | bounce |
+| 50 | 8.794 | terminal |
+
+### Setup confirmed
+
+- **Batch size:** 2 (no OOM at 60k points; peak 14.3GB/GPU)
+- **Wall-clock per epoch:** ~27 min (target promise met; 1.5x the 40k budget)
+- **Total wall-clock:** 23h08m for 50 epochs
+- **DDP:** 4 GPUs, no torch.compile (`--no-compile-model` per advisor warning)
+- **Notable:** test_primary/volume_pressure_rel_l2_pct = 12.89% vs full_val 5.91% — large train/test split gap on volume; the dataset's volume pressure scale on heldout test is harder than val.
+
+### Train command used
+
+```bash
+torchrun --nproc_per_node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema --lr 3e-4 --weight-decay 1e-4 --batch-size 2 \
+  --epochs 50 --lr-cosine-t-max 30 \
+  --train-surface-points 60000 --train-volume-points 60000 \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
+  --wandb-group bengio-stream1-emma --agent emma
+```
+
+- **Peak memory:** 14.3 GB/GPU
+- **W&B run ID:** kuk0oy8g
+- **W&B group:** bengio-stream1-emma
+
+### What happened
+
+60k point sampling at batch_size=2 trained cleanly throughout. Fourier PE (8 freqs, geometric base-2 progression) substituted for ContinuousSincosEmbed without crashing or stalling. Convergence trajectory was monotone and healthy through epoch 30. The cosine schedule with `T_max=30 < epochs=50` triggered the warm-restart at ep30, after which val degraded steadily by +0.58pp (8.214 → 8.794) — exactly the secondary-cycle pathology the advisor warned of.
+
+**test_primary/abupt = 9.329%** (best-val ckpt at ep32) is +1.12pp worse than the val number, which is consistent with the test split's harder volume_pressure region (12.89% vs 5.91% val). Per-channel test errors are otherwise close to val. The result is **not under the 8.0% threshold the advisor set for an immediate-merge winner**, so launching Trial B (T_max=50, monotone decay) per the authorization.
+
+### Suggested follow-ups
+
+- **Trial B (already authorized):** Same recipe with `--lr-cosine-t-max 50` so the LR decays monotonically through the full schedule. Launching immediately.
+- The val/test gap on `volume_pressure_rel_l2_pct` (5.91 → 12.89) is striking. Worth a separate investigation into whether the volume sampling distribution differs systematically between val and test (e.g., extreme drag cars over-represented in test).
+- `wall_shear_y/z` are the largest weakness vs AB-UPT (~3x worse) — these are the narrow-band lateral and vertical shear components. Consider directional loss weighting in a follow-up if Trial B doesn't close the gap.
+
+---
+

--- a/experiment_log/merged_2026-05-03_06-36.md
+++ b/experiment_log/merged_2026-05-03_06-36.md
@@ -1,0 +1,145 @@
+# Merged Experiments (6 winners)
+
+## #140: [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1)
+
+## Hypothesis
+
+**Curriculum (easy-first) case sampling via per-case gradient-norm difficulty proxy will improve convergence speed and final `abupt_axis_mean_rel_l2_pct`.**
+
+In Wave 1, all 16 runs used uniform random case sampling throughout training. However, DrivAerML cases vary substantially in aerodynamic complexity — some vehicles produce nearly laminar flow while others have strong separation and recirculation. Standard sampling presents hard and easy cases with equal frequency from epoch 0, potentially causing early gradient conflict and slowing the model's ability to build robust representations.
+
+The hypothesis: **training on "easy" (low gradient-norm) cases first and gradually introducing harder cases** mirrors classical curriculum learning findings and should help the model establish stable surface pressure and wall-shear representations before being overwhelmed by aerodynamically complex geometries. Once the model has a stable foundation (epochs 1–10), switching to uniform sampling ensures full coverage of the training distribution.
+
+This experiment uses the **alphonse Wave 1 leader recipe** (4L/256d/4H + Fourier PE + T_max=30 + no-EMA) as the base — the strongest known DDP4 configuration.
+
+---
+
+---
+
+## #74: [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1)
+
+## Hypothesis
+
+**Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseline**
+
+The strongest known DrivAerML result from the radford branch (PR #2593) used a specific recipe:
+- 4 transformer layers, 256 hidden dim (vs default 3L/192d)
+- No EMA (EMA was found to hurt on DrivAerML)
+- Fourier/sinusoidal positional encoding replacing the default ContinuousSincosEmbed
+- Cosine LR schedule with T_max=30
+- lr=3e-4, weight_decay=1e-4, batch_size=2
+
+This experiment replicates that recipe on the bengio branch to establish a confirmed baseline. Without this replication we are building on unconfirmed assumptions.
+
+**Source:** radford PR #2593, ~12.96% abupt_axis_mean_rel_l2_pct on the test set.
+
+---
+
+## #176: [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline
+
+## Hypothesis
+
+Wave 1 winner used lr=3e-4 (default). However, 3e-4 may be suboptimal for the Fourier PE baseline — the Fourier features expand the input space significantly and a slightly higher or lower lr may train more efficiently. This experiment sweeps two lr values (1e-4 and 5e-4) on the exact Wave 1 winner config to find the optimal lr for the Fourier PE regime. Run both as sequential trials.
+
+**Target gap:** val_abupt from 7.21% → below 6.8%.
+
+## Results
+
+### Trial A (lr=1e-4)
+- **Run 1 (`ro7ocwte`)**: killed at end of ep1 by val_primary kill threshold (abupt=40.97% at step 17,816 vs threshold <25). Cause: with lr-warmup-epochs=3, lr at end of ep1 was ~3.3e-5, three times lower than alphonse's lr at the same step.
+- **Run 2 (`lle5ylae`, kill threshold relaxed to step >= 100k)**: killed at advisor's request (abupt=40.5% at step 22,043 / step 100k+ assessed too late). lr=1e-4 is too low for AB-UPT under T_max=50 — model was severely under-trained and would not catch up before the cosine valley.
+
+**Conclusion:** lr=1e-4 is non-competitive with the FourierEmbed swap.
+
+### Trial B (lr=5e-4) — `ld3ff1gs`
+
+Per-epoch val_primary trajectory:
+
+| Epoch | step | abupt | surface_p | wall_shear | volume_p |
+|-------|------|-------|-----------|------------|----------|
+| 1 | 17,816 | 30.17 | 23.24 | 31.66 | 22.34 |
+| 2 | 35,633 | 14.98 | 10.34 | 16.03 | 11.01 |
+| 3 | 53,450 | 12.51 | 8.52 | 13.46 | 9.09 |
+| 4 | 71,267 | 11.41 | 7.65 | 12.28 | 8.33 |
+| 5 | 89,084 | 11.05 | 7.34 | 11.75 | 8.72 |
+| 6 | 106,901 | 10.34 | 6.83 | 11.21 | 7.41 |
+| 7 | 124,718 | 9.61 | 6.37 | 10.39 | 6.97 |
+| 8 | 142,535 | 9.37 | 6.23 | 10.17 | 6.76 |
+| 9 | 160,352 | 9.71 | 6.48 | 10.50 | 7.09 |
+| 10 | 178,169 | 9.21 | 6.09 | 10.00 | 6.62 |
+| **11 (best)** | **195,986** | **9.122** | **6.041** | **9.910** | **6.522** |
+| 12 | 213,803 | 10.44 | 7.09 | 11.16 | 7.95 |
+
+**Best so far (ep11):**
+
+| Metric | ep11 best | Baseline (alphonse, lr=3e-4) | Δ vs baseline |
+|--------|-----------|------------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.122** | 7.209 | **+1.91% (worse)** |
+| `val_primary/surface_pressure_rel_l2_pct` | 6.041 | 4.802 | +1.24% (worse) |
+| `val_primary/wall_shear_rel_l2_pct` | 9.910 | 8.160 | +1.75% (worse) |
+| `val_primary/volume_pressure_rel_l2_pct` | 6.522 | 4.166 | +2.36% (worse) |
+
+ep12 regression: all four primary metrics jumped together (+1.32% on abupt) with two large train/loss spikes (steps 199,522 and 211,125 at ~0.51 vs ~0.01 baseline) — destabilization signal, not noise.
+
+**Conclusion:** lr=5e-4 with `--lr-cosine-t-max 50` + Fourier PE is non-competitive vs alphonse's lr=3e-4 (T_max=30). Even at ep11-best, model is ~1.9% worse on abupt with declining slope and a paired-channel destabilization at ep12. Not worth running to ep31 valley.
+
+**Final command used (Trial B):**
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema \
+  --lr 5e-4 --epochs 50 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb-group bengio-wave2-lr-sweep --wandb-name chihiro/lr-sweep-5e-4 \
+  --agent chihiro
+```
+
+W&B run IDs (rank-0): Trial A v1 `ro7ocwte`, Trial A v2 `lle5ylae`, Trial B `ld3ff1gs` (group: `bengio-wave2-lr-sweep`).
+
+Peak GPU memory: ~10.85 GB / GPU (4× A100), all four GPUs ~90-95% util throughout.
+
+---
+
+## #354: [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline
+
+## Hypothesis
+
+A systematic +1.0–1.5 pp structural gap has been observed between every recent `fourier-pe nf=8` baseline-config run and the alphonse `m9775k1v` baseline (ep30, `val_abupt=7.2091%`). All the data points:
+
+| Run ID | Config | Best abupt |
+|--------|--------|-----------|
+| `m9775k1v` | alphonse baseline PR #74 (ep30 best) | **7.2091%** |
+| `67u9bilg` | haku surface-weight 2.0 (identical arch, 50ep) | 8.168% |
+| `kuz4na0j` | trial-B wsy/wsz 0.5 | 8.895% |
+| `w3thlivw` | mirror0.5 + sw2.0 | 8.919% |
+| `31s1j3a0` | gc=0.5 (grad clip) | 9.215% |
+| `0fhryk4r` | fern SWA-last5 (fourier-pe confirmed, ep10) | 9.270% |
+
+**Architecture-identical runs (3,249,813 params, FourierEmbed, lr=3e-4, cosine_t_max=30, no-EMA) still land ~1pp above alphonse.** This cannot be explained by hyperparameter difference — it is a codebase, data, or environment change between the alphonse merge (PR #74) and current HEAD.
+
+This affects every in-flight Wave 5–8 PR. Finding and fixing this regression is the highest-leverage action in the entire research programme right now.
+
+---
+
+## #174: [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule
+
+## Hypothesis
+
+Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. That config likely underfits given the short cosine schedule (30 epochs). Adding a 5th layer increases model capacity; pairing it with a longer T_max=50 schedule gives the deeper model sufficient time to converge. Wave 1 5L run (gilbert, #76) reached val_abupt=7.47% at ep30 — but was run WITHOUT Fourier PE and without the longer schedule. This run isolates depth+PE+schedule together.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+---
+
+## #487: Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d
+
+## Hypothesis
+
+The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num-freqs` = 8 (default in the codebase). The Fourier positional embedding maps 3D coordinates through sin/cos of 8 frequency bands, producing a 48-dim input (3 coords × 8 freqs × 2 = 48) before a linear projection to hidden_dim=256. Increasing the number of Fourier frequency bands to 16 (96-dim input) gives the model more high-frequency positional resolution, potentially capturing the fine-scale geometry variation in boundary-layer regions that drive wsy/wsz errors. Conversely, 4 bands (24-dim input) would test whether the current 8 bands are over-specified. The cost of more frequencies is only a larger input projection — the rest of the model is unchanged.
+
+This is a single architectural knob targeting positional encoding expressiveness.
+
+---
+

--- a/experiment_log/merged_2026-05-03_07-16.md
+++ b/experiment_log/merged_2026-05-03_07-16.md
@@ -1,0 +1,147 @@
+# Merged Experiments (6 winners)
+
+These PRs beat baseline and were merged, in chronological order.
+
+## #140: [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1)
+
+## Hypothesis
+
+**Curriculum (easy-first) case sampling via per-case gradient-norm difficulty proxy will improve convergence speed and final `abupt_axis_mean_rel_l2_pct`.**
+
+In Wave 1, all 16 runs used uniform random case sampling throughout training. However, DrivAerML cases vary substantially in aerodynamic complexity — some vehicles produce nearly laminar flow while others have strong separation and recirculation. Standard sampling presents hard and easy cases with equal frequency from epoch 0, potentially causing early gradient conflict and slowing the model's ability to build robust representations.
+
+The hypothesis: **training on "easy" (low gradient-norm) cases first and gradually introducing harder cases** mirrors classical curriculum learning findings and should help the model establish stable surface pressure and wall-shear representations before being overwhelmed by aerodynamically complex geometries. Once the model has a stable foundation (epochs 1–10), switching to uniform sampling ensures full coverage of the training distribution.
+
+This experiment uses the **alphonse Wave 1 leader recipe** (4L/256d/4H + Fourier PE + T_max=30 + no-EMA) as the base — the strongest known DDP4 configuration.
+
+---
+
+---
+
+## #74: [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1)
+
+## Hypothesis
+
+**Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseline**
+
+The strongest known DrivAerML result from the radford branch (PR #2593) used a specific recipe:
+- 4 transformer layers, 256 hidden dim (vs default 3L/192d)
+- No EMA (EMA was found to hurt on DrivAerML)
+- Fourier/sinusoidal positional encoding replacing the default ContinuousSincosEmbed
+- Cosine LR schedule with T_max=30
+- lr=3e-4, weight_decay=1e-4, batch_size=2
+
+This experiment replicates that recipe on the bengio branch to establish a confirmed baseline. Without this replication we are building on unconfirmed assumptions.
+
+**Source:** radford PR #2593, ~12.96% abupt_axis_mean_rel_l2_pct on the test set.
+
+---
+
+## #176: [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline
+
+## Hypothesis
+
+Wave 1 winner used lr=3e-4 (default). However, 3e-4 may be suboptimal for the Fourier PE baseline — the Fourier features expand the input space significantly and a slightly higher or lower lr may train more efficiently. This experiment sweeps two lr values (1e-4 and 5e-4) on the exact Wave 1 winner config to find the optimal lr for the Fourier PE regime. Run both as sequential trials.
+
+**Target gap:** val_abupt from 7.21% → below 6.8%.
+
+## Results
+
+### Trial A (lr=1e-4)
+- **Run 1 (`ro7ocwte`)**: killed at end of ep1 by val_primary kill threshold (abupt=40.97% at step 17,816 vs threshold <25). Cause: with lr-warmup-epochs=3, lr at end of ep1 was ~3.3e-5, three times lower than alphonse's lr at the same step.
+- **Run 2 (`lle5ylae`, kill threshold relaxed to step >= 100k)**: killed at advisor's request (abupt=40.5% at step 22,043 / step 100k+ assessed too late). lr=1e-4 is too low for AB-UPT under T_max=50 — model was severely under-trained and would not catch up before the cosine valley.
+
+**Conclusion:** lr=1e-4 is non-competitive with the FourierEmbed swap.
+
+### Trial B (lr=5e-4) — `ld3ff1gs`
+
+Per-epoch val_primary trajectory:
+
+| Epoch | step | abupt | surface_p | wall_shear | volume_p |
+|-------|------|-------|-----------|------------|----------|
+| 1 | 17,816 | 30.17 | 23.24 | 31.66 | 22.34 |
+| 2 | 35,633 | 14.98 | 10.34 | 16.03 | 11.01 |
+| 3 | 53,450 | 12.51 | 8.52 | 13.46 | 9.09 |
+| 4 | 71,267 | 11.41 | 7.65 | 12.28 | 8.33 |
+| 5 | 89,084 | 11.05 | 7.34 | 11.75 | 8.72 |
+| 6 | 106,901 | 10.34 | 6.83 | 11.21 | 7.41 |
+| 7 | 124,718 | 9.61 | 6.37 | 10.39 | 6.97 |
+| 8 | 142,535 | 9.37 | 6.23 | 10.17 | 6.76 |
+| 9 | 160,352 | 9.71 | 6.48 | 10.50 | 7.09 |
+| 10 | 178,169 | 9.21 | 6.09 | 10.00 | 6.62 |
+| **11 (best)** | **195,986** | **9.122** | **6.041** | **9.910** | **6.522** |
+| 12 | 213,803 | 10.44 | 7.09 | 11.16 | 7.95 |
+
+**Best so far (ep11):**
+
+| Metric | ep11 best | Baseline (alphonse, lr=3e-4) | Δ vs baseline |
+|--------|-----------|------------------------------|---------------|
+| `val_primary/abupt_axis_mean_rel_l2_pct` | **9.122** | 7.209 | **+1.91% (worse)** |
+| `val_primary/surface_pressure_rel_l2_pct` | 6.041 | 4.802 | +1.24% (worse) |
+| `val_primary/wall_shear_rel_l2_pct` | 9.910 | 8.160 | +1.75% (worse) |
+| `val_primary/volume_pressure_rel_l2_pct` | 6.522 | 4.166 | +2.36% (worse) |
+
+ep12 regression: all four primary metrics jumped together (+1.32% on abupt) with two large train/loss spikes (steps 199,522 and 211,125 at ~0.51 vs ~0.01 baseline) — destabilization signal, not noise.
+
+**Conclusion:** lr=5e-4 with `--lr-cosine-t-max 50` + Fourier PE is non-competitive vs alphonse's lr=3e-4 (T_max=30). Even at ep11-best, model is ~1.9% worse on abupt with declining slope and a paired-channel destabilization at ep12. Not worth running to ep31 valley.
+
+**Final command used (Trial B):**
+```bash
+cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
+  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
+  --no-use-ema \
+  --lr 5e-4 --epochs 50 --lr-cosine-t-max 50 --lr-min 1e-6 --lr-warmup-epochs 3 \
+  --fourier-pe \
+  --no-compile-model \
+  --kill-thresholds "500:train/loss<5,100000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
+  --wandb-group bengio-wave2-lr-sweep --wandb-name chihiro/lr-sweep-5e-4 \
+  --agent chihiro
+```
+
+W&B run IDs (rank-0): Trial A v1 `ro7ocwte`, Trial A v2 `lle5ylae`, Trial B `ld3ff1gs` (group: `bengio-wave2-lr-sweep`).
+
+Peak GPU memory: ~10.85 GB / GPU (4× A100), all four GPUs ~90-95% util throughout.
+
+---
+
+## #354: [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline
+
+## Hypothesis
+
+A systematic +1.0–1.5 pp structural gap has been observed between every recent `fourier-pe nf=8` baseline-config run and the alphonse `m9775k1v` baseline (ep30, `val_abupt=7.2091%`). All the data points:
+
+| Run ID | Config | Best abupt |
+|--------|--------|-----------|
+| `m9775k1v` | alphonse baseline PR #74 (ep30 best) | **7.2091%** |
+| `67u9bilg` | haku surface-weight 2.0 (identical arch, 50ep) | 8.168% |
+| `kuz4na0j` | trial-B wsy/wsz 0.5 | 8.895% |
+| `w3thlivw` | mirror0.5 + sw2.0 | 8.919% |
+| `31s1j3a0` | gc=0.5 (grad clip) | 9.215% |
+| `0fhryk4r` | fern SWA-last5 (fourier-pe confirmed, ep10) | 9.270% |
+
+**Architecture-identical runs (3,249,813 params, FourierEmbed, lr=3e-4, cosine_t_max=30, no-EMA) still land ~1pp above alphonse.** This cannot be explained by hyperparameter difference — it is a codebase, data, or environment change between the alphonse merge (PR #74) and current HEAD.
+
+This affects every in-flight Wave 5–8 PR. Finding and fixing this regression is the highest-leverage action in the entire research programme right now.
+
+---
+
+## #174: [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule
+
+## Hypothesis
+
+Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. That config likely underfits given the short cosine schedule (30 epochs). Adding a 5th layer increases model capacity; pairing it with a longer T_max=50 schedule gives the deeper model sufficient time to converge. Wave 1 5L run (gilbert, #76) reached val_abupt=7.47% at ep30 — but was run WITHOUT Fourier PE and without the longer schedule. This run isolates depth+PE+schedule together.
+
+**Target gap:** val_abupt from 7.21% → below 6.5% (stretch: below 6.0%).
+
+---
+
+## #487: Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d
+
+## Hypothesis
+
+The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num-freqs` = 8 (default in the codebase). The Fourier positional embedding maps 3D coordinates through sin/cos of 8 frequency bands, producing a 48-dim input (3 coords × 8 freqs × 2 = 48) before a linear projection to hidden_dim=256. Increasing the number of Fourier frequency bands to 16 (96-dim input) gives the model more high-frequency positional resolution, potentially capturing the fine-scale geometry variation in boundary-layer regions that drive wsy/wsz errors. Conversely, 4 bands (24-dim input) would test whether the current 8 bands are over-specified. The cost of more frequencies is only a larger input projection — the rest of the model is unchanged.
+
+This is a single architectural knob targeting positional encoding expressiveness.
+
+---
+

--- a/experiment_log/results_table_2026-05-03_06-36.md
+++ b/experiment_log/results_table_2026-05-03_06-36.md
@@ -1,0 +1,193 @@
+# Experiment Results Table
+
+Total: 157 PRs | Merged: 6 | Ran (not merged): 8 | Never ran: 148
+
+## Merged
+
+| PR | Title | val_loss |
+|---|---|---|
+| #140 | [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) | — |
+| #74 | [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) | — |
+| #176 | [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline | — |
+| #354 | [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline | — |
+| #174 | [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule | — |
+| #487 | Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d | — |
+
+## Ran but not merged (8)
+
+| PR | Title | val_loss | Hypothesis (short) |
+|---|---|---|---|
+| #332 | [tanjiro] Stack mirror-aug + surface-loss-weight=2.0 on alphonse Fourier base | — | Two independent Wave 5/6 results suggest small positive signals on the binding a |
+| #277 | [tanjiro] DomainLayerNorm: domain-specific affine LayerNorm for surface vs volume tokens | — | Different geometric domains (surface vs volume) in this CFD surrogate have funda |
+| #218 | [frieren] SO(3)-equivariant tangent-frame wall shear head | — | Wall shear stress is a vector field tangent to the surface. |
+| #182 | [violet] Volume loss downweight {0.5, 0.25} on Fourier PE baseline | — | Volume pressure already **beats** the AB-UPT target (4.166% vs. |
+| #178 | [kohaku] 6L/256d + Fourier PE + T_max=60 depth scaling | — | Wave 1 showed 4L → 5L (gilbert #76, no PE) improved from ~8.78% to ~7.47%. |
+| #84 | [edward] DrivAerML Dynamic Uncertainty Loss Weighting | — | The current model uses fixed loss weights for the different output modalities (s |
+| #80 | [tanjiro] DrivAerML Surface Loss Weight Sweep | — | The default training uses equal loss weights for surface and volume predictions. |
+| #79 | [emma] DrivAerML 60k Points + Fourier PE | — | The default training setup uses 40k surface points and 40k volume points per sam |
+
+## Never ran (148)
+
+| PR | Title | Hypothesis (short) |
+|---|---|---|
+| #498 | T_max cosine schedule sweep: 70 vs 100 on 5L/256d [Wave19] | The T_max=50 cosine annealing schedule was validated as +0.25pp better than T_ma |
+| #497 | Stack coord-norm fix + mirror-aug + SW=2.0 on 5L/256d [Wave19] | Stacking the coord-norm fix (fern #409) with mirror-augmentation + surface-weigh |
+| #495 | CoordConv dist-to-surface input feature for wsy/wsz [Wave18] | Wall-shear axes (wsy=8.7345%, wsz=10.5766%) are the dominant binding constraint  |
+| #494 | T_max cosine schedule sweep: 70 vs 100 on 5L/256d [Wave18] | The cosine annealing schedule T_max=50 was validated in PR #174 (alphonse) as a  |
+| #493 | Stack coord-norm fix + mirror-aug + SW=2.0 on 5L/256d [Wave18] | Two independently validated improvements — (1) coordinate normalization fix (fer |
+| #487 | Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d | The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num- |
+| #486 | Token budget 96k surface / 64k volume on 5L/256d+FourierPE | Increasing the per-training-step surface point budget from the default (32,768)  |
+| #477 | Dropout regularization dp=0.05/0.10 on 5L/256d+FourierEmbed baseline | The current best (PR #174, alphonse) uses 5L/256d+FourierEmbed+T_max=50 with no  |
+| #476 | Per-axis shear loss reweighting [1,3,3] to target wsy/wsz binding gap | Wall-shear (wsy, wsz) predictions are structurally much worse than shear-x: curr |
+| #475 | Tangent-frame shear loss decomposition to reduce wsy/wsz error | Wall-shear (wsy, wsz) predictions are structurally worse than surface-pressure — |
+| #469 | nezuko: metric-aware rel-L2 aux loss (w=0.05, 0.1) — Wave 16 | Adding a direct relative-L2 auxiliary loss term aligned with the primary validat |
+| #468 | edward: Port Muon optimizer to bengio (Wave 16) | The **Muon optimizer** (Keller Jordan, Modded-NanoGPT, 2024) applies Newton-Schu |
+| #465 | model-slices sweep {128, 192} on 5L/256d+T_max=50 — Wave 15 | **Sweep `--model-slices` {128, 192} on the current 5L/256d+T_max=50 baseline.**  |
+| #464 | Capacity scaling 6L/320d/5H (mid-scale model) — Wave 15 | **Modest capacity scaling: 6L/320d/5H** — one additional layer plus 25% wider hi |
+| #463 | Dropout regularization sweep dp=0.05/0.10 on 5L/256d — Wave 15 | **Light dropout (0.05) on the transformer trunk** may reduce overfitting on wall |
+| #462 | Surface-2x/Volume-0.5x point density reallocation — Wave 15 | **Double the surface point density during training** (80,000 surface points vs 4 |
+| #461 | Per-axis shear reweight [1,3,3] targeting wsy/wsz binding axes — Wave 15 | Apply **per-axis shear loss reweighting** that emphasizes wsy and wsz (the bindi |
+| #460 | Tangent-frame shear loss (local surface basis) — Wave 15 | Predict and supervise wall-shear stress in the **local surface tangent frame** ( |
+| #457 | Dropout=0.1 on 5L/256d + T_max=50 (regularization for wall-shear) | **Dropout=0.1 on 5L/256d + T_max=50 — regularization as wall-shear generalizatio |
+| #456 | LR warmup=3ep on 5L/256d + T_max=50 (single-variable isolation) | **Longer LR warmup (3 epochs) on 5L/256d + T_max=50 — single-variable isolation. |
+| #455 | SW=2.0 isolation on 5L/256d + T_max=50 (clean single-variable test) | **Surface-loss-weight=2.0 isolation on 5L/256d + T_max=50 (clean single-variable |
+| #448 | stark: coord-only FiLM in surface decoder (Wave 14 R2) | # Hypothesis: Coord-only FiLM in surface decoder (Wave 14 reassignment R2)
+
+**Re |
+| #447 | gilbert: surface-decoder-only FiLM normal conditioning for wsy/wsz (Wave 14 R2) | # Hypothesis: Surface-decoder-only FiLM normal conditioning for wsy/wsz (Wave 14 |
+| #446 | SWA on 5L/256d + T_max=50 — novel weight-averaging lever | Stochastic Weight Averaging (SWA; Izmailov et al. |
+| #445 | EMA isolation on 5L/256d + T_max=50 (clean single-variable test) | EMA (Exponential Moving Average) of model weights is a classical regularisation  |
+| #444 | Coord-only FiLM in surface decoder (signal-control vs gilbert #441 normal-FiLM) | Gilbert PR #346 (FiLM with **surface-normal** conditioning every-block in the tr |
+| #443 | Mirror-aug + SW=2.0 on 5L/256d/4H + T_max=50 (port of #332 to current best architecture) | The mirror-aug + SW=2.0 stack is constructive at early gates (PR #332 ep5 beat h |
+| #442 | OHEM spatial hard-mining for wall-shear wsy/wsz reduction | Gradient-based hard-example mining for wall-shear points — upweighting high-grad |
+| #441 | Surface-decoder-only FiLM normal conditioning for wsy/wsz | Surface-normal FiLM conditioning applied **only inside the surface decoder** (no |
+| #439 | SWA (Stochastic Weight Averaging) on 5L/256d + T_max=50 — novel lever | # Hypothesis: Stochastic Weight Averaging (SWA) on 5L/256d + T_max=50
+
+**Wave 13 |
+| #438 | EMA isolation on 5L/256d + T_max=50 (clean single-variable test) | # Hypothesis: EMA + 5L/256d + T_max=50 (Clean Isolation)
+
+**Wave 13 assignment f |
+| #437 | 6L/256d depth extension + T_max=50 on current best recipe | # Hypothesis: 6L/256d Depth Extension + T_max=50
+
+**Wave 13 assignment for alpho |
+| #434 | [bengio-w12] NF=32 Fourier PE on 5L/256d + T_max=50 (3rd attempt) | NF=32 Fourier PE frequencies on the 5L/256d + T_max=50 architecture will outperf |
+| #433 | [bengio-w12] gc=0.5 + T_max=50 stack on 5L/256d (3rd attempt) | Stacking gc=0.5 gradient clipping with T_max=50 cosine schedule on the current b |
+| #432 | [bengio-w12] 6L/256d depth extension + T_max=50 (3rd attempt) | Extending depth from 5L→6L on the current best architecture (5L/256d + FourierEm |
+| #428 | NF=32 Fourier PE on 5L/256d+T_max=50 — frequency count screen | **NF=32 Fourier PE on 5L/256d + T_max=50** — test whether doubling Fourier frequ |
+| #427 | Bengio Wave 11: gc=0.5 + T_max=50 stack on 5L/256d Fourier base | Stacking grad-clip-norm=0.5 with T_max=50 cosine schedule on the 5L/256d baselin |
+| #426 | Bengio Wave 11: 6L/256d depth extension with FourierPE + T_max=50 | Adding a 6th transformer layer (6L vs current 5L baseline) should increase model |
+| #418 | NF=32 Fourier PE on 5L/256d+T_max50 (Wave 11) | The current best uses `--fourier-pe` with the default number of frequencies (16) |
+| #417 | EMA vs no-EMA on 5L/256d+FourierPE+T_max50 (Wave 11) | Test whether EMA (Exponential Moving Average) of weights helps stabilize trainin |
+| #416 | Stack gc=0.5+T_max=50 on 5L/256d Fourier base (Wave 11) | Stack the two best-validated individual levers that have never been combined suc |
+| #415 | Bengio: 6L/256d depth extension with FourierPE + T_max=50 | Adding a 6th layer (6L/256d/4H with FourierPE) extends model capacity through de |
+| #413 | 6L/256d + FourierPE + T_max=50 — Depth Extension Wave 11 | Depth has been a consistent winner in this research programme: 4L → 5L gave −0.2 |
+| #412 | Attention heads sweep: 4H vs 8H on 5L/256d+FourierPE+T_max=50 | The current best baseline uses 5L/256d/**4H** (4 attention heads). |
+| #411 | Stack gc=0.5+T_max=50 on 5L/256d (both levers validated, first combined run) | Two independently validated levers have been confirmed:
+1. `gc=0.5` grad-clip (s |
+| #410 | NF=32 Fourier PE freqs on 5L/256d+T_max=50 baseline | Norman PR #239 shows NF=64 Fourier PE frequencies led at equal steps vs NF=16. |
+| #409 | Coord-norm fix on 5L/256d+T_max=50 (clean replay) | The FourierEmbed coordinate normalization fix (merged from fern PR #360, run `q4 |
+| #408 | DDP8 radford-champion: 4L/512d/8H+EMA+gc=0.5+T_max=50 | Port the radford-branch champion recipe to bengio using DDP8. |
+| #407 | Stack mirror-aug+SW=2.0+gc=0.5+T_max=50 on 5L/256d | Stack all validated Wave 9 wins onto the current best recipe (5L/256d + FourierP |
+| #406 | Screen mlp_ratio={4,6,8} on 5L/256d+FourierPE+T_max=50 | Increasing the MLP expansion ratio beyond the default (2×) in the transformer FF |
+| #402 | [frieren] Transolver model-slices sweep {64, 128} on 5L/256d base | **Sweeping `--model-slices` (Transolver slice-attention granularity) on the 5L/2 |
+| #399 | [violet] DDP8 radford-champion: 4L/512d/8H+EMA+gc=0.5+T_max=50 (Wave 10) | Your previous PR #330 (run `i4w5ahtq`) was closed for non-compliance but the run |
+| #398 | [fern] Coord-norm fix replay on 5L/256d + T_max=50 (Wave 10) | Your PR #360 (`q40rez85`) validated the FourierEmbed coordinate normalization fi |
+| #397 | [chihiro] Full stacked recipe: 5L/256d + gc=0.5 + T_max=50 + mirror + SW=2.0 | The most validated levers from Waves 1–9 on bengio have NEVER been fully stacked |
+| #392 | [edward] MLP-ratio sweep {4,6,8} on 5L/256d Fourier base (Wave 10) | The default MLP ratio (mlp_ratio=4) in each transformer block may be a capacity  |
+| #390 | [nezuko] EMA + 5L/256d + T_max=50 — isolate EMA effect on best arch (Wave 10) | EMA (Exponential Moving Average) model weights have never been cleanly isolated  |
+| #389 | [kohaku] Stack gc=0.5 + T_max=50 on 5L/256d Fourier base (Wave 10) | Senku #325 (gc=0.5) is on strong trajectory at ep20=8.504%. |
+| #388 | [haku] NF=32 Fourier PE + 5L/256d + T_max=50 stack (Wave 10) | Norman #239 is converging on NF=32 as the optimal Fourier PE frequency count (NF |
+| #386 | [askeladd] Attention heads sweep {4H,8H} on 5L/256d Fourier base (Wave 10) | On the 5L/256d Fourier base, the default 4 attention heads (64 dims/head) may be |
+| #384 | [edward] MLP-ratio sweep {4,6,8} on 5L/256d Fourier base (Wave 10) | The default MLP ratio (mlp_ratio=4) in the transformer blocks may be a capacity  |
+| #383 | [nezuko] EMA revival + T_max=50 on 4L/256d canonical recipe (Wave 9) | The alphonse Wave 1 baseline (PR #74) uses `--no-use-ema` (EMA disabled). |
+| #382 | [thorfinn] 6L/512d/8H + T_max=50 capacity scaling (Wave 9) | Every strong result on the bengio branch uses 4L/256d. |
+| #381 | [kohaku] Stack gc=0.5 + T_max=50 on 4L/256d Fourier base (Wave 9) | Senku #325 shows gc=0.5 (grad-clip-norm=0.5) produces a strong, smooth descent t |
+| #380 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on Wave 1 base (Wave 9) | The per-channel wall-shear MSE loss multiplier experiments (edward #304) establi |
+| #379 | [frieren] Weight-decay sweep {3e-4, 1e-3, 3e-3} on Wave 1 base (Wave 9) | Weight decay is a regularizer that controls the effective capacity of the model. |
+| #378 | [askeladd] Stack mirror-aug+SW=2.0+T_max=50 on 5L/256d (Wave 9) | Two independently validated levers exist on the bengio branch:
+1. **Mirror-augme |
+| #373 | [stark] Stochastic Weight Averaging over cosine tail (ep35-50) | **Stochastic Weight Averaging (SWA) over the cosine-decay tail will produce a fl |
+| #372 | [noam] Stack T_max=50 + grad-clip-norm=0.5 (alphonse + senku winners) | Stack alphonse #174's winning lever (T_max=50 cosine schedule) with senku #325's |
+| #361 | [frieren] Weight-decay sweep {3e-4, 1e-3, 3e-3} on baseline recipe | The baseline recipe (`m9775k1v`) uses the PyTorch AdamW default weight-decay of  |
+| #360 | [fern] Fix FourierEmbed coordinate normalization (restores alphonse baseline) | The +1pp structural regression vs alphonse `m9775k1v` (val_abupt=7.2091%) has be |
+| #354 | [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline | A systematic +1.0–1.5 pp structural gap has been observed between every recent ` |
+| #348 | [dazai] Weight-decay sweep {3e-4, 1e-3, 3e-3} on alphonse Fourier base | The bengio Wave 1 baseline `m9775k1v` (alphonse 4L/256d + Fourier PE + no-EMA +  |
+| #347 | [nezuko] Dedicated 2-block wall-shear sub-decoder (split surface head) | The current model uses **a single shared linear head** to produce all 4 surface  |
+| #346 | [gilbert] FiLM normal-conditioning at every transformer block (surface trunk) | Edward PR #304 (loss-weighting) and frieren PR #337 (tangent-frame head) approac |
+| #344 | [gilbert] Tangent-frame wall-shear head: predict (t1,t2,n) components, rotate to global | Edward PR #304 confirmed the wsy/wsz binding constraint is **not loss-weighting- |
+| #343 | [kohaku] Wall-shear-only rel-L2 aux loss sweep {0.1,0.5,1.0} (code edit + sweep) | Edward PR #304 falsified per-channel **MSE** loss reweighting (Trial A upweight  |
+| #342 | [emma] 96k surface+volume points scale-up on alphonse Fourier base | The alphonse Wave 1 baseline samples 40,000 surface points and 40,000 volume poi |
+| #341 | [haku] surface-loss-weight sweep {2.0,4.0,8.0} on alphonse Fourier base | The DrivAerML loss is `surface_loss_weight * surface_loss + volume_loss_weight * |
+| #340 | [thorfinn] model_slices sweep {128,192,256} on alphonse Fourier base | The alphonse Wave 1 baseline (4L/256d/4H + FourierEmbed PE, run `m9775k1v`, val_ |
+| #337 | Surface-normal tangent frame for wall shear prediction | The baseline predicts wall shear `[wsx, wsy, wsz]` in global coordinates directl |
+| #331 | [kohaku] Wall-shear-only squared rel-L2 aux loss sweep {0.1, 0.5, 1.0} | Chihiro PR #254 is sweeping the existing `--raw-rel-l2-weight` flag {0.05, 0.1}, |
+| #330 | [violet] DDP8 radford-champion port: 4L/512d/8H + Fourier + EMA + gc=0.5 + lr=4.8e-4 | The bengio Wave 1 winner (4L/256d/SincosEmbed/no-EMA, val_abupt=7.2091%) was fou |
+| #329 | [emma] 96k surface+volume points scale-up on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, val_abupt=7.2091%) trained on `--trai |
+| #328 | [askeladd] FourierEmbed standalone A/B vs ContinuousSincosEmbed (the missing baseline test) | The 2026-05-01 baseline correction revealed that the Wave 1 winner (PR #74 alpho |
+| #327 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #326 | [thorfinn] Model-slices sweep {128, 192, 256} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #325 | [senku] Grad-clip-norm sweep {0.5, 1.0, 2.0} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #310 | [frieren] Weight-decay + dropout regularisation sweep on 5L Fourier PE base | A systematic val/test gap (~2.5×) on `vol_p` has been observed across all bengio |
+| #308 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on alphonse Fourier base | The bengio baseline's surface metrics (sp=4.80%, ws=8.16%, wsy=9.10%, wsz=10.87% |
+| #307 | [kohaku] Wall-shear-only squared rel-L2 auxiliary loss sweep | The `--raw-rel-l2-weight` flag adds an extra rel-L2 penalty term to the **total* |
+| #306 | [thorfinn] Model-slices sweep {128, 192, 256} on alphonse Fourier base | Wave 1 kohaku showed `--model-slices 128` (vs default 96) improved abupt at mid- |
+| #305 | [senku] Grad-clip-norm sweep {0.5, 1.0, 2.0} on alphonse Fourier base | The current bengio baseline (alphonse `m9775k1v`) runs without explicit gradient |
+| #304 | [edward] Per-channel wall-shear loss multipliers (wsy/wsz upweight sweep) | The bengio baseline's binding constraints are **wall_shear_y (wsy=9.10% vs 3.65% |
+| #303 | [askeladd] FourierEmbed standalone A/B validation on 4L/256d alphonse base | The `--fourier-pe` flag (chihiro PR #176) was merged to bengio but has **never b |
+| #302 | [emma] 96k surface + 96k volume points scale-up v2 | Scale the per-step token budget from the default ~65k (32k surface + 32k volume) |
+| #301 | [violet] DDP8 radford champion port v2: 4L/512d/8H + EMA + gc=0.5 + lr=4.8e-4 | Port the **radford branch champion recipe** to bengio: 4L/512d/8H Transformer wi |
+| #278 | [gilbert] Train-time mirror-symmetry augmentation for wsy/wsz | DrivAerML vehicles are approximately symmetric about the longitudinal (xz) plane |
+| #276 | [fern] SWA over last 5 epochs: weight averaging for generalization | Stochastic Weight Averaging (SWA) averages model weights from the last K epochs  |
+| #275 | [emma] Scale point budget to 96k surface + volume points | Scale the point budget from the default ~65536 to 96,000 for both surface and vo |
+| #274 | [violet] DDP8 radford champion port: 4L/512d/8H + EMA=0.9995 + gc=0.5 + lr=4.8e-4 | Port the radford-branch champion recipe to bengio. |
+| #266 | stark: U-net long skip connections for wsy/wsz fine-detail injection | Add **U-net-style long skip connections** between symmetric layers of the Transo |
+| #260 | [thorfinn] model-slices sweep {64, 128, 192} on baseline | `--model-slices` controls the number of slice tokens that AB-UPT uses to attend  |
+| #259 | [senku] grad-clip-norm sweep {0.5, 2.0} on baseline | The bengio Wave 1 baseline uses default `--grad-clip-norm 1.0`. |
+| #258 | [kohaku] Squared rel-L2 aux loss on wall-shear (focal-loss-equivalent) | The standard MSE loss penalizes errors quadratically in absolute units, but the  |
+| #257 | [haku] High-shear curriculum oversampling with linear anneal | DrivAerML's 400 training cases vary widely in flow complexity. |
+| #256 | [frieren] Mirror-symmetry TTA for wsy reduction | Cars have approximate left-right symmetry (y-axis mirror). |
+| #255 | [edward] Fixed per-channel wsy/wsz loss multipliers | Wall-shear y/z axes are the dominant binding constraint:
+- val wsy=9.100% vs AB- |
+| #254 | [chihiro] Raw rel-L2 auxiliary loss sweep w in {0.05, 0.1} | The eval metrics (`*_rel_l2_pct`) are scale-invariant relative L2 errors, but th |
+| #253 | [askeladd] FourierEmbed vs ContinuousSincosEmbed standalone A/B | The current bengio Wave 1 baseline (PR #74, alphonse, val_abupt=7.2091%) actuall |
+| #239 | [norman] Fourier PE num_freqs sweep {16, 32, 64, 128} on Wave 1 recipe | **The number of Fourier PE frequency bands is an untuned hyperparameter on bengi |
+| #238 | [kohaku] High-shear curriculum oversampling for wsy/wsz tail | **A "hard-cases-first" curriculum that oversamples high-shear cars early in trai |
+| #237 | [haku] Squared rel-L2 aux loss for hard-sample focusing | **Adding a squared rel-L2 auxiliary loss term penalizes large per-sample errors  |
+| #236 | [edward] Fixed wsy/wsz loss multipliers — direct binding-constraint attack | **Fixed per-channel loss multipliers (`wsy×3, wsz×5, others×1`) directly attack  |
+| #235 | [askeladd] 4L/512d/8H width frontier — radford champion port | **The radford-branch champion config (4L/512d/8H + EMA=0.9995 + gc=0.5 + lr=4.8e |
+| #234 | [senku] Mirror-symmetry test-time augmentation for wsy free gain | **Mirror-symmetry test-time augmentation (TTA) should give a free 0.5–2pp gain o |
+| #221 | [violet] Per-channel adaptive loss reweighting toward AB-UPT targets | The binding wsy/wsz constraint (9.1% and 10.87% vs AB-UPT 3.65%/3.63%) suggests  |
+| #220 | [kohaku] Asinh surface pressure + 96k pts × 5L × T_max=40 | Two untested levers from the empirical compounders list:
+1. **Asinh normalizatio |
+| #219 | [haku] 5L depth + Fourier PE + GradNorm α=1.5 stack | Wave 1 confirmed two independent improvements over the Wave 0 baseline:
+- 8L dep |
+| #217 | [edward] Lion optimizer sweep vs AdamW | Lion optimizer (Chen et al. |
+| #216 | [askeladd] Per-axis loss autoweighting via running variance | The binding constraint is wsy and wsz (9.10% and 10.87% vs AB-UPT 3.65%/3.63%). |
+| #215 | [senku] SWA last-5-epoch averaging for free gain | Stochastic Weight Averaging (SWA) is a zero-cost ensemble technique: after the c |
+| #214 | [gilbert] k-NN local surface attention for wsy/wsz gap | Wall shear stress τ_y and τ_z are the hardest predictions in this benchmark — th |
+| #205 | [violet] Per-channel surface loss rebalance (adaptive weights) | The current loss function applies a single global weight to the entire surface p |
+| #190 | [haku] Radford champion port: 4L/512d/8H + EMA=0.9995 + DDP8 | Scale hidden dimension from 256 → 512 and attention heads from 4 → 8, re-enable  |
+| #188 | [gilbert] 4L/256d + Fourier PE + slices=192 (slice-count scaling) | The Wave 1 winning recipe (4L/256d + Fourier PE, val_abupt=7.2091%) uses the def |
+| #181 | [thorfinn] EMA revival {0.999, 0.9995} on Fourier PE + T_max=50 | Wave 1 baseline (PR #74, alphonse) **disabled EMA** with `--no-use-ema` because  |
+| #180 | [norman] Raw rel-L2 aux loss {0.1, 0.3} on Fourier PE baseline | Add a raw rel-L2 auxiliary loss to directly optimize for the eval metric. |
+| #179 | [nezuko] 5L/384d + Fourier PE + T_max=60 wide+deep scaling | Joint width + depth scaling on the Fourier PE baseline. |
+| #177 | [frieren] Surface loss upweight {3x,5x} to close ws_y/ws_z gap | The biggest abupt gap remaining is in wall_shear components: ws_y=9.100% (target |
+| #175 | [askeladd] 4L/384d + Fourier PE + T_max=50 width scaling | Wave 1 best (PR #74): 4L/256d + Fourier PE → val_abupt=7.2091%. |
+| #174 | [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule | Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. |
+| #160 | [edward] DrivAerML: Split surface output head — dedicated cp and wall-shear MLPs | The current `model.py` uses a single shared `LinearProjection(n_hidden, 4)` outp |
+| #145 | [senku] DrivAerML Metric-Aware Loss: MSE + Raw Rel-L2 Auxiliary (w=0.05) | The DrivAerML training objective uses per-task MSE losses in normalized (zero-me |
+| #140 | [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) | **Curriculum (easy-first) case sampling via per-case gradient-norm difficulty pr |
+| #137 | [edward] DrivAerML GradNorm Per-Task Gradient Equalization (wall-shear focus) | Wave 1 established that the binding constraint is `wall_shear_y` and `wall_shear |
+| #89 | [thorfinn] DrivAerML Tighter Gradient Clipping + Weight Decay | The current training uses no explicit gradient clipping and `weight_decay=1e-4`. |
+| #88 | [senku] DrivAerML Random Fourier Features Positional Encoding | The current `ContinuousSincosEmbed` uses a fixed sinusoidal basis with wavelengt |
+| #87 | [norman] DrivAerML Dropout Regularization: dropout=0.1 + Cosine Schedule | The current model uses no dropout (default dropout=0.0). |
+| #86 | [nezuko] DrivAerML MLP-Ratio=6: Wider FFN in Transformer Blocks | The Transolver uses transformer blocks with `mlp_ratio=4`, meaning the feed-forw |
+| #85 | [frieren] DrivAerML Cross-Attention Bridge Between Surface and Volume Tokens | The current Transolver uses a shared backbone that processes surface and volume  |
+| #83 | [chihiro] DrivAerML asinh Target Normalization for Wall Shear | Wall shear stress in CFD has a heavy-tailed distribution — most of the vehicle s |
+| #82 | [askeladd] DrivAerML SDF-Conditioned Volume Encoding | The Transolver currently treats surface and volume tokens symmetrically — both p |
+| #81 | [violet] DrivAerML Cosine Schedule + LR Sweep | The radford PR #2593 winner used T_max=30 with lr=3e-4. |
+| #78 | [kohaku] DrivAerML 128 Slices + Fourier PE | The Transolver attention mechanism groups tokens into slices for physics-aware p |
+| #77 | [haku] DrivAerML 4L/384d Width Scaling | The radford PR #2593 winner used hidden_dim=256. |
+| #76 | [gilbert] DrivAerML 5L/256d Depth Scaling + Fourier PE | The radford PR #2593 winner used 4 layers. |
+| #75 | [fern] DrivAerML LR Sweep with Fourier PE | The radford PR #2593 winner used lr=3e-4 with the 4L/256d+no-EMA+Fourier+T_max=3 |
+| #74 | [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) | **Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseli |

--- a/experiment_log/results_table_2026-05-03_07-16.md
+++ b/experiment_log/results_table_2026-05-03_07-16.md
@@ -1,0 +1,197 @@
+# Experiment Results Table
+
+Total: 161 PRs | Merged: 6 | Ran (not merged): 9 | Never ran: 151
+
+## Merged
+
+| PR | Title | val_loss |
+|---|---|---|
+| #140 | [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) | — |
+| #74 | [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) | — |
+| #176 | [chihiro] LR sweep {1e-4, 5e-4} on Fourier PE baseline | — |
+| #354 | [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline | — |
+| #174 | [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule | — |
+| #487 | Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d | — |
+
+## Ran but not merged (9)
+
+| PR | Title | val_loss | Hypothesis (short) |
+|---|---|---|---|
+| #417 | EMA vs no-EMA on 5L/256d+FourierPE+T_max50 (Wave 11) | — | Test whether EMA (Exponential Moving Average) of weights helps stabilize trainin |
+| #332 | [tanjiro] Stack mirror-aug + surface-loss-weight=2.0 on alphonse Fourier base | — | Two independent Wave 5/6 results suggest small positive signals on the binding a |
+| #277 | [tanjiro] DomainLayerNorm: domain-specific affine LayerNorm for surface vs volume tokens | — | Different geometric domains (surface vs volume) in this CFD surrogate have funda |
+| #218 | [frieren] SO(3)-equivariant tangent-frame wall shear head | — | Wall shear stress is a vector field tangent to the surface. |
+| #182 | [violet] Volume loss downweight {0.5, 0.25} on Fourier PE baseline | — | Volume pressure already **beats** the AB-UPT target (4.166% vs. |
+| #178 | [kohaku] 6L/256d + Fourier PE + T_max=60 depth scaling | — | Wave 1 showed 4L → 5L (gilbert #76, no PE) improved from ~8.78% to ~7.47%. |
+| #84 | [edward] DrivAerML Dynamic Uncertainty Loss Weighting | — | The current model uses fixed loss weights for the different output modalities (s |
+| #80 | [tanjiro] DrivAerML Surface Loss Weight Sweep | — | The default training uses equal loss weights for surface and volume predictions. |
+| #79 | [emma] DrivAerML 60k Points + Fourier PE | — | The default training setup uses 40k surface points and 40k volume points per sam |
+
+## Never ran (151)
+
+| PR | Title | Hypothesis (short) |
+|---|---|---|
+| #505 | SO(3)-equivariant shear head: tangent-frame vector prediction | **SO(3)-aware shear head: replace the scalar MLP output head for wsy/wsz with a  |
+| #504 | Trunk-split decoder: specialized surface/volume transformer branches | **Trunk-split surface decoder: split the transformer TRUNK (not the output head) |
+| #503 | Best-checkpoint weight soup: average top-3 run checkpoints | **Best-checkpoint EMA-soup: averaging late-epoch checkpoints from the three best |
+| #502 | Deep supervision: aux wsy/wsz losses at intermediate transformer layers | **Deep supervision: auxiliary wsy/wsz prediction losses at intermediate transfor |
+| #498 | T_max cosine schedule sweep: 70 vs 100 on 5L/256d [Wave19] | The T_max=50 cosine annealing schedule was validated as +0.25pp better than T_ma |
+| #497 | Stack coord-norm fix + mirror-aug + SW=2.0 on 5L/256d [Wave19] | Stacking the coord-norm fix (fern #409) with mirror-augmentation + surface-weigh |
+| #495 | CoordConv dist-to-surface input feature for wsy/wsz [Wave18] | Wall-shear axes (wsy=8.7345%, wsz=10.5766%) are the dominant binding constraint  |
+| #494 | T_max cosine schedule sweep: 70 vs 100 on 5L/256d [Wave18] | The cosine annealing schedule T_max=50 was validated in PR #174 (alphonse) as a  |
+| #493 | Stack coord-norm fix + mirror-aug + SW=2.0 on 5L/256d [Wave18] | Two independently validated improvements — (1) coordinate normalization fix (fer |
+| #487 | Fourier PE freq sweep: nf=4 vs nf=8 vs nf=16 on 5L/256d | The current best recipe uses `--fourier-pe` which defaults to `--fourier-pe-num- |
+| #486 | Token budget 96k surface / 64k volume on 5L/256d+FourierPE | Increasing the per-training-step surface point budget from the default (32,768)  |
+| #477 | Dropout regularization dp=0.05/0.10 on 5L/256d+FourierEmbed baseline | The current best (PR #174, alphonse) uses 5L/256d+FourierEmbed+T_max=50 with no  |
+| #476 | Per-axis shear loss reweighting [1,3,3] to target wsy/wsz binding gap | Wall-shear (wsy, wsz) predictions are structurally much worse than shear-x: curr |
+| #475 | Tangent-frame shear loss decomposition to reduce wsy/wsz error | Wall-shear (wsy, wsz) predictions are structurally worse than surface-pressure — |
+| #469 | nezuko: metric-aware rel-L2 aux loss (w=0.05, 0.1) — Wave 16 | Adding a direct relative-L2 auxiliary loss term aligned with the primary validat |
+| #468 | edward: Port Muon optimizer to bengio (Wave 16) | The **Muon optimizer** (Keller Jordan, Modded-NanoGPT, 2024) applies Newton-Schu |
+| #465 | model-slices sweep {128, 192} on 5L/256d+T_max=50 — Wave 15 | **Sweep `--model-slices` {128, 192} on the current 5L/256d+T_max=50 baseline.**  |
+| #464 | Capacity scaling 6L/320d/5H (mid-scale model) — Wave 15 | **Modest capacity scaling: 6L/320d/5H** — one additional layer plus 25% wider hi |
+| #463 | Dropout regularization sweep dp=0.05/0.10 on 5L/256d — Wave 15 | **Light dropout (0.05) on the transformer trunk** may reduce overfitting on wall |
+| #462 | Surface-2x/Volume-0.5x point density reallocation — Wave 15 | **Double the surface point density during training** (80,000 surface points vs 4 |
+| #461 | Per-axis shear reweight [1,3,3] targeting wsy/wsz binding axes — Wave 15 | Apply **per-axis shear loss reweighting** that emphasizes wsy and wsz (the bindi |
+| #460 | Tangent-frame shear loss (local surface basis) — Wave 15 | Predict and supervise wall-shear stress in the **local surface tangent frame** ( |
+| #457 | Dropout=0.1 on 5L/256d + T_max=50 (regularization for wall-shear) | **Dropout=0.1 on 5L/256d + T_max=50 — regularization as wall-shear generalizatio |
+| #456 | LR warmup=3ep on 5L/256d + T_max=50 (single-variable isolation) | **Longer LR warmup (3 epochs) on 5L/256d + T_max=50 — single-variable isolation. |
+| #455 | SW=2.0 isolation on 5L/256d + T_max=50 (clean single-variable test) | **Surface-loss-weight=2.0 isolation on 5L/256d + T_max=50 (clean single-variable |
+| #448 | stark: coord-only FiLM in surface decoder (Wave 14 R2) | # Hypothesis: Coord-only FiLM in surface decoder (Wave 14 reassignment R2)
+
+**Re |
+| #447 | gilbert: surface-decoder-only FiLM normal conditioning for wsy/wsz (Wave 14 R2) | # Hypothesis: Surface-decoder-only FiLM normal conditioning for wsy/wsz (Wave 14 |
+| #446 | SWA on 5L/256d + T_max=50 — novel weight-averaging lever | Stochastic Weight Averaging (SWA; Izmailov et al. |
+| #445 | EMA isolation on 5L/256d + T_max=50 (clean single-variable test) | EMA (Exponential Moving Average) of model weights is a classical regularisation  |
+| #444 | Coord-only FiLM in surface decoder (signal-control vs gilbert #441 normal-FiLM) | Gilbert PR #346 (FiLM with **surface-normal** conditioning every-block in the tr |
+| #443 | Mirror-aug + SW=2.0 on 5L/256d/4H + T_max=50 (port of #332 to current best architecture) | The mirror-aug + SW=2.0 stack is constructive at early gates (PR #332 ep5 beat h |
+| #442 | OHEM spatial hard-mining for wall-shear wsy/wsz reduction | Gradient-based hard-example mining for wall-shear points — upweighting high-grad |
+| #441 | Surface-decoder-only FiLM normal conditioning for wsy/wsz | Surface-normal FiLM conditioning applied **only inside the surface decoder** (no |
+| #439 | SWA (Stochastic Weight Averaging) on 5L/256d + T_max=50 — novel lever | # Hypothesis: Stochastic Weight Averaging (SWA) on 5L/256d + T_max=50
+
+**Wave 13 |
+| #438 | EMA isolation on 5L/256d + T_max=50 (clean single-variable test) | # Hypothesis: EMA + 5L/256d + T_max=50 (Clean Isolation)
+
+**Wave 13 assignment f |
+| #437 | 6L/256d depth extension + T_max=50 on current best recipe | # Hypothesis: 6L/256d Depth Extension + T_max=50
+
+**Wave 13 assignment for alpho |
+| #434 | [bengio-w12] NF=32 Fourier PE on 5L/256d + T_max=50 (3rd attempt) | NF=32 Fourier PE frequencies on the 5L/256d + T_max=50 architecture will outperf |
+| #433 | [bengio-w12] gc=0.5 + T_max=50 stack on 5L/256d (3rd attempt) | Stacking gc=0.5 gradient clipping with T_max=50 cosine schedule on the current b |
+| #432 | [bengio-w12] 6L/256d depth extension + T_max=50 (3rd attempt) | Extending depth from 5L→6L on the current best architecture (5L/256d + FourierEm |
+| #428 | NF=32 Fourier PE on 5L/256d+T_max=50 — frequency count screen | **NF=32 Fourier PE on 5L/256d + T_max=50** — test whether doubling Fourier frequ |
+| #427 | Bengio Wave 11: gc=0.5 + T_max=50 stack on 5L/256d Fourier base | Stacking grad-clip-norm=0.5 with T_max=50 cosine schedule on the 5L/256d baselin |
+| #426 | Bengio Wave 11: 6L/256d depth extension with FourierPE + T_max=50 | Adding a 6th transformer layer (6L vs current 5L baseline) should increase model |
+| #418 | NF=32 Fourier PE on 5L/256d+T_max50 (Wave 11) | The current best uses `--fourier-pe` with the default number of frequencies (16) |
+| #416 | Stack gc=0.5+T_max=50 on 5L/256d Fourier base (Wave 11) | Stack the two best-validated individual levers that have never been combined suc |
+| #415 | Bengio: 6L/256d depth extension with FourierPE + T_max=50 | Adding a 6th layer (6L/256d/4H with FourierPE) extends model capacity through de |
+| #413 | 6L/256d + FourierPE + T_max=50 — Depth Extension Wave 11 | Depth has been a consistent winner in this research programme: 4L → 5L gave −0.2 |
+| #412 | Attention heads sweep: 4H vs 8H on 5L/256d+FourierPE+T_max=50 | The current best baseline uses 5L/256d/**4H** (4 attention heads). |
+| #411 | Stack gc=0.5+T_max=50 on 5L/256d (both levers validated, first combined run) | Two independently validated levers have been confirmed:
+1. `gc=0.5` grad-clip (s |
+| #410 | NF=32 Fourier PE freqs on 5L/256d+T_max=50 baseline | Norman PR #239 shows NF=64 Fourier PE frequencies led at equal steps vs NF=16. |
+| #409 | Coord-norm fix on 5L/256d+T_max=50 (clean replay) | The FourierEmbed coordinate normalization fix (merged from fern PR #360, run `q4 |
+| #408 | DDP8 radford-champion: 4L/512d/8H+EMA+gc=0.5+T_max=50 | Port the radford-branch champion recipe to bengio using DDP8. |
+| #407 | Stack mirror-aug+SW=2.0+gc=0.5+T_max=50 on 5L/256d | Stack all validated Wave 9 wins onto the current best recipe (5L/256d + FourierP |
+| #406 | Screen mlp_ratio={4,6,8} on 5L/256d+FourierPE+T_max=50 | Increasing the MLP expansion ratio beyond the default (2×) in the transformer FF |
+| #402 | [frieren] Transolver model-slices sweep {64, 128} on 5L/256d base | **Sweeping `--model-slices` (Transolver slice-attention granularity) on the 5L/2 |
+| #399 | [violet] DDP8 radford-champion: 4L/512d/8H+EMA+gc=0.5+T_max=50 (Wave 10) | Your previous PR #330 (run `i4w5ahtq`) was closed for non-compliance but the run |
+| #398 | [fern] Coord-norm fix replay on 5L/256d + T_max=50 (Wave 10) | Your PR #360 (`q40rez85`) validated the FourierEmbed coordinate normalization fi |
+| #397 | [chihiro] Full stacked recipe: 5L/256d + gc=0.5 + T_max=50 + mirror + SW=2.0 | The most validated levers from Waves 1–9 on bengio have NEVER been fully stacked |
+| #392 | [edward] MLP-ratio sweep {4,6,8} on 5L/256d Fourier base (Wave 10) | The default MLP ratio (mlp_ratio=4) in each transformer block may be a capacity  |
+| #390 | [nezuko] EMA + 5L/256d + T_max=50 — isolate EMA effect on best arch (Wave 10) | EMA (Exponential Moving Average) model weights have never been cleanly isolated  |
+| #389 | [kohaku] Stack gc=0.5 + T_max=50 on 5L/256d Fourier base (Wave 10) | Senku #325 (gc=0.5) is on strong trajectory at ep20=8.504%. |
+| #388 | [haku] NF=32 Fourier PE + 5L/256d + T_max=50 stack (Wave 10) | Norman #239 is converging on NF=32 as the optimal Fourier PE frequency count (NF |
+| #386 | [askeladd] Attention heads sweep {4H,8H} on 5L/256d Fourier base (Wave 10) | On the 5L/256d Fourier base, the default 4 attention heads (64 dims/head) may be |
+| #384 | [edward] MLP-ratio sweep {4,6,8} on 5L/256d Fourier base (Wave 10) | The default MLP ratio (mlp_ratio=4) in the transformer blocks may be a capacity  |
+| #383 | [nezuko] EMA revival + T_max=50 on 4L/256d canonical recipe (Wave 9) | The alphonse Wave 1 baseline (PR #74) uses `--no-use-ema` (EMA disabled). |
+| #382 | [thorfinn] 6L/512d/8H + T_max=50 capacity scaling (Wave 9) | Every strong result on the bengio branch uses 4L/256d. |
+| #381 | [kohaku] Stack gc=0.5 + T_max=50 on 4L/256d Fourier base (Wave 9) | Senku #325 shows gc=0.5 (grad-clip-norm=0.5) produces a strong, smooth descent t |
+| #380 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on Wave 1 base (Wave 9) | The per-channel wall-shear MSE loss multiplier experiments (edward #304) establi |
+| #379 | [frieren] Weight-decay sweep {3e-4, 1e-3, 3e-3} on Wave 1 base (Wave 9) | Weight decay is a regularizer that controls the effective capacity of the model. |
+| #378 | [askeladd] Stack mirror-aug+SW=2.0+T_max=50 on 5L/256d (Wave 9) | Two independently validated levers exist on the bengio branch:
+1. **Mirror-augme |
+| #373 | [stark] Stochastic Weight Averaging over cosine tail (ep35-50) | **Stochastic Weight Averaging (SWA) over the cosine-decay tail will produce a fl |
+| #372 | [noam] Stack T_max=50 + grad-clip-norm=0.5 (alphonse + senku winners) | Stack alphonse #174's winning lever (T_max=50 cosine schedule) with senku #325's |
+| #361 | [frieren] Weight-decay sweep {3e-4, 1e-3, 3e-3} on baseline recipe | The baseline recipe (`m9775k1v`) uses the PyTorch AdamW default weight-decay of  |
+| #360 | [fern] Fix FourierEmbed coordinate normalization (restores alphonse baseline) | The +1pp structural regression vs alphonse `m9775k1v` (val_abupt=7.2091%) has be |
+| #354 | [fern] Bisect +1pp structural regression vs alphonse m9775k1v baseline | A systematic +1.0–1.5 pp structural gap has been observed between every recent ` |
+| #348 | [dazai] Weight-decay sweep {3e-4, 1e-3, 3e-3} on alphonse Fourier base | The bengio Wave 1 baseline `m9775k1v` (alphonse 4L/256d + Fourier PE + no-EMA +  |
+| #347 | [nezuko] Dedicated 2-block wall-shear sub-decoder (split surface head) | The current model uses **a single shared linear head** to produce all 4 surface  |
+| #346 | [gilbert] FiLM normal-conditioning at every transformer block (surface trunk) | Edward PR #304 (loss-weighting) and frieren PR #337 (tangent-frame head) approac |
+| #344 | [gilbert] Tangent-frame wall-shear head: predict (t1,t2,n) components, rotate to global | Edward PR #304 confirmed the wsy/wsz binding constraint is **not loss-weighting- |
+| #343 | [kohaku] Wall-shear-only rel-L2 aux loss sweep {0.1,0.5,1.0} (code edit + sweep) | Edward PR #304 falsified per-channel **MSE** loss reweighting (Trial A upweight  |
+| #342 | [emma] 96k surface+volume points scale-up on alphonse Fourier base | The alphonse Wave 1 baseline samples 40,000 surface points and 40,000 volume poi |
+| #341 | [haku] surface-loss-weight sweep {2.0,4.0,8.0} on alphonse Fourier base | The DrivAerML loss is `surface_loss_weight * surface_loss + volume_loss_weight * |
+| #340 | [thorfinn] model_slices sweep {128,192,256} on alphonse Fourier base | The alphonse Wave 1 baseline (4L/256d/4H + FourierEmbed PE, run `m9775k1v`, val_ |
+| #337 | Surface-normal tangent frame for wall shear prediction | The baseline predicts wall shear `[wsx, wsy, wsz]` in global coordinates directl |
+| #331 | [kohaku] Wall-shear-only squared rel-L2 aux loss sweep {0.1, 0.5, 1.0} | Chihiro PR #254 is sweeping the existing `--raw-rel-l2-weight` flag {0.05, 0.1}, |
+| #330 | [violet] DDP8 radford-champion port: 4L/512d/8H + Fourier + EMA + gc=0.5 + lr=4.8e-4 | The bengio Wave 1 winner (4L/256d/SincosEmbed/no-EMA, val_abupt=7.2091%) was fou |
+| #329 | [emma] 96k surface+volume points scale-up on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, val_abupt=7.2091%) trained on `--trai |
+| #328 | [askeladd] FourierEmbed standalone A/B vs ContinuousSincosEmbed (the missing baseline test) | The 2026-05-01 baseline correction revealed that the Wave 1 winner (PR #74 alpho |
+| #327 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #326 | [thorfinn] Model-slices sweep {128, 192, 256} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #325 | [senku] Grad-clip-norm sweep {0.5, 1.0, 2.0} on alphonse Fourier base | The bengio Wave 1 winner (PR #74 alphonse, run `m9775k1v`, val_abupt=7.2091%) us |
+| #310 | [frieren] Weight-decay + dropout regularisation sweep on 5L Fourier PE base | A systematic val/test gap (~2.5×) on `vol_p` has been observed across all bengio |
+| #308 | [haku] Surface-loss-weight sweep {2.0, 4.0, 8.0} on alphonse Fourier base | The bengio baseline's surface metrics (sp=4.80%, ws=8.16%, wsy=9.10%, wsz=10.87% |
+| #307 | [kohaku] Wall-shear-only squared rel-L2 auxiliary loss sweep | The `--raw-rel-l2-weight` flag adds an extra rel-L2 penalty term to the **total* |
+| #306 | [thorfinn] Model-slices sweep {128, 192, 256} on alphonse Fourier base | Wave 1 kohaku showed `--model-slices 128` (vs default 96) improved abupt at mid- |
+| #305 | [senku] Grad-clip-norm sweep {0.5, 1.0, 2.0} on alphonse Fourier base | The current bengio baseline (alphonse `m9775k1v`) runs without explicit gradient |
+| #304 | [edward] Per-channel wall-shear loss multipliers (wsy/wsz upweight sweep) | The bengio baseline's binding constraints are **wall_shear_y (wsy=9.10% vs 3.65% |
+| #303 | [askeladd] FourierEmbed standalone A/B validation on 4L/256d alphonse base | The `--fourier-pe` flag (chihiro PR #176) was merged to bengio but has **never b |
+| #302 | [emma] 96k surface + 96k volume points scale-up v2 | Scale the per-step token budget from the default ~65k (32k surface + 32k volume) |
+| #301 | [violet] DDP8 radford champion port v2: 4L/512d/8H + EMA + gc=0.5 + lr=4.8e-4 | Port the **radford branch champion recipe** to bengio: 4L/512d/8H Transformer wi |
+| #278 | [gilbert] Train-time mirror-symmetry augmentation for wsy/wsz | DrivAerML vehicles are approximately symmetric about the longitudinal (xz) plane |
+| #276 | [fern] SWA over last 5 epochs: weight averaging for generalization | Stochastic Weight Averaging (SWA) averages model weights from the last K epochs  |
+| #275 | [emma] Scale point budget to 96k surface + volume points | Scale the point budget from the default ~65536 to 96,000 for both surface and vo |
+| #274 | [violet] DDP8 radford champion port: 4L/512d/8H + EMA=0.9995 + gc=0.5 + lr=4.8e-4 | Port the radford-branch champion recipe to bengio. |
+| #266 | stark: U-net long skip connections for wsy/wsz fine-detail injection | Add **U-net-style long skip connections** between symmetric layers of the Transo |
+| #260 | [thorfinn] model-slices sweep {64, 128, 192} on baseline | `--model-slices` controls the number of slice tokens that AB-UPT uses to attend  |
+| #259 | [senku] grad-clip-norm sweep {0.5, 2.0} on baseline | The bengio Wave 1 baseline uses default `--grad-clip-norm 1.0`. |
+| #258 | [kohaku] Squared rel-L2 aux loss on wall-shear (focal-loss-equivalent) | The standard MSE loss penalizes errors quadratically in absolute units, but the  |
+| #257 | [haku] High-shear curriculum oversampling with linear anneal | DrivAerML's 400 training cases vary widely in flow complexity. |
+| #256 | [frieren] Mirror-symmetry TTA for wsy reduction | Cars have approximate left-right symmetry (y-axis mirror). |
+| #255 | [edward] Fixed per-channel wsy/wsz loss multipliers | Wall-shear y/z axes are the dominant binding constraint:
+- val wsy=9.100% vs AB- |
+| #254 | [chihiro] Raw rel-L2 auxiliary loss sweep w in {0.05, 0.1} | The eval metrics (`*_rel_l2_pct`) are scale-invariant relative L2 errors, but th |
+| #253 | [askeladd] FourierEmbed vs ContinuousSincosEmbed standalone A/B | The current bengio Wave 1 baseline (PR #74, alphonse, val_abupt=7.2091%) actuall |
+| #239 | [norman] Fourier PE num_freqs sweep {16, 32, 64, 128} on Wave 1 recipe | **The number of Fourier PE frequency bands is an untuned hyperparameter on bengi |
+| #238 | [kohaku] High-shear curriculum oversampling for wsy/wsz tail | **A "hard-cases-first" curriculum that oversamples high-shear cars early in trai |
+| #237 | [haku] Squared rel-L2 aux loss for hard-sample focusing | **Adding a squared rel-L2 auxiliary loss term penalizes large per-sample errors  |
+| #236 | [edward] Fixed wsy/wsz loss multipliers — direct binding-constraint attack | **Fixed per-channel loss multipliers (`wsy×3, wsz×5, others×1`) directly attack  |
+| #235 | [askeladd] 4L/512d/8H width frontier — radford champion port | **The radford-branch champion config (4L/512d/8H + EMA=0.9995 + gc=0.5 + lr=4.8e |
+| #234 | [senku] Mirror-symmetry test-time augmentation for wsy free gain | **Mirror-symmetry test-time augmentation (TTA) should give a free 0.5–2pp gain o |
+| #221 | [violet] Per-channel adaptive loss reweighting toward AB-UPT targets | The binding wsy/wsz constraint (9.1% and 10.87% vs AB-UPT 3.65%/3.63%) suggests  |
+| #220 | [kohaku] Asinh surface pressure + 96k pts × 5L × T_max=40 | Two untested levers from the empirical compounders list:
+1. **Asinh normalizatio |
+| #219 | [haku] 5L depth + Fourier PE + GradNorm α=1.5 stack | Wave 1 confirmed two independent improvements over the Wave 0 baseline:
+- 8L dep |
+| #217 | [edward] Lion optimizer sweep vs AdamW | Lion optimizer (Chen et al. |
+| #216 | [askeladd] Per-axis loss autoweighting via running variance | The binding constraint is wsy and wsz (9.10% and 10.87% vs AB-UPT 3.65%/3.63%). |
+| #215 | [senku] SWA last-5-epoch averaging for free gain | Stochastic Weight Averaging (SWA) is a zero-cost ensemble technique: after the c |
+| #214 | [gilbert] k-NN local surface attention for wsy/wsz gap | Wall shear stress τ_y and τ_z are the hardest predictions in this benchmark — th |
+| #205 | [violet] Per-channel surface loss rebalance (adaptive weights) | The current loss function applies a single global weight to the entire surface p |
+| #190 | [haku] Radford champion port: 4L/512d/8H + EMA=0.9995 + DDP8 | Scale hidden dimension from 256 → 512 and attention heads from 4 → 8, re-enable  |
+| #188 | [gilbert] 4L/256d + Fourier PE + slices=192 (slice-count scaling) | The Wave 1 winning recipe (4L/256d + Fourier PE, val_abupt=7.2091%) uses the def |
+| #181 | [thorfinn] EMA revival {0.999, 0.9995} on Fourier PE + T_max=50 | Wave 1 baseline (PR #74, alphonse) **disabled EMA** with `--no-use-ema` because  |
+| #180 | [norman] Raw rel-L2 aux loss {0.1, 0.3} on Fourier PE baseline | Add a raw rel-L2 auxiliary loss to directly optimize for the eval metric. |
+| #179 | [nezuko] 5L/384d + Fourier PE + T_max=60 wide+deep scaling | Joint width + depth scaling on the Fourier PE baseline. |
+| #177 | [frieren] Surface loss upweight {3x,5x} to close ws_y/ws_z gap | The biggest abupt gap remaining is in wall_shear components: ws_y=9.100% (target |
+| #175 | [askeladd] 4L/384d + Fourier PE + T_max=50 width scaling | Wave 1 best (PR #74): 4L/256d + Fourier PE → val_abupt=7.2091%. |
+| #174 | [alphonse] 5L/256d + Fourier PE + T_max=50 longer schedule | Wave 1 winner (PR #74): 4L/256d + Fourier PE + T_max=30 → val_abupt=7.2091%. |
+| #160 | [edward] DrivAerML: Split surface output head — dedicated cp and wall-shear MLPs | The current `model.py` uses a single shared `LinearProjection(n_hidden, 4)` outp |
+| #145 | [senku] DrivAerML Metric-Aware Loss: MSE + Raw Rel-L2 Auxiliary (w=0.05) | The DrivAerML training objective uses per-task MSE losses in normalized (zero-me |
+| #140 | [senku] DrivAerML Curriculum Mass-Weighted Case Sampling (E1) | **Curriculum (easy-first) case sampling via per-case gradient-norm difficulty pr |
+| #137 | [edward] DrivAerML GradNorm Per-Task Gradient Equalization (wall-shear focus) | Wave 1 established that the binding constraint is `wall_shear_y` and `wall_shear |
+| #89 | [thorfinn] DrivAerML Tighter Gradient Clipping + Weight Decay | The current training uses no explicit gradient clipping and `weight_decay=1e-4`. |
+| #88 | [senku] DrivAerML Random Fourier Features Positional Encoding | The current `ContinuousSincosEmbed` uses a fixed sinusoidal basis with wavelengt |
+| #87 | [norman] DrivAerML Dropout Regularization: dropout=0.1 + Cosine Schedule | The current model uses no dropout (default dropout=0.0). |
+| #86 | [nezuko] DrivAerML MLP-Ratio=6: Wider FFN in Transformer Blocks | The Transolver uses transformer blocks with `mlp_ratio=4`, meaning the feed-forw |
+| #85 | [frieren] DrivAerML Cross-Attention Bridge Between Surface and Volume Tokens | The current Transolver uses a shared backbone that processes surface and volume  |
+| #83 | [chihiro] DrivAerML asinh Target Normalization for Wall Shear | Wall shear stress in CFD has a heavy-tailed distribution — most of the vehicle s |
+| #82 | [askeladd] DrivAerML SDF-Conditioned Volume Encoding | The Transolver currently treats surface and volume tokens symmetrically — both p |
+| #81 | [violet] DrivAerML Cosine Schedule + LR Sweep | The radford PR #2593 winner used T_max=30 with lr=3e-4. |
+| #78 | [kohaku] DrivAerML 128 Slices + Fourier PE | The Transolver attention mechanism groups tokens into slices for physics-aware p |
+| #77 | [haku] DrivAerML 4L/384d Width Scaling | The radford PR #2593 winner used hidden_dim=256. |
+| #76 | [gilbert] DrivAerML 5L/256d Depth Scaling + Fourier PE | The radford PR #2593 winner used 4 layers. |
+| #75 | [fern] DrivAerML LR Sweep with Fourier PE | The radford PR #2593 winner used lr=3e-4 with the 4L/256d+no-EMA+Fourier+T_max=3 |
+| #74 | [alphonse] DrivAerML 4L/256d Fourier PE Baseline (Stream 1) | **Stream 1 — Replicate 4L/256d + no-EMA + Fourier PE + T_max=30 as bengio baseli |

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,967 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955", size = 6320619, upload-time = "2026-03-11T00:12:45.939Z" },
+    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "drivaerml"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "wandb" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "wandb" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/a4/72a6640e1f566e81f184a426e3e45298d4c6672664de41adb7eb6f64370a/wandb-0.26.1.tar.gz", hash = "sha256:eef2dbaea06f0b1c0cdc5d76f544ae4c2b8848fc512442a00bd59f0502fc8aa1", size = 42159814, upload-time = "2026-04-23T16:27:34.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/09/3296235f3906e904f06f2df29eed4d672fb23c0932c9486e2af64f2f2a66/wandb-0.26.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2955fe190c005fb83ee6d73f066c8a33f09f3212a1f2eb53faa6581440e456be", size = 24857204, upload-time = "2026-04-23T16:26:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ad/e39ca3086534129e42208ba00ed2c6247ce425f890219eeec33b4f162864/wandb-0.26.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:55d91cabde98162d7116a5e19ddd052bd9848556243f1da4cbb9ffb7ad435bfc", size = 26014649, upload-time = "2026-04-23T16:27:02.559Z" },
+    { url = "https://files.pythonhosted.org/packages/56/af/400d84a3bdce0b062b4baa70acb6becd2c8018697f4fbf5af9a9e1e406e5/wandb-0.26.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7c78bc2454cfe1ffa1c3a256060a387356eed8a4488e024d9d2eba8f2b5bd51d", size = 25421317, upload-time = "2026-04-23T16:27:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/b4bf8f3509dcea1cec52233a38991459654635b5a8e6a494eb912e1b9cfb/wandb-0.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a2c8eeec8706dcd2872e69c3b4d20ec523082fdb4440295491556e219ad2aa67", size = 27192831, upload-time = "2026-04-23T16:27:10.308Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cf/4a6dce0c782223ef0eeea7139daee73418a7322befcf083512c31cebaa18/wandb-0.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2fa768ee0636a569afb7541cf996e56309c47070566a38916823f94e02afe586", size = 25593326, upload-time = "2026-04-23T16:27:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/df/99/58c3d8c36ae8e2b7d70bf6493eb5daa1cca0231a04b025717b4cd1a78f1e/wandb-0.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5854928725cfeff1f284d5c043cd353f810e5da02eead2c120ef5056ad026fea", size = 27535542, upload-time = "2026-04-23T16:27:18.473Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d0/4e846ffc1d0cc435518dfa581ce73ac82cfd0ebbf35f3853c9277f632e5f/wandb-0.26.1-py3-none-win32.whl", hash = "sha256:5c2bd44e575ae9944e2764d1aaa031461178276bf2636d5558399c2816ef5cfe", size = 24968151, upload-time = "2026-04-23T16:27:22.086Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9b/487413eaccefdb58799a226726e24b486e9192d2671c75a4550c160aba23/wandb-0.26.1-py3-none-win_amd64.whl", hash = "sha256:5817785467d3f1676f1812ec19a89f77f6e56dfe67d9f47080075af95f705d3e", size = 24968155, upload-time = "2026-04-23T16:27:25.731Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dc/5baf3e99b3eeb709d6f75124b5bec8cb73d4b38d2b10df7fdcfde4966200/wandb-0.26.1-py3-none-win_arm64.whl", hash = "sha256:f848b7744f896bc04cabbb28360a2814d1551a91fa2c456243e06435729c8a2e", size = 22912416, upload-time = "2026-04-23T16:27:29.456Z" },
+]


### PR DESCRIPTION
# [senku] coord-norm + TTA-mirror stacked on 5L/256d (Wave 20)

## Hypothesis

**Stacking the coord-norm fix with y-mirror TTA at inference gives a free ensemble gain on top of the strongest recent improvement.** The coord-norm fix (fern #409) brought val_abupt from 7.21% to 7.16% at ep24 — a real but small improvement. y-mirror TTA (fern #514) is being tested in parallel as an inference-only free signal. If TTA works, combining it with coord-norm training from scratch should yield an additive gain.

This experiment is the training-time counterpart to fern #514's inference-only test:
- Train with `--coord-norm` (the coord-norm input normalization fix)
- Validate with both standard and y-mirror-averaged predictions
- Report both val_abupt numbers (standard and TTA)

If fern #514 TTA results come in while this run is in progress and the TTA gain is ≥0.1pp, that becomes strong supporting evidence. If TTA gives zero gain, this run's TTA head is noise — but the coord-norm training is still a separate hypothesis worth confirming at full 50-epoch budget.

**NOTE: coord-norm may already be the default in the codebase (check if `--coord-norm` is still an explicit flag or was merged in).** Verify with `python train.py --help` before running. If it's now the default, this experiment becomes a pure coord-norm + TTA compound test.

## Implementation

1. **Check `--coord-norm` flag status**: If it exists as an explicit opt-in flag, add it. If it's now the default (i.e. merged from fern #409), note this in the PR — then the experiment is just TTA + current best config.
2. **Implement `--tta-mirror` in validation loop only** (same implementation as fern #514):
   - Mirror input geometry (negate y-coordinates of surface + volume points)
   - Run forward pass, then negate the wsy channel of the mirrored prediction
   - Average original + symmetry-corrected mirrored prediction
   - Compute val metrics on the averaged prediction
3. Run the full 50-epoch training with coord-norm (if applicable) + TTA val.

## Reproduce command

```bash
cd target/ && torchrun --standalone --nproc-per-node=4 train.py \
  --model-layers 5 --model-hidden-dim 256 --model-heads 4 \
  --fourier-pe --no-use-ema \
  --lr 3e-4 --lr-cosine-t-max 50 \
  --no-compile-model \
  --coord-norm \
  --tta-mirror \
  --kill-thresholds "500:train/loss<5,89000:val_primary/abupt_axis_mean_rel_l2_pct<13,178000:val_primary/abupt_axis_mean_rel_l2_pct<10.5,267000:val_primary/abupt_axis_mean_rel_l2_pct<8.5,356000:val_primary/abupt_axis_mean_rel_l2_pct<8.0,445000:val_primary/abupt_axis_mean_rel_l2_pct<6.9549" \
  --wandb-group bengio-wave20 --wandb-name senku/coord-norm-tta-mirror --agent senku
```

*(If `--coord-norm` is not a valid flag because it is now the default, drop it from the command.)*

## Kill gates (standard)
- EP5 (step 89,080) abupt > 13.0% → kill
- EP10 (step 178,160) abupt > 10.5% → kill
- EP15 (step 267,240) abupt > 8.5% → kill
- EP20 (step 356,320) abupt > 8.0% → kill
- EP25 (step 445,400) abupt > 6.9549% (baseline) → kill

## Baseline (target to beat)

| Metric | PR #174 (baseline) | fern #409 ep24 (coord-norm only) | Goal |
|--------|-------------------|----------------------------------|------|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.9549** | 7.197 | < 6.8% |
| `val_primary/wall_shear_y_rel_l2_pct` | 8.7345 | ~8.5% | < 8.0% (TTA gain expected) |
| `val_primary/wall_shear_z_rel_l2_pct` | 10.5766 | ~10.0% | < 9.5% |

## Why this hypothesis is high-leverage

- Two proven (or nearly-proven) signals at zero additional compute: coord-norm (confirmed ~0.05pp above previous best) + TTA-mirror (being tested now by fern).
- If fern #514 shows TTA gives ≥0.1pp gain on the PR #174 checkpoint, this run is the "with-training" version that could give larger gains (TTA gain is usually larger on models trained to be symmetric).
- Strictly additive with gilbert's tangent-frame (#512) and alphonse's 6L/512d (#513).

## Constraints

- `--no-compile-model` mandatory.
- `--fourier-pe` mandatory.
- `--no-use-ema` mandatory.
- TTA must be val-only (training loss path unchanged).
- One PR, one hypothesis.
