### PR TITLE
gilbert: layer-wise LR decay (LLRD) sweep on 4L/512d Lion stack

### DIFF
--- a/train.py
+++ b/train.py
@@ -763,6 +763,7 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    llrd_decay: float = 1.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -924,6 +925,92 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_max_wavelength=config.pos_max_wavelength,
         learnable_pe=config.learnable_pe,
     )
+
+
+def build_llrd_param_groups(
+    model: SurfaceTransolver,
+    base_lr: float,
+    decay: float,
+) -> list[dict]:
+    """Build BERT-style layer-wise LR decay parameter groups.
+
+    Group ordering (group 0 = embed = smallest LR ... group N = head = full LR):
+        0: pe_embed   (PE, surface_bias, volume_bias, projects, placeholders, geom_encoder)
+        1..n_layers:  one per transformer block (and matching FiLM layer if present)
+        n_layers+1:   head (final norm, surface_out, volume_out)
+
+    With n_groups = n_layers + 2 groups, multiplier of group i is decay^(n_groups-1-i).
+    """
+    n_layers = len(model.backbone.blocks)
+    n_groups = n_layers + 2
+
+    embed_modules: list[tuple[str, nn.Module]] = [
+        ("pos_embed", model.pos_embed),
+        ("surface_bias", model.surface_bias),
+        ("volume_bias", model.volume_bias),
+    ]
+    if model.project_surface_features is not None:
+        embed_modules.append(("project_surface_features", model.project_surface_features))
+    if model.project_volume_features is not None:
+        embed_modules.append(("project_volume_features", model.project_volume_features))
+    if model.geom_encoder is not None:
+        embed_modules.append(("geom_encoder", model.geom_encoder))
+
+    head_modules: list[tuple[str, nn.Module]] = [
+        ("norm", model.norm),
+        ("surface_out", model.surface_out),
+        ("volume_out", model.volume_out),
+    ]
+
+    embed_params: list[nn.Parameter] = []
+    for _name, mod in embed_modules:
+        embed_params.extend(mod.parameters())
+    embed_params.append(model.surface_placeholder)
+    embed_params.append(model.volume_placeholder)
+
+    block_params: list[list[nn.Parameter]] = [[] for _ in range(n_layers)]
+    for i, block in enumerate(model.backbone.blocks):
+        block_params[i].extend(block.parameters())
+    if model.backbone.film_layers is not None:
+        for i, film in enumerate(model.backbone.film_layers):
+            block_params[i].extend(film.parameters())
+
+    head_params: list[nn.Parameter] = []
+    for _name, mod in head_modules:
+        head_params.extend(mod.parameters())
+
+    multipliers = [decay ** (n_groups - 1 - i) for i in range(n_groups)]
+    param_groups: list[dict] = [
+        {"params": embed_params, "lr": base_lr * multipliers[0], "name": "embed"},
+    ]
+    for i in range(n_layers):
+        param_groups.append(
+            {
+                "params": block_params[i],
+                "lr": base_lr * multipliers[1 + i],
+                "name": f"block_{i}",
+            }
+        )
+    param_groups.append(
+        {"params": head_params, "lr": base_lr * multipliers[-1], "name": "head"}
+    )
+
+    assigned_param_ids = set()
+    for pg in param_groups:
+        for p in pg["params"]:
+            assigned_param_ids.add(id(p))
+    all_trainable = [p for p in model.parameters() if p.requires_grad]
+    missing = [p for p in all_trainable if id(p) not in assigned_param_ids]
+    extra = len(assigned_param_ids) - sum(1 for p in all_trainable)
+    if missing:
+        raise RuntimeError(
+            f"build_llrd_param_groups: {len(missing)} trainable parameters not assigned to any group"
+        )
+    if extra != 0:
+        raise RuntimeError(
+            f"build_llrd_param_groups: param count mismatch (extra={extra})"
+        )
+    return param_groups
 
 
 def _metric_path(name: str) -> str:
@@ -1979,16 +2066,38 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_model = model
 
     optimizer_name = config.optimizer.lower()
-    if optimizer_name == "adamw":
-        optimizer = torch.optim.AdamW(
-            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+    use_llrd = config.llrd_decay < 1.0
+    if use_llrd and optimizer_name == "muon":
+        raise ValueError(
+            "--llrd-decay < 1.0 is not supported with --optimizer muon (Muon already uses its own param groups)."
         )
+    if use_llrd and (config.llrd_decay <= 0.0 or config.llrd_decay > 1.0):
+        raise ValueError(
+            f"--llrd-decay must be in (0, 1]; got {config.llrd_decay}"
+        )
+
+    if optimizer_name == "adamw":
+        if use_llrd:
+            llrd_groups = build_llrd_param_groups(model, config.lr, config.llrd_decay)
+            optimizer = torch.optim.AdamW(
+                llrd_groups, lr=config.lr, weight_decay=config.weight_decay
+            )
+        else:
+            optimizer = torch.optim.AdamW(
+                model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+            )
     elif optimizer_name == "lion":
         from lion_pytorch import Lion
 
-        optimizer = Lion(
-            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
-        )
+        if use_llrd:
+            llrd_groups = build_llrd_param_groups(model, config.lr, config.llrd_decay)
+            optimizer = Lion(
+                llrd_groups, lr=config.lr, weight_decay=config.weight_decay
+            )
+        else:
+            optimizer = Lion(
+                model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+            )
     elif optimizer_name == "muon":
         muon_2d_params = [p for p in model.parameters() if p.requires_grad and p.ndim == 2]
         muon_other_params = [p for p in model.parameters() if p.requires_grad and p.ndim != 2]
@@ -2037,6 +2146,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         print(
             f"Optimizer: {optimizer.__class__.__name__} "
             f"lr={config.lr} wd={config.weight_decay}"
+        )
+    if is_main and use_llrd:
+        print(
+            f"LLRD: decay={config.llrd_decay} across {len(optimizer.param_groups)} groups; "
+            "per-group LRs: "
+            + ", ".join(
+                f"{pg.get('name', f'g{i}')}={pg['lr']:.3e}"
+                for i, pg in enumerate(optimizer.param_groups)
+            )
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
@@ -2108,6 +2226,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/film/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
+    wandb.define_metric("train/lr_group_*", step_metric="global_step")
+    wandb.define_metric("train/lr_group/*", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_kind", step_metric="global_step")
 
@@ -2282,6 +2402,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 **gradient_metrics,
                 **weight_metrics,
             }
+            if use_llrd:
+                for pg_idx, pg in enumerate(optimizer.param_groups):
+                    pg_name = pg.get("name", f"group_{pg_idx}")
+                    train_log[f"train/lr_group_{pg_idx}"] = float(pg["lr"])
+                    train_log[f"train/lr_group/{pg_name}"] = float(pg["lr"])
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"


### PR DESCRIPTION
## Hypothesis

**Layer-wise learning-rate decay (LLRD)** is a Kaggle/BERT-fine-tuning standard that we have **not yet tested** on this architecture. The idea: deeper transformer blocks (closer to the output heads) get a larger LR, shallower blocks (closer to the input embedding/PE) get a smaller LR, with a multiplicative decay factor between layers.

Motivation in this CFD-surrogate setting:
1. The input PE block (sincos / fixed-omega) is doing work that is essentially **frequency selection** — small per-step changes have outsized effect on the spectral content the rest of the network sees. A smaller LR on the embedding/PE protects the input-side feature representation.
2. The output projection heads (per-channel decoders for surface_pressure, wall_shear, volume_pressure) need to be **most plastic** — they are where the per-task signal lives, especially under our 9-epoch budget.
3. The 4 transformer blocks in between should get a smooth ramp.
4. With Lion's sign-update, LR effectively controls the *step size in sign-space* per parameter group — LLRD modulates this directly per block.

This is a **single-flag CLI experiment** (after a small `train.py` change to wire the per-group LRs into the optimizer). Standard literature decay factors are 0.7–0.95; we'll sweep 3.

## Instructions

**Code change required.** Add a new flag `--llrd-decay <float>` (default `1.0` = no LLRD = current behavior) to `target/train.py`. When < 1.0:

1. **Identify parameter groups** in the model. The natural groups for our Transolver-style stack:

```python
groups = {
    "pe_embed":   <ContinuousSincosEmbed + any input projection>,
    "block_0":    <transformer block 0>,
    "block_1":    <transformer block 1>,
    "block_2":    <transformer block 2>,
    "block_3":    <transformer block 3>,
    "head":       <output projections / per-channel decoders>,
}
```

The exact module names depend on `train.py` — search for `nn.ModuleList` and the block iteration to find the 4 transformer layers, and find the output projection heads (search for `surface_head`, `volume_head`, or similar — the per-channel output projections).

2. **Apply LR multipliers** by depth from input (group 0 = pe_embed, group N = head):

```python
decay = float(self.config.llrd_decay)
n_groups = 6  # pe_embed + 4 blocks + head
# Multipliers: pe_embed gets decay^5, block_0 gets decay^4, ..., head gets decay^0 = 1.0
# i.e. shallow=small LR, deep=full LR
multipliers = [decay ** (n_groups - 1 - i) for i in range(n_groups)]
param_groups = [
    {"params": list(pe_embed.parameters()),  "lr": base_lr * multipliers[0]},
    {"params": list(block_0.parameters()),   "lr": base_lr * multipliers[1]},
    {"params": list(block_1.parameters()),   "lr": base_lr * multipliers[2]},
    {"params": list(block_2.parameters()),   "lr": base_lr * multipliers[3]},
    {"params": list(block_3.parameters()),   "lr": base_lr * multipliers[4]},
    {"params": list(head.parameters()),      "lr": base_lr * multipliers[5]},
]
optimizer = Lion(param_groups, weight_decay=...)
```

When `decay = 1.0` all groups get `base_lr` and behavior is identical to current.

3. **Verify** by logging the per-group LR at start of training (W&B `train/lr_group_<i>`). Critical: the LR-warmup and any cosine schedule must scale all groups proportionally — make sure the scheduler operates on the optimizer's `param_groups` (PyTorch's default `LRScheduler.step()` already does, but confirm by inspecting the actual `optimizer.param_groups[i]['lr']` values across an epoch).

**Run a 3-arm DDP-4 sweep on a single 4-GPU pod, sequential arms:**

| Arm | `--llrd-decay` | rationale |
|---|---|---|
| A | 0.95 | gentle: ~78% of base LR at PE, near-uniform — minimal-risk first try |
| B | 0.85 | medium: ~44% of base LR at PE, ~52% at block_0 — standard BERT setting |
| C | 0.75 | aggressive: ~24% of base LR at PE, ~32% at block_0 — Kaggle competitive setting |

(With 6 groups, decay^5 = 0.77 / 0.44 / 0.24 for A/B/C respectively at the PE layer.)

**Common config (Lion SOTA recipe — base LR is what gets multiplied):**

```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent gilbert \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r31-gilbert-llrd
```

Per-arm overrides: `--llrd-decay 0.95` / `0.85` / `0.75`.

**Optional Arm D (control)**: re-run `--llrd-decay 1.0` in the same group/seed for in-group reference if time permits.

No kill thresholds. Each arm gets the full 6h.

## What to report

Per-arm:
1. Best `val_primary/abupt_axis_mean_rel_l2_pct`, with corresponding test row.
2. Per-channel: `surface_pressure`, `volume_pressure`, `wall_shear`, `wall_shear_y`, `wall_shear_z`.
3. **Per-group LR snapshot** at start of epoch 2 (post-warmup) from W&B logs, to confirm the scheduler is moving all groups together.
4. **Per-group gradient-norm or weight-update-norm** if cheap to log — gives mechanistic evidence of which layers are actually changing.
5. W&B run IDs.

## Decision rule (advisor side)

- Any arm beats yi merge bar **9.039%** → merge candidate.
- Monotonic trend (A > B > C or reverse) → confirms LLRD is a real lever in this regime; assign next-round refinement around best decay.
- All 3 arms ≥ control → close; deeper-layer plasticity is not the bottleneck here.

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn).
- **Aspirational once PR #490 STRING-sep PE lands:** `< 7.546%`.
- Current production = uniform LR (decay=1.0).

## Notes

- LLRD is a **standard** Kaggle/BERT-fine-tune lever. We have ~17 PRs of optimizer/wd/clip/EMA work but zero on per-layer LR. Closing this gap is high-priority.
- Code change is small (~30 lines): one flag + one parameter-group construction block + a small W&B logging line.
- DDP-4, bs=4, 6h per arm → ~10 epochs. 3 arms × 6h = 18h. Sequential.
- If the param-group construction is awkward (modules deeply nested), a simpler 3-group split (`pe + first_half`, `second_half`, `head`) is acceptable — document the choice.
