### PR TITLE
Bug-fix: flip train.py defaults (compile_model, surface/volume sampling) to match every long DDP8 reference

### DIFF
--- a/train.py
+++ b/train.py
@@ -74,9 +74,9 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 2
     epochs: int = 50
-    train_surface_points: int = 40_000
+    train_surface_points: int = 65_536
     eval_surface_points: int = 40_000
-    train_volume_points: int = 40_000
+    train_volume_points: int = 16_384
     eval_volume_points: int = 40_000
     validation_every: int = 1
     surface_loss_weight: float = 1.0
@@ -117,7 +117,7 @@ class Config:
     kill_thresholds: str = ""
     seed: int = -1
     nonfinite_skip_abort: int = 200
-    compile_model: bool = True
+    compile_model: bool = False
     debug: bool = False
 
 


### PR DESCRIPTION
## Summary

Three `train.py` `Config` defaults silently disagree with what every healthy long DDP8 run on this branch actually uses. They bit me twice on PR #623 (40k/40k inverted the volume:surface gradient ratio under a surface-loss hypothesis; `compile_model=True` triggered a `torch._inductor` tiling assertion at end-of-EP1 with the corrected 65k/16k sampling). This PR flips the three defaults to match the working configuration.

## Changes

```python
# Before
train_surface_points: int = 40_000
train_volume_points: int = 40_000
compile_model: bool = True

# After
train_surface_points: int = 65_536
train_volume_points: int = 16_384
compile_model: bool = False
```

`eval_surface_points` / `eval_volume_points` are intentionally left at `40_000` per advisor scope.

## Evidence (from W&B configs of cited reference runs)

| Run | role | `compile_model` | `train_surface_points` / `train_volume_points` |
|---|---|---|---|
| `nh96x7m4` | PR #623 reference (strong tau) | False | 65,536 / 16,384 |
| `9mm3sz7x` | mild tau reference | False | 65,536 / 16,384 |
| `341czkol` | GradNorm reference | False | 65,536 / 16,384 |
| `ug6c3nks` | fern mild long (current branch, healthy) | False | 65,536 / 16,384 |

i.e. every long DDP8 run cited as a reference uses these settings explicitly. New students that omit them inherit defaults that diverge from the only known-good configuration on this stack.

## Concrete failure modes from PR #623 (today, 2026-05-04)

1. **Run `syl1zx3r` (40k/40k)** — defaults gave 0.61x surface and 2.44x volume points per training sample, inverting the volume:surface gradient ratio under a surface-loss hypothesis. Detected at EP5 by trajectory mismatch vs fern's mild long; killed.
2. **Run `xw6sp0rt` (compile_model=True default + corrected 65k/16k sampling)** — `torch._inductor.exc.InductorError: AssertionError` in `tiling_utils.py:271` at end-of-EP1, NCCL watchdog timed out the other ranks 600s later. Eager mode (`--no-compile-model`) compiled fine.

## Risk

- **Low.** All cited reference runs already explicitly override these defaults, so flipping the defaults to match changes nothing for any *current* long run command. It only changes behaviour for new commands that omit these flags — and in those cases the new behaviour matches the only known-good config on this stack.
- Tiny debug runs that relied on lighter sampling (40k/40k) for speed will become heavier; those callers should now explicitly pass `--train-surface-points 40000 --train-volume-points 40000` if they want the old behaviour.

## Test plan

- [x] Local default check: `python train.py --help | grep -E '(train-(surface|volume)-points|compile-model)'` shows the new defaults.
- [ ] (Advisor): run any of the existing long DDP8 commands without the three flags and confirm it produces identical W&B config to running with the explicit flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)