### PR TITLE
senku: sigmoid-l1 slice attention vs softmax (architecture A/B)

### DIFF
--- a/train.py
+++ b/train.py
@@ -282,15 +282,25 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        dropout: float = 0.0,
+        slice_attention: str = "softmax",
+    ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
+        if slice_attention not in {"softmax", "sigmoid-l1"}:
+            raise ValueError(f"unknown slice_attention: {slice_attention}")
         self.hidden_dim = hidden_dim
         self.num_heads = num_heads
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.slice_attention = slice_attention
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -300,12 +310,56 @@ class TransolverAttention(nn.Module):
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
 
+        # Per-step diagnostics (set in create_slices, read by training loop). Detached.
+        self.last_gate_l1_mean: torch.Tensor | None = None
+        self.last_slice_entropy_mean: torch.Tensor | None = None
+        self.last_gate_top1_mean: torch.Tensor | None = None
+        self.last_active_count_at_0p5: torch.Tensor | None = None
+
+    @staticmethod
+    def _masked_mean(values: torch.Tensor, attn_mask: torch.Tensor | None) -> torch.Tensor:
+        # values: [B, H, N]; attn_mask: [B, N] or None.
+        v = values.float()
+        if attn_mask is None:
+            return v.mean()
+        mask = attn_mask[:, None, :].to(dtype=v.dtype, device=v.device)
+        denom = mask.sum() * v.shape[1]
+        return (v * mask).sum() / denom.clamp(min=1.0)
+
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
-        slice_weights = F.softmax(slice_logits, dim=-1)
+
+        if self.slice_attention == "softmax":
+            slice_weights = F.softmax(slice_logits, dim=-1)
+            self.last_gate_l1_mean = None
+            self.last_gate_top1_mean = None
+            self.last_active_count_at_0p5 = None
+        else:  # sigmoid-l1
+            # Compute sigmoid + L1-renorm in fp32 for bf16 stability (low cost: only the
+            # K-axis sum and divide; sigmoid itself is stable in bf16).
+            slice_logits_fp32 = slice_logits.float()
+            gates = torch.sigmoid(slice_logits_fp32)
+            gate_l1 = gates.sum(dim=-1)  # [B, H, N]
+            with torch.no_grad():
+                self.last_gate_l1_mean = self._masked_mean(gate_l1, attn_mask).detach()
+                gate_top1 = gates.max(dim=-1).values  # [B, H, N]
+                self.last_gate_top1_mean = self._masked_mean(gate_top1, attn_mask).detach()
+                active = (gates > 0.5).to(gates.dtype).sum(dim=-1)  # [B, H, N]
+                self.last_active_count_at_0p5 = self._masked_mean(active, attn_mask).detach()
+            slice_weights = gates / (gate_l1.unsqueeze(-1) + 1e-6)
+            slice_weights = slice_weights.to(dtype=slice_logits.dtype)
+
+        # Slice usage entropy diagnostic over the (normalized) per-point distribution.
+        # Compute before the attn_mask multiplication so padded tokens (which become all-zero
+        # after masking) do not contaminate the average.
+        with torch.no_grad():
+            sw = slice_weights.detach().float()
+            entropy = -(sw.clamp(min=1e-12) * sw.clamp(min=1e-12).log()).sum(dim=-1)  # [B, H, N]
+            self.last_slice_entropy_mean = self._masked_mean(entropy, attn_mask)
+
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,
@@ -341,6 +395,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         drop_path_prob: float = 0.0,
+        slice_attention: str = "softmax",
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -350,6 +405,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            slice_attention=slice_attention,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -417,6 +473,7 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
         film_geom_dim: int = 0,
+        slice_attention: str = "softmax",
     ):
         super().__init__()
         if depth <= 1:
@@ -434,6 +491,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     drop_path_prob=drop_path_rates[i],
+                    slice_attention=slice_attention,
                 )
                 for i in range(depth)
             ]
@@ -481,6 +539,7 @@ class SurfaceTransolver(nn.Module):
         use_film: bool = False,
         film_encoder_dim: int = 64,
         pos_max_wavelength: int = 1000,
+        slice_attention: str = "softmax",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -523,6 +582,7 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
             film_geom_dim=film_encoder_dim if use_film else 0,
+            slice_attention=slice_attention,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -711,6 +771,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    slice_attention: str = "softmax"
     stochastic_depth_prob: float = 0.0
     use_film: bool = False
     film_encoder_dim: int = 64
@@ -897,7 +958,55 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_film=config.use_film,
         film_encoder_dim=config.film_encoder_dim,
         pos_max_wavelength=config.pos_max_wavelength,
+        slice_attention=config.slice_attention,
     )
+
+
+def collect_slice_attention_diagnostics(model: nn.Module) -> dict[str, float]:
+    """Average TransolverAttention per-step diagnostics across all blocks.
+
+    sigmoid-l1-only (omitted under softmax, where these are tautological):
+      - train/sigmoid_gate_l1_mean: mean unnormalized sigmoid-gate L1 across heads/points.
+        K/2 = uniform multi-membership; near 1 = winner-take-all (softmax-like collapse).
+      - train/sigmoid_gate_top1_mean: mean of pre-norm max-gate magnitude per point.
+        Near 0.5 = no saturation; approaching 1.0 = saturating high; 0 = saturating low.
+      - train/sigmoid_active_count_at_0p5: mean count of slices with pre-norm gate > 0.5
+        per point. K/2 if random; small int (1-5) if winner-take-all; large if uniform.
+
+    Reported for both arms:
+      - train/slice_entropy_mean: mean per-point Shannon entropy of the (normalized)
+        slice-membership distribution, in nats. log(K) = uniform; 0 = winner-take-all.
+      - train/slice_entropy_norm: slice_entropy_mean / log(K), in [0, 1].
+    """
+    gate_l1_vals: list[float] = []
+    entropy_vals: list[float] = []
+    gate_top1_vals: list[float] = []
+    active_vals: list[float] = []
+    num_slices = 0
+    for module in model.modules():
+        if isinstance(module, TransolverAttention):
+            num_slices = module.num_slices
+            if module.last_gate_l1_mean is not None:
+                gate_l1_vals.append(float(module.last_gate_l1_mean.item()))
+            if module.last_slice_entropy_mean is not None:
+                entropy_vals.append(float(module.last_slice_entropy_mean.item()))
+            if module.last_gate_top1_mean is not None:
+                gate_top1_vals.append(float(module.last_gate_top1_mean.item()))
+            if module.last_active_count_at_0p5 is not None:
+                active_vals.append(float(module.last_active_count_at_0p5.item()))
+    out: dict[str, float] = {}
+    if gate_l1_vals:
+        out["train/sigmoid_gate_l1_mean"] = sum(gate_l1_vals) / len(gate_l1_vals)
+    if gate_top1_vals:
+        out["train/sigmoid_gate_top1_mean"] = sum(gate_top1_vals) / len(gate_top1_vals)
+    if active_vals:
+        out["train/sigmoid_active_count_at_0p5"] = sum(active_vals) / len(active_vals)
+    if entropy_vals:
+        mean_entropy = sum(entropy_vals) / len(entropy_vals)
+        out["train/slice_entropy_mean"] = mean_entropy
+        if num_slices > 1:
+            out["train/slice_entropy_norm"] = mean_entropy / math.log(num_slices)
+    return out
 
 
 def _metric_path(name: str) -> str:
@@ -2220,6 +2329,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_loss_sum += float(loss.detach().cpu().item())
             n_batches += 1
             global_step += 1
+            slice_attn_diagnostics = collect_slice_attention_diagnostics(model)
             train_log: dict[str, object] = {
                 "train/loss": float(loss.detach().cpu().item()),
                 "train/surface_loss": batch_loss_metrics["surface_loss"],
@@ -2233,6 +2343,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,
+                **slice_attn_diagnostics,
             }
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[


### PR DESCRIPTION
## Hypothesis

Transolver (the architecture family our 4L/512d model uses) computes **slice attention**: each input point softly assigns probability over `K` slices via a softmax over a slice-logit projection. Each slice computes a context vector, and the per-point representation is read out as a softmax-weighted combination.

The softmax slicing creates a **winner-take-all dynamic**: most of a point's probability mass concentrates on 1–2 slices, and gradients to "non-selected" slices are tiny. This may be problematic for CFD where many points lie at slice boundaries (e.g. wake/free-stream interface, separated-flow regions) and would benefit from richer mixed-slice membership.

**Hypothesis**: replace the softmax slice assignment with a **sigmoid gate** (independent per-slice soft membership in [0,1] for each point), normalized to sum to 1 per point only at readout. This:

1. Allows multi-slice membership (e.g. a wake-edge point can belong to both "wake" and "free-stream" slices simultaneously).
2. Keeps gradient flow to all slices regardless of which is dominant — better signal during training.
3. Increases effective slice diversity (no winner-take-all collapse).

This is a small architectural change with strong literature precedent (sigmoid attention has been shown competitive with softmax attention in Tay 2023, "FLASH"; gated mixture-of-experts uses similar mechanics).

**Risk**: sigmoid attention with no-normalization baseline can blow up in scale. The fix is to L1-normalize the gates per-point at readout (so the slice mixture stays a convex-like combination): `gates_normalized = gates / (gates.sum(dim=-1, keepdim=True) + eps)`. This preserves the "convex combination" reading at output while allowing the slice-logits to express richer multi-membership during attention.

## Instructions

**Code change required.** Add a flag `--slice-attention <softmax|sigmoid-l1>` (default `softmax` = current behavior) to `target/train.py`. When set to `sigmoid-l1`:

1. Locate the slice-attention block. Search `train.py` for the slice-logit softmax — typically something like `slice_weights = F.softmax(slice_logits, dim=-1)` or similar in the forward of the Transolver attention layer.
2. Replace with:

```python
if self.config.slice_attention == "softmax":
    slice_weights = F.softmax(slice_logits, dim=-1)
elif self.config.slice_attention == "sigmoid-l1":
    gates = torch.sigmoid(slice_logits)
    slice_weights = gates / (gates.sum(dim=-1, keepdim=True) + 1e-6)
else:
    raise ValueError(f"unknown slice_attention: {self.config.slice_attention}")
```

3. The rest of the slice attention block (slice-context computation, per-point readout) is **unchanged** — only the gating function changes. This means everything that took `slice_weights` as an input continues to work.

4. **Verify** by logging a per-batch diagnostic at training start: the **mean L1 norm of `gates`** before normalization (call it `train/sigmoid_gate_l1_mean`). With softmax this would always be 1.0; with sigmoid it should be roughly K/2 = 64 at init (random logits → sigmoid ≈ 0.5). If it stays ≈ K/2 throughout training, the model is using all slices uniformly (good — signal of multi-membership). If it collapses toward 1.0 (winner-take-all), the sigmoid is recovering softmax behavior (signal of convergence to softmax-like solution).

**Run a 2-arm DDP-4 sweep on a single 4-GPU pod, sequential arms:**

| Arm | `--slice-attention` | rationale |
|---|---|---|
| A | `softmax` (control) | in-group reference |
| B | `sigmoid-l1` | multi-slice gated membership |

(Two arms is enough for a head-to-head. If B clearly wins, follow-ups can sweep alternatives like `sigmoid-l2`, temperature scaling, etc.)

**Common config (Lion SOTA recipe, 128 slices):**

```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r31-senku-slice-attention
```

Per-arm: `--slice-attention softmax` / `sigmoid-l1`.

No kill thresholds. Each arm gets the full 6h.

**Optional Arm C** (if both A/B finish under budget): `--slice-attention sigmoid-l1 --model-slices 64` to test whether multi-membership lets us use fewer slices for the same expressivity. Skip if time-bounded.

## What to report

Per-arm:
1. Best `val_primary/abupt_axis_mean_rel_l2_pct`, with corresponding test row.
2. Per-channel `surface_pressure`, `volume_pressure`, `wall_shear`, `wall_shear_y`, `wall_shear_z`.
3. **Critical diagnostic**: `train/sigmoid_gate_l1_mean` time series across training. Did the gates stay at ~K/2 (multi-membership) or collapse toward 1 (winner-take-all)?
4. **Slice usage entropy**: histogram of slice-assignment entropy across a held-out validation batch. Higher entropy = more multi-slice membership.
5. W&B run IDs.

## Decision rule (advisor side)

- Any arm beats yi merge bar **9.039%** → merge candidate.
- Sigmoid arm wins → multi-slice membership pays off; assign next-round refinements (alternative normalizations, learnable slice temperatures).
- Sigmoid arm draws and gates collapse to softmax behavior → null result, mechanism not exercised, close.
- Sigmoid arm clearly loses → winner-take-all is *desired* in this regime; close and document.

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn).
- **Aspirational once PR #490 STRING-sep PE lands:** `< 7.546%`.

## Notes

- Code change is small (~15 lines): one flag + one branch on the gating function + one diagnostic log.
- This is an **architecture experiment**, not a hyperparameter one. The advisor (per CLAUDE.md plateau protocol) is encouraging bold architectural moves.
- DDP-4, bs=4, 6h per arm → ~10 epochs. 2 arms × 6h = 12h. Sequential.
- Extension space (queued for follow-up depending on result): scaled sigmoid (`sigmoid(s · logits)` with learnable s), entmax-1.5 (interpolates between softmax and sparsemax), per-head separate gating function.
