### PR TITLE
Flow-aligned tau: predict wall shear in local surface tangent frame

### DIFF
--- a/train.py
+++ b/train.py
@@ -44,6 +44,7 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    compute_tangent_frame,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -137,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_flow_aligned_tau: bool = False
     debug: bool = False
 
 
@@ -219,6 +221,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_flow_aligned_tau": (
+            "Predict wall shear stress in a per-point local surface tangent "
+            "frame (cp, tau_t, tau_b) instead of global Cartesian (cp, tau_x, "
+            "tau_y, tau_z). The frame (t_hat, b_hat, n_hat) is built from the "
+            "dataset surface normals via Gram-Schmidt with an "
+            "axis-of-minimum-magnitude seed for numerical stability. The "
+            "model's surface head outputs 3 channels instead of 4, encoding "
+            "the physical no-slip constraint that wall shear has zero "
+            "wall-normal component. tau_t / tau_b normalisation uses a "
+            "rotation-invariant scale = sqrt(mean(std_x^2, std_y^2, std_z^2)). "
+            "At evaluation time predictions are rotated back to global "
+            "Cartesian for direct comparison with the global-frame baseline."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -285,6 +300,9 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
 
 
 def build_model(config: Config) -> SurfaceTransolver:
+    # In flow-aligned-tau mode the surface head emits (cp, tau_t, tau_b); the
+    # wall-normal component is constrained to zero by physics so we drop it.
+    surface_output_dim = 3 if config.use_flow_aligned_tau else 4
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -297,6 +315,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        surface_output_dim=surface_output_dim,
     )
 
 
@@ -310,9 +329,36 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_flow_aligned_tau: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
-    surface_target = transform.apply_surface(batch.surface_y)
+    extra_metrics: dict[str, float] = {}
+    if use_flow_aligned_tau:
+        normals = batch.surface_x[..., 3:6]
+        t_hat, b_hat, n_hat = compute_tangent_frame(normals)
+        cp_target = batch.surface_y[..., 0:1]
+        tau_global_target = batch.surface_y[..., 1:4]
+        tau_t_target = (tau_global_target * t_hat).sum(-1, keepdim=True)
+        tau_b_target = (tau_global_target * b_hat).sum(-1, keepdim=True)
+        target_local_raw = torch.cat([cp_target, tau_t_target, tau_b_target], dim=-1)
+        surface_target = transform.apply_surface_local(target_local_raw)
+        # Diagnostic: tau_n residual should be ~0 in raw units if normals and
+        # tau live in the same coordinate system. Logged to detect data
+        # misalignment early.
+        with torch.no_grad():
+            mask_f = batch.surface_mask.to(dtype=tau_global_target.dtype)
+            tau_n_abs = (tau_global_target * n_hat).sum(-1).abs()
+            denom = mask_f.sum().clamp_min(1.0)
+            extra_metrics["tau_n_residual_mean"] = float(
+                ((tau_n_abs * mask_f).sum() / denom).detach().cpu().item()
+            )
+            tau_norm = tau_global_target.norm(dim=-1)
+            tau_norm_mean = (tau_norm * mask_f).sum() / denom
+            extra_metrics["tau_n_residual_rel"] = float(
+                (extra_metrics["tau_n_residual_mean"] / max(float(tau_norm_mean.detach().cpu().item()), 1e-12))
+            )
+    else:
+        surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
         out = model(
@@ -335,13 +381,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(extra_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -734,16 +782,28 @@ def main(argv: Iterable[str] | None = None) -> None:
             volume_y_mean=stats["volume_y_mean"].to(device),
             volume_y_std=stats["volume_y_std"].to(device),
         )
+        if config.use_flow_aligned_tau:
+            transform.configure_local_surface_stats()
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())
-        # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
-        # the largest gap to AB-UPT, so we expose per-channel weights here.
-        surface_channel_weights = torch.tensor(
-            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
-            device=device,
-            dtype=torch.float32,
-        )
+        # Surface channel weights:
+        #  - global (default): [cp, tau_x, tau_y, tau_z], 4 channels
+        #  - flow-aligned tau: [cp, tau_t, tau_b], 3 channels — the advisor
+        #    keeps the global-frame --tau-y-loss-weight / --tau-z-loss-weight
+        #    flags but applies them to the local tangent components.
+        if config.use_flow_aligned_tau:
+            surface_channel_weights = torch.tensor(
+                [1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+                device=device,
+                dtype=torch.float32,
+            )
+        else:
+            surface_channel_weights = torch.tensor(
+                [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+                device=device,
+                dtype=torch.float32,
+            )
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
@@ -765,6 +825,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
         if config.use_gradnorm:
+            if config.use_flow_aligned_tau:
+                raise ValueError(
+                    "--use-gradnorm is not supported together with "
+                    "--use-flow-aligned-tau: GradNorm task names are tied to "
+                    "the global-frame channels (sp, tau_x, tau_y, tau_z, vp) "
+                    "and the local-frame surface head only emits 3 channels."
+                )
             if config.gradnorm_mode == "full" and config.compile_model:
                 raise ValueError(
                     "--use-gradnorm --gradnorm-mode full requires --no-compile-model "
@@ -826,9 +893,28 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"(log_freq[d, f] = log(sigmas[f % len(sigmas)]))"
                 )
             if use_channel_weights:
+                if config.use_flow_aligned_tau:
+                    print(
+                        f"Surface channel weights (local frame): cp=1.0 "
+                        f"tau_t={config.tau_y_loss_weight} "
+                        f"tau_b={config.tau_z_loss_weight}"
+                    )
+                else:
+                    print(
+                        f"Surface channel weights: cp=1.0 tau_x=1.0 "
+                        f"tau_y={config.tau_y_loss_weight} "
+                        f"tau_z={config.tau_z_loss_weight}"
+                    )
+            if config.use_flow_aligned_tau:
+                local_std = transform.surface_y_std_local
+                local_mean = transform.surface_y_mean_local
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
-                    f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                    "Flow-aligned tau enabled: surface head outputs "
+                    "(cp, tau_t, tau_b); tau_t/tau_b normalised by "
+                    f"rotation-invariant scale={float(local_std[1].cpu().item()):.4g} "
+                    f"(cp_mean={float(local_mean[0].cpu().item()):.4g}, "
+                    f"cp_std={float(local_std[0].cpu().item()):.4g}); "
+                    "tangent frame: Gram-Schmidt with axis-of-min-magnitude seed."
                 )
 
         run = init_wandb_run(
@@ -1008,6 +1094,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_flow_aligned_tau=config.use_flow_aligned_tau,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1048,6 +1135,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "tau_n_residual_mean" in batch_loss_metrics:
+                        train_log["train/flow_aligned/tau_n_residual_mean"] = (
+                            batch_loss_metrics["tau_n_residual_mean"]
+                        )
+                        train_log["train/flow_aligned/tau_n_residual_rel"] = (
+                            batch_loss_metrics["tau_n_residual_rel"]
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1211,6 +1305,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        use_flow_aligned_tau=config.use_flow_aligned_tau,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1225,6 +1320,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    use_flow_aligned_tau=config.use_flow_aligned_tau,
                 )
                 for name, loader in val_loaders.items()
             }

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -18,6 +18,7 @@ from typing import Iterable, Mapping
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, Sampler
@@ -187,6 +188,8 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.surface_y_mean_local: torch.Tensor | None = None
+        self.surface_y_std_local: torch.Tensor | None = None
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -205,6 +208,81 @@ class TargetTransform:
 
     def invert_volume(self, y: torch.Tensor) -> torch.Tensor:
         return y * self.volume_y_std.to(y.device) + self.volume_y_mean.to(y.device)
+
+    def configure_local_surface_stats(self) -> None:
+        """Derive 3-channel local-frame stats (cp, tau_t, tau_b) from the global ones.
+
+        The tau_t / tau_b channels share a single rotation-invariant scale =
+        sqrt(mean(std_x^2, std_y^2, std_z^2)) so the local-frame normalisation is
+        invariant under the choice of tangent seed (||tau||^2 is preserved under
+        any orthogonal rotation, so the magnitude scale must be too).
+        """
+
+        device = self.surface_y_std.device
+        cp_mean = self.surface_y_mean[0:1]
+        cp_std = self.surface_y_std[0:1]
+        tau_var_mean = (self.surface_y_std[1:4] ** 2).mean().clamp(min=1e-12)
+        tau_scale = tau_var_mean.sqrt().to(device).reshape(1)
+        zero = torch.zeros(1, dtype=cp_mean.dtype, device=device)
+        self.surface_y_mean_local = torch.cat([cp_mean, zero, zero], dim=0)
+        self.surface_y_std_local = torch.cat(
+            [cp_std, tau_scale, tau_scale], dim=0
+        ).clamp(min=1e-6)
+
+    def apply_surface_local(self, y_local: torch.Tensor) -> torch.Tensor:
+        """Normalise a 3-channel local-frame target (cp, tau_t, tau_b)."""
+
+        if self.surface_y_mean_local is None or self.surface_y_std_local is None:
+            raise RuntimeError(
+                "TargetTransform.apply_surface_local: local stats not configured. "
+                "Call configure_local_surface_stats() first."
+            )
+        return (
+            y_local - self.surface_y_mean_local.to(y_local.device)
+        ) / self.surface_y_std_local.to(y_local.device)
+
+    def invert_surface_local(self, y_local: torch.Tensor) -> torch.Tensor:
+        if self.surface_y_mean_local is None or self.surface_y_std_local is None:
+            raise RuntimeError(
+                "TargetTransform.invert_surface_local: local stats not configured. "
+                "Call configure_local_surface_stats() first."
+            )
+        return (
+            y_local * self.surface_y_std_local.to(y_local.device)
+            + self.surface_y_mean_local.to(y_local.device)
+        )
+
+
+def compute_tangent_frame(
+    normals: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a per-point orthonormal local frame (t_hat, b_hat, n_hat).
+
+    normals: tensor of shape ``[..., 3]``. Need not be unit-norm; defensive
+    renormalisation handles non-unit and zero-padded rows.
+
+    Uses Gram-Schmidt with the axis-of-minimum-magnitude seed: for each point
+    the seed is the Cartesian unit vector ê_i for ``i = argmin(|n_hat|)``. This
+    guarantees ``|n_hat × seed| >= sqrt(2/3) ≈ 0.816`` in the non-degenerate
+    case, avoiding numerical collapse when n_hat is nearly aligned with a
+    Cartesian axis. Padded zero-norm rows produce a finite (degenerate) frame
+    that the surface_mask zeroes out downstream.
+
+    Returns three tensors each shaped like ``normals``:
+        t_hat: first tangent vector (in surface)
+        b_hat: binormal (also in surface), b_hat = n_hat × t_hat (right-handed)
+        n_hat: outward unit normal
+    """
+
+    n_hat = F.normalize(normals.float(), dim=-1, eps=1e-12)
+    abs_n = n_hat.abs()
+    min_axis = abs_n.argmin(dim=-1, keepdim=True)
+    ref = torch.zeros_like(n_hat)
+    ref.scatter_(-1, min_axis, 1.0)
+    t_unnorm = ref - (ref * n_hat).sum(-1, keepdim=True) * n_hat
+    t_hat = F.normalize(t_unnorm, dim=-1, eps=1e-12)
+    b_hat = torch.linalg.cross(n_hat, t_hat)
+    return t_hat, b_hat, n_hat
 
 
 def autocast_context(device: torch.device, amp_mode: str):
@@ -955,9 +1033,20 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    use_flow_aligned_tau: bool = False,
 ) -> None:
     batch = batch.to(device)
-    surface_target_norm = transform.apply_surface(batch.surface_y)
+    if use_flow_aligned_tau:
+        normals = batch.surface_x[..., 3:6]
+        t_hat, b_hat, n_hat = compute_tangent_frame(normals)
+        cp_target = batch.surface_y[..., 0:1]
+        tau_global_target = batch.surface_y[..., 1:4]
+        tau_t_target = (tau_global_target * t_hat).sum(-1, keepdim=True)
+        tau_b_target = (tau_global_target * b_hat).sum(-1, keepdim=True)
+        target_local_raw = torch.cat([cp_target, tau_t_target, tau_b_target], dim=-1)
+        surface_target_norm = transform.apply_surface_local(target_local_raw)
+    else:
+        surface_target_norm = transform.apply_surface(batch.surface_y)
     volume_target_norm = transform.apply_volume(batch.volume_y)
     eval_module = unwrap_model(model)
     with autocast_context(device, amp_mode):
@@ -975,7 +1064,18 @@ def accumulate_eval_batch(
     accumulator.surface_loss_count += surface_count
     accumulator.volume_loss_sse += volume_sse
     accumulator.volume_loss_count += volume_count
-    surface_pred = transform.invert_surface(surface_pred_norm)
+    if use_flow_aligned_tau:
+        # Invert local-frame normalisation, then rotate (tau_t, tau_b) back to
+        # global Cartesian so all downstream metrics stay in the original frame
+        # and remain directly comparable to baseline.
+        surface_pred_local_raw = transform.invert_surface_local(surface_pred_norm)
+        pred_cp = surface_pred_local_raw[..., 0:1]
+        pred_tau_t = surface_pred_local_raw[..., 1:2]
+        pred_tau_b = surface_pred_local_raw[..., 2:3]
+        pred_tau_global = pred_tau_t * t_hat + pred_tau_b * b_hat
+        surface_pred = torch.cat([pred_cp, pred_tau_global], dim=-1)
+    else:
+        surface_pred = transform.invert_surface(surface_pred_norm)
     volume_pred = transform.invert_volume(volume_pred_norm)
 
     if bool(batch.surface_mask.any()):
@@ -1121,6 +1221,7 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    use_flow_aligned_tau: bool = False,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1132,6 +1233,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            use_flow_aligned_tau=use_flow_aligned_tau,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1446,6 +1548,7 @@ def run_final_evaluation(
     global_step: int,
     total_minutes: float,
 ) -> None:
+    use_flow_aligned_tau = bool(getattr(config, "use_flow_aligned_tau", False))
     checkpoint = torch.load(model_path, map_location=device, weights_only=True)
     model.load_state_dict(checkpoint["model"])
     print(
@@ -1466,7 +1569,14 @@ def run_final_evaluation(
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_flow_aligned_tau=use_flow_aligned_tau,
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1486,7 +1596,14 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_flow_aligned_tau=use_flow_aligned_tau,
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

Wall shear stress (tau_x, tau_y, tau_z) is currently predicted in global Cartesian coordinates (x, y, z). However, by physical law, wall shear stress must lie entirely in the surface tangent plane — the component normal to the surface is always zero. The model currently has no representation of this constraint.

**Hypothesis**: Predicting tau in a local surface-aligned frame (tangential t̂, binormal b̂, normal n̂) instead of global Cartesian will:
1. Reduce the effective dimensionality of the prediction target (tau_n = 0 always, so only 2 components matter)
2. Remove the frame-dependent rotational ambiguity that makes tau_y and tau_z harder to learn
3. Directly encode the physical constraint that wall shear must be tangential

Our val metrics for tau_y (8.36%) and tau_z (9.81%) are well above AB-UPT targets (3.65%/3.63%) and global frame prediction is the most likely reason — the network must learn the same physical relationship expressed differently at every surface point.

## Instructions

### Step 1 — Compute surface normals and tangent frame

In `target/train.py`, before the tau loss computation, compute the local tangent frame at each surface query point. The dataset provides surface mesh normals; use them to build an orthonormal tangent basis per surface point.

In the data loading/preprocessing section (or as a transform applied to surface point clouds), compute:

```python
def compute_tangent_frame(normals):
    """
    Given surface normals n_hat (N, 3), compute a consistent orthonormal
    tangent frame (t_hat, b_hat, n_hat) at each surface point.
    
    Returns:
        t_hat: (N, 3) first tangent vector
        b_hat: (N, 3) binormal (second tangent) vector
        n_hat: (N, 3) normalized normals (same as input, normalized)
    """
    n_hat = F.normalize(normals, dim=-1)  # (N, 3)
    
    # Build first tangent vector: find axis least aligned with n_hat
    # to avoid degeneracy
    abs_n = n_hat.abs()
    min_axis = abs_n.argmin(dim=-1)  # (N,) — index of smallest component
    
    # Reference vector: unit axis aligned with min component
    ref = torch.zeros_like(n_hat)
    ref.scatter_(-1, min_axis.unsqueeze(-1), 1.0)
    
    # Gram-Schmidt: project out normal component
    t_hat = ref - (ref * n_hat).sum(-1, keepdim=True) * n_hat
    t_hat = F.normalize(t_hat, dim=-1)  # (N, 3)
    
    # Binormal: complete right-hand orthonormal frame
    b_hat = torch.linalg.cross(n_hat, t_hat)  # (N, 3)
    
    return t_hat, b_hat, n_hat
```

### Step 2 — Transform tau targets to local frame

When loading the training targets, transform the tau_x/tau_y/tau_z ground truth from global Cartesian to the local frame:

```python
# surface_normals: (N, 3) — from dataset (already provided per surface point)
t_hat, b_hat, n_hat = compute_tangent_frame(surface_normals)

# tau_global: (N, 3) — [tau_x, tau_y, tau_z] ground truth
# Project onto local frame
tau_t = (tau_global * t_hat).sum(-1, keepdim=True)   # tangential component 1
tau_b = (tau_global * b_hat).sum(-1, keepdim=True)   # tangential component 2
# tau_n = (tau_global * n_hat).sum(-1) should be ~0 (physical constraint)
# We predict only (tau_t, tau_b) — 2 components instead of 3

tau_local = torch.cat([tau_t, tau_b], dim=-1)  # (N, 2) — local frame targets
```

### Step 3 — Modify model output for surface tau

Change the surface decoder head to output 2 tau components (tau_t, tau_b) instead of 3 (tau_x, tau_y, tau_z). Adjust the output dimension from 5 to 4 channels for the surface prediction head:
- Channel 0: surface_pressure (unchanged)
- Channel 1: tau_t (local tangential)
- Channel 2: tau_b (local binormal)

### Step 4 — Transform predictions back to global frame for evaluation

At evaluation time, transform predicted (tau_t, tau_b) back to global Cartesian for metric computation (to compare with baseline metrics):

```python
# pred_tau_t: (N, 1), pred_tau_b: (N, 1)
tau_pred_global = pred_tau_t * t_hat + pred_tau_b * b_hat  # (N, 3)
# tau_x_pred = tau_pred_global[:, 0], etc.
```

### Step 5 — Run the experiment

Use the full L=5 SOTA stack, only changing the tau representation:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-flow-aligned-tau \
  --wandb_group flow-aligned-tau
```

Add `--use-flow-aligned-tau` as a new CLI flag that activates the local-frame tau prediction path. If you find that surface normals aren't directly available in the current data pipeline, use finite-difference normals from the point cloud (PCA on local neighborhoods of surface points) as a fallback.

**Important notes:**
- Keep `--tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0` but applied to the local-frame components (tau_t, tau_b). If the local frame is well-aligned, you may find these weights become less necessary — but start with them in place.
- Ensure the tangent frame is computed consistently for train and val splits.
- Use `--no-compile-model` to avoid the torch.compile + DDP NCCL deadlock.
- Report both local-frame training loss and global-frame evaluation metrics (tau_x, tau_y, tau_z as usual) so results are comparable to baseline.

## Baseline (target to beat)

**Single-model SOTA** (PR #592, alphonse depth-L5):
- W&B run: `4k25s25e`, group `model-depth-sweep`, name `alphonse/depth-L5`
- **val_abupt = 6.5985%** ← must beat this
- val per-channel: surface_pressure=4.3322%, volume_pressure=3.9456%, tau_x=6.5420%, tau_y=8.3631%, tau_z=9.8099%
- test_abupt = 7.9915%

**AB-UPT paper targets** (what we're chasing):
- surface_pressure=3.82%, volume_pressure=6.08%, wall_shear=7.29%, tau_x=5.35%, tau_y=3.65%, tau_z=3.63%

Note: tau_y and tau_z are our worst channels at 8.36% and 9.81% vs paper targets of 3.65% and 3.63%. This experiment directly targets that gap.

Report `val_abupt` and per-channel breakdown in your PR comment results.
