### PR TITLE
EMA decay sweep {0.9993, 0.9997, 0.9999} on SOTA stack

### DIFF
--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1410,6 +1410,7 @@ def init_wandb_run(
             "val_budget_minutes": val_budget_minutes,
         },
         mode=os.environ.get("WANDB_MODE", "online"),
+        settings=wandb.Settings(init_timeout=300),
     )
     define_wandb_metrics()
     return run


### PR DESCRIPTION
## Hypothesis

The current SOTA (PR #571) uses `--ema-decay 0.999`. EMA is a form of implicit model averaging — a higher decay means more historical averaging, while a lower decay means faster adaptation to recent gradient updates. The optimal EMA decay depends on learning rate, batch size, and model dynamics, and **0.999 has never been swept** on the current SOTA stack.

We hypothesize that slightly higher decay values (0.9993–0.9999) may yield better-smoothed checkpoints with lower val_abupt, particularly for the high-frequency tau_y/tau_z channels that currently show the largest residual error. This is a low-risk, orthogonal, and potentially high-impact hyperparameter sweep.

**Reference:** "Polyak-Ruppert averaging" (Polyak & Juditsky 1992), "Stochastic Weight Averaging" (Izmailov et al. 2018) — EMA decay equivalently controls the effective window size: window ≈ 1/(1−α).

At α=0.999: window ≈ 1000 steps
At α=0.9993: window ≈ 1429 steps  
At α=0.9997: window ≈ 3333 steps
At α=0.9999: window ≈ 10000 steps

## Instructions

Run **3 arms** using `--wandb_group tanjiro-ema-decay-sweep` so all runs are grouped in W&B:

**Arm A: EMA decay = 0.9993**
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.9993 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13 \
  --wandb-group tanjiro-ema-decay-sweep \
  --wandb-name tanjiro/ema-decay-0.9993
```

**Arm B: EMA decay = 0.9997**
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  [same flags as above, except:] \
  --ema-decay 0.9997 \
  --wandb-name tanjiro/ema-decay-0.9997
```

**Arm C: EMA decay = 0.9999**
```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  [same flags as above, except:] \
  --ema-decay 0.9999 \
  --wandb-name tanjiro/ema-decay-0.9999
```

Run all three arms sequentially. Report results for all arms.

## Baseline

### Single-Model SOTA (PR #571, askeladd, EMA decay=0.999)
- **val_abupt = 6.7644%** | **test_abupt = 8.171%**
- surface_pressure: 4.455% | tau_x: ~6.7% | tau_y: 8.489% | tau_z: 9.997% | volume_pressure: 4.249%
- W&B run: `nh96x7m4` (group `askeladd-tau-sweep`)

### Gate to beat
- **val_abupt < 6.7644%** with all primary channel metrics non-NaN

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

**Note:** `--no-compile-model` is required — torch.compile + DDP causes NCCL deadlock at step 1.
