### PR TITLE
edward: variance-matching aux loss for τ_y/τ_z std collapse

### DIFF
--- a/train.py
+++ b/train.py
@@ -722,6 +722,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    var_match_lambda: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -825,6 +826,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "separate checks. STEP is a global optimizer step and METRIC must match "
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
+        ),
+        "var_match_lambda": (
+            "Weight for per-case std-matching auxiliary loss on tau_y (channel 2) "
+            "and tau_z (channel 3) of the surface predictions. Penalises the squared "
+            "difference between per-sample-in-batch std of pred and target over valid "
+            "(non-padded) surface points. 0.0 = off (default)."
         ),
     }
     for field in fields(Config):
@@ -1514,6 +1521,65 @@ def project_tangential(vec: torch.Tensor, normals: torch.Tensor) -> torch.Tensor
     return (vec_f - dot * n_hat).to(vec.dtype)
 
 
+def _masked_per_case_std(
+    x: torch.Tensor, mask: torch.Tensor, eps: float = 1e-8
+) -> torch.Tensor:
+    """Per-case std over valid (mask=1) points along the last dim.
+
+    x: [B, N], mask: [B, N] bool (1=valid, 0=padding). Returns: [B] std per case.
+
+    Implements ``sqrt(mean((x - mean)^2) + eps)`` with population denominator (n,
+    not n-1) over valid points, so a single-valid-point case gives std=0+eps
+    instead of dividing by zero. The eps clamp before sqrt avoids the infinite
+    gradient of ``sqrt`` at zero — needed when an early-training prediction is
+    near-constant within a case.
+    """
+    mask_f = mask.to(dtype=x.dtype)
+    n_valid = mask_f.sum(dim=-1).clamp(min=1.0)  # [B]
+    x_masked = x * mask_f
+    x_mean = (x_masked.sum(dim=-1) / n_valid).unsqueeze(-1)  # [B, 1]
+    centered = (x - x_mean) * mask_f  # padded entries -> 0 contribute nothing
+    var = centered.pow(2).sum(dim=-1) / n_valid
+    return (var + eps).sqrt()
+
+
+def var_match_loss(
+    pred_surface: torch.Tensor,
+    target_surface: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    lambda_vm: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Per-case std matching for tau_y (channel 2) and tau_z (channel 3).
+
+    Penalises ``Σ_{c ∈ {y,z}} mean_b (std_pred_c - std_true_c)^2`` where stds are
+    computed per sample over valid surface points. Operates in normalized
+    (z-scored) space — the same space the MSE backbone uses, so loss units
+    are commensurate.
+
+    Returns (lambda_vm * loss, diagnostics). Diagnostics contain mean per-case
+    std_pred / std_true / std_ratio for tauY and tauZ for W&B logging.
+    """
+    diag: dict[str, float] = {}
+    if lambda_vm <= 0.0:
+        return pred_surface.sum() * 0.0, diag
+    if not bool(mask.any()):
+        return pred_surface.sum() * 0.0, diag
+    loss = pred_surface.new_zeros(())
+    for ch, name in [(2, "tauY"), (3, "tauZ")]:
+        pred_ch = pred_surface[..., ch]    # [B, N]
+        tgt_ch = target_surface[..., ch]   # [B, N]
+        std_pred = _masked_per_case_std(pred_ch, mask)
+        std_true = _masked_per_case_std(tgt_ch, mask)
+        loss = loss + (std_pred - std_true).pow(2).mean()
+        std_pred_mean = float(std_pred.mean().detach().cpu().item())
+        std_true_mean = float(std_true.mean().detach().cpu().item())
+        diag[f"std_pred_{name}"] = std_pred_mean
+        diag[f"std_true_{name}"] = std_true_mean
+        diag[f"std_ratio_{name}"] = std_pred_mean / max(std_true_mean, 1e-8)
+    return lambda_vm * loss, diag
+
+
 def train_loss(
     model: nn.Module,
     batch: SurfaceBatch,
@@ -1528,6 +1594,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    var_match_lambda: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1586,6 +1653,17 @@ def train_loss(
             aux_rel_l2 = num / den
             loss = loss + aux_rel_l2_weight * aux_rel_l2
             aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
+        var_match_value: float | None = None
+        var_match_diag: dict[str, float] = {}
+        if var_match_lambda > 0.0:
+            vm_term, var_match_diag = var_match_loss(
+                surface_pred_norm.float(),
+                surface_target.float(),
+                batch.surface_mask,
+                lambda_vm=var_match_lambda,
+            )
+            loss = loss + vm_term
+            var_match_value = float(vm_term.detach().cpu().item())
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -1596,6 +1674,10 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if var_match_value is not None:
+        metrics["loss_var_match"] = var_match_value
+        for key, value in var_match_diag.items():
+            metrics[key] = value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if "geom_token" in out:
@@ -2172,6 +2254,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                var_match_lambda=config.var_match_lambda,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2290,6 +2373,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
                 ]
+            if "loss_var_match" in batch_loss_metrics:
+                train_log["train/loss_var_match"] = batch_loss_metrics[
+                    "loss_var_match"
+                ]
+                for vm_key in (
+                    "std_pred_tauY",
+                    "std_true_tauY",
+                    "std_ratio_tauY",
+                    "std_pred_tauZ",
+                    "std_true_tauZ",
+                    "std_ratio_tauZ",
+                ):
+                    if vm_key in batch_loss_metrics:
+                        train_log[f"train/{vm_key}"] = batch_loss_metrics[vm_key]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():


### PR DESCRIPTION
## Hypothesis

**Adding a per-batch prediction-variance matching auxiliary loss on τ_y and τ_z will narrow the dominant τ_y/τ_z gap (2.35× and 2.73× above AB-UPT target respectively).**

Neural networks trained with MSE have a well-known variance-smoothing bias: the optimal MSE prediction of an ambiguous distribution is the conditional mean, which systematically underpredicts variance. For τ_y and τ_z — which have heavy-tailed, spatially-correlated residuals driven by complex near-body flow features — this manifests as predicted distributions that are too narrow (low std) compared to targets. The result is systematic under-prediction of peak wall-shear events, which aligns perfectly with our observed τ_y/τ_z gaps.

The fix: add a differentiable variance-matching term that penalises the squared difference between the **predicted per-case std** and the **target per-case std** for τ_y and τ_z only:

```
L_var = Σ_{c ∈ {y,z}} λ_var · (std(pred_c) - std(target_c))^2
```

where `std` is computed over **surface points within each sample in the batch** (per-case, not batch-level, to avoid batch-size sensitivity). This is a second-moment regularizer — see Mathieu et al. 2015 (sharpness loss), Roth et al. distribution-matching, and standard moment-matching in domain adaptation literature.

**Why this should help τ_y/τ_z specifically:** the variance collapse is worst on channels where the model sees near-zero mean targets (τ_y and τ_z are small in most of the surface — only large near separation/vortex attachment). MSE drives the model to predict zero everywhere on these channels; the variance penalty forces the model to maintain spread, indirectly driving it to locate the high-shear regions.

**Key diagnostic to require:** log `train/std_pred_tauY`, `train/std_true_tauY`, `train/std_pred_tauZ`, `train/std_true_tauZ` every step — the ratio `std_pred/std_true` should start near 0 (collapsed) and approach 1 as the penalty takes effect.

## Instructions

Add a `--var-match-lambda` flag to `target/train.py`. Implement as follows:

### 1. Add CLI flag

```python
parser.add_argument('--var-match-lambda', type=float, default=0.0,
    help='Weight for per-case std matching loss on tau_y and tau_z (surface channels 2 and 3). 0 = off.')
```

### 2. Add variance matching loss function

After the main MSE loss computation, add (inside the training step):

```python
def var_match_loss(pred_surface, target_surface, lambda_vm):
    """
    Per-case std matching for tau_y (channel 2) and tau_z (channel 3).
    pred_surface, target_surface: [B, N_surf, C] where C=7 (px, py, pz, tau_x, tau_y, tau_z, ...)
    tau_y = channel 2 in the RAW (unstandardized) space is already surface channels index 2,3.
    """
    if lambda_vm <= 0:
        return torch.tensor(0.0, device=pred_surface.device)
    # tau_y = index 2, tau_z = index 3 in surface prediction
    loss = 0.0
    diag = {}
    for ch, name in [(2, 'tauY'), (3, 'tauZ')]:
        pred_ch = pred_surface[:, :, ch]   # [B, N_surf]
        tgt_ch  = target_surface[:, :, ch] # [B, N_surf]
        std_pred = pred_ch.std(dim=-1)     # [B]
        std_true = tgt_ch.std(dim=-1)      # [B]
        vm = ((std_pred - std_true) ** 2).mean()
        loss = loss + vm
        diag[f'train/std_pred_{name}'] = std_pred.mean().item()
        diag[f'train/std_true_{name}'] = std_true.mean().item()
        diag[f'train/std_ratio_{name}'] = (std_pred.mean() / (std_true.mean() + 1e-8)).item()
    return lambda_vm * loss, diag
```

Call this after the main loss and add to total:

```python
if args.var_match_lambda > 0:
    vm_loss, vm_diag = var_match_loss(surface_pred, surface_target, args.var_match_lambda)
    loss = loss + vm_loss
    wandb.log({**vm_diag, 'train/loss_var_match': vm_loss.item()}, step=global_step)
```

### 3. Sweep — run 3 arms sequentially on 4×H100 DDP

**Arm A (control):** `--var-match-lambda 0.0` (pure MSE baseline with learnable-PE)
**Arm B:** `--var-match-lambda 0.1`
**Arm C:** `--var-match-lambda 1.0`

Use `--wandb-group edward-r34-var-match` for all 3 arms.

**Full launch command for Arm A (control):**
```bash
cd target/
nohup torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --learnable-pe \
  --no-compile-model \
  --var-match-lambda 0.0 \
  --wandb-group edward-r34-var-match \
  --wandb-name edward-r34-arm-a-ctrl \
  --epochs 3 \
  > _runs/arm_a_ctrl.log 2>&1 &
echo "PID: $!"
```

Replace `--var-match-lambda 0.0` with `0.1` (Arm B) and `1.0` (Arm C). Run them **sequentially** (start B after A finishes; start C after B finishes). Each arm should finish in ~5.5–6h on 4×H100.

### 4. Diagnostics to log per step

- `train/loss_var_match` — the raw λ-weighted vm term
- `train/std_pred_tauY`, `train/std_true_tauY`, `train/std_ratio_tauY`
- `train/std_pred_tauZ`, `train/std_true_tauZ`, `train/std_ratio_tauZ`

These are critical: if `std_ratio` starts at 0.05 and grows to 0.8+ by epoch 3, the mechanism is working. If it stays near 0 even with λ=1.0, the channel index may be wrong — double-check by logging `target_surface[:, :, 2].std(dim=-1).mean()` at step 0 and confirm it's non-trivial.

### 5. IMPORTANT flag typo check

Use `--clip-grad-norm 0.5` (NOT `--grad-clip-norm`). Verify with:
```bash
python train.py --help | grep -i clip
```

## Results to report

For each arm, report:
1. W&B run id + group
2. Per-epoch `val/abupt_axis_mean_rel_l2_pct` table
3. Per-channel breakdown at best epoch: `surface_pressure`, `tau_y`, `tau_z`, `volume_pressure`
4. `std_ratio_tauY` and `std_ratio_tauZ` at final step (did variance collapse recover?)
5. `test/abupt_axis_mean_rel_l2_pct` from best-val checkpoint

Win criterion: **val_abupt < 9.032%** (current bar, PR #517 askeladd). Stretch: < 8.5%. If std_ratio rises to > 0.5 and val_abupt still doesn't improve, report this explicitly — it tells us that variance collapse is a symptom not a cause.

## Baseline

Current best on yi:
- **val_abupt: 9.032%** (PR #517 askeladd, W&B run `brat65z4`, Lion lr=1e-4 clip=0.5 without STRING-sep)
- STRING-sep learnable PE is now on yi via PR #490; frieren resumed run reached **8.087%** val_abupt with `--learnable-pe` (non-canonical resume, awaiting clean from-scratch confirmation from PR #539)
- Expected next bar: ~8.1–8.5% once PR #539 lands

AB-UPT reference targets:
- τ_y (ws_y): 3.65% — **current yi: ~8.58%, gap 2.35×**
- τ_z (ws_z): 3.63% — **current yi: ~9.93%, gap 2.73×**
- surface_pressure: 3.82%
- volume_pressure: 6.08%
- wall_shear (overall): 7.29%

Reproduce baseline (without var-match):
```bash
cd target/
torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --learnable-pe \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --epochs 3
```
