### PR TITLE
Model dropout regularization sweep (p=0.05 vs p=0.1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -658,15 +658,16 @@ class MLP(nn.Module):
 
 
 class UpActDownMlp(nn.Module):
-    def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
+    def __init__(self, hidden_dim: int, mlp_hidden_dim: int, dropout: float = 0.0):
         super().__init__()
         self.fc1 = nn.Linear(hidden_dim, mlp_hidden_dim)
         self.act = nn.GELU()
+        self.drop = nn.Dropout(dropout)
         self.fc2 = nn.Linear(mlp_hidden_dim, hidden_dim)
         self.apply(_init_linear)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.fc2(self.act(self.fc1(x)))
+        return self.fc2(self.drop(self.act(self.fc1(x))))
 
 
 class TransolverAttention(nn.Module):
@@ -740,7 +741,7 @@ class TransformerBlock(nn.Module):
             dropout=dropout,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim, dropout=dropout)
         self.drop_path = DropPath(drop_path_prob)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:


### PR DESCRIPTION
## Hypothesis

The yi baseline (4L/512d Transolver) does not use dropout. Given the moderate dataset size of DrivAerML and that our best runs still show some generalization gap, adding mild dropout (p=0.05 or p=0.1) to the attention and feedforward layers may improve validation metrics by preventing co-adaptation of neurons — particularly helpful for the τ_y/τ_z prediction which requires fine-grained geometric discrimination.

Dropout also acts as a form of implicit ensemble, which is beneficial for heteroscedastic uncertainty estimation (which we use via β-NLL). The model learns to be more uncertain in geometrically ambiguous regions if individual neurons are randomly silenced during training.

## Background

Dropout is underused in physics surrogate models. Standard transformers (ViT, BERT) use dropout throughout (p=0.1), yet Transolver-based CFD surrogates rarely apply it. Our model is well-regularized via weight decay and gradient clipping, but these forms of regularization are parameter-space constraints rather than model-capacity constraints. Dropout provides complementary regularization by operating at the activation level.

## Implementation

Add dropout to the Transolver model. Specifically:
1. **Attention dropout**: Apply dropout with probability p after the softmax in each attention head before the value multiplication. This is equivalent to DropAttention.
2. **FFN dropout**: Apply dropout after the first linear layer in each MLP/FFN block.
3. **Add `--model-dropout FLOAT` CLI flag** (default 0.0 for backward compat).

Modify `train.py` (or the model module it calls) to pass `dropout=args.model_dropout` into the Transolver model constructor. If the model already has a dropout parameter, use it.

**Three arms**:
- **Arm A**: `--model-dropout 0.05` (gentle, industry standard for CFD)
- **Arm B**: `--model-dropout 0.1` (standard transformer dropout)
- **Arm C**: `--model-dropout 0.0` (baseline control — run for 5 epochs to verify baseline is stable)

## Current Baseline Metrics (yi bar, PR #576)

| Metric | yi best | AB-UPT | Gap |
|---|---|---|---|
| **val_abupt** | **8.2528%** | — | merge bar |
| surface_pressure | 5.241% | 3.82% | 1.37× |
| wall_shear | 9.233% | 7.29% | 1.27× |
| volume_pressure | 12.438% | 6.08% | 2.05× |
| tau_x | 7.562% | 5.35% | 1.41× |
| tau_y | 9.233% | 3.65% | **2.53×** |
| tau_z | 10.449% | 3.63% | **2.88×** |

## Training Commands

**Arm A — dropout=0.05**:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent tanjiro --wandb-group yi-round36-dropout \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-dropout 0.05
```

**Arm B — dropout=0.1**:
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent tanjiro --wandb-group yi-round36-dropout \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-dropout 0.1
```

Run Arm A and B in parallel on 4 GPUs each.

## Decision Criteria

- **Epoch 5 gate**: If best arm `val_abupt > 9.5%`, dropout is too aggressive — stop both arms and report.
- **Epoch 10 gate**: If best arm `val_abupt > 8.5%`, report as negative result and close.
- **Continue to completion** if any arm shows `val_abupt < 8.0%` by epoch 10.
- **Winner**: Merge if best arm `val_abupt < 8.2528%`.

## Expected Outcome

- **Dropout 0.05**: Likely small improvement or neutral. Low risk.
- **Dropout 0.1**: Could help or hurt depending on whether the model is overfit. Check validation loss curve shape to understand.
- In either case, report per-metric improvements — τ_y/τ_z and volume_pressure are the primary targets.

## Notes

- Make sure to call `model.eval()` during validation (dropout disabled). This is standard but worth checking.
- If the model already accepts `dropout` in its constructor, just wire up the CLI flag — no need for a new implementation.
- Report the gradient norms from W&B for each arm — dropout often changes gradient statistics in informative ways.
