### PR TITLE
GNN EdgeConv surface pre-encoder for local τ_y/τ_z aggregation

### DIFF
--- a/train.py
+++ b/train.py
@@ -848,6 +848,107 @@ class Transformer(nn.Module):
         return x
 
 
+class EdgeConvBlock(nn.Module):
+    """Dynamic-EdgeConv (DGCNN-style) message-passing pre-encoder.
+
+    Builds a k-NN graph on the surface point cloud using XYZ coordinates and
+    aggregates edge features cat(h_i, h_j - h_i) through a 2-layer MLP with
+    LayerNorm + GELU, max-pooled across the k neighbours. Produces a per-point
+    feature update of the same dimensionality as the input so it can be added
+    as a residual to the raw surface features before the Transolver encoder.
+
+    Padding is masked so padded points are never selected as neighbours and
+    receive zero output. The final Linear is zero-initialised so the block is
+    identity at training start (residual-safe).
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        k: int = 16,
+        knn_chunk: int = 8192,
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.k = k
+        self.knn_chunk = knn_chunk
+        self.mlp = nn.Sequential(
+            nn.Linear(2 * in_dim, out_dim),
+            nn.LayerNorm(out_dim),
+            nn.GELU(),
+            nn.Linear(out_dim, out_dim),
+            nn.LayerNorm(out_dim),
+            nn.GELU(),
+        )
+        nn.init.trunc_normal_(self.mlp[0].weight, std=0.02)
+        nn.init.zeros_(self.mlp[0].bias)
+        nn.init.zeros_(self.mlp[3].weight)
+        nn.init.zeros_(self.mlp[3].bias)
+
+    @torch.no_grad()
+    def _build_knn(
+        self,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Chunked k-NN over XYZ. Padded rows are excluded as candidates and
+        self-loops are removed. Returns int64 indices of shape [B, N, k].
+        """
+        B, N, _ = coords.shape
+        coords_f = coords.float()
+        all_idx: list[torch.Tensor] = []
+        for b in range(B):
+            pts = coords_f[b]  # [N, 3]
+            pad_mask = ~mask[b].bool() if mask is not None else None  # True = padded
+            chunks: list[torch.Tensor] = []
+            for i in range(0, N, self.knn_chunk):
+                seg = pts[i : i + self.knn_chunk]
+                d = torch.cdist(
+                    seg, pts, compute_mode="use_mm_for_euclid_dist"
+                )  # [chunk_i, N]
+                if pad_mask is not None:
+                    d.masked_fill_(pad_mask.unsqueeze(0), float("inf"))
+                rows = torch.arange(seg.shape[0], device=coords.device)
+                d[rows, rows + i] = float("inf")
+                _, idx = d.topk(self.k, dim=-1, largest=False)
+                chunks.append(idx)
+            all_idx.append(torch.cat(chunks, dim=0))  # [N, k]
+        return torch.stack(all_idx, dim=0)  # [B, N, k]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, C = x.shape
+        if C < 3:
+            raise ValueError(
+                f"EdgeConvBlock expects first 3 input dims to be XYZ; got C={C}"
+            )
+        if N == 0:
+            # No real points to process. Run a dummy forward through the MLP so
+            # all params participate in the autograd graph: keeps DDP happy
+            # without enabling find_unused_parameters when other ranks have N>0.
+            dummy_in = x.new_zeros(1, 1, 2 * C)
+            dummy_out = self.mlp(dummy_in)
+            return x.new_zeros(B, 0, self.out_dim) + 0.0 * dummy_out.sum()
+        coords = x[:, :, :3]
+        knn_idx = self._build_knn(coords, mask)  # [B, N, k]
+        batch_idx = (
+            torch.arange(B, device=x.device).view(B, 1, 1).expand(B, N, self.k)
+        )
+        x_j = x[batch_idx, knn_idx]  # [B, N, k, C]
+        x_i = x.unsqueeze(2).expand(-1, -1, self.k, -1)  # [B, N, k, C]
+        edge_feat = torch.cat([x_i, x_j - x_i], dim=-1)  # [B, N, k, 2C]
+        h = self.mlp(edge_feat)  # [B, N, k, out_dim]
+        out = h.amax(dim=2)  # [B, N, out_dim]
+        if mask is not None:
+            out = out * mask.to(dtype=out.dtype).unsqueeze(-1)
+        return out
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -871,6 +972,8 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        gnn_surface_preenc: str = "none",
+        gnn_k: int = 16,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -885,6 +988,22 @@ class SurfaceTransolver(nn.Module):
         self.pos_max_wavelength = pos_max_wavelength
         self.learnable_pe = learnable_pe
         self.beta_nll = beta_nll
+        self.gnn_surface_preenc = gnn_surface_preenc
+        self.gnn_k = gnn_k
+
+        if gnn_surface_preenc == "edgeconv":
+            self.gnn_preenc = EdgeConvBlock(
+                in_dim=surface_input_dim,
+                out_dim=surface_input_dim,
+                k=gnn_k,
+            )
+        elif gnn_surface_preenc == "none":
+            self.gnn_preenc = None
+        else:
+            raise ValueError(
+                f"Unknown gnn_surface_preenc={gnn_surface_preenc!r}; "
+                f"supported: 'none', 'edgeconv'"
+            )
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -964,6 +1083,9 @@ class SurfaceTransolver(nn.Module):
         masks: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
+
+        if surface_x is not None and self.gnn_preenc is not None:
+            surface_x = surface_x + self.gnn_preenc(surface_x, surface_mask)
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
@@ -1158,6 +1280,8 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    gnn_surface_preenc: str = "none"
+    gnn_k: int = 16
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1365,6 +1489,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        gnn_surface_preenc=config.gnn_surface_preenc,
+        gnn_k=config.gnn_k,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The Transolver backbone treats all surface points as an unstructured set — slice-token attention provides global interaction but ignores local topology. The τ_y and τ_z wall-shear channels are strongly controlled by boundary-layer structure, which is inherently **local and anisotropic**. A k-NN graph message-passing encoder running on the surface point cloud, before feeding into the Transolver, should propagate local flow-gradient signals across nearby neighbours, giving the model geometry-aware local receptive fields it currently lacks.

The dominant open gaps on yi are **τ_y (2.35× AB-UPT)** and **τ_z (2.73× AB-UPT)**. Both are shear-stress channels dominated by near-wall boundary layer behaviour. No current WIP PR attacks this with explicit local neighbourhood aggregation.

Mechanistic reasoning: current input features `[x, y, z, nx, ny, nz, area]` give each surface point its own normal and area — but no information about adjacent points' curvature changes or shear gradients. Message-passing with `k=16` neighbours (Euclidean) passes those differences as edge features, directly encoding local τ gradients without any architectural changes to the Transolver layers.

References:
- PointNet++: deep hierarchical feature learning on point sets (Qi et al., NeurIPS 2017)  
- DynamicEdgeConv (DGCNN, Wang et al., ACM TOG 2019)  
- SPConv: sparse 3D surface convolutions for aerodynamics (used in AB-UPT)

## Instructions

Add a lightweight GNN message-passing pre-encoder that processes surface points before the Transolver surface encoder. Implement this in `train.py` as a new option (`--gnn-surface-preenc {none,edgeconv}`, default `none` = exact current behaviour).

### Step 1 — Add k-NN edge convolution to `train.py`

Add the following class near the top of `train.py` (after imports):

```python
import torch
import torch.nn as nn

class EdgeConvBlock(nn.Module):
    """
    Dynamic EdgeConv (DGCNN-style) message-passing block.
    Aggregates features from k nearest neighbours on the surface.
    Edge features: cat(h_i, h_j - h_i) -> MLP -> max-pool over neighbours.
    """
    def __init__(self, in_dim: int, out_dim: int, k: int = 16):
        super().__init__()
        self.k = k
        self.mlp = nn.Sequential(
            nn.Linear(2 * in_dim, out_dim),
            nn.LayerNorm(out_dim),
            nn.GELU(),
            nn.Linear(out_dim, out_dim),
            nn.LayerNorm(out_dim),
            nn.GELU(),
        )

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        """
        x: (B, N, C) — surface point features
        returns: (B, N, out_dim)
        """
        B, N, C = x.shape
        # Build kNN graph using pairwise distances (chunked to avoid OOM)
        chunk = 2048
        knn_idx = []
        for b in range(B):
            dists = []
            pts = x[b]  # (N, C)
            for i in range(0, N, chunk):
                seg = pts[i:i+chunk]  # (chunk, C)
                d = torch.cdist(seg, pts)  # (chunk, N)
                dists.append(d)
            dists = torch.cat(dists, dim=0)  # (N, N)
            _, idx = dists.topk(self.k + 1, dim=-1, largest=False)  # exclude self
            knn_idx.append(idx[:, 1:])  # (N, k)
        knn_idx = torch.stack(knn_idx, dim=0)  # (B, N, k)

        # Gather neighbour features
        idx_flat = knn_idx.reshape(B, -1)  # (B, N*k)
        x_j = torch.gather(
            x.unsqueeze(2).expand(-1, -1, N, -1),
            2,
            knn_idx.unsqueeze(-1).expand(-1, -1, -1, C)
        )  # (B, N, k, C)

        x_i = x.unsqueeze(2).expand_as(x_j)  # (B, N, k, C)
        edge_feat = torch.cat([x_i, x_j - x_i], dim=-1)  # (B, N, k, 2C)
        # MLP + max-pool
        out = self.mlp(edge_feat)  # (B, N, k, out_dim)
        out = out.max(dim=2).values  # (B, N, out_dim)
        return out
```

**NOTE on the gather:** The indexing above may be slow for N=65536. Use a simpler direct index:

```python
        x_j = x[
            torch.arange(B, device=x.device)[:, None, None],
            knn_idx,
        ]  # (B, N, k, C) — cleaner and faster
```

### Step 2 — Wire into the model

Add a CLI flag:
```python
parser.add_argument('--gnn-surface-preenc', type=str, default='none',
                    choices=['none', 'edgeconv'],
                    help='GNN pre-encoder for surface points before Transolver')
parser.add_argument('--gnn-k', type=int, default=16,
                    help='k for kNN graph in GNN surface pre-encoder')
```

Instantiate conditionally in model setup:
```python
if args.gnn_surface_preenc == 'edgeconv':
    gnn_preenc = EdgeConvBlock(
        in_dim=surface_input_dim,   # 7 (or 9 with curvatures)
        out_dim=surface_input_dim,  # keep same dim for residual add
        k=args.gnn_k,
    ).to(device)
    # Wrap with DDP if using DDP
    if use_ddp:
        gnn_preenc = torch.nn.parallel.DistributedDataParallel(gnn_preenc, device_ids=[local_rank])
else:
    gnn_preenc = None
```

In the training loop, apply before the surface encoder:
```python
if gnn_preenc is not None:
    # surface_pts: (B, N_surf, C_surf) — apply GNN pre-enc then add residual
    surface_enhanced = gnn_preenc(surface_pts)
    surface_pts = surface_pts + surface_enhanced  # residual connection
```

Ensure the `gnn_preenc` parameters are included in the optimizer parameter group and EMA state.

### Step 3 — Arm A (screening run, 3 epochs)

Run the standard 3-epoch screening config with GNN pre-encoder enabled:

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent norman \
  --wandb_group norman-round34-gnn-surface-preenc \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --clip-grad-norm 0.5 --no-compile-model --learnable-pe \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --gnn-surface-preenc edgeconv --gnn-k 16
```

Target: val_abupt < 9.032% (yi merge bar) within 3 epochs.

**OOM note:** k-NN on 65536 surface points with k=16 uses chunked cdist (chunk_size=2048 already in the EdgeConvBlock above). If OOM still occurs, reduce `--gnn-k 8` or add `--train-surface-points 32768 --eval-surface-points 32768`.

### Step 4 — If Arm A passes screening (<9.032%), run Arm B full-budget

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent norman \
  --wandb_group norman-round34-gnn-surface-preenc \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --clip-grad-norm 0.5 --no-compile-model --learnable-pe \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --gnn-surface-preenc edgeconv --gnn-k 16
```

(Same config — let SENPAI_MAX_EPOCHS/SENPAI_TIMEOUT_MINUTES from env control the full budget.)

## Baseline

**Current yi merge bar: val_abupt 9.032%** (PR #517, askeladd, W&B run `brat65z4`)

| Metric | yi SOTA (val, PR #517) | tay SOTA (test, PR #511) | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **9.032** | 8.313 | — |
| `surface_pressure_rel_l2_pct` | 5.702 | 4.271 | 3.82 |
| `wall_shear_rel_l2_pct` | 10.257 | 7.786 | 7.29 |
| `volume_pressure_rel_l2_pct` | 5.075 | 11.867 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 12.907 | 8.582 | 3.65 (**2.35×**) |
| `wall_shear_z_rel_l2_pct` | 12.957 | 9.927 | 3.63 (**2.73×**) |

**To beat: val_abupt < 9.032%**

Terminal results must include:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
