### PR TITLE
edward: decoupled τ_y/τ_z MLP head to break shared-head zero-sum

### DIFF
--- a/train.py
+++ b/train.py
@@ -920,6 +920,8 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.tau_yz_head = MLP(input_dim=n_hidden, hidden_dim=256, output_dim=2)
+        self.decouple_tau_yz = False
         if self.beta_nll:
             self.surface_log_var_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_log_var_out = LinearProjection(n_hidden, self.volume_output_dim)
@@ -1005,6 +1007,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.decouple_tau_yz:
+                tau_yz = self.tau_yz_head(surface_hidden) * surface_mask.unsqueeze(-1)
+                surface_preds = torch.cat([surface_preds[..., :2], tau_yz], dim=-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -1200,6 +1205,8 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    decouple_tau_yz: bool = False
+    tau_yz_head_lr_mult: float = 1.0
     beta_nll_beta: float = -1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
@@ -1243,6 +1250,7 @@ class Config:
     lr_warmup_epochs: int = 0
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
+    resume_strict: bool = True
     surface_curvature_features: str = "none"
     swa_start_fraction: float = -1.0
     swa_lr: float = 5e-6
@@ -3099,10 +3107,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         return
 
     model = build_model(config).to(device)
+    model.decouple_tau_yz = config.decouple_tau_yz
     resume_info: dict[str, float | str | int] = {}
     if config.resume_from:
         ckpt = torch.load(config.resume_from, map_location=device, weights_only=True)
-        model.load_state_dict(ckpt["model"], strict=True)
+        load_result = model.load_state_dict(ckpt["model"], strict=config.resume_strict)
+        missing_keys = list(getattr(load_result, "missing_keys", []) or [])
+        unexpected_keys = list(getattr(load_result, "unexpected_keys", []) or [])
         prev_epoch = ckpt.get("epoch", -1)
         prev_val_metrics = ckpt.get("val_metrics", {}) or {}
         prev_primary_val = float(
@@ -3114,12 +3125,20 @@ def main(argv: Iterable[str] | None = None) -> None:
             "resume_from_path": str(config.resume_from),
             "resume_prev_epoch": int(prev_epoch) if isinstance(prev_epoch, (int, float)) else -1,
             "resume_prev_val_abupt_pct": prev_primary_val,
+            "resume_strict": bool(config.resume_strict),
+            "resume_missing_keys": missing_keys,
+            "resume_unexpected_keys": unexpected_keys,
         }
         if is_main:
             print(
                 f"Resumed model weights from {config.resume_from} "
-                f"(saved at epoch {prev_epoch}, val_abupt={prev_primary_val:.4f}%)"
+                f"(saved at epoch {prev_epoch}, val_abupt={prev_primary_val:.4f}%, "
+                f"strict={config.resume_strict})"
             )
+            if missing_keys:
+                print(f"  Missing keys (re-init from random): {missing_keys}")
+            if unexpected_keys:
+                print(f"  Unexpected keys (ignored): {unexpected_keys}")
     if config.correction_mode:
         if not config.resume_from:
             raise ValueError(
@@ -3162,16 +3181,44 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
     optimizer_name = config.optimizer.lower()
+    head_param_ids: set[int] = set()
+    if (
+        config.decouple_tau_yz
+        and config.tau_yz_head_lr_mult != 1.0
+        and hasattr(model, "tau_yz_head")
+    ):
+        head_param_ids = {id(p) for p in model.tau_yz_head.parameters() if p.requires_grad}
+    head_lr_mult = config.tau_yz_head_lr_mult if head_param_ids else 1.0
+    head_lr = config.lr * head_lr_mult
+
+    def _split_param_groups() -> list[dict]:
+        trunk_params = [p for p in model.parameters() if p.requires_grad and id(p) not in head_param_ids]
+        head_params = [p for p in model.parameters() if p.requires_grad and id(p) in head_param_ids]
+        groups: list[dict] = [{"params": trunk_params, "lr": config.lr, "name": "trunk"}]
+        if head_params:
+            groups.append({"params": head_params, "lr": head_lr, "name": "tau_yz_head"})
+        return groups
+
     if optimizer_name == "adamw":
-        optimizer = torch.optim.AdamW(
-            trainable_params, lr=config.lr, weight_decay=config.weight_decay
-        )
+        if head_param_ids:
+            optimizer = torch.optim.AdamW(
+                _split_param_groups(), lr=config.lr, weight_decay=config.weight_decay
+            )
+        else:
+            optimizer = torch.optim.AdamW(
+                trainable_params, lr=config.lr, weight_decay=config.weight_decay
+            )
     elif optimizer_name == "lion":
         from lion_pytorch import Lion
 
-        optimizer = Lion(
-            trainable_params, lr=config.lr, weight_decay=config.weight_decay
-        )
+        if head_param_ids:
+            optimizer = Lion(
+                _split_param_groups(), lr=config.lr, weight_decay=config.weight_decay
+            )
+        else:
+            optimizer = Lion(
+                trainable_params, lr=config.lr, weight_decay=config.weight_decay
+            )
     elif optimizer_name == "muon":
         muon_2d_params = [p for p in model.parameters() if p.requires_grad and p.ndim == 2]
         muon_other_params = [p for p in model.parameters() if p.requires_grad and p.ndim != 2]
@@ -3221,6 +3268,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"Optimizer: {optimizer.__class__.__name__} "
             f"lr={config.lr} wd={config.weight_decay}"
         )
+        if head_param_ids:
+            n_head = sum(p.numel() for p in model.tau_yz_head.parameters() if p.requires_grad)
+            print(
+                f"Param-group split: tau_yz_head ({n_head/1e3:.1f}K params) at lr={head_lr:g}, "
+                f"trunk at lr={config.lr:g} (head_lr_mult={head_lr_mult:g})"
+            )
     initial_group_lrs = [pg["lr"] for pg in optimizer.param_groups]
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max_epochs)
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
@@ -3596,6 +3649,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "train/loss_tau_y": batch_loss_metrics["loss_tau_y"],
                 "train/loss_tau_z": batch_loss_metrics["loss_tau_z"],
                 "train/lr": float(optimizer.param_groups[0]["lr"]),
+                "train/lr_tau_yz_head": (
+                    float(optimizer.param_groups[1]["lr"])
+                    if len(optimizer.param_groups) > 1 and head_param_ids
+                    else float(optimizer.param_groups[0]["lr"])
+                ),
                 "train/nonfinite_skip_count": nonfinite_skip_count,
                 "global_step": global_step,
                 **gradient_metrics,


### PR DESCRIPTION
## Hypothesis

The current yi SOTA model uses a single shared `LinearProjection(n_hidden, 4)` surface head that simultaneously predicts cp, τ_x, τ_y, τ_z as four output channels. τ_y and τ_z are the weakest channels by far (val 9.87% and 11.25% vs AB-UPT targets of 3.65% and 3.63% respectively — 2.7× and 3.1× above target). Edward's PR #628 showed that simply upweighting τ_y/τ_z loss (×4, ×6) regressses volume_pressure monotonically, suggesting that the shared head creates a zero-sum optimization conflict.

**Hypothesis:** Giving τ_y and τ_z their own dedicated MLP head — separate weights, separate optimization gradient path — breaks the zero-sum interaction with cp/τ_x prediction and allows the model to develop a specialized representation for the tangential stress components. The decoupled head operates on the same surface hidden tokens but learns to extract features relevant specifically to tangential shear, not competing with cp or τ_x gradients.

Note: The `MLP(input_dim, hidden_dim, output_dim)` class already exists in `train.py` (lines 646–657): a 2-layer network (Linear → GELU → Linear) with `_init_linear` weight initialization.

## Instructions to the Student

This requires three code changes to `target/train.py`:

### 1. Add new `TrainConfig` field (in the `TrainConfig` dataclass, around line 1115–1117)

```python
# After wallshear_z_weight and wallshear_huber_delta, add:
decouple_tau_yz: bool = False
```

Add the corresponding CLI flag near the other wall-shear flags (search for `wallshear_z_weight` argument in the argparse section):
```python
parser.add_argument("--decouple-tau-yz", action="store_true", default=False,
                    help="Add a dedicated MLP head for tau_y/tau_z, decoupled from the shared surface head.")
```
And wire it up in the config construction:
```python
decouple_tau_yz=args.decouple_tau_yz,
```

### 2. Add `tau_yz_head` to the model constructor (in `__init__`, near line 921 where `self.surface_out` is defined)

```python
self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
# ADD THIS LINE:
self.tau_yz_head = MLP(input_dim=n_hidden, hidden_dim=256, output_dim=2)
```

Also add a `decouple_tau_yz` attribute to the model so the forward pass can check it:
```python
self.decouple_tau_yz = False  # overridden by TrainConfig after construction
```

### 3. Modify the forward pass (near line 1007 where `surface_preds` is computed)

Find this code:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

Replace with:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
if self.decouple_tau_yz:
    tau_yz = self.tau_yz_head(surface_hidden) * surface_mask.unsqueeze(-1)
    surface_preds = torch.cat([surface_preds[..., :2], tau_yz], dim=-1)
```

### 4. Set `model.decouple_tau_yz` from config after model construction

Find where the model is constructed and where `train_config` fields are used to configure it. After model construction (look for where `model = Transolver(...)` is called), add:
```python
model.decouple_tau_yz = train_config.decouple_tau_yz
```

### Important: No checkpoint resume for this run

The new `tau_yz_head` weights don't exist in any prior checkpoint, so **start from scratch** (do not use `--resume-from`). Use the full yi SOTA cold-start training config:

- 4L/512d/8h/128slices
- Lion lr=1e-4, weight-decay=5e-4, clip-grad-norm=0.5
- learnable-pe, grad-ema-alpha=0.5
- batch=4, 65536 surface/volume points, DDP 4-GPU
- validation-every 1

### Two Experimental Arms

**Arm A — Decoupled head only (W=1.0 for τ_y/τ_z):**
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward --wandb-group yi-round38-decouple-tau-yz \
  --wandb-name edward/decouple-tau-yz-armA-base \
  --decouple-tau-yz \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

**Arm B — Decoupled head + mild τ_y/τ_z upweighting (W=2.0):**

Since the gradient paths are now separate, modest upweighting of τ_y/τ_z loss should no longer zero-sum against cp/vol_pressure. W=2.0 is a conservative starting point to avoid regression.
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent edward --wandb-group yi-round38-decouple-tau-yz \
  --wandb-name edward/decouple-tau-yz-armB-w2 \
  --decouple-tau-yz \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

Run both arms and report the best per-arm val_abupt at any checkpoint. If Arm B regresses vol_pressure relative to Arm A, that confirms the decoupled head alone (Arm A) is the correct path.

## Baseline (yi SOTA — PR #637, W&B run `vzprvtaw`)

| Metric | val | test | AB-UPT target |
|--------|----:|-----:|:-------------|
| abupt_axis_mean_rel_l2_pct | **7.5373%** | 8.8533% | — |
| surface_pressure_rel_l2_pct | 4.9322% | 4.6968% | 3.82% |
| wall_shear_rel_l2_pct | 8.4774% | 8.4954% | 7.29% |
| volume_pressure_rel_l2_pct | 4.4102% | 11.4599% | 6.08% |
| τ_x (wall_shear_x_rel_l2_pct) | 7.2272% | 7.3046% | 5.35% |
| τ_y (wall_shear_y_rel_l2_pct) | 9.8691% | 9.8648% | **3.65%** ← 2.7× target |
| τ_z (wall_shear_z_rel_l2_pct) | 11.2477% | 10.9403% | **3.63%** ← 3.1× target |

**Merge bar: val_abupt < 7.5373%**

W&B: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml/runs/vzprvtaw

## Expected outcome

Arm A should show τ_y/τ_z improvement without vol_pressure regression. If Arm B also holds vol_pressure stable (unlike PR #628's W=4/W=6 which regressed it), that confirms the decoupled head breaks the optimization conflict. Success criteria: τ_y < 9.87% and τ_z < 11.25% without vol_pressure regression, and overall val_abupt < 7.5373%.

## Context

PR #628 (edward, τ_y/τ_z weight sweep W=4/W=6) showed that shared-head loss weight scaling is zero-sum:
- W=4: val_abupt=9.85%, vol_pressure rose from 4.41% to 5.85%
- W=6: val_abupt=12.09%, vol_pressure rose further

Root cause: `surface_out = LinearProjection(n_hidden, 4)` predicts [cp, τ_x, τ_y, τ_z] as a single 4-channel projection. Gradient signals compete for the same set of weights. This PR separates the gradient paths structurally rather than fighting over loss weights.
