### PR TITLE
Long DDP8: stronger bounded tau weights tau_y×1.5 / tau_z×2.0 (nh96x7m4 validation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -52,6 +52,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     make_loaders,
     masked_mse,
+    masked_mse_per_channel,
     metric_namespace,
     parse_kill_thresholds,
     primary_metric_log,
@@ -81,6 +82,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    tau_y_loss_weight: float = 1.0
+    tau_z_loss_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -190,6 +193,8 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    tau_y_loss_weight: float = 1.0,
+    tau_z_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -201,15 +206,27 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        # Per-channel surface MSE: channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]
+        ch_losses = masked_mse_per_channel(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_loss = ch_losses[0] + ch_losses[1] + ch_losses[2] + ch_losses[3]
+        surface_loss_weighted = (
+            ch_losses[0]
+            + ch_losses[1]
+            + tau_y_loss_weight * ch_losses[2]
+            + tau_z_loss_weight * ch_losses[3]
+        )
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
+        weighted_surface_loss = surface_loss_weight * surface_loss_weighted
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
+        "surface_loss_ch0_cp": float(ch_losses[0].detach().cpu().item()),
+        "surface_loss_ch1_tau_x": float(ch_losses[1].detach().cpu().item()),
+        "surface_loss_ch2_tau_y": float(ch_losses[2].detach().cpu().item()),
+        "surface_loss_ch3_tau_z": float(ch_losses[3].detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
@@ -329,6 +346,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    tau_y_loss_weight=config.tau_y_loss_weight,
+                    tau_z_loss_weight=config.tau_z_loss_weight,
                 )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -831,6 +831,21 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_mse_per_channel(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> list:
+    """Per-channel MSE for surface predictions.
+
+    Args:
+        pred:   (batch, n_pts, n_channels)
+        target: (batch, n_pts, n_channels)
+        mask:   (batch, n_pts)
+
+    Returns:
+        List of n_channels scalar tensors, one per channel.
+    """
+    n_channels = pred.shape[-1]
+    return [masked_mse(pred[..., c : c + 1], target[..., c : c + 1], mask) for c in range(n_channels)]
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Assignment: Stronger bounded tau weights — tau_y×1.5 / tau_z×2.0

**Student:** dl24-tanjiro  
**Wave:** drivaerml-long-20260504  
**Reference run:** `nh96x7m4` (tau_y=1.5, tau_z=2.0)  
**W&B group:** `drivaerml-long-tanjiro-tau-yz-strong`

---

## Hypothesis

The tau_y and tau_z channels are the hardest to predict in the DrivAerML surface field — across every frontier single-model run they sit at 2.3–2.6× their AB-UPT targets while tau_x is already close. Mild static upweighting (y=1.2, z=1.3, PR #611) improves these channels slightly, but the reference run `nh96x7m4` used a noticeably stronger schedule (y=1.5, z=2.0) and produced nearly identical aggregate performance while narrowing the tau_y/tau_z gap more aggressively. Under a full 24h DDP8 budget these stronger weights should further compress the cross-flow tau error floor, since early training epochs allocate more gradient signal toward the hardest channels.

**Why now:** This is item #2 in the human directive's highest-priority lever list. It requires only the two `--tau-y-loss-weight` and `--tau-z-loss-weight` flags present in the current branch's `train.py`. No code porting or architecture changes are needed.

---

## Pre-wave reference baselines

| Run | Mechanism | Test aggregate | Surface | Volume | Wall | tau_x / tau_y / tau_z |
|---|---|---:|---:|---:|---:|---:|
| `9mm3sz7x` | mild tau_y=1.2 / tau_z=1.3, lr 9e-5 | 8.123 | 4.128 | 12.051 | 7.454 | 6.566 / 8.326 / 9.543 |
| `nh96x7m4` | **tau_y=1.5 / tau_z=2.0 (reference)** | **8.171** | **4.209** | **12.118** | **7.505** | **6.649 / 8.348 / 9.531** |
| `341czkol` | GradNorm α=1.0 | 8.243 | 4.221 | 12.407 | 7.532 | 6.695 / 8.305 / 9.589 |

**Frieren long-run SOTA (PR #599, run `sogus8sx`):** val_abupt ≈ 6.582% — this is the current best in this wave.  
**Val SOTA gate (pre-wave, run `9mm3sz7x`):** 6.7644% — beat this to set a new SOTA.  
**AB-UPT targets (lower is better):**

| Channel | AB-UPT target |
|---|---:|
| tau_x | 5.35% |
| tau_y | 3.65% |
| tau_z | 3.63% |

The tau_y and tau_z error on all frontier runs (8–10% each) is 2.3–2.7× the AB-UPT target — this is the single biggest compressible gap in the surface field.

---

## Protocol

### Step 1 — DDP8 smoke gate (required before the long run)

Run exactly 2 epochs on DDP8 to verify init, dataset loading, W&B logging, checkpoint save/resume, gradient logging, and EMA shadow:

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 2 \
  --batch-size 4 \
  --lr 9e-5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 50 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --grad-clip-norm 0.5 \
  --use-ema \
  --ema-decay 0.999 \
  --gradient-log-every 100 \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_group drivaerml-long-tanjiro-tau-yz-strong \
  --wandb_run_name smoke-tanjiro-tau-yz-strong-v1
```

**Smoke pass criteria (all must be met before proceeding to long run):**
- Training completes 2 epochs without crash or NCCL deadlock
- W&B run appears in project `senpai-v1-drivaerml-ddp8` under group `drivaerml-long-tanjiro-tau-yz-strong`
- EP2 `val_primary/abupt_axis_mean_rel_l2_pct` is finite and < 30%
- Checkpoint is saved to disk (confirm path in logs)
- Gradient norms are logged and finite

Report the smoke W&B run ID and EP2 val metric in a PR comment before proceeding to Step 2.

---

### Step 2 — DDP8 long run (50 epochs / 24h cap)

After smoke passes:

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 50 \
  --batch-size 4 \
  --lr 9e-5 \
  --lr-warmup-epochs 2 \
  --lr-cosine-t-max 50 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --grad-clip-norm 0.5 \
  --use-ema \
  --ema-decay 0.999 \
  --gradient-log-every 100 \
  --kill-thresholds "3000:val_primary/abupt_axis_mean_rel_l2_pct>=30,8000:val_primary/abupt_axis_mean_rel_l2_pct>=15" \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_group drivaerml-long-tanjiro-tau-yz-strong \
  --wandb_run_name long-tanjiro-tau-yz-strong-v1
```

**Kill thresholds explained:** These are divergence guards. The run continues normally; it is only aborted if the metric *fails* to drop below these ceilings by the given step counts. At step 3000 the val_abupt must be below 30% (basic convergence check); at step 8000 it must be below 15% (healthy learning check).

**Checkpoint policy:** At the end of the run, reload from the **best validation checkpoint** (not the terminal epoch) and harvest full test metrics from `test_primary/*`.

---

### Step 3 — Volume guard check (required)

After the long run completes, check for volume-pressure collapse before claiming a win:

- `test_primary/volume_pressure_rel_l2_pct` must be ≤ 16.0% (the reference `nh96x7m4` volume was 12.118%)
- If volume pressure is > 16.0%, report this explicitly as a potential volume collapse and do **not** claim a clean win

---

### Step 4 — Test metric harvest and result reporting

Load the best-validation checkpoint and run test evaluation. Report these metrics in a PR comment:

| Metric | W&B key | Reference (`nh96x7m4`) |
|---|---|---:|
| Test aggregate | `test_primary/abupt_axis_mean_rel_l2_pct` | 8.171 |
| Surface pressure | `test_primary/surface_pressure_rel_l2_pct` | 4.209 |
| Volume pressure | `test_primary/volume_pressure_rel_l2_pct` | 12.118 |
| Wall shear (aggregate) | `test_primary/wall_shear_rel_l2_pct` | 7.505 |
| tau_x | `test_primary/wall_shear_x_rel_l2_pct` | 6.649 |
| tau_y | `test_primary/wall_shear_y_rel_l2_pct` | 8.348 |
| tau_z | `test_primary/wall_shear_z_rel_l2_pct` | 9.531 |
| Best val epoch | — | — |
| Total runtime (h) | — | — |
| Smoke passed | — | yes/no |

Once all test metrics are available and the run is terminal, post the structured result marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<long-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test_value>}}
```

---

## What to watch for

1. **tau_y and tau_z trajectory:** The key question is whether stronger weights (1.5/2.0) compress the cross-flow tau channels faster or deeper than mild weights (1.2/1.3). Log per-channel val metrics at every epoch.
2. **Surface vs volume balance:** Higher tau weights *may* slightly decrease surface pressure fidelity. If `surface_pressure_rel_l2_pct` degrades beyond 5.0% (vs 4.209% reference), note it.
3. **Convergence rate:** Does the stronger upweighting help the model converge faster in early epochs, or does it create instability? The gradient-log-every=100 setting will show this.
4. **Best epoch vs terminal:** If the run plateaus early (best val at epoch 20-25, no improvement for 10+ epochs), report this — it tells us the cosine schedule is well-calibrated for this weight regime.

---

## Notes

- This is a **single-arm** experiment (no sweep). One 50-epoch long run, one W&B run ID in the SENPAI-RESULT.
- No code changes are required — all flags exist in the current branch's `train.py`.
- No ensembles, model soups, or NNLS aggregation.
- If the run must be interrupted and resumed, use `--resume` to load the latest checkpoint and continue from the same W&B run.
- Your PR #601 (EMA-proxy GradNorm) was closed after the mechanism showed severe underperformance. This assignment is a fresh start on a well-motivated mechanism from the human directive.