### PR TITLE
askeladd: per-channel tau_y/tau_z loss reweighting on #488 SOTA stack

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -101,6 +102,8 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    tau_y_loss_weight: float = 1.0
+    tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -251,11 +254,16 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
 
 
-def parse_rff_init_sigmas(raw: str) -> list[float] | None:
-    if not raw:
+def parse_rff_init_sigmas(spec: str) -> list[float] | None:
+    spec = (spec or "").strip()
+    if not spec:
         return None
-    parsed = [float(x.strip()) for x in raw.split(",") if x.strip()]
-    return parsed or None
+    sigmas = [float(token.strip()) for token in spec.split(",") if token.strip()]
+    if not sigmas:
+        return None
+    if any(s <= 0.0 for s in sigmas):
+        raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
+    return sigmas
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -301,6 +309,7 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    surface_channel_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -312,7 +321,15 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        if surface_channel_weights is not None:
+            surface_loss = weighted_channel_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                surface_channel_weights,
+            )
+        else:
+            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -720,6 +737,16 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())
+        # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
+        # the largest gap to AB-UPT, so we expose per-channel weights here.
+        surface_channel_weights = torch.tensor(
+            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+            device=device,
+            dtype=torch.float32,
+        )
+        use_channel_weights = bool(
+            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+        )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -789,6 +816,21 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
         val_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
 
+        # Log multi-sigma RFF init layout for verification.
+        if state.is_main:
+            ss = getattr(base_model, "surface_string_sep", None)
+            if ss is not None and getattr(ss, "init_sigmas", None) is not None:
+                print(
+                    f"StringSep multi-sigma init: sigmas={ss.init_sigmas} "
+                    f"num_features={ss.num_features} layout=round-robin per axis "
+                    f"(log_freq[d, f] = log(sigmas[f % len(sigmas)]))"
+                )
+            if use_channel_weights:
+                print(
+                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
+                    f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                )
+
         run = init_wandb_run(
             config=config,
             state=state,
@@ -808,6 +850,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         config_path = output_dir / "config.yaml"
         with config_path.open("w") as f:
             yaml.safe_dump(asdict(config), f)
+
+        if state.is_main:
+            ss = getattr(base_model, "surface_string_sep", None)
+            init_sigmas_for_log = (
+                list(ss.init_sigmas)
+                if ss is not None and getattr(ss, "init_sigmas", None) is not None
+                else []
+            )
+            wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
+            wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
+            wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -954,6 +1007,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         config.amp_mode,
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
+                        surface_channel_weights=surface_channel_weights if use_channel_weights else None,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -990,6 +1044,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/tau_y_loss_weight": config.tau_y_loss_weight,
+                            "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
                 if gradnorm_metrics:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -832,6 +832,39 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def weighted_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor,
+) -> torch.Tensor:
+    """Per-channel weighted masked MSE with a single mean over all entries.
+
+    pred / target: [B, N, C]; mask: [B, N]; weights: [C].
+    Returns a single scalar averaged over (valid points × channels), with each
+    channel's squared error multiplied by its weight before averaging. This
+    matches the behaviour of ``masked_mse`` when ``weights = [1, 1, ..., 1]``
+    and only changes the relative gradient budget across channels — it does NOT
+    decompose into per-channel means (which would double-weight the smaller
+    channels and was the failure mode of PR #353).
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    weights_dev = weights.to(device=pred.device, dtype=pred.dtype)
+    if weights_dev.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"weights last-dim {weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    sq_err = (pred - target).square()
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighted = sq_err * weights_dev * mask_dev
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

With PR #488, volume_pressure has dropped below the AB-UPT reference (4.357% vs 6.08%). The remaining gaps are now concentrated in wall_shear — especially tau_y and tau_z — and surface_pressure:

| Metric | Current SOTA (PR #488) | AB-UPT target | Gap |
|---|---:|---:|---:|
| `surface_pressure` | 4.805% | 3.82% | +0.985pp |
| `wall_shear` | 8.347% | 7.29% | +1.057pp |
| `tau_y` | ~9.1% (from PR #387 test) | 3.65% | **~+5.5pp (2.5×)** |
| `tau_z` | ~10.3% (from PR #387 test) | 3.63% | **~+6.7pp (2.8×)** |
| `volume_pressure` | **4.357%** | 6.08% | **BEATEN** |

The model's training loss treats all 4 surface output channels equally (surface_pressure, tau_x, tau_y, tau_z). This is a strong implicit prior that the channels are equally important, even though:

1. The tau_y/tau_z gap to AB-UPT is **2.5–2.8× larger** than the surface_pressure gap
2. Wall shear is harder to predict (sharp geometric features, mirror wake, wheel arches)
3. Equal weighting means gradient budget is wasted on channels already near target

**Hypothesis:** Per-channel L2 loss weighting — specifically upweighting tau_y and tau_z proportional to their gap ratio vs AB-UPT — will push gradient signal toward the hardest channels, reducing tau_y/tau_z error while maintaining the gains on surface_pressure and volume_pressure.

This is NOT the same as PR #353 (Huber loss) which was negative: Huber *reduces* gradients on large residuals (wrong direction). This approach keeps L2 throughout and simply scales the gradient budget allocation across channels.

PR #496 (in-flight, tanjiro) is testing homoscedastic uncertainty weighting — that approach learns the weights dynamically. This PR tests manually tuned fixed weights calibrated to the gap ratios, which is simpler and faster to converge.

## Instructions

### Step 1: Add CLI flags to `target/train.py`

In the `Config` dataclass, add after existing loss weight params:

```python
tau_y_loss_weight: float = 1.0   # channel weight for tau_y (ch 2 of surface output)
tau_z_loss_weight: float = 1.0   # channel weight for tau_z (ch 3 of surface output)
```

Add `--tau-y-loss-weight` and `--tau-z-loss-weight` float arguments to `parse_args`.

### Step 2: Implement weighted channel loss in `target/trainer_runtime.py`

Find the surface loss computation — likely a `masked_mse` or similar call on the 4-channel surface predictions. Replace with a weighted version:

```python
def weighted_channel_mse(pred, target, mask, weights):
    """
    pred, target: [B, N, 4]  (surface_pressure, tau_x, tau_y, tau_z)
    mask: [B, N] boolean
    weights: [4] tensor
    Returns scalar loss. Single masked_mean over all channels — no per-channel separate means.
    """
    sq_err = (pred - target) ** 2           # [B, N, 4]
    weighted = sq_err * weights.to(sq_err.device)  # [B, N, 4]
    denom = mask.sum() * 4
    return (weighted * mask.unsqueeze(-1)).sum() / denom
```

**CRITICAL:** This must be a SINGLE masked mean over all 4 channels. PR #353's failure was caused by computing separate per-channel means which gave surface_pressure 4× extra relative weight. Do NOT compute `sp_loss + tau_loss` separately.

Construct the weight tensor from config:
```python
channel_weights = torch.tensor([
    1.0,                          # ch 0: surface_pressure
    1.0,                          # ch 1: tau_x
    config.tau_y_loss_weight,     # ch 2: tau_y
    config.tau_z_loss_weight,     # ch 3: tau_z
])
```

Log `train/tau_y_loss_weight` and `train/tau_z_loss_weight` to W&B each epoch.

### Step 3: Run two arms (grouped under same wandb-group)

Run sequentially. Post ep3 results from Run A before launching Run B.

**Run A — modest weights proportional to gap ratio (tau_y×2.0, tau_z×2.5):**

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --tau-y-loss-weight 2.0 --tau-z-loss-weight 2.5 \
  --wandb-group askeladd-tau-channel-reweight \
  --wandb-name askeladd/tau-reweight-w2.0-w2.5
```

**Run B — aggressive weights (tau_y×3.0, tau_z×4.0), only if Run A doesn't diverge:**

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --tau-y-loss-weight 3.0 --tau-z-loss-weight 4.0 \
  --wandb-group askeladd-tau-channel-reweight \
  --wandb-name askeladd/tau-reweight-w3.0-w4.0
```

### Expected behaviour

- `val_primary/wall_shear_y_rel_l2_pct` and `val_primary/wall_shear_z_rel_l2_pct` should decrease vs SOTA
- `val_primary/abupt_axis_mean_rel_l2_pct` may stay flat or improve slightly (depending on whether tau gains offset any surface_pressure regression)
- If val_abupt regresses significantly (>0.2pp vs SOTA), report ep5 results before completing Run A — I may want to abort

### What to report in your PR comment

From the **best-val checkpoint** for each run:
- `val_primary/abupt_axis_mean_rel_l2_pct`
- `test_primary/abupt_axis_mean_rel_l2_pct`
- Per-axis test: surface_pressure, tau_x, tau_y, tau_z, wall_shear, volume_pressure
- W&B run ID for each run
- Note any convergence anomalies at ep1-3

## Baseline

**Current SOTA: PR #488 alphonse — multi-sigma STRING-sep init**
W&B run: `ki2q9ko9`, EP11

| Metric | PR #488 SOTA | AB-UPT | Gap |
|---|---:|---:|---:|
| `val_abupt` (EP11) | **7.3672%** | — | — |
| `surface_pressure` (val) | 4.805% | 3.82% | +0.985pp |
| `wall_shear` (val) | 8.347% | 7.29% | +1.057pp |
| `volume_pressure` (val) | **4.357%** | 6.08% | **BEATEN** |

**Beat target: `val_primary/abupt_axis_mean_rel_l2_pct` < 7.3672%**

```bash
# Reproduce current SOTA (PR #488)
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0"
```
