### PR TITLE
SDF-proximity volume loss weighting to close the p_v gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -1159,6 +1159,8 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    sdf_proximity_alpha: float = 0.0
+    sdf_proximity_sigma: float = 0.1
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1874,10 +1876,23 @@ def check_kill_thresholds(
     return None
 
 
-def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-    if bool(mask.any()):
+def masked_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    per_point_weight: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not bool(mask.any()):
+        return pred.sum() * 0.0
+    if per_point_weight is None:
         return F.mse_loss(pred[mask], target[mask])
-    return pred.sum() * 0.0
+    diff_sq = (pred - target).pow(2)
+    mask_f = mask.unsqueeze(-1).to(pred.dtype)
+    weight = per_point_weight.to(pred.dtype).unsqueeze(-1)
+    n_channels = diff_sq.shape[-1]
+    valid = mask_f.sum().clamp_min(1)
+    return (diff_sq * weight * mask_f).sum() / valid / n_channels
 
 
 def weighted_masked_mse_per_channel(
@@ -1957,6 +1972,7 @@ def weighted_masked_beta_nll_per_channel(
     *,
     channel_weights: Iterable[float],
     beta: float,
+    per_point_weight: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, list[float], list[float]]:
     """Per-channel weighted masked β-NLL loss (Seitzer et al. 2022, ICLR).
 
@@ -1998,6 +2014,8 @@ def weighted_masked_beta_nll_per_channel(
     mask_f = mask.unsqueeze(-1).to(pred_mean.dtype)
     valid = mask_f.sum().clamp_min(1)
     weighted_diff = nll * weights.view(1, 1, -1)
+    if per_point_weight is not None:
+        weighted_diff = weighted_diff * per_point_weight.to(pred_mean.dtype).unsqueeze(-1)
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
 
     per_axis_diff_sq_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
@@ -2034,11 +2052,19 @@ def train_loss(
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
     beta_nll_beta: float = -1.0,
+    sdf_proximity_alpha: float = 0.0,
+    sdf_proximity_sigma: float = 0.1,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     use_beta_nll = beta_nll_beta >= 0.0
+    if sdf_proximity_alpha > 0.0:
+        sdf_vals = batch.volume_x[..., 3]
+        sigma = max(sdf_proximity_sigma, 1e-6)
+        prox_w = 1.0 + sdf_proximity_alpha * torch.exp(-sdf_vals.abs() / sigma)
+    else:
+        prox_w = None
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -2095,6 +2121,7 @@ def train_loss(
                 batch.volume_mask,
                 channel_weights=(1.0,),
                 beta=beta_nll_beta,
+                per_point_weight=prox_w,
             )
             volume_log_var_mean = vol_log_var_per_axis[0] if vol_log_var_per_axis else 0.0
         else:
@@ -2105,7 +2132,9 @@ def train_loss(
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 wallshear_huber_delta=wallshear_huber_delta,
             )
-            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+            volume_loss = masked_mse(
+                out["volume_preds"], volume_target, batch.volume_mask, per_point_weight=prox_w
+            )
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
@@ -2127,6 +2156,10 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
+    if prox_w is not None and bool(batch.volume_mask.any()):
+        metrics["sdf_prox_weight_mean"] = float(
+            prox_w[batch.volume_mask].float().mean().detach().cpu().item()
+        )
     if use_tangential_wallshear_loss and not use_beta_nll:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if use_beta_nll and per_axis_log_var is not None:
@@ -2788,6 +2821,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
+                sdf_proximity_alpha=config.sdf_proximity_alpha,
+                sdf_proximity_sigma=config.sdf_proximity_sigma,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2955,6 +2990,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[
                     "aux_rel_l2_loss"
+                ]
+            if "sdf_prox_weight_mean" in batch_loss_metrics:
+                train_log["train/sdf_prox_weight_mean"] = batch_loss_metrics[
+                    "sdf_prox_weight_mean"
                 ]
             for log_var_key in (
                 "log_var_surface_pressure",


### PR DESCRIPTION
# SDF-Proximity Volume Loss Weighting to Close the p_v Gap

## Hypothesis

Volume pressure residuals are worst near the vehicle surface, where pressure gradients are steepest. The volume input already contains the signed-distance field as the 4th feature channel (`batch.volume_x[:, :, 3]`). By weighting the per-point volume loss by a function of `|SDF|`, we push the model to fit near-surface volume points harder — exactly where the current model is weakest.

Proposed per-point weight:

```
w(sdf) = 1 + α · exp(−|sdf| / σ)
```

- `α` controls the maximum boost at the surface (w → 1+α as |sdf| → 0)
- `σ` (in normalized SDF units) controls how quickly the boost decays away from the surface

When `α = 0` this reduces to the unweighted baseline, making it a strict no-op extension.

**Primary target:** close the `volume_pressure` gap vs AB-UPT (yi test = 12.354% vs AB-UPT = 6.08%, factor 2.03×). Secondary benefit: near-surface volume points also influence `wall_shear_y` and `wall_shear_z` indirectly.

## Current Baseline (merge bar)

| Metric | val | test |
|---|---|---|
| **abupt_axis_mean_rel_l2_pct** | **8.686%** | **9.834%** |
| surface_pressure | 5.531% | 5.260% |
| wall_shear | 9.617% | 9.508% |
| volume_pressure | 5.648% | 12.354% |
| wall_shear_y | 11.490% | 11.360% |
| wall_shear_z | 12.646% | 12.115% |

Baseline W&B run: `86lxu1w0` (PR #590, grad-ema-alpha=0.5)

AB-UPT reference test: surface_pressure 3.82%, wall_shear 7.29%, volume_pressure 6.08%, wall_shear_y 3.65%, wall_shear_z 3.63%.

## Code Changes Required

You must add two new CLI flags to `train.py`:

```python
parser.add_argument('--sdf-proximity-alpha', type=float, default=0.0,
    help='Amplitude of SDF-proximity volume loss boost (0.0 = disabled)')
parser.add_argument('--sdf-proximity-sigma', type=float, default=0.1,
    help='Decay length (in normalized SDF units) for proximity boost')
```

In the volume loss computation, extract the SDF channel and compute per-point weights **before** the masked mean reduction. The SDF is already the 4th input channel of the volume batch (`index 3`). Locate where `volume_loss` or `vol_loss` is computed and insert:

```python
if args.sdf_proximity_alpha > 0.0:
    sdf_vals = batch.volume_x[:, :, 3]  # shape [B, N_volume]
    prox_w = 1.0 + args.sdf_proximity_alpha * torch.exp(
        -sdf_vals.abs() / args.sdf_proximity_sigma
    )
    # per_point_vol_loss has shape [B, N_volume] — multiply before mean
    per_point_vol_loss = per_point_vol_loss * prox_w
```

Make sure you identify the correct variable name for the per-point (unreduced) volume loss in your version of `train.py`. The key is to multiply element-wise **before** the `.mean()` or masked mean reduction step, not after.

## Experiment Arms

Run all three arms with `--wandb-group yi-round35-sdf-prox`:

**Arm A** — moderate boost, tighter decay (recommended first):
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent thorfinn --wandb-group yi-round35-sdf-prox \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 --ema-decay 0.999 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --sdf-proximity-alpha 2.0 --sdf-proximity-sigma 0.1
```

**Arm B** — high boost, tighter decay:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent thorfinn --wandb-group yi-round35-sdf-prox \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 --ema-decay 0.999 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --sdf-proximity-alpha 5.0 --sdf-proximity-sigma 0.05
```

**Arm C** — moderate boost, wider decay:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent thorfinn --wandb-group yi-round35-sdf-prox \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --lr-warmup-epochs 1 --ema-decay 0.999 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --sdf-proximity-alpha 2.0 --sdf-proximity-sigma 0.2
```

## Reporting

When complete, post results for all three arms. Report at minimum:

- W&B run IDs for all arms
- `val/abupt_axis_mean_rel_l2_pct` and `test/abupt_axis_mean_rel_l2_pct` for each arm
- Per-channel breakdown: `surface_pressure`, `wall_shear`, `volume_pressure`, `wall_shear_y`, `wall_shear_z`
- Best arm's training curves (loss, per-channel val metrics)

Use the best arm for the terminal `SENPAI-RESULT` marker. Close with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<best-arm-run-id>"],"primary_metric":{"name":"val/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Why This Is Worth Trying

- The SDF channel is **already in the training data** — zero data cost.
- Near-surface volume pressure is the single largest remaining gap vs AB-UPT (factor 2.03×).
- This is a pure loss-side change — no architectural risk, no risk of destabilising the surface predictions.
- If `α=0` is always equivalent to the baseline, you can verify the implementation is correct with a sanity-check run.
