### PR TITLE
Round 33 — Gradient EMA Smoothing Before Optimizer Update

### DIFF
--- a/train.py
+++ b/train.py
@@ -756,6 +756,7 @@ class Config:
     slope_log_fraction: float = 0.05
     kill_thresholds: str = ""
     clip_grad_norm: float = 0.0
+    grad_ema_alpha: float = 0.0
     compile_model: bool = True
     debug: bool = False
     seed: int = -1
@@ -2094,6 +2095,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("full_val/slope/*", step_metric="global_step")
     wandb.define_metric("test/slope/*", step_metric="global_step")
     wandb.define_metric("train/grad/*", step_metric="global_step")
+    wandb.define_metric("train/grad_ema_alpha", step_metric="global_step")
+    wandb.define_metric("train/grad_norm_raw", step_metric="global_step")
+    wandb.define_metric("train/grad_norm_smoothed", step_metric="global_step")
+    wandb.define_metric("train/grad_noise_ratio", step_metric="global_step")
     wandb.define_metric("train/grad_module/*", step_metric="global_step")
     wandb.define_metric("train/grad_param/*", step_metric="global_step")
     wandb.define_metric("train/grad_type/*", step_metric="global_step")
@@ -2137,6 +2142,9 @@ def main(argv: Iterable[str] | None = None) -> None:
     train_start = time.time()
     val_budget_minutes = float(os.environ.get("SENPAI_VAL_BUDGET_MINUTES", "90"))
     train_timeout_minutes = max(1.0, timeout_minutes - val_budget_minutes)
+    grad_ema_state: dict[int, torch.Tensor] = {}
+    if config.grad_ema_alpha > 0 and is_main:
+        print(f"Gradient EMA smoothing: alpha={config.grad_ema_alpha}")
 
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
@@ -2208,6 +2216,55 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if should_log_gradients
                 else {}
             )
+            grad_ema_metrics: dict[str, float] = {}
+            if config.grad_ema_alpha > 0:
+                raw_sq = torch.zeros((), device=device)
+                smooth_sq = torch.zeros((), device=device)
+                diff_sq = torch.zeros((), device=device)
+                grads_finite_local = True
+                with torch.no_grad():
+                    for p in model.parameters():
+                        if p.grad is None:
+                            continue
+                        g = p.grad
+                        raw_sq = raw_sq + g.float().pow(2).sum()
+                        if not torch.isfinite(g).all():
+                            grads_finite_local = False
+                            break
+                    if grads_finite_local:
+                        for p in model.parameters():
+                            if p.grad is None:
+                                continue
+                            pid = id(p)
+                            if pid not in grad_ema_state:
+                                grad_ema_state[pid] = p.grad.detach().clone()
+                                smooth_sq = smooth_sq + grad_ema_state[pid].float().pow(2).sum()
+                            else:
+                                grad_ema_state[pid].mul_(config.grad_ema_alpha).add_(
+                                    p.grad.data, alpha=1.0 - config.grad_ema_alpha
+                                )
+                                smooth_sq = smooth_sq + grad_ema_state[pid].float().pow(2).sum()
+                                diff_sq = diff_sq + (
+                                    p.grad - grad_ema_state[pid]
+                                ).float().pow(2).sum()
+                                p.grad.data.copy_(grad_ema_state[pid])
+                if grads_finite_local:
+                    raw_norm = float(torch.sqrt(raw_sq).item())
+                    smooth_norm = float(torch.sqrt(smooth_sq).item())
+                    diff_norm = float(torch.sqrt(diff_sq).item())
+                    grad_ema_metrics = {
+                        "train/grad_ema_alpha": config.grad_ema_alpha,
+                        "train/grad_norm_raw": raw_norm,
+                        "train/grad_norm_smoothed": smooth_norm,
+                        "train/grad_noise_ratio": diff_norm / max(smooth_norm, 1e-12),
+                    }
+                else:
+                    grad_ema_metrics = {
+                        "train/grad_ema_alpha": config.grad_ema_alpha,
+                        "train/grad_norm_raw": float("nan"),
+                        "train/grad_norm_smoothed": float("nan"),
+                        "train/grad_noise_ratio": float("nan"),
+                    }
             grad_is_finite = True
             if config.clip_grad_norm > 0:
                 pre_clip_norm = torch.nn.utils.clip_grad_norm_(
@@ -2280,6 +2337,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/nonfinite_skip_count": nonfinite_skip_count,
                 "global_step": global_step,
                 **gradient_metrics,
+                **grad_ema_metrics,
                 **weight_metrics,
             }
             if "wallshear_pred_normal_rms" in batch_loss_metrics:


### PR DESCRIPTION
# Round 33 — Gradient EMA Smoothing Before Optimizer Update

## Hypothesis

Stochastic gradient noise in mini-batch training causes the optimizer to chase noisy directions, especially for low-signal targets like τ_y and τ_z. Rather than clipping gradients (which discards information) or increasing batch size (which is memory-limited), we apply an **exponential moving average (EMA) directly to the gradient signal** before the optimizer update step. This gives the optimizer a smoother, lower-variance gradient estimate without changing the learning rate schedule or optimizer dynamics — it is equivalent to a form of gradient momentum that's separate from Adam's m1 estimate.

**Key distinction from Adam's β1 momentum:** Adam's m1 is a bias-corrected EMA of gradients used internally in the denominator/numerator. Gradient EMA here is applied to the raw gradient *before* it enters the optimizer, so it works with any optimizer (Lion, AdamW, etc.) and does not require changing internal optimizer logic.

Current gaps (vs. tay SOTA PR #511):
- τ_y: 2.35× gap  
- τ_z: 2.73× gap  
- vol_pressure: 1.95× gap

## Mechanism

Before calling `optimizer.step()`, replace `p.grad` with an EMA of past gradients:

```python
# After loss.backward(), before optimizer.step():
for p in model.parameters():
    if p.grad is None:
        continue
    state = grad_ema_state.get(id(p))
    if state is None:
        grad_ema_state[id(p)] = p.grad.data.clone()
    else:
        state.mul_(grad_ema_alpha).add_(p.grad.data, alpha=1 - grad_ema_alpha)
        p.grad.data.copy_(state)
```

With `grad_ema_alpha` ∈ {0.9, 0.95, 0.99} we interpolate between:
- α=0 → standard SGD (no smoothing, same as current)
- α=0.9 → mild smoothing (10% new gradient, 90% history)
- α=0.99 → heavy smoothing (1% new gradient, 99% history)

The EMA state is maintained in a separate `grad_ema_state` dict, keyed by `id(p)`. This is a ~100% parameter-count memory overhead (one extra tensor per param) but negligible relative to activations.

**Interaction with Lion optimizer:** Lion uses sign(m) for updates, so the gradient EMA effectively smooths what enters the Lion momentum accumulator. The combination should yield lower-variance sign decisions, particularly for small-magnitude gradients like τ_y/τ_z where the signal/noise ratio is lowest.

**Clip-grad-norm ordering:** Apply gradient EMA *before* `torch.nn.utils.clip_grad_norm_()`. The EMA state should be on the same device as the parameter.

## Code Changes Required

Add `--grad-ema-alpha <float>` flag (default 0.0 = disabled):

```python
# In train.py, define grad_ema_state outside the training loop:
grad_ema_state = {}

# In the training loop, after loss.backward() and before clip_grad_norm_ / optimizer.step():
if args.grad_ema_alpha > 0:
    for p in model.parameters():
        if p.grad is None:
            continue
        pid = id(p)
        if pid not in grad_ema_state:
            grad_ema_state[pid] = p.grad.data.clone()
        else:
            grad_ema_state[pid].mul_(args.grad_ema_alpha).add_(
                p.grad.data, alpha=1 - args.grad_ema_alpha
            )
            p.grad.data.copy_(grad_ema_state[pid])
```

**DDP note:** In DDP training, `loss.backward()` triggers gradient all-reduce across ranks. The gradient EMA should be applied *after* the all-reduce (i.e., after `loss.backward()` returns in DDP context), so each rank maintains its own synchronized EMA state.

**Memory:** grad_ema_state ≈ 1× parameter count in extra float32 tensors (same as EMA shadow model). Total overhead ~same as adding one extra EMA. With 4L/512d model, this is ~100–200MB.

Log to W&B every step:
- `train/grad_ema_alpha` — the α value in use
- `train/grad_norm_raw` — gradient norm before EMA (if computable; may need to capture before replacement)
- `train/grad_norm_smoothed` — gradient norm after EMA smoothing
- `train/grad_noise_ratio` — `||g_raw - g_smooth|| / ||g_smooth||` (signal of how much smoothing is doing)

## Sweep Plan (3 arms, 4-GPU DDP)

Use `--wandb_group yi-round33-gradient-ema` for all arms.

**Arm A — α=0.9 (mild smoothing)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --wandb_group yi-round33-gradient-ema \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --grad-ema-alpha 0.9 \
  --epochs 50
```

**Arm B — α=0.95 (moderate smoothing)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --wandb_group yi-round33-gradient-ema \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --grad-ema-alpha 0.95 \
  --epochs 50
```

**Arm C — α=0.99 (heavy smoothing)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --wandb_group yi-round33-gradient-ema \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --grad-ema-alpha 0.99 \
  --epochs 50
```

## Current Baseline (target to beat)

| Metric | yi best (PR #517) |
|--------|-------------------|
| val_abupt | **9.032%** |
| surface_pressure_rel_l2_pct | 5.702% |
| wall_shear_rel_l2_pct | 10.257% |
| wall_shear_x_rel_l2_pct | 8.520% |
| wall_shear_y_rel_l2_pct | 12.907% |
| wall_shear_z_rel_l2_pct | 12.957% |
| volume_pressure_rel_l2_pct | 5.075% |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`

## Win Criterion

- **Merge**: val_abupt < 9.032% with any α arm
- **Request changes**: val_abupt close but not under bar — try α=0.97 or combine with higher lr (gradient smoothing allows slightly higher lr without instability)
- **Close**: All arms regress >2% from baseline — gradient EMA is slowing learning too much

## Key Diagnostics to Report

1. `train/grad_noise_ratio` per epoch (high noise ratio = high smoothing benefit potential; should decrease as model converges)
2. `train/grad_norm_raw` vs `train/grad_norm_smoothed` — shows how much EMA is damping gradient spikes
3. Per-arm best val_abupt with epoch number
4. Whether τ_y/τ_z specifically improve (predicted: high noise ratio for small-signal tasks)
5. Memory overhead: report if grad_ema_state causes OOM — reduce model size only as last resort
