### PR TITLE
fern: cosine annealing with warm restarts (SGDR T0=6, Tmult=2)

### DIFF
--- a/train.py
+++ b/train.py
@@ -111,6 +111,7 @@ class Config:
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
+    lr_cosine_t_mult: int = 1
     lr_min: float = 1e-6
     grad_clip_norm: float = 1.0
     gradient_log_every: int = 250

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1253,11 +1253,20 @@ def build_lr_scheduler(
     max_epochs: int,
 ) -> torch.optim.lr_scheduler.LRScheduler:
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
-    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-        optimizer,
-        T_max=max(1, t_max),
-        eta_min=config.lr_min,
-    )
+    t_mult = max(1, getattr(config, "lr_cosine_t_mult", 1))
+    if t_mult > 1:
+        cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=max(1, t_max),
+            T_mult=t_mult,
+            eta_min=config.lr_min,
+        )
+    else:
+        cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer,
+            T_max=max(1, t_max),
+            eta_min=config.lr_min,
+        )
     if config.lr_warmup_epochs <= 0:
         return cosine_scheduler
     warmup_scheduler = torch.optim.lr_scheduler.LinearLR(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1254,7 +1254,9 @@ def build_lr_scheduler(
 ) -> torch.optim.lr_scheduler.LRScheduler:
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     t_mult = max(1, getattr(config, "lr_cosine_t_mult", 1))
-    if t_mult > 1:
+    cosine_epochs = max_epochs - max(0, config.lr_warmup_epochs)
+    use_warm_restarts = t_mult > 1 or t_max < cosine_epochs
+    if use_warm_restarts:
         cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
             optimizer,
             T_0=max(1, t_max),


### PR DESCRIPTION
## Hypothesis

The current SOTA uses `CosineAnnealingLR` with a single monotonic decay from `lr=1e-4` to 0 over 13 epochs. The loss landscape of CFD surrogates (especially for high-frequency surface quantities like tau_y/tau_z near geometric discontinuities) likely contains many local minima. Once the cosine schedule reaches a low LR at EP13, the optimizer cannot escape any local trap it fell into mid-training.

**Hypothesis:** Replacing the single cosine schedule with `CosineAnnealingWarmRestarts` (T_0=6, T_mult=1) gives two complete cycles over 13 epochs:
- Cycle 1: EP1→6 (full cosine decay from lr=1e-4 to ≈0)
- Cycle 2: EP7→13 (full cosine decay from lr=1e-4 to ≈0 again)

Each restart re-injects high LR momentum and can escape local minima that formed during the first cycle. This is particularly beneficial for tau_y/tau_z because those channels require the model to learn high-frequency geometric features — the kind most sensitive to optimizer trajectory.

The warm-restart technique (SGDR — Stochastic Gradient Descent with Warm Restarts) was introduced by Loshchilov & Hutter (ICLR 2017) and has documented convergence improvements over single-cycle cosine. The key insight is that ensemble effects over warm-restart cycles act as implicit model soups — each restart basin is different, and the EMA checkpoint captures the final accumulated state.

The 1-epoch warmup in the SOTA stack is retained for Cycle 1, applied at the very start. Cycle 2 starts at full lr=1e-4 directly (no warmup — the model is already pre-trained and doesn't benefit from a second ramp).

## Instructions

### Step 1: Add CLI flag to `target/train.py`

In the `Config` dataclass (near `lr_cosine_t_max`), add:

```python
lr_cosine_t_mult: int = 1    # T_mult for CosineAnnealingWarmRestarts (1 = equal-length cycles, 2 = doubling cycles)
```

Add corresponding CLI argument to `parse_args`:

```python
parser.add_argument("--lr-cosine-t-mult", type=int, default=1,
                    help="T_mult for warm-restart cosine schedule (default: 1, equal cycles)")
```

### Step 2: Modify `build_lr_scheduler` in `target/trainer_runtime.py`

Change the function to use `CosineAnnealingWarmRestarts` when `lr_cosine_t_mult > 1` OR when a new flag is set. Keep full backward compatibility for the existing `CosineAnnealingLR` path.

Locate the `build_lr_scheduler` function and update it:

```python
def build_lr_scheduler(
    optimizer,
    config,
    max_epochs: int,
) -> torch.optim.lr_scheduler.LRScheduler:
    if config.lr_cosine_t_max > 0:
        if getattr(config, 'lr_cosine_t_mult', 1) > 1:
            # Warm restarts: CosineAnnealingWarmRestarts with T_0=lr_cosine_t_max
            cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
                optimizer,
                T_0=config.lr_cosine_t_max,
                T_mult=config.lr_cosine_t_mult,
                eta_min=0,
            )
        else:
            # Standard single-cycle cosine (existing behaviour)
            cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
                optimizer,
                T_max=config.lr_cosine_t_max,
                eta_min=0,
            )
        if config.lr_warmup_epochs > 0:
            warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
                optimizer,
                start_factor=1e-6,
                end_factor=1.0,
                total_iters=config.lr_warmup_epochs,
            )
            return torch.optim.lr_scheduler.SequentialLR(
                optimizer,
                schedulers=[warmup_scheduler, cosine_scheduler],
                milestones=[config.lr_warmup_epochs],
            )
        return cosine_scheduler
    # fallback: constant LR
    return torch.optim.lr_scheduler.LambdaLR(optimizer, lambda epoch: 1.0)
```

**IMPORTANT:** The `T_0` for `CosineAnnealingWarmRestarts` should be set to `lr_cosine_t_max` (which we set to 6 for 2 cycles of 6+7 epochs = 13 total). The scheduler uses `T_0` as the period of the first cycle.

### Step 3: Run the experiment

Use the SOTA stack with the following single change — `--lr-cosine-t-max 6 --lr-cosine-t-mult 2` (T_0=6, T_mult=2 means: cycle 1 = 6 epochs, cycle 2 = 12 epochs — but since we only run 13 epochs, cycle 2 truncates at EP7+6=EP13):

**Wait** — actually use `T_mult=1` with `T_0=6` for symmetric cycles (cycle 1: EP1-6, cycle 2: EP7-12, partial cycle 3: EP13). Or better: `T_0=7` with `T_mult=1` for EP1-7 / EP8-13 exactly.

**Use this exact config for the experiment:**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 6 --lr-cosine-t-mult 2 \
  --epochs 13 \
  --surface-loss-weight 2.0 \
  --wandb-group fern-warm-restarts --wandb-name fern-sgdr-t0-6-tmult-2
```

This sets T_0=6 (first 6 epochs), T_mult=2 (second cycle = 12 epochs, truncated at EP13). The optimizer gets a full warm restart at EP7 with lr=1e-4.

**Win condition:** val_abupt < **7.0063%** (current SOTA PR #510).

**EP3 gate:** val_abupt ≤ 14.15% (2× SOTA EP3 budget for budget headroom). If EP3 exceeds 14.15%, report it — don't abort, warm restart runs may not show strong early performance.

**Note:** Log the LR schedule using `wandb.log({"train/lr": ...})` at each step if not already done (it is — the existing code logs `scheduler.get_last_lr()[0]`). Verify the W&B `train/lr` curve shows two cosine cycles, not one, to confirm the scheduler is correctly installed.

## Baseline

**Current SOTA: alphonse PR #510 (slw=2.0, EP5 EMA), W&B run `qqtdnlwq`**

| Metric | SOTA #510 val | SOTA #510 test | AB-UPT target |
|---|---:|---:|---:|
| `abupt` | **7.0063%** | 8.2921% | — |
| `surface_pressure` | 4.5994% | 4.2381% | 3.82% |
| `wall_shear` | 7.8939% | 7.6341% | 7.29% |
| `volume_pressure` | 4.1643% | 12.1047% | 6.08% |
| `tau_x` | 6.8150% | 6.6657% | 5.35% |
| `tau_y` | 8.9516% | 8.6452% | 3.65% |
| `tau_z` | 10.5010% | 9.8066% | 3.63% |

```bash
# Reproduce SOTA (single-cycle cosine, T_max=13):
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 --surface-loss-weight 2.0
```
