### PR TITLE
Long DDP8: tau_y×1.2 / tau_z×1.3 per-channel surface weighting (AdamW clean retest)

### DIFF
--- a/train.py
+++ b/train.py
@@ -52,6 +52,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     make_loaders,
     masked_mse,
+    masked_mse_per_channel,
     metric_namespace,
     parse_kill_thresholds,
     primary_metric_log,
@@ -81,6 +82,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    tau_y_loss_weight: float = 1.0
+    tau_z_loss_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -190,6 +193,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    tau_y_loss_weight: float = 1.0,
+    tau_z_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -201,15 +206,27 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        # Per-channel surface MSE: channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]
+        ch_losses = masked_mse_per_channel(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_loss = ch_losses[0] + ch_losses[1] + ch_losses[2] + ch_losses[3]
+        surface_loss_weighted = (
+            ch_losses[0]
+            + ch_losses[1]
+            + tau_y_loss_weight * ch_losses[2]
+            + tau_z_loss_weight * ch_losses[3]
+        )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
+        weighted_surface_loss = surface_loss_weight * surface_loss_weighted
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_loss_ch0_cp": float(ch_losses[0].detach().cpu().item()),
+        "surface_loss_ch1_tau_x": float(ch_losses[1].detach().cpu().item()),
+        "surface_loss_ch2_tau_y": float(ch_losses[2].detach().cpu().item()),
+        "surface_loss_ch3_tau_z": float(ch_losses[3].detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
@@ -329,6 +346,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    tau_y_loss_weight=config.tau_y_loss_weight,
+                    tau_z_loss_weight=config.tau_z_loss_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/train.py
+++ b/train.py
@@ -206,15 +206,18 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        # Per-channel surface MSE: channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]
+        # Per-channel surface MSE: channels are [cp=0, tau_x=1, tau_y=2, tau_z=3].
+        # Divide channel sums by n_channels so surface_loss matches masked_mse(...) over
+        # all channels when all channel weights are 1.0.
         ch_losses = masked_mse_per_channel(out["surface_preds"], surface_target, batch.surface_mask)
-        surface_loss = ch_losses[0] + ch_losses[1] + ch_losses[2] + ch_losses[3]
+        n_ch = len(ch_losses)
+        surface_loss = (ch_losses[0] + ch_losses[1] + ch_losses[2] + ch_losses[3]) / n_ch
         surface_loss_weighted = (
             ch_losses[0]
             + ch_losses[1]
             + tau_y_loss_weight * ch_losses[2]
             + tau_z_loss_weight * ch_losses[3]
-        )
+        ) / n_ch
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss_weighted
         weighted_volume_loss = volume_loss_weight * volume_loss

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -831,6 +831,21 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_mse_per_channel(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> list:
+    """Per-channel MSE for surface predictions.
+
+    Args:
+        pred:   (batch, n_pts, n_channels)
+        target: (batch, n_pts, n_channels)
+        mask:   (batch, n_pts)
+
+    Returns:
+        List of n_channels scalar tensors, one per channel.
+    """
+    n_channels = pred.shape[-1]
+    return [masked_mse(pred[..., c : c + 1], target[..., c : c + 1], mask) for c in range(n_channels)]
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Mild per-channel surface loss weighting on tau_y (×1.2) and tau_z (×1.3) will selectively pressure the model to improve wall shear estimation on the y and z axes, improving the aggregate test error vs the pre-wave reference `9mm3sz7x` (agg 8.123%, tau_y 8.326%, tau_z 9.543%).

This is a clean retest of the channel-weighting mechanism, isolated from the 4 config failures in PR #598 (Lion optimizer instability, surface_loss_weight=2.0 amplification, compile_model deadlock). All known failure modes have been eliminated.

**This branch contains the implementation.** The necessary code changes are already committed:
1. `masked_mse_per_channel()` added to `trainer_runtime.py`
2. `tau_y_loss_weight` and `tau_z_loss_weight` fields added to `Config` dataclass (auto-generates `--tau-y-loss-weight` / `--tau-z-loss-weight` CLI flags)
3. `train_loss()` modified to apply per-channel weights before the global `surface_loss_weight` scalar
4. Per-channel surface losses logged to W&B for diagnostic visibility

Surface output channels: `[cp=0, tau_x=1, tau_y=2, tau_z=3]`

## Instructions

**Do NOT modify train.py or trainer_runtime.py** — the implementation is already in the branch. Pull the branch and run experiments.

### Smoke run (EP1 gate — must complete before long run)

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 3 \
  --agent fern \
  --wandb-name "fern/tau-mild-v2-smoke" \
  --wandb-group "fern-tau-static-mild-v2" \
  --batch-size 4 \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.2 \
  --tau-z-loss-weight 1.3 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --train-surface-points 65536 \
  --train-volume-points 16384 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 50 \
  --no-compile-model \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

**Smoke pass criteria:** EP1 `val_primary/abupt_axis_mean_rel_l2_pct` must be below 30%. If it diverges or hits the kill threshold, report the W&B run ID and EP1 metric — do NOT proceed to the long run.

### Long run (only after smoke passes EP1 < 30%)

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 50 \
  --agent fern \
  --wandb-name "fern/tau-mild-v2-long" \
  --wandb-group "fern-tau-static-mild-v2" \
  --batch-size 4 \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.2 \
  --tau-z-loss-weight 1.3 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --train-surface-points 65536 \
  --train-volume-points 16384 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 50 \
  --no-compile-model \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

**Expected runtime:** ~24h on DDP8 for 50 epochs.

## Config rationale

| Param | Value | Reason |
|-------|-------|--------|
| `tau_y_loss_weight` | 1.2 | Mild upweight — matches pre-wave reference `9mm3sz7x` |
| `tau_z_loss_weight` | 1.3 | Mild upweight — matches pre-wave reference `9mm3sz7x` |
| `surface_loss_weight` | **1.0** | CRITICAL: 2.0 caused catastrophic EP1=70.78% without tay stack |
| `batch_size` | 4 | Matches reference `9mm3sz7x` for stable gradient updates |
| `lr` | 9e-5 | Matches reference `9mm3sz7x` |
| `lr_warmup_epochs` | 1 | Critical: short warmup caused Lion divergence in v1 |
| `lr_cosine_t_max` | 50 | Full cosine over all epochs |
| `grad_clip_norm` | 0.5 | Tighter than default; matches reference `9mm3sz7x` |
| `train_volume_points` | 16384 | Lighter volume load; matches reference `9mm3sz7x` |
| `--no-compile-model` | required | `compile_model=True` deadlocks at bs=4 on DDP8 |

## Baseline (targets to beat)

Pre-wave reference `9mm3sz7x` (same mechanism, tay branch):

| Metric | Value |
|--------|-------|
| `test_primary/abupt_axis_mean_rel_l2_pct` | **8.123** |
| `test_primary/surface_pressure_rel_l2_pct` | 4.128 |
| `test_primary/volume_pressure_rel_l2_pct` | 12.051 |
| `test_primary/wall_shear_rel_l2_pct` | 7.454 |
| `test_primary/wall_shear_x_rel_l2_pct` | 6.566 |
| `test_primary/wall_shear_y_rel_l2_pct` | 8.326 |
| `test_primary/wall_shear_z_rel_l2_pct` | 9.543 |

No in-wave merged results yet — any successful run establishes the first in-wave baseline.

## Failure history (PR #598) — closed, not this PR

| Attempt | Root cause | Status |
|---------|-----------|--------|
| v1 (Lion) | 7 config mismatches vs reference; Lion hit full lr 44× too fast | Diverged |
| v2 (NCCL deadlock) | compile_model=True + bs=4 + large points → ALLREDUCE desync | Deadlock |
| v3 (NCCL deadlock) | Same as v2 | Deadlock |
| v4 (surface=2.0) | surface_loss_weight=2.0 without tay stack → EP1=70.78% | Diverged |

All failures were config failures, not mechanism failures. The tau weighting hypothesis itself has never been cleanly tested.

## Results

Please report:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
