### PR TITLE
RFF surface geometry lift — isolated single-variable test (dim=64,128)

### DIFF
--- a/train.py
+++ b/train.py
@@ -871,6 +871,8 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        rff_dim: int = 0,
+        rff_sigma: float = 10.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -885,6 +887,18 @@ class SurfaceTransolver(nn.Module):
         self.pos_max_wavelength = pos_max_wavelength
         self.learnable_pe = learnable_pe
         self.beta_nll = beta_nll
+        self.rff_dim = rff_dim
+
+        if rff_dim > 0:
+            # Random Fourier Features (Rahimi & Recht 2007): fixed random projection
+            # matrix B ~ N(0, sigma^2) of shape (rff_dim, 3).  At forward time we lift
+            # the surface xyz coords as [sin(xyz @ B.T), cos(xyz @ B.T)] and append the
+            # resulting 2*rff_dim channels to the surface feature vector.  The buffer is
+            # non-trainable but persisted in checkpoints so inference is deterministic.
+            rff_B = torch.randn(rff_dim, 3) * rff_sigma
+            self.register_buffer("rff_B", rff_B)
+        else:
+            self.rff_B = None
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -967,6 +981,15 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            # Apply Random Fourier Features to surface xyz coords when enabled.
+            # rff_B has shape (rff_dim, 3); xyz has shape (B, N, 3).
+            # The RFF expansion [sin(xyz @ B.T), cos(xyz @ B.T)] is appended
+            # as additional feature channels after the existing surface features.
+            if self.rff_dim > 0 and self.rff_B is not None:
+                xyz = surface_x[:, :, : self.space_dim].float()
+                proj = xyz @ self.rff_B.T  # (B, N, rff_dim)
+                rff_feats = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # (B, N, 2*rff_dim)
+                surface_x = torch.cat([surface_x, rff_feats.to(surface_x.dtype)], dim=-1)
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -1163,6 +1186,8 @@ class Config:
     swa_lr: float = 5e-6
     swa_anneal_epochs: int = 1
     swa_update_every_steps: int = 500
+    surface_rff_dim: int = 0
+    surface_rff_sigma: float = 10.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1355,7 +1380,8 @@ def make_loaders(
 
 def build_model(config: Config) -> SurfaceTransolver:
     extra_curv = 2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0
-    surface_input_dim = SURFACE_X_DIM + extra_curv
+    # RFF adds 2*rff_dim channels (sin + cos) to the surface feature vector.
+    surface_input_dim = SURFACE_X_DIM + extra_curv + 2 * config.surface_rff_dim
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -1370,6 +1396,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        rff_dim=config.surface_rff_dim,
+        rff_sigma=config.surface_rff_sigma,
     )
 
 
@@ -2689,7 +2717,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_batch_size": config.batch_size * world_size,
             "lr_warmup_steps_effective": effective_warmup_steps,
             "surface_input_dim_effective": SURFACE_X_DIM
-            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0),
+            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0)
+            + 2 * config.surface_rff_dim,
             "curvature_k_neighbors": (
                 CURVATURE_K_NEIGHBORS
                 if config.surface_curvature_features in ("h_k", "k1_k2")


### PR DESCRIPTION
## Hypothesis

Random Fourier Features (RFF) applied to surface XYZ coordinates can improve surface-field predictions — particularly the anisotropic wall-shear axes τ_y and τ_z — by giving the input MLP a richer, frequency-diverse representation of geometry beyond raw XYZ. 

The RFF lift γ(x) = [sin(B·x), cos(B·x)] with B ~ N(0, σ²I) is the Bochner-spectral approximation of a Gaussian kernel (Rahimi & Recht 2007). Appending these features to the surface input vector lets the model learn combinations of high-frequency geometric signals without increasing positional encoding capacity — the RFF matrix is fixed at init and stored as a non-trainable buffer.

The prior haku/fourier-surface-geometry-features branch implemented this correctly (commit 4dfddb5) but the PR stalled without a run. This is a clean, isolated re-run: **only** `--surface-rff-dim` and `--surface-rff-sigma` vary; **no** `--surface-curvature-features` (that adds its own 2 channels and would conflate two variables). Everything else is the full yi stack.

Reference: Rahimi, A. & Recht, B. (2007). "Random Features for Large-Scale Kernel Machines." NeurIPS.

## Instructions

### Step 1: Cherry-pick the RFF implementation from the old branch

The RFF code is already implemented in commit `4dfddb5` from `origin/haku/fourier-surface-geometry-features`. Cherry-pick it onto the current yi codebase:

```bash
git fetch origin
git cherry-pick 4dfddb5
```

This adds to `train.py`:
- `Config.surface_rff_dim: int = 0` and `Config.surface_rff_sigma: float = 10.0`
- `SurfaceTransolver.__init__`: `register_buffer("rff_B", torch.randn(rff_dim, 3) * rff_sigma)`
- `SurfaceTransolver.forward`: appends `[sin(xyz @ rff_B.T), cos(xyz @ rff_B.T)]` to surface_x
- `build_model`: `surface_input_dim = SURFACE_X_DIM + extra_curv + 2 * config.surface_rff_dim`
- CLI flags: `--surface-rff-dim` and `--surface-rff-sigma`

Verify the cherry-pick compiles with a quick smoke test:
```bash
cd /workspace/senpai/target
python -c "from train import build_model, Config; c = Config(); c.surface_rff_dim=64; m = build_model(c); print('OK surface_input_dim:', m.surface_input_dim if hasattr(m, 'surface_input_dim') else 'check build_model')"
```

If the cherry-pick conflicts, resolve manually — the diff is small (~50 lines total; see the diff from the old PR).

### Step 2: Run two arms in parallel

**DO NOT** add `--surface-curvature-features` — we isolate RFF as the single variable.

**Arm A — RFF dim=64, σ=10 (default)**
```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node=2 train.py \
  --agent haku \
  --wandb-group yi-round37-rff-surface-iso \
  --wandb-name haku/rff-dim64-sigma10-arm-a \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-rff-dim 64 --surface-rff-sigma 10.0 \
  --kill-thresholds "2720:val_primary/abupt_axis_mean_rel_l2_pct>50"
```

**Arm B — RFF dim=128, σ=10 (more frequency capacity)**
```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=2,3 torchrun --standalone --nproc_per_node=2 train.py \
  --agent haku \
  --wandb-group yi-round37-rff-surface-iso \
  --wandb-name haku/rff-dim128-sigma10-arm-b \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --surface-rff-dim 128 --surface-rff-sigma 10.0 \
  --kill-thresholds "2720:val_primary/abupt_axis_mean_rel_l2_pct>50"
```

Run both arms simultaneously on 2 GPUs each (4 GPUs total). Each arm uses `--nproc_per_node=2` — adjust CUDA_VISIBLE_DEVICES to match your actual GPU layout.

### Step 3: Early gate at EP1 (step ~2720)

After EP1, check val_abupt vs baseline. Kill any arm diverging (>50% val_abupt at step 2720 — the kill-threshold handles this automatically). If both arms look reasonable, let them run to EP5 for a proper screening result.

### Step 4: Report results

Report val_abupt for both arms at every epoch. The key per-channel metrics to watch:
- `val_primary/wall_shear_y_rel_l2_pct` (τ_y, currently 9.87% — target: <9.87%)
- `val_primary/wall_shear_z_rel_l2_pct` (τ_z, currently 11.25% — target: <11.25%)
- `val_primary/abupt_axis_mean_rel_l2_pct` (composite — beat **7.3914%** (current yi SOTA, PR #658) to merge)

## Updated SOTA (yi, PR #658, W&B run `pxsnrw36`)

| Metric | val |
|--------|----:|
| abupt_axis_mean_rel_l2_pct | **7.3914%** |

**Merge bar (current): val_abupt < 7.3914%**

## Prior baseline (yi, PR #637, W&B run `vzprvtaw`)

| Metric | val | test |
|--------|----:|-----:|
| abupt_axis_mean_rel_l2_pct | **7.5373%** | 8.8533% |
| surface_pressure_rel_l2_pct | 4.9322% | 4.6968% |
| wall_shear_rel_l2_pct | 8.4774% | 8.4954% |
| volume_pressure_rel_l2_pct | 4.4102% | 11.4599% |
| wall_shear_x_rel_l2_pct (τ_x) | 7.2272% | 7.3046% |
| wall_shear_y_rel_l2_pct (τ_y) | 9.8691% | 9.8648% |
| wall_shear_z_rel_l2_pct (τ_z) | 11.2477% | 10.9403% |

The yi full stack:
- `--learnable-pe` (STRING-sep PE, PR #576)
- `--optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5`
- `--grad-ema-alpha 0.5` (PR #590)
- `--beta-nll-beta 0.5` (PR #583)
- `--surface-curvature-features k1_k2` (PR #580) — **NOT included in this experiment** (isolating RFF)
- `--model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128`

Note: the baseline run `vzprvtaw` was a resume at lr=1e-5 from checkpoint. These fresh arms start from scratch at lr=1e-4. Expect the fresh runs to be slower to reach the baseline level — give them at least 5 epochs. If both arms reach <9% by EP5, extend to EP10+.

## Expected surface_input_dim

| Config | surface_input_dim |
|--------|-------------------|
| baseline (no RFF, no curv) | 7 |
| Arm A: RFF dim=64 | 7 + 2×64 = **135** |
| Arm B: RFF dim=128 | 7 + 2×128 = **263** |

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-run-id>","<arm-b-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best-val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-at-best-val>}}
```

