### PR TITLE
asinh target-space normalization for wall-shear loss (τ_y/τ_z gap attack)

### DIFF
--- a/run_asinh_arms.sh
+++ b/run_asinh_arms.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Sequential 2-arm sweep for PR #595 asinh wall-shear target-norm.
+set -u
+cd /workspace/senpai/target
+mkdir -p train_logs
+
+export SENPAI_TIMEOUT_MINUTES=${SENPAI_TIMEOUT_MINUTES:-360}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1,2,3}
+
+COMMON=(
+  --learnable-pe
+  --optimizer lion
+  --lr 1e-4
+  --clip-grad-norm 0.5
+  --weight-decay 5e-4
+  --lr-warmup-epochs 1
+  --ema-decay 0.999
+  --model-layers 4
+  --model-hidden-dim 512
+  --model-heads 8
+  --model-slices 128
+  --batch-size 4
+  --train-surface-points 65536 --eval-surface-points 65536
+  --train-volume-points 65536 --eval-volume-points 65536
+  --epochs 50
+  --validation-every 1
+  --no-compile-model
+  --agent alphonse
+  --wandb-group yi-round34-asinh-ws-target-norm
+)
+
+run_arm() {
+  local arm_name="$1"
+  local scale="$2"
+  local logfile="train_logs/${arm_name}.log"
+  local donefile="train_logs/${arm_name}.done"
+  echo "[$(date -Is)] launching ${arm_name} scale=${scale}"
+  torchrun --standalone --nproc_per_node=4 train.py \
+    "${COMMON[@]}" \
+    --ws-asinh-scale "${scale}" \
+    --wandb-name "alphonse/asinh-target-${arm_name}" \
+    > "${logfile}" 2>&1
+  local rc=$?
+  echo "[$(date -Is)] ${arm_name} exited rc=${rc}" | tee -a "${donefile}"
+  return $rc
+}
+
+run_arm "armA-scale0p1" 0.1
+echo "[$(date -Is)] arm A done — Arm B cancelled per advisor decision (saturation kill-gate hit, see PR #595 comment 16:16 UTC)"
+# run_arm "armB-scale0p01" 0.01  # cancelled
+echo "[$(date -Is)] sweep complete (Arm A only)" | tee -a train_logs/asinh_sweep_done

--- a/train.py
+++ b/train.py
@@ -722,6 +722,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    ws_asinh_scale: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1528,6 +1529,7 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    ws_asinh_scale: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -1567,6 +1569,38 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
+        if ws_asinh_scale > 0.0:
+            # asinh(x/scale) wall-shear target-norm. Denormalize ch1:4 to
+            # physical Pa, transform in fp32 (bf16 underflows the asinh
+            # derivative 1/sqrt(1+(x/s)^2) at large x/s), then keep the asinh
+            # result in fp32 alongside the cp channel cast to fp32. The
+            # downstream MSE auto-promotes (target is fp32) so this matches the
+            # baseline's effective fp32 MSE compute. cp (ch0) is untouched
+            # numerically. Eval/metrics see raw surface_pred_norm.
+            ws_std_t = transform.surface_y_std[1:4].to(
+                device=surface_pred_used.device, dtype=torch.float32
+            )
+            ws_mean_t = transform.surface_y_mean[1:4].to(
+                device=surface_pred_used.device, dtype=torch.float32
+            )
+            ws_pred_phys = surface_pred_used[..., 1:4].float() * ws_std_t + ws_mean_t
+            ws_true_phys = surface_target_used[..., 1:4].float() * ws_std_t + ws_mean_t
+            scale_t = float(ws_asinh_scale)
+            ws_pred_asinh = torch.asinh(ws_pred_phys / scale_t)
+            ws_true_asinh = torch.asinh(ws_true_phys / scale_t)
+            surface_pred_used = torch.cat(
+                [surface_pred_used[..., :1].float(), ws_pred_asinh], dim=-1
+            )
+            surface_target_used = torch.cat(
+                [surface_target_used[..., :1].float(), ws_true_asinh], dim=-1
+            )
+            if ws_pred_asinh.numel() > 0:
+                ws_asinh_max_pred_t = ws_pred_asinh.detach().abs().amax()
+                ws_asinh_max_target_t = ws_true_asinh.detach().abs().amax()
+            else:
+                _zero = torch.zeros((), device=ws_pred_asinh.device)
+                ws_asinh_max_pred_t = _zero
+                ws_asinh_max_target_t = _zero
         surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
             surface_pred_used,
             surface_target_used,
@@ -1598,6 +1632,10 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if ws_asinh_scale > 0.0:
+        metrics["ws_asinh_scale"] = float(ws_asinh_scale)
+        metrics["ws_asinh_max_pred"] = float(ws_asinh_max_pred_t.cpu().item())
+        metrics["ws_asinh_max_target"] = float(ws_asinh_max_target_t.cpu().item())
     if "geom_token" in out:
         geom_token = out["geom_token"].detach().float()
         metrics["film/geom_token_norm_mean"] = float(
@@ -2172,6 +2210,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                ws_asinh_scale=config.ws_asinh_scale,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2290,6 +2329,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
                 ]
+            for asinh_key in ("ws_asinh_scale", "ws_asinh_max_pred", "ws_asinh_max_target"):
+                if asinh_key in batch_loss_metrics:
+                    train_log[f"train/{asinh_key}"] = batch_loss_metrics[asinh_key]
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():


### PR DESCRIPTION
## Hypothesis

Wall-shear targets (τ_x, τ_y, τ_z) span multiple decades of magnitude across a vehicle surface — stagnation regions (τ ≈ 0) vs. leading edges (τ >> 0). Training the MSE/Huber loss directly on these raw values causes the loss to be dominated by the high-magnitude regions, leaving the near-zero regions (which often coincide with τ_y and τ_z over flat panels) effectively untrained.

**Applying asinh normalization to the wall-shear targets before loss computation** compresses the dynamic range from ~4 decades to ~1.5 decades, giving near-zero and large-magnitude regions equal gradient weight. This is fundamentally different from the closed PR #485 (asinh loss *scale sweep* on the input) — here we transform the **target space** so the loss landscape sees uniformly calibrated residuals.

Expected improvement: 10–25% reduction in wall_shear_y and wall_shear_z (dominant 2.35–2.73× gap vs AB-UPT), with neutral impact on surface_pressure and volume_pressure.

Reference: asinh normalization is standard in seismology and signal processing for heavy-tailed distributions. In ML: Yeo-Johnson transformation, Box-Cox.

## Instructions

Modify `target/train.py` to apply **asinh normalization** to the wall-shear target channels (channels 1, 2, 3 of the surface target tensor) before loss computation, and inverse-asinh the predictions before metric evaluation.

### Specific changes

**Step 1: Add a global scale constant near the top of `train.py`** (after imports):
```python
# asinh normalization scale for wall-shear targets (tau_x, tau_y, tau_z)
# Set to the ~75th percentile of |wall_shear| across training set to normalize the "typical" value to ~0.88
# Use 0.1 as a conservative starting point (1 Pa ≈ 1.0 in scaled units)
WS_ASINH_SCALE = 0.1  # Arm A: 0.1, Arm B: 0.01
```

**Step 2: In the surface loss computation** (find where `surface_loss` is computed), apply the transform to wall-shear channels only:
```python
# Apply asinh normalization to wall-shear target channels (1,2,3)
# surface_targets shape: [B, N, 4] — ch0=surface_pressure, ch1-3=tau_{x,y,z}
surface_targets_ws = surface_targets[..., 1:4]
surface_preds_ws   = surface_preds[..., 1:4]

# Normalize
surface_targets_ws_norm = torch.asinh(surface_targets_ws / WS_ASINH_SCALE)
surface_preds_ws_norm   = torch.asinh(surface_preds_ws   / WS_ASINH_SCALE)

# Replace wall-shear channels in loss computation only (not in metric eval)
surface_targets_for_loss = torch.cat([surface_targets[..., :1], surface_targets_ws_norm], dim=-1)
surface_preds_for_loss   = torch.cat([surface_preds[..., :1],   surface_preds_ws_norm],   dim=-1)
# Use surface_targets_for_loss and surface_preds_for_loss in the loss, but
# use the ORIGINAL surface_targets and surface_preds for metric computation.
```

**Step 3: Ensure metrics are computed on raw (un-normalized) predictions** — verify that the `compute_metrics()` or equivalent call receives the original `surface_preds` (not the asinh-transformed version).

**Step 4: Add CLI flags** so the scale is tunable without code changes:
```python
parser.add_argument("--ws-asinh-scale", type=float, default=0.0,
                    help="If > 0, apply asinh(x/scale) normalization to wall-shear loss targets. 0 = disabled.")
```
When `--ws-asinh-scale 0` (default), the behavior is identical to the current baseline (no regression).

### Arms to run

Run **2 arms sequentially** (use watchdog / background launch pattern for Arm B):

**Arm A** — scale=0.1:
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --agent alphonse \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --clip-grad-norm 0.5 \
  --weight-decay 5e-4 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50 \
  --ws-asinh-scale 0.1 \
  --wandb-group yi-round34-asinh-ws-target-norm
```

**Arm B** — scale=0.01 (finer compression, more aggressive for near-zero regions):
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --agent alphonse \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --clip-grad-norm 0.5 \
  --weight-decay 5e-4 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50 \
  --ws-asinh-scale 0.01 \
  --wandb-group yi-round34-asinh-ws-target-norm
```

### Important implementation notes
- `torch.asinh` is differentiable and available in PyTorch ≥ 1.7.
- The asinh transform is applied **only to loss computation**, not to metric logging. Metrics must be computed on raw predictions in physical units.
- Do NOT apply asinh to `surface_pressure` (channel 0) — that channel is already well-conditioned (range ~[−1, 1] Cp).
- Do NOT apply asinh to volume targets.
- Check that `WS_ASINH_SCALE` does not cause the normalized residuals to saturate (asinh(x/scale) should remain < 3 for typical values; if scale=0.01 produces large values, report it).

## Baseline (yi — must beat)

| Metric | val | W&B run |
|---|---:|---|
| `val_abupt` | **9.032%** | `brat65z4` |
| `surface_pressure_rel_l2_pct` | 5.702% | `brat65z4` |
| `wall_shear_rel_l2_pct` | 10.257% | `brat65z4` |
| `volume_pressure_rel_l2_pct` | 5.075% | `brat65z4` |
| `wall_shear_x_rel_l2_pct` | 8.520% | `brat65z4` |
| `wall_shear_y_rel_l2_pct` | 12.907% | `brat65z4` |
| `wall_shear_z_rel_l2_pct` | 12.957% | `brat65z4` |

**Win gate: val_abupt < 9.032% on either arm.**

Focus: expected τ_y/τ_z improvement. Surface pressure should be neutral (transform not applied to ch0).

## W&B group
`yi-round34-asinh-ws-target-norm`
