### PR TITLE
norman: volume-only coord transform (signed-log / asinh) — #449 follow-up

### DIFF
--- a/train.py
+++ b/train.py
@@ -481,6 +481,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        volume_coord_transform: str = "none",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -493,6 +494,11 @@ class SurfaceTransolver(nn.Module):
         self.use_film = use_film
         self.film_encoder_dim = film_encoder_dim
         self.pos_max_wavelength = pos_max_wavelength
+        if volume_coord_transform not in ("none", "signed-log", "asinh"):
+            raise ValueError(
+                f"volume_coord_transform must be 'none', 'signed-log', or 'asinh'; got {volume_coord_transform!r}"
+            )
+        self.volume_coord_transform = volume_coord_transform
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -576,9 +582,22 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
+            vol_x_for_encoder = volume_x
+            if self.volume_coord_transform != "none":
+                vol_pos = volume_x[..., : self.space_dim]
+                if self.volume_coord_transform == "signed-log":
+                    vol_pos = torch.sign(vol_pos) * torch.log1p(torch.abs(vol_pos))
+                else:  # "asinh"
+                    vol_pos = torch.asinh(vol_pos)
+                if volume_x.shape[-1] > self.space_dim:
+                    vol_x_for_encoder = torch.cat(
+                        [vol_pos, volume_x[..., self.space_dim :]], dim=-1
+                    )
+                else:
+                    vol_x_for_encoder = vol_pos
             tokens.append(
                 self._encode_group(
-                    volume_x,
+                    vol_x_for_encoder,
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
@@ -715,6 +734,7 @@ class Config:
     use_film: bool = False
     film_encoder_dim: int = 64
     pos_max_wavelength: int = 1000
+    volume_coord_transform: str = "none"  # "none" | "signed-log" | "asinh" — applied to volume xyz before PE encoder input only
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -897,6 +917,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        volume_coord_transform=config.volume_coord_transform,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Your in-flight PR #449 tested log-x coordinate compression applied to **both** surface and volume streams. The advisor follow-up flagged a likely surface↔volume asymmetry: surface points are concentrated near the car body (narrow x range, dense), while volume points span the full domain (wide x range, sparse far-field).

**This experiment isolates the volume stream**: apply log-x **only on volume coordinates**, leaving surface coordinates in raw Cartesian. The motivation:

1. Volume `x` spans a much wider range (free-stream + downstream wake, ~±2 in normalized units) than surface `x` (~±1, vehicle bounds). A single global PE bandwidth can't simultaneously resolve fine near-car wake structure and coarse far-field flow.
2. `log(1 + |x|)·sign(x)` (or `arcsinh(x/scale)`) compresses the wide volume range, giving the volume PE more of its frequency budget to fine near-car structure where the gradient (and pressure variation) is concentrated.
3. Surface points don't need this transform — they're already in a tight range where sincos at our chosen wavelength performs well.

If volume-only log-x improves `volume_pressure` (currently 12.438% test, 2.05× AB-UPT — our second-largest gap after wall_shear_y/z) **without regressing** surface metrics, this is a clean targeted win.

## Instructions

**Code change required.** Add a new flag `--volume-coord-transform <none|signed-log|asinh>` (default `none`) to `target/train.py`. When set to `signed-log` or `asinh`:

1. Locate the volume coordinate processing path. Search `train.py` for where volume points (`vol_pts`, `volume_pos`, or the equivalent) are passed into the encoder/PE — there should be a clear `surface` vs `volume` split in the forward pass.
2. **Apply the transform only to volume coordinates** (NOT surface):
   ```python
   if self.config.volume_coord_transform == "signed-log":
       vol_pts_transformed = torch.sign(vol_pts) * torch.log1p(torch.abs(vol_pts))
   elif self.config.volume_coord_transform == "asinh":
       vol_pts_transformed = torch.asinh(vol_pts)
   else:
       vol_pts_transformed = vol_pts
   # Surface points pass through unchanged
   ```
3. The transform replaces volume coordinates **only as PE encoder input**. If the model also uses raw `vol_pts` for output decoding (e.g. cross-attention queries), keep the original `vol_pts` for those paths. Be explicit in your code about which path gets which.

**Run a 3-arm DDP-4 sweep on a single 4-GPU pod, sequential arms:**

| Arm | `--volume-coord-transform` | rationale |
|---|---|---|
| A | `none` (control) | in-group reference |
| B | `signed-log` | log compression, sign-preserving |
| C | `asinh` | smooth alternative, no sign() discontinuity at zero |

**Common config (Lion SOTA recipe):**

```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent norman \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r31-norman-volume-only-log-x
```

Per-arm: `--volume-coord-transform none` / `signed-log` / `asinh`.

No kill thresholds. Each arm gets the full 6h.

## What to report

Per-arm:
1. Best `val_primary/abupt_axis_mean_rel_l2_pct`, with corresponding test row.
2. **Specifically `volume_pressure_rel_l2_pct`** — that's the targeted channel.
3. **Surface metrics** (`surface_pressure`, `wall_shear`, `wall_shear_y`, `wall_shear_z`) — must NOT regress; if they do, the transform is leaking into surface paths.
4. W&B run IDs.

## Decision rule (advisor side)

- Any arm beats yi merge bar **9.039%** → merge candidate.
- Volume_pressure improves ≥ 0.5pp without surface regression → orthogonal win, merge.
- Surface regresses → bug in path isolation, send back.
- No movement → close; volume_pressure gap is upstream of coordinate representation.

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn).
- **Aspirational once PR #490 STRING-sep PE lands:** `< 7.546%`.
- **Volume_pressure target gap:** test 12.438% (PR #311 reference) vs AB-UPT 6.08% — 2.05×, the second-largest channel gap.

## Notes

- Complement to your PR #449 (which tests log-x globally). If #449 wins on surface but loses on volume — or vice-versa — this experiment isolates the cause cleanly. We are deliberately running these in parallel because they are testing different cuts of the same hypothesis space.
- Code change is small (~10 lines). Critical: keep the transform out of the surface path and out of any decoder query paths. Only the volume **PE encoder input** is transformed.
- DDP-4, bs=4, 6h per arm → ~10 epochs. 3 arms × 6h = 18h. Sequential.
