### PR TITLE
Long DDP8: extended cosine T_max=60 on SOTA STRING config (50-epoch run)

### DIFF
--- a/experiments/nezuko-extended-cosine-t60.txt
+++ b/experiments/nezuko-extended-cosine-t60.txt
@@ -1,0 +1,13 @@
+extended-cosine-t60-long
+wandb_group: extended-cosine-t60-sota
+lr_cosine_t_max: 60
+epochs: 50
+optimizer: lion
+lr: 1e-4
+batch_size: 2
+model_pe: string_multisigma
+pe_init_sigmas: 0.25,0.5,1.0,2.0,4.0
+surface_loss_weight: 1.0
+volume_loss_weight: 1.0
+train_surface_points: 40000
+no_compile_model: true


### PR DESCRIPTION
## Hypothesis

Extending the cosine annealing period beyond the training window (T_max=60 on a 50-epoch run) keeps the learning rate from fully decaying to zero, maintaining a sustained gradient signal through the final epochs. Instead of LR reaching ~0% at EP50, it reaches ~26% of peak — preventing the optimizer from settling into a premature local minimum in the late phase of training.

Pre-wave reference: `5o7jc7wi` (T_max=13) achieved the **best volume score** (11.867%) among all pre-wave references, suggesting that cosine schedule shape meaningfully affects training dynamics even without other changes.

**Why now:** PR #670 was merged to the advisor branch, but the 50-epoch long run was never launched (only a 3-epoch smoke validation `rse0oh3w` was completed). This PR executes the intended experiment.

## Change

**Pure CLI change — no code modifications required.**

Only change from SOTA base config:
- Add `--lr-cosine-t-max 60` (T_max extends beyond 50-epoch training window)

## Baseline to beat

| Metric | Value |
|--------|-------|
| Wave SOTA (`sogus8sx`, PR #599) | **7.9303%** test_primary/abupt_axis_mean_rel_l2_pct |
| Pre-wave extended cosine (`5o7jc7wi`, T_max=13) | 8.313% test agg |

Sub-targets (AB-UPT public benchmarks):
- surface_pressure: 3.82% | wall_shear: 7.29% | volume_pressure: 6.08%
- tau_x: 5.35% | tau_y: 3.65% | tau_z: 3.63%

## Prior smoke run (already validated)

Run `rse0oh3w` (3 epochs from PR #670 smoke) confirmed no divergence. You can skip a new smoke and launch the long run directly.

## Long run command (50 epochs) — v2 (CORRECTED)

```bash
torchrun --nproc_per_node=8 train.py \
  --wandb-group extended-cosine-t60-sota-v2 \
  --epochs 50 \
  --batch-size 2 \
  --lr 1e-4 \
  --optimizer lion \
  --use-ema \
  --ema-decay 0.999 \
  --lr-warmup-steps 500 \
  --lr-cosine-t-max 60 \
  --train-surface-points 40000 \
  --eval-surface-points 40000 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-compile-model \
  --train-volume-points 65000 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128
```

## Active long run (W&B run IDs) — v2

- **Group:** `extended-cosine-t60-sota-v2`
- **Started:** 2026-05-05T11:13:50Z
- **Rank-0 run ID (primary):** [`sbzspuf2`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/sbzspuf2)
- **All 8 DDP ranks:** `sbzspuf2` (rank0), `njqsu3dz` (rank1), `i27j8t95` (rank2), `5kzmzn39` (rank3), `1kuph530` (rank4), `6kxnit9b` (rank5), `8bcu20pl` (rank6), `i00vm4uq` (rank7)
- **Model:** 12.93M params (layers=4, hidden_dim=512, heads=4, slices=128) — SOTA size

### Prior runs (killed)

- **v0 (`5lpqv10n` group `extended-cosine-t60-sota`)**: launched 10:42Z, killed at EP3 by advisor (2026-05-05T11:07:22Z). Root cause: PR body command was missing the model-dimension flags, so it used the small default 1.45M model instead of the SOTA 12.93M model. Symptom: catastrophic EP1=40.80%, EP2=18.51%, EP3=13.00%.
- **First broken launch at 10:17Z**: missing `--train-volume-points 65000`, killed and replaced with corrected command.

## Kill gates (advisor revised)

Per advisor comment 2026-05-05T10:54:14Z, the gates apply from EP5 onward:

| Epoch | Continue if val/abupt ≤ |
|-------|------------------------|
| EP5   | 8.5%                   |
| EP10  | 7.8%                   |
| EP15  | 7.2%                   |
| EP50  | terminal SENPAI-RESULT report |

## Reporting

Post val metrics at each advisor gate (EP5/EP10/EP15). At run completion, post a terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test_value>}}
```

Also report per-channel test breakdowns: surface_pressure_rel_l2_pct, wall_shear_rel_l2_pct, volume_pressure_rel_l2_pct, wall_shear_x/y/z_rel_l2_pct.

