### PR TITLE
haku: adaptive surface_pressure loss-weight decay (1.0→0.3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -699,6 +699,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    surface_pressure_loss_weight_decay: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1502,6 +1503,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    sp_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1545,7 +1547,7 @@ def train_loss(
             surface_pred_used,
             surface_target_used,
             batch.surface_mask,
-            channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+            channel_weights=(sp_loss_weight, 1.0, wallshear_y_weight, wallshear_z_weight),
             wallshear_huber_delta=wallshear_huber_delta,
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
@@ -2111,6 +2113,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            if config.surface_pressure_loss_weight_decay > 0.0:
+                sp_progress = min(1.0, global_step / max(1, total_estimated_steps))
+                sp_w_init = 1.0
+                sp_w_final = config.surface_pressure_loss_weight_decay
+                sp_loss_weight_now = sp_w_init + sp_progress * (sp_w_final - sp_w_init)
+            else:
+                sp_loss_weight_now = 1.0
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,
@@ -2124,6 +2133,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                sp_loss_weight=sp_loss_weight_now,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2230,6 +2240,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "train/lr": float(optimizer.param_groups[0]["lr"]),
                 "train/nonfinite_skip_count": nonfinite_skip_count,
+                "train/sp_loss_weight_now": float(sp_loss_weight_now),
                 "global_step": global_step,
                 **gradient_metrics,
                 **weight_metrics,


### PR DESCRIPTION
## Hypothesis

**Adaptive per-channel loss weighting** — start with the current static weights (`sp=1.0, ws_x=1.0, ws_y=2.0, ws_z=2.0, vp=1.0`), and over the course of training, monotonically decay the surface_pressure loss weight from `1.0 → 0.3` linearly across the budget. The motivation:

- Surface pressure converges fastest on yi (~5.5% at convergence vs 8.5–10% for wall_shear channels). Once it reaches a low residual, additional gradient signal on it is **wasted capacity** that could be flowing into harder channels (wall_shear_y/z, volume_pressure).
- The current static weighting (`sp=1, ws_y=2, ws_z=2`) bakes in an a-priori judgment about channel difficulty. This experiment tests a **time-varying** weighting that lets the optimization budget reflow toward the channels that haven't converged yet.
- This is **gradient capacity reallocation** by direct loss-weight scheduling — orthogonal to PR #529 (stream-normal per-point weighting, which is geometric) and PR #518 (asinh residual transform, which is robust-loss). It does not change the loss form, just its time-varying scalar weight.

This is a closer, more controllable cousin of GradNorm (Chen et al. 2017) without the auxiliary network — we use a fixed schedule rather than learning the weights, since the convergence ordering on yi is already known empirically.

## Instructions

### Code change

Add a new flag `--surface-pressure-loss-weight-decay <final_value>` (default `0.0` = OFF, i.e. constant weight). When set to a value `w_final` < 1.0:

1. Locate the loss-weighting block in `target/train.py` where `surface_pressure_loss_weight` (or whatever the variable is named — likely `sp_w` or similar; trace from the existing static config field) is multiplied with the surface_pressure residual.

2. Replace the static weight with a time-varying linear schedule:
```python
if config.surface_pressure_loss_weight_decay > 0.0:
    progress = global_step / max(1, total_steps)  # 0.0 at start, 1.0 at end
    progress = min(1.0, progress)
    w_init = 1.0  # initial weight
    w_final = config.surface_pressure_loss_weight_decay
    sp_w_now = w_init + progress * (w_final - w_init)  # linear interpolation
else:
    sp_w_now = config.surface_pressure_loss_weight  # static existing value
```

3. Log `train/sp_loss_weight_now` every `gradient_log_every` steps so the schedule is visible in W&B.

4. **Do not modify** the wall_shear or volume_pressure weight code paths. This is a one-channel intervention.

### Training run — single arm DDP-4

```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent haku \
  --wandb-group haku-r32-sp-loss-decay \
  --wandb-name haku-r32-sp-decay-1.0-to-0.3 \
  --optimizer lion \
  --lr 1e-4 --weight-decay 1e-4 \
  --no-compile-model --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1 --clip-grad-norm 0.5 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --epochs 50 \
  --surface-pressure-loss-weight-decay 0.3
```

Single arm only — this is a hypothesis-test, not a sweep. If it wins, we sweep `0.5 / 0.3 / 0.1` afterwards.

### Reporting

| Metric | yi baseline (PR #309 control) | This run | Δ |
|---|---:|---:|---:|
| val_abupt | 9.039% | | |
| surface_pressure (val) | ~5.5% | | |
| wall_shear (val) | ~10.5% | | |
| wall_shear_y (val) | ~10.5% | | |
| wall_shear_z (val) | ~11.8% | | |
| volume_pressure (val) | ~13.5% | | |
| test_abupt | ~10.2% | | |

Plus: best `train/sp_loss_weight_now` trajectory across training (W&B chart), best epoch, W&B run ID.

## What success looks like

- val_abupt < 9.039% bar → MERGE
- surface_pressure regresses ≤ +0.5pp (acceptable trade) AND wall_shear or volume_pressure improves ≥ 0.5pp → mechanism confirmed even if val_abupt is null; follow-up sweeps justified
- All channels regress → adaptive weighting is hurting; close
- val_abupt improves but surface_pressure regresses > 1.0pp → still merge (val_abupt is the primary metric), but flag the surface trade-off

## Baseline

- **Active merge bar:** `val_primary/abupt_axis_mean_rel_l2_pct < 9.039%` (PR #309 thorfinn grad-clip=0.5 on yi).
- **Aspirational tay number for context:** 7.546% (PR #311) and 7.1792% (PR #489) are tay-branch results, NOT on yi. They are not the merge bar for this experiment.

## Notes

- This is a **time-varying weighting**, not a static one. The whole point of the experiment is the schedule. Confirm the W&B-logged `sp_loss_weight_now` is monotonically decreasing across training.
- `--epochs 50` keeps the schedule denominator at the canonical config; actual training will hit timeout at ~3 epochs ≈ 16k steps, so the surface-pressure weight at termination will be `1.0 + (16k/272k) × (0.3 - 1.0) ≈ 0.96`. This means the schedule is barely engaged — that's a problem.
- **Better: use `--epochs 3` so the schedule fires properly.** With `--epochs 3` and ~16k total steps, the weight transitions linearly from 1.0 to 0.3 over the actual run — the schedule fully engages. Use `--epochs 3` in your launch.

(Replace `--epochs 50` in the command above with `--epochs 3` for actual launch.)
