### PR TITLE
kohaku: loss-side asinh wallshear (no inverse pipeline) — corrected #485

### DIFF
--- a/train.py
+++ b/train.py
@@ -699,6 +699,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    wallshear_asinh_loss_delta: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1418,6 +1419,7 @@ def weighted_masked_mse_per_channel(
     *,
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
+    wallshear_asinh_loss_delta: float = 0.0,
 ) -> tuple[torch.Tensor, list[float]]:
     """Per-channel weighted masked loss for surface predictions.
 
@@ -1433,6 +1435,19 @@ def weighted_masked_mse_per_channel(
         loss_elem = r^2                          if |r| <  delta
                   = 2 * delta * (|r| - delta/2)  if |r| >= delta
     Channel 0 (cp / surface_pressure) keeps the standard MSE loss.
+
+    With ``wallshear_asinh_loss_delta > 0.0`` (PR #518), channels 1..3 use a
+    soft-Huber-via-asinh on the standardized residual:
+        loss_elem = asinh(r / delta)^2 * delta^2
+    For ``|r| << delta`` this recovers MSE (asinh(x) ≈ x for small x); for
+    ``|r| >> delta`` the gradient is log-bounded (asinh(x) ≈ ln(2x)), giving a
+    smooth Huber-like saturation that reduces gradient dominance from heavy-tail
+    tau_x outliers. Crucially this is *inside-loss only* — predictions, eval,
+    and metric computation see no transform, so there is no inverse-pipeline
+    Jacobian amplification (the failure mode of the target-space asinh in PR
+    #485). Channel 0 (cp) keeps MSE. ``wallshear_asinh_loss_delta`` and
+    ``wallshear_huber_delta`` are mutually exclusive; if both are positive,
+    asinh wins.
 
     Note: PR #317's spec used a *relative* Huber ``(pred-target)/(|target|+eps)``,
     but standardized targets cross zero frequently, so dividing by ``|target|``
@@ -1454,7 +1469,15 @@ def weighted_masked_mse_per_channel(
     valid = mask_f.sum().clamp_min(1)
     n_channels = diff_sq.shape[-1]
 
-    if wallshear_huber_delta > 0.0 and n_channels >= 4:
+    if wallshear_asinh_loss_delta > 0.0 and n_channels >= 4:
+        delta_t = pred.new_full((), float(wallshear_asinh_loss_delta))
+        # Soft-Huber via asinh on standardized residuals; bounded gradient at heavy tails.
+        # asinh(r/delta)^2 * delta^2 -> r^2 for |r|<<delta, log-bounded for |r|>>delta.
+        asinh_elem = torch.asinh(diff / delta_t).pow(2) * delta_t.pow(2)
+        loss_elem = torch.cat([diff_sq[..., :1], asinh_elem[..., 1:4]], dim=-1)
+        if n_channels > 4:
+            loss_elem = torch.cat([loss_elem, diff_sq[..., 4:]], dim=-1)
+    elif wallshear_huber_delta > 0.0 and n_channels >= 4:
         abs_err = diff.abs()
         delta_t = pred.new_full((), float(wallshear_huber_delta))
         huber_elem = torch.where(
@@ -1502,6 +1525,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    wallshear_asinh_loss_delta: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1547,6 +1571,7 @@ def train_loss(
             batch.surface_mask,
             channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
             wallshear_huber_delta=wallshear_huber_delta,
+            wallshear_asinh_loss_delta=wallshear_asinh_loss_delta,
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -2124,6 +2149,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                wallshear_asinh_loss_delta=config.wallshear_asinh_loss_delta,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())


### PR DESCRIPTION
## Hypothesis

Your previous PR #485 cleanly falsified **target-space** asinh normalization on wall-shear: the inverse-pipeline Jacobian (`scale·sinh(z·σ+μ)`) exponentially amplifies prediction errors for heavy-tail samples, so we compressed the loss but inflated the metric.

The original underlying motivation — "the wall-shear gradient signal is dominated by tau_x's heavy-tailed magnitude, drowning tau_y/tau_z" — is still well-founded. The **right** way to test that motivation is to apply the asinh transform **inside the loss only**, on the residual, with **no inverse transform on the prediction pipeline**. Predictions, validation, and test metrics all stay in original (z-scored) space; only the gradient flow gets the soft-log-tail treatment.

This makes the experiment a clean **gradient-rebalancing intervention**:

- Prediction `ŷ`, target `y` (both standardized) — unchanged.
- Loss replaces `MSE(ŷ, y)` for the 3 wall-shear channels with `(asinh((ŷ - y)/δ))² · δ²` (a soft-Huber-like penalty).
- For small residuals (|r| << δ): behavior recovers MSE.
- For large residuals (|r| >> δ): gradient becomes log-bounded → reduced dominance of heavy-tail tau_x outliers, more relative gradient mass goes to tau_y/tau_z.

Crucially, the metric is unchanged (still computed in original space), so this is a clean intervention on the **gradient pathway** only. No Jacobian amplification, no test-time inverse, no metric distortion.

## Instructions

**Code change required.** Add a new flag `--wallshear-asinh-loss-delta <float>` (default `0.0` = OFF / pure MSE) to `target/train.py`. When > 0:

1. Locate the per-channel wall-shear loss computation (the place where `--wallshear-y-weight` and `--wallshear-z-weight` are applied; search `train.py` for `wallshear_y_weight` to find the right block).
2. The current code computes per-axis `mse = (pred - target)**2`, then weights and reduces. Replace with:

```python
delta = float(self.config.wallshear_asinh_loss_delta)
if delta > 0.0:
    # Soft-Huber-via-asinh on standardized residuals; bounded gradient at heavy tails
    r = (pred - target) / delta
    per_pt_loss = torch.asinh(r).pow(2) * (delta ** 2)
else:
    per_pt_loss = (pred - target).pow(2)
```

3. Apply this **only to the 3 wall-shear channels (indices 1..3 of the surface output)**. Surface pressure (channel 0) stays on plain MSE — keep it as control.
4. Predictions, eval, and metric computation are unchanged: this is **inside-loss only**.

**Run a 3-arm DDP-4 sweep on a single 4-GPU pod, sequential arms (one per timeout window):**

| Arm | δ | rationale |
|---|---|---|
| A | 0.5 | tight: most aggressive heavy-tail suppression |
| B | 1.0 | medium: bounded beyond ~1σ residual |
| C | 2.0 | gentle: MSE-like for the bulk, log-bounded only for worst outliers |

**Common config (all arms — Lion SOTA recipe, no `--use-tangential-wallshear-loss`, no `--wallshear-y-weight`/`-z-weight` overrides — keep them at production defaults):**

```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent kohaku \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r31-kohaku-loss-side-asinh
```

Per-arm overrides:
- **Arm A**: `--wallshear-asinh-loss-delta 0.5`
- **Arm B**: `--wallshear-asinh-loss-delta 1.0`
- **Arm C**: `--wallshear-asinh-loss-delta 2.0`

No kill thresholds. Each arm gets the full 6h.

**Optional Arm D (control)**: re-run with `--wallshear-asinh-loss-delta 0.0` in the same W&B group, same seed, to provide an in-group reference. Recommended if you have time after the 3 main arms.

## What to report

Per-arm in the result comment:
1. Best `val_primary/abupt_axis_mean_rel_l2_pct` over training, with corresponding test-row at best-val checkpoint.
2. Per-channel `surface_pressure`, `volume_pressure`, `wall_shear`, `wall_shear_x`, `wall_shear_y`, `wall_shear_z`.
3. **Critical diagnostic**: report ratios `ws_y/ws_x` and `ws_z/ws_x` per arm. The hypothesis predicts these drop monotonically with smaller δ. If they drop even when val_abupt doesn't win, the gradient-rebalancing mechanism is confirmed and motivates a follow-up combining this with #370/#367/#425.
4. W&B run IDs.

## Decision rule (advisor side)

- Any arm beats yi merge bar **9.039%** → merge candidate.
- `ws_y/ws_x` or `ws_z/ws_x` improves directionally vs Arm D control → mechanism confirmed; publish as ablation evidence even if null on val_abupt.
- Both ratios and val_abupt regress → hypothesis falsified more thoroughly than #485; close.

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn).
- **Aspirational once PR #490 STRING-sep PE lands:** `< 7.546%` (PR #311 reference, W&B run `gcwx9yaa`).
- **Current per-channel test gaps vs AB-UPT (PR #311 row):**
  - `wall_shear_y` 9.233% (2.53× AB-UPT 3.65%)
  - `wall_shear_z` 10.449% (2.88× AB-UPT 3.63%)
  - `wall_shear_x` 7.253% (1.36× AB-UPT 5.35%)
  - Ratios `ws_y/ws_x` = 1.27, `ws_z/ws_x` = 1.44 — cross-flow disadvantage measurable.

## Notes

- This is **not** PR #485 with new numbers — it's the structurally correct version. The Jacobian amplification problem of #485 is mechanically impossible here because we don't transform the prediction pipeline.
- Small localized code change (~10 lines). Keep the diff minimal: single new flag, single per-channel branch.
- DDP-4, bs=4, 6h budget per arm → ~10 epochs each. Sequential arms over 3 windows = 18h.
