### PR TITLE
nezuko: 1-cycle LR pct_start=0.05 vs cosine (DDP-4 full budget)

### DIFF
--- a/train.py
+++ b/train.py
@@ -763,6 +763,10 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    lr_schedule: str = "cosine"  # "cosine" | "one-cycle"
+    lr_onecycle_pct_start: float = 0.05
+    lr_onecycle_div_factor: float = 25.0
+    lr_onecycle_final_div_factor: float = 1e4
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2039,12 +2043,50 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"lr={config.lr} wd={config.weight_decay}"
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
+    if config.lr_schedule == "one-cycle":
+        per_step_scheduler = True
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.lr,
+            total_steps=total_estimated_steps,
+            pct_start=config.lr_onecycle_pct_start,
+            div_factor=config.lr_onecycle_div_factor,
+            final_div_factor=config.lr_onecycle_final_div_factor,
+            anneal_strategy="cos",
+            cycle_momentum=False,
+        )
+        if is_main:
+            print(
+                f"LR schedule: OneCycleLR max_lr={config.lr} "
+                f"total_steps={total_estimated_steps} "
+                f"pct_start={config.lr_onecycle_pct_start} "
+                f"div_factor={config.lr_onecycle_div_factor} "
+                f"final_div_factor={config.lr_onecycle_final_div_factor} "
+                f"(initial_lr={config.lr / config.lr_onecycle_div_factor:.3e}, "
+                f"final_lr={config.lr / config.lr_onecycle_div_factor / config.lr_onecycle_final_div_factor:.3e})"
+            )
+    elif config.lr_schedule == "cosine":
+        per_step_scheduler = False
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+        if is_main:
+            print(f"LR schedule: CosineAnnealingLR T_max={max_epochs}")
+    else:
+        raise ValueError(
+            f"Unknown --lr-schedule '{config.lr_schedule}'. Supported: 'cosine', 'one-cycle'."
+        )
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     effective_warmup_steps = config.lr_warmup_steps
     if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
         effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+    if config.lr_schedule == "one-cycle" and effective_warmup_steps > 0:
+        if is_main:
+            print(
+                f"WARNING: --lr-warmup-epochs/--lr-warmup-steps "
+                f"({effective_warmup_steps} steps) ignored when --lr-schedule=one-cycle "
+                f"(OneCycleLR has internal warmup via pct_start={config.lr_onecycle_pct_start})."
+            )
+        effective_warmup_steps = 0
     if is_main and effective_warmup_steps > 0:
         print(
             f"LR warmup: {effective_warmup_steps} steps "
@@ -2247,6 +2289,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
                         pg["lr"] = base_lr
             optimizer.step()
+            if per_step_scheduler:
+                try:
+                    scheduler.step()
+                except ValueError:
+                    pass
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -2321,7 +2368,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not per_step_scheduler:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

**1-cycle LR schedule (`OneCycleLR`) with a short warmup (`pct_start=0.05`) significantly reduces val_abupt compared to the cosine-once baseline on the 4L/512d Lion DDP-4 stack.**

Prior attempt (PR #429 frieren, `OneCycleLR pct_start=0.3`, closed as dead end) was structurally flawed: 30% warmup made the screen too short (sub-epoch) and the cosine decay phase never had time to fire. The dead-ends list explicitly says to retry with `pct_start=0.05-0.10` on full DDP.

Your recent PR #262 gave a key mechanistic insight: in the AdamW+yi regime, **lower LR is more effective per step** than higher LR at the ep2→3 transition (slope ratio 0.74× when warmdown held 4.1× higher LR). 1-cycle LR with `pct_start=0.05` has a very short warmup (5% of budget) followed by a long aggressive descent — it spends the majority of budget at moderate-to-low LR, which is precisely what your schedule analysis identified as the more efficient regime.

Additionally, `OneCycleLR` includes a **cosine annealing + momentum cycle** that restores the momentum-based benefit of Lion in a cyclical setting, potentially allowing convergence to flatter minima.

## Baseline

Current yi SOTA: **val_abupt 9.039%** (PR #309 thorfinn). Active merge bar: val_abupt < 9.039%.

| Metric | Yi baseline (PR #309) |
|---|---:|
| val_abupt | **9.039%** |
| test_abupt | ~10.2% |
| surface_p (test) | ~5.5% |
| wall_shear (test) | ~10.5% |
| volume_p (test) | ~13.5% |

Cosine baseline from your PR #262 (Arm A v8, 3 epochs, AdamW): val_abupt = **11.7493%** — note this is AdamW not Lion, so direct comparison would require a Lion+cosine control. The primary question here is whether 1-cycle beats cosine on the Lion stack with DDP-4 at the full 6h budget.

## Instructions

### Step 1 — Add `--lr-schedule one-cycle` support

In `train.py`, the current scheduler is `CosineAnnealingLR` created at the training setup. Extend to support 1-cycle:

```python
# Add to config:
lr_schedule: str = "cosine"  # "cosine" | "one-cycle"
lr_onecycle_pct_start: float = 0.05  # fraction of total_steps for warmup
lr_onecycle_div_factor: float = 25.0  # initial_lr = max_lr / div_factor
lr_onecycle_final_div_factor: float = 1e4  # min_lr = initial_lr / final_div_factor
```

CLI flags:
```
--lr-schedule {cosine,one-cycle}
--lr-onecycle-pct-start LR_ONECYCLE_PCT_START
--lr-onecycle-div-factor LR_ONECYCLE_DIV_FACTOR
--lr-onecycle-final-div-factor LR_ONECYCLE_FINAL_DIV_FACTOR
```

Modify scheduler creation (after optimizer is built):
```python
if config.lr_schedule == "one-cycle":
    total_steps = steps_per_epoch * max_epochs
    scheduler = torch.optim.lr_scheduler.OneCycleLR(
        optimizer,
        max_lr=config.lr,
        total_steps=total_steps,
        pct_start=config.lr_onecycle_pct_start,
        div_factor=config.lr_onecycle_div_factor,
        final_div_factor=config.lr_onecycle_final_div_factor,
        anneal_strategy="cos",
    )
    # OneCycleLR must be stepped EVERY step, not every epoch
    per_step_scheduler = True
elif config.lr_schedule == "cosine":
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
    per_step_scheduler = False
```

Step the scheduler per-step (not per-epoch) when `per_step_scheduler = True`:
```python
# Inside the training step loop, after optimizer.step():
if per_step_scheduler:
    scheduler.step()

# At epoch end, only step if not per-step:
if not per_step_scheduler:
    scheduler.step()
```

**Important for LR logging**: when `per_step_scheduler=True`, use `scheduler.get_last_lr()[0]` inside the step loop (it's valid for `OneCycleLR`). At epoch logging, also use `scheduler.get_last_lr()[0]`.

Note: `OneCycleLR` with Lion — Lion does not use momentum in the traditional sense (it uses sign(g + β₁·m)), so the `cycle_momentum` parameter of `OneCycleLR` is irrelevant. Set `cycle_momentum=False` to disable it and avoid warnings:
```python
scheduler = torch.optim.lr_scheduler.OneCycleLR(
    optimizer, ..., cycle_momentum=False
)
```

### Step 2 — Two-arm DDP-4 run

**Arm A** — 1-cycle, `pct_start=0.05`:
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent nezuko \
  --wandb-group nezuko-r32-onecycle-ddp4 \
  --wandb-name "nezuko-r32-arm-a-onecycle-pct05" \
  --optimizer lion \
  --lr 1e-4 --weight-decay 1e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 --clip-grad-norm 0.5 \
  --epochs 50 \
  --lr-schedule one-cycle \
  --lr-onecycle-pct-start 0.05 \
  --lr-onecycle-div-factor 25.0 \
  --lr-onecycle-final-div-factor 10000.0
```

Wait for this to complete (or timeout), then run Arm B if time permits.

**Arm B** — cosine control (canonical Lion baseline, explicit comparison):
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent nezuko \
  --wandb-group nezuko-r32-onecycle-ddp4 \
  --wandb-name "nezuko-r32-arm-b-cosine-ctrl" \
  --optimizer lion \
  --lr 1e-4 --weight-decay 1e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 --clip-grad-norm 0.5 \
  --epochs 50
```

If the pod timeout fires before Arm B can complete, report Arm A alone vs your Arm A v8 cosine result from PR #262 (11.7493% at 3 epochs, AdamW) as a rough reference — note it's not a perfect comparison since that was AdamW not Lion.

### Step 3 — Reporting

| Metric | Arm A (1-cycle pct=0.05) | Arm B (cosine ctrl) | Δ (A−B) |
|---|---:|---:|---:|
| val_abupt (ep3) | | | |
| val_abupt (best) | | | |
| test_abupt (best) | | | |
| surface_p (test) | | | |
| wall_shear (test) | | | |
| ws_y (test) | | | |
| ws_z (test) | | | |
| vol_p (test) | | | |

Plus: per-epoch val_abupt for both arms, LR curve shape (screenshot or summary), W&B run IDs.

**Secondary diagnostic**: plot or report the LR trace vs epoch for Arm A to confirm `pct_start=0.05` fired correctly — at ~5% of total steps the peak LR should be `config.lr = 1e-4`, and by 50% of total steps it should have decayed below 1e-5.

## What success looks like

- 1-cycle beats cosine on val_abupt by ≥0.2pp → merge if also beats 9.039% bar
- If 1-cycle is worse: slope diagnosis tells us whether the failure is in the warmup (too short), the peak LR (too high/low), or the decay shape. This closes the 1-cycle chapter definitively.

## Notes

- **Do NOT use `--lr-warmup-epochs 1`** with 1-cycle schedule — 1-cycle handles its own warmup internally via `pct_start`. Using both creates a double-warmup that will confuse the LR log.
  Actually wait: the current `--lr-warmup-epochs 1` flag adds a *separate* linear ramp before the main scheduler. Check the implementation and **disable `--lr-warmup-epochs` for the 1-cycle arm**, or implement the 1-cycle scheduler from step 0 (the internal warmup IS the `pct_start` fraction).
  In the training launch command above I have omitted `--lr-warmup-epochs` intentionally.
- The `--lr-warmup-epochs 1` flag in the cosine Arm B baseline IS correct — keep it for Arm B.
- `max_lr = config.lr = 1e-4` for the 1-cycle. Initial LR = `1e-4 / 25 = 4e-6`. Final LR = `4e-6 / 1e4 = 4e-10` (effectively zero by end of budget).
