### PR TITLE
Round 33 — ADOPT Optimizer (Provably Convergent Adam Variant)

### DIFF
--- a/train.py
+++ b/train.py
@@ -49,6 +49,135 @@ from data import (
 
 
 # ---------------------------------------------------------------------------
+# ADOPT optimizer (Adam variant with provable O(1/sqrt(T)) convergence for any eps>0)
+# Tamura et al., NeurIPS 2024. https://arxiv.org/abs/2411.02853
+# Reference implementation: https://github.com/iShohei220/adopt
+# ---------------------------------------------------------------------------
+
+
+class ADOPT(torch.optim.Optimizer):
+    """ADOPT: provably-convergent Adam variant that decouples the adaptive
+    denominator from the current gradient.
+
+    Update (per parameter, t >= 1):
+        denom_t   = max(sqrt(v_{t-1}), eps)
+        g_norm_t  = g_t / denom_t                       # (optionally clipped to [-c, c])
+        m_t       = beta1 * m_{t-1} + (1 - beta1) * g_norm_t
+        theta_t   = theta_{t-1} - lr * m_t
+        v_t       = beta2 * v_{t-1} + (1 - beta2) * g_t^2
+
+    Step 0 is special: v_0 <- g_0^2 and the parameter update is skipped.
+    This avoids the 0/0 condition on the first step and matches Algorithm 1
+    of the paper / the official iShohei220/adopt reference implementation.
+
+    Args:
+        lr: learning rate.
+        betas: (beta1, beta2). Note that beta2=0.9999 is the canonical default
+            (load-bearing for the convergence guarantee), not Adam's 0.999.
+        eps: lower bound for the denominator (paper uses 1e-6).
+        weight_decay: coefficient (decoupled AdamW-style by default).
+        clip_lambda: optional per-coordinate clip on the normalized update;
+            0 disables, positive value applies a constant clamp to [-c, c].
+        decoupled: if True, weight decay is applied to the parameter directly
+            (AdamW-style). If False, weight decay is added into the gradient
+            before normalization (Adam-style L2).
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        betas: tuple[float, float] = (0.9, 0.9999),
+        eps: float = 1e-6,
+        weight_decay: float = 0.0,
+        clip_lambda: float = 0.0,
+        decoupled: bool = True,
+    ):
+        if lr <= 0.0:
+            raise ValueError(f"ADOPT lr must be > 0, got {lr}")
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(f"ADOPT beta1 must be in [0, 1), got {betas[0]}")
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(f"ADOPT beta2 must be in [0, 1), got {betas[1]}")
+        if eps <= 0.0:
+            raise ValueError(f"ADOPT eps must be > 0, got {eps}")
+        if clip_lambda < 0.0:
+            raise ValueError(f"ADOPT clip_lambda must be >= 0, got {clip_lambda}")
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            clip_lambda=clip_lambda,
+            decoupled=decoupled,
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            beta1, beta2 = group["betas"]
+            lr = group["lr"]
+            eps = group["eps"]
+            wd = group["weight_decay"]
+            clip_lambda = group.get("clip_lambda", 0.0)
+            decoupled = group.get("decoupled", True)
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad
+                if g.is_sparse:
+                    raise RuntimeError("ADOPT does not support sparse gradients")
+
+                state = self.state[p]
+                if len(state) == 0:
+                    state["step"] = 0
+                    state["m"] = torch.zeros_like(p, memory_format=torch.preserve_format)
+                    state["v"] = torch.zeros_like(p, memory_format=torch.preserve_format)
+
+                step_count = state["step"]
+                m = state["m"]
+                v = state["v"]
+
+                if step_count == 0:
+                    # Initialize v with g^2; skip the parameter update.
+                    v.addcmul_(g, g, value=1.0)
+                    state["step"] = 1
+                    continue
+
+                # Decoupled (AdamW) weight decay applied directly to the parameter,
+                # so that the adaptive normalization sees only the raw task gradient.
+                if wd > 0.0 and decoupled:
+                    p.data.mul_(1.0 - lr * wd)
+
+                grad_for_v = g
+                if wd > 0.0 and not decoupled:
+                    grad_for_v = g.add(p, alpha=wd)
+
+                # ADOPT denominator uses v from the PREVIOUS step.
+                denom = v.sqrt().clamp_(min=eps)
+                normed_g = grad_for_v / denom
+                if clip_lambda > 0.0:
+                    normed_g.clamp_(-clip_lambda, clip_lambda)
+
+                m.mul_(beta1).add_(normed_g, alpha=1.0 - beta1)
+                p.data.add_(m, alpha=-lr)
+
+                # Update second moment with current raw gradient (for next step).
+                v.mul_(beta2).addcmul_(grad_for_v, grad_for_v, value=1.0 - beta2)
+
+                state["step"] = step_count + 1
+
+        return loss
+
+
+# ---------------------------------------------------------------------------
 # Muon optimizer (Newton-Schulz orthogonalized momentum)
 # Reference: https://github.com/KellerJordan/Muon  (Keller Jordan, 2024)
 # ---------------------------------------------------------------------------
@@ -704,10 +833,15 @@ class EMA:
 class Config:
     lr: float = 3e-4
     weight_decay: float = 1e-4
-    optimizer: str = "adamw"  # "adamw" or "muon"
+    optimizer: str = "adamw"  # "adamw", "lion", "muon", or "adopt"
     muon_momentum: float = 0.95
     muon_ns_steps: int = 5
     muon_adamw_lr_scale: float = 0.1  # adamw fallback LR = lr * this
+    adopt_beta1: float = 0.9
+    adopt_beta2: float = 0.9999  # canonical ADOPT default (NOT Adam's 0.999)
+    adopt_eps: float = 1e-6
+    adopt_clip_lambda: float = 0.0  # 0 = no per-coord clipping
+    adopt_decoupled_wd: bool = True  # AdamW-style decoupled weight decay
     batch_size: int = 2
     epochs: int = 50
     train_surface_points: int = 40_000
@@ -1989,6 +2123,22 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = Lion(
             model.parameters(), lr=config.lr, weight_decay=config.weight_decay
         )
+    elif optimizer_name == "adopt":
+        if is_main:
+            print(
+                f"Optimizer: ADOPT (lr={config.lr}, betas=({config.adopt_beta1}, "
+                f"{config.adopt_beta2}), eps={config.adopt_eps}, wd={config.weight_decay} "
+                f"decoupled={config.adopt_decoupled_wd}, clip_lambda={config.adopt_clip_lambda})"
+            )
+        optimizer = ADOPT(
+            model.parameters(),
+            lr=config.lr,
+            betas=(config.adopt_beta1, config.adopt_beta2),
+            eps=config.adopt_eps,
+            weight_decay=config.weight_decay,
+            clip_lambda=config.adopt_clip_lambda,
+            decoupled=config.adopt_decoupled_wd,
+        )
     elif optimizer_name == "muon":
         muon_2d_params = [p for p in model.parameters() if p.requires_grad and p.ndim == 2]
         muon_other_params = [p for p in model.parameters() if p.requires_grad and p.ndim != 2]
@@ -2031,9 +2181,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         )
     else:
         raise ValueError(
-            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion', 'muon'."
+            f"Unknown optimizer '{config.optimizer}'. Supported: 'adamw', 'lion', 'muon', 'adopt'."
         )
-    if is_main and optimizer_name != "muon":
+    if is_main and optimizer_name not in ("muon", "adopt"):
         print(
             f"Optimizer: {optimizer.__class__.__name__} "
             f"lr={config.lr} wd={config.weight_decay}"


### PR DESCRIPTION
# Round 33 — ADOPT Optimizer (Adaptive and Optimal Descent)

## Hypothesis

Lion optimizer has been our best optimizer (PRs #68, #97, confirmed yi SOTA). However, Lion's sign-based updates can cause instabilities on heterogeneous multi-task loss landscapes like ours (5 output types with very different gradient scales). ADOPT (Tamura et al. 2024, NeurIPS 2024) is a recently proposed Adam variant that removes the dependence on ε in the denominator by decoupling the adaptive gradient scaling from the current gradient — mathematically proven to converge at O(1/√T) regardless of ε. This makes ADOPT more robust on tasks with sparse or heterogeneous gradients.

ADOPT has shown superior convergence over Adam and AdamW on a range of vision and NLP tasks. For our multi-task CFD regression, the decoupled denominator may specifically help τ_y/τ_z gradients which are typically much smaller in magnitude than τ_x.

Current gaps (vs. tay SOTA PR #511):
- τ_y: 2.35× gap
- τ_z: 2.73× gap
- vol_pressure: 1.95× gap

## Mechanism

ADOPT modifies Adam's update rule to decouple the gradient from the adaptive denominator:

Standard Adam:
```
m_t = β1 * m_{t-1} + (1-β1) * g_t
v_t = β2 * v_{t-1} + (1-β2) * g_t²
θ_t = θ_{t-1} - lr * m_t / (√v_t + ε)
```

ADOPT (key difference — denominator uses previous-step gradient, not current):
```
m_t = β1 * m_{t-1} + (1-β1) * g_t / max(√v_{t-1}, ε)  # ← uses v_{t-1}
v_t = β2 * v_{t-1} + (1-β2) * g_t²
θ_t = θ_{t-1} - lr * m_t
```

By using `v_{t-1}` in the denominator instead of `v_t`, ADOPT breaks the circularity that causes Adam's convergence to depend on ε — making it provably convergent for any ε > 0.

## Code Changes Required

Add `--optimizer adopt` option. Implement ADOPT from scratch or use the reference implementation:

```python
class ADOPT(torch.optim.Optimizer):
    """
    ADOPT: Modified Adam That Can Provably Solve Any L-Smooth Unconstrained Optimization Problem.
    Tamura et al. NeurIPS 2024. https://arxiv.org/abs/2411.02853
    """
    def __init__(self, params, lr=1e-4, betas=(0.9, 0.999), eps=1e-6, weight_decay=0.0,
                 clip_lambda=None):
        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay,
                       clip_lambda=clip_lambda)
        super().__init__(params, defaults)
    
    def step(self, closure=None):
        loss = None
        if closure is not None:
            with torch.enable_grad():
                loss = closure()
        
        for group in self.param_groups:
            beta1, beta2 = group['betas']
            lr = group['lr']
            eps = group['eps']
            wd = group['weight_decay']
            clip_lambda = group.get('clip_lambda', None)
            
            for p in group['params']:
                if p.grad is None:
                    continue
                
                g = p.grad.data
                if g.is_sparse:
                    raise RuntimeError('ADOPT does not support sparse gradients')
                
                state = self.state[p]
                
                # State initialization
                if len(state) == 0:
                    state['step'] = 0
                    state['m'] = torch.zeros_like(p.data)
                    state['v'] = g.pow(2).clone()  # initialize v with g² (not zeros)
                
                state['step'] += 1
                m, v = state['m'], state['v']
                step = state['step']
                
                # Weight decay
                if wd != 0:
                    g = g.add(p.data, alpha=wd)
                
                # Optional gradient clipping (per-parameter, not global)
                if clip_lambda is not None:
                    clip_val = clip_lambda * (v.sqrt() + eps)
                    g = g.clamp(-clip_val, clip_val)
                
                # ADOPT update: use v_{t-1} in denominator (key difference from Adam)
                if step == 1:
                    # First step: standard Adam-like update
                    m.mul_(beta1).add_(g, alpha=1 - beta1)
                else:
                    # ADOPT: normalize g by previous v before updating m
                    denom = v.sqrt().add_(eps)
                    m.mul_(beta1).add_(g / denom, alpha=1 - beta1)
                
                # Update v with current gradient
                v.mul_(beta2).addcmul_(g, g, value=1 - beta2)
                
                # Parameter update
                p.data.add_(m, alpha=-lr)
        
        return loss
```

**Implementation notes:**
- The `v` state is initialized with `g²` (not zeros) to avoid a 0/0 issue on the first step
- `clip_lambda` implements optional per-coordinate gradient clipping (Tamura et al. recommend `clip_lambda=None` for most tasks, but it can help stability in early training)
- No bias correction needed (v initialization absorbs the warm-up)

Use `--optimizer adopt --lr 1e-4` as the primary arm; also try `--lr 2e-4` since ADOPT's different update scale may benefit from a slightly higher LR.

## Sweep Plan (3 arms, 4-GPU DDP)

Use `--wandb_group yi-round33-adopt-optimizer` for all arms.

**Arm A — ADOPT lr=1e-4 (matched to Lion baseline)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --wandb_group yi-round33-adopt-optimizer \
  --learnable-pe \
  --optimizer adopt \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --epochs 50
```

**Arm B — ADOPT lr=2e-4 (slightly higher, exploiting ADOPT's stability)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --wandb_group yi-round33-adopt-optimizer \
  --learnable-pe \
  --optimizer adopt \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --epochs 50
```

**Arm C — ADOPT lr=1e-4 + gradient clip per coordinate (clip_lambda=1.0)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --wandb_group yi-round33-adopt-optimizer \
  --learnable-pe \
  --optimizer adopt \
  --lr 1e-4 \
  --adopt-clip-lambda 1.0 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --epochs 50
```

## Current Baseline (target to beat)

| Metric | yi best (PR #517) |
|--------|-------------------|
| val_abupt | **9.032%** |
| surface_pressure_rel_l2_pct | 5.702% |
| wall_shear_rel_l2_pct | 10.257% |
| wall_shear_x_rel_l2_pct | 8.520% |
| wall_shear_y_rel_l2_pct | 12.907% |
| wall_shear_z_rel_l2_pct | 12.957% |
| volume_pressure_rel_l2_pct | 5.075% |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`

## Win Criterion

- **Merge**: val_abupt < 9.032% — optimizer change is architecture-agnostic and should compound with all other improvements
- **Request changes**: ADOPT converges faster (better epoch-10 metrics) but doesn't beat baseline by epoch 50 — try LR=3e-4 or different β values (0.95, 0.99)
- **Close**: All arms clearly diverge or produce NaN — ADOPT implementation incorrect; verify against paper

## Key Diagnostics to Report

1. Learning curves vs. baseline Lion run at matched epochs — does ADOPT converge faster?
2. val_abupt at epoch 10, 25, 50 for each arm
3. Per-task loss components: are τ_y/τ_z converging faster with ADOPT?
4. Gradient norm statistics per arm (ADOPT should show more uniform gradient norms across tasks)
5. Best val_abupt per arm with epoch number

## Reference

Tamura, S., et al. (2024). ADOPT: Modified Adam That Can Provably Solve Any L-Smooth Unconstrained Optimization Problem. NeurIPS 2024. https://arxiv.org/abs/2411.02853
