### PR TITLE
Long DDP8: mild tau_y=1.2/tau_z=1.3 static weighting + lr=9e-5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -52,6 +52,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     make_loaders,
     masked_mse,
+    masked_mse_per_channel,
     metric_namespace,
     parse_kill_thresholds,
     primary_metric_log,
@@ -81,6 +82,11 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    tau_y_loss_weight: float = 1.0
+    tau_z_loss_weight: float = 1.0
+    optimizer: str = "adamw"
+    lion_beta1: float = 0.9
+    lion_beta2: float = 0.99
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -181,6 +187,29 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
+    optimizer_name = config.optimizer.lower()
+    if optimizer_name == "adamw":
+        return torch.optim.AdamW(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+    if optimizer_name == "lion":
+        from lion_pytorch import Lion
+
+        return Lion(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+    raise ValueError(
+        f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
+    )
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -190,6 +219,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    tau_y_loss_weight: float = 1.0,
+    tau_z_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -201,18 +232,30 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_per_ch = masked_mse_per_channel(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )  # [4]: 0=cp, 1=tau_x, 2=tau_y, 3=tau_z
+        channel_weights = out["surface_preds"].new_tensor(
+            [1.0, 1.0, tau_y_loss_weight, tau_z_loss_weight]
+        )
+        surface_loss = (surface_per_ch * channel_weights).mean()
+        surface_loss_unweighted = surface_per_ch.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
+        base_mse_loss = surface_loss_unweighted + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_loss_unweighted": float(surface_loss_unweighted.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "surface_loss_cp": float(surface_per_ch[0].detach().cpu().item()),
+        "surface_loss_tau_x": float(surface_per_ch[1].detach().cpu().item()),
+        "surface_loss_tau_y": float(surface_per_ch[2].detach().cpu().item()),
+        "surface_loss_tau_z": float(surface_per_ch[3].detach().cpu().item()),
     }
 
 
@@ -257,7 +300,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-        optimizer = torch.optim.AdamW(base_model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
@@ -329,6 +372,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    tau_y_loss_weight=config.tau_y_loss_weight,
+                    tau_z_loss_weight=config.tau_z_loss_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -364,9 +409,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/loss": float(loss.detach().cpu().item()),
                             "train/base_mse_loss": batch_loss_metrics["base_mse_loss"],
                             "train/surface_loss": batch_loss_metrics["surface_loss"],
+                            "train/surface_loss_unweighted": batch_loss_metrics["surface_loss_unweighted"],
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/surface_loss_cp": batch_loss_metrics["surface_loss_cp"],
+                            "train/surface_loss_tau_x": batch_loss_metrics["surface_loss_tau_x"],
+                            "train/surface_loss_tau_y": batch_loss_metrics["surface_loss_tau_y"],
+                            "train/surface_loss_tau_z": batch_loss_metrics["surface_loss_tau_z"],
                         }
                     )
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -831,6 +831,16 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_mse_per_channel(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """MSE per output channel [C]; pred/target: [B, N, C], mask: [B, N]."""
+    sq = (pred - target).square()
+    mask_f = mask.unsqueeze(-1).to(dtype=sq.dtype, device=sq.device)
+    n_valid = mask_f.expand_as(sq).sum(dim=(0, 1))
+    return (sq * mask_f).sum(dim=(0, 1)) / n_valid.clamp_min(1.0)
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Mild per-channel loss weighting on the cross-flow wall shear channels (tau_y × 1.2, tau_z × 1.3) combined with a reduced learning rate of lr=9e-5 will improve single-model aggregate test error and specifically lower tau_y and tau_z, without destabilising surface or volume pressure.

**Evidence base (W&B run `9mm3sz7x`, PR #516, prior wave):**
- Test aggregate 8.1229 — best verified single-model point in the research map.
- Test tau_y 8.326 / tau_z 9.543 (vs AB-UPT targets 3.65 / 3.63).
- Per-module gradient read: surface_out median 0.180, volume_out median 0.201; no nonfinite gradients; early-clipped then relaxed by end. The model did not explode; it simply learned into a healthier allocation regime.
- Validation slope -0.0211 per 1k steps at 4.7 h cutoff — still descending. A 24 h DDP8 run should let the mechanism fully resolve.

**Why mild rather than aggressive:**
The map shows extreme tau weighting (`rtajk53c` y=15/z=15) regresses test 10.580 → 11.022 and worsens the target channels. The mild regime (y=1.2/z=1.3) keeps surface_out and volume_out gradient medians balanced while shifting learning emphasis toward cross-flow channels. This PR validates whether that shift survives long DDP8.

**Single-model only, no ensembles.** One mechanism. One long run.

---

## Instructions

**Step 0 — Source provenance (fetch reference branches)**

```bash
# In target/
git fetch origin tay:refs/remotes/origin/tay yi:refs/remotes/origin/yi bengio:refs/remotes/origin/bengio
# Inspect how Lion optimizer was implemented on tay (used in the reference wave)
git show origin/tay:train.py | grep -A30 "lion\|Lion\|lionw\|LionW" | head -60
```

Copy the minimal Lion optimizer class (the standard `pytorch-optimizer` `Lion` or an equivalent `lionw` wrapper) from the `tay`/`yi` branch into `train.py`. Add a `--optimizer` flag (`adamw` | `lion`, default `adamw`) to `Config` and `parse_args`.  If Lion is too invasive to copy cleanly in one PR, fall back to AdamW at lr=9e-5 — the per-channel weighting is the primary mechanism to test.

**Step 1 — Add per-channel surface loss weights to `Config`**

In `train.py`, add two fields to the `Config` dataclass (before `manifest`):

```python
tau_y_loss_weight: float = 1.0
tau_z_loss_weight: float = 1.0
```

Because `parse_args` auto-generates CLI flags from `Config` fields, this immediately adds `--tau-y-loss-weight` and `--tau-z-loss-weight` as valid training flags.

**Step 2 — Add `masked_mse_per_channel` helper**

Add this function near `masked_mse` in `trainer_runtime.py`:

```python
def masked_mse_per_channel(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
    """MSE per output channel [C]; pred/target: [B, N, C], mask: [B, N]."""
    sq = (pred - target).square()  # [B, N, C]
    mask_f = mask.unsqueeze(-1).to(dtype=sq.dtype, device=sq.device)  # [B, N, 1]
    n_valid = mask_f.expand_as(sq).sum(dim=(0, 1))  # [C]
    return (sq * mask_f).sum(dim=(0, 1)) / n_valid.clamp_min(1.0)  # [C]
```

Import it in `train.py`.

**Step 3 — Modify `train_loss` to apply per-channel weights**

In `train_loss`, replace:

```python
surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

with:

```python
# surface channels: 0=cp, 1=tau_x, 2=tau_y, 3=tau_z
channel_weights = out["surface_preds"].new_tensor(
    [1.0, 1.0, tau_y_loss_weight, tau_z_loss_weight]
)
surface_per_ch = masked_mse_per_channel(
    out["surface_preds"], surface_target, batch.surface_mask
)  # [4]
surface_loss = (surface_per_ch * channel_weights).mean()
```

Also pass the new weights through `train_loss`'s signature:

```python
def train_loss(
    model, batch, transform, device, amp_mode,
    *, surface_loss_weight=1.0, volume_loss_weight=1.0,
    tau_y_loss_weight=1.0, tau_z_loss_weight=1.0,
) -> ...:
```

Update the call site in `main` to forward `config.tau_y_loss_weight` and `config.tau_z_loss_weight`.

**Step 4 — Log per-channel surface losses**

In the W&B logging block, add:

```python
"train/surface_loss_cp": float(surface_per_ch[0].detach().cpu().item()),
"train/surface_loss_tau_x": float(surface_per_ch[1].detach().cpu().item()),
"train/surface_loss_tau_y": float(surface_per_ch[2].detach().cpu().item()),
"train/surface_loss_tau_z": float(surface_per_ch[3].detach().cpu().item()),
```

Return `surface_per_ch` from `train_loss` (or log within the function directly).

**Step 5 — DDP8 smoke run (REQUIRED before the long run)**

Run a 2-epoch smoke to verify DDP init, dataset access, per-channel loss logging, W&B config, and checkpoint save:

```bash
torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 \
  --optimizer lion \
  --tau-y-loss-weight 1.2 \
  --tau-z-loss-weight 1.3 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 200 \
  --epochs 2 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 50 \
  --wandb-group tau-static-mild-9mm3sz7x-long \
  --wandb-name fern-smoke-tau-mild \
  --seed 42
```

Confirm in W&B: `train/surface_loss_tau_y` and `train/surface_loss_tau_z` are present and finite. Confirm no nonfinite gradients. Confirm checkpoint saved.

**Step 6 — Long DDP8 run (only after smoke passes)**

```bash
torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 \
  --optimizer lion \
  --tau-y-loss-weight 1.2 \
  --tau-z-loss-weight 1.3 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 500 \
  --epochs 50 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 250 \
  --wandb-group tau-static-mild-9mm3sz7x-long \
  --wandb-name fern-tau-mild-long \
  --seed 42
```

Let `SENPAI_TIMEOUT_MINUTES` govern the wall-clock ceiling (up to 1440 min / 24 h).

**Step 7 — Volume guard check**

Before posting results, verify test volume does not regress vs. the pre-wave reference. The reference `9mm3sz7x` test volume was 12.051. If your long run's `test_primary/volume_pressure_rel_l2_pct` is worse than ~12.5, flag it in the results comment alongside the tau improvement.

**Step 8 — Results comment**

Post a comment with:
- W&B run URL (both smoke and long run)
- Table of all test_primary/* metrics (aggregate, surface, volume, wall, tau_x, tau_y, tau_z)
- Runtime and whether the run was still improving at cutoff (from validation slope)
- Whether smoke passed
- Checkpoint selection rule (best-validation checkpoint)

Then post the terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

---

## Baseline

**Current in-wave best:** none yet (wave just started — no merged single-model results on `drivaerml-long-20260504`).

**Pre-wave reference to beat (single-model, external evidence):**

| Run | Mechanism | Test agg | Surface | Volume | Wall | tau_x / tau_y / tau_z |
|---|---|---:|---:|---:|---:|---|
| `9mm3sz7x` (target) | tau_y=1.2/tau_z=1.3, lr=9e-5 | **8.1229** | 4.1275 | 12.0512 | 7.4535 | 6.566 / 8.326 / 9.543 |
| unweighted AdamW baseline (est.) | `main` 4L/512 | ~10.5+ | — | — | — | — |

**AB-UPT targets (lower is better):**

| Metric | Target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |

**Goal:** Beat test aggregate 8.1229 and specifically improve tau_y below 8.326 and tau_z below 9.543. Volume must not regress above ~12.5.

**Git SHA of advisor branch at assignment:** `1b3aca5` (`drivaerml-long-20260504` 2026-05-04)
**DDP world size:** 8
**Source provenance policy:** fetch `tay`/`yi`/`bengio` for Lion code; cite the source SHA and verify it matches the reference run config.
