### PR TITLE
[violet] Surface normal vectors as surface input features (τ_y/τ_z attack)

### DIFF
--- a/train.py
+++ b/train.py
@@ -871,6 +871,8 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        surface_normal_rff_dim: int = 0,
+        surface_normal_rff_sigma: float = 4.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -885,6 +887,20 @@ class SurfaceTransolver(nn.Module):
         self.pos_max_wavelength = pos_max_wavelength
         self.learnable_pe = learnable_pe
         self.beta_nll = beta_nll
+        self.surface_normal_rff_dim = int(surface_normal_rff_dim)
+        self.surface_normal_rff_sigma = float(surface_normal_rff_sigma)
+        if self.surface_normal_rff_dim > 0:
+            # Deterministic, rank-independent init so DDP ranks share the same RFF
+            # frequency basis. Buffer is also broadcast by DDP at forward-pass start.
+            rff_gen = torch.Generator()
+            rff_gen.manual_seed(0xCAFE + self.surface_normal_rff_dim)
+            normal_rff_B = (
+                torch.randn(self.surface_normal_rff_dim, 3, generator=rff_gen)
+                * self.surface_normal_rff_sigma
+            )
+        else:
+            normal_rff_B = torch.zeros(0, 3)
+        self.register_buffer("normal_rff_B", normal_rff_B, persistent=True)
 
         self.pos_embed = ContinuousSincosEmbed(
             hidden_dim=n_hidden,
@@ -945,6 +961,17 @@ class SurfaceTransolver(nn.Module):
             hidden = hidden + project_features(x[:, :, self.space_dim :])
         return bias(hidden) + placeholder
 
+    def _augment_surface_with_normal_rff(self, x: torch.Tensor) -> torch.Tensor:
+        if self.surface_normal_rff_dim <= 0:
+            return x
+        # surface_x layout: [x, y, z, nx, ny, nz, area, ...curvature...]
+        # Extract unit normals at channels [3:6] and project onto random Gaussian B,
+        # then concatenate sin/cos as 2 * surface_normal_rff_dim extra channels.
+        n = x[:, :, 3:6]
+        proj = n @ self.normal_rff_B.t()
+        rff = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)
+        return torch.cat([x, rff.to(dtype=x.dtype)], dim=-1)
+
     def forward(
         self,
         *,
@@ -966,6 +993,7 @@ class SurfaceTransolver(nn.Module):
         volume_tokens = 0
 
         if surface_x is not None:
+            surface_x = self._augment_surface_with_normal_rff(surface_x)
             surface_tokens = surface_x.shape[1]
             tokens.append(
                 self._encode_group(
@@ -1159,6 +1187,8 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     resume_from: str = ""
     surface_curvature_features: str = "none"
+    surface_normal_rff_dim: int = 0
+    surface_normal_rff_sigma: float = 4.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1351,7 +1381,8 @@ def make_loaders(
 
 def build_model(config: Config) -> SurfaceTransolver:
     extra_curv = 2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0
-    surface_input_dim = SURFACE_X_DIM + extra_curv
+    extra_normal_rff = 2 * max(0, int(config.surface_normal_rff_dim))
+    surface_input_dim = SURFACE_X_DIM + extra_curv + extra_normal_rff
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -1366,6 +1397,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        surface_normal_rff_dim=int(config.surface_normal_rff_dim),
+        surface_normal_rff_sigma=float(config.surface_normal_rff_sigma),
     )
 
 
@@ -2666,7 +2699,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_batch_size": config.batch_size * world_size,
             "lr_warmup_steps_effective": effective_warmup_steps,
             "surface_input_dim_effective": SURFACE_X_DIM
-            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0),
+            + (2 if config.surface_curvature_features in ("h_k", "k1_k2") else 0)
+            + (2 * max(0, int(config.surface_normal_rff_dim))),
+            "surface_normal_rff_dim": int(config.surface_normal_rff_dim),
+            "surface_normal_rff_sigma": float(config.surface_normal_rff_sigma),
+            "surface_normal_rff_extra_channels": 2 * max(0, int(config.surface_normal_rff_dim)),
             "curvature_k_neighbors": (
                 CURVATURE_K_NEIGHBORS
                 if config.surface_curvature_features in ("h_k", "k1_k2")


### PR DESCRIPTION
## Hypothesis

Wall shear stress (τ_x, τ_y, τ_z) is by definition tangential to the surface — it lies in the plane perpendicular to the surface normal. Adding explicit unit outward normal vectors `(nₓ, nᵧ, n_z)` as 3 additional surface input channels gives the model a direct geometric basis for decomposing shear into its y and z components, targeting the dominant τ_y (~2.70×) and τ_z (~3.10×) gaps.

**Why this is mechanistically motivated:**
- τ = μ(∂u/∂n) — shear stress magnitude depends on the velocity gradient along the surface normal direction
- The y and z decomposition of wall shear is hardest when the surface is oblique — the model must currently infer normal direction from geometry alone
- Explicit normals provide a direct coordinate frame: the model can learn to project predicted shear into the correct local tangential plane
- This is distinct from existing WIP: PR #661 (haku) tests isolated RFF frequency lifting of surface coordinates, PR #662 (chihiro) adds κ₁/κ₂ curvature scalars on full stack — neither provides a directional normal vector

**Distinct from curvature features:** Curvature scalars (κ₁, κ₂) describe how much the surface bends but not which direction it faces. Normal vectors describe orientation — the information needed for τ decomposition.

## Implementation

You need to add surface normal vectors as 3 additional input channels to the surface stream.

### Step 1 — Inspect the dataset for available normal fields

```bash
python -c "
import h5py, os, glob
files = sorted(glob.glob('/workspace/senpai/target/data/train/*.h5'))[:1]
with h5py.File(files[0]) as f:
    print(list(f.keys()))
    for k in f.keys():
        print(k, f[k].shape, f[k].dtype)
"
```

Also check if normals appear as `nx`, `ny`, `nz` or `normal_x` etc. If not precomputed, estimate them via PCA on local k-NN patches from the surface point cloud (sklearn.neighbors.NearestNeighbors, k=20).

### Step 2 — Add a CLI flag

Add `--surface-normal-features` (boolean flag, default False) to `train.py`:

```python
parser.add_argument('--surface-normal-features', action='store_true', default=False,
                    help='Add unit outward normal vectors (nx, ny, nz) as 3 additional surface input channels')
```

### Step 3 — Concatenate to surface input tensor

In the surface input pipeline, when `--surface-normal-features` is set, load or compute unit normals and concatenate along the channel dimension:

```python
if args.surface_normal_features:
    normals = surface_batch['normals']  # shape: [B, N_surf, 3]
    # Normalize to unit length (defensive)
    normals = normals / (normals.norm(dim=-1, keepdim=True).clamp(min=1e-8))
    surface_features = torch.cat([surface_features, normals], dim=-1)  # [B, N_surf, C+3]
```

Update the surface input channel count accordingly (add 3 to the input dim).

### Step 4 — Run on full yi SOTA stack

Run on the full yi SOTA configuration (STRING-sep + learnable PE + Lion + grad-ema), **cold-start from scratch** so the architecture change is cleanly tested.

## Reproduce Command

```bash
cd /workspace/senpai/target

torchrun --standalone --nproc_per_node=4 train.py \
  --agent violet \
  --wandb-group yi-round37-surface-normal-features \
  --wandb-name violet/surface-normal-features-full-stack \
  --surface-normal-features \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 \
  --clip-grad-norm 0.5 --no-compile-model --learnable-pe \
  --grad-ema-alpha 0.5 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 128 --ema-decay 0.999 --lr-warmup-epochs 1
```

**Note:** Run for the full budget (up to `SENPAI_MAX_EPOCHS`). EP1 gate: val_abupt ≤ 15% → continue.

## Baseline (yi merge bar — PR #637, fern, run `vzprvtaw`)

| Metric | yi SOTA (val) | AB-UPT target | Gap |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **7.5373%** | — | — |
| `surface_pressure_rel_l2_pct` | 4.9322% | 3.82% | 1.29× |
| `wall_shear_rel_l2_pct` | 8.4774% | 7.29% | 1.16× |
| `volume_pressure_rel_l2_pct` | 4.4102% | 6.08% | ✓ |
| `wall_shear_x_rel_l2_pct` | 7.2272% | 5.35% | 1.35× |
| `wall_shear_y_rel_l2_pct` | 9.8691% | 3.65% | **2.70×** |
| `wall_shear_z_rel_l2_pct` | 11.2477% | 3.63% | **3.10×** |

**To beat the yi bar: `abupt_axis_mean_rel_l2_pct` < 7.5373% on validation.**

## EP Gate

- **EP1 gate**: val_abupt ≤ 15% → continue; 15–25% → marginal (post results, ask advisor); >25% → close immediately
- **EP2 kill gate**: val_abupt ≤ 12% → continue to full run; >12% → kill and post results

## Result Reporting

When training completes (or at each EP gate), post a comment with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"abupt_axis_mean_rel_l2_pct","value":<value>},"test_metric":{"name":"abupt_axis_mean_rel_l2_pct","value":<value>}}
```

Include the full per-axis breakdown in your comment body.
