### PR TITLE
Flow-aligned tau: predict in local surface tangent frame (t̂,n̂,ŝ)

### DIFF
--- a/train.py
+++ b/train.py
@@ -129,6 +129,8 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    use_tangent_frame_tau: bool = False
+    tangent_frame_seed_axis: str = "x"
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -219,6 +221,33 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_tangent_frame_tau": (
+            "Predict wall shear (tau_x, tau_y, tau_z) loss in the local "
+            "surface tangent frame [t_hat, n_hat, s_hat] instead of the "
+            "global Cartesian (x, y, z) frame. Rotates pred and target tau "
+            "vectors into the local frame before computing the MSE; cp "
+            "(channel 0) and the volume_pressure loss are unaffected. "
+            "n_hat is taken directly from the provided surface normals "
+            "(channels 3:6 of surface_x), avoiding the PCA cost / sign "
+            "ambiguity of estimating normals from k-NN; t_hat is built via "
+            "Gram-Schmidt against --tangent-frame-seed-axis (default 'x', "
+            "the DrivAerML freestream direction); s_hat = n_hat x t_hat. "
+            "Combined with non-trivial --tau-y-loss-weight / "
+            "--tau-z-loss-weight (which now apply to the n_hat / s_hat "
+            "components in the rotated frame) this produces a different "
+            "anisotropic loss; with isotropic channel weights the rotation "
+            "is mathematically a no-op (orthogonal MSE invariance). The "
+            "model still outputs tau in the global frame and all reported "
+            "metrics are in the global frame. Default: False."
+        ),
+        "tangent_frame_seed_axis": (
+            "Tangent seed axis used by --use-tangent-frame-tau. 'x' "
+            "(DrivAerML freestream / streamwise direction) gives a "
+            "(streamwise-tangent, normal, spanwise) decomposition. 'y' "
+            "is also accepted. Points whose normal is nearly parallel to "
+            "the seed are handled with an automatic orthogonal fallback "
+            "to avoid a singular Gram-Schmidt projection. Default: 'x'."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +329,75 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+_TANGENT_SEED_AXES = {
+    "x": (1.0, 0.0, 0.0),
+    "y": (0.0, 1.0, 0.0),
+    "z": (0.0, 0.0, 1.0),
+}
+
+
+def build_tangent_frame_from_normals(
+    normals: torch.Tensor,
+    seed_axis: str = "x",
+) -> torch.Tensor:
+    """Build a per-point local surface tangent frame from given unit normals.
+
+    Args:
+        normals: tensor of shape (..., 3) of unit-norm surface normals.
+            Padded points may carry zero-norm rows; they get a degenerate
+            but finite frame and are masked out of the loss downstream.
+        seed_axis: 'x' (default, DrivAerML freestream/streamwise direction),
+            'y', or 'z'. Points whose normal is nearly parallel to this
+            axis fall back to the next coordinate axis to avoid a
+            singular Gram-Schmidt projection.
+
+    Returns:
+        R: (..., 3, 3) rotation matrices. ``R @ tau`` yields
+        ``[t_component, n_component, s_component]``; rows are
+        ``[t_hat, n_hat, s_hat]``.
+    """
+
+    seed_axis = seed_axis.lower()
+    if seed_axis not in _TANGENT_SEED_AXES:
+        raise ValueError(
+            f"--tangent-frame-seed-axis must be one of {sorted(_TANGENT_SEED_AXES)}; "
+            f"got '{seed_axis}'"
+        )
+    seed_idx = "xyz".index(seed_axis)
+    fallback_idx = (seed_idx + 1) % 3
+
+    n = torch.nn.functional.normalize(normals.float(), dim=-1, eps=1e-12)
+
+    seed_primary = torch.zeros_like(n)
+    seed_primary[..., seed_idx] = 1.0
+    seed_fallback = torch.zeros_like(n)
+    seed_fallback[..., fallback_idx] = 1.0
+    use_fallback = n[..., seed_idx : seed_idx + 1].abs() > 0.9
+    seed = torch.where(use_fallback, seed_fallback, seed_primary)
+
+    t = seed - (seed * n).sum(dim=-1, keepdim=True) * n
+    t = torch.nn.functional.normalize(t, dim=-1, eps=1e-12)
+    s = torch.linalg.cross(n, t, dim=-1)
+    return torch.stack([t, n, s], dim=-2)
+
+
+def rotate_tau_to_local_frame(
+    surface_tensor: torch.Tensor,
+    R: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate the wall-shear channels (1:4) of a surface tensor into the local frame.
+
+    Channel 0 (surface_pressure / cp) is left unchanged. Returns a new tensor
+    of the same shape with float32 dtype to keep the loss numerically clean
+    under bf16 autocast.
+    """
+
+    cp = surface_tensor[..., 0:1].float()
+    tau = surface_tensor[..., 1:4].float()
+    tau_local = torch.einsum("...ij,...j->...i", R, tau)
+    return torch.cat([cp, tau_local], dim=-1)
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,6 +408,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_tangent_frame_tau: bool = False,
+    tangent_frame_seed_axis: str = "x",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -321,15 +421,26 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred_for_loss = out["surface_preds"]
+        surface_target_for_loss = surface_target
+        if use_tangent_frame_tau:
+            R = build_tangent_frame_from_normals(
+                batch.surface_x[..., 3:6],
+                seed_axis=tangent_frame_seed_axis,
+            )
+            surface_pred_for_loss = rotate_tau_to_local_frame(out["surface_preds"], R)
+            surface_target_for_loss = rotate_tau_to_local_frame(surface_target, R)
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
+                surface_pred_for_loss,
+                surface_target_for_loss,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(
+                surface_pred_for_loss, surface_target_for_loss, batch.surface_mask
+            )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -826,9 +937,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"(log_freq[d, f] = log(sigmas[f % len(sigmas)]))"
                 )
             if use_channel_weights:
+                if config.use_tangent_frame_tau:
+                    print(
+                        f"Surface channel weights (local frame, seed={config.tangent_frame_seed_axis}): "
+                        f"cp=1.0 tau_t=1.0 tau_n={config.tau_y_loss_weight} "
+                        f"tau_s={config.tau_z_loss_weight}"
+                    )
+                else:
+                    print(
+                        f"Surface channel weights: cp=1.0 tau_x=1.0 "
+                        f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                    )
+            if config.use_tangent_frame_tau:
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
-                    f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                    f"Tangent-frame tau loss enabled: rotating tau (chan 1:4) "
+                    f"to local frame [t_hat, n_hat, s_hat] from provided "
+                    f"surface normals; seed_axis={config.tangent_frame_seed_axis}"
                 )
 
         run = init_wandb_run(
@@ -861,6 +985,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_tangent_frame_tau"] = bool(config.use_tangent_frame_tau)
+            wandb.summary["loss/tangent_frame_seed_axis"] = (
+                config.tangent_frame_seed_axis if config.use_tangent_frame_tau else ""
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1008,6 +1136,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_tangent_frame_tau=config.use_tangent_frame_tau,
+                        tangent_frame_seed_axis=config.tangent_frame_seed_axis,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
## Hypothesis

The model predicts wall shear stress (tau) in global Cartesian (x,y,z), but the physically meaningful decomposition is in the local surface frame: tangential (t̂), normal (n̂), and spanwise (ŝ). Predicting tau in global coords forces the model to implicitly learn the local geometry — a hard auxiliary task. Predicting in the surface-local tangent frame decouples geometric transformation from physical prediction. This should directly benefit tau_y and tau_z (currently 8.49% and 10.0% vs AB-UPT targets of 3.65%/3.63% — the two largest gaps in our error profile).

Compute the local tangent frame via PCA of k=20 nearest surface neighbors at each point. The model outputs (τ_t, τ_n, τ_s) in local frame; compute loss in the local frame (cleaner gradients), then rotate predictions back to global for metric reporting.

## Instructions

Add `--use-tangent-frame-tau` flag to `target/train.py`. Implementation:

### 1. Local tangent frame computation (add as a utility function)

```python
def compute_surface_tangent_frames(surface_xyz, k=20):
    """k-NN PCA tangent frames. Returns R (N,3,3): rows=[t_hat, n_hat, s_hat]"""
    N = surface_xyz.shape[0]
    dists = torch.cdist(surface_xyz.unsqueeze(0), surface_xyz.unsqueeze(0)).squeeze(0)
    _, knn_idx = dists.topk(k+1, dim=-1, largest=False)
    knn_idx = knn_idx[:, 1:]  # exclude self
    neighbors = surface_xyz[knn_idx]  # (N, k, 3)
    centered = neighbors - neighbors.mean(dim=1, keepdim=True)
    cov = torch.bmm(centered.transpose(1, 2), centered) / (k - 1)
    eigenvalues, eigenvectors = torch.linalg.eigh(cov)  # ascending eigenvalues
    n_hat = eigenvectors[:, :, 0]   # smallest = surface normal
    t_hat = eigenvectors[:, :, 2]   # largest = principal tangent
    s_hat = torch.cross(n_hat, t_hat, dim=-1)
    R = torch.stack([t_hat, n_hat, s_hat], dim=1)  # (N,3,3)
    return R
```

### 2. In the loss computation (when `--use-tangent-frame-tau` is set)

```python
# R: (B, N, 3, 3) - compute once per batch from surface_xyz
R = compute_surface_tangent_frames(surface_xyz[b], k=20)  # compute per-sample

# Rotate both pred and target to local frame for loss
tau_pred_local  = torch.einsum('nij,nj->ni', R, tau_pred)   # (N,3)
tau_target_local = torch.einsum('nij,nj->ni', R, tau_target) # (N,3)
loss_tau = criterion(tau_pred_local, tau_target_local)

# For metrics: rotate pred back to global
tau_pred_global = torch.einsum('nji,nj->ni', R, tau_pred_local)  # R^T
```

**Cache R**: geometry is fixed per mesh — compute once and cache to avoid redundant k-NN computation across epochs.

**GPU efficiency**: keep `surface_xyz` on CUDA when calling `compute_surface_tangent_frames`.

### 3. Run command

```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13 \
  --use-tangent-frame-tau \
  --wandb-group tay-flow-aligned-tau
```

### Report in PR comment
- val_abupt overall + per-channel (surface_pressure, tau_x, tau_y, tau_z, volume_pressure)
- Did tau_y and tau_z improve vs baseline?
- W&B run ID

## Baseline

**Single-model SOTA** (gate to beat): val_abupt = **6.7258%**
- PR #594 (askeladd rff32), W&B run `d777epep`

| Channel | Current | AB-UPT target | Gap |
|---|---|---|---|
| surface_pressure | ~3.82% | 3.82% | ~0% |
| wall_shear_x | ~5.35% | 5.35% | ~0% |
| wall_shear_y | ~8.489% | 3.65% | **+4.84pp** |
| wall_shear_z | ~9.997% | 3.63% | **+6.37pp** |
| volume_pressure | ~6.08% | 6.08% | ~0% |

Win condition: val_abupt < **6.7258%**
