### PR TITLE
Long DDP8: multi-sigma STRING log-freq init (ki2q9ko9 validation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wandb/
 *.pth
 *.ckpt
 data/point_counts.json
+logs/

--- a/model.py
+++ b/model.py
@@ -72,6 +72,92 @@ class ContinuousSincosEmbed(nn.Module):
         return emb
 
 
+class StringSeparableEncoding(nn.Module):
+    """STRING-separable positional encoding with multi-sigma log-frequency init.
+
+    Per-axis learnable spectral basis:
+        phi_d(x_d) = sin(exp(log_freq_d) * 2pi * x_d + phase_d)
+        psi_d(x_d) = cos(exp(log_freq_d) * 2pi * x_d + phase_d)
+
+    With ``init_sigmas`` of length > 1, ``log_freq`` is initialised round-robin per
+    feature so the encoding starts with broad spectral coverage across frequency
+    octaves; per-axis specialisation is acquired through gradient descent.
+
+    Source: copied verbatim from origin/tay@d97fb09:model.py (PR #511 reapply of
+    PR #488 multi-sigma init that powered W&B run ki2q9ko9). Identical class
+    body and constructor semantics; only the in-line comments were trimmed.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        num_features: int = 32,
+        sigma: float = 1.0,
+        init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        if init_sigmas is not None and len(init_sigmas) > 1:
+            log_sigmas = torch.tensor(
+                [math.log(init_sigmas[f % len(init_sigmas)]) for f in range(num_features)],
+                dtype=torch.float32,
+            )
+            log_freq_init = log_sigmas.unsqueeze(0).expand(in_dim, num_features).clone()
+            self.log_freq = nn.Parameter(log_freq_init)
+        else:
+            self.log_freq = nn.Parameter(
+                torch.full((in_dim, num_features), math.log(sigma))
+            )
+        self.phase = nn.Parameter(torch.zeros(in_dim, num_features))
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.in_dim * self.num_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        freq = torch.exp(self.log_freq.to(dtype=x.dtype))
+        phase = self.phase.to(dtype=x.dtype)
+        proj = 2.0 * math.pi * x.unsqueeze(-1) * freq + phase
+        enc = torch.cat([proj.sin(), proj.cos()], dim=-1)
+        return enc.flatten(start_dim=-2)
+
+
+class MultiSigmaStringPosEmbed(nn.Module):
+    """Drop-in replacement for ContinuousSincosEmbed using multi-sigma STRING.
+
+    Wraps StringSeparableEncoding (per-axis learnable log-frequency basis with
+    multi-sigma init) plus a linear projection to ``hidden_dim`` so the
+    surrounding model sees the same [B, N, hidden_dim] interface.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        input_dim: int,
+        num_features: int = 16,
+        init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_features = num_features
+        self.init_sigmas = list(init_sigmas) if init_sigmas else None
+        self.string = StringSeparableEncoding(
+            in_dim=input_dim,
+            num_features=num_features,
+            init_sigmas=self.init_sigmas,
+        )
+        self.project = nn.Linear(self.string.output_dim, hidden_dim)
+        nn.init.trunc_normal_(self.project.weight, std=0.02)
+        nn.init.zeros_(self.project.bias)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords_f = coords.float()
+        enc = self.string(coords_f)
+        return self.project(enc)
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
         super().__init__()
@@ -226,6 +312,9 @@ class SurfaceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        pe_kind: str = "sincos",
+        pe_num_features: int = 16,
+        pe_init_sigmas: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,10 +322,27 @@ class SurfaceTransolver(nn.Module):
         self.surface_output_dim = surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
+        self.pe_kind = pe_kind
+        self.pe_num_features = pe_num_features
+        self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
+        if pe_kind == "sincos":
+            self.pos_embed: nn.Module = ContinuousSincosEmbed(
+                hidden_dim=n_hidden, input_dim=space_dim
+            )
+        elif pe_kind == "string_multisigma":
+            self.pos_embed = MultiSigmaStringPosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                num_features=pe_num_features,
+                init_sigmas=self.pe_init_sigmas,
+            )
+        else:
+            raise ValueError(
+                f"Unknown pe_kind '{pe_kind}'. Supported: sincos, string_multisigma."
+            )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -93,6 +93,12 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    model_pe: str = "sincos"
+    pe_num_features: int = 16
+    pe_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    optimizer: str = "adamw"
+    lion_beta1: float = 0.9
+    lion_beta2: float = 0.99
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -170,6 +176,14 @@ def set_optimizer_lr(optimizer: torch.optim.Optimizer, lr: float) -> None:
         param_group["lr"] = lr
 
 
+def parse_pe_init_sigmas(spec: str) -> list[float] | None:
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    sigmas = [float(s) for s in spec.split(",") if s.strip()]
+    return sigmas or None
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -178,6 +192,32 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
+        pe_kind=config.model_pe,
+        pe_num_features=config.pe_num_features,
+        pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+    )
+
+
+def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
+    optimizer_name = config.optimizer.lower()
+    if optimizer_name == "adamw":
+        return torch.optim.AdamW(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+    if optimizer_name == "lion":
+        from lion_pytorch import Lion
+
+        return Lion(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+    raise ValueError(
+        f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
     )
 
 
@@ -257,7 +297,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-        optimizer = torch.optim.AdamW(base_model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
@@ -278,6 +318,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_timeout_minutes=train_timeout_minutes,
             val_budget_minutes=val_budget_minutes,
         )
+        if state.is_main:
+            pe_class = type(base_model.pos_embed).__name__
+            run.config.update(
+                {
+                    "pe_class": pe_class,
+                    "pe_source_branch": (
+                        "origin/tay" if config.model_pe == "string_multisigma" else "n/a"
+                    ),
+                    "pe_source_sha": (
+                        "d97fb09" if config.model_pe == "string_multisigma" else "n/a"
+                    ),
+                    "pe_source_run_ki2q9ko9": (
+                        config.model_pe == "string_multisigma"
+                    ),
+                },
+                allow_val_change=True,
+            )
 
         output_dir = Path(config.output_dir) / f"run-{run.id}"
         output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Hypothesis

Replacing the default `ContinuousSincosEmbed` positional encoder with a **multi-sigma STRING log-frequency init** will improve the learned spectral geometry representation, specifically lowering volume pressure error and aggregate test error.

**Evidence base (W&B run `ki2q9ko9`, PR #488 + #511/#516 provenance fix):**
- Test aggregate 8.4791 — tied for then-best with `m9775k1v` (23.9 h run) after only 4.7 h.
- Test volume pressure 11.503 — **best single-model volume** in the entire research map (vs 12.051 for the tau-weighted SOTA `9mm3sz7x`).
- Validation slope -0.0548 per 1k steps at 4.7 h cutoff — strongly still descending. Under 24 h DDP8 this should converge much further.
- The matched-control analysis confirms STRING beats RFF/baseline positional encoding across all physics buckets (test 8.771 vs 10.721 for the same 4L/512 Lion stack).

**Provenance caveat (important):**
PR #488's reported idea was real as a W&B run (`ki2q9ko9`) but the merged code had provenance drift — multi-sigma STRING was only fully present in the branch after patches #511/#516. You must verify that the code you copy actually implements multi-sigma log-frequency STRING (not a plain sincos or single-sigma RFF). Run IDs and explicit configs are stronger evidence than PR prose.

**Single-model only, no ensembles.** One mechanism. One long run.

---

## Instructions

**Step 0 — Fetch reference branches and locate multi-sigma STRING code**

```bash
# In target/
git fetch origin tay:refs/remotes/origin/tay yi:refs/remotes/origin/yi bengio:refs/remotes/origin/bengio
# Also fetch the named alphonse branch that contains a reference multi-sigma STRING implementation
git fetch origin alphonse/multi-sigma-string-init:refs/remotes/origin/alphonse/multi-sigma-string-init

# Compare the model files to find STRING positional encoder:
git show origin/alphonse/multi-sigma-string-init:model.py | grep -n "STRING\|string\|sigma\|log_freq\|LogFreq\|separable" | head -40
git show origin/tay:model.py | grep -n "STRING\|string\|sigma\|log_freq\|LogFreq\|separable" | head -40
```

Locate the class that implements the multi-sigma STRING separable log-frequency positional encoder. It should:
- Learn multiple bandwidth sigmas (not a single fixed omega bank).
- Initialize frequencies in log space (not linearly or uniformly).
- Be separable across spatial dimensions (or axis-grouped).

Verify the W&B run config for `ki2q9ko9` to confirm the exact architecture:
```
W&B: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ki2q9ko9
```
Check the run's config tab. The architecture params, PE class name, and sigma initialization scheme must match what you copy.

**Step 1 — Copy minimal STRING encoder into `model.py`**

Copy only the positional encoder class (and any helper classes it depends on) from the reference branch into `model.py`. Do not import or wholesale merge the reference branch's entire model. Keep the existing `SurfaceTransolver` backbone structure; only swap the positional encoder.

Add a `model_pe` field to `Config` in `train.py` (choices: `sincos`, `string_multisigma`; default `sincos`):

```python
model_pe: str = "sincos"  # "sincos" | "string_multisigma"
```

In `build_model`, select the PE based on `config.model_pe`.

**Step 2 — Log the source provenance**

At the top of your training script or in the W&B run config, log:

```python
"pe_class": "<ClassName>",
"pe_source_branch": "alphonse/multi-sigma-string-init",  # or actual branch
"pe_source_sha": "<git SHA of the commit you copied from>",
```

This lets us verify the replication if results diverge from the reference.

**Step 3 — DDP8 smoke run (REQUIRED before long run)**

Run a 2-epoch smoke with DDP8 to verify: PE loads without shape errors, DDP init across 8 GPUs, W&B config logs `pe_class` and `pe_source_sha`, checkpoint saves, and the architecture-mismatch guard does not fire.

```bash
torchrun --nproc_per_node=8 train.py \
  --model-pe string_multisigma \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 200 \
  --epochs 2 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 50 \
  --wandb-group string-multisigma-ki2q9ko9-long \
  --wandb-name frieren-smoke-string-multisigma \
  --seed 42
```

Confirm no shape errors, no NaN in outputs, no nonfinite gradients. Confirm W&B config shows the right PE class.

**Step 4 — Long DDP8 run (only after smoke passes)**

```bash
torchrun --nproc_per_node=8 train.py \
  --model-pe string_multisigma \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 500 \
  --epochs 50 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 250 \
  --wandb-group string-multisigma-ki2q9ko9-long \
  --wandb-name frieren-string-multisigma-long \
  --seed 42
```

Let `SENPAI_TIMEOUT_MINUTES` govern the wall-clock ceiling (up to 1440 min / 24 h).

**Step 5 — Results comment**

Post a comment with:
- W&B run URL (smoke and long run)
- The PE class name, source branch, source SHA you used
- Table of all test_primary/* metrics (aggregate, surface, volume, wall, tau_x, tau_y, tau_z)
- Runtime and whether the run was still improving at cutoff (validation slope)
- Whether smoke passed
- Checkpoint selection rule

Then post the terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

---

## Baseline

**Current in-wave best:** none yet (wave just started — no merged single-model results on `drivaerml-long-20260504`).

**Pre-wave reference to beat:**

| Run | Mechanism | Test agg | Surface | Volume | Wall | tau_x / tau_y / tau_z |
|---|---|---:|---:|---:|---:|---|
| `ki2q9ko9` (target) | multi-sigma STRING log-freq init | 8.4791 | 4.449 | **11.503** | 8.139 | 7.090 / 9.066 / 10.282 |
| `9mm3sz7x` (wave SOTA ref) | tau_y=1.2/tau_z=1.3, lr=9e-5 | 8.1229 | 4.128 | 12.051 | 7.454 | 6.566 / 8.326 / 9.543 |

**AB-UPT targets (lower is better):**

| Metric | Target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |

**Goal:** Beat test aggregate 8.4791 from the censored `ki2q9ko9` reference, and specifically confirm that test volume pressure (11.503 in the reference) holds or improves under a full 24 h run. The volume metric is the key differentiator for this PR.

**Git SHA of advisor branch at assignment:** `1b3aca5` (`drivaerml-long-20260504` 2026-05-04)
**DDP world size:** 8
**Source provenance policy:** cite exact SHA of copied PE code; verify PE class matches `ki2q9ko9` W&B config before the long run.
