### PR TITLE
thorfinn: BF16 → FP32 last-2-epoch fine-final-precision policy

### DIFF
--- a/train.py
+++ b/train.py
@@ -763,6 +763,7 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    fp32_final_epochs: int = 0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2144,6 +2145,51 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print(f"Timeout ({timeout_minutes:.1f} min). Stopping.")
             break
 
+        # Decide precision policy for this epoch. With fp32_final_epochs > 0,
+        # disable autocast (full FP32) for the last N epochs of training.
+        # Use both an epoch-count check and a time-based estimate so the trigger
+        # fires correctly in either epoch-bounded or timeout-bounded runs.
+        if config.fp32_final_epochs > 0:
+            remaining_epochs_by_count = max_epochs - epoch
+            if epoch > 0:
+                elapsed_minutes = (time.time() - train_start) / 60.0
+                avg_epoch_minutes = elapsed_minutes / max(epoch, 1)
+                time_left_minutes = max(
+                    train_timeout_minutes - elapsed_minutes, 0.0
+                )
+                remaining_epochs_by_time = (
+                    time_left_minutes / max(avg_epoch_minutes, 1e-3) + 1.0
+                )
+            else:
+                remaining_epochs_by_time = float("inf")
+            remaining_epochs_estimate = min(
+                remaining_epochs_by_count, remaining_epochs_by_time
+            )
+            use_fp32_this_epoch = (
+                remaining_epochs_estimate <= config.fp32_final_epochs
+            )
+        else:
+            remaining_epochs_estimate = float(max_epochs - epoch)
+            use_fp32_this_epoch = False
+        epoch_amp_mode = "none" if use_fp32_this_epoch else config.amp_mode
+        if is_main:
+            wandb.log(
+                {
+                    "train/amp_dtype_active": 0 if use_fp32_this_epoch else 1,
+                    "train/fp32_final_epochs_remaining_estimate": float(
+                        remaining_epochs_estimate
+                    ),
+                    "epoch": epoch + 1,
+                    "global_step": global_step,
+                }
+            )
+            if use_fp32_this_epoch:
+                print(
+                    f"Epoch {epoch + 1}/{max_epochs}: switching to FP32 "
+                    f"(remaining_epochs_estimate={remaining_epochs_estimate:.2f}, "
+                    f"fp32_final_epochs={config.fp32_final_epochs})"
+                )
+
         if is_distributed and isinstance(train_loader.sampler, DistributedSampler):
             train_loader.sampler.set_epoch(epoch)
         if torch.cuda.is_available():
@@ -2164,7 +2210,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 batch,
                 transform,
                 device,
-                config.amp_mode,
+                epoch_amp_mode,
                 surface_loss_weight=config.surface_loss_weight,
                 volume_loss_weight=config.volume_loss_weight,
                 aux_rel_l2_weight=config.aux_rel_l2_weight,
@@ -2336,6 +2382,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             "train/epoch_loss": epoch_train_loss,
             "lr": scheduler.get_last_lr()[0],
             "epoch_time_s": dt,
+            "epoch_time_s_fp32": dt if use_fp32_this_epoch else 0.0,
+            "epoch_time_s_bf16": 0.0 if use_fp32_this_epoch else dt,
+            "epoch_amp_dtype_active": 0 if use_fp32_this_epoch else 1,
             "global_step": global_step,
         }
         if early_stop_reason is not None:

--- a/train.py
+++ b/train.py
@@ -764,6 +764,7 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     fp32_final_epochs: int = 0
+    fp32_final_accum_steps: int = 1
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1515,6 +1516,35 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def _split_surface_batch(batch: SurfaceBatch, n_chunks: int) -> list[SurfaceBatch]:
+    if n_chunks <= 1:
+        return [batch]
+    bs = batch.surface_x.shape[0]
+    if bs < 2:
+        return [batch]
+    n = min(n_chunks, bs)
+    base = bs // n
+    sizes = [base + (1 if i < bs - base * n else 0) for i in range(n)]
+    chunks: list[SurfaceBatch] = []
+    start = 0
+    for sz in sizes:
+        end = start + sz
+        chunks.append(
+            SurfaceBatch(
+                case_ids=list(batch.case_ids[start:end]),
+                surface_x=batch.surface_x[start:end],
+                surface_y=batch.surface_y[start:end],
+                surface_mask=batch.surface_mask[start:end],
+                volume_x=batch.volume_x[start:end],
+                volume_y=batch.volume_y[start:end],
+                volume_mask=batch.volume_mask[start:end],
+                metadata=list(batch.metadata[start:end]),
+            )
+        )
+        start = end
+    return chunks
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -2176,6 +2206,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.log(
                 {
                     "train/amp_dtype_active": 0 if use_fp32_this_epoch else 1,
+                    "train/precision_mode_int": 1 if use_fp32_this_epoch else 0,
                     "train/fp32_final_epochs_remaining_estimate": float(
                         remaining_epochs_estimate
                     ),
@@ -2190,10 +2221,29 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"fp32_final_epochs={config.fp32_final_epochs})"
                 )
 
+        accum_steps = (
+            max(1, config.fp32_final_accum_steps)
+            if use_fp32_this_epoch
+            else 1
+        )
         if is_distributed and isinstance(train_loader.sampler, DistributedSampler):
             train_loader.sampler.set_epoch(epoch)
         if torch.cuda.is_available():
+            torch.cuda.empty_cache()
             torch.cuda.reset_peak_memory_stats()
+        if is_main:
+            wandb.log(
+                {
+                    "train/grad_accum_steps": accum_steps,
+                    "epoch": epoch + 1,
+                    "global_step": global_step,
+                }
+            )
+            if accum_steps > 1:
+                print(
+                    f"Epoch {epoch + 1}/{max_epochs}: gradient accumulation "
+                    f"with {accum_steps} micro-batches per step"
+                )
         t0 = time.time()
         train_model.train()
         train_loss_sum = 0.0
@@ -2205,39 +2255,103 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
-            loss, batch_loss_metrics = train_loss(
-                train_model,
-                batch,
-                transform,
-                device,
-                epoch_amp_mode,
-                surface_loss_weight=config.surface_loss_weight,
-                volume_loss_weight=config.volume_loss_weight,
-                aux_rel_l2_weight=config.aux_rel_l2_weight,
-                use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
-                wallshear_y_weight=config.wallshear_y_weight,
-                wallshear_z_weight=config.wallshear_z_weight,
-                wallshear_huber_delta=config.wallshear_huber_delta,
-            )
             optimizer.zero_grad(set_to_none=True)
-            loss_is_finite = bool(torch.isfinite(loss).item())
-            if not loss_is_finite:
-                nonfinite_skip_count += 1
-                wandb.log(
-                    {
-                        "train/nonfinite_skip_count": nonfinite_skip_count,
-                        "train/nonfinite_skip_kind": 1,
-                        "global_step": global_step,
-                    }
+            if accum_steps > 1:
+                sub_batches = _split_surface_batch(batch, accum_steps)
+                effective_steps = len(sub_batches)
+                sub_losses: list[float] = []
+                sub_metrics_list: list[dict[str, float]] = []
+                nonfinite_in_micro = False
+                supports_no_sync = (
+                    is_distributed and hasattr(train_model, "no_sync")
                 )
-                if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
-                    raise RuntimeError(
-                        f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
-                        f"loss/grad steps; training is structurally broken."
+                for i, sub in enumerate(sub_batches):
+                    is_last = i == effective_steps - 1
+                    sync_ctx = (
+                        train_model.no_sync()
+                        if (not is_last and supports_no_sync)
+                        else nullcontext()
                     )
-                global_step += 1
-                continue
-            loss.backward()
+                    with sync_ctx:
+                        sub_loss, sub_metrics = train_loss(
+                            train_model,
+                            sub,
+                            transform,
+                            device,
+                            epoch_amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            aux_rel_l2_weight=config.aux_rel_l2_weight,
+                            use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                            wallshear_y_weight=config.wallshear_y_weight,
+                            wallshear_z_weight=config.wallshear_z_weight,
+                            wallshear_huber_delta=config.wallshear_huber_delta,
+                        )
+                        if not bool(torch.isfinite(sub_loss).item()):
+                            nonfinite_in_micro = True
+                            break
+                        (sub_loss / float(effective_steps)).backward()
+                        sub_losses.append(float(sub_loss.detach().item()))
+                        sub_metrics_list.append(sub_metrics)
+                if nonfinite_in_micro:
+                    optimizer.zero_grad(set_to_none=True)
+                    nonfinite_skip_count += 1
+                    wandb.log(
+                        {
+                            "train/nonfinite_skip_count": nonfinite_skip_count,
+                            "train/nonfinite_skip_kind": 1,
+                            "global_step": global_step,
+                        }
+                    )
+                    if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                        raise RuntimeError(
+                            f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                            f"loss/grad steps; training is structurally broken."
+                        )
+                    global_step += 1
+                    continue
+                loss_value = sum(sub_losses) / max(len(sub_losses), 1)
+                loss = torch.tensor(loss_value, device=device)
+                batch_loss_metrics = {
+                    k: float(
+                        sum(m[k] for m in sub_metrics_list)
+                        / len(sub_metrics_list)
+                    )
+                    for k in sub_metrics_list[0]
+                }
+            else:
+                loss, batch_loss_metrics = train_loss(
+                    train_model,
+                    batch,
+                    transform,
+                    device,
+                    epoch_amp_mode,
+                    surface_loss_weight=config.surface_loss_weight,
+                    volume_loss_weight=config.volume_loss_weight,
+                    aux_rel_l2_weight=config.aux_rel_l2_weight,
+                    use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                    wallshear_y_weight=config.wallshear_y_weight,
+                    wallshear_z_weight=config.wallshear_z_weight,
+                    wallshear_huber_delta=config.wallshear_huber_delta,
+                )
+                loss_is_finite = bool(torch.isfinite(loss).item())
+                if not loss_is_finite:
+                    nonfinite_skip_count += 1
+                    wandb.log(
+                        {
+                            "train/nonfinite_skip_count": nonfinite_skip_count,
+                            "train/nonfinite_skip_kind": 1,
+                            "global_step": global_step,
+                        }
+                    )
+                    if nonfinite_skip_count > NONFINITE_SKIP_ABORT:
+                        raise RuntimeError(
+                            f"Aborting: more than {NONFINITE_SKIP_ABORT} non-finite "
+                            f"loss/grad steps; training is structurally broken."
+                        )
+                    global_step += 1
+                    continue
+                loss.backward()
             should_log_gradients = (
                 config.gradient_log_every > 0
                 and (global_step + 1) % config.gradient_log_every == 0
@@ -2385,6 +2499,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             "epoch_time_s_fp32": dt if use_fp32_this_epoch else 0.0,
             "epoch_time_s_bf16": 0.0 if use_fp32_this_epoch else dt,
             "epoch_amp_dtype_active": 0 if use_fp32_this_epoch else 1,
+            "epoch_precision_mode_int": 1 if use_fp32_this_epoch else 0,
             "global_step": global_step,
         }
         if early_stop_reason is not None:


### PR DESCRIPTION
## Hypothesis

Our current training stack runs **BF16 throughout** for compute speed (`amp=bf16` per `train.py` defaults). BF16 has good dynamic range (8-bit exponent matches FP32) but limited mantissa precision (7 bits) — fine during the noisy bulk of training, but potentially **limiting in the final epochs** when the model is converging and small parameter updates matter for final quality.

**Hypothesis**: switching to **FP32 (or TF32 on Blackwell) for the last 2 epochs** allows the optimizer to make finer parameter updates near convergence, improving the final val_abupt floor. This is a well-known trick in vision and LLM training ("fine-final-precision"), zero-architecture-change, runs at full Lion SOTA recipe.

This is testable cheaply with a **2-arm sweep** at exactly the same compute and config except for the final-epochs precision policy:

| Arm | precision policy | rationale |
|---|---|---|
| A | BF16 throughout (control) | current production behavior |
| B | BF16 for first N-2 epochs, FP32 for last 2 epochs | hypothesis |

If B beats A, this is a free 0.x-pp win at zero training-throughput cost (last 2 epochs run slower in FP32, but on a 9-10 epoch schedule, bf16-7-epochs + fp32-2-epochs is only ~10-15% wall-clock overhead).

## Instructions

**Code change required.** Add a flag `--fp32-final-epochs <int>` (default `0` = OFF / current behavior) to `target/train.py`. When > 0:

1. Locate the autocast / mixed-precision setup. Search `train.py` for `torch.autocast` or `amp` configuration.
2. At the start of each epoch, **if** `epoch >= max_epochs - fp32_final_epochs`, **switch the autocast dtype to FP32** (or disable autocast entirely):

```python
remaining_epochs = max_epochs - epoch
use_fp32 = (self.config.fp32_final_epochs > 0
            and remaining_epochs <= self.config.fp32_final_epochs)
if use_fp32:
    autocast_ctx = torch.autocast(device_type="cuda", enabled=False)
else:
    autocast_ctx = torch.autocast(device_type="cuda", dtype=torch.bfloat16)
# Apply autocast_ctx to forward/backward in the inner loop
```

Alternatively (simpler): set the autocast dtype to `torch.float32` inside the existing autocast context manager creation:

```python
amp_dtype = torch.float32 if use_fp32 else torch.bfloat16
with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=True):
    ...
```

3. **Verify** by logging `train/amp_dtype_active` at start of each epoch (a string in W&B config or a numeric flag — 1 for bf16, 0 for fp32).
4. **Important**: keep model weights in FP32 master copy throughout (PyTorch's optimizer state already does this for `Lion` — confirm by checking `param.dtype` is float32 across all groups). Only the **activation/gradient computation precision** changes; the weights themselves stay FP32 master always.

**Run a 2-arm DDP-4 sweep on a single 4-GPU pod, sequential arms:**

**Common config (Lion SOTA recipe):**

```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --seed 42 \
  --wandb-group yi-r31-thorfinn-fp32-final
```

Per-arm:
- **Arm A**: `--fp32-final-epochs 0` (control)
- **Arm B**: `--fp32-final-epochs 2`

No kill thresholds. Each arm gets the full 6h.

**Optional Arm C** (if A and B both finish under budget): `--fp32-final-epochs 1` for sensitivity.

## What to report

Per-arm:
1. Best `val_primary/abupt_axis_mean_rel_l2_pct`, with corresponding test row.
2. Per-channel `surface_pressure`, `volume_pressure`, `wall_shear`, `wall_shear_y`, `wall_shear_z`.
3. **Per-epoch val_abupt curve** for both arms — the hypothesis predicts the curves coincide for first N-2 epochs and diverge in the last 2.
4. **Wall-clock time per epoch** for the FP32 final epochs vs BF16 epochs — overhead measurement.
5. **Gradient norm distribution** in the FP32 epochs — expected to look the same or slightly cleaner than BF16.
6. W&B run IDs.

## Decision rule (advisor side)

- Either arm beats yi merge bar **9.039%** → merge candidate (B preferred if both win, since it's the hypothesis arm).
- B beats A by ≥ 0.2pp → mechanism confirmed, merge.
- A and B coincide (Δ < 0.1pp) → null on this architecture; FP32 final precision not the bottleneck. Close.
- B regresses → either bug in autocast switching or BF16 was actually helping. Investigate gradient distribution.

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn).
- **Aspirational once PR #490 STRING-sep PE lands:** `< 7.546%`.

## Notes

- This is a **post-training free-win** category, similar to PR #491 (fern, EMA model soup). Two orthogonal post-training levers running in parallel.
- Code change is small (~10 lines): one flag + one branch in the autocast context creation + one diagnostic log.
- DDP-4, bs=4, 6h per arm → ~10 epochs (last 2 in FP32 for arm B). 2 arms × 6h = 12h. Sequential.
- If win, follow-ups: try `--fp32-final-epochs 1` (cheaper, similar gain?), or `--fp32-final-fraction 0.2` of total steps (more granular policy).
