### PR TITLE
Lookahead wrapper around Lion optimizer for better generalization

### DIFF
--- a/train.py
+++ b/train.py
@@ -1040,6 +1040,87 @@ class SurfaceTransolver(nn.Module):
         return result
 
 
+class Lookahead(torch.optim.Optimizer):
+    """Lookahead optimizer wrapper (Zhang et al. 2019, arxiv 1907.08610).
+
+    Maintains slow weights that interpolate toward fast weights every ``k`` steps:
+    ``slow <- slow + alpha * (fast - slow)``, then ``fast <- slow``. The wrapped
+    base optimizer (e.g. Lion) keeps its own momentum/state intact — Lookahead
+    only modifies the parameter values themselves.
+    """
+
+    def __init__(
+        self,
+        base_optimizer: torch.optim.Optimizer,
+        k: int = 5,
+        alpha: float = 0.5,
+    ):
+        if k < 1:
+            raise ValueError(f"Lookahead k must be >= 1, got {k}")
+        if not 0.0 < alpha <= 1.0:
+            raise ValueError(f"Lookahead alpha must be in (0, 1], got {alpha}")
+        self.base_optimizer = base_optimizer
+        self.k = int(k)
+        self.alpha = float(alpha)
+        self._step_count = 0
+        self.slow_weights: list[list[torch.Tensor]] = []
+        for group in self.base_optimizer.param_groups:
+            self.slow_weights.append(
+                [p.detach().clone() for p in group["params"]]
+            )
+
+    @property
+    def param_groups(self):
+        return self.base_optimizer.param_groups
+
+    @property
+    def state(self):
+        return self.base_optimizer.state
+
+    @property
+    def defaults(self):
+        return self.base_optimizer.defaults
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        self.base_optimizer.zero_grad(set_to_none=set_to_none)
+
+    @torch.no_grad()
+    def _sync_slow_weights(self) -> None:
+        for group, slow_group in zip(self.base_optimizer.param_groups, self.slow_weights):
+            for fast, slow in zip(group["params"], slow_group):
+                slow.add_(fast.data - slow, alpha=self.alpha)
+                fast.data.copy_(slow)
+
+    def step(self, closure=None):
+        loss = self.base_optimizer.step(closure)
+        self._step_count += 1
+        if self._step_count % self.k == 0:
+            self._sync_slow_weights()
+        return loss
+
+    def state_dict(self) -> dict:
+        return {
+            "base_optimizer": self.base_optimizer.state_dict(),
+            "k": self.k,
+            "alpha": self.alpha,
+            "step_count": self._step_count,
+            "slow_weights": [
+                [t.detach().cpu() for t in group] for group in self.slow_weights
+            ],
+        }
+
+    def load_state_dict(self, state: dict) -> None:
+        self.base_optimizer.load_state_dict(state["base_optimizer"])
+        self.k = int(state.get("k", self.k))
+        self.alpha = float(state.get("alpha", self.alpha))
+        self._step_count = int(state.get("step_count", 0))
+        slow = state.get("slow_weights")
+        if slow is not None:
+            for group_slow, saved_group in zip(self.slow_weights, slow):
+                for tensor, saved in zip(group_slow, saved_group):
+                    tensor.data.copy_(saved.to(tensor.device))
+
+
 class EMA:
     def __init__(self, model: nn.Module, decay: float = 0.999, start_step: int = 0):
         self.decay = decay
@@ -1097,7 +1178,10 @@ class EMA:
 class Config:
     lr: float = 3e-4
     weight_decay: float = 1e-4
-    optimizer: str = "adamw"  # "adamw" or "muon"
+    optimizer: str = "adamw"  # "adamw", "lion", or "muon"
+    use_lookahead: bool = False
+    lookahead_k: int = 5
+    lookahead_alpha: float = 0.5
     muon_momentum: float = 0.95
     muon_ns_steps: int = 5
     muon_adamw_lr_scale: float = 0.1  # adamw fallback LR = lr * this
@@ -2628,6 +2712,16 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"Optimizer: {optimizer.__class__.__name__} "
             f"lr={config.lr} wd={config.weight_decay}"
         )
+    if config.use_lookahead:
+        base_optimizer_name = optimizer.__class__.__name__
+        optimizer = Lookahead(
+            optimizer, k=config.lookahead_k, alpha=config.lookahead_alpha
+        )
+        if is_main:
+            print(
+                f"Lookahead wrapper enabled: base={base_optimizer_name} "
+                f"k={config.lookahead_k} alpha={config.lookahead_alpha}"
+            )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None


### PR DESCRIPTION
## Hypothesis

Lion optimizer gives fast, aggressive updates with sign-based momentum. Wrapping Lion with **Lookahead** (slow weights + fast weights) can improve generalization by averaging over a short trajectory of fast-weight updates before committing. Lookahead has been shown to reduce variance and improve convergence in noisy settings — exactly what τ_y/τ_z are (noisy, high-variance targets). The slow weight step every k=5 fast steps acts as an implicit ensemble over recent update trajectories.

The hypothesis: Lookahead-Lion will generalize better on τ_y/τ_z than raw Lion, because the slow/fast weight averaging damps noisy gradient directions.

## Instructions

Implement **Lookahead wrapper around Lion optimizer** in `train.py`:

1. **Add Lookahead wrapper** (from `torch_optimizer` or implement manually):
   ```python
   from torch_optimizer import Lookahead  # pip install torch-optimizer
   # OR implement manually:
   class Lookahead(torch.optim.Optimizer):
       def __init__(self, base_optimizer, k=5, alpha=0.5):
           ...
   
   base_optimizer = Lion(model.parameters(), lr=1e-4, weight_decay=5e-4)
   optimizer = Lookahead(base_optimizer, k=5, alpha=0.5)
   ```

2. **Lookahead hyperparameters**: k=5 (sync every 5 fast steps), alpha=0.5 (interpolation factor).

3. **Keep all other yi baseline settings** unchanged:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent emma --wandb-group yi-round36-lookahead-lion \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

4. You'll need to modify the optimizer construction section in `train.py` to wrap Lion with Lookahead. Add the Lookahead step to the training loop's optimizer.step() call.

5. Also try **Arm B**: k=10, alpha=0.8 if Arm A shows promise at epoch 5.

**Decision at epoch 5:**
- Val_abupt < 8.5%: continue to completion, launch Arm B.
- Val_abupt 8.5–9.0%: continue Arm A only.
- Val_abupt > 9.0%: stop, report.

Report τ_y, τ_z, τ_x, surface_pressure, volume_pressure, val_abupt per epoch. Include W&B run IDs.

## Baseline (yi, PR #576)

| Metric | yi best | AB-UPT target | Gap |
|--------|---------|---------------|-----|
| val_abupt | **8.2528%** | — | — |
| surface_pressure | 5.127% | 3.82% | 1.34× |
| wall_shear | 9.233% | 7.29% | 1.27× |
| volume_pressure | 12.438% | 6.08% | **2.05×** |
| τ_x | 7.815% | 5.35% | 1.46× |
| τ_y | 9.233% | 3.65% | **2.53×** |
| τ_z | 10.449% | 3.63% | **2.88×** |

Beat `val_abupt < 8.2528%` to land on yi.

