### PR TITLE
violet: online hard example mining for τ_y/τ_z wall-shear loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -722,6 +722,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    wallshear_ohem_k: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1444,7 +1445,8 @@ def weighted_masked_mse_per_channel(
     *,
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
-) -> tuple[torch.Tensor, list[float]]:
+    wallshear_ohem_k: float = 0.0,
+) -> tuple[torch.Tensor, list[float], float]:
     """Per-channel weighted masked loss for surface predictions.
 
     pred, target: [B, N, C]. mask: [B, N] bool.
@@ -1460,6 +1462,13 @@ def weighted_masked_mse_per_channel(
                   = 2 * delta * (|r| - delta/2)  if |r| >= delta
     Channel 0 (cp / surface_pressure) keeps the standard MSE loss.
 
+    With ``wallshear_ohem_k`` in (0, 1] and 4+ channels, apply Online Hard
+    Example Mining (OHEM) to the wall-shear channels: per sample, score every
+    surface point by ``τ_y² + τ_z²`` residual and keep only the top-k_fraction
+    hardest points for the τ-channel (1..3) loss. Channel 0 (cp) keeps the
+    standard masked MSE. The /n_channels normalization matches the non-OHEM
+    path so k=1.0 numerically recovers the standard MSE (when masks are full).
+
     Note: PR #317's spec used a *relative* Huber ``(pred-target)/(|target|+eps)``,
     but standardized targets cross zero frequently, so dividing by ``|target|``
     blows up the gradient (pre-clip grad-norms 50–300× the MSE control) and
@@ -1469,16 +1478,69 @@ def weighted_masked_mse_per_channel(
     rescaling keeps the L2 regime matched to the MSE control for clean
     interpretation of delta. Per-axis diagnostic loss keys remain MSE-based for
     cross-run comparability.
+
+    Returns
+    -------
+    weighted_loss : torch.Tensor
+        Scalar loss (matches the same /n_channels scale as standard MSE).
+    per_axis_mean : list[float]
+        Per-channel masked MSE diagnostics over *all* valid points (independent
+        of OHEM/Huber selection) for cross-run comparability.
+    ohem_mean_yz_residual : float
+        Mean ``τ_y² + τ_z²`` residual on the OHEM-selected hard points. NaN when
+        OHEM is disabled.
     """
     weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
     if not bool(mask.any()):
         per_axis = [0.0] * int(weights.numel())
-        return pred.sum() * 0.0, per_axis
+        return pred.sum() * 0.0, per_axis, float("nan")
     diff = pred - target  # [B, N, C]
     diff_sq = diff.pow(2)
     mask_f = mask.unsqueeze(-1).to(pred.dtype)
     valid = mask_f.sum().clamp_min(1)
     n_channels = diff_sq.shape[-1]
+
+    use_ohem = wallshear_ohem_k > 0.0 and n_channels >= 4
+    ohem_mean_yz_residual = float("nan")
+
+    if use_ohem:
+        # Score per surface point = τ_y² + τ_z² residual (channels 2 and 3).
+        yz_residual = diff_sq[..., 2] + diff_sq[..., 3]  # [B, N]
+        # Mask padded points so they are never picked by topk.
+        score = yz_residual.masked_fill(~mask, float("-inf"))
+        n_points = pred.shape[1]
+        k = max(1, int(round(n_points * float(wallshear_ohem_k))))
+        k = min(k, n_points)
+        _, hard_idx = score.topk(k, dim=1)  # [B, k]
+        hard_mask = mask.gather(1, hard_idx)  # [B, k] bool
+        hard_mask_f = hard_mask.unsqueeze(-1).to(pred.dtype)  # [B, k, 1]
+        # Gather τ-channel squared residuals on hard points.
+        idx_tau = hard_idx.unsqueeze(-1).expand(-1, -1, 3)
+        tau_diff_sq_hard = diff_sq[..., 1:4].gather(1, idx_tau)  # [B, k, 3]
+        tau_weights = weights[1:4].view(1, 1, -1)
+        # Per-channel mean over OHEM-selected valid points.
+        valid_hard = hard_mask_f.sum().clamp_min(1)
+        tau_loss_hard = (tau_diff_sq_hard * tau_weights * hard_mask_f).sum() / (
+            valid_hard * n_channels
+        )
+        # cp (channel 0) keeps standard masked MSE, normalized by /n_channels.
+        cp_loss = (diff_sq[..., 0:1] * weights[0:1].view(1, 1, -1) * mask_f).sum() / (
+            valid * n_channels
+        )
+        weighted_loss = cp_loss + tau_loss_hard
+        # Per-axis diagnostic: full-coverage masked MSE on every channel.
+        per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
+        per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
+        # Mean τ_y² + τ_z² on selected hard points (averaged over valid hard points).
+        yz_residual_hard = yz_residual.gather(1, hard_idx)  # [B, k]
+        yz_valid_count = hard_mask.to(pred.dtype).sum().clamp_min(1).detach()
+        ohem_mean_yz_residual = float(
+            (
+                (yz_residual_hard * hard_mask.to(pred.dtype)).sum().detach().float()
+                / yz_valid_count.float()
+            ).cpu().item()
+        )
+        return weighted_loss, per_axis_mean, ohem_mean_yz_residual
 
     if wallshear_huber_delta > 0.0 and n_channels >= 4:
         abs_err = diff.abs()
@@ -1499,7 +1561,7 @@ def weighted_masked_mse_per_channel(
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
     per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
-    return weighted_loss, per_axis_mean
+    return weighted_loss, per_axis_mean, ohem_mean_yz_residual
 
 
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
@@ -1528,6 +1590,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    wallshear_ohem_k: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1567,12 +1630,15 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
-            surface_pred_used,
-            surface_target_used,
-            batch.surface_mask,
-            channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
-            wallshear_huber_delta=wallshear_huber_delta,
+        surface_loss, per_axis_unweighted, ohem_mean_yz_residual = (
+            weighted_masked_mse_per_channel(
+                surface_pred_used,
+                surface_target_used,
+                batch.surface_mask,
+                channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+                wallshear_huber_delta=wallshear_huber_delta,
+                wallshear_ohem_k=wallshear_ohem_k,
+            )
         )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -1598,6 +1664,9 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if wallshear_ohem_k > 0.0:
+        metrics["ohem_hard_frac"] = float(wallshear_ohem_k)
+        metrics["ohem_mean_yz_residual"] = float(ohem_mean_yz_residual)
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -2172,6 +2241,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                wallshear_ohem_k=config.wallshear_ohem_k,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2285,6 +2355,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "ohem_hard_frac" in batch_loss_metrics:
+                train_log["train/ohem_hard_frac"] = batch_loss_metrics[
+                    "ohem_hard_frac"
+                ]
+                train_log["train/ohem_mean_yz_residual"] = batch_loss_metrics[
+                    "ohem_mean_yz_residual"
                 ]
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[

--- a/train.py
+++ b/train.py
@@ -1446,7 +1446,7 @@ def weighted_masked_mse_per_channel(
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
     wallshear_ohem_k: float = 0.0,
-) -> tuple[torch.Tensor, list[float], float]:
+) -> tuple[torch.Tensor, list[float], dict[str, float]]:
     """Per-channel weighted masked loss for surface predictions.
 
     pred, target: [B, N, C]. mask: [B, N] bool.
@@ -1486,14 +1486,19 @@ def weighted_masked_mse_per_channel(
     per_axis_mean : list[float]
         Per-channel masked MSE diagnostics over *all* valid points (independent
         of OHEM/Huber selection) for cross-run comparability.
-    ohem_mean_yz_residual : float
-        Mean ``τ_y² + τ_z²`` residual on the OHEM-selected hard points. NaN when
-        OHEM is disabled.
+    ohem_metrics : dict[str, float]
+        Empty when OHEM is disabled. When enabled, contains diagnostics on the
+        hard-mined subset: ``mean_yz_residual`` (mean τ_y²+τ_z² on hard points),
+        ``mask_frac_tau_y`` / ``mask_frac_tau_z`` (effective hard-point fraction
+        of valid points; identical for joint-yz OHEM), ``loss_tau_y_hard`` /
+        ``loss_tau_y_easy`` and ``loss_tau_z_hard`` / ``loss_tau_z_easy`` (mean
+        squared residual on the hard vs easy subsets — ratio should grow over
+        training as easy points are mastered first).
     """
     weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
     if not bool(mask.any()):
         per_axis = [0.0] * int(weights.numel())
-        return pred.sum() * 0.0, per_axis, float("nan")
+        return pred.sum() * 0.0, per_axis, {}
     diff = pred - target  # [B, N, C]
     diff_sq = diff.pow(2)
     mask_f = mask.unsqueeze(-1).to(pred.dtype)
@@ -1501,7 +1506,7 @@ def weighted_masked_mse_per_channel(
     n_channels = diff_sq.shape[-1]
 
     use_ohem = wallshear_ohem_k > 0.0 and n_channels >= 4
-    ohem_mean_yz_residual = float("nan")
+    ohem_metrics: dict[str, float] = {}
 
     if use_ohem:
         # Score per surface point = τ_y² + τ_z² residual (channels 2 and 3).
@@ -1531,16 +1536,45 @@ def weighted_masked_mse_per_channel(
         # Per-axis diagnostic: full-coverage masked MSE on every channel.
         per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
         per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
-        # Mean τ_y² + τ_z² on selected hard points (averaged over valid hard points).
-        yz_residual_hard = yz_residual.gather(1, hard_idx)  # [B, k]
-        yz_valid_count = hard_mask.to(pred.dtype).sum().clamp_min(1).detach()
-        ohem_mean_yz_residual = float(
-            (
-                (yz_residual_hard * hard_mask.to(pred.dtype)).sum().detach().float()
-                / yz_valid_count.float()
-            ).cpu().item()
-        )
-        return weighted_loss, per_axis_mean, ohem_mean_yz_residual
+
+        # ---- OHEM diagnostics (no grad) ----
+        # Build a per-point boolean "is_hard" indicator over [B, N].
+        is_hard = torch.zeros_like(mask)  # [B, N] bool
+        is_hard.scatter_(1, hard_idx, hard_mask)
+        easy_mask = mask & ~is_hard  # valid AND not selected
+        valid_easy_f = easy_mask.to(pred.dtype).sum().clamp_min(1).detach()
+        valid_hard_f = is_hard.to(pred.dtype).sum().clamp_min(1).detach()
+        valid_total_f = mask.to(pred.dtype).sum().clamp_min(1).detach()
+
+        ds = diff_sq.detach()
+        tau_y_sq = ds[..., 2]
+        tau_z_sq = ds[..., 3]
+        is_hard_f = is_hard.to(pred.dtype)
+        easy_mask_f = easy_mask.to(pred.dtype)
+
+        loss_tau_y_hard = (tau_y_sq * is_hard_f).sum() / valid_hard_f
+        loss_tau_y_easy = (tau_y_sq * easy_mask_f).sum() / valid_easy_f
+        loss_tau_z_hard = (tau_z_sq * is_hard_f).sum() / valid_hard_f
+        loss_tau_z_easy = (tau_z_sq * easy_mask_f).sum() / valid_easy_f
+        # Effective hard-point fraction (≈ k_fraction; deviates only when masks
+        # are not fully populated). One mask is shared across τ_y/τ_z under
+        # joint-yz OHEM, so both per-channel reports collapse to the same value.
+        mask_frac = (valid_hard_f / valid_total_f).float()
+
+        ohem_metrics = {
+            "ohem_hard_frac": float(wallshear_ohem_k),
+            "ohem_mask_frac_tau_y": float(mask_frac.cpu().item()),
+            "ohem_mask_frac_tau_z": float(mask_frac.cpu().item()),
+            "ohem_loss_tau_y_hard": float(loss_tau_y_hard.float().cpu().item()),
+            "ohem_loss_tau_y_easy": float(loss_tau_y_easy.float().cpu().item()),
+            "ohem_loss_tau_z_hard": float(loss_tau_z_hard.float().cpu().item()),
+            "ohem_loss_tau_z_easy": float(loss_tau_z_easy.float().cpu().item()),
+            "ohem_mean_yz_residual": float(
+                ((tau_y_sq + tau_z_sq) * is_hard_f).sum().float().cpu().item()
+                / float(valid_hard_f.cpu().item())
+            ),
+        }
+        return weighted_loss, per_axis_mean, ohem_metrics
 
     if wallshear_huber_delta > 0.0 and n_channels >= 4:
         abs_err = diff.abs()
@@ -1561,7 +1595,7 @@ def weighted_masked_mse_per_channel(
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
     per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
-    return weighted_loss, per_axis_mean, ohem_mean_yz_residual
+    return weighted_loss, per_axis_mean, ohem_metrics
 
 
 def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
@@ -1630,7 +1664,7 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
-        surface_loss, per_axis_unweighted, ohem_mean_yz_residual = (
+        surface_loss, per_axis_unweighted, ohem_metrics = (
             weighted_masked_mse_per_channel(
                 surface_pred_used,
                 surface_target_used,
@@ -1664,9 +1698,8 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
-    if wallshear_ohem_k > 0.0:
-        metrics["ohem_hard_frac"] = float(wallshear_ohem_k)
-        metrics["ohem_mean_yz_residual"] = float(ohem_mean_yz_residual)
+    if wallshear_ohem_k > 0.0 and ohem_metrics:
+        metrics.update(ohem_metrics)
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -2356,13 +2389,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
                 ]
-            if "ohem_hard_frac" in batch_loss_metrics:
-                train_log["train/ohem_hard_frac"] = batch_loss_metrics[
-                    "ohem_hard_frac"
-                ]
-                train_log["train/ohem_mean_yz_residual"] = batch_loss_metrics[
-                    "ohem_mean_yz_residual"
-                ]
+            for ohem_key in (
+                "ohem_hard_frac",
+                "ohem_mean_yz_residual",
+                "ohem_mask_frac_tau_y",
+                "ohem_mask_frac_tau_z",
+                "ohem_loss_tau_y_hard",
+                "ohem_loss_tau_y_easy",
+                "ohem_loss_tau_z_hard",
+                "ohem_loss_tau_z_easy",
+            ):
+                if ohem_key in batch_loss_metrics:
+                    train_log[f"train/{ohem_key}"] = batch_loss_metrics[ohem_key]
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"


### PR DESCRIPTION
## Hypothesis

The τ_y and τ_z wall-shear channels have a 2.35× and 2.73× gap respectively vs the AB-UPT targets. Static loss weights (PRs #244, #454) and stream-normal weights (PR #529) were both null. The key insight those approaches missed: the model's τ_y/τ_z errors are **not uniformly distributed** — they concentrate on a small fraction of surface points with high cross-flow separation (A-pillar, side-mirror, wheel-arch). A per-sample **online hard example mining (OHEM)** approach on the wall-shear loss will focus gradient signal exactly where the model is failing most.

OHEM selects, per forward pass, the top-k% hardest surface points by τ_y + τ_z squared residual and computes loss only on those points. This is analogous to SSD-style OHEM (Shrivastava et al. 2016, https://arxiv.org/abs/1604.03540) applied to regression. Unlike static weights, OHEM adapts: early in training it selects points with high-magnitude shear (globally informative), and late in training it shifts to the residual-dominated separation zones (where the model is structurally failing). No new hyperparameters are needed except the top-k fraction.

This is **different from PR #529** (stream-normal per-point weight, static γ applied to all points proportional to n_y^2 + n_z^2 — a fixed weight, not a dynamic hard-mining scheme).

## Instructions

### 1. Add OHEM to the wall-shear loss computation

In `target/train.py`, locate the wall-shear MSE loss over surface points. It currently computes `loss_ws = mean((pred_ws - target_ws)^2)` over all N surface points. Replace with OHEM when `--wallshear-ohem-k` is set:

```python
def wallshear_ohem_loss(pred_ws, target_ws, k_fraction: float):
    """
    pred_ws, target_ws: (B, N, 3) — predicted and target wall-shear τ_x/y/z
    k_fraction: float in (0, 1] — fraction of hardest points to retain
    """
    # Compute per-point squared residual on τ_y and τ_z only (channels 1 and 2)
    residual_yz = ((pred_ws - target_ws)[..., 1:3] ** 2).sum(dim=-1)  # (B, N)
    
    # Select top-k% hardest points per sample
    k = max(1, int(residual_yz.shape[1] * k_fraction))
    _, hard_idx = residual_yz.topk(k, dim=1)  # (B, k)
    
    # Gather and compute full 3-channel MSE on hard points only
    pred_hard = pred_ws.gather(1, hard_idx.unsqueeze(-1).expand(-1, -1, 3))   # (B, k, 3)
    tgt_hard  = target_ws.gather(1, hard_idx.unsqueeze(-1).expand(-1, -1, 3)) # (B, k, 3)
    return ((pred_hard - tgt_hard) ** 2).mean()
```

Add flag:
```python
parser.add_argument("--wallshear-ohem-k", type=float, default=0.0,
    help="Fraction of hardest-τ_y/z surface points for OHEM loss (0=disabled, e.g. 0.25).")
```

When `--wallshear-ohem-k > 0`, use `wallshear_ohem_loss(pred_ws, target_ws, k_fraction=args.wallshear_ohem_k)` in place of the standard wall-shear MSE. All other losses (surface pressure, volume pressure) remain unchanged.

Log per step:
- `train/ohem_hard_frac` = args.wallshear_ohem_k (constant, for sanity)
- `train/ohem_mean_yz_residual` = mean τ_y/z residual on the *selected* hard points (watch this converge)

### 2. Sweep plan (3 arms, 4-GPU DDP, full budget 50 epochs)

Use `--wandb-group yi-r34-violet-ohem-ws` to group all arms.

**Arm A — k=1.0 (control, equivalent to current MSE):**
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --grad-clip-norm 0.5 \
  --weight-decay 5e-4 --lr-warmup-epochs 1 --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50 \
  --wallshear-ohem-k 1.0 \
  --wandb-group yi-r34-violet-ohem-ws
```

**Arm B — k=0.25 (top 25% hardest by τ_y/z residual):**
Same as Arm A with `--wallshear-ohem-k 0.25`.

**Arm C — k=0.10 (top 10% hardest):**
Same as Arm A with `--wallshear-ohem-k 0.10`.

Start Arm A and B simultaneously. If Arm B shows clear improvement by epoch 2 (val_abupt improving vs control), also launch Arm C.

### 3. Decision rule

- Any arm beats val_abupt < 9.032% AND τ_y or τ_z component improves ≥5% relative → open merge request.
- All arms within 0.2pp of Arm A with no τ_y/τ_z asymmetric improvement → close as null (static hard-mining doesn't help this regime).
- If τ_y/τ_z improve but val_primary regresses (surface pressure or volume worsen) → send back with `--wallshear-ohem-k 0.50` as middle ground.

## Baseline

**Current yi merge bar: val_abupt 9.032%** (PR #517 askeladd, W&B run `brat65z4`)

| Metric | yi bar (PR #517) | AB-UPT target | Gap |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | 9.032 | — | — |
| `wall_shear_y_rel_l2_pct` | ~12.9 (est) | 3.65 | **2.35×** |
| `wall_shear_z_rel_l2_pct` | ~13.0 (est) | 3.63 | **2.73×** |
| `surface_pressure_rel_l2_pct` | ~5.3 (est) | 3.82 | 1.12× |
| `volume_pressure_rel_l2_pct` | ~5.5 (est) | 6.08 | 0.9× (OK) |

W&B: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/brat65z4

**Reproduce baseline:**
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --grad-clip-norm 0.5 \
  --weight-decay 5e-4 --lr-warmup-epochs 1 --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50
```
