### PR TITLE
Inverse local point density loss weighting for sparse surface regions

### DIFF
--- a/train.py
+++ b/train.py
@@ -1159,6 +1159,9 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    surface_density_weight_scale: float = 0.0
+    surface_density_weight_k: int = 10
+    surface_density_weight_clamp_quantile: float = 0.95
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1880,6 +1883,96 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+@torch.no_grad()
+def compute_inverse_density_weights(
+    surface_pos: torch.Tensor,
+    surface_mask: torch.Tensor,
+    *,
+    scale: float,
+    k: int = 10,
+    chunk_size: int = 4096,
+    clamp_quantile: float = 0.95,
+    eps: float = 1e-8,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Per-point inverse-density weights for the surface loss.
+
+    For each surface point, the raw weight is the mean Euclidean distance to its
+    k nearest **valid** neighbours (sparse regions get larger weight, dense
+    regions get smaller). The cdist matrix is built in chunks of ``chunk_size``
+    query rows, batched over B in a single fused call, to keep peak memory at
+    O(B * chunk_size * N * 4B) instead of O(B * N^2 * 4B). Padded points are
+    removed from the candidate set via masked_fill (so they are never selected
+    as neighbours) and receive output weight 1.0.
+
+    Per sample b, given valid raw weights w_raw (= mean_nn_dist + eps):
+        p95     = quantile(w_raw, clamp_quantile)
+        w_clamp = w_raw.clamp(max=p95)
+        w_norm  = w_clamp / mean(w_clamp)              # mean over valid = 1.0
+        w_blend = 1.0 + scale * (w_norm - 1.0)         # scale=0 → 1; scale=1 → full
+
+    Returns the [B, N] weight tensor (padded entries = 1.0) plus diagnostic
+    statistics aggregated over valid points across the batch.
+    """
+    B, N, _ = surface_pos.shape
+    device = surface_pos.device
+    weight = torch.ones((B, N), device=device, dtype=torch.float32)
+    diag_zero = {
+        "density_weight/max": 1.0,
+        "density_weight/min": 1.0,
+        "density_weight/std": 0.0,
+        "density_weight/pre_clamp_max_ratio": 1.0,
+    }
+    if scale == 0.0:
+        return weight, diag_zero
+
+    pos_f = surface_pos.float()
+    INF_DIST = 1.0e10
+    invalid = ~surface_mask  # [B, N]
+    mean_dists = torch.empty((B, N), device=device, dtype=torch.float32)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        chunk_pts = pos_f[:, start:end, :]  # [B, chunk, 3]
+        d = torch.cdist(chunk_pts, pos_f)  # [B, chunk, N]
+        d = d.masked_fill(invalid.unsqueeze(1), INF_DIST)
+        topk_d, _ = torch.topk(d, k + 1, dim=-1, largest=False)
+        mean_dists[:, start:end] = topk_d[..., 1:].mean(dim=-1)
+
+    diag_max = -float("inf")
+    diag_min = float("inf")
+    diag_std_max = 0.0
+    diag_pre_clamp_max_ratio = 0.0
+    for b in range(B):
+        mask_b = surface_mask[b]
+        n_valid = int(mask_b.sum().item())
+        if n_valid <= k + 1:
+            continue
+        valid_dists = mean_dists[b].masked_select(mask_b)
+        w_raw = valid_dists + eps
+        median_v = torch.quantile(w_raw, 0.5).clamp_min(eps)
+        diag_pre_clamp_max_ratio = max(
+            diag_pre_clamp_max_ratio, float((w_raw.max() / median_v).item())
+        )
+        p95 = torch.quantile(w_raw, clamp_quantile)
+        w_clamped_v = w_raw.clamp(max=p95)
+        mean_v = w_clamped_v.mean().clamp_min(eps)
+        w_norm_v = w_clamped_v / mean_v
+        w_blend_v = 1.0 + scale * (w_norm_v - 1.0)
+        full = torch.ones(N, device=device, dtype=torch.float32)
+        full = full.masked_scatter(mask_b, w_blend_v)
+        weight[b] = full
+        diag_max = max(diag_max, float(w_blend_v.max().item()))
+        diag_min = min(diag_min, float(w_blend_v.min().item()))
+        diag_std_max = max(diag_std_max, float(w_blend_v.std().item()))
+
+    diag = {
+        "density_weight/max": diag_max if math.isfinite(diag_max) else 1.0,
+        "density_weight/min": diag_min if math.isfinite(diag_min) else 1.0,
+        "density_weight/std": diag_std_max,
+        "density_weight/pre_clamp_max_ratio": diag_pre_clamp_max_ratio,
+    }
+    return weight, diag
+
+
 def weighted_masked_mse_per_channel(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -1887,6 +1980,7 @@ def weighted_masked_mse_per_channel(
     *,
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
+    point_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, list[float]]:
     """Per-channel weighted masked loss for surface predictions.
 
@@ -1939,6 +2033,8 @@ def weighted_masked_mse_per_channel(
         loss_elem = diff_sq
 
     weighted_diff = loss_elem * weights.view(1, 1, -1)
+    if point_weights is not None:
+        weighted_diff = weighted_diff * point_weights.to(pred.dtype).unsqueeze(-1)
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
     per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
@@ -1957,6 +2053,7 @@ def weighted_masked_beta_nll_per_channel(
     *,
     channel_weights: Iterable[float],
     beta: float,
+    point_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, list[float], list[float]]:
     """Per-channel weighted masked β-NLL loss (Seitzer et al. 2022, ICLR).
 
@@ -1998,6 +2095,8 @@ def weighted_masked_beta_nll_per_channel(
     mask_f = mask.unsqueeze(-1).to(pred_mean.dtype)
     valid = mask_f.sum().clamp_min(1)
     weighted_diff = nll * weights.view(1, 1, -1)
+    if point_weights is not None:
+        weighted_diff = weighted_diff * point_weights.to(pred_mean.dtype).unsqueeze(-1)
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
 
     per_axis_diff_sq_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
@@ -2034,11 +2133,24 @@ def train_loss(
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
     beta_nll_beta: float = -1.0,
+    surface_density_weight_scale: float = 0.0,
+    surface_density_weight_k: int = 10,
+    surface_density_weight_clamp_quantile: float = 0.95,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     use_beta_nll = beta_nll_beta >= 0.0
+    surface_point_weights: torch.Tensor | None = None
+    density_diag: dict[str, float] = {}
+    if surface_density_weight_scale > 0.0:
+        surface_point_weights, density_diag = compute_inverse_density_weights(
+            batch.surface_x[..., :3],
+            batch.surface_mask,
+            scale=surface_density_weight_scale,
+            k=surface_density_weight_k,
+            clamp_quantile=surface_density_weight_clamp_quantile,
+        )
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -2087,6 +2199,7 @@ def train_loss(
                 batch.surface_mask,
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 beta=beta_nll_beta,
+                point_weights=surface_point_weights,
             )
             volume_loss, _, vol_log_var_per_axis = weighted_masked_beta_nll_per_channel(
                 out["volume_preds"],
@@ -2104,6 +2217,7 @@ def train_loss(
                 batch.surface_mask,
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 wallshear_huber_delta=wallshear_huber_delta,
+                point_weights=surface_point_weights,
             )
             volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -2144,6 +2258,8 @@ def train_loss(
         metrics["film/geom_token_abs_mean"] = float(
             geom_token.abs().mean().cpu().item()
         )
+    for k, v in density_diag.items():
+        metrics[k] = v
     return loss, metrics
 
 
@@ -2788,6 +2904,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
+                surface_density_weight_scale=config.surface_density_weight_scale,
+                surface_density_weight_k=config.surface_density_weight_k,
+                surface_density_weight_clamp_quantile=config.surface_density_weight_clamp_quantile,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -2968,7 +3087,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():
-                if key.startswith("film/"):
+                if key.startswith("film/") or key.startswith("density_weight/"):
                     train_log[f"train/{key}"] = value
             train_log.update(
                 train_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis

Low-density surface regions (e.g., trailing edges, sharp corners, wake-adjacent surfaces) are geometrically critical for predicting τ_y/τ_z but are under-represented in loss computation due to having fewer points. Inversely weighting the loss by local point density should push gradient signal toward these sparse-but-critical surface patches.

## Background

The yi baseline uses uniform loss weighting across all surface points. This means densely sampled flat surfaces dominate the gradient, while sharp edges and curved regions — which are hardest to model and most critical for τ_y/τ_z accuracy — contribute proportionally less to the loss. Inverse density weighting is a standard technique in point cloud learning (used in PointNet++, ConvONet) that is a natural fit here.

## Implementation

Modify `train.py` to compute inverse point density weights per surface point:

1. **Density estimation**: For each surface point, compute its local density as the mean distance to its k=10 nearest neighbors (use `torch.cdist` or `faiss`). Lower mean-NN-distance = higher density.

2. **Weight computation**:
   ```python
   mean_nn_dist = knn_mean_distances(surface_pos, k=10)  # shape [N]
   density = 1.0 / (mean_nn_dist + eps)
   density_weight = 1.0 / (density + eps)  # inverse density = low-density → higher weight
   # normalize so mean weight = 1.0 (preserve loss scale)
   density_weight = density_weight / density_weight.mean()
   ```

3. **Application**: Multiply the per-point surface loss (tau_x, tau_y, tau_z, surface_pressure) by `density_weight` before aggregating. Volume points keep uniform weighting.

4. **Two arms**: Try `density_weight_scale=1.0` (full inverse density) and `density_weight_scale=0.5` (half-strength blend):
   ```python
   w = 1.0 + density_weight_scale * (density_weight - 1.0)
   # scale=0: uniform; scale=1: full inverse density
   ```

Add a CLI flag `--surface-density-weight-scale FLOAT` (default 0.0 for backward compat).

## Current Baseline Metrics (yi bar, PR #576)

| Metric | yi best | AB-UPT | Gap |
|---|---|---|---|
| **val_abupt** | **8.2528%** | — | merge bar |
| surface_pressure | 5.241% | 3.82% | 1.37× |
| wall_shear | 9.233% | 7.29% | 1.27× |
| volume_pressure | 12.438% | 6.08% | 2.05× |
| tau_x | 7.562% | 5.35% | 1.41× |
| tau_y | 9.233% | 3.65% | **2.53×** |
| tau_z | 10.449% | 3.63% | **2.88×** |

## Training Commands

**Arm A — scale=1.0 (full inverse density)**:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent gilbert --wandb-group yi-round36-inverse-density \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-density-weight-scale 1.0
```

**Arm B — scale=0.5 (half-strength blend)**:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent gilbert --wandb-group yi-round36-inverse-density \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-density-weight-scale 0.5
```

Run Arm A and B in parallel on 4 GPUs each (use two separate GPU nodes or run sequentially if constrained).

## Decision Criteria

- **Epoch 5 gate**: If both arms have `val_abupt > 10%`, stop — density weighting may be destabilizing training.
- **Epoch 10 gate**: If best arm `val_abupt > 9.0%`, stop and report.
- **Continue to completion** if any arm shows `val_abupt < 8.5%` by epoch 10 — this is a promising direction.
- **Winner**: Merge if best arm `val_abupt < 8.2528%` (current bar).

## Success Metrics

Primary: `val_abupt` below 8.2528%. Secondary: improvement in `tau_y` and `tau_z` specifically (hypothesis is that these benefit most from upweighting sparse surface regions).

## Expected Outcome

Moderate improvement in τ_y/τ_z (−5–15%) with possible slight regression in surface_pressure from redistributed loss. The net effect on val_abupt depends on the balance.

## References

- PointNet++ (Qi et al., 2017): inverse density sampling for irregular point clouds
- ConvONet (Peng et al., 2020): density-adaptive feature aggregation
