### PR TITLE
NorMuon optimizer: normalized Muon for 2D weight matrices

### DIFF
--- a/train.py
+++ b/train.py
@@ -275,6 +275,7 @@ class NorMuon(torch.optim.Optimizer):
             eps=eps,
         )
         super().__init__(params, defaults)
+        self._last_post_ns5_step_rms: list[float] = []
 
     @staticmethod
     def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5) -> torch.Tensor:
@@ -298,6 +299,8 @@ class NorMuon(torch.optim.Optimizer):
         if closure is not None:
             with torch.enable_grad():
                 loss = closure()
+
+        post_ns5_step_rms_tensors: list[torch.Tensor] = []
 
         for group in self.param_groups:
             lr = group["lr"]
@@ -361,9 +364,42 @@ class NorMuon(torch.optim.Optimizer):
 
                 # Canonical Muon RMS-1 scaling (sqrt of larger dim).
                 scale = max(p.size(-2), p.size(-1)) ** 0.5
+                update = g.float() * (lr * scale)
+                post_ns5_step_rms_tensors.append(
+                    update.pow(2).mean().sqrt()
+                )
                 p.add_(g, alpha=-lr * scale)
 
+        if post_ns5_step_rms_tensors:
+            self._last_post_ns5_step_rms = (
+                torch.stack(post_ns5_step_rms_tensors).detach().cpu().tolist()
+            )
+        else:
+            self._last_post_ns5_step_rms = []
+
         return loss
+
+
+def _collect_normuon_step_rms(opt) -> list[float]:
+    """Return per-parameter post-NS5 update RMS values from any NorMuon
+    sub-optimizer wrapped inside ``opt`` (or ``opt`` itself if it is NorMuon).
+
+    Used for the advisor's "post-NS5 update RMS" diagnostic — the actual
+    per-element step magnitude after Newton-Schulz orthogonalization and the
+    canonical sqrt(max_dim) scaling, evaluated at peak LR. The orthogonalized
+    update is unit-norm by construction, so this quantity ≈ lr × 1, but the
+    diagnostic catches any drift from that design value.
+    """
+    if isinstance(opt, NorMuon):
+        return list(opt._last_post_ns5_step_rms)
+    sub_opts = getattr(opt, "optimizers", None)
+    if sub_opts is None:
+        return []
+    out: list[float] = []
+    for sub in sub_opts:
+        if isinstance(sub, NorMuon):
+            out.extend(sub._last_post_ns5_step_rms)
+    return out
 
 
 class CompositeOptimizer(torch.optim.Optimizer):
@@ -1308,6 +1344,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        normuon_rms = _collect_normuon_step_rms(optimizer)
+                        if normuon_rms:
+                            train_log["train/normuon/post_ns5_step_rms_max"] = max(normuon_rms)
+                            train_log["train/normuon/post_ns5_step_rms_mean"] = sum(normuon_rms) / len(normuon_rms)
 
                 train_log.update(
                     train_slope_tracker.update(

--- a/train.py
+++ b/train.py
@@ -128,6 +128,10 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    normuon_lr: float = 0.02
+    normuon_momentum: float = 0.95
+    normuon_beta2: float = 0.95
+    normuon_ns_steps: int = 5
     vol_points_schedule: str = ""
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
@@ -233,6 +237,175 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+class NorMuon(torch.optim.Optimizer):
+    """Row-RMS NorMuon (PR #568 redesign, advisor-spec).
+
+    For each 2D weight matrix:
+      1. Maintain per-row second-moment EMA on the gradient:
+           v_t = beta2 * v_{t-1} + (1 - beta2) * mean_cols(g * g)
+         and divide each row of the gradient by sqrt(v_t) + eps.
+      2. Apply standard Muon momentum (with Nesterov) on the row-normalised g.
+      3. Newton-Schulz5 orthogonalize the momentum-augmented update.
+      4. Apply the canonical sqrt(max(rows, cols)) scaling to keep RMS ~1.
+
+    Reference: arxiv 2510.05491; Modded-NanoGPT records #41 / #144.
+    Per-row pre-NS5 RMS replaces the failed whole-tensor pre-norm (PR #568
+    runs `1nf7rm2d`/`ii3vh18d`, which diverged at the EP1->EP2 transition).
+
+    Only intended for params with ndim == 2. Any accidentally-included
+    1D/ND param falls back to plain SGD-momentum.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 0.02,
+        momentum: float = 0.95,
+        nesterov: bool = True,
+        beta2: float = 0.95,
+        ns_steps: int = 5,
+        eps: float = 1e-8,
+    ):
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            nesterov=nesterov,
+            beta2=beta2,
+            ns_steps=ns_steps,
+            eps=eps,
+        )
+        super().__init__(params, defaults)
+
+    @staticmethod
+    def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5) -> torch.Tensor:
+        assert G.ndim >= 2
+        a, b, c = (3.4445, -4.7750, 2.0315)
+        X = G.float()
+        X = X / (X.norm() + 1e-7)
+        transposed = G.size(-2) > G.size(-1)
+        if transposed:
+            X = X.T
+        for _ in range(steps):
+            A = X @ X.T
+            X = a * X + b * A @ X + c * A @ A @ X
+        if transposed:
+            X = X.T
+        return X.to(dtype=G.dtype)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            nesterov = group["nesterov"]
+            beta2 = group["beta2"]
+            ns_steps = group["ns_steps"]
+            eps = group["eps"]
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad
+                if g.ndim < 2:
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(p)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g + momentum * buf
+                    else:
+                        g = buf
+                    p.add_(g, alpha=-lr)
+                    continue
+
+                state = self.state[p]
+
+                # Per-row RMSNorm of the gradient (advisor-spec). row_v
+                # tracks an EMA of per-row second moment. Bias-corrected
+                # so step 1 row_rms is close to sqrt(row_sq) rather than
+                # ~sqrt(1-beta2)*sqrt(row_sq) (which would amplify g
+                # ~1/sqrt(1-beta2)x at startup before LR warmup absorbs it).
+                if "row_v" not in state:
+                    state["row_v"] = torch.zeros(
+                        g.shape[0], device=g.device, dtype=torch.float32
+                    )
+                    state["row_v_step"] = 0
+                row_v = state["row_v"]
+                row_sq = (g.float() * g.float()).mean(
+                    dim=tuple(range(1, g.ndim))
+                )
+                row_v.mul_(beta2).add_(row_sq, alpha=(1.0 - beta2))
+                state["row_v_step"] += 1
+                bias_correction = 1.0 - (beta2 ** state["row_v_step"])
+                row_rms = (
+                    (row_v / bias_correction).sqrt() + eps
+                ).reshape(-1, *([1] * (g.ndim - 1))).to(dtype=g.dtype)
+                g = g / row_rms
+
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    g = g + momentum * buf
+                else:
+                    g = buf
+
+                g = self._zeropower_via_newtonschulz5(g, steps=ns_steps)
+
+                # Canonical Muon RMS-1 scaling (sqrt of larger dim).
+                scale = max(p.size(-2), p.size(-1)) ** 0.5
+                p.add_(g, alpha=-lr * scale)
+
+        return loss
+
+
+class CompositeOptimizer(torch.optim.Optimizer):
+    """Wrap multiple sub-optimizers behind a single torch.optim.Optimizer-like API.
+
+    Inherits from ``torch.optim.Optimizer`` only to satisfy the isinstance
+    check inside ``torch.optim.lr_scheduler``; the real state lives in the
+    wrapped sub-optimizers. ``param_groups`` is shared (a flat concatenation
+    of each sub-optimizer's groups), so LR schedulers update the sub-groups
+    in place.
+    """
+
+    def __init__(self, optimizers):
+        self.optimizers = list(optimizers)
+        self.param_groups = []
+        for opt in self.optimizers:
+            self.param_groups.extend(opt.param_groups)
+        self.defaults = {}
+        self.state = {}
+
+    def zero_grad(self, set_to_none: bool = True):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=set_to_none)
+
+    def step(self, closure=None):
+        for opt in self.optimizers:
+            opt.step(closure)
+
+    def state_dict(self):
+        return {"optimizers": [opt.state_dict() for opt in self.optimizers]}
+
+    def load_state_dict(self, state_dict):
+        for opt, sd in zip(self.optimizers, state_dict["optimizers"]):
+            opt.load_state_dict(sd)
+
+    def add_param_group(self, param_group):
+        raise NotImplementedError(
+            "CompositeOptimizer does not support add_param_group; "
+            "configure sub-optimizers at construction time."
+        )
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
     if optimizer_name == "adamw":
@@ -251,7 +424,38 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
             betas=(config.lion_beta1, config.lion_beta2),
             use_triton=False,
         )
-    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+    if optimizer_name == "normuon":
+        from lion_pytorch import Lion
+
+        # Partition: pure 2D matrices (Linear weights, etc.) -> NorMuon.
+        # Everything else (1D bias/scale, 3D/4D placeholders & temperature) -> Lion.
+        normuon_params = [
+            p for p in model.parameters() if p.requires_grad and p.ndim == 2
+        ]
+        other_params = [
+            p for p in model.parameters() if p.requires_grad and p.ndim != 2
+        ]
+        normuon_opt = NorMuon(
+            [{"params": normuon_params}],
+            lr=config.normuon_lr,
+            momentum=config.normuon_momentum,
+            nesterov=True,
+            beta2=config.normuon_beta2,
+            ns_steps=config.normuon_ns_steps,
+        )
+        if not other_params:
+            return normuon_opt
+        lion_opt = Lion(
+            [{"params": other_params}],
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+        return CompositeOptimizer([normuon_opt, lion_opt])
+    raise ValueError(
+        f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion, normuon."
+    )
 
 
 def parse_rff_init_sigmas(spec: str) -> list[float] | None:


### PR DESCRIPTION
## Hypothesis

The Modded-NanoGPT record (rank #41) demonstrates that **NorMuon** — a normalized variant of the Muon optimizer — can train small transformer-like models faster and to lower loss than AdamW. NorMuon normalizes each parameter's gradient to unit norm before applying Newton-Schulz (NS5) orthogonalization, which makes it significantly more stable than vanilla Muon (which failed in PR #261 with optimizer instability at our small 400-car dataset scale). We hypothesize that applying NorMuon to all 2D weight matrices (attention projections and FFN weights) while keeping Lion for embeddings, coordinate-encoding layers, and 1D parameters will yield faster convergence and a lower val_abupt than Lion alone.

**Prior context:** PR #261 (yi, vanilla Muon) did NOT beat SOTA — the optimizer diverged with instability at our small dataset scale. NorMuon's unit-norm gradient scaling before orthogonalization is specifically designed to address this problem. This is the high-priority remaining experiment from Issue #252.

**Reference:** Modded-NanoGPT, record rank 41 (NorMuon): https://github.com/KellerJordan/modded-nanogpt

## Instructions

All changes go in `target/train.py`.

### 1. Implement the NorMuon optimizer class

Add the following class to `target/train.py` (near the top-level, before `build_optimizer`):

```python
class NorMuon(torch.optim.Optimizer):
    """
    Normalized Muon optimizer.
    Applies unit-norm scaling to each parameter's gradient before
    Newton-Schulz (NS5) orthogonalization. Designed for 2D weight matrices
    (attention projections, FFN weights). Based on Modded-NanoGPT record #41.

    Only use on params with ndim >= 2. For all other params (embeddings,
    1D bias/scale, coord-encoding), use a separate Adam/Lion param group.
    """

    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
        super().__init__(params, defaults)

    @staticmethod
    def _zeropower_via_newtonschulz5(G, steps=5):
        """Return X s.t. X @ X.T ≈ I and X.T @ X ≈ I (approx square root inverse)."""
        assert G.ndim >= 2
        a, b, c = (3.4445, -4.7750, 2.0315)
        X = G / (G.norm() + 1e-7)
        if G.size(-2) > G.size(-1):
            X = X.T
        for _ in range(steps):
            A = X @ X.T
            X = a * X + b * A @ X + c * A @ A @ X
        if G.size(-2) > G.size(-1):
            X = X.T
        return X

    @torch.no_grad()
    def step(self, closure=None):
        loss = None
        if closure is not None:
            with torch.enable_grad():
                loss = closure()

        for group in self.param_groups:
            lr = group["lr"]
            momentum = group["momentum"]
            nesterov = group["nesterov"]
            ns_steps = group["ns_steps"]

            for p in group["params"]:
                if p.grad is None:
                    continue
                g = p.grad
                if g.ndim < 2:
                    # Fallback: plain SGD-momentum for any accidentally-included 1D param
                    state = self.state[p]
                    if "momentum_buffer" not in state:
                        state["momentum_buffer"] = torch.zeros_like(p)
                    buf = state["momentum_buffer"]
                    buf.mul_(momentum).add_(g)
                    if nesterov:
                        g = g + momentum * buf
                    else:
                        g = buf
                    p.add_(g, alpha=-lr)
                    continue

                # Normalize gradient to unit norm before NS5
                g = g / (g.norm() + 1e-7)

                state = self.state[p]
                if "momentum_buffer" not in state:
                    state["momentum_buffer"] = torch.zeros_like(g)
                buf = state["momentum_buffer"]
                buf.mul_(momentum).add_(g)
                if nesterov:
                    g = g + momentum * buf
                else:
                    g = buf

                # Orthogonalize via Newton-Schulz
                g = self._zeropower_via_newtonschulz5(g, steps=ns_steps)

                # Scale update by sqrt(max(rows, cols)) for RMS ~1
                scale = max(p.size(-2), p.size(-1)) ** 0.5
                p.add_(g, alpha=-lr * scale)

        return loss
```

### 2. Add NorMuon to `build_optimizer`

Locate the `build_optimizer` function (currently supports `"adamw"` and `"lion"`). Add support for `"normuon"` by splitting parameters into two groups:

```python
elif args.optimizer == "normuon":
    # Split params: 2D matrices → NorMuon, everything else → Lion
    normuon_params = [p for p in model.parameters() if p.requires_grad and p.ndim >= 2]
    lion_params = [p for p in model.parameters() if p.requires_grad and p.ndim < 2]
    normuon_lr = args.lr * 0.1  # NorMuon typically uses lower LR than Lion
    optimizer = NorMuon(
        [{"params": normuon_params}],
        lr=normuon_lr,
        momentum=0.95,
        nesterov=True,
        ns_steps=5,
    )
    # Add Lion for 1D params (bias, scale, embeddings) using the regular LR
    if lion_params:
        lion_opt = Lion(
            [{"params": lion_params}],
            lr=args.lr,
            weight_decay=args.weight_decay,
            betas=(0.9, 0.99),
        )
        # Wrap as a composite optimizer — use the existing ChainedOptimizer if available,
        # otherwise just call both step() functions manually by patching the returned object
        # or create a simple wrapper:
        class CompositeOptimizer:
            def __init__(self, opts):
                self.optimizers = opts
                # Expose param_groups for LR scheduler compatibility
                self.param_groups = []
                for opt in opts:
                    self.param_groups.extend(opt.param_groups)
            def zero_grad(self, **kwargs):
                for opt in self.optimizers: opt.zero_grad(**kwargs)
            def step(self, closure=None):
                for opt in self.optimizers: opt.step(closure)
            def state_dict(self):
                return [opt.state_dict() for opt in self.optimizers]
            def load_state_dict(self, state):
                for opt, sd in zip(self.optimizers, state): opt.load_state_dict(sd)
        optimizer = CompositeOptimizer([optimizer, lion_opt])
```

> **Note:** If `train.py` already has a `ChainedOptimizer` or similar multi-optimizer wrapper, prefer using that over the inline `CompositeOptimizer` above.

### 3. LR scheduler compatibility

The current LR scheduler (cosine + warmup) iterates over `optimizer.param_groups`. If using `CompositeOptimizer`, ensure `param_groups` is correctly forwarded (the implementation above does this). If the scheduler calls `optimizer.param_groups` directly and it breaks, adjust accordingly — the NorMuon param group should use `normuon_lr = args.lr * 0.1` and the Lion param group uses `args.lr`.

### 4. Run command

Use the full SOTA stack from PR #523 + GradNorm EMA-proxy, replacing `--optimizer lion` with `--optimizer normuon`:

```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent alphonse --optimizer normuon --lr 1e-4 --weight-decay 5e-4 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 \
  --epochs 13 \
  --surface-loss-weight 2.0 \
  --use-gradnorm --gradnorm-mode ema_proxy --gradnorm-alpha 0.5 \
  --gradnorm-min-weight 0.7 --gradnorm-ema-beta 0.9 \
  --wandb-group fern-normuon-v1 --wandb-name fern-normuon-lr1e-4
```

**If the first run converges cleanly, also try `--lr 3e-4`** (NorMuon may benefit from a slightly higher LR than Lion). Use `--wandb-group fern-normuon-v1` for both runs so they appear together in W&B.

## Baseline

Current single-model SOTA: **PR #523** (thorfinn), W&B run `wyz68o8r`

| Metric | Value |
|---|---|
| val_abupt | **6.9246%** |
| test_abupt | **8.2355%** |
| val surface_pressure | 4.5840% |
| val wall_shear | 7.7457% |
| val volume_pressure | 4.3040% |
| val tau_x | 6.7193% |
| val tau_y | 8.7197% |
| val tau_z | 10.2960% |

W&B link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/wyz68o8r

## Win condition

- **Primary**: `val_abupt < 6.9246%` AND `test_abupt ≤ 8.30%`
- **Secondary watch metric**: Improvement in `val tau_y` and `val tau_z` (currently the highest-error channels at 8.72% and 10.30% respectively)

## Expected behavior

- If NorMuon causes instability (loss spikes, NaN), add `--grad-clip-norm 0.3` (tighter clip) and retry.
- If the CompositeOptimizer/LR-scheduler interaction is problematic, consider applying NorMuon to ALL params (including 1D) with the `ndim < 2` fallback path — this is simpler and should still work.
- Monitor the W&B loss curve closely in the first 2 epochs for signs of divergence.

## Suggested follow-ups (if this wins)

1. Sweep NorMuon `lr` (0.5×, 1×, 2× of the winning LR)
2. Try NorMuon with `ns_steps=10` (more accurate orthogonalization)
3. Combine NorMuon with batch-size schedule (the other Modded-NanoGPT idea not yet tried)
