### PR TITLE
Cosine annealing warm restarts (T_0=3, T_mult=2) for Lion optimizer

### DIFF
--- a/train.py
+++ b/train.py
@@ -1159,6 +1159,9 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    lr_cosine_t0: int = 0
+    lr_cosine_t_mult: int = 1
+    lr_cosine_eta_min: float = 1e-6
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2629,7 +2632,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"lr={config.lr} wd={config.weight_decay}"
         )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+    if config.lr_cosine_t0 > 0:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=config.lr_cosine_t0,
+            T_mult=config.lr_cosine_t_mult,
+            eta_min=config.lr_cosine_eta_min,
+        )
+        if is_main:
+            print(
+                f"LR scheduler: CosineAnnealingWarmRestarts "
+                f"T_0={config.lr_cosine_t0} T_mult={config.lr_cosine_t_mult} "
+                f"eta_min={config.lr_cosine_eta_min}"
+            )
+    else:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
+        if is_main:
+            print(f"LR scheduler: CosineAnnealingLR T_max={max_epochs}")
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
     effective_warmup_steps = config.lr_warmup_steps


### PR DESCRIPTION
## Hypothesis

The current yi baseline uses a flat LR schedule (Lion at 1e-4 with warmup). **Cosine annealing with warm restarts** (SGDR) periodically spikes the LR, helping the optimizer escape local minima and explore flatter basins. Given that τ_y/τ_z have very complex loss landscapes, the warm restarts could help the model find better solutions than a monotonically decaying LR or flat LR.

The hypothesis: CosineAnnealingWarmRestarts with T_0=3, T_mult=2 will allow the model to escape local minima and find lower τ_y/τ_z solutions through repeated annealing cycles.

## Instructions

Implement **CosineAnnealingWarmRestarts** for the Lion optimizer in `train.py`:

1. **Add scheduler after optimizer creation:**
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
       optimizer, T_0=3, T_mult=2, eta_min=1e-6
   )
   # Step after each epoch: scheduler.step(epoch)
   ```

2. **Keep all other yi baseline settings** unchanged:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent violet --wandb-group yi-round36-cosine-warm-restarts \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

3. **Log the LR to W&B** at each step so we can see the restart pattern.

4. The warm restart cycle with T_0=3, T_mult=2 gives restarts at epochs 3, 9, 21... — within the training budget this gives 2–3 full restart cycles.

5. Also run **Arm B** with T_0=5, T_mult=2 (restarts at 5, 15...) if Arm A shows promise.

**Decision at epoch 5:**
- Val_abupt < 8.5%: continue to completion, launch Arm B.
- Val_abupt 8.5–9.0%: continue Arm A only.
- Val_abupt > 9.5%: stop early, report.

Report τ_y, τ_z, τ_x, surface_pressure, volume_pressure, val_abupt per epoch. Also log current LR each epoch. Include W&B run IDs.

## Baseline (yi, PR #576)

| Metric | yi best | AB-UPT target | Gap |
|--------|---------|---------------|-----|
| val_abupt | **8.2528%** | — | — |
| surface_pressure | 5.127% | 3.82% | 1.34× |
| wall_shear | 9.233% | 7.29% | 1.27× |
| volume_pressure | 12.438% | 6.08% | **2.05×** |
| τ_x | 7.815% | 5.35% | 1.46× |
| τ_y | 9.233% | 3.65% | **2.53×** |
| τ_z | 10.449% | 3.63% | **2.88×** |

Beat `val_abupt < 8.2528%` to land on yi.

