### PR TITLE
tanjiro: O(2) y-symmetry pair loss for τ_y/τ_z bias

### DIFF
--- a/train.py
+++ b/train.py
@@ -1163,9 +1163,39 @@ class Config:
     swa_lr: float = 5e-6
     swa_anneal_epochs: int = 1
     swa_update_every_steps: int = 500
+    y_symmetry_pair_loss: bool = False
+    y_symmetry_test_avg: bool = False
 
 
 NONFINITE_SKIP_ABORT = 200
+
+
+def _mirror_batch_y(batch: SurfaceBatch) -> SurfaceBatch:
+    """Reflect a SurfaceBatch about the y=0 plane.
+
+    Surface input layout `[x, y, z, nx, ny, nz, area, ...]`: y-coord (idx 1) and
+    ny normal (idx 4) flip sign. Surface targets `[cp, tau_x, tau_y, tau_z]`:
+    only tau_y (idx 2) flips. Volume input `[x, y, z, sdf]`: only y (idx 1)
+    flips. Volume target (scalar pressure) is invariant. Optional curvature
+    channels (idx 7..) are intrinsic invariants and are preserved.
+    """
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = -surface_x[..., 1]
+    surface_x[..., 4] = -surface_x[..., 4]
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = -surface_y[..., 2]
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = -volume_x[..., 1]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
 
 
 class TargetTransform:
@@ -2038,7 +2068,37 @@ def train_loss(
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
     beta_nll_beta: float = -1.0,
+    y_symmetry_pair_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
+    if y_symmetry_pair_loss:
+        batch = batch.to(device)
+        kwargs = dict(
+            surface_loss_weight=surface_loss_weight,
+            volume_loss_weight=volume_loss_weight,
+            aux_rel_l2_weight=aux_rel_l2_weight,
+            use_tangential_wallshear_loss=use_tangential_wallshear_loss,
+            wallshear_y_weight=wallshear_y_weight,
+            wallshear_z_weight=wallshear_z_weight,
+            wallshear_huber_delta=wallshear_huber_delta,
+            beta_nll_beta=beta_nll_beta,
+        )
+        loss_orig, metrics_orig = train_loss(
+            model, batch, transform, device, amp_mode, **kwargs
+        )
+        batch_mirror = _mirror_batch_y(batch)
+        loss_mirror, metrics_mirror = train_loss(
+            model, batch_mirror, transform, device, amp_mode, **kwargs
+        )
+        loss = 0.5 * (loss_orig + loss_mirror)
+        metrics: dict[str, float] = dict(metrics_orig)
+        for k, v in metrics_mirror.items():
+            metrics[f"mirror_{k}"] = v
+        metrics["sym_loss_orig"] = float(loss_orig.detach().cpu().item())
+        metrics["sym_loss_mirror"] = float(loss_mirror.detach().cpu().item())
+        metrics["sym_loss_diff_abs"] = abs(
+            metrics["sym_loss_orig"] - metrics["sym_loss_mirror"]
+        )
+        return loss, metrics
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -2199,6 +2259,7 @@ def evaluate_split(
     device: torch.device,
     *,
     amp_mode: str = "none",
+    y_symmetry_test_avg: bool = False,
 ) -> dict[str, float]:
     model.eval()
     surface_loss_sse = 0.0
@@ -2238,6 +2299,20 @@ def evaluate_split(
             )
         surface_pred_norm = out["surface_preds"].float()
         volume_pred_norm = out["volume_preds"].float()
+        if y_symmetry_test_avg:
+            batch_mirror = _mirror_batch_y(batch)
+            with autocast_context(device, amp_mode):
+                out_mirror = model(
+                    surface_x=batch_mirror.surface_x,
+                    surface_mask=batch_mirror.surface_mask,
+                    volume_x=batch_mirror.volume_x,
+                    volume_mask=batch_mirror.volume_mask,
+                )
+            surface_pred_mirror = out_mirror["surface_preds"].float()
+            volume_pred_mirror = out_mirror["volume_preds"].float()
+            surface_pred_mirror[..., 2] = -surface_pred_mirror[..., 2]
+            surface_pred_norm = 0.5 * (surface_pred_norm + surface_pred_mirror)
+            volume_pred_norm = 0.5 * (volume_pred_norm + volume_pred_mirror)
         surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
         volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
         surface_loss_sse += surface_sse
@@ -2834,6 +2909,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
+                y_symmetry_pair_loss=config.y_symmetry_pair_loss,
             )
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
@@ -3110,7 +3186,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ema.store(model)
             ema.copy_to(model)
         val_metrics = {
-            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+            name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, y_symmetry_test_avg=config.y_symmetry_test_avg)
             for name, loader in val_loaders.items()
         }
         if ema is not None:
@@ -3237,7 +3313,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, y_symmetry_test_avg=config.y_symmetry_test_avg)
         for name, loader in val_loaders.items()
     }
     full_val_primary = full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -3271,8 +3347,37 @@ def main(argv: Iterable[str] | None = None) -> None:
     if is_main:
         print_metrics("full_val", full_val_metrics["val_surface"])
 
+    if config.y_symmetry_pair_loss:
+        full_val_alt_avg = not config.y_symmetry_test_avg
+        full_val_metrics_alt = {
+            name: evaluate_split(
+                model, loader, transform, device,
+                amp_mode=config.amp_mode,
+                y_symmetry_test_avg=full_val_alt_avg,
+            )
+            for name, loader in val_loaders.items()
+        }
+        alt_suffix = "tta" if full_val_alt_avg else "no_tta"
+        full_val_alt_log: dict[str, object] = {
+            f"full_val_primary_{alt_suffix}/abupt_axis_mean_rel_l2_pct": full_val_metrics_alt["val_surface"]["abupt_axis_mean_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/surface_pressure_rel_l2_pct": full_val_metrics_alt["val_surface"]["surface_pressure_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/wall_shear_rel_l2_pct": full_val_metrics_alt["val_surface"]["wall_shear_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/wall_shear_x_rel_l2_pct": full_val_metrics_alt["val_surface"]["wall_shear_x_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/wall_shear_y_rel_l2_pct": full_val_metrics_alt["val_surface"]["wall_shear_y_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/wall_shear_z_rel_l2_pct": full_val_metrics_alt["val_surface"]["wall_shear_z_rel_l2_pct"],
+            f"full_val_primary_{alt_suffix}/volume_pressure_rel_l2_pct": full_val_metrics_alt["val_surface"]["volume_pressure_rel_l2_pct"],
+            "global_step": global_step,
+        }
+        for split_name, metrics in full_val_metrics_alt.items():
+            for key, value in metrics.items():
+                full_val_alt_log[f"full_val_{alt_suffix}/{split_name}/{key}"] = value
+        wandb.log(full_val_alt_log)
+        wandb.summary.update(_numeric_metric_items(full_val_alt_log))
+        if is_main:
+            print_metrics(f"full_val_{alt_suffix}", full_val_metrics_alt["val_surface"])
+
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode, y_symmetry_test_avg=config.y_symmetry_test_avg)
         for name, loader in test_loaders.items()
     }
     test_primary = test_metrics["test_surface"]["abupt_axis_mean_rel_l2_pct"]
@@ -3408,6 +3513,35 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Logged SWA artifact '{swa_artifact_name}'")
         checkpoint_reload = torch.load(model_path, map_location=device, weights_only=True)
         model.load_state_dict(checkpoint_reload["model"], strict=True)
+
+    if config.y_symmetry_pair_loss:
+        test_alt_avg = not config.y_symmetry_test_avg
+        test_metrics_alt = {
+            name: evaluate_split(
+                model, loader, transform, device,
+                amp_mode=config.amp_mode,
+                y_symmetry_test_avg=test_alt_avg,
+            )
+            for name, loader in test_loaders.items()
+        }
+        alt_suffix = "tta" if test_alt_avg else "no_tta"
+        test_alt_log: dict[str, object] = {
+            f"test_primary_{alt_suffix}/abupt_axis_mean_rel_l2_pct": test_metrics_alt["test_surface"]["abupt_axis_mean_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/surface_pressure_rel_l2_pct": test_metrics_alt["test_surface"]["surface_pressure_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/wall_shear_rel_l2_pct": test_metrics_alt["test_surface"]["wall_shear_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/wall_shear_x_rel_l2_pct": test_metrics_alt["test_surface"]["wall_shear_x_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/wall_shear_y_rel_l2_pct": test_metrics_alt["test_surface"]["wall_shear_y_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/wall_shear_z_rel_l2_pct": test_metrics_alt["test_surface"]["wall_shear_z_rel_l2_pct"],
+            f"test_primary_{alt_suffix}/volume_pressure_rel_l2_pct": test_metrics_alt["test_surface"]["volume_pressure_rel_l2_pct"],
+            "global_step": global_step,
+        }
+        for split_name, metrics in test_metrics_alt.items():
+            for key, value in metrics.items():
+                test_alt_log[f"test_{alt_suffix}/{split_name}/{key}"] = value
+        wandb.log(test_alt_log)
+        wandb.summary.update(_numeric_metric_items(test_alt_log))
+        if is_main:
+            print_metrics(f"test_surface_{alt_suffix}", test_metrics_alt["test_surface"])
 
     if is_main:
         log_model_artifact(

--- a/train.py
+++ b/train.py
@@ -1164,6 +1164,7 @@ class Config:
     swa_anneal_epochs: int = 1
     swa_update_every_steps: int = 500
     y_symmetry_pair_loss: bool = False
+    y_symmetry_augment: bool = False
     y_symmetry_test_avg: bool = False
 
 
@@ -2895,6 +2896,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            mirror_this_step = (
+                config.y_symmetry_augment
+                and not config.y_symmetry_pair_loss
+                and (global_step % 2 == 1)
+            )
+            if mirror_this_step:
+                batch = _mirror_batch_y(batch)
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,
@@ -2911,6 +2919,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 beta_nll_beta=config.beta_nll_beta,
                 y_symmetry_pair_loss=config.y_symmetry_pair_loss,
             )
+            if config.y_symmetry_augment and not config.y_symmetry_pair_loss:
+                batch_loss_metrics["sym_aug_mirrored"] = float(mirror_this_step)
             optimizer.zero_grad(set_to_none=True)
             loss_is_finite = bool(torch.isfinite(loss).item())
             if not loss_is_finite:
@@ -3347,7 +3357,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     if is_main:
         print_metrics("full_val", full_val_metrics["val_surface"])
 
-    if config.y_symmetry_pair_loss:
+    if config.y_symmetry_pair_loss or config.y_symmetry_augment:
         full_val_alt_avg = not config.y_symmetry_test_avg
         full_val_metrics_alt = {
             name: evaluate_split(
@@ -3514,7 +3524,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         checkpoint_reload = torch.load(model_path, map_location=device, weights_only=True)
         model.load_state_dict(checkpoint_reload["model"], strict=True)
 
-    if config.y_symmetry_pair_loss:
+    if config.y_symmetry_pair_loss or config.y_symmetry_augment:
         test_alt_avg = not config.y_symmetry_test_avg
         test_metrics_alt = {
             name: evaluate_split(


### PR DESCRIPTION
## Hypothesis

DrivAer vehicles have approximate bilateral y-symmetry (left–right mirror symmetry about the y=0 plane). By training with mirrored copies of every input, we inject a structural symmetry constraint that directly biases the model toward lower τ_y and τ_z error — without any architecture changes.

**Mechanism**: For each batch, create a mirrored input by flipping the y-coordinate of every surface and volume point (`y → −y`). Reflect the labels accordingly: τ_y channel negated, τ_x/τ_z/p_s/p_v unchanged (they are y-symmetric under the bilateral mirror). Compute loss on both original and mirrored forward passes, average, and backprop. At test time, average original + mirrored predictions for a free ensemble boost.

**Why this targets τ_y/τ_z**: The dominant open gaps are τ_y (~2.70× vs AB-UPT) and τ_z (~3.10× vs AB-UPT). These are the shear components most sensitive to left–right asymmetry in the predictions. The symmetry pair loss acts as a regularizer that forces the model to satisfy the physical bilateral symmetry, directly attacking the axes where the model struggles most.

## Current Baseline (yi SOTA — PR #658 fern, W&B `pxsnrw36`)

**Merge bar: val_abupt < 7.3914%** (updated 2026-05-05; was 7.5373% at PR open).

| Metric | val | test | AB-UPT target | Gap |
|---|---:|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **7.3914%** | — | — | — |
| `surface_pressure_rel_l2_pct` (PR #637 ref) | 4.9322% | 4.6968% | 3.82% | 1.23× |
| `wall_shear_rel_l2_pct` (PR #637 ref) | 8.4774% | 8.4954% | 7.29% | 1.16× |
| `volume_pressure_rel_l2_pct` (PR #637 ref) | 4.4102% | 11.4599% | 6.08% | — |
| `wall_shear_x_rel_l2_pct` (PR #637 ref) | 7.2272% | 7.3046% | 5.35% | 1.35× |
| `wall_shear_y_rel_l2_pct` (PR #637 ref) | **9.8691%** | **9.8648%** | **3.65%** | **2.70×** |
| `wall_shear_z_rel_l2_pct` (PR #637 ref) | **11.2477%** | **10.9403%** | **3.63%** | **3.10×** |

Note: PR #658 only reports the abupt headline; per-axis numbers above are from the prior PR #637 reference, which is the most recent run with detailed breakdowns. The τ_y/τ_z gap argument still holds — these were the dominant open axes when this hypothesis was drafted.

## Implementation Instructions

Implement a `--y-symmetry-pair-loss` flag in `train.py`. The full yi stack is used as base (cold-start, no resume).

### What to implement

In the training loop, after drawing a batch:

1. **Mirror the surface input**: create `surface_x_mirror` by copying `surface_x` and negating the y-column (axis index 1 in xyz). Leave all other surface input channels unchanged.

2. **Mirror the volume input**: create `volume_x_mirror` by copying `volume_x` and negating the y-column.

3. **Mirror the labels**: create `surface_y_mirror` and `volume_y_mirror`:
   - Surface: negate the τ_y channel (wall shear y). All other channels (p_s, τ_x, τ_z) are unchanged.
   - Volume: negate the p_y or any y-component that is anti-symmetric. For p_v, no change (pressure is scalar symmetric). For τ_y on volume (if present), negate.
   - **Note**: Check the channel ordering in the dataset code. Surface channels are typically [p_s, τ_x, τ_y, τ_z]; τ_y is index 2. Verify before hardcoding.

4. **Two forward passes per step**: 
   ```python
   loss_orig = criterion(model(surface_x, volume_x, ...), labels_orig)
   loss_mirror = criterion(model(surface_x_mirror, volume_x_mirror, ...), labels_mirror)
   loss = 0.5 * (loss_orig + loss_mirror)
   ```
   
5. **Test-time symmetry averaging** (optional, implement as separate `--y-symmetry-test-avg` flag):
   ```python
   pred_orig = model(surface_x, volume_x, ...)
   pred_mirror = model(surface_x_mirror, volume_x_mirror, ...)
   # un-mirror pred_mirror (negate τ_y channel back)
   pred_mirror_unmirrored = pred_mirror.clone()
   pred_mirror_unmirrored[..., tau_y_channel] *= -1
   pred_avg = 0.5 * (pred_orig + pred_mirror_unmirrored)
   ```

### Two arms

**Arm A — symmetry pair loss only** (3 epochs):
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent tanjiro --wandb-group yi-round38-y-symmetry-pair-loss \
  --wandb-name tanjiro/y-symmetry-pair-loss-arm-a \
  --y-symmetry-pair-loss \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --no-compile-model --learnable-pe --grad-ema-alpha 0.5 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1
```

**Arm B — symmetry pair loss + test-time averaging** (3 epochs, same training as Arm A but evaluate with `--y-symmetry-test-avg`):
```bash
torchrun --standalone --nproc_per_node=4 train.py \
  --agent tanjiro --wandb-group yi-round38-y-symmetry-pair-loss \
  --wandb-name tanjiro/y-symmetry-pair-loss-arm-b \
  --y-symmetry-pair-loss --y-symmetry-test-avg \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --no-compile-model --learnable-pe --grad-ema-alpha 0.5 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --ema-decay 0.999 --lr-warmup-epochs 1
```

### EP gates

- **EP1 gate**: val_abupt ≤ 15% → continue. 15–25% → marginal (report and continue). > 25% → close immediately.
- **EP2 kill gate**: val_abupt ≤ 12% → continue to EP3. > 12% → stop, close PR.
- **Watch τ_y and τ_z specifically**: the hypothesis succeeds if these improve even if overall abupt is similar.

### Implementation notes

- The mirror forward pass doubles compute per step. If you hit OOM, reduce `--batch-size` to 2 and double `--train-surface-points` to maintain batch diversity. Alternatively, alternate mirror/non-mirror every other step.
- Verify channel ordering before hardcoding τ_y index. Print `dataset.surface_channels` or equivalent to confirm.
- The mirrored labels must satisfy: mirror(mirror(x)) = x. A quick sanity check: apply the mirror twice and verify you recover the original labels.
- `--no-compile-model` is **required** (torch.compile inductor broadcast bug with `--learnable-pe`).

## Success Criteria

Primary: val_abupt < 7.3914% (beat current yi SOTA, PR #658 fern).
Secondary: τ_y val < 9.8691% and/or τ_z val < 11.2477% (closing the dominant gaps from the most recent per-axis reference, PR #637).

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
