### PR TITLE
Reissue surface curvature (H + K via k-NN PCA k=20) on current SOTA stack

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,10 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_surface_curvature: bool = False,
+        curvature_knn_k: int = 20,
+        curvature_chunk_size: int = 4096,
+        curvature_ref_size: int = 4096,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,7 +358,13 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
-        surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        self.use_surface_curvature = use_surface_curvature
+        self.curvature_knn_k = curvature_knn_k
+        self.curvature_chunk_size = curvature_chunk_size
+        self.curvature_ref_size = curvature_ref_size
+        # Curvature features (H, K) appended to the surface input as 2 extra channels.
+        self.curvature_extra_dim = 2 if use_surface_curvature else 0
+        surface_extra_dim = max(0, self.surface_input_dim - space_dim) + self.curvature_extra_dim
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_separable":
@@ -448,6 +458,93 @@ class SurfaceTransolver(nn.Module):
             hidden = hidden + project_features(features)
         return bias(hidden) + placeholder
 
+    @torch.no_grad()
+    def _compute_surface_curvature(
+        self, pos: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Compute (B, N, 2) curvature features [H, K] via k-NN PCA.
+
+        Mean curvature H = (kappa_1 + kappa_2) / 2 and Gaussian curvature
+        K = kappa_1 * kappa_2 are estimated from the eigenvalues of the
+        local k-NN covariance: with eigenvalues lambda_1 <= lambda_2 <= lambda_3
+        we use kappa_1 = sqrt(lambda_2 / lambda_3), kappa_2 = sqrt(lambda_1 / lambda_3).
+        Per-case z-score normalization with +-3 sigma clip over valid points.
+
+        Efficiency note: the candidate pool for k-NN is a random subsample of
+        size `curvature_ref_size` (default 4096) drawn from the valid points of
+        each case. With N=65536 sampled points per case, full-cloud k-NN has
+        cdist cost ~O(N^2) which makes the 13-epoch budget infeasible. Using a
+        ~16x sparser reference cloud trades a ~2.5x larger physical neighborhood
+        radius for a ~14x curvature compute speedup. The resulting H/K still
+        captures regional convex/concave/saddle structure that is the intended
+        physics-informed signal. Self is excluded from the candidate set by
+        masking exact-zero distances to +inf.
+        """
+
+        B, N, _ = pos.shape
+        device = pos.device
+        out_dtype = pos.dtype
+        out = torch.zeros(B, N, 2, device=device, dtype=out_dtype)
+        mask_bool = mask.bool() if mask is not None else None
+        k_target = self.curvature_knn_k
+        chunk_size = self.curvature_chunk_size
+        ref_size = self.curvature_ref_size
+
+        # eigh has no bf16/fp16 CUDA kernel — keep this path in fp32 outside autocast.
+        autocast_dtype = "cuda" if device.type == "cuda" else "cpu"
+        with torch.amp.autocast(device_type=autocast_dtype, enabled=False):
+            pos_f32 = pos.float()
+
+            for b in range(B):
+                if mask_bool is not None:
+                    valid_idx = mask_bool[b].nonzero(as_tuple=True)[0]
+                else:
+                    valid_idx = torch.arange(N, device=device)
+                n_valid = int(valid_idx.numel())
+                if n_valid <= 1:
+                    continue
+                valid_pts = pos_f32[b].index_select(0, valid_idx)  # (Nv, 3)
+
+                # Subsampled reference cloud for k-NN candidates.
+                ref_n = min(ref_size, n_valid)
+                ref_indices = torch.randperm(n_valid, device=device)[:ref_n]
+                ref_pts = valid_pts.index_select(0, ref_indices)  # (ref_n, 3)
+                kk = min(k_target, ref_n - 1)
+                if kk < 1:
+                    continue
+
+                curv = torch.zeros(n_valid, 2, device=device, dtype=torch.float32)
+                for start in range(0, n_valid, chunk_size):
+                    end = min(start + chunk_size, n_valid)
+                    chunk = valid_pts[start:end]  # (C, 3)
+                    dist = torch.cdist(chunk, ref_pts)  # (C, ref_n)
+                    # Exclude self: mask exact-zero distances to inf.
+                    dist = dist.masked_fill(dist < 1e-8, float("inf"))
+                    _, knn_idx = dist.topk(kk, dim=-1, largest=False)  # (C, kk)
+
+                    neighbors = ref_pts.index_select(0, knn_idx.reshape(-1)).reshape(
+                        end - start, kk, 3
+                    )  # (C, kk, 3)
+                    centroid = neighbors.mean(dim=1, keepdim=True)
+                    centered = neighbors - centroid
+                    cov = torch.bmm(centered.transpose(1, 2), centered) / float(kk)
+                    eigenvalues, _ = torch.linalg.eigh(cov)  # ascending
+
+                    lam = eigenvalues.clamp_min(0.0)
+                    eps = 1e-8
+                    kappa1 = torch.sqrt(lam[:, 1] / (lam[:, 2] + eps))
+                    kappa2 = torch.sqrt(lam[:, 0] / (lam[:, 2] + eps))
+                    H = 0.5 * (kappa1 + kappa2)
+                    K = kappa1 * kappa2
+                    curv[start:end] = torch.stack([H, K], dim=-1)
+
+                mean = curv.mean(dim=0, keepdim=True)
+                std = curv.std(dim=0, keepdim=True).clamp_min(1e-8)
+                curv = ((curv - mean) / std).clamp(-3.0, 3.0)
+                out[b].index_copy_(0, valid_idx, curv.to(out_dtype))
+
+        return out
+
     def forward(
         self,
         *,
@@ -462,6 +559,11 @@ class SurfaceTransolver(nn.Module):
             raise ValueError("SurfaceTransolver requires surface_mask when surface_x is provided")
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
+
+        if self.use_surface_curvature and surface_x is not None:
+            pos = surface_x[:, :, : self.space_dim]
+            curv = self._compute_surface_curvature(pos, surface_mask)
+            surface_x = torch.cat([surface_x, curv], dim=-1)
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []

--- a/train.py
+++ b/train.py
@@ -102,6 +102,10 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_surface_curvature: bool = False
+    curvature_knn_k: int = 20
+    curvature_chunk_size: int = 4096
+    curvature_ref_size: int = 4096
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -297,6 +301,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_surface_curvature=config.use_surface_curvature,
+        curvature_knn_k=config.curvature_knn_k,
+        curvature_chunk_size=config.curvature_chunk_size,
+        curvature_ref_size=config.curvature_ref_size,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #605 merged surface curvature features (mean curvature H + Gaussian curvature K via k-NN PCA) but produced zero experimental results — the run never completed or the data was never logged. This PR reissues the same hypothesis on the **current SOTA stack** (rff16, multi-sigma init, vol-points schedule, lion optimizer) to definitively test whether physics-informed curvature features reduce the tau_y/tau_z gap.

**Why this matters:** Our single-model SOTA achieves tau_y=8.489%, tau_z=9.997% versus the AB-UPT targets of 3.65% and 3.63% respectively — a 2.3–2.75× gap. Surface curvature (the principal curvatures κ₁, κ₂ of the vehicle geometry) is a local geometric invariant that encodes whether a surface region is convex, concave, or saddle-shaped. This directly modulates flow separation and reattachment, which are the dominant sources of shear stress anisotropy. The hypothesis is that providing H and K as explicit input channels gives the model a geometric inductive bias that reduces the tau shear prediction errors.

## Gate

**Beat:** `val_abupt < 6.7258%` (PR #594, W&B run `d777epep`, EP4 step 43,462)

## Current Baseline Metrics (PR #594 single-model SOTA)

| Metric | Current SOTA | AB-UPT Target |
|--------|-------------|---------------|
| val_abupt_axis_mean_rel_l2_pct | 6.7258% | ~5.0% |
| val_surface_pressure_rel_l2_pct | 4.455% | 3.82% |
| val_tau_x_rel_l2_pct | ~6.7% | 5.35% |
| val_tau_y_rel_l2_pct | **8.489%** | **3.65%** |
| val_tau_z_rel_l2_pct | **9.997%** | **3.63%** |
| val_volume_pressure_rel_l2_pct | 4.249% | 6.08% |

## Implementation Instructions

### 1. Curvature Feature Computation

Add a standalone function `compute_surface_curvature(points, k=20)` that computes mean curvature H and Gaussian curvature K for each surface point via k-NN PCA:

```python
import torch
import torch.nn.functional as F

def compute_surface_curvature(points: torch.Tensor, k: int = 20) -> torch.Tensor:
    """
    Compute mean curvature H and Gaussian curvature K for each surface point
    via k-NN PCA of the local neighborhood.
    
    Args:
        points: (N, 3) surface point coordinates
        k: number of nearest neighbors for local PCA
    
    Returns:
        curvature: (N, 2) tensor with columns [H, K] where
                   H = (κ₁ + κ₂) / 2  (mean curvature)
                   K = κ₁ * κ₂         (Gaussian curvature)
    """
    N = points.shape[0]
    device = points.device
    
    # Build k-NN graph
    # Compute pairwise distances
    diff = points.unsqueeze(1) - points.unsqueeze(0)  # (N, N, 3)
    dist_sq = (diff ** 2).sum(-1)  # (N, N)
    
    # Get k nearest neighbors (excluding self)
    _, knn_idx = dist_sq.topk(k + 1, dim=-1, largest=False)
    knn_idx = knn_idx[:, 1:]  # (N, k) — exclude self
    
    # Local neighborhoods
    neighbors = points[knn_idx]  # (N, k, 3)
    centroid = neighbors.mean(dim=1, keepdim=True)  # (N, 1, 3)
    centered = neighbors - centroid  # (N, k, 3)
    
    # PCA: compute covariance matrix and eigenvalues
    # cov = centered^T @ centered / k  →  (N, 3, 3)
    cov = torch.bmm(centered.transpose(1, 2), centered) / k
    
    # Eigendecomposition — eigenvalues in ascending order
    eigenvalues, _ = torch.linalg.eigh(cov)  # (N, 3), ascending
    
    # The two smallest eigenvalues λ₁ ≤ λ₂ ≤ λ₃:
    # λ₁ ≈ 0 (normal direction), κ₁ ∝ sqrt(λ₂/λ₃), κ₂ ∝ sqrt(λ₁/λ₃)
    # Use shape-index approximation: κ_i ∝ sqrt(eigenvalue)
    # Clamp to avoid negative sqrt from numerical noise
    lam = eigenvalues.clamp(min=0)  # (N, 3)
    lam1 = lam[:, 0]  # smallest
    lam2 = lam[:, 1]  # middle
    lam3 = lam[:, 2]  # largest (normalize)
    
    eps = 1e-8
    kappa1 = torch.sqrt(lam2 / (lam3 + eps))
    kappa2 = torch.sqrt(lam1 / (lam3 + eps))
    
    H = (kappa1 + kappa2) / 2.0  # mean curvature
    K = kappa1 * kappa2           # Gaussian curvature
    
    return torch.stack([H, K], dim=-1)  # (N, 2)
```

**Memory consideration:** The `(N, N, 3)` pairwise diff is O(N²) and will OOM for N=65536. Use chunked or batched k-NN instead:

```python
def compute_surface_curvature_chunked(points: torch.Tensor, k: int = 20, chunk_size: int = 4096) -> torch.Tensor:
    """Memory-efficient chunked version for large N."""
    N = points.shape[0]
    device = points.device
    curvatures = torch.zeros(N, 2, device=device)
    
    for start in range(0, N, chunk_size):
        end = min(start + chunk_size, N)
        chunk = points[start:end]  # (C, 3)
        
        # Distance from chunk to all points
        diff = chunk.unsqueeze(1) - points.unsqueeze(0)  # (C, N, 3)
        dist_sq = (diff ** 2).sum(-1)  # (C, N)
        
        _, knn_idx = dist_sq.topk(k + 1, dim=-1, largest=False)
        knn_idx = knn_idx[:, 1:]  # (C, k)
        
        neighbors = points[knn_idx]  # (C, k, 3)
        centroid = neighbors.mean(dim=1, keepdim=True)
        centered = neighbors - centroid
        
        cov = torch.bmm(centered.transpose(1, 2), centered) / k
        eigenvalues, _ = torch.linalg.eigh(cov)
        
        lam = eigenvalues.clamp(min=0)
        lam1, lam2, lam3 = lam[:, 0], lam[:, 1], lam[:, 2]
        
        eps = 1e-8
        kappa1 = torch.sqrt(lam2 / (lam3 + eps))
        kappa2 = torch.sqrt(lam1 / (lam3 + eps))
        
        H = (kappa1 + kappa2) / 2.0
        K = kappa1 * kappa2
        
        curvatures[start:end] = torch.stack([H, K], dim=-1)
    
    return curvatures
```

### 2. Normalization

After computing curvature for the batch:

```python
def normalize_curvature(curv: torch.Tensor) -> torch.Tensor:
    """Normalize H and K to zero-mean/unit-std, clip at ±3σ."""
    mean = curv.mean(dim=0, keepdim=True)
    std = curv.std(dim=0, keepdim=True) + 1e-8
    curv_norm = (curv - mean) / std
    return curv_norm.clamp(-3.0, 3.0)
```

### 3. Integration into train.py

Compute curvature for surface points before the model forward pass and concatenate as additional input channels. The surface input currently has 3 coordinate + N feature channels. Add H and K as 2 extra channels:

```python
# In the surface encoding step, before model forward:
if use_surface_curvature:
    curv = compute_surface_curvature_chunked(surface_coords, k=20)  # (N_surf, 2)
    curv = normalize_curvature(curv)
    surface_features = torch.cat([surface_features, curv], dim=-1)  # append 2 channels
```

Add a CLI flag `--use-surface-curvature` (boolean, default False) to enable this path.

The model input head will need to accept the extra 2 channels. If the model uses a linear projection to embed input features, ensure the projection weight matrix is sized for `input_dim + 2`.

### 4. Training Command

```bash
torchrun --standalone --nproc_per_node=8 target/train.py \
  --agent edward \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --lr-cosine-t-max 13 --epochs 13 \
  --use-surface-curvature \
  --wandb_group edward-surface-curvature-v2 \
  --wandb_name "edward/curvature-H-K-knn20-v2"
```

**CRITICAL:** `--no-compile-model` is **required** — torch.compile + DDP NCCL causes a deadlock at step 1.

### 5. What to Report

In your PR comment, please report:
1. W&B run ID and link
2. Per-channel val metrics at best checkpoint: `val_surface_pressure_rel_l2_pct`, `val_tau_x/y/z_rel_l2_pct`, `val_volume_pressure_rel_l2_pct`, `val_abupt_axis_mean_rel_l2_pct`
3. Whether tau_y and tau_z improved vs baseline (8.489%, 9.997%)
4. Training time and memory usage with curvature enabled
5. Any numerical issues (NaN curvatures, OOM errors) and how you handled them

## Background

Surface curvature is a classical geometric quantity in differential geometry. In CFD:
- **Regions of high mean curvature** (sharp edges, wheel arches) correlate with flow separation and elevated shear stress magnitude
- **Gaussian curvature sign** distinguishes convex (K>0, forward stagnation zones) from saddle (K<0, trailing edges) regions
- Both are coordinate-invariant, making them natural physics-informed features

Prior work (PR #605) successfully merged the implementation but returned no metrics — so this is a clean reissue on the current SOTA stack. This test will tell us definitively whether curvature features add geometric information that the model cannot learn from coordinates alone.

## References

- PR #605: `edward/surface-curvature-features` — original implementation (merged, zero metrics)
- PR #594: `askeladd/rff32-on-pr571-sota` — current single-model SOTA gate (val_abupt=6.7258%)
- W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
