### PR TITLE
Long DDP8: volume-loss upweight x2.0 (direct volume-pressure gap attack)

### DIFF
--- a/experiments/nezuko-volume-loss-upweight.md
+++ b/experiments/nezuko-volume-loss-upweight.md
@@ -1,0 +1,2 @@
+# Volume Loss Upweight Experiment
+Assigned to nezuko pod kn2rs. See PR body for full config.


### PR DESCRIPTION
## Hypothesis

The volume-pressure channel is our worst gap vs. AB-UPT: best pre-wave run `ki2q9ko9` achieved **11.503%** (target: 6.08%, a 5.4 pp gap). All previous loss-weighting experiments focused on surface (`qqtdnlwq`: `--surface-loss-weight 2.0`) or per-axis tau components — **no run has tried directly upweighting the volume loss**.

Mirror signal from `qqtdnlwq`: raising surface weight to 2.0 caused volume pressure to *worsen* (12.105 vs 12.051 reference). The inverse predicts that upweighting volume loss should pull gradient capacity toward the volume channels. This is the most direct and untested lever for the volume-pressure gap.

Proposed mechanism: `--volume-loss-weight 2.0`

No code changes needed — `--volume-loss-weight` is a native CLI flag in `train.py`.

---

## Current baselines (pre-wave, single-model)

| Metric | Best pre-wave | AB-UPT target |
|--------|-------------|---------------|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **8.123** (`9mm3sz7x`) | — |
| `test_primary/surface_pressure_rel_l2_pct` | 4.128 | 3.82 |
| `test_primary/volume_pressure_rel_l2_pct` | **11.503** (`ki2q9ko9`) | **6.08** |
| `test_primary/wall_shear_rel_l2_pct` | 7.454 | 7.29 |
| `test_primary/wall_shear_x_rel_l2_pct` | 6.566 | 5.35 |
| `test_primary/wall_shear_y_rel_l2_pct` | 8.326 | 3.65 |
| `test_primary/wall_shear_z_rel_l2_pct` | 9.531 | 3.63 |

---

## Phase 1 — Smoke run (2 epochs, confirm no divergence)

```bash
torchrun --nproc_per_node=8 train.py \
  --wandb_group nezuko-vol-upweight \
  --lr 9e-5 \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --grad-clip-norm 0.5 \
  --no-compile-model \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 16384 \
  --eval-volume-points 16384 \
  --epochs 2 \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<50"
```

Gate: epoch 2 val `abupt_axis_mean` < 50%. If it diverges or exceeds 50%, stop and report — do not proceed to long run.

---

## Phase 2 — Long run (50 epochs, DDP8)

If smoke passes:

```bash
torchrun --nproc_per_node=8 train.py \
  --wandb_group nezuko-vol-upweight \
  --lr 9e-5 \
  --volume-loss-weight 2.0 \
  --batch-size 4 \
  --grad-clip-norm 0.5 \
  --no-compile-model \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 16384 \
  --eval-volume-points 16384 \
  --lr-warmup-steps 500 \
  --lr-cosine-t-max 50 \
  --epochs 50 \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<50"
```

---

## Optional Arm B — Combined surface + volume upweight

If the primary run shows volume improving but surface regressing, try as a second arm:

```bash
# Same as long run above, plus:
  --surface-loss-weight 1.5 \
  --volume-loss-weight 2.0
```

This tests whether balanced dual upweighting recovers surface without sacrificing volume gains.

---

## Checkpoint gates

| CKP | Steps | Action |
|-----|-------|--------|
| CKP1 | ~5,494 | Report val metrics; kill if `abupt_axis_mean` > 50% |
| CKP2 | ~10,988 | Report; kill if > 40% |
| CKP3 | ~16,482 | Report; kill if > 30% |
| CKP4 | ~21,976 | Report; kill if not trending below 15% |
| CKP5 | ~27,470 | Report; kill if not trending below 12% |
| CKP6 | ~32,964 | Report; primary gate — kill if > 9% |
| CKP7 | ~38,458 | Report; SOTA gate — mark terminal if < 8.123% |
| Final | epoch 50 | Full metrics; post terminal SENPAI-RESULT |

---

## Results template

After each checkpoint, please report:

```
CKP<N> — step <X>, epoch <E>
val_primary/abupt_axis_mean_rel_l2_pct: X.XXXX
val_primary/surface_pressure_rel_l2_pct: X.XXXX
val_primary/volume_pressure_rel_l2_pct: X.XXXX
val_primary/wall_shear_rel_l2_pct: X.XXXX
W&B run: <run-id>
```

---

## Terminal result format

When training completes (or you decide to terminate early with a final result), post:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

If Arm B is also run, include both run IDs and report both in a table.

---

## Key implementation notes

- `--no-compile-model` is **required** — torch.compile causes NCCL ALLREDUCE deadlocks under bs=4 DDP8
- Use `--batch-size 4` (not 2) with Lion-equivalent lr scaling at `9e-5`
- `--volume-loss-weight` is a native flag; **no code changes needed**
- `--wandb_group nezuko-vol-upweight` groups smoke and long run together in W&B