### PR TITLE
Round 33 — Model Soup: Weight-Space Checkpoint Averaging

### DIFF
--- a/train.py
+++ b/train.py
@@ -695,6 +695,35 @@ class EMA:
         self.backup = None
 
 
+def make_model_soup_state(checkpoint_paths: list) -> dict[str, torch.Tensor]:
+    """Equal-weight average of checkpoint state_dicts (Wortsman et al. 2022).
+
+    Float tensors are averaged in float32 then cast back to the original dtype.
+    Non-float entries (e.g. int counters) are passed through from the first
+    checkpoint, which is fine because they should be identical across our soup
+    range (no BatchNorm; no scheduler state in these checkpoints)."""
+    n = len(checkpoint_paths)
+    if n == 0:
+        raise ValueError("make_model_soup_state needs at least one checkpoint path")
+    state_dicts = [
+        torch.load(p, map_location="cpu", weights_only=True)["model"]
+        for p in checkpoint_paths
+    ]
+    keys = list(state_dicts[0].keys())
+    soup_state: dict[str, torch.Tensor] = {}
+    for key in keys:
+        ref0 = state_dicts[0][key]
+        if not torch.is_tensor(ref0):
+            soup_state[key] = ref0
+            continue
+        if ref0.is_floating_point():
+            stacked = torch.stack([sd[key].to(torch.float32) for sd in state_dicts])
+            soup_state[key] = stacked.mean(dim=0).to(ref0.dtype)
+        else:
+            soup_state[key] = ref0.clone()
+    return soup_state
+
+
 # ---------------------------------------------------------------------------
 # Training helpers
 # ---------------------------------------------------------------------------
@@ -763,6 +792,10 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    model_soup: bool = False
+    soup_save_freq: int = 2
+    soup_start_epoch: int = 40
+    soup_ema_targets: bool = False
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2089,6 +2122,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("full_val_primary/*", step_metric="global_step")
     wandb.define_metric("test/*", step_metric="global_step")
     wandb.define_metric("test_primary/*", step_metric="global_step")
+    wandb.define_metric("soup/*", step_metric="global_step")
     wandb.define_metric("train/slope/*", step_metric="global_step")
     wandb.define_metric("val/slope/*", step_metric="global_step")
     wandb.define_metric("full_val/slope/*", step_metric="global_step")
@@ -2325,6 +2359,35 @@ def main(argv: Iterable[str] | None = None) -> None:
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0
+
+        if config.model_soup and is_main:
+            epoch_one_indexed = epoch + 1
+            soup_freq = max(config.soup_save_freq, 1)
+            if (
+                epoch_one_indexed >= config.soup_start_epoch
+                and (epoch_one_indexed - config.soup_start_epoch) % soup_freq == 0
+            ):
+                soup_path = output_dir / f"soup_epoch_{epoch_one_indexed:03d}.pt"
+                if config.soup_ema_targets and ema is not None:
+                    ema.store(model)
+                    ema.copy_to(model)
+                    torch.save(
+                        {"model": model.state_dict(), "epoch": epoch_one_indexed},
+                        soup_path,
+                    )
+                    ema.restore(model)
+                else:
+                    torch.save(
+                        {"model": model.state_dict(), "epoch": epoch_one_indexed},
+                        soup_path,
+                    )
+                print(
+                    f"  saved soup checkpoint epoch {epoch_one_indexed} "
+                    f"(ema_targets={config.soup_ema_targets})"
+                )
+        if is_distributed:
+            dist.barrier()
+
         should_validate = (
             epoch == 0
             or (epoch + 1) % max(config.validation_every, 1) == 0
@@ -2562,6 +2625,97 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.summary.update(_numeric_metric_items(test_log))
     if is_main:
         print_metrics("test_surface", test_metrics["test_surface"])
+
+    if config.model_soup:
+        soup_ckpt_path = output_dir / "soup_checkpoint.pt"
+        soup_paths_present: list[Path] = []
+        if is_main:
+            soup_paths_present = sorted(output_dir.glob("soup_epoch_*.pt"))
+            if soup_paths_present:
+                print(
+                    f"\nBuilding model soup from {len(soup_paths_present)} checkpoints: "
+                    f"{[p.name for p in soup_paths_present]}"
+                )
+                soup_state = make_model_soup_state(soup_paths_present)
+                soup_meta = {
+                    "model": soup_state,
+                    "soup_checkpoint_files": [p.name for p in soup_paths_present],
+                    "soup_n_checkpoints": len(soup_paths_present),
+                    "soup_ema_targets": bool(config.soup_ema_targets),
+                }
+                torch.save(soup_meta, soup_ckpt_path)
+            else:
+                print("\nmodel_soup enabled but no soup_epoch_*.pt checkpoints found; skipping soup eval.")
+        if is_distributed:
+            dist.barrier()
+
+        if soup_ckpt_path.exists():
+            soup_ckpt = torch.load(soup_ckpt_path, map_location=device, weights_only=True)
+            model.load_state_dict(soup_ckpt["model"])
+            n_soup = int(soup_ckpt.get("soup_n_checkpoints", 0))
+            soup_files = soup_ckpt.get("soup_checkpoint_files", [])
+
+            soup_full_val_metrics = {
+                name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in val_loaders.items()
+            }
+            soup_test_metrics = {
+                name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in test_loaders.items()
+            }
+            soup_full_val_primary = soup_full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
+            soup_test_primary = soup_test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]
+
+            soup_log: dict[str, object] = {
+                "soup/n_checkpoints": n_soup,
+                "soup/ema_targets": 1.0 if config.soup_ema_targets else 0.0,
+                "soup/full_val_primary/abupt_axis_mean_rel_l2_pct": soup_full_val_primary,
+                "soup/full_val_primary/abupt_axis_mean_rel_l2": soup_full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2"],
+                "soup/full_val_primary/surface_pressure_rel_l2_pct": soup_full_val_metrics["val_surface"]["surface_pressure_rel_l2_pct"],
+                "soup/full_val_primary/wall_shear_rel_l2_pct": soup_full_val_metrics["val_surface"]["wall_shear_rel_l2_pct"],
+                "soup/full_val_primary/wall_shear_x_rel_l2_pct": soup_full_val_metrics["val_surface"]["wall_shear_x_rel_l2_pct"],
+                "soup/full_val_primary/wall_shear_y_rel_l2_pct": soup_full_val_metrics["val_surface"]["wall_shear_y_rel_l2_pct"],
+                "soup/full_val_primary/wall_shear_z_rel_l2_pct": soup_full_val_metrics["val_surface"]["wall_shear_z_rel_l2_pct"],
+                "soup/full_val_primary/volume_pressure_rel_l2_pct": soup_full_val_metrics["val_surface"]["volume_pressure_rel_l2_pct"],
+                "soup/full_val_primary/surface_pressure_mae": soup_full_val_metrics["val_surface"]["surface_pressure_mae"],
+                "soup/full_val_primary/wall_shear_mae": soup_full_val_metrics["val_surface"]["wall_shear_mae"],
+                "soup/full_val_primary/volume_pressure_mae": soup_full_val_metrics["val_surface"]["volume_pressure_mae"],
+                "soup/test_primary/abupt_axis_mean_rel_l2_pct": soup_test_primary,
+                "soup/test_primary/abupt_axis_mean_rel_l2": soup_test_metrics["test_surface"]["abupt_axis_mean_rel_l2"],
+                "soup/test_primary/surface_pressure_rel_l2_pct": soup_test_metrics["test_surface"]["surface_pressure_rel_l2_pct"],
+                "soup/test_primary/wall_shear_rel_l2_pct": soup_test_metrics["test_surface"]["wall_shear_rel_l2_pct"],
+                "soup/test_primary/wall_shear_x_rel_l2_pct": soup_test_metrics["test_surface"]["wall_shear_x_rel_l2_pct"],
+                "soup/test_primary/wall_shear_y_rel_l2_pct": soup_test_metrics["test_surface"]["wall_shear_y_rel_l2_pct"],
+                "soup/test_primary/wall_shear_z_rel_l2_pct": soup_test_metrics["test_surface"]["wall_shear_z_rel_l2_pct"],
+                "soup/test_primary/volume_pressure_rel_l2_pct": soup_test_metrics["test_surface"]["volume_pressure_rel_l2_pct"],
+                "soup/test_primary/surface_pressure_mae": soup_test_metrics["test_surface"]["surface_pressure_mae"],
+                "soup/test_primary/wall_shear_mae": soup_test_metrics["test_surface"]["wall_shear_mae"],
+                "soup/test_primary/volume_pressure_mae": soup_test_metrics["test_surface"]["volume_pressure_mae"],
+                "global_step": global_step,
+            }
+            for split_name, metrics in soup_full_val_metrics.items():
+                for key, value in metrics.items():
+                    soup_log[f"soup/full_val/{split_name}/{key}"] = value
+            for split_name, metrics in soup_test_metrics.items():
+                for key, value in metrics.items():
+                    soup_log[f"soup/test/{split_name}/{key}"] = value
+            wandb.log(soup_log)
+            wandb.summary.update(_numeric_metric_items(soup_log))
+            if is_main:
+                wandb.summary["soup/checkpoint_files"] = ",".join(soup_files)
+                best_full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
+                best_test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]
+                delta_full_val = soup_full_val_primary - best_full_val_primary
+                delta_test = soup_test_primary - best_test_primary
+                wandb.summary["soup/delta_full_val_abupt_pct"] = delta_full_val
+                wandb.summary["soup/delta_test_abupt_pct"] = delta_test
+                print(
+                    f"Soup eval ({n_soup} ckpts, ema_targets={config.soup_ema_targets}): "
+                    f"full_val_abupt_pct={soup_full_val_primary:.4f} (best={best_full_val_primary:.4f}, delta={delta_full_val:+.4f}); "
+                    f"test_abupt_pct={soup_test_primary:.4f} (best={best_test_primary:.4f}, delta={delta_test:+.4f})"
+                )
+                print_metrics("soup_full_val", soup_full_val_metrics["val_surface"])
+                print_metrics("soup_test", soup_test_metrics["test_surface"])
 
     if is_main:
         log_model_artifact(


### PR DESCRIPTION
# Round 33 — Model Soup: Weight-Space Checkpoint Averaging

## Hypothesis

The model's EMA shadow (`--ema-decay 0.999`) tracks a single trajectory through weight space. **Model soup** (Wortsman et al. 2022, ICML) shows that averaging multiple independently-finetuned models or multiple checkpoints from the same run in *weight space* (not prediction space) typically outperforms any individual checkpoint. Applied to DrivAerML, we average the last K checkpoints (e.g., epochs 40–50) before final evaluation. This leverages the fact that late training checkpoints explore different basins in the loss landscape and their average lies in a flat region with better generalization.

**Key distinction from EMA:** Standard `--ema-decay 0.999` weights recent updates far more than old ones. Model soup gives *equal weight* to each saved checkpoint, treating epochs 40–50 as equally valid representatives of the loss landscape at convergence.

Current gaps (vs. tay SOTA PR #511):
- τ_y: 2.35× gap  
- τ_z: 2.73× gap  
- vol_pressure: 1.95× gap

## Mechanism

At the end of training:
1. Load K saved checkpoints from epochs 40, 42, 44, 46, 48, 50 (every 2 epochs in final 10)
2. Average their weights: `soup_state = {k: mean([ckpt[k] for ckpt in checkpoints]) for k in state_dict}`
3. Load soup into model and evaluate on validation set
4. Report soup val_abupt alongside best single-checkpoint val_abupt

The weight averaging can be done with a simple loop:
```python
def make_model_soup(checkpoint_paths, model):
    """Average checkpoint weights in weight space."""
    state_dicts = [torch.load(p, map_location='cpu')['model_state_dict'] 
                   for p in checkpoint_paths]
    
    soup_state = {}
    for key in state_dicts[0].keys():
        # Average all checkpoints for this parameter
        soup_state[key] = torch.stack([sd[key].float() for sd in state_dicts]).mean(dim=0)
    
    model.load_state_dict(soup_state)
    return model
```

**Checkpoint saving:** Requires saving full model state every 2 epochs from epoch 40 onwards (not just best). Add `--soup-save-freq 2 --soup-start-epoch 40` flags.

**Interaction with EMA:** Two variants:
- Arm A: Average the *raw model* checkpoints (not EMA shadow) — direct weight soup
- Arm B: Average the *EMA shadow* checkpoints — compound EMA + soup averaging

**Why this might work:** The DrivAerML validation set has high variance across vehicle shapes. Different epochs may be better at different vehicle types. Weight-space averaging finds a consensus point that's robust across all vehicle types — potentially the same effect as using a larger batch size or longer training.

## Code Changes Required

Add `--model-soup --soup-save-freq <int> --soup-start-epoch <int> --soup-ema-targets` flags:

```python
# In training loop, after each epoch:
if args.model_soup and epoch >= args.soup_start_epoch and epoch % args.soup_save_freq == 0:
    soup_ckpt_path = f"{args.output_dir}/soup_epoch_{epoch}.pt"
    if args.soup_ema_targets:
        # Save EMA shadow model weights
        torch.save({'epoch': epoch, 'model_state_dict': ema_model.state_dict()}, soup_ckpt_path)
    else:
        torch.save({'epoch': epoch, 'model_state_dict': model.state_dict()}, soup_ckpt_path)
    
# After training completes:
if args.model_soup:
    soup_paths = sorted(glob(f"{args.output_dir}/soup_epoch_*.pt"))
    soup_model = make_model_soup(soup_paths, model)
    # Evaluate soup model on validation set
    soup_metrics = evaluate(soup_model, val_loader)
    wandb.log({'soup/val_abupt': soup_metrics['val_abupt'], **{f'soup/{k}': v for k, v in soup_metrics.items()}})
    
    # Save soup model as the final checkpoint for test evaluation
    if soup_metrics['val_abupt'] < best_val_abupt:
        torch.save({'model_state_dict': soup_model.state_dict(), 'metrics': soup_metrics}, 
                   f"{args.output_dir}/best_soup.pt")
```

**Memory note:** Loading K=5 checkpoints × model size ~500MB each = ~2.5GB peak CPU RAM during soup construction. GPU memory not affected (soup built on CPU, then moved to GPU for eval). Report soup vs. non-soup val_abupt in results.

Log to W&B:
- `soup/val_abupt` — soup model validation metric
- `soup/n_checkpoints` — number of checkpoints averaged
- `soup/epochs_averaged` — which epochs were included
- Compare against `val/best_val_abupt` (single checkpoint EMA)

## Sweep Plan (2 arms, 4-GPU DDP)

Use `--wandb_group yi-round33-model-soup` for all arms.

**Arm A — Soup of raw model checkpoints (epochs 40–50, every 2 epochs)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent violet \
  --wandb_group yi-round33-model-soup \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-soup \
  --soup-save-freq 2 \
  --soup-start-epoch 40 \
  --epochs 50
```

**Arm B — Soup of EMA shadow checkpoints (epochs 40–50, every 2 epochs)**
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent violet \
  --wandb_group yi-round33-model-soup \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 5e-4 \
  --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --model-soup \
  --soup-save-freq 2 \
  --soup-start-epoch 40 \
  --soup-ema-targets \
  --epochs 50
```

## Current Baseline (target to beat)

| Metric | yi best (PR #517) |
|--------|-------------------|
| val_abupt | **9.032%** |
| surface_pressure_rel_l2_pct | 5.702% |
| wall_shear_rel_l2_pct | 10.257% |
| wall_shear_x_rel_l2_pct | 8.520% |
| wall_shear_y_rel_l2_pct | 12.907% |
| wall_shear_z_rel_l2_pct | 12.957% |
| volume_pressure_rel_l2_pct | 5.075% |

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`

## Win Criterion

- **Merge**: soup val_abupt < 9.032% on either arm
- **Request changes**: soup improves over single checkpoint but doesn't beat baseline — try broader range (epochs 30–50) or more frequent saves (every 1 epoch)
- **Close**: Soup model is worse than single best checkpoint — weight averaging diverges the model

## Key Diagnostics to Report

1. `soup/val_abupt` vs `val/best_val_abupt` — key comparison: does weight averaging help?
2. `soup/n_checkpoints` and which epochs were averaged
3. Per-component improvement: does soup help uniformly or primarily on τ_y/τ_z?
4. CPU RAM peak during soup construction (sanity check)
5. Arm A vs Arm B comparison: raw model vs EMA shadow averaging

## Reference

Wortsman, M., Ilharco, G., Gadre, S. Y., Roelofs, R., Gontijo-Lopes, R., Morcos, A. S., ... & Schmidt, L. (2022). Model soups: averaging weights of multiple fine-tuned models improves accuracy without increasing inference time. ICML 2022.
