### PR TITLE
tanjiro: tangent-frame output head for wall-shear (τ→{t1,t2,n})

### DIFF
--- a/train.py
+++ b/train.py
@@ -699,6 +699,8 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    use_tangent_frame_output: bool = False
+    tangent_normal_reg: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1488,6 +1490,179 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def build_tangent_frame(
+    normals: torch.Tensor,
+    *,
+    degenerate_threshold: float = 0.9,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a per-point right-handed tangent basis (t1, t2, n_hat) from surface normals.
+
+    normals: [..., 3] (need not be unit). Returns (t1, t2, n_hat) each [..., 3] (fp32).
+
+    Uses Gram-Schmidt against world-z by default; switches to world-x where
+    ``|n_z| > degenerate_threshold`` (roof/floor surfaces) so the projected
+    reference does not collapse. ``t1 = ref - (ref . n_hat) n_hat`` is in the
+    tangent plane and aligned with the world reference; ``t2 = n_hat x t1`` is
+    the orthogonal in-plane companion. The basis is right-handed:
+    ``cross(t1, t2) = n_hat``.
+
+    Cross-product against a fixed axis (the prior-attempt convention) is
+    avoided here because it has a branch-cut at ``n parallel ref`` where the
+    cross-product magnitude collapses and the direction flips with sign. The
+    Gram-Schmidt projection is the more stable construction recommended by
+    the advisor in PR #530.
+
+    The frame depends only on the input geometry; the returned tensors are
+    detached so gradients do not flow through the frame construction.
+    """
+    n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+    ref_z = torch.tensor([0.0, 0.0, 1.0], device=n_hat.device, dtype=n_hat.dtype)
+    ref_x = torch.tensor([1.0, 0.0, 0.0], device=n_hat.device, dtype=n_hat.dtype)
+    use_x = n_hat[..., 2].abs() > degenerate_threshold
+    ref = torch.where(
+        use_x.unsqueeze(-1),
+        ref_x.expand_as(n_hat),
+        ref_z.expand_as(n_hat),
+    )
+    proj = (ref * n_hat).sum(dim=-1, keepdim=True)
+    t1 = ref - proj * n_hat
+    t1 = F.normalize(t1, dim=-1, eps=1e-8)
+    t2 = torch.cross(n_hat, t1, dim=-1)
+    t2 = F.normalize(t2, dim=-1, eps=1e-8)
+    return t1.detach(), t2.detach(), n_hat.detach()
+
+
+@torch.no_grad()
+def tangent_basis_continuity_stats(
+    surface_xyz: torch.Tensor,
+    normals: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    knn_k: int = 8,
+    max_points: int = 4096,
+) -> dict[str, float]:
+    """Diagnose tangent-basis continuity by KNN angular jump.
+
+    For each sampled valid point, computes the angle between its ``t1`` and
+    each of its ``knn_k`` nearest neighbours' ``t1`` vectors (``arccos`` of
+    the absolute dot product, so antipodal vectors are treated as continuous
+    since the basis is sign-equivalent under flip ``t1 -> -t1``).
+
+    Returns angular-jump statistics in degrees plus the fraction of points
+    falling in the world-x fallback regime. Used at training start to
+    sanity-check that the basis is continuous over the actual surface
+    geometry, per the advisor's guard 1 in PR #530.
+    """
+    if not bool(mask.any()):
+        return {"mean_deg": float("nan"), "p99_deg": float("nan"), "max_deg": float("nan"), "fraction_x_fallback": float("nan")}
+    valid_xyz = surface_xyz[mask].float()
+    valid_normals = normals[mask].float()
+    n_valid = valid_xyz.shape[0]
+    if n_valid > max_points:
+        idx = torch.randperm(n_valid, device=valid_xyz.device)[:max_points]
+        valid_xyz = valid_xyz[idx]
+        valid_normals = valid_normals[idx]
+        n_valid = valid_xyz.shape[0]
+    t1, _, n_hat = build_tangent_frame(valid_normals)
+    fraction_x = float((n_hat[..., 2].abs() > 0.9).float().mean().item())
+    k = min(knn_k + 1, n_valid)
+    if k < 2:
+        return {
+            "mean_deg": float("nan"),
+            "p99_deg": float("nan"),
+            "max_deg": float("nan"),
+            "fraction_x_fallback": fraction_x,
+        }
+    diff = valid_xyz.unsqueeze(0) - valid_xyz.unsqueeze(1)
+    dist_sq = diff.pow(2).sum(dim=-1)
+    _, idx = torch.topk(dist_sq, k=k, dim=-1, largest=False)
+    nbr_idx = idx[:, 1:k]
+    dot = (t1.unsqueeze(1) * t1[nbr_idx]).sum(dim=-1).abs().clamp(0.0, 1.0)
+    angles_deg = torch.acos(dot) * (180.0 / math.pi)
+    flat = angles_deg.flatten()
+    return {
+        "mean_deg": float(flat.mean().item()),
+        "p99_deg": float(flat.quantile(0.99).item()),
+        "max_deg": float(flat.max().item()),
+        "fraction_x_fallback": fraction_x,
+    }
+
+
+def rotate_local_to_global(
+    local_phys_ws: torch.Tensor,
+    t1: torch.Tensor,
+    t2: torch.Tensor,
+    n_hat: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate a per-point wallshear vector from local frame {t1,t2,n} to global xyz.
+
+    local_phys_ws: [..., 3] with components (tau_t1, tau_t2, tau_n) in physical units.
+    Returns [..., 3] with global xyz components in physical units.
+    """
+    return (
+        local_phys_ws[..., 0:1] * t1
+        + local_phys_ws[..., 1:2] * t2
+        + local_phys_ws[..., 2:3] * n_hat
+    )
+
+
+def rotate_global_to_local(
+    global_phys_ws: torch.Tensor,
+    t1: torch.Tensor,
+    t2: torch.Tensor,
+    n_hat: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate a per-point wallshear vector from global xyz to local frame {t1,t2,n}.
+
+    global_phys_ws: [..., 3] with components (tau_x, tau_y, tau_z) in physical units.
+    Returns [..., 3] with local components (tau_t1, tau_t2, tau_n) in physical units.
+    """
+    g = global_phys_ws.float()
+    tau_t1 = (g * t1).sum(dim=-1, keepdim=True)
+    tau_t2 = (g * t2).sum(dim=-1, keepdim=True)
+    tau_n = (g * n_hat).sum(dim=-1, keepdim=True)
+    return torch.cat([tau_t1, tau_t2, tau_n], dim=-1)
+
+
+def _wallshear_scalar_std(transform: "TargetTransform") -> torch.Tensor:
+    """Scalar wall-shear std: sqrt(mean(std_x^2, std_y^2, std_z^2)).
+
+    Used to normalize the local-frame wallshear components when
+    ``use_tangent_frame_output`` is enabled. A single scalar means rotation between
+    global and local frames is an exact isometry in normalized space.
+    """
+    ws_std = transform.surface_y_std[1:4].float()
+    return ws_std.pow(2).mean().sqrt().clamp(min=1e-6)
+
+
+def tangent_frame_local_to_global_norm(
+    surface_pred_norm: torch.Tensor,
+    surface_x: torch.Tensor,
+    transform: "TargetTransform",
+) -> torch.Tensor:
+    """Convert tangent-frame surface predictions to global-frame normalized predictions.
+
+    surface_pred_norm: [B, N, C>=4]. Channels:
+      - 0: cp normalized (already in global cp normalization).
+      - 1..3: wallshear in local frame {t1, t2, n}, normalized by scalar wallshear std.
+    Returns same shape with channels 1..3 in global xyz normalized using the
+    standard per-channel mean/std (compatible with ``transform.invert_surface``).
+    """
+    normals = surface_x[..., 3:6]
+    t1, t2, n_hat = build_tangent_frame(normals)
+    ws_std_scalar = _wallshear_scalar_std(transform).to(surface_pred_norm.device)
+    ws_mean = transform.surface_y_mean[1:4].to(surface_pred_norm.device)
+    ws_std = transform.surface_y_std[1:4].to(surface_pred_norm.device)
+    pred_local_norm = surface_pred_norm[..., 1:4]
+    pred_local_phys = pred_local_norm.float() * ws_std_scalar
+    pred_global_phys = rotate_local_to_global(pred_local_phys, t1, t2, n_hat)
+    pred_global_norm = (pred_global_phys - ws_mean) / ws_std
+    return torch.cat(
+        [surface_pred_norm[..., :1], pred_global_norm.to(surface_pred_norm.dtype)],
+        dim=-1,
+    )
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1502,6 +1677,8 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    use_tangent_frame_output: bool = False,
+    tangent_normal_reg: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1515,7 +1692,49 @@ def train_loss(
         )
         surface_pred_norm = out["surface_preds"]
         normal_rms = float("nan")
-        if use_tangential_wallshear_loss:
+        tangent_pred_n_rms = float("nan")
+        tangent_target_n_rms = float("nan")
+        normal_reg_value: float | None = None
+        if use_tangent_frame_output:
+            # Reparameterize wall-shear output into local frame {t1, t2, n}:
+            # model channels [1,2,3] are (tau_t1, tau_t2, tau_n) normalized by a
+            # scalar wallshear std. Rotate the target to local frame for the loss.
+            normals = batch.surface_x[..., 3:6]
+            t1, t2, n_hat = build_tangent_frame(normals)
+            ws_std_scalar = _wallshear_scalar_std(transform).to(surface_pred_norm.device)
+            ws_target_phys = batch.surface_y[..., 1:4].float()
+            target_local_phys = rotate_global_to_local(ws_target_phys, t1, t2, n_hat)
+            target_local_norm = target_local_phys / ws_std_scalar
+            surface_target_used = torch.cat(
+                [
+                    surface_target[..., :1],
+                    target_local_norm.to(surface_target.dtype),
+                ],
+                dim=-1,
+            )
+            surface_pred_used = surface_pred_norm
+            if bool(batch.surface_mask.any()):
+                pred_n_norm = surface_pred_norm[..., 3]
+                target_n_norm = target_local_norm[..., 2]
+                tangent_pred_n_rms = float(
+                    (pred_n_norm[batch.surface_mask] * ws_std_scalar)
+                    .square()
+                    .mean()
+                    .sqrt()
+                    .detach()
+                    .cpu()
+                    .item()
+                )
+                tangent_target_n_rms = float(
+                    (target_n_norm[batch.surface_mask] * ws_std_scalar)
+                    .square()
+                    .mean()
+                    .sqrt()
+                    .detach()
+                    .cpu()
+                    .item()
+                )
+        elif use_tangential_wallshear_loss:
             # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
             # in normalized space does not equal physical-space tangent projection.
             # Denormalize -> project in physical space -> renormalize.
@@ -1550,10 +1769,15 @@ def train_loss(
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        if use_tangent_frame_output and tangent_normal_reg > 0.0 and bool(batch.surface_mask.any()):
+            pred_n_norm = surface_pred_norm[..., 3]
+            normal_reg = pred_n_norm[batch.surface_mask].pow(2).mean()
+            loss = loss + tangent_normal_reg * normal_reg
+            normal_reg_value = float(normal_reg.detach().cpu().item())
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
-            surf_pred_f = surface_pred_norm.float()
-            surf_true_f = surface_target.float()
+            surf_pred_f = surface_pred_used.float()
+            surf_true_f = surface_target_used.float()
             mask_f = batch.surface_mask.float().unsqueeze(-1)
             num = ((surf_pred_f - surf_true_f) ** 2 * mask_f).sum()
             den = (surf_true_f ** 2 * mask_f).sum().clamp_min(1e-8)
@@ -1572,6 +1796,14 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if use_tangent_frame_output:
+        metrics["tangent_pred_n_rms"] = tangent_pred_n_rms
+        metrics["tangent_target_n_rms"] = tangent_target_n_rms
+        metrics["loss_tangent_t1"] = per_axis_unweighted[1]
+        metrics["loss_tangent_t2"] = per_axis_unweighted[2]
+        metrics["loss_tangent_n"] = per_axis_unweighted[3]
+        if normal_reg_value is not None:
+            metrics["tangent_normal_reg_loss"] = normal_reg_value
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -1631,6 +1863,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    use_tangent_frame_output: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -1657,6 +1890,10 @@ def evaluate_split(
         "volume_pressure": {},
     }
 
+    tangent_pred_n_sq_sum = 0.0
+    tangent_target_n_sq_sum = 0.0
+    tangent_n_count = 0
+
     for batch in loader:
         batch = batch.to(device)
         surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -1670,6 +1907,27 @@ def evaluate_split(
             )
         surface_pred_norm = out["surface_preds"].float()
         volume_pred_norm = out["volume_preds"].float()
+        if use_tangent_frame_output and surface_pred_norm.numel() > 0:
+            if bool(batch.surface_mask.any()):
+                ws_std_scalar = _wallshear_scalar_std(transform).to(surface_pred_norm.device)
+                normals_eval = batch.surface_x[..., 3:6].float()
+                t1_eval, t2_eval, n_hat_eval = build_tangent_frame(normals_eval)
+                pred_n_phys = surface_pred_norm[..., 3] * ws_std_scalar
+                target_local_phys = rotate_global_to_local(
+                    batch.surface_y[..., 1:4].float(), t1_eval, t2_eval, n_hat_eval
+                )
+                target_n_phys = target_local_phys[..., 2]
+                mask_b = batch.surface_mask
+                tangent_pred_n_sq_sum += float(
+                    pred_n_phys[mask_b].square().sum().detach().cpu().item()
+                )
+                tangent_target_n_sq_sum += float(
+                    target_n_phys[mask_b].square().sum().detach().cpu().item()
+                )
+                tangent_n_count += int(mask_b.sum().item())
+            surface_pred_norm = tangent_frame_local_to_global_norm(
+                surface_pred_norm, batch.surface_x.float(), transform
+            )
         surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
         volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
         surface_loss_sse += surface_sse
@@ -1757,7 +2015,17 @@ def evaluate_split(
     }
     wall_shear_vector_mae = wall_shear_vector_abs_sum / max(wall_shear_vector_count, 1)
     loss = (surface_loss_sse + volume_loss_sse) / max(surface_loss_count + volume_loss_count, 1)
-    return {
+    tangent_metrics: dict[str, float] = {}
+    if use_tangent_frame_output and tangent_n_count > 0:
+        pred_n_rms = math.sqrt(tangent_pred_n_sq_sum / tangent_n_count)
+        target_n_rms = math.sqrt(tangent_target_n_sq_sum / tangent_n_count)
+        tangent_metrics["tangent_pred_n_rms"] = pred_n_rms
+        tangent_metrics["tangent_target_n_rms"] = target_n_rms
+        scalar_std = float(_wallshear_scalar_std(transform).item())
+        if scalar_std > 0.0:
+            tangent_metrics["tangent_pred_n_rms_over_tau"] = pred_n_rms / scalar_std
+            tangent_metrics["tangent_target_n_rms_over_tau"] = target_n_rms / scalar_std
+    metrics_out = {
         "loss": loss,
         "surface_loss": surface_loss_sse / max(surface_loss_count, 1),
         "volume_loss": volume_loss_sse / max(volume_loss_count, 1),
@@ -1786,6 +2054,8 @@ def evaluate_split(
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
     }
+    metrics_out.update(tangent_metrics)
+    return metrics_out
 
 
 def _sanitize_artifact_token(value: str) -> str:
@@ -2090,6 +2360,33 @@ def main(argv: Iterable[str] | None = None) -> None:
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
 
+    if config.use_tangent_frame_output and is_main:
+        try:
+            sample_batch = next(iter(train_loader))
+            sample_batch = sample_batch.to(device)
+            cont_stats = tangent_basis_continuity_stats(
+                sample_batch.surface_x[..., :3].float(),
+                sample_batch.surface_x[..., 3:6].float(),
+                sample_batch.surface_mask,
+            )
+            scalar_std_val = float(_wallshear_scalar_std(transform).item())
+            print(
+                "[tangent-frame] basis continuity (k=8 nbrs, ~4096 pts): "
+                f"mean={cont_stats['mean_deg']:.2f}deg, "
+                f"p99={cont_stats['p99_deg']:.2f}deg, "
+                f"max={cont_stats['max_deg']:.2f}deg, "
+                f"x_fallback_frac={cont_stats['fraction_x_fallback']:.4f}, "
+                f"scalar_std={scalar_std_val:.4f}"
+            )
+            if run is not None:
+                run.summary["tangent/basis_jump_mean_deg"] = cont_stats["mean_deg"]
+                run.summary["tangent/basis_jump_p99_deg"] = cont_stats["p99_deg"]
+                run.summary["tangent/basis_jump_max_deg"] = cont_stats["max_deg"]
+                run.summary["tangent/x_fallback_fraction"] = cont_stats["fraction_x_fallback"]
+                run.summary["tangent/wallshear_scalar_std"] = scalar_std_val
+        except Exception as exc:
+            print(f"[tangent-frame] basis continuity check skipped: {exc}")
+
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
             if is_main:
@@ -2124,6 +2421,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                use_tangent_frame_output=config.use_tangent_frame_output,
+                tangent_normal_reg=config.tangent_normal_reg,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2242,6 +2541,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
                 ]
+            for tangent_key in (
+                "tangent_pred_n_rms",
+                "tangent_target_n_rms",
+                "loss_tangent_t1",
+                "loss_tangent_t2",
+                "loss_tangent_n",
+                "tangent_normal_reg_loss",
+            ):
+                if tangent_key in batch_loss_metrics:
+                    train_log[f"train/{tangent_key}"] = batch_loss_metrics[tangent_key]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():
@@ -2319,7 +2628,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_tangent_frame_output=config.use_tangent_frame_output)
             for name, loader in val_loaders.items()
         }
         if ema is not None:
@@ -2446,7 +2755,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_tangent_frame_output=config.use_tangent_frame_output)
         for name, loader in val_loaders.items()
     }
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -2481,7 +2790,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, use_tangent_frame_output=config.use_tangent_frame_output)
         for name, loader in test_loaders.items()
     }
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]


### PR DESCRIPTION
## Hypothesis

Wall-shear output is currently predicted in the global world frame (τ_x, τ_y, τ_z). But wall shear is **definitionally tangential to the surface**: τ·n = 0 by physics. The model must learn this implicit constraint from scratch in 3D global coordinates, wasting representational capacity on a dimension that is always near-zero.

This PR tests **tangent-frame output reparameterization**: rewrite the wall-shear target into a local frame {t1, t2, n} at each surface point before computing loss, and rotate predictions back to global frame at eval time. In local frame, τ_n ≈ 0 by construction — the model only needs to learn 2 meaningful degrees of freedom per point (τ_t1, τ_t2) instead of 3.

**Motivation:** The largest AB-UPT gaps on yi are wall_shear_y (9.233% vs 3.65%, 2.53×) and wall_shear_z (10.449% vs 3.63%, 2.88×). These are in the global-frame components that are most sensitive to the surface orientation distribution. A local-frame prediction aligns with the physics and may let the model close these gaps.

The surface normals (nx, ny, nz) are already available as inputs in `surface_x[..., 3:6]`, so no new input features are needed.

## Implementation

Add a `--use-tangent-frame-output` flag (default: off). When enabled:

### 1. Build tangent frame from surface normals

```python
def build_tangent_frame(normals):
    """
    normals: [B, N, 3], unit surface normals
    Returns t1, t2: [B, N, 3] tangent basis vectors (unit, orthogonal to n)
    """
    # Choose a reference vector that avoids degeneracy with n
    ref = torch.zeros_like(normals)
    ref[..., 1] = 1.0  # [0, 1, 0]
    # Where normal is close to [0,1,0], use [1,0,0] instead
    degenerate = (normals[..., 1].abs() > 0.9)
    ref[degenerate, 0] = 1.0
    ref[degenerate, 1] = 0.0
    
    t1 = torch.cross(normals, ref, dim=-1)
    t1 = F.normalize(t1, dim=-1)
    t2 = torch.cross(normals, t1, dim=-1)
    t2 = F.normalize(t2, dim=-1)
    return t1, t2
```

### 2. Rotate wall-shear target to local frame (in loss computation)

```python
# batch.surface_y[..., 1:4] = [tau_x, tau_y, tau_z] (global)
# batch.surface_x[..., 3:6] = surface normals
normals = batch.surface_x[..., 3:6]  # [B, N, 3]
t1, t2 = build_tangent_frame(normals)

tau_global = batch.surface_y[..., 1:4]  # [B, N, 3]
tau_t1 = (tau_global * t1).sum(-1, keepdim=True)   # [B, N, 1]
tau_t2 = (tau_global * t2).sum(-1, keepdim=True)   # [B, N, 1]
tau_n  = (tau_global * normals).sum(-1, keepdim=True)  # [B, N, 1] ≈ 0 by physics

# Replace shear target with local frame representation for loss
surface_y_local = torch.cat([batch.surface_y[..., :1], tau_t1, tau_t2, tau_n], dim=-1)
```

### 3. Rotate predictions back to global frame at eval/test

```python
# model output in local frame: pred[..., 1:4] = [pred_t1, pred_t2, pred_n]
pred_global_shear = (
    pred[..., 1:2] * t1 +   # tau_t1 * t1
    pred[..., 2:3] * t2 +   # tau_t2 * t2
    pred[..., 3:4] * normals  # tau_n * n (should be ≈ 0)
)
# pred for metrics = concat(surface_pressure, pred_global_shear) in global frame
```

### 4. Optional: normal-component regularization

Add `--tangent-normal-reg` (float, default 0.0). When > 0, add a loss term:
```python
L_normal_reg = tangent_normal_reg * (pred[..., 3:4] ** 2).mean()
```
This explicitly penalizes the model for predicting non-zero normal shear.

### 5. All loss metrics still computed in global frame

At validation/test time, convert predictions back to global frame before computing all metrics (surface_pressure, wall_shear_x/y/z, val_abupt). This ensures the reported metrics are comparable to the baseline.

## Training Command

```bash
torchrun --nproc_per_node=4 train.py \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 1e-4 \
  --clip-grad-norm 0.5 \
  --batch-size 4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --use-tangent-frame-output \
  --wandb-group tanjiro/tangent-frame-head-ddp4
```

**Optional second run** (to test normal regularization):
```bash
# same as above but add:
  --use-tangent-frame-output \
  --tangent-normal-reg 0.01 \
  --wandb-group tanjiro/tangent-frame-head-ddp4
```

## What to report

Please report in a PR comment:
- W&B run ID(s) and link(s)
- val_abupt (primary metric, lower is better)
- Individual surface metrics: surface_pressure, wall_shear_x, wall_shear_y, wall_shear_z
- Volume metric: volume_pressure
- Whether the model predicted lower |τ_n| than the baseline (confirming the physics prior is being captured)
- Any training instabilities

## Current Baseline (yi branch)

| Metric | Baseline (PR #309) | AB-UPT target | Gap ratio |
|---|---|---|---|
| **val_abupt** | **9.039%** | — | — |
| surface_pressure | 4.485% | 3.82% | 1.17× |
| wall_shear_x | 7.003% | 3.63% | 1.93× |
| wall_shear_y | 9.233% | 3.65% | **2.53×** |
| wall_shear_z | 10.449% | 3.63% | **2.88×** |
| volume_pressure | 12.438% | 6.08% | 2.05× |

**Target to beat:** val_abupt < 9.039%

The wall_shear_y and wall_shear_z gaps are the largest — this is the primary motivation for the tangent-frame hypothesis. If the model can predict in a physically meaningful 2D subspace aligned with the surface, these components should improve most.
