### PR TITLE
nezuko: greedy forward ensemble member selection (Caruana 2004) on candidate pool

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -41,10 +41,12 @@ import wandb
 import yaml
 
 from data import load_data, pad_collate
+from data.loader import SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EvalAccumulator,
     TargetTransform,
+    accumulate_eval_batch,
     autocast_context,
     finalize_eval_accumulator,
     _accumulate_case_rel_l2,
@@ -337,6 +339,295 @@ def evaluate_single_member(
     return evaluate_ensemble_split([model], loader, transform, device, amp_mode)
 
 
+@torch.no_grad()
+def cache_member_predictions_split(
+    model: SurfaceTransolver,
+    loader,
+    device: torch.device,
+    amp_mode: str,
+    *,
+    capture_meta: bool,
+    storage_dtype: torch.dtype = torch.bfloat16,
+) -> tuple[list[dict[str, torch.Tensor | list[str]]], list[tuple[torch.Tensor, torch.Tensor]]]:
+    """Run one forward pass over a split, return per-batch predictions on CPU.
+
+    When ``capture_meta`` is True we additionally cache batch metadata
+    (case_ids, masks, targets) so subsequent candidates can skip storing
+    duplicates.
+
+    Predictions are stored as ``storage_dtype`` (default bf16) on CPU pinned
+    memory for fast greedy ensemble averaging across many candidates without
+    re-running the model.
+    """
+
+    model.eval()
+    batch_meta: list[dict[str, torch.Tensor | list[str]]] = []
+    pred_list: list[tuple[torch.Tensor, torch.Tensor]] = []
+    for batch in loader:
+        batch = batch.to(device)
+        with autocast_context(device, amp_mode):
+            out = model(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+        surface_pred = out["surface_preds"].float().detach()
+        volume_pred = out["volume_preds"].float().detach()
+        pred_list.append(
+            (
+                surface_pred.to(dtype=storage_dtype, device="cpu", copy=True),
+                volume_pred.to(dtype=storage_dtype, device="cpu", copy=True),
+            )
+        )
+        if capture_meta:
+            batch_meta.append(
+                {
+                    "case_ids": list(batch.case_ids),
+                    "surface_y": batch.surface_y.detach().cpu(),
+                    "volume_y": batch.volume_y.detach().cpu(),
+                    "surface_mask": batch.surface_mask.detach().cpu(),
+                    "volume_mask": batch.volume_mask.detach().cpu(),
+                }
+            )
+    return batch_meta, pred_list
+
+
+def pred_cache_path(cache_root: Path, run_id: str, split_label: str) -> Path:
+    return cache_root / "predictions" / run_id / f"{split_label}.pt"
+
+
+def meta_cache_path(cache_root: Path, split_label: str) -> Path:
+    return cache_root / "predictions" / "_meta" / f"{split_label}.pt"
+
+
+def _atomic_torch_save(obj, path: Path) -> None:
+    """Save with a pid-stamped tmp filename so concurrent writers don't collide."""
+
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    torch.save(obj, tmp)
+    try:
+        tmp.replace(path)
+    except FileNotFoundError:
+        # Another worker may have completed the rename concurrently.
+        pass
+
+
+def save_pred_cache_to_disk(
+    pred_list: list[tuple[torch.Tensor, torch.Tensor]],
+    path: Path,
+) -> None:
+    _atomic_torch_save(pred_list, path)
+
+
+def save_meta_cache_to_disk(
+    batch_meta: list[dict[str, torch.Tensor | list[str]]],
+    path: Path,
+) -> None:
+    _atomic_torch_save(batch_meta, path)
+
+
+def load_pred_cache_from_disk(path: Path) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def load_meta_cache_from_disk(path: Path) -> list[dict[str, torch.Tensor | list[str]]]:
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def reconstruct_batch_from_meta(
+    meta: dict[str, torch.Tensor | list[str]],
+    device: torch.device,
+) -> SurfaceBatch:
+    """Build a minimal ``SurfaceBatch`` from cached metadata.
+
+    The ``surface_x`` / ``volume_x`` slots are filled with empty placeholders
+    because the accumulator only consumes targets, masks, and case_ids — but
+    SurfaceBatch.to() still needs valid tensors.
+    """
+
+    surface_y = meta["surface_y"]
+    volume_y = meta["volume_y"]
+    return SurfaceBatch(
+        case_ids=list(meta["case_ids"]),
+        surface_x=torch.empty(
+            (surface_y.shape[0], surface_y.shape[1], 0),
+            dtype=torch.float32,
+        ),
+        surface_y=surface_y,
+        surface_mask=meta["surface_mask"],
+        volume_x=torch.empty(
+            (volume_y.shape[0], volume_y.shape[1], 0),
+            dtype=torch.float32,
+        ),
+        volume_y=volume_y,
+        volume_mask=meta["volume_mask"],
+        metadata=[],
+    ).to(device)
+
+
+def metrics_for_member_set_from_cache(
+    member_run_ids: list[str],
+    batch_meta: list[dict[str, torch.Tensor | list[str]]],
+    pred_cache_split: dict[str, list[tuple[torch.Tensor, torch.Tensor]]],
+    transform: TargetTransform,
+    device: torch.device,
+) -> dict[str, float]:
+    """Compute split metrics for an ensemble subset using cached predictions.
+
+    Predictions are averaged across ``member_run_ids`` (duplicates allowed —
+    used by Caruana's with-replacement variant). No model forward passes are
+    triggered.
+    """
+
+    if not member_run_ids:
+        raise ValueError("member_run_ids must be non-empty")
+    accumulator = EvalAccumulator()
+    n = float(len(member_run_ids))
+    for batch_idx, meta in enumerate(batch_meta):
+        sum_surf: torch.Tensor | None = None
+        sum_vol: torch.Tensor | None = None
+        for run_id in member_run_ids:
+            sp, vp = pred_cache_split[run_id][batch_idx]
+            sp = sp.to(device=device, dtype=torch.float32, non_blocking=True)
+            vp = vp.to(device=device, dtype=torch.float32, non_blocking=True)
+            sum_surf = sp if sum_surf is None else sum_surf + sp
+            sum_vol = vp if sum_vol is None else sum_vol + vp
+        avg_surf = sum_surf / n
+        avg_vol = sum_vol / n
+        batch = reconstruct_batch_from_meta(meta, device)
+        accumulate_ensemble_batch(
+            accumulator,
+            batch=batch,
+            surface_pred_norm=avg_surf,
+            volume_pred_norm=avg_vol,
+            transform=transform,
+            device=device,
+        )
+    return finalize_eval_accumulator(accumulator)
+
+
+def greedy_forward_select(
+    candidate_run_ids: list[str],
+    batch_meta_val: list[dict[str, torch.Tensor | list[str]]],
+    pred_cache_val: dict[str, list[tuple[torch.Tensor, torch.Tensor]]],
+    transform: TargetTransform,
+    device: torch.device,
+    *,
+    max_k: int,
+    min_improvement: float,
+    allow_replacement: bool,
+    selection_metric_key: str = "abupt_axis_mean_rel_l2_pct",
+) -> tuple[list[str], list[dict[str, float | str]], dict[str, dict[str, float]]]:
+    """Greedy forward ensemble selection on the val split (Caruana 2004).
+
+    Returns ``(selected_run_ids, trajectory, per_candidate_metrics)``:
+
+    * ``selected_run_ids`` — the chosen ensemble in selection order.
+    * ``trajectory`` — one row per step with selected_run_id, ensemble_size,
+      val metric and delta vs the previous step.
+    * ``per_candidate_metrics`` — full single-member val metrics for every
+      candidate (handy for diagnostics and the W&B summary).
+
+    The selection metric is minimised. Early stopping triggers when the best
+    next candidate improves the metric by less than ``min_improvement``.
+    """
+
+    if max_k < 1:
+        raise ValueError("max_k must be >= 1")
+
+    print("\n=== Greedy step 0: per-candidate val metrics ===")
+    per_candidate_metrics: dict[str, dict[str, float]] = {}
+    for run_id in candidate_run_ids:
+        m = metrics_for_member_set_from_cache(
+            [run_id],
+            batch_meta_val,
+            pred_cache_val,
+            transform=transform,
+            device=device,
+        )
+        per_candidate_metrics[run_id] = m
+        print(
+            f"  {run_id}: val_{selection_metric_key}={m[selection_metric_key]:.4f}  "
+            f"surface_p={m['surface_pressure_rel_l2_pct']:.4f}  "
+            f"wall_shear={m['wall_shear_rel_l2_pct']:.4f}  "
+            f"vp={m['volume_pressure_rel_l2_pct']:.4f}"
+        )
+
+    seed_run_id = min(
+        candidate_run_ids,
+        key=lambda r: per_candidate_metrics[r][selection_metric_key],
+    )
+    seed_metric = per_candidate_metrics[seed_run_id][selection_metric_key]
+    selected: list[str] = [seed_run_id]
+    trajectory: list[dict[str, float | str]] = [
+        {
+            "step": 1,
+            "selected_run_id": seed_run_id,
+            "ensemble_size": 1,
+            "val_metric": float(seed_metric),
+            "delta_val_metric": float("nan"),
+        }
+    ]
+    print(
+        f"\nGreedy step 1: seed = {seed_run_id} "
+        f"(val_{selection_metric_key}={seed_metric:.4f})"
+    )
+
+    while len(selected) < max_k:
+        if allow_replacement:
+            candidates_to_try = list(candidate_run_ids)
+        else:
+            candidates_to_try = [c for c in candidate_run_ids if c not in selected]
+        if not candidates_to_try:
+            print("Greedy: candidate pool exhausted (no-replacement mode); stopping.")
+            break
+        prev_metric = trajectory[-1]["val_metric"]
+        best_c = None
+        best_metric = float("inf")
+        best_full_metrics: dict[str, float] | None = None
+        for c in candidates_to_try:
+            trial_set = selected + [c]
+            m = metrics_for_member_set_from_cache(
+                trial_set,
+                batch_meta_val,
+                pred_cache_val,
+                transform=transform,
+                device=device,
+            )
+            metric = m[selection_metric_key]
+            if metric < best_metric:
+                best_metric = metric
+                best_c = c
+                best_full_metrics = m
+        delta = float(prev_metric) - float(best_metric)
+        next_step = len(selected) + 1
+        print(
+            f"Greedy step {next_step}: best candidate = {best_c} "
+            f"(val_{selection_metric_key}={best_metric:.4f}, delta={delta:+.4f}pp)"
+        )
+        if delta < min_improvement:
+            print(
+                f"  -> delta {delta:+.4f}pp < min_improvement {min_improvement:.4f}pp; stopping."
+            )
+            break
+        selected.append(best_c)
+        trajectory.append(
+            {
+                "step": next_step,
+                "selected_run_id": best_c,
+                "ensemble_size": len(selected),
+                "val_metric": float(best_metric),
+                "delta_val_metric": float(delta),
+            }
+        )
+
+    return selected, trajectory, per_candidate_metrics
+
+
 def primary_log_payload(prefix: str, metrics: dict[str, float]) -> dict[str, float]:
     keys = (
         "abupt_axis_mean_rel_l2_pct",
@@ -361,8 +652,13 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--run-ids",
         nargs="+",
-        required=True,
-        help="W&B run IDs to ensemble. Each run must have a 'best' model artifact.",
+        required=False,
+        default=None,
+        help=(
+            "W&B run IDs to ensemble (fixed-set mode). Each run must have a "
+            "'best' model artifact. Either --run-ids or (--greedy with "
+            "--candidate-run-ids) is required."
+        ),
     )
     parser.add_argument(
         "--split",
@@ -402,11 +698,449 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         default=0,
         help="Optional cap on the number of batches per split (debug).",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--greedy",
+        action="store_true",
+        help="Enable greedy forward ensemble selection (Caruana 2004) on the val split.",
+    )
+    parser.add_argument(
+        "--candidate-run-ids",
+        type=str,
+        default="",
+        help=(
+            "Comma-separated W&B run IDs forming the candidate pool for "
+            "--greedy. Each run must have a 'best' model artifact."
+        ),
+    )
+    parser.add_argument(
+        "--max-k",
+        type=int,
+        default=8,
+        help="Greedy: maximum ensemble size (default 8).",
+    )
+    parser.add_argument(
+        "--min-improvement",
+        type=float,
+        default=0.005,
+        help=(
+            "Greedy: early-stop threshold (val_abupt percentage points). "
+            "Stop if best next candidate improves the metric by less than "
+            "this value (default 0.005pp)."
+        ),
+    )
+    parser.add_argument(
+        "--allow-replacement",
+        action="store_true",
+        help=(
+            "Greedy: allow the same member to be picked multiple times "
+            "(Caruana's original formulation; off by default)."
+        ),
+    )
+    parser.add_argument(
+        "--selection-metric",
+        default="abupt_axis_mean_rel_l2_pct",
+        help="Greedy: validation metric to minimise (default abupt_axis_mean_rel_l2_pct).",
+    )
+    parser.add_argument(
+        "--pred-cache-dir",
+        type=str,
+        default="",
+        help=(
+            "Directory for caching per-candidate predictions to disk so multiple "
+            "GPU workers can share inference cost. When set, predictions are "
+            "loaded from disk if present (skipping inference) and saved after "
+            "running inference. Must outlive a single process."
+        ),
+    )
+    parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help=(
+            "Greedy: run inference and save predictions to --pred-cache-dir, "
+            "then exit. Used for distributing inference across GPUs."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.greedy:
+        if not args.candidate_run_ids.strip():
+            parser.error("--greedy requires --candidate-run-ids")
+    else:
+        if not args.run_ids:
+            parser.error("--run-ids is required when --greedy is not set")
+    return args
+
+
+def fetch_run_meta(api: wandb.Api, entity: str, project: str, run_id: str) -> dict:
+    run_obj = api.run(f"{entity}/{project}/{run_id}")
+    return {
+        "run_id": run_id,
+        "agent": run_obj.config.get("agent"),
+        "group": run_obj.group,
+        "wandb_name": run_obj.config.get("wandb_name"),
+        "best_epoch": run_obj.summary_metrics.get("best_epoch"),
+        "val_abupt": run_obj.summary_metrics.get(
+            "val_primary/abupt_axis_mean_rel_l2_pct"
+        ),
+        "full_val_abupt": run_obj.summary_metrics.get(
+            "full_val_primary/abupt_axis_mean_rel_l2_pct"
+        ),
+        "test_abupt": run_obj.summary_metrics.get(
+            "test_primary/abupt_axis_mean_rel_l2_pct"
+        ),
+    }
+
+
+def main_greedy(args: argparse.Namespace) -> None:
+    """Greedy forward ensemble selection (Caruana 2004) over a candidate pool.
+
+    Inference cost is one forward pass per candidate per requested split.
+    Selection itself is O(K * |pool|) tensor averages on cached predictions.
+    """
+
+    entity = os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    project = os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+
+    candidate_run_ids = [
+        rid.strip() for rid in args.candidate_run_ids.split(",") if rid.strip()
+    ]
+    if not candidate_run_ids:
+        raise ValueError("--candidate-run-ids parsed to an empty list")
+    print(f"Greedy candidate pool size: {len(candidate_run_ids)}")
+    splits_requested = list(args.split)
+    if "val" not in splits_requested:
+        raise ValueError("--greedy requires 'val' in --split (selection runs on val)")
+
+    cache_root = Path(args.cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    api = wandb.Api()
+
+    # Resolve candidates: download artifacts; drop ones missing a 'best' artifact.
+    resolved: list[tuple[str, Path, dict]] = []
+    skipped: list[tuple[str, str]] = []
+    for run_id in candidate_run_ids:
+        try:
+            print(f"Fetching artifact for candidate {run_id}...")
+            member_dir = download_checkpoint(api, entity, project, run_id, cache_root)
+            run_meta = fetch_run_meta(api, entity, project, run_id)
+            resolved.append((run_id, member_dir, run_meta))
+        except Exception as exc:  # noqa: BLE001 — best-effort skip
+            print(f"  WARNING: skipping {run_id} ({exc})")
+            skipped.append((run_id, str(exc)))
+    if not resolved:
+        raise RuntimeError("No candidates resolved successfully")
+    if skipped:
+        print(f"Skipped {len(skipped)} candidate(s) due to missing artifacts.")
+
+    print("\nLoading data...")
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=args.manifest,
+        root=args.data_root or None,
+        train_surface_points=args.eval_surface_points,
+        eval_surface_points=args.eval_surface_points,
+        train_volume_points=args.eval_volume_points,
+        eval_volume_points=args.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    splits_to_run: dict[str, dict[str, torch.utils.data.Dataset]] = {}
+    if "val" in splits_requested:
+        splits_to_run["val"] = val_splits
+    if "test" in splits_requested:
+        splits_to_run["test"] = test_splits
+
+    # Phase 1: inference per candidate. Predictions on CPU bf16; metadata once
+    # per split (assumes deterministic eval_chunk loader yields the same order).
+    batch_meta_per_split: dict[str, list[dict]] = {label: [] for label in splits_to_run}
+    pred_cache: dict[str, dict[str, list[tuple[torch.Tensor, torch.Tensor]]]] = {
+        label: {} for label in splits_to_run
+    }
+
+    candidate_run_ids_resolved = [r for r, _, _ in resolved]
+    member_meta_by_id: dict[str, dict] = {meta["run_id"]: meta for _, _, meta in resolved}
+
+    pred_cache_dir = Path(args.pred_cache_dir) if args.pred_cache_dir else None
+    if pred_cache_dir is not None:
+        pred_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Try to load batch metadata from disk first (any worker that ran inference
+    # may have written it). Otherwise capture in this process from the first
+    # candidate that runs inference.
+    if pred_cache_dir is not None:
+        for split_label in splits_to_run:
+            mp = meta_cache_path(pred_cache_dir, split_label)
+            if mp.exists():
+                batch_meta_per_split[split_label] = load_meta_cache_from_disk(mp)
+                print(f"Loaded batch metadata for {split_label} from disk ({len(batch_meta_per_split[split_label])} batches)")
+
+    print("\n=== Phase 1: caching per-candidate predictions ===")
+    inference_done_for: set[str] = set()
+    load_failures: list[tuple[str, str]] = []
+    for cand_idx, (run_id, dirpath, _) in enumerate(resolved):
+        # Try to load all per-split predictions from disk first.
+        loaded_all_splits = pred_cache_dir is not None
+        if pred_cache_dir is not None:
+            for split_label in splits_to_run:
+                pp = pred_cache_path(pred_cache_dir, run_id, split_label)
+                if pp.exists():
+                    pred_cache[split_label][run_id] = load_pred_cache_from_disk(pp)
+                else:
+                    loaded_all_splits = False
+            if loaded_all_splits:
+                print(
+                    f"  [{cand_idx + 1}/{len(resolved)}] {run_id}: "
+                    f"loaded all splits from disk cache"
+                )
+                continue
+
+        # Fall back to inference for the splits that aren't cached yet. We
+        # tolerate model-architecture mismatches (e.g. multi-band variants that
+        # cannot be reconstructed from the current build_model_from_config) by
+        # skipping the candidate rather than aborting the whole run.
+        try:
+            model, _ = load_member(run_id, dirpath, device)
+        except Exception as exc:  # noqa: BLE001 — best-effort skip
+            print(f"  WARNING: skipping {run_id} during load_member ({exc})")
+            load_failures.append((run_id, str(exc)))
+            for split_label in list(splits_to_run.keys()):
+                pred_cache[split_label].pop(run_id, None)
+            continue
+        for split_label, datasets in splits_to_run.items():
+            if run_id in pred_cache[split_label]:
+                continue  # already loaded from disk above
+            for _, dataset in datasets.items():
+                loader = make_eval_loader(dataset, args.batch_size, args.num_workers)
+                t0 = time.time()
+                capture_meta = not bool(batch_meta_per_split[split_label])
+                meta_list, pred_list = cache_member_predictions_split(
+                    model=model,
+                    loader=loader,
+                    device=device,
+                    amp_mode=args.amp_mode,
+                    capture_meta=capture_meta,
+                )
+                if capture_meta:
+                    batch_meta_per_split[split_label] = meta_list
+                    if pred_cache_dir is not None:
+                        save_meta_cache_to_disk(
+                            meta_list, meta_cache_path(pred_cache_dir, split_label)
+                        )
+                pred_cache[split_label][run_id] = pred_list
+                if pred_cache_dir is not None:
+                    save_pred_cache_to_disk(
+                        pred_list, pred_cache_path(pred_cache_dir, run_id, split_label)
+                    )
+                print(
+                    f"  [{cand_idx + 1}/{len(resolved)}] {run_id} {split_label}: "
+                    f"{len(pred_list)} batches cached ({time.time() - t0:.1f}s)"
+                )
+        inference_done_for.add(run_id)
+        del model
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    if load_failures:
+        # Drop failed candidates from the working pool so greedy doesn't try
+        # to reference them. Retain the metadata for diagnostics.
+        failed_ids = {rid for rid, _ in load_failures}
+        candidate_run_ids_resolved = [
+            r for r in candidate_run_ids_resolved if r not in failed_ids
+        ]
+        skipped.extend(load_failures)
+        print(
+            f"Dropped {len(failed_ids)} candidate(s) due to model-load failures: "
+            f"{sorted(failed_ids)}"
+        )
+
+    if args.cache_only:
+        print(
+            f"\n--cache-only: ran inference for {len(inference_done_for)} candidate(s); "
+            "exiting before greedy selection."
+        )
+        return
+
+    for split_label in splits_to_run:
+        if not batch_meta_per_split[split_label]:
+            raise RuntimeError(
+                f"No batch metadata for split '{split_label}'. "
+                "Run inference once with --pred-cache-dir to populate it, "
+                "or include at least one candidate not in the disk cache."
+            )
+
+    # Phase 2: greedy selection on val.
+    print("\n=== Phase 2: greedy forward selection on val ===")
+    selected, trajectory, per_candidate_metrics = greedy_forward_select(
+        candidate_run_ids=candidate_run_ids_resolved,
+        batch_meta_val=batch_meta_per_split["val"],
+        pred_cache_val=pred_cache["val"],
+        transform=transform,
+        device=device,
+        max_k=args.max_k,
+        min_improvement=args.min_improvement,
+        allow_replacement=args.allow_replacement,
+        selection_metric_key=args.selection_metric,
+    )
+
+    print("\nSelected ensemble:")
+    for step in trajectory:
+        delta = step["delta_val_metric"]
+        delta_str = "—" if (isinstance(delta, float) and math.isnan(delta)) else f"{delta:+.4f}pp"
+        print(
+            f"  step={step['step']:>2} K={step['ensemble_size']:>2}  "
+            f"+{step['selected_run_id']}  "
+            f"val_{args.selection_metric}={step['val_metric']:.4f}  "
+            f"delta={delta_str}"
+        )
+
+    # Phase 3: final ensemble metrics on val and test.
+    final_metrics: dict[str, dict[str, float]] = {}
+    for split_label in splits_to_run:
+        final_metrics[split_label] = metrics_for_member_set_from_cache(
+            selected,
+            batch_meta_per_split[split_label],
+            pred_cache[split_label],
+            transform=transform,
+            device=device,
+        )
+    print("\n=== Final ensemble metrics ===")
+    for split_label, m in final_metrics.items():
+        print(
+            f"  [{split_label}] abupt={m['abupt_axis_mean_rel_l2_pct']:.4f}  "
+            f"surface_p={m['surface_pressure_rel_l2_pct']:.4f}  "
+            f"wall_shear={m['wall_shear_rel_l2_pct']:.4f}  "
+            f"vp={m['volume_pressure_rel_l2_pct']:.4f}  "
+            f"tau_x={m['wall_shear_x_rel_l2_pct']:.4f}  "
+            f"tau_y={m['wall_shear_y_rel_l2_pct']:.4f}  "
+            f"tau_z={m['wall_shear_z_rel_l2_pct']:.4f}"
+        )
+
+    # Phase 4: W&B logging.
+    run = None
+    if not args.no_wandb:
+        wandb_config = {
+            "mode": "greedy_forward_selection",
+            "candidate_pool_size": len(candidate_run_ids_resolved),
+            "candidate_run_ids": candidate_run_ids_resolved,
+            "skipped_candidate_run_ids": skipped,
+            "max_k": args.max_k,
+            "min_improvement": args.min_improvement,
+            "allow_replacement": args.allow_replacement,
+            "selection_metric": args.selection_metric,
+            "eval_surface_points": args.eval_surface_points,
+            "eval_volume_points": args.eval_volume_points,
+            "batch_size": args.batch_size,
+            "amp_mode": args.amp_mode,
+            "splits_evaluated": splits_requested,
+            "members": [member_meta_by_id[r] for r in candidate_run_ids_resolved],
+        }
+        run = wandb.init(
+            entity=entity,
+            project=project,
+            group=args.wandb_group,
+            name=args.wandb_name,
+            tags=list(args.wandb_tags) + ["greedy"],
+            config=wandb_config,
+            mode=os.environ.get("WANDB_MODE", "online"),
+        )
+        wandb.define_metric("greedy_step")
+        wandb.define_metric("greedy/*", step_metric="greedy_step")
+        wandb.define_metric("ensemble_full_val/*")
+        wandb.define_metric("ensemble_test/*")
+        wandb.define_metric("full_val_primary/*")
+        wandb.define_metric("test_primary/*")
+        wandb.define_metric("candidate_val/*")
+        wandb.define_metric("member_val/*")
+        wandb.define_metric("member_test/*")
+
+    # Per-step trajectory rows
+    if run is not None:
+        for step in trajectory:
+            delta = step["delta_val_metric"]
+            wandb.log(
+                {
+                    "greedy_step": int(step["step"]),
+                    "greedy/ensemble_size": int(step["ensemble_size"]),
+                    "greedy/selected_run_id": str(step["selected_run_id"]),
+                    f"greedy/val_{args.selection_metric}": float(step["val_metric"]),
+                    f"greedy/delta_val_{args.selection_metric}": (
+                        0.0 if isinstance(delta, float) and math.isnan(delta) else float(delta)
+                    ),
+                }
+            )
+
+    summary: dict[str, float | str | int] = {
+        "ensemble_size_k": int(len(selected)),
+        "selected_run_ids": ",".join(selected),
+        "candidate_pool_size": int(len(candidate_run_ids_resolved)),
+        "max_k": int(args.max_k),
+        "allow_replacement": bool(args.allow_replacement),
+    }
+    log_payload: dict[str, float] = {}
+
+    for split_label, m in final_metrics.items():
+        ensemble_prefix = f"ensemble_{split_label}"
+        mirror_prefix = "full_val_primary" if split_label == "val" else "test_primary"
+        payload = primary_log_payload(ensemble_prefix, m)
+        payload.update(primary_log_payload(mirror_prefix, m))
+        for k, v in m.items():
+            payload[f"{ensemble_prefix}/{k}"] = float(v)
+        log_payload.update(payload)
+        summary.update(payload)
+        summary[f"{ensemble_prefix}/abupt_axis_mean_rel_l2_pct"] = float(
+            m["abupt_axis_mean_rel_l2_pct"]
+        )
+
+    # Per-candidate single-member val metrics (for diagnostics).
+    for run_id, m in per_candidate_metrics.items():
+        for k, v in m.items():
+            log_payload[f"candidate_val/{run_id}/{k}"] = float(v)
+        summary[f"candidate_val/{run_id}/abupt_axis_mean_rel_l2_pct"] = float(
+            m["abupt_axis_mean_rel_l2_pct"]
+        )
+
+    if args.include_per_member:
+        # Per-member metrics across both splits using the cache (zero extra inference).
+        for run_id in candidate_run_ids_resolved:
+            for split_label in splits_to_run:
+                member_metrics = metrics_for_member_set_from_cache(
+                    [run_id],
+                    batch_meta_per_split[split_label],
+                    pred_cache[split_label],
+                    transform=transform,
+                    device=device,
+                )
+                for k, v in member_metrics.items():
+                    log_payload[f"member_{split_label}/{run_id}/{k}"] = float(v)
+                summary[f"member_{split_label}/{run_id}/abupt_axis_mean_rel_l2_pct"] = float(
+                    member_metrics["abupt_axis_mean_rel_l2_pct"]
+                )
+
+    if torch.cuda.is_available():
+        peak_gb = torch.cuda.max_memory_allocated(device) / 1e9
+        log_payload["peak_memory_gb"] = peak_gb
+        summary["peak_memory_gb"] = peak_gb
+        print(f"\nPeak GPU memory: {peak_gb:.2f} GB")
+
+    if run is not None:
+        wandb.log(log_payload)
+        wandb.summary.update(summary)
+        wandb.finish()
 
 
 def main(argv: Iterable[str] | None = None) -> None:
     args = parse_args(argv)
+    if args.greedy:
+        main_greedy(args)
+        return
+
     entity = os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
     project = os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,10 @@
 # SENPAI Research State — `tay` (DrivAerML / DDP8)
 
-- **Date:** 2026-05-01 (PR #556 nezuko ensemble merged — new ensemble SOTA; nezuko now idle, re-assignment pending)
+- **Date:** 2026-05-04 (Round 12 — all 8 students active, 0 review-ready, 0 idle)
 - **Branch:** `tay`
 - **Target repo:** `morganmcg1/DrivAerML`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
-- **Fleet:** 1 idle student (nezuko), 7 WIP PRs, 0 review-ready
+- **Fleet:** 0 idle students, 8 WIP PRs, 0 review-ready
 - **Tay-deployed students:** alphonse, askeladd, edward, fern, frieren, nezuko, tanjiro, thorfinn (8 total)
 
 ## ENSEMBLE SOTA — PR #556 nezuko K=5 inference-time ensemble — val_abupt **6.2681%** / test_abupt **7.5813%**
@@ -63,16 +63,16 @@ No new directives as of 2026-05-01 (issues #285, #252, #48 all have current advi
 
 | PR | Student | Lever | Status |
 |---|---|---|---|
-| #516 | askeladd | per-channel tau_y/tau_z reweight v2 (1.2x/1.3x) — micro rebased | running EP1 (rs06rnob) |
-| #538 | fern | SGDR cosine warm restarts T0=6 Tmult=2 (group `fern-sgdr-budget-aware`) | running EP1 (9motyy0i) |
-| #561 | edward | rff-num-features 32 clean retry — group `edward-rff32-v2` | just assigned (PR #549 closed: merge conflict, run data preserved) |
-| #552 | thorfinn | GradNorm-EMA min_weight floor sweep | running (jdidw8i4); sibling crash recovered |
-| #553 | alphonse | input coord jitter regularization | running EP1 (ivh3ytmx) |
-| #555 | frieren | GradNorm alpha sweep / tau-channel reweighting v2 | running EP1 (glir84cj) |
-| ~~#556~~ | nezuko | K=5 inference-time ensemble — **MERGED (ENSEMBLE SOTA 6.2681% val)** | idle — re-assignment pending |
-| #557 | tanjiro | NEW: multi-band fused encoding (24-feat) + hidden_dim 576 (PR #534 follow-up) | just assigned |
+| #516 | askeladd | per-channel tau_y/tau_z reweight v2 (1.2x/1.3x) — rebased onto #556 | EP3=7.5660% (`akjwpzd8`); on track → EP6 best-val expected ~6.87% |
+| #538 | fern | SGDR cosine warm restarts T_max=2 Tmult=1 (v3) | EP3=7.4551% (`9motyy0i`); warm restart fired correctly; EP4 in-flight |
+| #552 | thorfinn | GradNorm-EMA min_weight floor sweep (0.5 / 0.3) | acknowledged; arms queued; awaiting EP1 |
+| #553 | alphonse | input coord jitter regularization (sigma sweep 0.0→0.02) | sigma=0.0 sanity EP2=8.727% tracking SOTA; sweep arms queued |
+| #555 | frieren | GradNorm alpha sweep (alpha=0.25 / 0.75) | Arm B (0.75) EP2=9.0395% (`glir84cj`); Arm A queued |
+| #557 | tanjiro | multi-band fused encoding (24-feat) + hidden_dim 576 | assigned; awaiting acknowledgment |
+| #561 | edward | rff-num-features 32 clean retry on SOTA GradNorm stack | assigned; awaiting first comment |
+| #562 | nezuko | greedy forward ensemble selection (Caruana 2004) from val≤7.5% pool | assigned; awaiting first comment |
 
-Round-12 focus: defend SOTA, attack tau_y/tau_z gap from new orthogonal angles (regularization, weight averaging, dynamic rebalancing, multi-band capacity).
+Round-12 focus: attack tau_y/tau_z gap from multiple orthogonal angles simultaneously (regularization, dynamic rebalancing, multi-band capacity, schedule diversity, ensemble selection) while defending single-model SOTA 6.9246%.
 
 ---
 
@@ -106,12 +106,12 @@ Round-12 focus: defend SOTA, attack tau_y/tau_z gap from new orthogonal angles (
 - **Active attacks (this round):**
   - GradNorm-EMA tighter floor (#552 thorfinn) — proven mechanism, more aggressive redistribution
   - Coord jitter regularization (#553 alphonse) — Tikhonov regularizer, attack overfitting on hard channels
-  - Checkpoint averaging / model soup (#554 nezuko) — variance reduction, target slow-converging channels
-  - Per-channel reweight v2 (#516 askeladd) — micro-bump 1.2x/1.3x
-  - Multi-band fused StringSep (#534 tanjiro) — spectral diversity per-band
-  - rff-num-features 32 (#549 edward) — double feature budget
-  - lr-min cosine floor (#550 frieren) — prevent decay-to-zero
-  - SGDR warm restarts (#538 fern) — multi-cycle convergence
+  - Greedy ensemble selection (#562 nezuko) — Caruana 2004 applied to full val≤7.5% candidate pool
+  - Per-channel reweight v2 (#516 askeladd) — micro-bump 1.2x/1.3x; EP3=7.57% already tracking SOTA+beat
+  - Multi-band fused StringSep + hidden_dim 576 (#557 tanjiro) — capacity + spectral diversity
+  - rff-num-features 32 (#561 edward) — double feature budget on SOTA stack
+  - GradNorm alpha sweep (#555 frieren) — alpha=0.25 (faster equalization) vs 0.75 (slower)
+  - SGDR warm restarts (#538 fern) — multi-cycle convergence; EP3=7.4551%, warm restart fired correctly
 
 ### 2. Negative-direction confirmed (do not retry on current stack)
 - **Static channel reweighting** is now 4× negative (#142, #454, #467, #531) — askeladd #516 v2 is final attempt at this angle before the lever is exhausted


### PR DESCRIPTION
# Hypothesis: Greedy forward ensemble member selection beats fixed top-K by val ranking

## Background

PR #556 merged the K=5 inference-time ensemble as the new **Ensemble SOTA**:
- val_abupt = **6.2681%** (−8.76% vs single-model SOTA 6.9246%)
- test_abupt = **7.5813%** (−6.66% vs single-model SOTA 8.2355%)
- Members chosen by simple top-5 by val_abupt: `9mm3sz7x` (askeladd), `49aimdiz` (alphonse), `wyz68o8r` (thorfinn/SOTA), `qqtdnlwq` (alphonse), `5o7jc7wi` (edward)
- W&B group: `ensemble-inference-v1`
- Eval script merged at `ensemble_eval.py`

**The problem with top-K-by-val ranking:** it ignores inter-member error correlation. Two strong members making the same kinds of mistakes provide less ensemble lift than a slightly weaker member whose errors are decorrelated. Greedy forward selection (Caruana et al. 2004 — "Ensemble Selection from Libraries of Models") iteratively picks the candidate that most reduces the ensemble metric, naturally accounting for correlation.

## Hypothesis

Given a **larger candidate pool** (e.g. all `tay`-branch runs with val_abupt ≤ 7.5%), greedy forward selection will produce an ensemble whose val_abupt is lower than the current top-5 K=5 ensemble (6.2681%). We expect:
- Different membership than top-5
- Possibly different optimal K (could be smaller or larger than 5)
- Improved test_abupt as well, if the val improvement is not selection overfitting

## What to build

Add greedy forward selection mode to `ensemble_eval.py`. New CLI flags:

- `--greedy` — enable greedy forward selection mode
- `--candidate-run-ids w1,w2,w3,...` — the larger pool to select from (required when `--greedy` is set)
- `--max-k N` — maximum ensemble size to grow to (default 8)
- `--min-improvement F` — early-stop threshold; stop if best candidate improves val_abupt by less than F percentage points (default 0.005, i.e. 0.005pp)
- `--allow-replacement` — optional: allow the same member to be picked multiple times (Caruana's original formulation; off by default — pick each member at most once)

### Algorithm (selection on val split)

```
1. Load predictions for ALL candidate runs on the val split (cache them — only one forward pass per candidate)
2. Compute per-candidate val_abupt; pick the best one as the seed of the ensemble
3. While |E| < max_k:
     For each candidate c not in E (or all candidates if --allow-replacement):
         Form predictions: mean of (E ∪ {c})
         Compute val_abupt
     Pick the c that minimizes val_abupt
     If improvement < min-improvement: break
     Else: E ← E ∪ {c}, log selection step
4. Re-evaluate the final ensemble E on the TEST split (single pass) — this is the headline metric
5. Report: selection trajectory, final |E|, members in selection order, val_abupt and test_abupt
```

### Implementation notes

- **Cache prediction tensors per candidate** for both val AND test splits up-front (one forward pass per run per split). Selection itself becomes pure tensor averaging — extremely fast.
- Memory: surface predictions ~ N_surf × 4 channels × float32, volume ~ N_vol × 3 × float32 per sample × N_eval_samples. With current N_surf=N_vol=65536 eval points and ~50 val samples, this is ~50 MB/run/split — easily fits for a candidate pool of 20+ runs.
- Log to W&B: each greedy step as a step row (`step`, `selected_run_id`, `ensemble_size`, `val_abupt`, `delta_val_abupt`); final summary as run summary metrics.
- Use group `nezuko-ensemble-greedy-v1` for the W&B run.

### Candidate pool

Use the following candidate run IDs as the initial pool (12 candidates — all known `tay` runs that finished and reported val_abupt ≤ ~7.5%; expand if you find more in the W&B project):

- `wyz68o8r` (thorfinn / single-model SOTA, val 6.9246%)
- `9mm3sz7x` (askeladd)
- `49aimdiz` (alphonse)
- `qqtdnlwq` (alphonse)
- `5o7jc7wi` (edward)
- `19qf6di1` (tanjiro fused 3-band, val 6.956%)

If you want more, query W&B project `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8` for runs on branch `tay` with `summary.val_abupt ≤ 7.5` and finished status. Document the final candidate pool in your results comment.

## Reproduce / run command

```bash
# After implementing --greedy in ensemble_eval.py:
python ensemble_eval.py \
  --greedy \
  --candidate-run-ids "wyz68o8r,9mm3sz7x,49aimdiz,qqtdnlwq,5o7jc7wi,19qf6di1,<add more if found>" \
  --max-k 8 \
  --min-improvement 0.005 \
  --split val \
  --eval-surface-points 65536 \
  --eval-volume-points 65536 \
  --batch-size 1 \
  --wandb-group nezuko-ensemble-greedy-v1 \
  --wandb-name greedy-k8-pool12 \
  --include-per-member
```

Then run the SAME selected ensemble on test:
```bash
python ensemble_eval.py \
  --run-ids "<selected-members-from-greedy-step>" \
  --split test \
  --eval-surface-points 65536 \
  --eval-volume-points 65536 \
  --batch-size 1 \
  --wandb-group nezuko-ensemble-greedy-v1 \
  --wandb-name greedy-final-test
```

(Or fold the test pass into the same `--greedy` invocation — your call.)

## Baseline to beat

| Metric | Current Ensemble SOTA (PR #556 K=5 top-val) | Single-Model SOTA (PR #523) | Target |
|---|---:|---:|---|
| val_abupt | **6.2681%** | 6.9246% | < 6.2681% |
| test_abupt | **7.5813%** | 8.2355% | < 7.5813% |

## Success criteria

- **Win:** greedy ensemble val_abupt < 6.2681% AND test_abupt < 7.5813% → merge as new Ensemble SOTA
- **Interesting:** val improves but test does not (selection overfit) → close as informative null result; record finding
- **No improvement:** greedy converges to the same top-5 set or worse → close, but log the selection trajectory for future reference

## Reporting

In your results PR comment include:
1. Final candidate pool (run IDs, val_abupt each)
2. Greedy selection trajectory: step → selected_run_id → ensemble_val_abupt → delta
3. Final ensemble: members + size K_chosen
4. Headline metrics: val_abupt, test_abupt, per-channel test_surface_pressure, test_wall_shear, test_tau_y, test_tau_z
5. Verdict vs baselines

## Constraints

- One forward pass per candidate per split — no retraining
- Eval-only — do NOT modify `train.py`
- Keep `ensemble_eval.py` backward-compatible: `--greedy` is opt-in; existing `--run-ids` mode must still work identically

## Reference

Caruana, R., Niculescu-Mizil, A., Crew, G., & Ksikes, A. (2004). *Ensemble Selection from Libraries of Models*. ICML.
