### PR TITLE
Long DDP8: EMA-proxy GradNorm α=0.5 + volume guard (wyz68o8r)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm",
     "wandb",
     "pyyaml",
+    "lion-pytorch",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ from typing import Iterable
 
 import numpy as np
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import wandb
 import yaml
@@ -52,6 +53,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     make_loaders,
     masked_mse,
+    masked_mse_per_channel,
     metric_namespace,
     parse_kill_thresholds,
     primary_metric_log,
@@ -118,6 +120,14 @@ class Config:
     seed: int = -1
     nonfinite_skip_abort: int = 200
     compile_model: bool = True
+    optimizer: str = "adamw"
+    lion_beta1: float = 0.9
+    lion_beta2: float = 0.99
+    gradnorm_alpha: float = 0.0
+    gradnorm_beta: float = 0.5
+    gradnorm_weight_min: float = 0.5
+    gradnorm_weight_max: float = 4.0
+    volume_guard_pct: float = 0.0
     debug: bool = False
 
 
@@ -181,6 +191,79 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
+    name = config.optimizer.lower()
+    if name == "adamw":
+        return torch.optim.AdamW(
+            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+        )
+    if name == "lion":
+        from lion_pytorch import Lion
+
+        return Lion(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+            betas=(config.lion_beta1, config.lion_beta2),
+            use_triton=False,
+        )
+    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+
+
+# Channel index convention shared with logging. Surface output has 4 channels:
+# [cp, tau_x, tau_y, tau_z]; volume output has 1 channel: [volume_p].
+GRADNORM_CHANNEL_NAMES = ("cp", "tau_x", "tau_y", "tau_z", "volume")
+
+
+class GradNormEMAWeighter:
+    """EMA-proxy GradNorm for per-channel loss weighting.
+
+    Tracks an EMA of each channel's gradient-norm proxy and updates per-channel
+    loss weights so that all channels learn at a similar rate. The 4 surface
+    channels share the surface_out gradient-norm proxy (so they receive
+    identical dynamic weights), and the volume channel uses the volume_out
+    gradient-norm proxy. Weights are clamped per-channel and renormalised so
+    sum(weights) = n_channels.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        alpha: float,
+        beta: float,
+        w_min: float = 0.5,
+        w_max: float = 4.0,
+    ):
+        self.alpha = alpha
+        self.beta = beta
+        self.w_min = w_min
+        self.w_max = w_max
+        self.n = n_channels
+        self.grad_norm_ema = [1.0] * n_channels
+        self.weights = [1.0] * n_channels
+        self.steps = 0
+
+    def update(self, grad_norms: list[float]) -> list[float]:
+        """Update the per-channel EMA and weights given current gradient norms."""
+        for i, gn in enumerate(grad_norms):
+            safe_gn = max(float(gn), 1e-8)
+            self.grad_norm_ema[i] = (
+                self.alpha * self.grad_norm_ema[i] + (1.0 - self.alpha) * safe_gn
+            )
+        mean_g = sum(self.grad_norm_ema) / self.n
+        new_weights = []
+        for i in range(self.n):
+            ratio = mean_g / max(self.grad_norm_ema[i], 1e-8)
+            new_w = self.weights[i] * (ratio ** self.beta)
+            new_w = max(self.w_min, min(self.w_max, new_w))
+            new_weights.append(new_w)
+        total = sum(new_weights)
+        if total > 0:
+            self.weights = [w * self.n / total for w in new_weights]
+        self.steps += 1
+        return self.weights
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -190,7 +273,17 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    channel_weights: list[float] | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
+    """Compute the weighted training loss.
+
+    When ``channel_weights`` is provided (length 5: cp, tau_x, tau_y, tau_z,
+    volume), the per-channel surface MSE losses and the volume MSE loss are
+    multiplied by these weights before being averaged into the final loss. The
+    surface contribution is averaged across the 4 surface channels so the
+    overall scale matches the unweighted (mean-of-channels) baseline when all
+    weights are 1.
+    """
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -201,10 +294,18 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_per_ch = masked_mse_per_channel(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )
+        surface_loss = surface_per_ch.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
-        weighted_volume_loss = volume_loss_weight * volume_loss
+        if channel_weights is not None:
+            cw = surface_per_ch.new_tensor(channel_weights)
+            weighted_surface_loss = surface_loss_weight * (surface_per_ch * cw[:4]).mean()
+            weighted_volume_loss = volume_loss_weight * cw[4] * volume_loss
+        else:
+            weighted_surface_loss = surface_loss_weight * surface_loss
+            weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
     return loss, {
@@ -213,7 +314,21 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "surface_loss_cp": float(surface_per_ch[0].detach().cpu().item()),
+        "surface_loss_tau_x": float(surface_per_ch[1].detach().cpu().item()),
+        "surface_loss_tau_y": float(surface_per_ch[2].detach().cpu().item()),
+        "surface_loss_tau_z": float(surface_per_ch[3].detach().cpu().item()),
     }
+
+
+def _module_grad_norm(module: nn.Module) -> float:
+    """Compute the L2 norm of all gradients in a module's parameters."""
+    total_sq = 0.0
+    for p in module.parameters():
+        if p.grad is None:
+            continue
+        total_sq += float(p.grad.detach().float().pow(2).sum().item())
+    return math.sqrt(total_sq)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -257,9 +372,23 @@ def main(argv: Iterable[str] | None = None) -> None:
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
-        optimizer = torch.optim.AdamW(base_model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+        weighter: GradNormEMAWeighter | None = None
+        if config.gradnorm_alpha > 0.0:
+            weighter = GradNormEMAWeighter(
+                n_channels=len(GRADNORM_CHANNEL_NAMES),
+                alpha=config.gradnorm_alpha,
+                beta=config.gradnorm_beta,
+                w_min=config.gradnorm_weight_min,
+                w_max=config.gradnorm_weight_max,
+            )
+            if state.is_main:
+                print(
+                    f"GradNormEMA: alpha={config.gradnorm_alpha} beta={config.gradnorm_beta} "
+                    f"clamp=[{config.gradnorm_weight_min}, {config.gradnorm_weight_max}]"
+                )
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
         if kill_thresholds and state.is_main:
             print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
@@ -321,6 +450,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                channel_weights = list(weighter.weights) if weighter is not None else None
                 loss, batch_loss_metrics = train_loss(
                     model,
                     batch,
@@ -329,6 +459,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    channel_weights=channel_weights,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -367,6 +498,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/surface_loss_cp": batch_loss_metrics["surface_loss_cp"],
+                            "train/surface_loss_tau_x": batch_loss_metrics["surface_loss_tau_x"],
+                            "train/surface_loss_tau_y": batch_loss_metrics["surface_loss_tau_y"],
+                            "train/surface_loss_tau_z": batch_loss_metrics["surface_loss_tau_z"],
                         }
                     )
 
@@ -374,6 +509,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
+                    surface_grad_norm = volume_grad_norm = 0.0
+                    if weighter is not None:
+                        surface_grad_norm = _module_grad_norm(base_model.surface_out)
+                        volume_grad_norm = _module_grad_norm(base_model.volume_out)
+                        if state.enabled:
+                            grad_norm_buf = torch.tensor(
+                                [surface_grad_norm, volume_grad_norm],
+                                device=device,
+                                dtype=torch.float32,
+                            )
+                            dist.all_reduce(grad_norm_buf, op=dist.ReduceOp.AVG)
+                            surface_grad_norm = float(grad_norm_buf[0].item())
+                            volume_grad_norm = float(grad_norm_buf[1].item())
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
                             base_model.parameters(),
@@ -411,6 +559,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if skip_step:
                         optimizer.zero_grad(set_to_none=True)
                     else:
+                        if weighter is not None:
+                            weighter.update([
+                                surface_grad_norm,
+                                surface_grad_norm,
+                                surface_grad_norm,
+                                surface_grad_norm,
+                                volume_grad_norm,
+                            ])
                         set_optimizer_lr(optimizer, current_lr)
                         optimizer.step()
                         if ema is not None:
@@ -427,6 +583,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        if weighter is not None:
+                            train_log.update(
+                                {
+                                    "train/gradnorm_w_cp": weighter.weights[0],
+                                    "train/gradnorm_w_tau_x": weighter.weights[1],
+                                    "train/gradnorm_w_tau_y": weighter.weights[2],
+                                    "train/gradnorm_w_tau_z": weighter.weights[3],
+                                    "train/gradnorm_w_volume": weighter.weights[4],
+                                    "train/gradnorm_ema_surface": weighter.grad_norm_ema[0],
+                                    "train/gradnorm_ema_volume": weighter.grad_norm_ema[4],
+                                    "train/gradnorm_grad_surface": surface_grad_norm,
+                                    "train/gradnorm_grad_volume": volume_grad_norm,
+                                }
+                            )
 
                 if skip_step:
                     nonfinite_skip_count += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -831,6 +831,16 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_mse_per_channel(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """MSE per output channel [C]; pred/target: [B, N, C], mask: [B, N]."""
+    sq = (pred - target).square()
+    mask_f = mask.unsqueeze(-1).to(dtype=sq.dtype, device=sq.device)
+    n_valid = mask_f.expand_as(sq).sum(dim=(0, 1))
+    return (sq * mask_f).sum(dim=(0, 1)) / n_valid.clamp_min(1.0)
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

An EMA-proxy GradNorm dynamic loss weighting scheme (α=0.5) — where per-channel loss weights are updated based on an exponential moving average of each channel's gradient norm relative to the target rate — will improve tau_y and tau_z compared to fixed weighting, while a **volume guard** prevents the typical volume-pressure regression seen in alpha=0.75/1.0 variants.

**Evidence base (W&B run `wyz68o8r`, PR #523, prior wave):**
- Test aggregate 8.2355 — strong single-model result, better than the static `9mm3sz7x` (8.1229) on tau_x (6.556 vs 6.566) but worse on tau_y (8.466 vs 8.326).
- Validation slope -0.0148 per 1k steps at 4.7 h — still descending at cutoff.
- Gradient forensics: stable operation with surface_out median 0.240, volume_out median 0.152; early clip, final unclipped; no nonfinite gradients. Bounded and healthier than alpha=1.0 (`341czkol`).

**Why α=0.5 and not α=0.75/1.0:**
The map compares three alphas:
- `wyz68o8r` α=0.5: test 8.2355, volume 12.213, **stable allocation**
- `glir84cj` α=0.75: test 8.2169, volume 12.335, more surface emphasis
- `341czkol` α=1.0: best tau_y 8.305 but volume 12.407 — worse test aggregate

The research directive explicitly flags volume guards as required because GradNorm-style tau wins "trade against volume and need a volume guard." α=0.5 is the most conservative point; this PR uses an explicit failure threshold to catch any volume regression early.

**Key distinction from PR #598 (fern):** fern tests *static* per-channel weights at fixed values (y=1.2/z=1.3). This PR tests *dynamic* weights that adapt based on actual gradient behaviour during training. These two PRs together give us: is the tau-channel weighting direction best served statically or dynamically?

**Single-model only, no ensembles.** One mechanism. One long run.

---

## Instructions

**Step 0 — No external branch copies required for core mechanism**

The EMA-proxy GradNorm is implemented as a stateful callback in `train.py`, not a separate external module. You may inspect the `yi`/`tay`/`bengio` branches for reference implementations:

```bash
git fetch origin tay:refs/remotes/origin/tay yi:refs/remotes/origin/yi
git show origin/tay:train.py | grep -n -A20 "GradNorm\|gradnorm\|ema.*weight\|loss_weight.*ema"
```

But implement it in `train.py` on `main` from scratch — the mechanism is simple enough to audit.

Also: fetch and copy the Lion optimizer from `tay`/`yi` as described in PR #598.

**Step 1 — EMA-proxy GradNorm: concept**

Standard GradNorm is too expensive in this loop (requires multiple autograd backward passes). The proxy version uses a single backward per step and approximates the gradient norms using an EMA:

For each task channel `i` (surface_p, tau_x, tau_y, tau_z, volume_p):
1. After backward, read the gradient norm of the shared trunk with respect to channel `i`'s contribution. In practice, approximate this with the **total surface output gradient norm** for the surface channels and the **total volume output gradient norm** for the volume channel.
2. Maintain an EMA of each channel's gradient norm: `G_i(t) = α * G_i(t−1) + (1−α) * ||grad_i(t)||`.
3. Set the target rate `r_i` = the desired relative gradient norm for channel `i` (default: equal weight = 1.0 for all channels).
4. Update loss weight: `w_i(t) ← w_i(t−1) * (r_i * mean_G / G_i(t))^β`, clamped to `[0.5, 4.0]`.
5. Renormalize: `w_i ← w_i * C / sum(w_j)` where `C` is the number of channels (5), so total weight stays fixed.

Use `α=0.5` (EMA decay for gradient norms) and `β=0.5` (adaptation rate for the weight update — controls how strongly the weights respond to gradient imbalance).

The current `train_loss` function aggregates all surface channels into one MSE. To implement per-channel dynamic weights, you first need per-channel MSE losses. Follow the same pattern as PR #598 (fern): add `masked_mse_per_channel` to `trainer_runtime.py` and use it here.

**Step 2 — Add config fields**

In `Config` in `train.py`, add:

```python
gradnorm_alpha: float = 0.0      # EMA decay for gradient norm tracking; 0.0 = disabled
gradnorm_beta: float = 0.5       # Weight update responsiveness
gradnorm_weight_min: float = 0.5  # Minimum loss weight per channel
gradnorm_weight_max: float = 4.0  # Maximum loss weight per channel
volume_guard_pct: float = 0.0     # Kill if test volume > (reference + volume_guard_pct). 0=disabled
```

**Step 3 — Add `GradNormEMAWeighter` class**

Add a stateful class in `train.py`:

```python
class GradNormEMAWeighter:
    """EMA-proxy GradNorm for per-channel loss weighting."""

    def __init__(self, n_channels: int, alpha: float, beta: float,
                 w_min: float = 0.5, w_max: float = 4.0):
        self.alpha = alpha
        self.beta = beta
        self.w_min = w_min
        self.w_max = w_max
        self.n = n_channels
        # Running EMA of gradient norms, one per channel
        self.grad_norm_ema = [1.0] * n_channels
        # Current loss weights (start at 1.0 for all)
        self.weights = [1.0] * n_channels

    def update(self, grad_norms: list[float]) -> list[float]:
        """Call after backward() with the gradient norm estimate for each channel.
        Returns updated loss weights (normalized so they sum to n_channels)."""
        # Update EMA
        for i, gn in enumerate(grad_norms):
            self.grad_norm_ema[i] = self.alpha * self.grad_norm_ema[i] + (1 - self.alpha) * max(gn, 1e-8)
        mean_g = sum(self.grad_norm_ema) / self.n
        # Update weights
        new_weights = []
        for i in range(self.n):
            ratio = mean_g / self.grad_norm_ema[i]
            new_w = self.weights[i] * (ratio ** self.beta)
            new_w = max(self.w_min, min(self.w_max, new_w))
            new_weights.append(new_w)
        # Renormalize so sum = n_channels
        total = sum(new_weights)
        self.weights = [w * self.n / total for w in new_weights]
        return self.weights
```

**Step 4 — Compute per-channel losses and integrate weighter into training loop**

The surface output has 4 channels: ch0=cp, ch1=tau_x, ch2=tau_y, ch3=tau_z. Use `masked_mse_per_channel` to get per-channel losses.

After `loss.backward()`, read gradient norms for each channel's contribution. Because exact per-channel backward is expensive, use the following approximation:
- For the 4 surface channels: use `surface_out` module gradient norm (same for all 4 channels) as the proxy. This is a simplification but keeps the code to one backward call.
- For the volume channel: use `volume_out` module gradient norm.

Log the dynamic weights and per-channel gradient norm EMAs each step so the advisor can audit the allocation:

```python
"train/gradnorm_w_cp": weighter.weights[0],
"train/gradnorm_w_tau_x": weighter.weights[1],
"train/gradnorm_w_tau_y": weighter.weights[2],
"train/gradnorm_w_tau_z": weighter.weights[3],
"train/gradnorm_w_volume": weighter.weights[4],
"train/gradnorm_ema_surface": weighter.grad_norm_ema[0],  # surface proxy
"train/gradnorm_ema_volume": weighter.grad_norm_ema[4],   # volume proxy
```

**Step 5 — Volume guard via kill threshold**

After the long run completes its first validation pass (around step 500), check if test volume is tracking toward regression. The map's reference `9mm3sz7x` had test volume 12.051. A regression past 13.0 is a signal that the volume guard should activate.

Use the built-in `--kill-thresholds` mechanism — but only for validation proxies during training:

```bash
--kill-thresholds "5000:val_primary/abupt_axis_mean_rel_l2_pct>15"
```

This is a conservative stability guard (not a tight volume guard). You can add a custom volume guard: if `full_val_primary/volume_pressure_rel_l2_pct > 13.5` after the first full validation, log a warning and consider early stopping. But do not hard-kill on the validation volume alone — wait for test evidence.

**Step 6 — DDP8 smoke run (REQUIRED before long run)**

```bash
torchrun --nproc_per_node=8 train.py \
  --gradnorm-alpha 0.5 \
  --gradnorm-beta 0.5 \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 200 \
  --epochs 2 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 50 \
  --wandb-group gradnorm-ema-alpha05-wyz68o8r-long \
  --wandb-name tanjiro-smoke-gradnorm-ema05 \
  --kill-thresholds "300:val_primary/abupt_axis_mean_rel_l2_pct>15" \
  --seed 42
```

Confirm: `train/gradnorm_w_tau_y`, `train/gradnorm_w_tau_z`, `train/gradnorm_ema_surface`, `train/gradnorm_ema_volume` appear in W&B. Confirm weights start at 1.0 and begin to adapt by step 50. Confirm no nonfinite gradients. Confirm checkpoint saved.

**Step 7 — Long DDP8 run (only after smoke passes)**

```bash
torchrun --nproc_per_node=8 train.py \
  --gradnorm-alpha 0.5 \
  --gradnorm-beta 0.5 \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 500 \
  --epochs 50 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --gradient-log-every 250 \
  --wandb-group gradnorm-ema-alpha05-wyz68o8r-long \
  --wandb-name tanjiro-gradnorm-ema05-long \
  --kill-thresholds "5000:val_primary/abupt_axis_mean_rel_l2_pct>15" \
  --seed 42
```

Let `SENPAI_TIMEOUT_MINUTES` govern the wall-clock ceiling (up to 1440 min / 24 h).

**Step 8 — Results comment**

Post a comment with:
- W&B run URL (smoke and long run)
- A chart or table of `gradnorm_w_tau_y` and `gradnorm_w_tau_z` over training (show the allocation actually moved)
- Table of all test_primary/* metrics (aggregate, surface, volume, wall, tau_x, tau_y, tau_z)
- Runtime and whether the run was still improving at cutoff (validation slope)
- Whether smoke passed
- Whether the volume guard triggered

Then post the terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

---

## Baseline

**Current in-wave best:** none yet (wave just started — no merged single-model results on `drivaerml-long-20260504`).

**Pre-wave reference to beat:**

| Run | Mechanism | Test agg | Surface | Volume | Wall | tau_x / tau_y / tau_z |
|---|---|---:|---:|---:|---:|---|
| `wyz68o8r` (target) | EMA-proxy GradNorm α=0.5 | 8.2355 | 4.271 | 12.213 | 7.504 | 6.556 / **8.466** / 9.672 |
| `9mm3sz7x` (wave SOTA ref) | tau_y=1.2/tau_z=1.3 static | **8.1229** | 4.128 | 12.051 | 7.454 | 6.566 / 8.326 / 9.543 |
| `341czkol` (α=1.0 ref) | GradNorm α=1.0 | 8.2433 | 4.221 | 12.407 | 7.532 | 6.695 / **8.305** / 9.589 |

**AB-UPT targets (lower is better):**

| Metric | Target |
|---|---:|
| `test_primary/surface_pressure_rel_l2_pct` | 3.82 |
| `test_primary/wall_shear_rel_l2_pct` | 7.29 |
| `test_primary/volume_pressure_rel_l2_pct` | 6.08 |
| `test_primary/wall_shear_x_rel_l2_pct` | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 3.63 |

**Goal:** Beat test aggregate 8.2355 from the censored `wyz68o8r` reference. The volume guard must confirm test volume stays near 12.2 (not regressing toward 12.4 like `341czkol`). This is the dynamic-weighting foil to PR #598 (static weights at y=1.2/z=1.3).

**Git SHA of advisor branch at assignment:** `1b3aca5` (`drivaerml-long-20260504` 2026-05-04)
**DDP world size:** 8
**Source provenance:** no external branch copies needed for core mechanism; Lion can be copied from `tay`/`yi`.
