### PR TITLE
nezuko: y-mirror training augmentation for tau_y/tau_z gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -82,6 +82,7 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    mirror_aug_prob: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -223,6 +224,45 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_mirror_y_aug(batch, prob: float) -> tuple[object, float]:
+    """Per-sample y-mirror (xz-plane) augmentation.
+
+    Sign conventions (from data/loader.py):
+      surface_x layout: [x(0), y(1), z(2), nx(3), ny(4), nz(5), area(6)]
+      surface_y layout: [cp(0), tau_x(1), tau_y(2), tau_z(3)]
+      volume_x  layout: [x(0), y(1), z(2), sdf(3)]
+
+    Under y-reflection only the y position, y normal, and tau_y target flip sign;
+    cp / tau_x / tau_z / area / nx / nz / sdf and volume_y (scalar pressure) are
+    invariant. Returns the (possibly augmented) batch and the realized fraction
+    of flipped samples for logging.
+    """
+    if prob <= 0.0:
+        return batch, 0.0
+
+    B = batch.surface_x.shape[0]
+    flip_mask = torch.rand(B, device=batch.surface_x.device) < prob  # [B]
+    flip_frac = float(flip_mask.float().mean().item())
+    if not bool(flip_mask.any().item()):
+        return batch, flip_frac
+
+    sign = torch.where(flip_mask, -1.0, 1.0).to(batch.surface_x.dtype)  # [B]
+    surface_sign = sign[:, None]  # [B, 1]
+    volume_sign = sign[:, None]   # [B, 1]
+
+    surface_x = batch.surface_x.clone()
+    surface_y = batch.surface_y.clone()
+    volume_x = batch.volume_x.clone()
+
+    surface_x[:, :, 1] = surface_x[:, :, 1] * surface_sign
+    surface_x[:, :, 4] = surface_x[:, :, 4] * surface_sign
+    surface_y[:, :, 2] = surface_y[:, :, 2] * surface_sign
+    volume_x[:, :, 1] = volume_x[:, :, 1] * volume_sign
+
+    import dataclasses
+    return dataclasses.replace(batch, surface_x=surface_x, surface_y=surface_y, volume_x=volume_x), flip_frac
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -232,8 +272,12 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    mirror_aug_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    mirror_aug_frac = 0.0
+    if mirror_aug_prob > 0.0:
+        batch, mirror_aug_frac = apply_mirror_y_aug(batch, mirror_aug_prob)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -255,6 +299,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "mirror_aug_frac": mirror_aug_frac,
     }
 
 
@@ -501,6 +546,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    mirror_aug_prob=config.mirror_aug_prob,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -537,6 +583,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/mirror_aug_frac": batch_loss_metrics["mirror_aug_frac"],
                         }
                     )
 


### PR DESCRIPTION
## Hypothesis

The DrivAerML cars are geometrically symmetric about the xz-plane (y=0). A y-mirror (flip about xz-plane) is an exact physics symmetry: reflected surface pressure `cp` is unchanged, reflected wall shear `tau_y` negates (antisymmetric), reflected `tau_x` and `tau_z` are unchanged. Training with y-mirror augmentation therefore effectively doubles the training dataset from 400 to 800 cars at zero data-collection cost.

Our current tau_y gap is 8.77% vs AB-UPT 3.65% — a 2.4× shortfall. tau_y is the antisymmetric channel under y-flip; a sign-correct mirror augmentation provides the model with balanced positive- and negative-tau_y training signal, which should reduce the model's bias on this channel. tau_z (orthogonal to the flip axis) and surface_pressure should be unaffected or slightly improved from the doubled dataset.

**Key insight:** This is NOT the same as the inference-time TTA that failed in PR #499. That experiment trained *without* augmentation but applied the average at inference, which picked the wrong checkpoint. Here we augment during *training* so the model learns invariance directly from data. Training augmentation and inference TTA are fundamentally different interventions.

**Precedent:** On the `bengio` track, y-mirror training augmentation (PR #278) improved wall shear accuracy. We are re-implementing it from scratch on `tay` as the code was never ported. The commit `b1dc4ca` on the `bengio` track shows the correct sign-flip channels.

## Instructions

Add `--mirror-aug-prob P` CLI flag (float in [0, 1], default 0.0 = off) and apply per-sample independent y-mirror augmentation in the `train_loss` function **during training only** (never applied in eval/test).

### Implementation

Add the following to `train.py`:

**1. Add CLI argument** (in `parse_args`):
```python
parser.add_argument("--mirror-aug-prob", type=float, default=0.0,
    help="Per-sample y-mirror augmentation probability during training (0.0 = disabled)")
```

**2. Add to Config dataclass:**
```python
mirror_aug_prob: float = 0.0
```

**3. Add augmentation function** (near the top of train.py, after imports):
```python
def apply_mirror_y_aug(batch, prob: float) -> object:
    """Randomly flip each sample about the xz-plane (y -> -y) with given probability.
    
    Sign conventions (from data/loader.py):
      surface_x dim layout: [x(0), y(1), z(2), nx(3), ny(4), nz(5), area(6)]
      surface_y dim layout: [cp(0), tau_x(1), tau_y(2), tau_z(3)]
      volume_x dim layout:  [x(0), y(1), z(2), sdf(3)] (4-dim, y at index 1)
    
    Under y-reflection (xz-plane):
      surface_x[:, :, 1] (y pos)     -> negate
      surface_x[:, :, 4] (ny normal) -> negate
      surface_y[:, :, 2] (tau_y)     -> negate   (antisymmetric)
      volume_x[:, :, 1]  (y pos)     -> negate
      all other channels are sign-invariant (cp, tau_x, tau_z, area, nx, nz, sdf unchanged)
    """
    if prob <= 0.0:
        return batch
    
    B = batch.surface_x.shape[0]
    flip_mask = torch.rand(B, device=batch.surface_x.device) < prob  # [B]
    
    if not flip_mask.any():
        return batch
    
    # Clone only the tensors we'll modify (avoid in-place on original batch)
    surface_x = batch.surface_x.clone()
    surface_y = batch.surface_y.clone()
    volume_x = batch.volume_x.clone()
    
    # Apply flip to selected samples: expand mask to [B, N, 1] for broadcasting
    flip_3d = flip_mask[:, None, None]  # [B, 1, 1]
    
    # surface_x: negate y (col 1) and ny (col 4)
    surface_x[:, :, 1] = torch.where(flip_3d.squeeze(-1), -surface_x[:, :, 1], surface_x[:, :, 1])
    surface_x[:, :, 4] = torch.where(flip_3d.squeeze(-1), -surface_x[:, :, 4], surface_x[:, :, 4])
    
    # surface_y: negate tau_y (col 2 only — antisymmetric under y-flip)
    surface_y[:, :, 2] = torch.where(flip_3d.squeeze(-1), -surface_y[:, :, 2], surface_y[:, :, 2])
    
    # volume_x: negate y (col 1)
    volume_x[:, :, 1] = torch.where(flip_3d.squeeze(-1), -volume_x[:, :, 1], volume_x[:, :, 1])
    
    # Return a new batch-like object with augmented tensors
    # Replace the relevant fields using dataclasses.replace or manual construction
    import dataclasses
    return dataclasses.replace(batch, surface_x=surface_x, surface_y=surface_y, volume_x=volume_x)
```

**4. Modify `train_loss` to accept and apply augmentation:**

Change the signature to add `mirror_aug_prob: float = 0.0`:
```python
def train_loss(
    model: nn.Module,
    batch,
    transform: TargetTransform,
    device: torch.device,
    amp_mode: str,
    *,
    surface_loss_weight: float = 1.0,
    volume_loss_weight: float = 1.0,
    mirror_aug_prob: float = 0.0,
) -> tuple[torch.Tensor, dict[str, float]]:
    batch = batch.to(device)
    # Apply y-mirror augmentation BEFORE computing targets (so flip applies to both x and y)
    if mirror_aug_prob > 0.0:
        batch = apply_mirror_y_aug(batch, mirror_aug_prob)
    surface_target = transform.apply_surface(batch.surface_y)
    ...
```

**5. Pass the flag through in the training call** (find where `train_loss` is called in the training loop and add `mirror_aug_prob=config.mirror_aug_prob`).

**6. Log the augmentation fraction** for monitoring:
```python
# Inside train_loss, after flip_mask computation:
logs["train/mirror_aug_frac"] = float(flip_mask.float().mean().item())
```

### Run command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --mirror-aug-prob 0.5 \
  --wandb-group nezuko-mirror-y-aug --wandb-name nezuko-mirror-aug-p50
```

**Note:** Use `--train-volume-points 65536` (constant, not `--vol-points-schedule`) to match the SOTA #511 stack. The `--eval-volume-points` applies to validation — **do NOT apply mirror-aug during eval/test**, the augmentation is training-only.

## Gate structure

- **EP3 gate**: val_abupt ≤ 14.0%
- **EP5 gate**: val_abupt ≤ 9.2% (sanity: augmentation should not hurt)
- **EP8 gate**: val_abupt ≤ 7.8%
- **Win condition**: val_abupt < **7.0134%** (PR #511 SOTA)

## Baseline

**Current SOTA: edward PR #511, W&B run `5o7jc7wi`, val_abupt=7.0134%, test_abupt=8.3130% (EP13)**

| Metric | PR #511 (SOTA) | AB-UPT ref |
|---|---:|---:|
| val_abupt | 7.0134% | — |
| val_surface_pressure | 4.5104% | 3.82% |
| val_wall_shear | 7.9650% | 7.29% |
| val_volume_pressure | 4.2168% | 6.08% (BEATEN) |
| val_tau_x | 7.0053% | 5.35% |
| **val_tau_y** | **8.7717%** | **3.65%** |
| **val_tau_z** | **10.5629%** | **3.63%** |
| test_abupt | 8.3130% | — |

tau_y (8.77%) and tau_z (10.56%) are 2.4× and 2.9× above the AB-UPT reference. These are the primary open problem.

## Monitoring

During training, monitor `train/mirror_aug_frac` to confirm augmentation is firing (~0.5 expected). At EP3, report:
1. val_abupt vs SOTA EP3 trajectory (SOTA was ~14% at EP3)
2. Per-axis breakdown: specifically val_tau_y and val_tau_z
3. `train/mirror_aug_frac` average

The critical test is whether tau_y closes faster (per-epoch improvement rate) than the SOTA baseline's trajectory.
