### PR TITLE
RFF spectral budget sweep: 8 vs 32 features on PR #571 SOTA stack

### DIFF
--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -10,6 +10,7 @@ import math
 import os
 import re
 import subprocess
+import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -1387,7 +1388,13 @@ def init_wandb_run(
     tags = [config.agent] if config.agent else []
     if state.enabled:
         tags.extend(["ddp", f"rank:{state.rank}"])
-    run = wandb.init(
+    # Serialize wandb.init across DDP ranks to avoid the wandb-core service-spawn
+    # race and graphql 404 retry loops that intermittently leave one rank stuck in
+    # "setting up run" forever, hanging the next NCCL collective. Each rank waits
+    # for the previous rank to finish init before starting its own. ~10s/rank →
+    # ~80s total startup overhead vs ~37 min/epoch is negligible.
+    os.environ.setdefault("WANDB__SERVICE_WAIT", "300")
+    init_kwargs = dict(
         entity=os.environ.get("WANDB_ENTITY"),
         project=os.environ.get("WANDB_PROJECT"),
         group=wandb_group_for_rank(config, state),
@@ -1411,6 +1418,14 @@ def init_wandb_run(
         },
         mode=os.environ.get("WANDB_MODE", "online"),
     )
+    if state.enabled:
+        run = None
+        for r in range(state.world_size):
+            if state.rank == r:
+                run = wandb.init(**init_kwargs)
+            distributed_barrier(state)
+    else:
+        run = wandb.init(**init_kwargs)
     define_wandb_metrics()
     return run
 


### PR DESCRIPTION
## Hypothesis

Doubling the RFF (Random Fourier Features) spectral feature budget from 16 to 32 on the full PR #571 SOTA stack may improve metric quality, particularly for wall-shear components (tau_y, tau_z) which require finer spatial discrimination.

The current SOTA uses `--rff-num-features 16` with a 5-sigma multi-scale init (`0.25,0.5,1.0,2.0,4.0`). RFF features approximate a kernel mapping using random frequencies drawn from a spectral distribution: more features → lower approximation variance → richer positional encoding. The PR #387 sweep tested 32 features, but on an older stack without tau loss weights (tau_y×1.5, tau_z×2.0), vol-curriculum, or the multi-sigma init — meaning the current SOTA stack may benefit differently.

Mechanism: The surface mesh has complex local geometry around wheel arches, underbody vanes, and mirror housings — regions where tau_y/tau_z show the largest errors. More RFF features better resolve these high-frequency spatial patterns. With the augmented tau loss weights already directing gradient attention to these regions, the additional spectral capacity has a better chance of being "used" productively.

**Ablation run:** Also run with `--rff-num-features 8` as a control to confirm the 16→32 direction (establishes whether we're capacity-limited or spectral-density-limited). This gives 2 runs for direct comparison.

## Instructions

Run **two** training runs using the full PR #571 SOTA configuration, varying only `--rff-num-features`. Use `--wandb_group rff32-sweep-pr571` to group them.

**Run A — rff-num-features 32 (main hypothesis):**
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 32 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13 \
  --wandb_group rff32-sweep-pr571
```

**Run B — rff-num-features 8 (lower-bound ablation):**
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 8 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13 \
  --wandb_group rff32-sweep-pr571
```

**Evaluation:** Report the per-axis val metrics for all runs in a table:
- val_abupt (primary gate: must beat 6.7644%)
- surface_pressure, wall_shear, volume_pressure, tau_x, tau_y, tau_z

The winning config is whichever of 8/16/32 achieves the lowest val_abupt, compared to the PR #571 SOTA baseline of 6.7644%.

## Baseline

Current single-model SOTA (PR #571, askeladd, merged):
- **val_abupt: 6.7644%** (gate — must beat this to merge)
- **test_abupt: 8.171%**

Per-axis val metrics (PR #571):
| Metric | Val % |
|---|---|
| surface_pressure | ~3.9% |
| wall_shear | ~7.5% |
| volume_pressure | ~12.5% |
| tau_x | ~5.5% |
| tau_y | 8.489% |
| tau_z | 9.997% |

AB-UPT targets (must eventually beat for paper):
| Metric | AB-UPT |
|---|---|
| surface_pressure | 3.82% |
| wall_shear | 7.29% |
| volume_pressure | 6.08% |
| tau_x | 5.35% |
| tau_y | 3.65% |
| tau_z | 3.63% |

Baseline W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

Reproduce command (PR #571 SOTA):
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13
```
