### PR TITLE
alphonse: asymmetric tau_y/tau_z weighting + curvature-focal loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -1115,6 +1115,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    wallshear_curvature_focal_gamma: float = 0.0
     beta_nll_beta: float = -1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
@@ -1945,6 +1946,80 @@ def weighted_masked_mse_per_channel(
     return weighted_loss, per_axis_mean
 
 
+def curvature_focal_weighted_mse_per_channel(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    surface_x: torch.Tensor,
+    *,
+    channel_weights: Iterable[float],
+    curvature_focal_gamma: float,
+    n_curvature_channels: int = 2,
+    wallshear_huber_delta: float = 0.0,
+) -> tuple[torch.Tensor, list[float]]:
+    """Per-channel weighted masked surface loss with per-point curvature focal upweight.
+
+    For tau channels (1..3), each surface point i gets an additional multiplicative
+    weight ``focal_w(i) = 1 + |kappa(i)|^gamma`` where
+    ``|kappa(i)| = sqrt(k1_tilde^2 + k2_tilde^2)`` is sourced from the last
+    ``n_curvature_channels`` of ``surface_x`` (already standardized in the loader).
+    Channel 0 (cp) is unaffected. ``gamma=0`` reduces to standard weighted MSE.
+
+    Diagnostic per-axis MSE returned without focal or channel-weight scaling so the
+    keys remain comparable across runs.
+    """
+    weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
+    if not bool(mask.any()):
+        per_axis = [0.0] * int(weights.numel())
+        return pred.sum() * 0.0, per_axis
+
+    diff = pred - target  # [B, N, C]
+    diff_sq = diff.pow(2)
+    mask_f = mask.unsqueeze(-1).to(pred.dtype)
+    valid = mask_f.sum().clamp_min(1)
+    n_channels = diff_sq.shape[-1]
+
+    if wallshear_huber_delta > 0.0 and n_channels >= 4:
+        abs_err = diff.abs()
+        delta_t = pred.new_full((), float(wallshear_huber_delta))
+        huber_elem = torch.where(
+            abs_err < delta_t,
+            diff_sq,
+            2.0 * delta_t * (abs_err - 0.5 * delta_t),
+        )
+        loss_elem = torch.cat([diff_sq[..., :1], huber_elem[..., 1:4]], dim=-1)
+        if n_channels > 4:
+            loss_elem = torch.cat([loss_elem, diff_sq[..., 4:]], dim=-1)
+    else:
+        loss_elem = diff_sq
+
+    if curvature_focal_gamma > 0.0 and n_curvature_channels > 0 and n_channels >= 4:
+        curv = surface_x[..., -n_curvature_channels:].float()  # [B, N, n_curv]
+        curv_mag = curv.pow(2).sum(dim=-1, keepdim=True).clamp_min(1e-12).sqrt()
+        focal_w = 1.0 + curv_mag.pow(curvature_focal_gamma)  # [B, N, 1]
+        focal_w = focal_w.to(loss_elem.dtype)
+        ones_cp = torch.ones_like(focal_w)
+        focal_tau = focal_w.expand(-1, -1, 3)
+        if n_channels > 4:
+            ones_extra = torch.ones(
+                focal_w.shape[0],
+                focal_w.shape[1],
+                n_channels - 4,
+                device=focal_w.device,
+                dtype=focal_w.dtype,
+            )
+            focal_scale = torch.cat([ones_cp, focal_tau, ones_extra], dim=-1)
+        else:
+            focal_scale = torch.cat([ones_cp, focal_tau], dim=-1)
+        loss_elem = loss_elem * focal_scale.detach()
+
+    weighted_diff = loss_elem * weights.view(1, 1, -1)
+    weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
+    per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
+    per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
+    return weighted_loss, per_axis_mean
+
+
 LOG_VAR_CLAMP_MIN = -10.0
 LOG_VAR_CLAMP_MAX = 5.0
 
@@ -1957,6 +2032,9 @@ def weighted_masked_beta_nll_per_channel(
     *,
     channel_weights: Iterable[float],
     beta: float,
+    surface_x: torch.Tensor | None = None,
+    curvature_focal_gamma: float = 0.0,
+    n_curvature_channels: int = 2,
 ) -> tuple[torch.Tensor, list[float], list[float]]:
     """Per-channel weighted masked β-NLL loss (Seitzer et al. 2022, ICLR).
 
@@ -1994,6 +2072,31 @@ def weighted_masked_beta_nll_per_channel(
     nll = 0.5 * (diff_sq / var + log_var)
     if beta > 0.0:
         nll = nll * var.detach().pow(beta)
+
+    if (
+        curvature_focal_gamma > 0.0
+        and n_curvature_channels > 0
+        and surface_x is not None
+        and n_channels >= 4
+    ):
+        curv = surface_x[..., -n_curvature_channels:].float()  # [B, N, n_curv]
+        curv_mag = curv.pow(2).sum(dim=-1, keepdim=True).clamp_min(1e-12).sqrt()
+        focal_w = 1.0 + curv_mag.pow(curvature_focal_gamma)  # [B, N, 1]
+        focal_w = focal_w.to(nll.dtype)
+        ones_cp = torch.ones_like(focal_w)
+        focal_tau = focal_w.expand(-1, -1, 3)
+        if n_channels > 4:
+            ones_extra = torch.ones(
+                focal_w.shape[0],
+                focal_w.shape[1],
+                n_channels - 4,
+                device=focal_w.device,
+                dtype=focal_w.dtype,
+            )
+            focal_scale = torch.cat([ones_cp, focal_tau, ones_extra], dim=-1)
+        else:
+            focal_scale = torch.cat([ones_cp, focal_tau], dim=-1)
+        nll = nll * focal_scale.detach()
 
     mask_f = mask.unsqueeze(-1).to(pred_mean.dtype)
     valid = mask_f.sum().clamp_min(1)
@@ -2033,6 +2136,8 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    wallshear_curvature_focal_gamma: float = 0.0,
+    n_curvature_channels: int = 0,
     beta_nll_beta: float = -1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
@@ -2077,6 +2182,9 @@ def train_loss(
 
         per_axis_log_var: list[float] | None = None
         volume_log_var_mean: float | None = None
+        focal_active = (
+            wallshear_curvature_focal_gamma > 0.0 and n_curvature_channels > 0
+        )
         if use_beta_nll:
             surface_log_var = out["surface_log_var"]
             volume_log_var = out["volume_log_var"]
@@ -2087,6 +2195,11 @@ def train_loss(
                 batch.surface_mask,
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 beta=beta_nll_beta,
+                surface_x=batch.surface_x if focal_active else None,
+                curvature_focal_gamma=(
+                    wallshear_curvature_focal_gamma if focal_active else 0.0
+                ),
+                n_curvature_channels=n_curvature_channels if focal_active else 0,
             )
             volume_loss, _, vol_log_var_per_axis = weighted_masked_beta_nll_per_channel(
                 out["volume_preds"],
@@ -2098,13 +2211,25 @@ def train_loss(
             )
             volume_log_var_mean = vol_log_var_per_axis[0] if vol_log_var_per_axis else 0.0
         else:
-            surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
-                surface_pred_used,
-                surface_target_used,
-                batch.surface_mask,
-                channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
-                wallshear_huber_delta=wallshear_huber_delta,
-            )
+            if focal_active:
+                surface_loss, per_axis_unweighted = curvature_focal_weighted_mse_per_channel(
+                    surface_pred_used,
+                    surface_target_used,
+                    batch.surface_mask,
+                    batch.surface_x,
+                    channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+                    curvature_focal_gamma=wallshear_curvature_focal_gamma,
+                    n_curvature_channels=n_curvature_channels,
+                    wallshear_huber_delta=wallshear_huber_delta,
+                )
+            else:
+                surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
+                    surface_pred_used,
+                    surface_target_used,
+                    batch.surface_mask,
+                    channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
+                    wallshear_huber_delta=wallshear_huber_delta,
+                )
             volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
         aux_rel_l2_value: float | None = None
@@ -2773,6 +2898,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_iter = tqdm(
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
+        n_curv_channels_for_loss = (
+            2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0
+        )
         for batch in train_iter:
             loss, batch_loss_metrics = train_loss(
                 train_model,
@@ -2787,6 +2915,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                wallshear_curvature_focal_gamma=config.wallshear_curvature_focal_gamma,
+                n_curvature_channels=n_curv_channels_for_loss,
                 beta_nll_beta=config.beta_nll_beta,
             )
             optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

The τ_y/τ_z gap is the largest remaining problem on yi:
- τ_y: 9.233% vs AB-UPT target 3.65% → **2.53× gap**
- τ_z: 10.449% vs AB-UPT target 3.63% → **2.88× gap**
- τ_z is ~14% harder than τ_y

PR #628 (Edward, in-flight) sweeps **symmetric** W_y=W_z=4 and W_y=W_z=6. This PR attacks two **orthogonal, untested** directions:

1. **Asymmetric weighting** (W_z > W_y to match the asymmetric gap magnitude)
2. **Per-point curvature-focal loss** — upweight τ channel loss at high-curvature surface points (wheel arches, sharp edges) where shear errors concentrate

The curvature features κ₁, κ₂ are already computed and present in `batch.surface_x[..., -2:]` when `--surface-curvature-features k1_k2` is enabled. A per-point focal modifier `w(i) = 1 + |κ(i)|^γ` (where κ magnitude = sqrt(κ₁² + κ₂²)) can upweight high-curvature boundary points without any architectural changes.

## Implementation

You need to:

### 1. Add a new CLI flag
In the `Config` dataclass (around line 1184), add:
```python
wallshear_curvature_focal_gamma: float = 0.0
```
The `_` → `-` auto-parser will produce `--wallshear-curvature-focal-gamma`.

### 2. Add a curvature-focal loss function
Add a new function after `weighted_masked_mse_per_channel` (around line 1973):

```python
def curvature_focal_weighted_mse_per_channel(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    surface_x: torch.Tensor,
    *,
    channel_weights: Iterable[float],
    curvature_focal_gamma: float,
    n_curvature_channels: int = 2,
    wallshear_huber_delta: float = 0.0,
) -> tuple[torch.Tensor, list[float]]:
    """Per-channel weighted masked loss with per-point curvature-focal upweighting.

    For τ channels (indices 1-3), each surface point i gets an additional
    multiplicative weight:
        focal_w(i) = 1 + (|κ(i)|)^gamma
    where |κ(i)| = sqrt(κ₁(i)² + κ₂(i)²), sourced from the last
    n_curvature_channels of surface_x. Channel 0 (cp) is unaffected.

    gamma=0 → no focal effect (reduces to standard weighted MSE).
    gamma=1 → linear upweighting by curvature magnitude.
    gamma=2 → quadratic emphasis on sharp-edge points.
    """
    weights = torch.tensor(list(channel_weights), device=pred.device, dtype=pred.dtype)
    if not bool(mask.any()):
        per_axis = [0.0] * int(weights.numel())
        return pred.sum() * 0.0, per_axis

    diff = pred - target  # [B, N, C]
    diff_sq = diff.pow(2)
    mask_f = mask.unsqueeze(-1).to(pred.dtype)
    valid = mask_f.sum().clamp_min(1)
    n_channels = diff_sq.shape[-1]

    # Huber on tau channels if requested
    if wallshear_huber_delta > 0.0 and n_channels >= 4:
        abs_err = diff.abs()
        delta_t = pred.new_full((), float(wallshear_huber_delta))
        huber_elem = torch.where(
            abs_err < delta_t,
            diff_sq,
            2.0 * delta_t * (abs_err - 0.5 * delta_t),
        )
        loss_elem = torch.cat([diff_sq[..., :1], huber_elem[..., 1:4]], dim=-1)
        if n_channels > 4:
            loss_elem = torch.cat([loss_elem, diff_sq[..., 4:]], dim=-1)
    else:
        loss_elem = diff_sq  # [B, N, C]

    # Per-point curvature-focal weights for tau channels (1..3)
    if curvature_focal_gamma > 0.0 and n_curvature_channels > 0:
        # surface_x last n_curvature_channels channels are κ₁_tilde, κ₂_tilde
        curv = surface_x[..., -n_curvature_channels:].float()  # [B, N, 2]
        curv_mag = curv.pow(2).sum(dim=-1, keepdim=True).sqrt()  # [B, N, 1]
        focal_w = 1.0 + curv_mag.pow(curvature_focal_gamma)  # [B, N, 1]
        # Apply focal only to tau channels (1..3); leave cp (ch 0) unweighted
        focal_scale = torch.cat(
            [torch.ones_like(focal_w), focal_w.expand(-1, -1, 3)], dim=-1
        )  # [B, N, 4]
        if n_channels > 4:
            focal_scale = torch.cat([focal_scale, torch.ones(
                focal_scale.shape[0], focal_scale.shape[1], n_channels - 4,
                device=focal_scale.device, dtype=focal_scale.dtype
            )], dim=-1)
        loss_elem = loss_elem * focal_scale.detach()  # stop-grad on focal weights

    weighted_diff = loss_elem * weights.view(1, 1, -1)
    weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
    # Diagnostic: per-axis unweighted MSE (no focal, no channel weights) for cross-run comparability
    per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
    per_axis_mean = (per_axis_sum / valid.detach().float()).cpu().tolist()
    return weighted_loss, per_axis_mean
```

### 3. Wire into the training step
In `compute_loss_and_metrics` (around line 2129), replace the `weighted_masked_mse_per_channel` call with:

```python
if curvature_focal_gamma > 0.0 and config.surface_curvature_features in ("h_k", "k1_k2"):
    n_curv = 2  # always 2 curvature channels
    surface_loss, per_axis_unweighted = curvature_focal_weighted_mse_per_channel(
        surface_pred_used,
        surface_target_used,
        batch.surface_mask,
        batch.surface_x,
        channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
        curvature_focal_gamma=curvature_focal_gamma,
        n_curvature_channels=n_curv,
        wallshear_huber_delta=wallshear_huber_delta,
    )
else:
    surface_loss, per_axis_unweighted = weighted_masked_mse_per_channel(
        surface_pred_used,
        surface_target_used,
        batch.surface_mask,
        channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
        wallshear_huber_delta=wallshear_huber_delta,
    )
```

You also need to extract `curvature_focal_gamma` from config at the top of `compute_loss_and_metrics`, alongside the existing `wallshear_y_weight` extraction:
```python
curvature_focal_gamma: float = config.wallshear_curvature_focal_gamma
```

Apply the same pattern for the beta-NLL branch — if `curvature_focal_gamma > 0.0`, use the curvature-focal variant on the surface loss.

### 4. Log the focal gamma in W&B config
In the W&B init section, add `curvature_focal_gamma` to the logged config dict so it appears in run comparisons.

## Experiment Arms

Both arms use the **full yi baseline stack**: Lion lr=1e-4, wd=5e-4, clip=0.5, grad-ema α=0.5, β-NLL β=0.5, learnable-PE, k1_k2 curvature features.

### Arm A — Asymmetric weights only (no focal)
W_y=3, W_z=5 (proportional to the asymmetric τ_y vs τ_z gap ratio).

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent alphonse \
  --wandb-group yi-round35-tau-focal \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --wallshear-y-weight 3.0 \
  --wallshear-z-weight 5.0 \
  --wallshear-curvature-focal-gamma 0.0 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

### Arm B — Asymmetric weights + curvature-focal (γ=1)
W_y=3, W_z=5 plus per-point focal upweighting at high-curvature boundary points with γ=1 (linear in curvature magnitude).

```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 train.py \
  --agent alphonse \
  --wandb-group yi-round35-tau-focal \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --wallshear-y-weight 3.0 \
  --wallshear-z-weight 5.0 \
  --wallshear-curvature-focal-gamma 1.0 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

## Sequencing

Run **Arm A first**. If it beats baseline, run Arm B while the result is pending review (the focal component is the incremental test on top of asymmetric weighting). If Arm A converges without improvement, try Arm B anyway — the focal modifier may compensate where static weighting cannot.

## Current Baseline to Beat

**val_abupt = 8.2528%** (PR #576, frieren, STRING-sep learnable PE + Lion lr=1e-4 + grad-ema α=0.5)

Per-channel test metrics (lower is better):
| Channel | Current | AB-UPT Target | Gap |
|---|---|---|---|
| surface_pressure | 4.485% | 3.82% | 1.17× |
| wall_shear | 8.227% | 7.29% | 1.13× |
| volume_pressure | 12.438% | 6.08% | 2.05× |
| τ_x | 7.253% | 5.35% | 1.36× |
| **τ_y** | **9.233%** | **3.65%** | **2.53×** |
| **τ_z** | **10.449%** | **3.63%** | **2.88×** |

The primary metric is **val_primary** (= val_abupt, lower is better).

## Expected Outcome

- Arm A tests whether **asymmetric W_z > W_y** (matching the gap magnitude ratio) outperforms Edward's symmetric sweep — addressing a clear blind spot in the loss weight design space.
- Arm B adds **geometry-aware per-point upweighting** of high-curvature regions — the curvature information is already available in the feature vector and requires no additional data loading.
- Success would be val_abupt < 8.2528% with reduced τ_y and/or τ_z test error.
