### PR TITLE
alphonse: point-level pre-slice STRING rotation in Transolver

### DIFF
--- a/model.py
+++ b/model.py
@@ -136,6 +136,86 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class PreSliceStringRoPE(nn.Module):
+    """Learnable per-axis STRING-style rotation applied to per-point hidden
+    channels before slice formation in ``TransolverAttention.create_slices``.
+
+    Splits ``head_dim // 2`` rotation pairs roughly evenly across ``ndim``
+    spatial axes (with leading axes getting the extra pair when not divisible).
+    Each (axis, pair_index) gets its own learnable ``log_freq`` and ``phase``.
+    Frequencies are initialised by round-robin over ``init_sigmas`` so the
+    encoding starts with broad spectral coverage matching
+    :class:`StringSeparableEncoding`.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        ndim: int = 3,
+        init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+    ):
+        super().__init__()
+        if head_dim < 2 * ndim:
+            raise ValueError(
+                f"head_dim={head_dim} is too small for {ndim}-axis pair rotation"
+            )
+        self.head_dim = head_dim
+        self.ndim = ndim
+        total_pairs = head_dim // 2
+        base = total_pairs // ndim
+        extra = total_pairs % ndim
+        self.pairs_per_axis = [base + (1 if axis < extra else 0) for axis in range(ndim)]
+        max_pairs = max(self.pairs_per_axis)
+        self.total_pairs = sum(self.pairs_per_axis)
+        self.rot_dim = self.total_pairs * 2
+        log_freq = torch.zeros(ndim, max_pairs)
+        for axis, pairs in enumerate(self.pairs_per_axis):
+            for j in range(pairs):
+                log_freq[axis, j] = math.log(init_sigmas[j % len(init_sigmas)])
+        self.log_freq = nn.Parameter(log_freq)
+        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
+
+    def angle_tensor(self, coords: torch.Tensor) -> torch.Tensor:
+        """Compute per-axis rotation angles theta for each pair.
+
+        ``coords`` has shape ``[..., 3]`` (in the standard call site
+        ``[B, 1, N, 3]``). Returns ``[..., total_pairs]`` of float angles in
+        the same dtype as ``coords``.
+        """
+
+        parts: list[torch.Tensor] = []
+        for axis, pairs in enumerate(self.pairs_per_axis):
+            freq = self.log_freq[axis, :pairs].exp().to(dtype=coords.dtype)
+            phase = self.phase[axis, :pairs].to(dtype=coords.dtype)
+            theta = 2.0 * math.pi * coords[..., axis : axis + 1] * freq + phase
+            parts.append(theta)
+        return torch.cat(parts, dim=-1)
+
+    def rotate(self, x: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        """Apply RoPE-style 2D rotation pair-wise to the first ``rot_dim``
+        channels of ``x``.
+
+        ``x`` has shape ``[B, H, N, head_dim]`` and ``coords`` has shape
+        ``[B, 1, N, ndim]`` so the same rotation is broadcast across heads.
+        Channels beyond ``rot_dim`` (when ``head_dim`` is odd or partial
+        coverage is desired) are returned unchanged.
+        """
+
+        theta = self.angle_tensor(coords)  # [B, 1, N, total_pairs]
+        rot_dim = self.rot_dim
+        x_rot = x[..., :rot_dim].float()
+        x_rot = x_rot.reshape(*x_rot.shape[:-1], theta.shape[-1], 2)
+        cos = theta.cos().unsqueeze(-1).float()
+        sin = theta.sin().unsqueeze(-1).float()
+        x0 = x_rot[..., 0:1]
+        x1 = x_rot[..., 1:2]
+        rotated = torch.cat([x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1)
+        rotated = rotated.flatten(start_dim=-2).to(dtype=x.dtype)
+        if rot_dim < x.shape[-1]:
+            return torch.cat([rotated, x[..., rot_dim:]], dim=-1)
+        return rotated
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -196,6 +276,10 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        pre_slice_string_rope: bool = False,
+        pre_slice_string_rope_full: bool = False,
+        pre_slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        pre_slice_string_rope_ndim: int = 3,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -220,11 +304,30 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+        self.pre_slice_string_rope_full = pre_slice_string_rope_full
+        if pre_slice_string_rope:
+            self.pre_slice_rope = PreSliceStringRoPE(
+                head_dim=self.dim_head,
+                ndim=pre_slice_string_rope_ndim,
+                init_sigmas=tuple(pre_slice_string_rope_init_sigmas),
+            )
+        else:
+            self.pre_slice_rope = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        if self.pre_slice_rope is not None and point_coords is not None:
+            coords_b1n3 = point_coords.unsqueeze(1)  # [B, 1, N, 3]
+            x_mid = self.pre_slice_rope.rotate(x_mid, coords_b1n3)
+            if self.pre_slice_string_rope_full:
+                fx_mid = self.pre_slice_rope.rotate(fx_mid, coords_b1n3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
@@ -236,8 +339,15 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(
+            x, attn_mask=attn_mask, point_coords=point_coords
+        )
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -265,6 +375,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        pre_slice_string_rope: bool = False,
+        pre_slice_string_rope_full: bool = False,
+        pre_slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -275,13 +388,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            pre_slice_string_rope=pre_slice_string_rope,
+            pre_slice_string_rope_full=pre_slice_string_rope_full,
+            pre_slice_string_rope_init_sigmas=pre_slice_string_rope_init_sigmas,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, point_coords=point_coords)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -298,6 +419,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        pre_slice_string_rope: bool = False,
+        pre_slice_string_rope_full: bool = False,
+        pre_slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -309,14 +433,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    pre_slice_string_rope=pre_slice_string_rope,
+                    pre_slice_string_rope_full=pre_slice_string_rope_full,
+                    pre_slice_string_rope_init_sigmas=pre_slice_string_rope_init_sigmas,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, point_coords=point_coords)
         return x
 
 
@@ -342,6 +474,9 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        pre_slice_string_rope: bool = False,
+        pre_slice_string_rope_full: bool = False,
+        pre_slice_string_rope_init_sigmas: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +489,13 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.pre_slice_string_rope = pre_slice_string_rope
+        self.pre_slice_string_rope_full = pre_slice_string_rope_full
+        self.pre_slice_string_rope_init_sigmas = (
+            tuple(pre_slice_string_rope_init_sigmas)
+            if pre_slice_string_rope_init_sigmas
+            else (0.25, 0.5, 1.0, 2.0, 4.0)
+        )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -417,6 +559,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            pre_slice_string_rope=pre_slice_string_rope,
+            pre_slice_string_rope_full=pre_slice_string_rope_full,
+            pre_slice_string_rope_init_sigmas=self.pre_slice_string_rope_init_sigmas,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -465,6 +610,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -481,6 +627,7 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            coords.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -495,10 +642,12 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            coords.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        point_coords = torch.cat(coords, dim=1) if self.pre_slice_string_rope else None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, point_coords=point_coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -102,6 +102,9 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    pre_slice_string_rope: bool = False
+    pre_slice_string_rope_full: bool = False
+    pre_slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -284,6 +287,54 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_pre_slice_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Aggregate ``log_freq`` and ``phase`` statistics across all
+    ``PreSliceStringRoPE`` instances in the backbone.
+
+    Logs both backbone-wide aggregates and per-layer log_freq means so we can
+    track whether early vs late layers learn different frequencies. Active
+    pairs only (per-axis ``pairs_per_axis`` slice) are included; padded slots
+    in non-rectangular layouts are ignored.
+    """
+
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None or not hasattr(backbone, "blocks"):
+        return metrics
+    layer_log_freqs: list[torch.Tensor] = []
+    for layer_idx, block in enumerate(backbone.blocks):
+        rope = getattr(block.attention, "pre_slice_rope", None)
+        if rope is None:
+            continue
+        active_log_freq_parts: list[torch.Tensor] = []
+        active_phase_parts: list[torch.Tensor] = []
+        for axis, pairs in enumerate(rope.pairs_per_axis):
+            active_log_freq_parts.append(rope.log_freq[axis, :pairs].detach().float())
+            active_phase_parts.append(rope.phase[axis, :pairs].detach().float())
+        if not active_log_freq_parts:
+            continue
+        layer_lf = torch.cat(active_log_freq_parts, dim=0)
+        layer_ph = torch.cat(active_phase_parts, dim=0)
+        layer_log_freqs.append(layer_lf)
+        prefix = f"pre_slice_rope/layer_{layer_idx}"
+        metrics[f"{prefix}/log_freq_mean"] = float(layer_lf.mean().item())
+        metrics[f"{prefix}/log_freq_std"] = float(layer_lf.std().item())
+        metrics[f"{prefix}/phase_mean"] = float(layer_ph.mean().item())
+        metrics[f"{prefix}/phase_std"] = float(layer_ph.std().item())
+        for axis, pairs in enumerate(rope.pairs_per_axis):
+            axis_lf = rope.log_freq[axis, :pairs].detach().float()
+            metrics[f"{prefix}/log_freq_axis_{axis}_mean"] = float(axis_lf.mean().item())
+            metrics[f"{prefix}/log_freq_axis_{axis}_std"] = float(axis_lf.std().item())
+    if layer_log_freqs:
+        all_lf = torch.cat(layer_log_freqs, dim=0)
+        metrics["pre_slice_rope/log_freq_mean"] = float(all_lf.mean().item())
+        metrics["pre_slice_rope/log_freq_std"] = float(all_lf.std().item())
+        metrics["pre_slice_rope/log_freq_min"] = float(all_lf.min().item())
+        metrics["pre_slice_rope/log_freq_max"] = float(all_lf.max().item())
+        metrics["pre_slice_rope/num_active_layers"] = float(len(layer_log_freqs))
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +348,11 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        pre_slice_string_rope=config.pre_slice_string_rope,
+        pre_slice_string_rope_full=config.pre_slice_string_rope_full,
+        pre_slice_string_rope_init_sigmas=parse_rff_init_sigmas(
+            config.pre_slice_string_rope_init_sigmas
+        ),
     )
 
 
@@ -1240,6 +1296,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_pre_slice_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The current `tay` STRING implementation injects coordinate features *before* the Transolver slice bottleneck — it is additive input geometry encoding. This is PR #311's big win and the foundation of the current SOTA stack.

But there is a stronger version of the hypothesis: if we apply coordinate-dependent rotations *before* slices are formed — on the per-point hidden channels — then the slice assignment process itself becomes geometry-aware. Points with similar coordinates and similar features will aggregate into the same slices more consistently, rather than relying entirely on learned slice weights.

**This experiment tests point-level pre-slice STRING rotation**: modify `TransolverAttention.create_slices()` to rotate the per-point projection channels (`x_mid` and/or `fx_mid`) by learnable-frequency STRING-style rotations using actual point coordinates, *before* those channels are used to compute slice assignments and slice content.

This is fundamentally different from:
- Input-level STRING-sep (PR #311): additive features appended before the backbone
- Slice-centroid RoPE (PR #621): rotates Q/K of slice tokens using centroid coordinates

This experiment rotates the representation while it still has true per-point coordinates, before the coordinate information is irreversibly aggregated into learned slices.

**Why this matters:** Transolver's learned slices cluster points by feature similarity. If the point projection uses coordinate-blind weights, similar-pressure points at different locations may mix into the same slice, reducing geometric specialization. Pre-slice coordinate rotation breaks this degeneracy: it makes the projection and slice-assignment space geometry-dependent.

**Implementation:** Add a `LearnableStringRoPE` module (same `log_freq` + `phase` parameterization as `StringSeparableEncoding`, same multi-sigma init at sigmas `[0.25, 0.5, 1.0, 2.0, 4.0]`) and apply it inside `create_slices()` before slice-weight computation.

Reference: Issue #618, Proposed Experiment 2. This is one of four parallel STRING/RoPE experiments being run simultaneously — nezuko is running Exp 1 (slice-centroid RoPE on Q/K).

## Instructions

### Three-arm sweep

Run three arms, all with the full SOTA config (L=5, lion, all loss weights, vol-points-schedule). Add `--wandb-group alphonse-presl-rope-sweep` to all runs.

**Arm A — Control (no pre-slice rotation)**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group alphonse-presl-rope-sweep --wandb-name alphonse/arm-a-control
```

**Arm B — Pre-slice rotation of `x_mid` only (slice assignment geometry-aware)**

Add flags `--pre-slice-string-rope` (enables rotation of `x_mid` before slice-weight softmax):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pre-slice-string-rope \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group alphonse-presl-rope-sweep --wandb-name alphonse/arm-b-xmid-only
```

**Arm C — Pre-slice rotation of both `x_mid` and `fx_mid` (assignment + content both geometry-aware)**

Add flags `--pre-slice-string-rope --pre-slice-string-rope-full` (rotates both projections):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pre-slice-string-rope --pre-slice-string-rope-full \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group alphonse-presl-rope-sweep --wandb-name alphonse/arm-c-xmid-and-fxmid
```

### Implementation

You will need to add `--pre-slice-string-rope` and `--pre-slice-string-rope-full` flags to `train.py` and implement the corresponding logic in `model.py`. Key implementation details:

**New module (add to `model.py`):**
```python
class PreSliceStringRoPE(nn.Module):
    """Learnable per-axis STRING rotation applied to per-point hidden channels
    before slice formation in TransolverAttention.create_slices()."""

    def __init__(self, head_dim: int, ndim: int = 3,
                 init_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0)):
        super().__init__()
        self.head_dim = head_dim
        self.ndim = ndim
        total_pairs = head_dim // 2
        base = total_pairs // ndim
        extra = total_pairs % ndim
        self.pairs_per_axis = [base + (axis < extra) for axis in range(ndim)]
        # learnable log-freq + phase, same parameterization as StringSeparableEncoding
        max_pairs = max(self.pairs_per_axis)
        self.log_freq = nn.Parameter(torch.zeros(ndim, max_pairs))
        self.phase    = nn.Parameter(torch.zeros(ndim, max_pairs))
        for axis, pairs in enumerate(self.pairs_per_axis):
            for j in range(pairs):
                self.log_freq.data[axis, j] = math.log(
                    init_sigmas[j % len(init_sigmas)])

    def rotate(self, x: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
        """
        x:      [B, H, N, head_dim]   — per-point, per-head projections
        coords: [B, 1, N, 3]          — raw xyz coordinates broadcast over heads
        Returns rotated x, same shape.
        """
        parts = []
        for axis, pairs in enumerate(self.pairs_per_axis):
            freq  = self.log_freq[axis, :pairs].exp().to(dtype=coords.dtype)
            phase = self.phase[axis, :pairs].to(dtype=coords.dtype)
            theta = (2.0 * math.pi * coords[..., axis:axis+1] * freq + phase)
            parts.append(theta)                          # [B, 1, N, pairs]
        theta = torch.cat(parts, dim=-1)                 # [B, 1, N, total_pairs]
        rot_dim = theta.shape[-1] * 2
        x_rot = x[..., :rot_dim].float()
        x_rot = x_rot.reshape(*x_rot.shape[:-1], theta.shape[-1], 2)
        cos = theta.cos()[..., None]
        sin = theta.sin()[..., None]
        x0, x1 = x_rot[..., 0:1], x_rot[..., 1:2]
        rotated = torch.cat([x0 * cos - x1 * sin,
                              x0 * sin + x1 * cos], dim=-1)
        rotated = rotated.flatten(start_dim=-2).to(dtype=x.dtype)
        if rot_dim < x.shape[-1]:
            return torch.cat([rotated, x[..., rot_dim:]], dim=-1)
        return rotated
```

**Modify `TransolverAttention.create_slices()` to accept `point_coords`:**
```python
def create_slices(self, x, attn_mask=None, point_coords=None):
    B, N, D = x.shape
    H = self.num_heads
    C = D // H

    fx_mid = self.in_project_fx(x).view(B, N, H, C).permute(0, 2, 1, 3)
    x_mid  = self.in_project_x(x).view(B, N, H, C).permute(0, 2, 1, 3)

    if self.pre_slice_rope is not None and point_coords is not None:
        coords = point_coords[:, None, :, :].expand(-1, H, -1, -1)  # [B, H, N, 3]
        # Always rotate x_mid (slice assignment)
        x_mid = self.pre_slice_rope.rotate(x_mid, coords[:, :1])
        if self.pre_slice_rope_full:
            # Also rotate fx_mid (slice content)
            fx_mid = self.pre_slice_rope.rotate(fx_mid, coords[:, :1])

    slice_logits  = self.in_project_slice(x_mid) / self.temperature  # [B, H, N, S]
    slice_weights = slice_logits.softmax(dim=-1)
    slice_tokens  = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights)
    # ... rest of create_slices unchanged ...
```

**Thread `point_coords` from `SurfaceTransolver.forward()` through `backbone.forward()` to each `TransolverAttention` layer.** Exact plumbing will depend on how `GroupedTransolver` passes args to `TransolverAttention`; follow the same pattern as `attn_mask`.

**Config fields in `train.py`:**
```python
pre_slice_string_rope: bool = False           # enables rotation of x_mid
pre_slice_string_rope_full: bool = False       # additionally rotates fx_mid
pre_slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
```

**Diagnostics to log (optional but helpful):**
- `pre_slice_rope/log_freq_axis_{0,1,2}_mean` — track frequency learning
- `pre_slice_rope/xmid_cos_sim_pre_post` — how much rotation changes x_mid cosine similarity
- `pre_slice_rope/slice_entropy_mean` — whether slices sharpen or diffuse after rotation

### Decision rule

- **Continue / report results** only if Arm B **or** Arm C beats the matched Arm A control by **≥ 0.15 pp val_abupt** at end of run.
- If neither arm beats the control by ≥ 0.15 pp: close the PR; this direction is not productive.
- If an arm beats the single-model SOTA (6.5985%) it is a winner — report full sub-metrics.

### Reporting

Report results in a PR comment table:

| Arm | Config | val_abupt | surf_pres | vol_pres | wall_shear_y | wall_shear_z | W&B Run |
|-----|--------|-----------|-----------|----------|--------------|--------------|---------|
| A | control | — | — | — | — | — | — |
| B | xmid-only | — | — | — | — | — | — |
| C | xmid+fxmid | — | — | — | — | — | — |

Include best-epoch val_abupt for each arm. Flag any training instabilities or NaN losses. Report diagnostics logs if implemented.

## Current Baselines

| Metric | Value | PR | W&B Run |
|--------|-------|----|---------|
| val_abupt (single model) | 6.5985% | #592 (alphonse) | `4k25s25e` |
| surface_pressure | 4.3322% | #592 | `4k25s25e` |
| volume_pressure | 3.9456% | #592 | `4k25s25e` |
| wall_shear_x | 6.5420% | #592 | `4k25s25e` |
| wall_shear_y | 8.3631% | #592 | `4k25s25e` |
| wall_shear_z | 9.8099% | #592 | `4k25s25e` |
| test_abupt (single model) | 7.9915% | #592 | `4k25s25e` |
| val_abupt (ensemble K=7) | 6.1751% | #612 (nezuko) | `5veexq8r` |
| test_abupt (ensemble K=7) | 7.5347% | #612 (nezuko) | `5veexq8r` |

**Single-model training gate:** val_abupt < **6.5985%**

**Related parallel experiments:**
- PR #621 (nezuko): Exp 1 — slice-centroid STRING-RoPE on Q/K (different from this)
- This PR: Exp 2 — point-level pre-slice rotation
- Exps 3 & 4 (no-slice Anchor-STRING, AB-UPT-style) — to be assigned separately
