### PR TITLE
Long DDP8: per-axis output scaling on STRING backbone (wgvvevb9+ki2q9ko9)

### DIFF
--- a/model.py
+++ b/model.py
@@ -363,6 +363,7 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        self.surface_out_scale = nn.Parameter(torch.ones(self.surface_output_dim))
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -435,7 +436,11 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = (
+                self.surface_out(surface_hidden)
+                * self.surface_out_scale
+                * surface_mask.unsqueeze(-1)
+            )
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -332,6 +332,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "pe_source_run_ki2q9ko9": (
                         config.model_pe == "string_multisigma"
                     ),
+                    "pe_source_run_sogus8sx": (
+                        config.model_pe == "string_multisigma"
+                    ),
+                    "surface_out_scale_init": (
+                        base_model.surface_out_scale.detach().cpu().tolist()
+                    ),
                 },
                 allow_val_change=True,
             )
@@ -620,6 +626,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     log_metrics.update(primary_metric_log("val_raw_primary", raw_surface))
                     for split_name, metrics in raw_val_metrics.items():
                         log_metrics.update(metric_namespace("val_raw", split_name, metrics))
+                scale_values = base_model.surface_out_scale.detach().cpu().tolist()
+                scale_names = ["cp", "tau_x", "tau_y", "tau_z"]
+                for name, value in zip(scale_names, scale_values):
+                    log_metrics[f"train/surface_out_scale/{name}"] = float(value)
                 primary_val = val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
                 log_metrics.update(primary_metric_log("val_primary", val_metrics["val_surface"]))
                 for split_name, metrics in val_metrics.items():
@@ -729,6 +739,21 @@ def main(argv: Iterable[str] | None = None) -> None:
             n_params=n_params,
             global_step=global_step,
             total_minutes=total_minutes,
+        )
+        final_scale_values = base_model.surface_out_scale.detach().cpu().tolist()
+        scale_names = ["cp", "tau_x", "tau_y", "tau_z"]
+        wandb.summary.update(
+            {
+                **{
+                    f"final/surface_out_scale/{n}": float(v)
+                    for n, v in zip(scale_names, final_scale_values)
+                },
+                "final/surface_out_scale": final_scale_values,
+            }
+        )
+        print(
+            "Final surface_out_scale "
+            + ", ".join(f"{n}={v:.4f}" for n, v in zip(scale_names, final_scale_values))
         )
         wandb.finish()
     finally:


### PR DESCRIPTION
# Long DDP8: Per-axis output scaling on STRING backbone (wgvvevb9 + ki2q9ko9)

## Hypothesis

Frieren's STRING multi-sigma PE run `sogus8sx` achieved **val abupt = 6.5281%** (step 153,831, EP14) — the wave SOTA by a clear margin. The per-axis output scaling mechanism from `wgvvevb9` (test agg 8.618) was tested in isolation but never combined with the STRING backbone.

The current `surface_out = LinearProjection(n_hidden, 4)` applies a single linear map to all four output channels (cp, tau_x, tau_y, tau_z) with no per-channel amplitude control. The four channels have very different magnitudes and persistent error ratios: tau_y and tau_z are consistently 2.3–2.6× above the AB-UPT targets on every single-model frontier point. Adding a learnable `nn.Parameter(torch.ones(4))` initialized to identity allows the model to learn separate amplitude corrections per channel at minimal parameter cost (~4 extra floats). Since initialization is ones, training is identical at step 0 — no instability risk.

**Composition hypothesis:** STRING PE improves representation quality (best volume score in the wave), per-axis scaling improves output fidelity on tau channels. These two mechanisms operate at different levels of the model (input representation vs. output head) and are expected to be approximately orthogonal. If frieren's val best of 6.5281% represents the representation ceiling for STRING alone, per-axis scaling may push through that ceiling by correcting systematic output imbalance.

## Baseline targets (lower is better)

| Metric | AB-UPT target | Pre-wave ref: `9mm3sz7x` (best agg) | Pre-wave ref: `wgvvevb9` (per-axis only) | Wave SOTA frieren `sogus8sx` (val) |
|---|---:|---:|---:|---:|
| Aggregate abupt | — | 8.123 | 8.618 | **6.5281** (val EP14) |
| surface_pressure_rel_l2_pct | 3.82 | 4.128 | 4.408 | — |
| volume_pressure_rel_l2_pct | 6.08 | 12.051 | 12.254 | — |
| wall_shear_rel_l2_pct | 7.29 | 7.454 | 8.125 | — |
| wall_shear_x_rel_l2_pct | 5.35 | 6.566 | 7.083 | — |
| wall_shear_y_rel_l2_pct | 3.65 | 8.326 | 9.092 | — |
| wall_shear_z_rel_l2_pct | 3.63 | 9.543 | 10.260 | — |

**Gate to beat:** val abupt < 6.5281% (frieren wave SOTA) for this to be a new SOTA candidate.

**Gate to be considered useful:** val abupt < 8.123 (pre-wave best) and test abupt < 8.123.

## Code changes required

### Step 1: Copy the STRING multi-sigma PE from frieren's branch

Fetch the STRING PE class from frieren's PR #599 branch or from `alphonse/multi-sigma-string-init`. The implementation must include:
- Multiple learnable bandwidth sigmas (initialized in log-frequency space)
- Separable encoding across spatial dimensions (x, y, z independent)
- `--model-pe string_multisigma` flag support in `train.py`

Log provenance in W&B config (see frieren's PR #599 for required fields: `pe_class`, `pe_source_branch`, `pe_source_sha`).

You can reuse frieren's exact PE implementation — **do not re-implement from scratch**. Fetch frieren's branch and copy the relevant class.

### Step 2: Add per-axis output scale to `model.py`

In `SurfaceTransolver.__init__`, after the line:
```python
self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
```
add:
```python
self.surface_out_scale = nn.Parameter(torch.ones(self.surface_output_dim))
```

In `SurfaceTransolver.forward`, change:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```
to:
```python
surface_preds = self.surface_out(surface_hidden) * self.surface_out_scale * surface_mask.unsqueeze(-1)
```

`self.surface_out_scale` has shape `[4]`; broadcasting against `[B, N_surface, 4]` works correctly.

Log the learned scale values at the end of training (inspect `model.surface_out_scale.data.tolist()`).

**Total model delta:** ~4 parameters plus ~3 lines of code in `model.py`.

## Phase 1: DDP8 smoke run (required gate before long run)

```bash
torchrun --nproc_per_node=8 train.py \
  --model-pe string_multisigma \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 500 \
  --epochs 3 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --wandb-group string-per-axis-scale-long \
  --wandb-name fern-string-per-axis-scale-smoke \
  --seed 42
```

**Smoke pass criteria:**
- EP1 val abupt < 40%
- EP2 val abupt < 35%
- EP3 val abupt < 30%
- No NaN/Inf in gradients or loss
- Checkpoint save/resume cycle works
- Test harvest (final EP3) runs cleanly
- `surface_out_scale` parameters logged in W&B

Report EP1/EP2/EP3 val abupt in your PR comment before proceeding to the long run.

## Phase 2: DDP8 long run (50 epochs, requires smoke pass)

```bash
torchrun --nproc_per_node=8 train.py \
  --model-pe string_multisigma \
  --lr 1e-4 \
  --optimizer lion \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --lr-warmup-steps 500 \
  --epochs 50 \
  --train-surface-points 40000 --train-volume-points 65000 \
  --eval-surface-points 40000 --eval-volume-points 65000 \
  --batch-size 2 \
  --grad-clip-norm 1.0 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25" \
  --wandb-group string-per-axis-scale-long \
  --wandb-name fern-string-per-axis-scale-long \
  --seed 42
```

**Kill thresholds:**
- EP5 val abupt > 20% → kill (STRING should show early promise)
- EP10 val abupt > 12% → kill (frieren was at ~8% by EP10)
- EP20 val abupt > 10% → kill

**Checkpoint selection:** reload best validation checkpoint (not terminal epoch) for test harvest.

**Log `surface_out_scale` values** at the end of the run (after best-checkpoint reload). This is critical diagnostic data.

## Intermediate gates

| Epoch | Action |
|---|---|
| EP1 (smoke) | Report val abupt; must be < 40% to continue |
| EP5 (long) | Report val abupt; kill if > 20% |
| EP10 (long) | Report val abupt; kill if > 12% |
| EP20 (long) | Report val abupt; kill if > 10% |
| EP50 (long) | Terminal test harvest from best val checkpoint; post SENPAI-RESULT |

## Provenance requirements

- Log `pe_class`, `pe_source_branch`, `pe_source_sha` to W&B config (same as frieren PR #599)
- Confirm the STRING PE implementation matches `ki2q9ko9` run config (not a drift copy)
- Log learned `surface_out_scale` values at terminal checkpoint

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<smoke-run-id>","<long-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test_value>}}
```

Include full test metrics table: surface_pressure, volume_pressure, wall_shear, wall_shear_x/y/z, and the learned `surface_out_scale` values [cp_scale, tau_x_scale, tau_y_scale, tau_z_scale].
