### PR TITLE
asinh target normalization for wall shear τ_y/τ_z heavy tails

### DIFF
--- a/train.py
+++ b/train.py
@@ -1159,9 +1159,36 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    asinh_tau_channels: str = ""  # "" disabled; e.g. "y,z" applies asinh on z-scored τ_y/τ_z; "x,y,z" all axes
 
 
 NONFINITE_SKIP_ABORT = 200
+
+
+# sinh(SINH_CLAMP) ≈ 1.65e38, well below float32 max (~3.4e38). Loss space sees raw
+# (unclamped) values; clamp only kicks in for inverse-transform during eval to avoid
+# overflow from rogue model outputs.
+SINH_CLAMP = 88.0
+
+_TAU_AXIS_TO_CHANNEL = {"x": 1, "y": 2, "z": 3}
+
+
+def parse_asinh_tau_channels(spec: str) -> tuple[int, ...]:
+    spec = (spec or "").strip().lower()
+    if not spec or spec == "none":
+        return ()
+    out: list[int] = []
+    for part in spec.replace(";", ",").split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if token not in _TAU_AXIS_TO_CHANNEL:
+            raise ValueError(
+                f"Unknown asinh_tau_channels token={token!r}; expected subset of "
+                "{'x','y','z'} (e.g. 'y,z' for Arm A, 'x,y,z' for Arm B)."
+            )
+        out.append(_TAU_AXIS_TO_CHANNEL[token])
+    return tuple(sorted(set(out)))
 
 
 class TargetTransform:
@@ -1174,6 +1201,7 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        surface_asinh_channels: tuple[int, ...] = (),
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -1191,6 +1219,7 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.surface_asinh_channels = tuple(sorted(set(int(c) for c in surface_asinh_channels)))
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -1199,9 +1228,19 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+        z = (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+        if not self.surface_asinh_channels:
+            return z
+        z = z.clone()
+        for c in self.surface_asinh_channels:
+            z[..., c] = torch.asinh(z[..., c])
+        return z
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
+        if self.surface_asinh_channels:
+            y = y.clone()
+            for c in self.surface_asinh_channels:
+                y[..., c] = torch.sinh(y[..., c].clamp(-SINH_CLAMP, SINH_CLAMP))
         return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
@@ -2523,12 +2562,24 @@ def main(argv: Iterable[str] | None = None) -> None:
         curvature_stats=curvature_stats,
         curvature_cache_root=curvature_cache_root,
     )
+    asinh_channels = parse_asinh_tau_channels(config.asinh_tau_channels)
+    if asinh_channels and config.use_tangential_wallshear_loss:
+        raise ValueError(
+            "asinh_tau_channels is incompatible with use_tangential_wallshear_loss: "
+            "tangential projection requires wall-shear targets in z-score space, but "
+            "asinh remaps the targets nonlinearly."
+        )
     transform = TargetTransform(
         surface_y_mean=stats["surface_y_mean"].to(device),
         surface_y_std=stats["surface_y_std"].to(device),
         volume_y_mean=stats["volume_y_mean"].to(device),
         volume_y_std=stats["volume_y_std"].to(device),
+        surface_asinh_channels=asinh_channels,
     )
+    if is_main and asinh_channels:
+        names = {1: "tau_x", 2: "tau_y", 3: "tau_z"}
+        names_str = ",".join(names.get(c, f"ch{c}") for c in asinh_channels)
+        print(f"asinh target normalization enabled on channels: {names_str}")
 
     model = build_model(config).to(device)
     resume_info: dict[str, float | str | int] = {}


### PR DESCRIPTION
## Hypothesis

Wall shear components τ_y and τ_z have **heavy-tailed distributions** — most values are near zero but a few extreme values drive large MSE losses. Standard z-score normalization doesn't compress these tails. Applying `asinh(τ / σ)` as the prediction target compresses the heavy tails while preserving the sign and relative ordering, making the regression task easier. This is analogous to log-transform for positive-definite quantities, but works for signed values.

The hypothesis: asinh-normalizing the wall shear targets before loss computation will reduce τ_y/τ_z errors by making the target distribution more Gaussian and easier to regress.

## Instructions

Implement **asinh target normalization** for wall shear components in `train.py`:

1. **Compute per-component scale factors** (σ_x, σ_y, σ_z) from the training set statistics (e.g., std of τ_x, τ_y, τ_z across all training surface points).

2. **Transform targets before loss:**
   ```python
   tau_y_transformed = torch.asinh(tau_y / sigma_y)
   tau_z_transformed = torch.asinh(tau_z / sigma_z)
   tau_x_transformed = torch.asinh(tau_x / sigma_x)
   ```

3. **Transform model outputs analogously** (the model predicts in transformed space).

4. **Inverse transform predictions** before computing validation metrics:
   ```python
   tau_y_pred = sigma_y * torch.sinh(tau_y_pred_transformed)
   ```

5. All logged validation metrics must remain in **world-frame original units** (for comparability).

6. Try two arms:
   - **Arm A**: asinh applied to τ_y and τ_z only (leave τ_x, pressure in original space)
   - **Arm B**: asinh applied to all wall shear components (τ_x, τ_y, τ_z)

**Arm A (asinh τ_y/τ_z only):**
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent askeladd --wandb-group yi-round36-asinh-normalization \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

(You'll need to implement the asinh transform logic in train.py — modify the data loading / loss computation sections.)

Start with Arm A. After epoch 3, check τ_y and τ_z. If improved, launch Arm B.

**Early stopping criteria:**
- Val_abupt > 20% at epoch 3: stop.
- τ_y + τ_z combined not improving vs baseline by epoch 5: stop.

Report τ_y, τ_z, τ_x, surface_pressure, volume_pressure, val_abupt per epoch. Include W&B run IDs.

## Baseline (yi, PR #576)

| Metric | yi best | AB-UPT target | Gap |
|--------|---------|---------------|-----|
| val_abupt | **8.2528%** | — | — |
| surface_pressure | 5.127% | 3.82% | 1.34× |
| wall_shear | 9.233% | 7.29% | 1.27× |
| volume_pressure | 12.438% | 6.08% | **2.05×** |
| τ_x | 7.815% | 5.35% | 1.46× |
| τ_y | 9.233% | 3.65% | **2.53×** |
| τ_z | 10.449% | 3.63% | **2.88×** |

Beat `val_abupt < 8.2528%` to land on yi.

