### PR TITLE
asinh wall-shear target norm for tau_y/tau_z gap attack (yi SOTA)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 — all 16 students active, no PRs ready for review)
+- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 18:00 UTC — all 16 students active, 19 WIP PRs, no PRs ready for review, no human issues)
 - **CURRENT SOTA (yi branch): PR #637 (fern, extended low-LR training at lr=1e-5 from t4qaysur checkpoint) — val_abupt 7.5373%**. Active yi merge bar: **7.5373%** (run `vzprvtaw`).
 - **PR #576 (frieren STRING-sep learnable PE + Lion) MERGED to yi.** The `--learnable-pe` flag is available in yi `train.py`. Requires `--no-compile-model` (torch.compile inductor broadcast bug).
 - **PR #637 (fern extended low-LR continuation) MERGED to yi.** New SOTA 7.5373%.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 18:10 UTC — all 16 students active, 19 WIP PRs, no PRs ready for review, no human issues)
+- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 20:00 UTC — all 16 students active, 19 WIP PRs, no PRs ready for review, no human issues)
 - **CURRENT SOTA (yi branch): PR #637 (fern, extended low-LR training at lr=1e-5 from t4qaysur checkpoint) — val_abupt 7.5373%**. Active yi merge bar: **7.5373%** (run `vzprvtaw`).
 - **PR #576 (frieren STRING-sep learnable PE + Lion) MERGED to yi.** The `--learnable-pe` flag is available in yi `train.py`. Requires `--no-compile-model` (torch.compile inductor broadcast bug).
 - **PR #637 (fern extended low-LR continuation) MERGED to yi.** New SOTA 7.5373%.
@@ -36,7 +36,7 @@ Dominant open gaps: τ_z (~2.45×), τ_y (~2.05×), vol_p (~1.78×).
 | #635 | kohaku | RANS Laplace regularizer on far-field volume pressure | WIP |
 | #636 | gilbert | Inverse local point density loss weighting | WIP |
 | #638 | tanjiro | Model dropout regularization sweep (p=0.05 vs p=0.1) | WIP |
-| #642 | haku | Fourier surface geometry features for tau_y/z gap (RFF input lift) | WIP |
+| #661 | haku | RFF surface geometry lift — isolated single-variable test (dim=64,128) | WIP (reassigned from closed #642) |
 | #645 | norman | 6L/512d clean depth ablation — isolated (no k1_k2, no β-NLL, lr-warmup-epochs=2) | WIP |
 | #646 | alphonse | Asymmetric τ_y/τ_z weighting + curvature-focal loss | WIP |
 | #652 | frieren | Muon optimizer on full yi stack (STRING-sep + grad-ema + β-NLL + k1_k2) | WIP |
@@ -53,6 +53,7 @@ Dominant open gaps: τ_z (~2.45×), τ_y (~2.05×), vol_p (~1.78×).
 ### Recently closed this cycle:
 | PR | Student | Result |
 |---|---|---|
+| #642 | haku | CLOSED — no training activity after 5 escalation nudges; implementation complete; hypothesis reassigned to PR #661 |
 | #631 | violet | CLOSED — CosineAnnealingWarmRestarts null in cold-start: val_abupt=10.74% (+30% vs SOTA). Within-cycle LR decay dominates 3-epoch budget. |
 | #634 | nezuko | CLOSED positive mechanism, below bar — SWA improved ALL metrics vs best-ckpt by 0.61pp (τ_y +0.87pp, τ_z +0.79pp). Needs staged trajectory to beat bar. |
 | #633 | norman | CLOSED — 6L/512d depth scale-up: EP1 abort (18.9% >> 15% gate). Reassigned to PR #645. |
@@ -68,7 +69,7 @@ Dominant open gaps: τ_z (~2.45×), τ_y (~2.05×), vol_p (~1.78×).
 2. **τ_y/τ_z structural attack (multi-prong):**
    - τ_y/τ_z loss weight sweep W=4,6 (PR #628 edward) — direct upweighting
    - Asymmetric tau weights + curvature-focal (PR #646 alphonse) — geometry-informed
-   - Fourier surface geometry RFF features (PR #642 haku) — input lift for τ channels
+   - Fourier surface geometry RFF features (PR #661 haku) — input lift for τ channels (dim=64,128 isolated test)
    - Model dropout p=0.05/0.1 (PR #638 tanjiro) — regularization to reduce τ overfitting
 
 3. **Volume pressure gap attack:**

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-05 (Round 37 — advisor cycle, updated: PR #662 chihiro curvature + PR #663 kohaku stochastic-depth assigned)
+- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 — all 16 students active, no PRs ready for review)
 - **CURRENT SOTA (yi branch): PR #637 (fern, extended low-LR training at lr=1e-5 from t4qaysur checkpoint) — val_abupt 7.5373%**. Active yi merge bar: **7.5373%** (run `vzprvtaw`).
 - **PR #576 (frieren STRING-sep learnable PE + Lion) MERGED to yi.** The `--learnable-pe` flag is available in yi `train.py`. Requires `--no-compile-model` (torch.compile inductor broadcast bug).
 - **PR #637 (fern extended low-LR continuation) MERGED to yi.** New SOTA 7.5373%.

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 18:00 UTC — all 16 students active, 19 WIP PRs, no PRs ready for review, no human issues)
+- 2026-05-04 (Round 37 — advisor cycle check, updated: 2026-05-04 18:10 UTC — all 16 students active, 19 WIP PRs, no PRs ready for review, no human issues)
 - **CURRENT SOTA (yi branch): PR #637 (fern, extended low-LR training at lr=1e-5 from t4qaysur checkpoint) — val_abupt 7.5373%**. Active yi merge bar: **7.5373%** (run `vzprvtaw`).
 - **PR #576 (frieren STRING-sep learnable PE + Lion) MERGED to yi.** The `--learnable-pe` flag is available in yi `train.py`. Requires `--no-compile-model` (torch.compile inductor broadcast bug).
 - **PR #637 (fern extended low-LR continuation) MERGED to yi.** New SOTA 7.5373%.

--- a/train.py
+++ b/train.py
@@ -1116,6 +1116,7 @@ class Config:
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
     beta_nll_beta: float = -1.0
+    ws_asinh_scale: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -1221,6 +1222,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "separate checks. STEP is a global optimizer step and METRIC must match "
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
+        ),
+        "ws_asinh_scale": (
+            "If > 0, apply asinh(target / scale) transform to wall-shear targets and "
+            "predictions before loss computation (normalized space). Predictions remain "
+            "in raw space; only the loss is affected. Useful for compressing heavy-tailed "
+            "tau_y/tau_z distributions. Default 0.0 = disabled."
         ),
     }
     for field in fields(Config):
@@ -2034,6 +2041,7 @@ def train_loss(
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
     beta_nll_beta: float = -1.0,
+    ws_asinh_scale: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -2074,6 +2082,16 @@ def train_loss(
         else:
             surface_pred_used = surface_pred_norm
             surface_target_used = surface_target
+
+        if ws_asinh_scale > 0.0:
+            ws_pred_loss = torch.asinh(surface_pred_used[..., 1:4] / ws_asinh_scale)
+            ws_target_loss = torch.asinh(surface_target_used[..., 1:4] / ws_asinh_scale)
+            surface_pred_used = torch.cat(
+                [surface_pred_used[..., :1], ws_pred_loss, surface_pred_used[..., 4:]], dim=-1
+            )
+            surface_target_used = torch.cat(
+                [surface_target_used[..., :1], ws_target_loss, surface_target_used[..., 4:]], dim=-1
+            )
 
         per_axis_log_var: list[float] | None = None
         volume_log_var_mean: float | None = None
@@ -2788,6 +2806,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
+                ws_asinh_scale=config.ws_asinh_scale,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())


### PR DESCRIPTION
## Hypothesis

Wall-shear τ_y and τ_z are the dominant remaining gaps vs AB-UPT (τ_y: 9.86% vs target 3.65%, 2.7×; τ_z: 11.25% vs target 3.63%, 3.1×). These channels have a heavy-tailed distribution: near-zero wall-shear values far outnumber high-magnitude values, so MSE loss spends most gradient budget on the dense near-zero region and underweights the rare large-magnitude regions (sharp curvatures, separation zones) that drive error.

**Hypothesis:** Applying an asinh transform to wall-shear targets before loss computation compresses the long tail, equalising gradient contributions across the magnitude range. `asinh(x/scale)` behaves as `x/scale` near zero (linear, preserving gradient signal for near-zero regions) and as `sign(x)·log(2|x|/scale)` for large `|x|` (log-scale compression of the heavy tail). The model predicts in raw space; the transform is only applied inside the loss function, so model outputs and all metrics remain unchanged.

This is a targeted τ_y/τ_z intervention layered on the full current yi SOTA stack:
- STRING-sep learnable PE (`--learnable-pe`)
- Lion lr=1e-4, weight-decay 5e-4, clip-grad-norm 0.5
- Grad-EMA α=0.5 (`--grad-ema-alpha 0.5`)
- β-NLL β=0.5 (`--beta-nll-beta 0.5`)
- Principal surface curvatures (`--surface-curvature-features k1_k2`)

Reference: Asinh normalization for heavy-tailed regression is standard in signal processing (e.g. in seismic inversion); closely related to log1p/Huber ideas already validated here (Huber wall-shear loss PR #317, β-NLL PR #583).

## Instructions

### 1. Implement `--ws-asinh-scale` flag in `target/train.py`

This flag currently does NOT exist. You need to add it. Here is the exact implementation:

**a) Add the argument parser entry** (near the other loss-related flags like `--beta-nll-beta`):

```python
parser.add_argument(
    "--ws-asinh-scale",
    type=float,
    default=0.0,
    help="If > 0, apply asinh(target / scale) transform to wall-shear targets before "
         "loss computation. Predictions remain in raw space; only the loss is affected. "
         "Useful for compressing heavy-tailed tau_y/tau_z distributions. Default 0.0 = disabled.",
)
```

**b) Find the wall-shear loss computation** in the training loop (look for where `wall_shear` targets are used to compute loss, likely near `surface_pressure` and `volume_pressure` losses).

**c) Add the transform before wall-shear loss only:**

```python
if args.ws_asinh_scale > 0:
    ws_targets_loss = torch.asinh(ws_targets / args.ws_asinh_scale)
    ws_preds_loss   = torch.asinh(ws_preds   / args.ws_asinh_scale)
else:
    ws_targets_loss = ws_targets
    ws_preds_loss   = ws_preds
# Use ws_targets_loss / ws_preds_loss in the loss computation
# Continue to use ws_targets / ws_preds for metric logging (raw space)
```

Make sure the `ws_preds` here refers to the model's raw output predictions (not the EMA model), and that the per-axis metric logging (`wall_shear_y_rel_l2_pct`, etc.) is still computed from raw predictions vs raw targets.

### 2. Run two arms in a single session with `--wandb_group`

Use `--wandb-group gilbert-asinh-ws-scale-sweep` to group the runs.

**Arm A — scale=0.1:**
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent gilbert \
  --wandb-group gilbert-asinh-ws-scale-sweep \
  --wandb-name gilbert/asinh-ws-arm-a-scale0.1 \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --ws-asinh-scale 0.1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999
```

**Arm B — scale=0.01:**
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent gilbert \
  --wandb-group gilbert-asinh-ws-scale-sweep \
  --wandb-name gilbert/asinh-ws-arm-b-scale0.01 \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --ws-asinh-scale 0.01 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999
```

Run both arms sequentially (Arm A first, then Arm B). If Arm A diverges (EP1 > 25%) or shows severe regression at EP3 (> 12%), do not run Arm B — report the failure.

### 3. Verification checklist

After implementing the flag, verify:
1. `python train.py --help | grep ws-asinh` shows the new flag
2. With `--ws-asinh-scale 0.0` (default), loss values are identical to the baseline run (sanity check: run 1 step, compare loss tensors)
3. Metric logging (val metrics table, wandb) shows raw-space metrics (not asinh-transformed values)

### 4. EP gates

- **EP1 kill gate:** val_abupt > 25% → stop, report failure
- **EP3 kill gate:** val_abupt > 12% → stop, report failure  
- **EP3 SOTA proximity:** val_abupt < 9.5% → strong candidate, continue to convergence
- **Merge bar:** val_abupt < 7.5373% (current yi SOTA, PR #637 fern, W&B run `vzprvtaw`)

### 5. Expected mechanism

- `scale=0.1`: asinh transform activates for |τ| > ~0.1 (moderate compression of the high-magnitude tail; near-zero gradients largely unchanged)
- `scale=0.01`: stronger compression, activates at |τ| > ~0.01 (aggressive tail compression; may improve τ_y/τ_z at risk of slight τ_x regression)
- If neither arm improves τ_y/τ_z but surface_pressure regresses, the transform is too aggressive — report and close

## Baseline (yi SOTA — PR #637 fern, W&B run `vzprvtaw`)

| Metric | val | test |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **7.5373%** | **8.8533%** |
| `surface_pressure_rel_l2_pct` | 4.9322% | 4.6968% |
| `wall_shear_rel_l2_pct` | 8.4774% | 8.4954% |
| `volume_pressure_rel_l2_pct` | 4.4102% | 11.4599% |
| `wall_shear_x_rel_l2_pct` (τ_x) | 7.2272% | 7.3046% |
| `wall_shear_y_rel_l2_pct` (τ_y) | **9.8691%** | **9.8648%** |
| `wall_shear_z_rel_l2_pct` (τ_z) | **11.2477%** | **10.9403%** |

**AB-UPT reference targets (test):** τ_y = 3.65%, τ_z = 3.63% — τ_y and τ_z are the primary attack surfaces.

**Baseline W&B run:** `vzprvtaw` (group: `yi-round36-extended-training`)

**Full yi SOTA stack (PR #637 baseline):**
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent gilbert \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999
```

## Terminal result format

When complete, post a comment with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-run-id>","<arm-b-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best-value>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-value>}}
```
