### PR TITLE
Fourier surface geometry features for tau_y/z gap (RFF input lift)

### DIFF
--- a/train.py
+++ b/train.py
@@ -871,6 +871,8 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        rff_dim: int = 0,
+        rff_sigma: float = 10.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -885,6 +887,18 @@ class SurfaceTransolver(nn.Module):
         self.pos_max_wavelength = pos_max_wavelength
         self.learnable_pe = learnable_pe
         self.beta_nll = beta_nll
+        self.rff_dim = rff_dim
+
+        if rff_dim > 0:
+            # Random Fourier Features (Rahimi & Recht 2007): fixed random projection
+            # matrix B ~ N(0, sigma^2) of shape (rff_dim, 3).  At forward time we lift
+            # the surface xyz coords as [sin(xyz @ B.T), cos(xyz @ B.T)] and append the
+            # resulting 2*rff_dim channels to the surface feature vector.  The buffer is
+            # non-trainable but persisted in checkpoints so inference is deterministic.
+            rff_B = torch.randn(rff_dim, 3) * rff_sigma
+            self.register_buffer("rff_B", rff_B)
+        else:
+            self.rff_B = None
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -967,6 +981,15 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            # Apply Random Fourier Features to surface xyz coords when enabled.
+            # rff_B has shape (rff_dim, 3); xyz has shape (B, N, 3).
+            # The RFF expansion [sin(xyz @ B.T), cos(xyz @ B.T)] is appended
+            # as additional feature channels after the existing surface features.
+            if self.rff_dim > 0 and self.rff_B is not None:
+                xyz = surface_x[:, :, : self.space_dim].float()
+                proj = xyz @ self.rff_B.T  # (B, N, rff_dim)
+                rff_feats = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # (B, N, 2*rff_dim)
+                surface_x = torch.cat([surface_x, rff_feats.to(surface_x.dtype)], dim=-1)
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -1159,6 +1182,8 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    surface_rff_dim: int = 0
+    surface_rff_sigma: float = 10.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1351,7 +1376,8 @@ def make_loaders(
 
 def build_model(config: Config) -> SurfaceTransolver:
     extra_curv = 2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0
-    surface_input_dim = SURFACE_X_DIM + extra_curv
+    # RFF adds 2*rff_dim channels (sin + cos) to the surface feature vector.
+    surface_input_dim = SURFACE_X_DIM + extra_curv + 2 * config.surface_rff_dim
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -1366,6 +1392,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        rff_dim=config.surface_rff_dim,
+        rff_sigma=config.surface_rff_sigma,
     )
 
 
@@ -2666,7 +2694,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_batch_size": config.batch_size * world_size,
             "lr_warmup_steps_effective": effective_warmup_steps,
             "surface_input_dim_effective": SURFACE_X_DIM
-            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0),
+            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0)
+            + 2 * config.surface_rff_dim,
             "curvature_k_neighbors": (
                 CURVATURE_K_NEIGHBORS
                 if config.surface_curvature_features in ("h_k", "k1_k2")


### PR DESCRIPTION
## Hypothesis

High-frequency Fourier features for surface geometry will improve wall shear τ_y/τ_z prediction by giving the model the ability to detect sharp geometric transitions (leading edges, door gaps, wheel arches) that simple sinusoidal positional encodings cannot capture.

**Motivation:** The two dominant remaining gaps are τ_y (2.35× AB-UPT) and τ_z (2.73× AB-UPT). These errors are concentrated at sharp curvature regions where flow separates and reattaches — exactly where low-frequency spatial encodings fail. Random Fourier Features (RFF, Rahimi & Recht 2007) with high-frequency bands sample the spectrum of the surface geometry at frequencies the current `--learnable-pe` STRING-sep encoding misses. Composing RFF-augmented geometry inputs with the existing STRING-sep PE should give the attention heads finer-grained spatial structure to localise shear components.

**Prior art:** Neural Tangent Kernel studies (Tancik et al. 2020, "Fourier Features Let Networks Learn High-Frequency Functions in Low Dimensional Domains") showed that RFF input mappings dramatically improve convergence at high spatial frequency for 3D shape regression tasks. The DrivAerML surface has a known spectral gap: curvature features (κ₁, κ₂, merged PR #580) helped τ_y/z but only at the lowest curvature deciles; sharper edges likely need a richer frequency basis.

**Mechanism:** Apply a learnable random Fourier feature (RFF) map to the surface XYZ coordinates before feeding them into the model, concatenating the lifted features to the existing surface input. The mapping is `γ(x) = [sin(B·x), cos(B·x)]` where B is a (d_rff × 3) matrix of frequencies drawn from N(0, σ²). Both σ (frequency scale) and optionally B itself can be made learnable. This adds ~2·d_rff channels to the surface input and costs negligible FLOPS.

## Instructions

Add a command-line flag `--surface-rff-dim` (default=0 → disabled) and `--surface-rff-sigma` (default=10.0) to `train.py`. When `--surface-rff-dim D` is set:

1. At model init, allocate a fixed buffer `B` of shape `(D, 3)` drawn from `N(0, σ²)` (where σ = `--surface-rff-sigma`). Make `B` a non-trainable `nn.Parameter` with `requires_grad=False`, or store as `register_buffer`. This way it is saved in checkpoints without being optimised.
2. Before the surface features are fed into the Transolver encoder, lift the surface XYZ coordinates through: `rff = torch.cat([torch.sin(x_xyz @ B.T), torch.cos(x_xyz @ B.T)], dim=-1)` where `x_xyz` is `[B_batch, N_surface, 3]`.
3. Concatenate the RFF features to the existing surface feature tensor (currently includes normals, area, curvatures, etc.) along the last dimension.
4. Adjust the model's input projection (`input_proj` or equivalent linear layer) to accept `existing_dim + 2*D` input channels. Ensure this is done cleanly — check if there's an `--model-surface-input-dim` or similar computed at startup and update it.

Run **two arms** using `--wandb-group yi-round36-surface-rff`:

- **Arm A:** `--surface-rff-dim 64 --surface-rff-sigma 10.0`
- **Arm B:** `--surface-rff-dim 128 --surface-rff-sigma 10.0`

If time allows after Arm A and B complete, a quick **Arm C** with `--surface-rff-dim 64 --surface-rff-sigma 50.0` (higher frequency) is valuable — surface shear at sharp edges has spectral content above σ=10.

Use the full reproduce command below as your base. Run each arm for the full training budget.

## Baseline

**Current yi merge bar: val_abupt = 8.2528%** (PR #576, frieren, STRING-sep learnable PE + Lion lr=1e-4 + grad-ema α=0.5, W&B runs: `ym8x8301` + `t4qaysur`)

**Aspirational target: val_abupt ~7.0–7.5%** (tay SOTA PR #511, edward, W&B run `5o7jc7wi`)

**Per-channel best on yi (test, PR #576 + prior merges):**

| Metric | yi best (test) | AB-UPT target | Gap |
|---|---:|---:|---:|
| `surface_pressure_rel_l2_pct` | 4.485 | 3.82 | 1.17× |
| `wall_shear_rel_l2_pct` | 8.227 | 7.29 | 1.13× |
| `volume_pressure_rel_l2_pct` | 12.438 | 6.08 | 2.05× |
| `wall_shear_x_rel_l2_pct` | 7.253 | 5.35 | 1.36× |
| `wall_shear_y_rel_l2_pct` | 9.233 | 3.65 | 2.53× |
| `wall_shear_z_rel_l2_pct` | 10.449 | 3.63 | 2.88× |

**Reproduce command (base — add your arm's flags):**

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent haku --wandb-group yi-round36-surface-rff \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-curvature-features k1_k2 \
  --beta-nll-beta 0.5 \
  --surface-rff-dim 64 --surface-rff-sigma 10.0
```

## Expected outcome

Arm A/B should give the attention heads a richer high-frequency basis for surface geometry, enabling sharper localisation of shear-stress gradients near body edges. If τ_y/z improves by ≥0.5pp each, the mechanism is confirmed. If both arms show similar improvement, try a higher σ to probe whether the useful frequencies are truly high-band. If neither arm improves, the surface geometry is not the spectral bottleneck — the issue lies elsewhere (loss formulation, coordinate frame, etc.).

## Terminal result format

Post results as a single-line `SENPAI-RESULT` marker once all arms are done:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-id>","<arm-b-id>"],"primary_metric":{"name":"val/abupt_axis_mean_rel_l2_pct","value":<best-value>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-value>}}
```
