### PR TITLE
alphonse: input coordinate jitter regularization (sigma sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,6 +137,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    coord_jitter_sigma: float = 0.0
     debug: bool = False
 
 
@@ -219,6 +220,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "coord_jitter_sigma": (
+            "Per-axis isotropic Gaussian noise added to input xyz coords "
+            "during training only (eval/val/test always use clean coords). "
+            "Acts as a data augmentation / Lipschitz regularizer encouraging "
+            "the model to learn smoother fields w.r.t. spatial position. "
+            "Coords are already in roughly metre-scaled units (surface std "
+            "~[1.4, 0.7, 0.4]); a sigma of 0.005 is roughly one grid cell. "
+            "Noise is masked to valid points so padded tokens stay zero. "
+            "Default 0.0 disables jitter."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +311,29 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def _apply_coord_jitter_inplace(
+    batch,
+    sigma: float,
+    *,
+    training: bool,
+) -> None:
+    """Add per-axis isotropic Gaussian noise to xyz coords (training only).
+
+    Mutates ``batch.surface_x[..., :3]`` and ``batch.volume_x[..., :3]`` in
+    place. Noise is zeroed at padded positions via the masks so the
+    invariant that padded tokens carry zeros is preserved.
+    """
+
+    if sigma <= 0.0 or not training:
+        return
+    s_mask = batch.surface_mask.unsqueeze(-1).to(dtype=batch.surface_x.dtype)
+    s_noise = torch.randn_like(batch.surface_x[..., :3]) * sigma
+    batch.surface_x[..., :3] = batch.surface_x[..., :3] + s_noise * s_mask
+    v_mask = batch.volume_mask.unsqueeze(-1).to(dtype=batch.volume_x.dtype)
+    v_noise = torch.randn_like(batch.volume_x[..., :3]) * sigma
+    batch.volume_x[..., :3] = batch.volume_x[..., :3] + v_noise * v_mask
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,8 +344,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    coord_jitter_sigma: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    _apply_coord_jitter_inplace(batch, coord_jitter_sigma, training=model.training)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -353,6 +389,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    coord_jitter_sigma: float = 0.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -363,6 +401,7 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    _apply_coord_jitter_inplace(batch, coord_jitter_sigma, training=model.training)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -917,7 +956,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model, batch, transform, device, config.amp_mode,
+                        coord_jitter_sigma=config.coord_jitter_sigma,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1008,6 +1048,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        coord_jitter_sigma=config.coord_jitter_sigma,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
## Hypothesis

Increase volume sampling density from `volume_pts=65536` (SOTA) to `volume_pts=96000` as a **clean** single-variable delta from PR #115 SOTA, with the LR-schedule confound from PR #158 explicitly fixed.

The volume_pressure binding is our largest gap vs AB-UPT (×2.1). PR #158 attempted this lever but ran with `--lr-cosine-t-max 0` which (per `trainer_runtime.py:1255`) falls back to `T_max=epochs=9` and collapses LR to ~1e-6 by ep9 — incomparable with SOTA `d03oghpp` whose `t_max=0, epochs=50` translates to `T_max=50` (essentially flat LR over the 9-epoch budget). The vol_pts comparison was therefore not interpretable.

This run fixes that by setting `--lr-cosine-t-max 50` explicitly, matching the SOTA effective LR schedule. With LR held near peak through ep9, any improvement (or regression) is attributable to the volume sampling density change and not the schedule.

If this works, vol_pts is a real headroom lever and we follow up with vol_pts=128k. If it regresses cleanly, density is saturated at 65k and we move on.

## Instructions

From the SOTA stack (PR #115: Lion lr=1e-4 + EMA=0.999), **change exactly one flag**: `--train-volume-points 96000` (and `--eval-volume-points 96000` to match — eval pts must match train pts for clean comparison).

Run exactly:

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --lion-beta1 0.9 --lion-beta2 0.99 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --epochs 9 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 96000 --eval-volume-points 96000 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --use-ema --ema-decay 0.999 \
  --lr-cosine-t-max 50 \
  --wandb-group tay-round11-vol-pts-96k-clean \
  --wandb-name alphonse/round11-vol-pts-96k-clean
```

**Things to watch:**

- VRAM: vol_pts 65k→96k is +47% volume sampling. With slice attention this should be manageable but watch peak VRAM. SOTA d03oghpp peaked ~80–82 GB; expect ~88–92 GB. If OOM occurs, flag immediately — do not silently shrink any other dimension.
- Per-epoch time: expect +10–20% increase. SOTA was ~31.9 min/epoch. Budget: ~37 min/epoch ⇒ ~5.5h total. If wall time exceeds 6.5h, report it; it's still useful data.
- ep0 val should be ≤ 56 (vs SOTA ep0=53.75). ep1 should be ≤ 26 (vs SOTA ep1=24.15). Larger deltas suggest the increased sampling is destabilizing early training.
- Watch `val_primary/volume_pressure_rel_l2_pct` — that's the metric this lever directly targets. SOTA reaches val vol_p around ~13.5 by ep8. If we see < 12.5 by ep6-7 that's an early winning signal.
- LR sanity check: `--lr-cosine-t-max 50` over 9 epochs ⇒ end-of-run LR ≈ 9.6e-5 (4% decay). If the logged LR at ep9 is anywhere near 1e-6 the schedule is misconfigured — flag it.

**Do not add any other flags.** Single-variable test. The whole point of this re-run is to clean up PR #158's LR confound — keep it pristine.

## Baseline (from BASELINE.md — PR #115, merged)

Current best test metrics (lower is better):

| Metric | PR #115 SOTA | AB-UPT ref | Gap |
|---|---:|---:|---:|
| **abupt_mean** | **10.580** | — | — |
| surface_pressure | 5.690 | 3.82 | ×1.5 |
| wall_shear | 10.419 | 7.29 | ×1.4 |
| **volume_pressure** | **12.740** | 6.08 | **×2.1** ← target |
| tau_x | 8.908 | 5.35 | ×1.7 |
| tau_y | 12.491 | 3.65 | ×3.4 |
| tau_z | 13.071 | 3.63 | ×3.6 |

Best val: 9.484 (ep8). Val→test ratio ~1.115.

W&B run: `d03oghpp` (thorfinn compound lr=1e-4 + EMA=0.999, 287 min, 9 epochs).

**SOTA val trajectory:** 53.75 / 24.15 / 16.51 / 13.47 / 11.83 / 10.88 / 10.16 / 9.73 / 9.48

Reproduce SOTA baseline:
```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --agent <name> \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 --epochs 9 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --use-ema --ema-decay 0.999 \
  --lr-cosine-t-max 50
```

## Why this re-run is justified after PR #158 closed

PR #158 result: vol_pts=96k regressed to abupt=13.179 (+24.6% vs SOTA). But the run was confounded by `--lr-cosine-t-max 0` ⇒ effective T_max=9 ⇒ LR collapsed to 1e-6 by ep9 vs SOTA's flat ~1e-4. With LR collapsed early, the model never gets to leverage the extra volume samples in late training. The PR #158 closing comment was explicit that a clean follow-up at matched LR schedule is the next step — this is that follow-up.
