### PR TITLE
Tangential wallshear loss on full SOTA stack — τ_y/τ_z frame fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -2052,7 +2052,7 @@ def train_loss(
         )
         surface_pred_norm = out["surface_preds"]
         normal_rms = float("nan")
-        if use_tangential_wallshear_loss and not use_beta_nll:
+        if use_tangential_wallshear_loss:
             # Wall-shear stds are non-uniform ([2.08, 1.36, 1.11]), so projecting
             # in normalized space does not equal physical-space tangent projection.
             # Denormalize -> project in physical space -> renormalize.
@@ -2131,7 +2131,7 @@ def train_loss(
     }
     if aux_rel_l2_value is not None:
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
-    if use_tangential_wallshear_loss and not use_beta_nll:
+    if use_tangential_wallshear_loss:
         metrics["wallshear_pred_normal_rms"] = normal_rms
     if use_beta_nll and per_axis_log_var is not None:
         metrics["log_var_surface_pressure"] = per_axis_log_var[0]


### PR DESCRIPTION
## Hypothesis

Decomposing wall shear stress into surface-tangent components (tangential-normal frame) before computing the training loss provides a better-conditioned regression target for τ_y and τ_z. The `--use-tangential-wallshear-loss` flag is already implemented in `yi` `train.py`.

The intuition: raw τ_x/τ_y/τ_z in the global Cartesian frame have a strong dependence on local surface orientation. Near a swept wing edge, τ_z in global frame can be large simply because the surface tilts — not because the shear magnitude is large. By projecting τ onto the surface tangent/normal basis before computing MSE, the loss aligns with the physically meaningful shear magnitude and direction, reducing noise from orientation-dependent cross-terms.

τ_y=9.6% and τ_z=11.1% are respectively 2.6× and 3.0× above AB-UPT targets. This is the primary remaining gap. A coordinate-frame change is a zero-cost (no new parameters) structural improvement that could directly target this gap.

## Instructions

This is a cold-start run on the full yi SOTA stack. Enable tangential wallshear loss with `--use-tangential-wallshear-loss`:

```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent fern \
  --wandb-group yi-round39-tangential-wallshear \
  --wandb-name fern/tangential-wallshear-cold-start \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --surface-curvature-features k1_k2 \
  --use-tangential-wallshear-loss \
  --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

**No code changes required** — the `--use-tangential-wallshear-loss` flag is already present in `yi` `train.py`. Just run the command above.

## Kill gates

- EP1 val_abupt > 20%: kill and report
- EP3 val_abupt > 12%: kill and report
- Otherwise: run to timeout

## What to report

In addition to the standard metrics, please report τ_y and τ_z separately at each validation epoch — these are the primary targets of this intervention. Also note whether τ_y/τ_z improve relative to surface_pressure, which would confirm the coordinate-frame hypothesis.

## Baseline

Current yi SOTA: **val_abupt = 7.3914%**, test_abupt = 8.7189% (PR #658, nezuko, run `pxsnrw36`)

| Metric | val | test |
|---|---:|---:|
| abupt_axis_mean_rel_l2_pct | **7.3914%** | 8.7189% |
| surface_pressure_rel_l2_pct | 4.8552% | — |
| wall_shear_rel_l2_pct | 8.3192% | — |
| volume_pressure_rel_l2_pct | 4.3156% | — |
| wall_shear_x_rel_l2_pct (τ_x) | 7.1166% | — |
| wall_shear_y_rel_l2_pct (τ_y) | 9.6123% | — |
| wall_shear_z_rel_l2_pct (τ_z) | 11.0573% | — |

AB-UPT targets (val): surface_pressure 3.82%, τ_x 5.35%, τ_y 3.65%, τ_z 3.63%

τ_y and τ_z are the primary research targets (2.6× and 3.0× above AB-UPT). Beat val_abupt < 7.3914% to set a new SOTA.

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml`
