### PR TITLE
NorMuon optimizer on L=5 SOTA stack (Newton-Schulz orthogonalization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,6 +128,13 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    normuon_momentum: float = 0.95
+    normuon_beta2: float = 0.9
+    normuon_ns_steps: int = 5
+    normuon_adamw_lr_mult: float = 3.0
+    normuon_adamw_beta1: float = 0.9
+    normuon_adamw_beta2: float = 0.95
+    normuon_shape_lr_scale: bool = True
     vol_points_schedule: str = ""
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
@@ -233,6 +240,203 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """Newton-Schulz iteration to approximate the polar factor U from G = U Σ V^T.
+
+    Runs in bfloat16 for speed; uses the classic 5-step coefficient triple
+    (3.4445, -4.7750, 2.0315) from Jordan's modded-nanogpt Muon recipe.
+    """
+    assert G.ndim == 2
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X = X / (X.norm() + eps)
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        X = a * X + b * (A @ X) + c * (A @ A @ X)
+    if transposed:
+        X = X.T
+    return X.to(G.dtype)
+
+
+class NorMuon(torch.optim.Optimizer):
+    """NorMuon: Muon (Newton-Schulz orthogonalized momentum) + Adafactor-style
+    per-row variance reduction for 2D weight matrices, with AdamW fallback for
+    non-2D parameters (biases, norms, scalars, embedding/freq tables).
+
+    Param-group 0 ('use_muon'=True) holds the 2D weights and uses NorMuon.
+    Param-group 1 ('use_muon'=False) holds everything else and uses AdamW.
+
+    DDP: standard contract — gradients are already allreduced by DDP backward
+    hooks before step() is called, so each rank's optimizer state evolves
+    identically. No custom communication.
+
+    References
+    ----------
+    - Muon: https://github.com/KellerJordan/modded-nanogpt
+    - NorMuon variance reduction: https://arxiv.org/abs/2510.05491
+    """
+
+    def __init__(
+        self,
+        params_2d: list[torch.nn.Parameter],
+        params_1d: list[torch.nn.Parameter],
+        lr: float = 2e-4,
+        momentum: float = 0.95,
+        beta2: float = 0.9,
+        ns_steps: int = 5,
+        weight_decay: float = 0.0,
+        shape_lr_scale: bool = True,
+        adamw_lr: float = 6e-4,
+        adamw_betas: tuple[float, float] = (0.9, 0.95),
+        adamw_eps: float = 1e-8,
+        adamw_weight_decay: float = 0.0,
+    ):
+        if not params_2d and not params_1d:
+            raise ValueError("NorMuon requires at least one parameter")
+        param_groups = [
+            {
+                "params": list(params_2d),
+                "use_muon": True,
+                "lr": lr,
+                "momentum": momentum,
+                "beta2": beta2,
+                "ns_steps": ns_steps,
+                "weight_decay": weight_decay,
+                "shape_lr_scale": shape_lr_scale,
+            },
+            {
+                "params": list(params_1d),
+                "use_muon": False,
+                "lr": adamw_lr,
+                "betas": adamw_betas,
+                "eps": adamw_eps,
+                "weight_decay": adamw_weight_decay,
+            },
+        ]
+        super().__init__(param_groups, defaults={})
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            if group.get("use_muon", False):
+                self._normuon_step(group)
+            else:
+                self._adamw_step(group)
+        return loss
+
+    def _normuon_step(self, group: dict) -> None:
+        lr = group["lr"]
+        momentum = group["momentum"]
+        beta2 = group["beta2"]
+        ns_steps = group["ns_steps"]
+        weight_decay = group["weight_decay"]
+        shape_lr_scale = group["shape_lr_scale"]
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+            assert p.ndim == 2, "NorMuon path requires 2D parameters"
+            g = p.grad.float()
+            state = self.state[p]
+            if len(state) == 0:
+                state["momentum_buffer"] = torch.zeros_like(p, dtype=torch.float32)
+                # Per-row second moment along the longer axis. After Newton-Schulz
+                # the orthogonalized step has rank min(rows, cols); the longer
+                # axis carries redundant directions that benefit from
+                # row-wise (Adafactor-style) variance reduction.
+                red_dim = -1 if p.shape[0] >= p.shape[1] else -2
+                sm_shape = list(p.shape)
+                sm_shape[red_dim] = 1
+                state["second_moment"] = torch.zeros(
+                    sm_shape, dtype=torch.float32, device=p.device
+                )
+                state["red_dim"] = red_dim
+            buf = state["momentum_buffer"]
+            sm = state["second_moment"]
+            red_dim = state["red_dim"]
+            # Heavy-ball + Nesterov-style lookahead
+            buf.mul_(momentum).add_(g)
+            g_eff = g.add(buf, alpha=momentum)
+            v = zeropower_via_newtonschulz5(g_eff, steps=ns_steps).float()
+            # Adafactor-style per-row second-moment normalization (the "Nor"
+            # in NorMuon).
+            v_sq_mean = v.square().mean(dim=red_dim, keepdim=True)
+            sm.lerp_(v_sq_mean, 1.0 - beta2)
+            denom = sm.clamp_min(1e-10).sqrt()
+            v_norm = v / denom
+            # Renormalize to preserve the orthogonalized step's global magnitude.
+            ref_norm = v.norm()
+            cur_norm = v_norm.norm().clamp_min(1e-10)
+            v_norm = v_norm * (ref_norm / cur_norm)
+            if shape_lr_scale:
+                fan_out, fan_in = p.shape[0], p.shape[1]
+                step_lr = lr * (max(1.0, fan_out / fan_in) ** 0.5)
+            else:
+                step_lr = lr
+            if weight_decay > 0.0:
+                p.mul_(1.0 - step_lr * weight_decay)
+            p.add_(v_norm.to(p.dtype), alpha=-step_lr)
+
+    def _adamw_step(self, group: dict) -> None:
+        lr = group["lr"]
+        b1, b2 = group["betas"]
+        eps = group["eps"]
+        wd = group["weight_decay"]
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+            g = p.grad.float()
+            state = self.state[p]
+            if len(state) == 0:
+                state["step"] = 0
+                state["exp_avg"] = torch.zeros_like(p, dtype=torch.float32)
+                state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["step"] += 1
+            t = state["step"]
+            m, v = state["exp_avg"], state["exp_avg_sq"]
+            m.lerp_(g, 1.0 - b1)
+            v.lerp_(g.square(), 1.0 - b2)
+            m_hat = m / (1.0 - b1**t)
+            v_hat = v / (1.0 - b2**t)
+            update = m_hat / (v_hat.sqrt() + eps)
+            if wd > 0.0:
+                p.mul_(1.0 - lr * wd)
+            p.add_(update.to(p.dtype), alpha=-lr)
+
+
+def split_params_for_normuon(
+    model: nn.Module,
+) -> tuple[list[torch.nn.Parameter], list[torch.nn.Parameter], list[str], list[str]]:
+    """Split trainable parameters into (NorMuon 2D, AdamW non-2D) groups.
+
+    Excludes string-separable RoPE frequency tables (`*_string_sep.log_freq`,
+    `*_string_sep.phase`) from the NorMuon group: those are 2D but are learned
+    frequency tables, not weight matrices, and Newton-Schulz orthogonalization
+    is inappropriate for them.
+    """
+    params_2d: list[torch.nn.Parameter] = []
+    params_1d: list[torch.nn.Parameter] = []
+    names_2d: list[str] = []
+    names_1d: list[str] = []
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        is_freq_table = "string_sep" in name
+        if p.dim() == 2 and not is_freq_table:
+            params_2d.append(p)
+            names_2d.append(name)
+        else:
+            params_1d.append(p)
+            names_1d.append(name)
+    return params_2d, params_1d, names_2d, names_1d
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
     if optimizer_name == "adamw":
@@ -251,7 +455,45 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
             betas=(config.lion_beta1, config.lion_beta2),
             use_triton=False,
         )
-    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+    if optimizer_name == "normuon":
+        params_2d, params_1d, names_2d, names_1d = split_params_for_normuon(model)
+        if not params_2d:
+            raise RuntimeError(
+                "NorMuon requires at least one 2D weight parameter; none found "
+                "(check that string_sep filter is not removing every 2D param)."
+            )
+        if int(os.environ.get("RANK", "0")) == 0:
+            n_2d = sum(p.numel() for p in params_2d)
+            n_1d = sum(p.numel() for p in params_1d)
+            print(
+                f"NorMuon param split: 2D group {len(params_2d)} tensors, "
+                f"{n_2d / 1e6:.2f}M params (NorMuon path); "
+                f"non-2D group {len(params_1d)} tensors, {n_1d / 1e6:.3f}M "
+                f"params (AdamW path)"
+            )
+            print(f"  NorMuon lr={config.lr:.2e} momentum={config.normuon_momentum} "
+                  f"beta2={config.normuon_beta2} ns_steps={config.normuon_ns_steps} "
+                  f"shape_lr_scale={config.normuon_shape_lr_scale}")
+            print(f"  AdamW lr={config.lr * config.normuon_adamw_lr_mult:.2e} "
+                  f"betas=({config.normuon_adamw_beta1},{config.normuon_adamw_beta2}) "
+                  f"weight_decay={config.weight_decay}")
+        return NorMuon(
+            params_2d,
+            params_1d,
+            lr=config.lr,
+            momentum=config.normuon_momentum,
+            beta2=config.normuon_beta2,
+            ns_steps=config.normuon_ns_steps,
+            weight_decay=config.weight_decay,
+            shape_lr_scale=config.normuon_shape_lr_scale,
+            adamw_lr=config.lr * config.normuon_adamw_lr_mult,
+            adamw_betas=(config.normuon_adamw_beta1, config.normuon_adamw_beta2),
+            adamw_eps=1e-8,
+            adamw_weight_decay=config.weight_decay,
+        )
+    raise ValueError(
+        f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion, normuon."
+    )
 
 
 def parse_rff_init_sigmas(spec: str) -> list[float] | None:


### PR DESCRIPTION
## Hypothesis

NorMuon (Normalized Muon) optimizer may outperform Lion on the L=5 SOTA stack. Muon uses Newton-Schulz orthogonalization to compute quasi-Newton steps for 2D weight matrices, which produces gradient updates with unit spectral norm. NorMuon is the normalized variant that removes the sensitivity to learning rate scale, making it easier to tune.

Recent evidence: NorMuon (and its predecessor Muon) set the world record on Modded-NanoGPT (https://github.com/KellerJordan/modded-nanogpt), consistently outperforming AdamW and Lion on transformer-style models. Transolver's slice-attention is architecturally similar — it has many 2D weight matrices (Q, K, V projections, FFN layers) that are exactly the target for Muon's orthogonalization.

Previous experiment PR #299 tested Muon (non-normalized) and was not merged. NorMuon differs by normalizing the update norm, which our previous experiment did not test. The hypothesis is that NorMuon's normalized updates will improve convergence on Transolver's attention matrices compared to Lion's sign-based updates.

Paper/code reference: https://github.com/KellerJordan/modded-nanogpt (NorMuon section) — NorMuon is implemented as `class NorMuon` using `zeropower_via_newtonschulz5` for orthogonalization on 2D params, AdamW fallback for 1D/embedding/bias params.

## Instructions

Implement NorMuon as a hybrid optimizer: apply NorMuon to all 2D weight matrices in the model (Linear layers, attention projections), and use AdamW for all remaining parameters (biases, norms, embeddings, 1D tensors).

### Step 1 — Add NorMuon to train.py

In `target/train.py`, add the NorMuon optimizer class. Copy the reference implementation from modded-nanogpt:

```python
import torch

def zeropower_via_newtonschulz5(G, steps=5, eps=1e-7):
    """Newton-Schulz iteration to compute zeroth power / orthogonalize G."""
    assert len(G.shape) == 2
    a, b, c = (3.4445, -4.7750,  2.0315)
    X = G.bfloat16() / (G.norm() + eps)
    if G.size(0) > G.size(1):
        X = X.T
    for _ in range(steps):
        A = X @ X.T
        X = a * X + b * A @ X + c * A @ A @ X
    if G.size(0) > G.size(1):
        X = X.T
    return X

class NorMuon(torch.optim.Optimizer):
    """
    NorMuon: Normalized Muon optimizer.
    Applies Newton-Schulz orthogonalization to 2D weight matrices.
    Uses AdamW for 1D params (biases, norms, embeddings).
    """
    def __init__(self, params_2d, params_1d, lr=2e-4, momentum=0.95,
                 adamw_lr=3e-4, adamw_betas=(0.95, 0.95), adamw_wd=0.01):
        # params_2d: list of 2D weight tensors for NorMuon updates
        # params_1d: list of other params for AdamW fallback
        defaults = dict(lr=lr, momentum=momentum)
        super().__init__([
            {'params': params_2d, 'use_muon': True},
            {'params': params_1d, 'use_muon': False,
             'lr': adamw_lr, 'betas': adamw_betas, 'weight_decay': adamw_wd}
        ], defaults)
        self.adamw_lr = adamw_lr
        self.adamw_betas = adamw_betas
        self.adamw_wd = adamw_wd
        # Init AdamW state for 1D params
        self._adamw = None  # lazily initialized

    @torch.no_grad()
    def step(self):
        for group in self.param_groups:
            if group.get('use_muon', False):
                # NorMuon update for 2D params
                lr = group['lr']
                momentum = group['momentum']
                for p in group['params']:
                    if p.grad is None:
                        continue
                    g = p.grad
                    state = self.state[p]
                    if 'momentum_buffer' not in state:
                        state['momentum_buffer'] = torch.zeros_like(g)
                    buf = state['momentum_buffer']
                    buf.mul_(momentum).add_(g)
                    # Newton-Schulz orthogonalization
                    g_orth = zeropower_via_newtonschulz5(buf)
                    # Normalize
                    scale = max(1, g.size(0) / g.size(1)) ** 0.5
                    p.add_(g_orth * (-lr * scale))
            else:
                # AdamW fallback for 1D, bias, norm, embedding params
                lr_1d = group.get('lr', self.adamw_lr)
                betas = group.get('betas', self.adamw_betas)
                wd = group.get('weight_decay', self.adamw_wd)
                b1, b2 = betas
                for p in group['params']:
                    if p.grad is None:
                        continue
                    g = p.grad.float()
                    state = self.state[p]
                    if 'step' not in state:
                        state['step'] = 0
                        state['m'] = torch.zeros_like(p, dtype=torch.float32)
                        state['v'] = torch.zeros_like(p, dtype=torch.float32)
                    state['step'] += 1
                    m, v = state['m'], state['v']
                    m.lerp_(g, 1 - b1)
                    v.lerp_(g.square(), 1 - b2)
                    step = state['step']
                    m_hat = m / (1 - b1**step)
                    v_hat = v / (1 - b2**step)
                    update = m_hat / (v_hat.sqrt() + 1e-8)
                    p.add_(update * (-lr_1d))
                    p.mul_(1 - lr_1d * wd)
```

### Step 2 — Integrate into optimizer selection

In `train.py`, in the section where the optimizer is created (look for `--optimizer` argument handling), add NorMuon as a new option:

```python
elif args.optimizer == 'normuon':
    # Separate 2D weight params (for NorMuon) from 1D/other params (for AdamW fallback)
    params_2d = [p for name, p in model.named_parameters()
                 if p.requires_grad and p.dim() == 2]
    params_1d = [p for name, p in model.named_parameters()
                 if p.requires_grad and p.dim() != 2]
    optimizer = NorMuon(
        params_2d, params_1d,
        lr=args.lr,                  # NorMuon lr for 2D params
        momentum=0.95,
        adamw_lr=args.lr * 3.0,     # AdamW lr for 1D params (typically 3x higher)
        adamw_betas=(0.95, 0.95),
        adamw_wd=args.weight_decay
    )
```

### Step 3 — Run the experiment

Use the full L=5 SOTA stack, replacing Lion with NorMuon. Start with `lr=2e-4` for the 2D params (NorMuon is sign-based like Lion but normalized; Lion uses `lr=9e-5`; NorMuon typically wants ~2-3x higher lr):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer normuon \
  --lr 2e-4 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb_group normuon-optimizer-sweep
```

If `lr=2e-4` diverges or loss spikes early, try `lr=1e-4`. If it converges well but underfits, try `lr=3e-4`. Report all runs in the PR comment.

**IMPORTANT**: Use `--no-compile-model` to avoid the torch.compile + DDP NCCL deadlock.

## Baseline (target to beat)

**Single-model SOTA** (PR #592, alphonse depth-L5):
- W&B run: `4k25s25e`, group `model-depth-sweep`, name `alphonse/depth-L5`
- **val_abupt = 6.5985%** ← must beat this
- val per-channel: surface_pressure=4.3322%, volume_pressure=3.9456%, tau_x=6.5420%, tau_y=8.3631%, tau_z=9.8099%
- test_abupt = 7.9915%

**AB-UPT paper targets** (what we're chasing):
- surface_pressure=3.82%, volume_pressure=6.08%, wall_shear=7.29%, tau_x=5.35%, tau_y=3.65%, tau_z=3.63%

**Ensemble SOTA** (PR #612, nezuko greedy K=7):
- val_abupt = 6.1751%, test_abupt = 7.5347%

Report `val_abupt` and per-channel breakdown in your PR comment results.
