### PR TITLE
Curvature-focal γ=1 at canonical W_y=2/W_z=2 weights (full SOTA stack)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1115,6 +1115,7 @@ class Config:
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
+    wallshear_curvature_focal_gamma: float = 0.0
     beta_nll_beta: float = -1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
@@ -1884,6 +1885,32 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return pred.sum() * 0.0
 
 
+def _curvature_focal_multiplier(
+    curvature: torch.Tensor,
+    *,
+    gamma: float,
+    n_channels: int,
+    focal_channels: Iterable[int] | None,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Per-element focal weight broadcastable to ``[B, N, C]``.
+
+    ``focal_w(i) = 1 + |kappa(i)|^gamma`` for channels in ``focal_channels``;
+    other channels get a multiplier of 1.0 (standard MSE / NLL). When
+    ``focal_channels`` is None the multiplier applies to every channel.
+    Curvature is detached so no gradient flows back through the data tensor.
+    """
+    focal_w_point = 1.0 + curvature.detach().abs().pow(gamma)  # [B, N]
+    focal_w_point = focal_w_point.to(dtype).unsqueeze(-1)  # [B, N, 1]
+    if focal_channels is None:
+        return focal_w_point
+    apply_mask = torch.zeros(n_channels, device=curvature.device, dtype=dtype)
+    for c in focal_channels:
+        apply_mask[c] = 1.0
+    # 1 for non-focal channels; focal_w_point for focal channels.
+    return 1.0 + (focal_w_point - 1.0) * apply_mask.view(1, 1, -1)
+
+
 def weighted_masked_mse_per_channel(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -1891,6 +1918,9 @@ def weighted_masked_mse_per_channel(
     *,
     channel_weights: Iterable[float],
     wallshear_huber_delta: float = 0.0,
+    focal_curvature: torch.Tensor | None = None,
+    focal_gamma: float = 0.0,
+    focal_channels: Iterable[int] | None = None,
 ) -> tuple[torch.Tensor, list[float]]:
     """Per-channel weighted masked loss for surface predictions.
 
@@ -1942,6 +1972,16 @@ def weighted_masked_mse_per_channel(
     else:
         loss_elem = diff_sq
 
+    if focal_curvature is not None and focal_gamma > 0.0:
+        focal_mult = _curvature_focal_multiplier(
+            focal_curvature,
+            gamma=float(focal_gamma),
+            n_channels=n_channels,
+            focal_channels=focal_channels,
+            dtype=pred.dtype,
+        )
+        loss_elem = loss_elem * focal_mult
+
     weighted_diff = loss_elem * weights.view(1, 1, -1)
     weighted_loss = (weighted_diff * mask_f).sum() / valid / n_channels
     per_axis_sum = (diff_sq * mask_f).sum(dim=(0, 1)).detach().float()
@@ -1961,6 +2001,9 @@ def weighted_masked_beta_nll_per_channel(
     *,
     channel_weights: Iterable[float],
     beta: float,
+    focal_curvature: torch.Tensor | None = None,
+    focal_gamma: float = 0.0,
+    focal_channels: Iterable[int] | None = None,
 ) -> tuple[torch.Tensor, list[float], list[float]]:
     """Per-channel weighted masked β-NLL loss (Seitzer et al. 2022, ICLR).
 
@@ -1998,6 +2041,16 @@ def weighted_masked_beta_nll_per_channel(
     nll = 0.5 * (diff_sq / var + log_var)
     if beta > 0.0:
         nll = nll * var.detach().pow(beta)
+
+    if focal_curvature is not None and focal_gamma > 0.0:
+        focal_mult = _curvature_focal_multiplier(
+            focal_curvature,
+            gamma=float(focal_gamma),
+            n_channels=n_channels,
+            focal_channels=focal_channels,
+            dtype=pred_mean.dtype,
+        )
+        nll = nll * focal_mult
 
     mask_f = mask.unsqueeze(-1).to(pred_mean.dtype)
     valid = mask_f.sum().clamp_min(1)
@@ -2037,12 +2090,25 @@ def train_loss(
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
+    wallshear_curvature_focal_gamma: float = 0.0,
+    surface_curvature_features: str = "none",
     beta_nll_beta: float = -1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     use_beta_nll = beta_nll_beta >= 0.0
+    use_curvature_focal = (
+        wallshear_curvature_focal_gamma > 0.0
+        and surface_curvature_features in ("h_k", "k1_k2")
+    )
+    if use_curvature_focal:
+        # Curvature features occupy the LAST 2 channels of surface_x
+        # (k1_k2 -> [k1_tilde_std, k2_tilde_std]; h_k -> [H_tilde_std, K_tilde_std]).
+        # Magnitude proxy = mean of |c1|, |c2| in standardized signed-log space.
+        focal_curvature = batch.surface_x[..., -2:].abs().mean(dim=-1)
+    else:
+        focal_curvature = None
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -2091,6 +2157,9 @@ def train_loss(
                 batch.surface_mask,
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 beta=beta_nll_beta,
+                focal_curvature=focal_curvature,
+                focal_gamma=wallshear_curvature_focal_gamma,
+                focal_channels=(1, 2, 3),
             )
             volume_loss, _, vol_log_var_per_axis = weighted_masked_beta_nll_per_channel(
                 out["volume_preds"],
@@ -2108,6 +2177,9 @@ def train_loss(
                 batch.surface_mask,
                 channel_weights=(1.0, 1.0, wallshear_y_weight, wallshear_z_weight),
                 wallshear_huber_delta=wallshear_huber_delta,
+                focal_curvature=focal_curvature,
+                focal_gamma=wallshear_curvature_focal_gamma,
+                focal_channels=(1, 2, 3),
             )
             volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
@@ -2148,6 +2220,24 @@ def train_loss(
         metrics["film/geom_token_abs_mean"] = float(
             geom_token.abs().mean().cpu().item()
         )
+    if focal_curvature is not None:
+        # Diagnostics: distribution of the per-point focal multiplier
+        # (1 + |kappa|^gamma) over valid surface points.
+        with torch.no_grad():
+            mask_b = batch.surface_mask
+            if bool(mask_b.any()):
+                focal_w = 1.0 + focal_curvature.detach().abs().pow(
+                    float(wallshear_curvature_focal_gamma)
+                )
+                focal_w_valid = focal_w[mask_b].float()
+                metrics["focal/curv_mag_mean"] = float(
+                    focal_curvature.detach().abs()[mask_b].float().mean().cpu().item()
+                )
+                metrics["focal/weight_mean"] = float(focal_w_valid.mean().cpu().item())
+                metrics["focal/weight_max"] = float(focal_w_valid.max().cpu().item())
+                metrics["focal/weight_p99"] = float(
+                    torch.quantile(focal_w_valid, 0.99).cpu().item()
+                )
     return loss, metrics
 
 
@@ -2741,6 +2831,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     wandb.define_metric("train/weight_hist/*", step_metric="global_step")
     wandb.define_metric("train/weight_hist_param/*", step_metric="global_step")
     wandb.define_metric("train/film/*", step_metric="global_step")
+    wandb.define_metric("train/focal/*", step_metric="global_step")
     wandb.define_metric("lr", step_metric="global_step")
     wandb.define_metric("train/lr", step_metric="global_step")
     wandb.define_metric("train/nonfinite_skip_count", step_metric="global_step")
@@ -2833,6 +2924,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
+                wallshear_curvature_focal_gamma=config.wallshear_curvature_focal_gamma,
+                surface_curvature_features=config.surface_curvature_features,
                 beta_nll_beta=config.beta_nll_beta,
             )
             optimizer.zero_grad(set_to_none=True)
@@ -3033,7 +3126,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():
-                if key.startswith("film/"):
+                if key.startswith("film/") or key.startswith("focal/"):
                     train_log[f"train/{key}"] = value
             train_log.update(
                 train_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis

Curvature-focal loss (γ=1) re-tested at canonical wallshear weights (W_y=2, W_z=2) isolates the focal mechanism from aggressive upweighting confounds.

PR #646 validated that focal γ=1 is directionally better than γ=0 (Arm B=8.9488% vs Arm A=9.181%) but both arms used W_y=3/W_z=5 — heavy upweighting that interacted with the focal term. The closing analysis showed that W_y=3/W_z=5 by itself may be driving the regression (vs W_y=2/W_z=2 from current SOTA stack), so we can't cleanly attribute the focal effect.

This PR tests γ=1 at W_y=2/W_z=2 — the canonical weights already in the current SOTA stack — to isolate the focal mechanism. τ_y=9.6% and τ_z=11.1% are ~2.6× and ~3.0× above AB-UPT targets (3.65%, 3.63%), so per-point upweighting of high-curvature regions is a well-motivated inductive bias for this problem.

## Implementation (REQUIRED — flag not yet in train.py)

The `--wallshear-curvature-focal-gamma` flag does NOT exist in the current `yi` `train.py`. You must add it.

### 1. Add to Config dataclass

Locate the `Config` dataclass in `train.py` and add:

```python
wallshear_curvature_focal_gamma: float = 0.0
```

alongside the existing `wallshear_y_weight`, `wallshear_z_weight` fields.

### 2. Add the focal weighting function

After the existing `weighted_masked_mse_per_channel` function, add:

```python
def curvature_focal_weighted_mse_per_channel(
    pred: torch.Tensor,       # (B, N, C)
    target: torch.Tensor,     # (B, N, C)
    mask: torch.Tensor,       # (B, N) bool
    channel_weights: torch.Tensor,  # (C,)
    curvature: torch.Tensor,  # (B, N) — absolute curvature magnitude
    gamma: float,             # focal exponent (e.g. 1.0)
) -> torch.Tensor:
    """Per-point curvature-focal weighted MSE.
    focal_w(i) = 1 + |kappa(i)|^gamma  (always >= 1, no suppression of flat regions).
    """
    focal_w = 1.0 + curvature.unsqueeze(-1).abs().pow(gamma)  # (B, N, 1)
    diff2 = (pred - target).pow(2) * focal_w                   # (B, N, C)
    mask_f = mask.float().unsqueeze(-1)                        # (B, N, 1)
    weighted = diff2 * mask_f * channel_weights.unsqueeze(0).unsqueeze(0)
    return weighted.sum() / (mask_f.sum() * channel_weights.sum() + 1e-8)
```

### 3. Wire into compute_loss_and_metrics

In `compute_loss_and_metrics` (or wherever `compute_surface_loss` is called), find where the surface loss is computed and add a branch:

```python
# Existing code computes surface_loss via weighted_masked_mse_per_channel.
# Add this block after the existing surface_loss computation:
if config.wallshear_curvature_focal_gamma > 0.0 and \
   config.surface_curvature_features in ("h_k", "k1_k2"):
    # Extract curvature magnitude from surface inputs
    # Surface features layout: [x, y, z, nx, ny, nz, h, k1, k2] or similar
    # The curvature features are appended last — check surface_input_dim
    # Use mean absolute principal curvature: |k1| + |k2| / 2
    curv_feats = surface_features[..., -2:]  # last 2 dims are k1, k2 when k1_k2 mode
    curv_mag = curv_feats.abs().mean(dim=-1)  # (B, N)
    # Recompute wallshear surface loss with focal weighting
    # (replace or add to existing wallshear component only, not pressure)
    wallshear_loss_focal = curvature_focal_weighted_mse_per_channel(
        pred_wallshear, target_wallshear, surface_mask,
        channel_weights, curv_mag,
        gamma=config.wallshear_curvature_focal_gamma,
    )
    # Replace the wallshear portion of surface_loss with focal version
    surface_loss = surface_pressure_loss + wallshear_loss_focal
```

**Important:** Study the existing `compute_loss_and_metrics` code carefully to understand exactly how `surface_features`, `pred_wallshear`, `target_wallshear`, `surface_mask`, and `channel_weights` are defined and referenced. The pseudocode above is a guide — adapt to actual variable names and shapes in the code. The key invariant: curvature features must already be active (`--surface-curvature-features k1_k2`) for this path to execute.

### 4. Wire up CLI argument

The `Config` dataclass auto-generates `--wallshear-curvature-focal-gamma` from the field name (underscore-to-hyphen). No `argparse` changes needed if the codebase uses the standard dataclass-based arg parsing pattern.

## Training command

Full yi SOTA stack + curvature-focal γ=1 at canonical weights:

```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent alphonse \
  --wandb-group yi-round39-curvature-focal-canonical \
  --wandb-name alphonse/curvature-focal-gamma1-w2w2 \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --wallshear-y-weight 2.0 --wallshear-z-weight 2.0 \
  --wallshear-curvature-focal-gamma 1.0 \
  --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

**Note:** This is a cold start from the full SOTA stack (STRING-sep PE + Lion + grad-EMA + β-NLL + k1_k2 curvature features). The focal weighting adds a per-point curvature-sensitive multiplier on top of the existing W_y=2/W_z=2 channel weights.

## Kill gates

- EP1 val_abupt > 20%: kill and report
- EP3 val_abupt > 12%: kill and report
- Otherwise: run to timeout

## Baseline

Current yi SOTA: **val_abupt = 7.3914%**, test_abupt = 8.7189% (PR #658, nezuko, run `pxsnrw36`)

| Metric | val | test |
|---|---:|---:|
| abupt_axis_mean_rel_l2_pct | **7.3914%** | 8.7189% |
| surface_pressure_rel_l2_pct | 4.8552% | — |
| wall_shear_rel_l2_pct | 8.3192% | — |
| volume_pressure_rel_l2_pct | 4.3156% | — |
| wall_shear_x_rel_l2_pct (τ_x) | 7.1166% | — |
| wall_shear_y_rel_l2_pct (τ_y) | 9.6123% | — |
| wall_shear_z_rel_l2_pct (τ_z) | 11.0573% | — |

AB-UPT targets (val): surface_pressure 3.82%, τ_x 5.35%, τ_y 3.65%, τ_z 3.63%

τ_y and τ_z are the primary research targets (2.6× and 3.0× above AB-UPT). Beat val_abupt < 7.3914% to set a new SOTA.

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`
