### PR TITLE
Sparse MoE on Transolver slice-token FF layers (E=4, E=8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,6 +28,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.utils.checkpoint
 import wandb
 import yaml
 from torch import Tensor
@@ -743,18 +744,20 @@ class SparseMoE(nn.Module):
             dispatch_dtype = x_flat.dtype
         x_flat_disp = x_flat.to(dtype=dispatch_dtype)
         weights_disp = topk_weights.to(dtype=dispatch_dtype)
-        out_flat = torch.zeros_like(x_flat_disp)
-        # Always call every expert (even with empty input) so DDP keeps every
-        # expert's parameters in the autograd graph and find_unused_parameters
-        # is not required. Use in-place index_add_ to avoid allocating E
-        # intermediate (T, D) tensors that backward would otherwise hold.
-        for e in range(self.num_experts):
-            mask = topk_idx == e  # (T, k) bool
-            token_idx, slot_idx = mask.nonzero(as_tuple=True)
-            weights_e = weights_disp[token_idx, slot_idx].unsqueeze(-1)
-            expert_in = x_flat_disp.index_select(0, token_idx)
-            expert_out = self.experts[e](expert_in) * weights_e
-            out_flat.index_add_(0, token_idx, expert_out)
+        # Gradient-checkpoint the dispatch: the FF in this Transolver runs on
+        # per-point tokens (T = B * N_points ~ 5e5), so 2x top-k experts each
+        # storing (T_e, mlp_hidden) activations OOMs. Recompute experts during
+        # backward; ~30% extra compute but fits in 95 GiB.
+        if self.training and torch.is_grad_enabled():
+            out_flat = torch.utils.checkpoint.checkpoint(
+                self._dispatch_experts,
+                x_flat_disp,
+                weights_disp,
+                topk_idx,
+                use_reentrant=False,
+            )
+        else:
+            out_flat = self._dispatch_experts(x_flat_disp, weights_disp, topk_idx)
         out = out_flat.reshape(B, S, D)
 
         if self.training:
@@ -768,6 +771,26 @@ class SparseMoE(nn.Module):
             self._last_expert_load = None
             self._last_router_entropy = None
         return out
+
+    def _dispatch_experts(
+        self,
+        x_flat_disp: torch.Tensor,
+        weights_disp: torch.Tensor,
+        topk_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        out_flat = torch.zeros_like(x_flat_disp)
+        # Always call every expert (even with empty input) so DDP keeps every
+        # expert's parameters in the autograd graph and find_unused_parameters
+        # is not required. Use in-place index_add_ to avoid allocating E
+        # intermediate (T, D) tensors that backward would otherwise hold.
+        for e in range(self.num_experts):
+            mask = topk_idx == e  # (T, k) bool
+            token_idx, slot_idx = mask.nonzero(as_tuple=True)
+            weights_e = weights_disp[token_idx, slot_idx].unsqueeze(-1)
+            expert_in = x_flat_disp.index_select(0, token_idx)
+            expert_out = self.experts[e](expert_in) * weights_e
+            out_flat.index_add_(0, token_idx, expert_out)
+        return out_flat
 
 
 def collect_moe_state(model: nn.Module) -> dict[str, list[torch.Tensor]]:

--- a/train.py
+++ b/train.py
@@ -669,6 +669,125 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SparseMoE(nn.Module):
+    """Sparse top-k Mixture-of-Experts feedforward, drop-in for UpActDownMlp.
+
+    Each expert is a 2-layer MLP matching UpActDownMlp's structure. Gate
+    softmax is computed in fp32 for numerical stability under bf16 autocast
+    (per ST-MoE). Implements Switch-style load-balance aux loss and ST-MoE
+    z-loss; both are stored on the module after the forward pass and consumed
+    by the outer trainer via collect_moe_state().
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        mlp_hidden_dim: int,
+        num_experts: int,
+        top_k: int = 2,
+        gate_init_std: float = 0.01,
+    ):
+        super().__init__()
+        if num_experts < 1:
+            raise ValueError("num_experts must be >= 1")
+        self.hidden_dim = hidden_dim
+        self.mlp_hidden_dim = mlp_hidden_dim
+        self.num_experts = num_experts
+        self.top_k = min(top_k, num_experts)
+        self.experts = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(hidden_dim, mlp_hidden_dim),
+                    nn.GELU(),
+                    nn.Linear(mlp_hidden_dim, hidden_dim),
+                )
+                for _ in range(num_experts)
+            ]
+        )
+        for expert in self.experts:
+            expert.apply(_init_linear)
+        self.gate = nn.Linear(hidden_dim, num_experts, bias=False)
+        nn.init.normal_(self.gate.weight, std=gate_init_std)
+        self._last_aux_loss: torch.Tensor | None = None
+        self._last_z_loss: torch.Tensor | None = None
+        self._last_expert_load: torch.Tensor | None = None
+        self._last_router_entropy: torch.Tensor | None = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, S, D = x.shape
+        x_flat = x.reshape(B * S, D)
+        # Router logits in fp32 to avoid bf16 softmax instability (ST-MoE).
+        logits = self.gate(x_flat).float()  # (T, E)
+        topk_logits, topk_idx = torch.topk(logits, self.top_k, dim=-1)  # (T, k)
+        # Mixtral-style: renormalize softmax over selected experts only.
+        topk_weights = F.softmax(topk_logits, dim=-1)  # (T, k)
+        # Switch aux load-balance loss (top-1 hard count for f_i, soft P_i).
+        full_softmax = F.softmax(logits, dim=-1)
+        P_i = full_softmax.mean(dim=0)  # (E,)
+        top1 = topk_idx[:, 0]
+        f_i = F.one_hot(top1, num_classes=self.num_experts).float().mean(dim=0)
+        aux_loss = self.num_experts * (f_i * P_i).sum()
+        # ST-MoE z-loss: penalize large pre-softmax logits.
+        z_loss = (torch.logsumexp(logits, dim=-1) ** 2).mean()
+        with torch.no_grad():
+            expert_load = f_i.detach().clone()
+            log_p = torch.log(full_softmax.clamp_min(1e-12))
+            router_entropy = -(full_softmax * log_p).sum(dim=-1).mean().detach()
+
+        topk_weights_cast = topk_weights.to(dtype=x_flat.dtype)
+        out_flat = torch.zeros_like(x_flat)
+        # Always call every expert (even with empty input) so DDP keeps every
+        # expert's parameters in the autograd graph and find_unused_parameters
+        # is not required.
+        for e in range(self.num_experts):
+            mask = topk_idx == e  # (T, k) bool
+            token_idx, slot_idx = mask.nonzero(as_tuple=True)
+            weights_e = topk_weights_cast[token_idx, slot_idx].unsqueeze(-1)
+            expert_in = x_flat.index_select(0, token_idx)
+            expert_out = self.experts[e](expert_in) * weights_e
+            out_flat = out_flat.index_add(0, token_idx, expert_out)
+        out = out_flat.reshape(B, S, D)
+
+        if self.training:
+            self._last_aux_loss = aux_loss
+            self._last_z_loss = z_loss
+            self._last_expert_load = expert_load
+            self._last_router_entropy = router_entropy
+        else:
+            self._last_aux_loss = None
+            self._last_z_loss = None
+            self._last_expert_load = None
+            self._last_router_entropy = None
+        return out
+
+
+def collect_moe_state(model: nn.Module) -> dict[str, list[torch.Tensor]]:
+    """Walk model, return current MoE telemetry per layer; clear stored state.
+
+    Keys: aux_losses, z_losses, expert_loads, entropies.
+    """
+    aux_losses: list[torch.Tensor] = []
+    z_losses: list[torch.Tensor] = []
+    expert_loads: list[torch.Tensor] = []
+    entropies: list[torch.Tensor] = []
+    for m in model.modules():
+        if isinstance(m, SparseMoE) and m._last_aux_loss is not None:
+            aux_losses.append(m._last_aux_loss)
+            z_losses.append(m._last_z_loss)
+            expert_loads.append(m._last_expert_load)
+            entropies.append(m._last_router_entropy)
+            m._last_aux_loss = None
+            m._last_z_loss = None
+            m._last_expert_load = None
+            m._last_router_entropy = None
+    return {
+        "aux_losses": aux_losses,
+        "z_losses": z_losses,
+        "expert_loads": expert_loads,
+        "entropies": entropies,
+    }
+
+
 class TransolverAttention(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
         super().__init__()
@@ -729,6 +848,8 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         drop_path_prob: float = 0.0,
+        moe_experts: int = 0,
+        moe_top_k: int = 2,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -740,7 +861,17 @@ class TransformerBlock(nn.Module):
             dropout=dropout,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if moe_experts > 0:
+            self.mlp = SparseMoE(
+                hidden_dim=hidden_dim,
+                mlp_hidden_dim=mlp_hidden_dim,
+                num_experts=moe_experts,
+                top_k=moe_top_k,
+            )
+        else:
+            self.mlp = UpActDownMlp(
+                hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim
+            )
         self.drop_path = DropPath(drop_path_prob)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
@@ -805,6 +936,8 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         stochastic_depth_prob: float = 0.0,
         film_geom_dim: int = 0,
+        moe_experts: int = 0,
+        moe_top_k: int = 2,
     ):
         super().__init__()
         if depth <= 1:
@@ -822,6 +955,8 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     drop_path_prob=drop_path_rates[i],
+                    moe_experts=moe_experts,
+                    moe_top_k=moe_top_k,
                 )
                 for i in range(depth)
             ]
@@ -871,6 +1006,8 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        moe_experts: int = 0,
+        moe_top_k: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -916,6 +1053,8 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             stochastic_depth_prob=stochastic_depth_prob,
             film_geom_dim=film_encoder_dim if use_film else 0,
+            moe_experts=moe_experts,
+            moe_top_k=moe_top_k,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -1158,6 +1297,10 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    moe_experts: int = 0
+    moe_top_k: int = 2
+    moe_aux_loss_weight: float = 0.01
+    moe_z_loss_weight: float = 0.001
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1365,6 +1508,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        moe_experts=config.moe_experts,
+        moe_top_k=config.moe_top_k,
     )
 
 
@@ -2033,6 +2178,8 @@ def train_loss(
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
     beta_nll_beta: float = -1.0,
+    moe_aux_loss_weight: float = 0.0,
+    moe_z_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -2116,6 +2263,32 @@ def train_loss(
             aux_rel_l2 = num / den
             loss = loss + aux_rel_l2_weight * aux_rel_l2
             aux_rel_l2_value = float(aux_rel_l2.detach().cpu().item())
+        moe_state = collect_moe_state(model)
+        moe_aux_value: float | None = None
+        moe_z_value: float | None = None
+        moe_router_entropy_value: float | None = None
+        moe_load_max_imbalance_value: float | None = None
+        moe_load_min_value: float | None = None
+        moe_load_max_value: float | None = None
+        if moe_state["aux_losses"]:
+            moe_aux_total = torch.stack(moe_state["aux_losses"]).sum()
+            moe_z_total = torch.stack(moe_state["z_losses"]).sum()
+            if moe_aux_loss_weight > 0.0:
+                loss = loss + moe_aux_loss_weight * moe_aux_total
+            if moe_z_loss_weight > 0.0:
+                loss = loss + moe_z_loss_weight * moe_z_total
+            moe_aux_value = float(moe_aux_total.detach().cpu().item())
+            moe_z_value = float(moe_z_total.detach().cpu().item())
+            entropies = torch.stack(moe_state["entropies"])
+            moe_router_entropy_value = float(entropies.mean().detach().cpu().item())
+            loads = torch.stack(moe_state["expert_loads"])  # (L, E)
+            min_load = loads.min(dim=-1).values  # (L,)
+            max_load = loads.max(dim=-1).values  # (L,)
+            moe_load_min_value = float(min_load.min().detach().cpu().item())
+            moe_load_max_value = float(max_load.max().detach().cpu().item())
+            moe_load_max_imbalance_value = (
+                moe_load_max_value - moe_load_min_value
+            )
     metrics: dict[str, float] = {
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
@@ -2126,6 +2299,20 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if moe_aux_value is not None:
+        metrics["moe_aux_loss"] = moe_aux_value
+        metrics["moe_z_loss"] = moe_z_value
+        metrics["moe_router_entropy"] = moe_router_entropy_value
+        metrics["moe_load_min"] = moe_load_min_value
+        metrics["moe_load_max"] = moe_load_max_value
+        metrics["moe_load_max_imbalance"] = moe_load_max_imbalance_value
+        # Per-layer per-expert load fractions for collapse detection.
+        for layer_idx, layer_load in enumerate(moe_state["expert_loads"]):
+            layer_load_cpu = layer_load.detach().cpu()
+            for expert_idx in range(layer_load_cpu.numel()):
+                metrics[f"moe_load/layer{layer_idx}_e{expert_idx}"] = float(
+                    layer_load_cpu[expert_idx].item()
+                )
     if use_tangential_wallshear_loss and not use_beta_nll:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if use_beta_nll and per_axis_log_var is not None:
@@ -2780,6 +2967,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
+                moe_aux_loss_weight=config.moe_aux_loss_weight,
+                moe_z_loss_weight=config.moe_z_loss_weight,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2907,6 +3096,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             ):
                 if log_var_key in batch_loss_metrics:
                     train_log[f"train/{log_var_key}"] = batch_loss_metrics[log_var_key]
+            for moe_key in (
+                "moe_aux_loss",
+                "moe_z_loss",
+                "moe_router_entropy",
+                "moe_load_min",
+                "moe_load_max",
+                "moe_load_max_imbalance",
+            ):
+                if moe_key in batch_loss_metrics:
+                    train_log[f"train/{moe_key}"] = batch_loss_metrics[moe_key]
+            for key, value in batch_loss_metrics.items():
+                if key.startswith("moe_load/"):
+                    train_log[f"train/{key}"] = value
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():

--- a/train.py
+++ b/train.py
@@ -734,18 +734,27 @@ class SparseMoE(nn.Module):
             log_p = torch.log(full_softmax.clamp_min(1e-12))
             router_entropy = -(full_softmax * log_p).sum(dim=-1).mean().detach()
 
-        topk_weights_cast = topk_weights.to(dtype=x_flat.dtype)
-        out_flat = torch.zeros_like(x_flat)
+        # Run dispatch in autocast dtype (bf16) when active to halve activation
+        # memory; LayerNorm produces fp32 input but the original UpActDownMlp
+        # also runs in bf16 internally under autocast, so behavior is matched.
+        if torch.is_autocast_enabled():
+            dispatch_dtype = torch.get_autocast_gpu_dtype()
+        else:
+            dispatch_dtype = x_flat.dtype
+        x_flat_disp = x_flat.to(dtype=dispatch_dtype)
+        weights_disp = topk_weights.to(dtype=dispatch_dtype)
+        out_flat = torch.zeros_like(x_flat_disp)
         # Always call every expert (even with empty input) so DDP keeps every
         # expert's parameters in the autograd graph and find_unused_parameters
-        # is not required.
+        # is not required. Use in-place index_add_ to avoid allocating E
+        # intermediate (T, D) tensors that backward would otherwise hold.
         for e in range(self.num_experts):
             mask = topk_idx == e  # (T, k) bool
             token_idx, slot_idx = mask.nonzero(as_tuple=True)
-            weights_e = topk_weights_cast[token_idx, slot_idx].unsqueeze(-1)
-            expert_in = x_flat.index_select(0, token_idx)
+            weights_e = weights_disp[token_idx, slot_idx].unsqueeze(-1)
+            expert_in = x_flat_disp.index_select(0, token_idx)
             expert_out = self.experts[e](expert_in) * weights_e
-            out_flat = out_flat.index_add(0, token_idx, expert_out)
+            out_flat.index_add_(0, token_idx, expert_out)
         out = out_flat.reshape(B, S, D)
 
         if self.training:


### PR DESCRIPTION
## Hypothesis

The Transolver uses **uniform slice-token MLP layers** — every slice token passes through the same feedforward block. This is a capacity bottleneck: the same MLP must simultaneously handle near-wall boundary layer tokens (τ_y/τ_z dominated) and far-field pressure tokens (vol_p dominated). These are physically different regimes with different spectral content.

**Mixture-of-Experts (MoE) routing on slice tokens** replaces the dense per-slice MLP with a sparse top-2 gating over `E` expert MLPs. Each expert specialises on a sub-population of slice tokens — boundary-layer physics, wake structure, or far-field pressure — without increasing inference cost at the per-token level. This is a direct architectural backbone replacement per Issue #18.

Why this should work for τ_y/τ_z and vol_p:
- The dominant gaps are physically distinct: τ_y/τ_z is near-wall anisotropy, vol_p is far-field divergence-free pressure. A single shared MLP must compromise between them.
- With MoE, expert specialisation emerges naturally: tokens with strong τ gradients consistently route to different experts than pressure-dominated tokens.
- Capacity scales with E (number of experts) without changing the active param count per forward pass.

References:
- Sparse MoE (Shazeer et al. 2017, "Outrageously Large Neural Networks")
- Switch Transformer (Fedus et al. 2022)  
- Mixtral (Jiang et al. 2024) — expert routing with load balancing  
- ST-MoE (Zoph et al. 2022) — stable MoE training

## Instructions

Add a sparse MoE option that replaces the feedforward sublayer in each Transolver layer. Implement as a new flag `--moe-experts N` (default `0` = exact current behaviour, dense MLP).

### Step 1 — Implement the MoE feedforward block in `train.py`

Add after imports:

```python
class SparseMoE(nn.Module):
    """
    Top-2 sparse MoE feedforward block.
    Replaces the dense MLP in each Transolver layer.
    Each expert is a 2-layer MLP (same structure as original FF).
    """
    def __init__(self, hidden_dim: int, num_experts: int, mlp_ratio: float = 4.0,
                 top_k: int = 2):
        super().__init__()
        self.num_experts = num_experts
        self.top_k = top_k
        ff_dim = int(hidden_dim * mlp_ratio)
        # E independent MLP experts
        self.experts = nn.ModuleList([
            nn.Sequential(
                nn.Linear(hidden_dim, ff_dim),
                nn.GELU(),
                nn.Linear(ff_dim, hidden_dim),
            )
            for _ in range(num_experts)
        ])
        # Router: linear gate over token representations
        self.gate = nn.Linear(hidden_dim, num_experts, bias=False)

    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
        """
        x: (B, S, D) where S = num_slices (slice tokens)
        returns: (output (B, S, D), aux_loss scalar)
        """
        B, S, D = x.shape
        x_flat = x.reshape(B * S, D)  # (BS, D)

        # Compute router logits and top-k weights
        logits = self.gate(x_flat)  # (BS, E)
        weights, indices = torch.topk(logits, self.top_k, dim=-1)  # (BS, k)
        weights = torch.softmax(weights, dim=-1)  # (BS, k)

        # Dispatch to experts
        out = torch.zeros_like(x_flat)  # (BS, D)
        for k in range(self.top_k):
            expert_idx = indices[:, k]  # (BS,)
            w = weights[:, k:k+1]  # (BS, 1)
            for e in range(self.num_experts):
                mask = (expert_idx == e)
                if mask.any():
                    out[mask] += w[mask] * self.experts[e](x_flat[mask])

        out = out.reshape(B, S, D)

        # Auxiliary load-balancing loss (encourages uniform expert utilisation)
        # fraction of tokens routed to each expert
        token_fraction = torch.zeros(self.num_experts, device=x.device)
        for e in range(self.num_experts):
            token_fraction[e] = (indices == e).float().mean()
        router_prob = torch.softmax(logits, dim=-1).mean(dim=0)  # (E,)
        aux_loss = self.num_experts * (token_fraction * router_prob).sum()

        return out, aux_loss
```

### Step 2 — Wire into the Transolver

Add CLI flags:
```python
parser.add_argument('--moe-experts', type=int, default=0,
                    help='Number of MoE experts per Transolver FF layer (0=disabled, dense MLP)')
parser.add_argument('--moe-aux-loss-weight', type=float, default=0.01,
                    help='Weight for MoE load-balancing auxiliary loss')
```

In model construction, when building Transolver layers, replace each dense feedforward sublayer with `SparseMoE(hidden_dim, args.moe_experts)` when `args.moe_experts > 0`. If the Transolver layer class is not easily modifiable, wrap it: after the attention output, apply MoE in place of the original MLP.

Track the accumulated auxiliary loss across layers and add to total loss:
```python
total_loss = task_loss + args.moe_aux_loss_weight * sum(aux_losses)
```

Log `moe_aux_loss` to W&B separately so it can be monitored.

### Step 3 — Arm A: E=4 experts (screening, 3 epochs)

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --wandb_group senku-round34-moe-slice \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --clip-grad-norm 0.5 --no-compile-model --learnable-pe \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --moe-experts 4 --moe-aux-loss-weight 0.01
```

### Step 4 — Arm B: E=8 experts (if Arm A is promising)

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent senku \
  --wandb_group senku-round34-moe-slice \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --clip-grad-norm 0.5 --no-compile-model --learnable-pe \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1 \
  --moe-experts 8 --moe-aux-loss-weight 0.01
```

Report:
1. Best val_abupt per arm
2. Per-axis breakdown: τ_y, τ_z, vol_p (the dominant gaps)
3. Expert utilisation distribution (are experts actually specialising, or collapsing?)
4. `moe_aux_loss` convergence curve
5. Any OOM issues and how resolved

## Baseline

**Current yi merge bar: val_abupt 9.032%** (PR #517, askeladd, W&B run `brat65z4`)

| Metric | yi SOTA (val, PR #517) | tay SOTA (test, PR #511) | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **9.032** | 8.313 | — |
| `surface_pressure_rel_l2_pct` | 5.702 | 4.271 | 3.82 |
| `wall_shear_rel_l2_pct` | 10.257 | 7.786 | 7.29 |
| `volume_pressure_rel_l2_pct` | 5.075 | 11.867 | 6.08 |
| `wall_shear_y_rel_l2_pct` | 12.907 | 8.582 | 3.65 (**2.35×**) |
| `wall_shear_z_rel_l2_pct` | 12.957 | 9.927 | 3.63 (**2.73×**) |

**To beat: val_abupt < 9.032%**

Terminal results must include:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
