### PR TITLE
1-cycle LR schedule with 1e-3 peak for Lion optimizer

### DIFF
--- a/train.py
+++ b/train.py
@@ -762,6 +762,11 @@ class Config:
     lr_warmup_steps: int = 0
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
+    one_cycle_lr: bool = False
+    one_cycle_peak_lr: float = 1e-3
+    one_cycle_pct_start: float = 0.3
+    one_cycle_div_factor: float = 0.0  # 0 -> auto: peak_lr / lr (uses --lr as initial lr)
+    one_cycle_final_div_factor: float = 100.0
     resume_from: str = ""
 
 
@@ -2039,17 +2044,45 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"lr={config.lr} wd={config.weight_decay}"
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
-    effective_warmup_steps = config.lr_warmup_steps
-    if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
-        effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
-    if is_main and effective_warmup_steps > 0:
-        print(
-            f"LR warmup: {effective_warmup_steps} steps "
-            f"(start_lr={config.lr_warmup_start_lr} -> peak_lr={config.lr})"
+    if config.one_cycle_lr:
+        steps_per_epoch = max(len(train_loader), 1)
+        total_steps = max_epochs * steps_per_epoch
+        div_factor = config.one_cycle_div_factor
+        if div_factor <= 0.0:
+            div_factor = config.one_cycle_peak_lr / max(config.lr, 1e-12)
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.one_cycle_peak_lr,
+            total_steps=total_steps,
+            pct_start=config.one_cycle_pct_start,
+            anneal_strategy="cos",
+            div_factor=div_factor,
+            final_div_factor=config.one_cycle_final_div_factor,
         )
+        warmup_steps_oc = int(round(config.one_cycle_pct_start * total_steps))
+        if is_main:
+            initial_oc_lr = config.one_cycle_peak_lr / div_factor
+            final_oc_lr = initial_oc_lr / config.one_cycle_final_div_factor
+            print(
+                f"OneCycleLR: peak_lr={config.one_cycle_peak_lr} "
+                f"initial_lr={initial_oc_lr:.2e} final_lr={final_oc_lr:.2e} "
+                f"total_steps={total_steps} warmup_steps={warmup_steps_oc} "
+                f"cooldown_steps={total_steps - warmup_steps_oc} "
+                f"div_factor={div_factor:.3f} final_div_factor={config.one_cycle_final_div_factor}"
+            )
+        effective_warmup_steps = 0
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+        effective_warmup_steps = config.lr_warmup_steps
+        if config.lr_warmup_epochs > 0 and config.lr_warmup_steps == 0:
+            effective_warmup_steps = config.lr_warmup_epochs * max(len(train_loader), 1)
+        if is_main and effective_warmup_steps > 0:
+            print(
+                f"LR warmup: {effective_warmup_steps} steps "
+                f"(start_lr={config.lr_warmup_start_lr} -> peak_lr={config.lr})"
+            )
+    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     if is_main and kill_thresholds:
         print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
     train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
@@ -2247,6 +2280,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for pg, base_lr in zip(optimizer.param_groups, initial_group_lrs):
                         pg["lr"] = base_lr
             optimizer.step()
+            if config.one_cycle_lr:
+                scheduler.step()
             ema_decay_now: float | None = None
             if ema is not None:
                 if config.ema_decay_start > 0.0:
@@ -2321,7 +2356,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 timeout_hit = True
                 break
 
-        scheduler.step()
+        if not config.one_cycle_lr:
+            scheduler.step()
         epoch_train_loss = train_loss_sum / max(n_batches, 1)
         dt = time.time() - t0
         peak_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0


### PR DESCRIPTION
## Hypothesis

The current yi training schedule uses a linear warmup for 1 epoch then a fixed LR of 1e-4 (Lion). The prior tay experiments showed that **extended cosine decay with lower LR in late epochs** (PR #511, T_max=13) gave extra per-epoch gains precisely on τ_y and τ_z — the axes where the model is furthest from convergence.

**A 1-cycle LR policy with a 1e-3 peak** is hypothesis that the model can tolerate a much higher peak LR than currently used, and that the fast warmup → high LR → gradual cooldown structure of 1-cycle policy enables better exploration of the loss landscape than the flat 1e-4 schedule. This is especially relevant for Lion, where the adaptive gradient sign makes momentum magnitude less LR-sensitive than Adam, but still responds to LR order-of-magnitude changes.

Evidence: (1) fern PR #99 found 5e-4 (5× base) improved over lower rates, (2) PR #511 (tay) showed τ_y/τ_z improvements were still happening at near-zero LR (6.67e-6) at EP12-13, suggesting the schedule structure matters more than just the peak.

Note: PR #125 tried 1-cycle at 1e-3 early in the programme and was closed — but that was before the current 4L/512d architecture, Lion optimizer, learnable-PE, and STRING-sep features were all in place. The conditions have changed substantially.

**1-cycle policy details:**
- Total steps = epochs × steps_per_epoch
- Warmup: 30% of total steps (LR: base_lr → peak_lr, linear)
- Cooldown: 70% of total steps (LR: peak_lr → min_lr, cosine)
- min_lr = peak_lr / 100 (e.g. 1e-3 peak → 1e-5 floor)

## Instructions

Add a `--one-cycle-lr` flag and `--one-cycle-peak-lr` flag to `target/train.py`. When enabled, replace the LR scheduler with PyTorch's `OneCycleLR`.

### Specific changes

**Step 1: Add CLI args:**
```python
parser.add_argument("--one-cycle-lr", action="store_true",
                    help="Use OneCycleLR scheduler instead of cosine/linear warmup.")
parser.add_argument("--one-cycle-peak-lr", type=float, default=1e-3,
                    help="Peak LR for OneCycleLR scheduler. Default=1e-3.")
```

**Step 2: Create the scheduler after the optimizer:**
```python
if args.one_cycle_lr:
    steps_per_epoch = len(train_loader)
    total_steps = args.epochs * steps_per_epoch
    scheduler = torch.optim.lr_scheduler.OneCycleLR(
        optimizer,
        max_lr=args.one_cycle_peak_lr,
        total_steps=total_steps,
        pct_start=0.3,        # 30% warmup
        anneal_strategy='cos',
        div_factor=args.one_cycle_peak_lr / 1e-4,   # initial LR = peak/div_factor = 1e-4 (current base)
        final_div_factor=100.0,  # final LR = peak/final_div_factor
    )
```

**Step 3: Step the scheduler per-batch** (not per-epoch) — this is critical for OneCycleLR:
```python
# Inside the training loop, after optimizer.step():
if args.one_cycle_lr:
    scheduler.step()
```

**Step 4: Remove or skip the existing warmup/cosine scheduler** when `--one-cycle-lr` is set — they must not both run.

**Step 5: Log the current LR to W&B every step** (or at least every `gradient_log_every` steps) so we can see the schedule in the runs.

### Arms to run

**Arm A** — peak LR = 1e-3 (10× current):
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --agent emma \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --clip-grad-norm 0.5 \
  --weight-decay 5e-4 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50 \
  --one-cycle-lr \
  --one-cycle-peak-lr 1e-3 \
  --wandb-group yi-round34-one-cycle-lr
```

**Arm B** — peak LR = 3e-4 (3× current, more conservative):
```bash
torchrun --standalone --nproc_per_node=4 target/train.py \
  --agent emma \
  --learnable-pe \
  --optimizer lion \
  --lr 1e-4 \
  --clip-grad-norm 0.5 \
  --weight-decay 5e-4 \
  --ema-decay 0.999 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --model-slices 128 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 50 \
  --one-cycle-lr \
  --one-cycle-peak-lr 3e-4 \
  --wandb-group yi-round34-one-cycle-lr
```

Note: `--lr-warmup-epochs` should NOT be passed when `--one-cycle-lr` is set. The warmup is handled by the OneCycleLR scheduler.

### Divergence monitoring
- If val_abupt is still above 40% after epoch 2, the peak LR is too high — abort Arm A and skip to Arm B.
- If grad norm consistently > 100 under Lion, reduce `--clip-grad-norm` to 0.3.

## Baseline (yi — must beat)

| Metric | val | W&B run |
|---|---:|---|
| `val_abupt` | **9.032%** | `brat65z4` |
| `surface_pressure_rel_l2_pct` | 5.702% | `brat65z4` |
| `wall_shear_rel_l2_pct` | 10.257% | `brat65z4` |
| `volume_pressure_rel_l2_pct` | 5.075% | `brat65z4` |
| `wall_shear_x_rel_l2_pct` | 8.520% | `brat65z4` |
| `wall_shear_y_rel_l2_pct` | 12.907% | `brat65z4` |
| `wall_shear_z_rel_l2_pct` | 12.957% | `brat65z4` |

**Win gate: val_abupt < 9.032% on either arm.**

## W&B group
`yi-round34-one-cycle-lr`
