### PR TITLE
Round 33 — Progressive Resolution Curriculum

### DIFF
--- a/train.py
+++ b/train.py
@@ -1159,9 +1159,110 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    progressive_points_schedule: str = ""
 
 
 NONFINITE_SKIP_ABORT = 200
+
+
+def parse_progressive_schedule(schedule_str: str) -> list[tuple[int, int]]:
+    """Parse '16384:10,32768:25,65536:50' into [(16384, 10), (32768, 25), (65536, 50)].
+
+    Each pair is ``(n_points_per_view, end_epoch_inclusive_1based)``. ``end_epoch``
+    must be strictly increasing. Returns ``[]`` for an empty/whitespace string.
+    """
+    if not schedule_str.strip():
+        return []
+    phases: list[tuple[int, int]] = []
+    for raw_part in schedule_str.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        if ":" not in part:
+            raise ValueError(
+                f"progressive_points_schedule entry {part!r} must be 'N_POINTS:END_EPOCH'"
+            )
+        n_pts_str, end_epoch_str = part.split(":", 1)
+        n_pts = int(n_pts_str)
+        end_epoch = int(end_epoch_str)
+        if n_pts <= 0 or end_epoch <= 0:
+            raise ValueError(
+                f"progressive_points_schedule entry {part!r} must be positive integers"
+            )
+        if phases and end_epoch <= phases[-1][1]:
+            raise ValueError(
+                f"progressive_points_schedule end_epoch values must be strictly increasing: "
+                f"{schedule_str!r}"
+            )
+        phases.append((n_pts, end_epoch))
+    return phases
+
+
+def get_current_resolution(
+    epoch_zero_based: int, schedule: list[tuple[int, int]], default: int
+) -> int:
+    """Return the points-per-view for the current 0-indexed epoch.
+
+    Schedule end_epochs are 1-based and inclusive (``end_epoch=10`` covers
+    epochs 1..10, i.e. zero-based 0..9). Past the end of the schedule, the
+    final phase's resolution sticks.
+    """
+    if not schedule:
+        return default
+    epoch_1based = epoch_zero_based + 1
+    for n_pts, end_epoch in schedule:
+        if epoch_1based <= end_epoch:
+            return n_pts
+    return schedule[-1][0]
+
+
+def _subsample_modality(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    mask: torch.Tensor,
+    n_target: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Sample ``n_target`` rows per batch item, preferring valid (mask=True) rows.
+
+    Padding rows (mask=False) are sampled only if there are fewer valid rows than
+    ``n_target``. Output rows are sorted by index within each item to preserve a
+    stable ordering.
+    """
+    B, N = mask.shape
+    if N <= n_target:
+        return x, y, mask
+    scores = torch.rand(B, N, device=x.device)
+    scores = scores.masked_fill(~mask, float("inf"))
+    idx = scores.argsort(dim=-1)[:, :n_target]
+    idx, _ = idx.sort(dim=-1)
+    new_x = torch.gather(x, 1, idx.unsqueeze(-1).expand(-1, -1, x.shape[-1]))
+    new_y = torch.gather(y, 1, idx.unsqueeze(-1).expand(-1, -1, y.shape[-1]))
+    new_mask = torch.gather(mask, 1, idx)
+    return new_x, new_y, new_mask
+
+
+def subsample_batch(
+    batch: "SurfaceBatch",
+    n_surface: int,
+    n_volume: int,
+) -> "SurfaceBatch":
+    """Randomly subsample each item to ``n_surface`` and ``n_volume`` rows."""
+    surface_x, surface_y, surface_mask = _subsample_modality(
+        batch.surface_x, batch.surface_y, batch.surface_mask, n_surface
+    )
+    volume_x, volume_y, volume_mask = _subsample_modality(
+        batch.volume_x, batch.volume_y, batch.volume_mask, n_volume
+    )
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=surface_mask,
+        volume_x=volume_x,
+        volume_y=volume_y,
+        volume_mask=volume_mask,
+        metadata=list(batch.metadata),
+    )
 
 
 class TargetTransform:
@@ -2753,6 +2854,22 @@ def main(argv: Iterable[str] | None = None) -> None:
     if config.grad_ema_alpha > 0 and is_main:
         print(f"Gradient EMA smoothing: alpha={config.grad_ema_alpha}")
 
+    progressive_schedule = parse_progressive_schedule(config.progressive_points_schedule)
+    if progressive_schedule:
+        max_schedule_pts = max(n for n, _ in progressive_schedule)
+        if max_schedule_pts > config.train_surface_points:
+            raise ValueError(
+                f"progressive_points_schedule max {max_schedule_pts} exceeds "
+                f"--train-surface-points {config.train_surface_points}"
+            )
+        if max_schedule_pts > config.train_volume_points:
+            raise ValueError(
+                f"progressive_points_schedule max {max_schedule_pts} exceeds "
+                f"--train-volume-points {config.train_volume_points}"
+            )
+        if is_main:
+            print(f"Progressive resolution schedule: {progressive_schedule}")
+
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
             if is_main:
@@ -2768,12 +2885,25 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        current_surface_pts = get_current_resolution(
+            epoch, progressive_schedule, config.train_surface_points
+        )
+        current_volume_pts = get_current_resolution(
+            epoch, progressive_schedule, config.train_volume_points
+        )
+        progressive_active = bool(progressive_schedule) and (
+            current_surface_pts < config.train_surface_points
+            or current_volume_pts < config.train_volume_points
+        )
+
         train_iter = train_loader
         if is_main:
             train_iter = tqdm(
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            if progressive_active:
+                batch = subsample_batch(batch, current_surface_pts, current_volume_pts)
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,
@@ -2943,6 +3073,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "train/lr": float(optimizer.param_groups[0]["lr"]),
                 "train/nonfinite_skip_count": nonfinite_skip_count,
+                "train/current_surface_points": current_surface_pts,
+                "train/current_volume_points": current_volume_pts,
                 "global_step": global_step,
                 **gradient_metrics,
                 **grad_ema_metrics,


### PR DESCRIPTION
# Round 33 — Progressive Resolution Curriculum

## Hypothesis

Training with the full 65536 surface/volume points from epoch 1 may be suboptimal: the model sees high-frequency detail before it has learned coarse structure, analogous to training a neural network on high-res images before it can classify low-res ones. A progressive resolution curriculum — starting with 16k points (coarse structure) and scaling to 65536 (full detail) — should accelerate early convergence and produce better-calibrated representations in the final layers.

This is analogous to progressive training in GANs (Karras et al. 2018) and curriculum learning (Bengio et al. 2009), adapted to point cloud regression.

Current gaps (vs. tay SOTA PR #511):
- τ_y: 2.35× gap
- τ_z: 2.73× gap
- vol_pressure: 1.95× gap

## Mechanism

Divide 50 epochs into 3 phases:
- **Phase 1** (epochs 1–10): 16384 surface + 16384 volume points — fast, coarse structure learning
- **Phase 2** (epochs 11–25): 32768 surface + 32768 volume points — intermediate resolution
- **Phase 3** (epochs 26–50): 65536 surface + 65536 volume points — full resolution (matches baseline)

Since later phases use more points per batch, effective gradient signal increases as training progresses — complementing the LR warmup by ensuring the model first learns global structure before being asked to fit fine-grained surface details.

**Expected benefit**: Better initialization for Phase 3 by having learned smooth global structure first; faster convergence (fewer steps needed at full resolution); potential regularization effect (underfitting coarse structure rather than overfitting noise).

## Code Changes Required

Add `--progressive-points-schedule <str>` flag, e.g. `"16384:10,32768:25,65536:50"` meaning:
- Use 16384 pts for epochs 1–10
- Use 32768 pts for epochs 11–25
- Use 65536 pts for epochs 26–50

```python
def parse_progressive_schedule(schedule_str):
    """
    Parse "16384:10,32768:25,65536:50" into list of (n_points, end_epoch).
    Returns: [(16384, 10), (32768, 25), (65536, 50)]
    """
    phases = []
    for part in schedule_str.split(','):
        n_pts, end_epoch = part.split(':')
        phases.append((int(n_pts), int(end_epoch)))
    return phases

def get_current_resolution(epoch, schedule):
    """
    schedule: [(n_points, end_epoch), ...]
    Returns: n_points for the current epoch
    """
    for n_pts, end_epoch in schedule:
        if epoch <= end_epoch:
            return n_pts
    return schedule[-1][0]  # fallback to last

# In training loop, at start of each epoch:
current_pts = get_current_resolution(epoch, progressive_schedule)
train_loader = DataLoader(
    dataset,
    batch_size=args.batch_size,
    collate_fn=lambda batch: sample_points(batch, n_surface=current_pts, n_volume=current_pts)
)
```

Log to W&B every epoch:
- `train/current_surface_points` — current resolution phase
- `train/current_volume_points`
- `train/loss` — should show phase transitions as steps in training curve

## Sweep Plan (2 arms, 4-GPU DDP)

Use `--wandb_group yi-round33-progressive-resolution` for all arms.

**Arm A — Standard progressive curriculum (16k→32k→65k)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent nezuko \
  --wandb_group yi-round33-progressive-resolution \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --progressive-points-schedule "16384:10,32768:25,65536:50" \
  --epochs 50
```

**Arm B — Fast progressive curriculum (32k→65k, skip 16k phase)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent nezuko \
  --wandb_group yi-round33-progressive-resolution \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --progressive-points-schedule "32768:15,65536:50" \
  --epochs 50
```

Note: `--train-surface-points` and `--train-volume-points` set the *maximum* resolution. The progressive schedule overrides them per-epoch. `--eval-surface-points` and `--eval-volume-points` always use full resolution.

## Current Baseline (target to beat)

| Metric | yi best (PR #517) |
|--------|-------------------|
| val_abupt | **9.032%** |
| surface_pressure_rel_l2_pct | 5.702% |
| wall_shear_rel_l2_pct | 10.257% |
| wall_shear_x_rel_l2_pct | 8.520% |
| wall_shear_y_rel_l2_pct | 12.907% |
| wall_shear_z_rel_l2_pct | 12.957% |
| volume_pressure_rel_l2_pct | 5.075% |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`

## Win Criterion

- **Merge**: val_abupt < 9.032% — improvement may come from any component
- **Request changes**: val_abupt within 0.5% of baseline but training curves show faster convergence in Phase 1 — try adjusting phase boundaries (e.g. longer Phase 1 at 16k) or steeper schedule
- **Close**: All arms regress significantly from baseline — progressive curriculum hurts by prolonging underfitting

## Key Diagnostics to Report

1. Training loss curves across phase transitions (epochs 10 and 25 for Arm A) — look for beneficial step changes
2. `val_abupt` at end of Phase 1 (epoch 10) vs. a baseline trained only 10 epochs — confirms coarse learning
3. Best val_abupt per arm with epoch number
4. Wall time per epoch across phases (Phase 1 should be ~4× faster than Phase 3)
5. Whether Phase 3 converges to a better minimum than a baseline that trained at 65536 pts from epoch 1
