### PR TITLE
Normal-penalty wallshear tangency regularizer (λ·|ws·n̂|²)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1112,6 +1112,7 @@ class Config:
     volume_loss_weight: float = 1.0
     aux_rel_l2_weight: float = 0.0
     use_tangential_wallshear_loss: bool = False
+    wallshear_normal_penalty_weight: float = 0.0
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
     wallshear_huber_delta: float = 0.0
@@ -2034,6 +2035,7 @@ def train_loss(
     volume_loss_weight: float = 1.0,
     aux_rel_l2_weight: float = 0.0,
     use_tangential_wallshear_loss: bool = False,
+    wallshear_normal_penalty_weight: float = 0.0,
     wallshear_y_weight: float = 1.0,
     wallshear_z_weight: float = 1.0,
     wallshear_huber_delta: float = 0.0,
@@ -2111,6 +2113,21 @@ def train_loss(
             )
             volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         loss = surface_loss_weight * surface_loss + volume_loss_weight * volume_loss
+        normal_penalty_value: float | None = None
+        if wallshear_normal_penalty_weight > 0.0:
+            normals = batch.surface_x[..., 3:6]
+            n_hat = F.normalize(normals.float(), dim=-1, eps=1e-8)
+            ws_std = transform.surface_y_std[1:4].to(surface_pred_norm.device)
+            ws_mean = transform.surface_y_mean[1:4].to(surface_pred_norm.device)
+            ws_pred_phys = surface_pred_norm[..., 1:4].float() * ws_std + ws_mean
+            normal_component = (ws_pred_phys * n_hat).sum(dim=-1)
+            mask_f = batch.surface_mask.float()
+            penalty_num = (normal_component.pow(2) * mask_f).sum()
+            penalty_den = mask_f.sum().clamp_min(1.0)
+            normal_penalty = penalty_num / penalty_den
+            loss = loss + wallshear_normal_penalty_weight * normal_penalty.to(loss.dtype)
+            normal_penalty_value = float(normal_penalty.detach().cpu().item())
+            normal_rms = math.sqrt(max(normal_penalty_value, 0.0))
         aux_rel_l2_value: float | None = None
         if aux_rel_l2_weight > 0.0:
             surf_pred_f = surface_pred_norm.float()
@@ -2133,6 +2150,9 @@ def train_loss(
         metrics["aux_rel_l2_loss"] = aux_rel_l2_value
     if use_tangential_wallshear_loss and not use_beta_nll:
         metrics["wallshear_pred_normal_rms"] = normal_rms
+    if wallshear_normal_penalty_weight > 0.0 and normal_penalty_value is not None:
+        metrics["wallshear_pred_normal_rms"] = normal_rms
+        metrics["wallshear_pred_normal_penalty"] = normal_penalty_value
     if use_beta_nll and per_axis_log_var is not None:
         metrics["log_var_surface_pressure"] = per_axis_log_var[0]
         metrics["log_var_wall_shear_x"] = per_axis_log_var[1]
@@ -2830,6 +2850,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 volume_loss_weight=config.volume_loss_weight,
                 aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
+                wallshear_normal_penalty_weight=config.wallshear_normal_penalty_weight,
                 wallshear_y_weight=config.wallshear_y_weight,
                 wallshear_z_weight=config.wallshear_z_weight,
                 wallshear_huber_delta=config.wallshear_huber_delta,
@@ -3016,6 +3037,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"
+                ]
+            if "wallshear_pred_normal_penalty" in batch_loss_metrics:
+                train_log["train/wallshear_pred_normal_penalty"] = batch_loss_metrics[
+                    "wallshear_pred_normal_penalty"
                 ]
             if "aux_rel_l2_loss" in batch_loss_metrics:
                 train_log["train/aux_rel_l2_loss"] = batch_loss_metrics[


### PR DESCRIPTION
## Hypothesis

Wall-shear predictions must be physically tangent to the surface — the normal component `ws·n̂` should be zero by the no-penetration condition. Our current best model (PR #658, val_abupt=7.3914%) makes unconstrained predictions, so nothing prevents learning non-zero normal components that inflate τ_y and τ_z error.

Previous attempt (PR #680) tried projecting training *targets* onto the tangent plane, but this created a catastrophic train/eval asymmetry (τ_z=131.31% at eval). The fix is to penalise the **predictions** instead, as a soft physics-informed regulariser added to the existing β-NLL loss:

```
penalty = mean( (ws_pred_phys · n̂)² )
total_loss = beta_nll_loss + λ * penalty
```

This preserves the original training targets (no asymmetry) and pushes the model to internalise the tangency constraint via gradient pressure. The normal penalty adds zero overhead at inference.

**Expected gains:** τ_y and τ_z are 2.63× and 3.05× above AB-UPT targets. Even a 5–10% relative improvement on these axes (−0.5 to −1.0 pp) would advance the primary abupt metric meaningfully.

## Instructions

Add a `--wallshear-normal-penalty-weight` flag (default=0.0, i.e. backward-compatible) to `target/train.py`. In the loss computation, after computing the β-NLL loss, add the penalty term:

1. Extract τ_x/y/z predictions from surface outputs: `ws_pred = surface_preds[:, :, 1:4]`  (channels 1,2,3; shape `[B, N_surface, 3]`).
2. Denormalise predictions to physical units using the same stats used for target denormalisation.
3. Access surface normals from the batch: `n = batch_normals` (shape `[B, N_surface, 3]`, should already be normalised to unit vectors; or normalise with `n / n.norm(dim=-1, keepdim=True).clamp(min=1e-8)`).
4. Compute `normal_component = (ws_pred * n).sum(dim=-1)` → shape `[B, N_surface]`.
5. Compute `penalty = normal_component.pow(2).mean()`.
6. Add `args.wallshear_normal_penalty_weight * penalty` to the total loss.

If surface normals are not directly available in the batch object, they can be found in the surface feature tensor (features 3–5 per the programme spec: `[x, y, z, nx, ny, nz, area]`).

Run two arms under the full yi SOTA stack (cold-start, no checkpoint resume):

**Arm A — λ=0.1:**
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent fern --wandb-group yi-round38-normal-penalty \
  --wandb-name fern/normal-penalty-lambda-0.1 \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 --beta-nll-beta 0.5 --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wallshear-normal-penalty-weight 0.1 \
  --kill-thresholds '2720:val_primary/abupt_axis_mean_rel_l2_pct>=50' \
  --epochs 10
```

**Arm B — λ=1.0:**
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --agent fern --wandb-group yi-round38-normal-penalty \
  --wandb-name fern/normal-penalty-lambda-1.0 \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 --beta-nll-beta 0.5 --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wallshear-normal-penalty-weight 1.0 \
  --kill-thresholds '2720:val_primary/abupt_axis_mean_rel_l2_pct>=50' \
  --epochs 10
```

**Diagnostics to log:** Add a W&B scalar `train/wallshear_pred_normal_rms = sqrt(penalty)` so we can see the penalty evolve during training. This also confirms the mechanism is active. In PR #680's failed run, `train/wallshear_pred_normal_rms` climbed to ~1.68 by mid-EP1 — the penalty should suppress this.

If both arms land above baseline at EP3/EP4, try λ=0.01 (lighter regularisation) before abandoning.

## Baseline

**Current yi SOTA — PR #658 (nezuko, SWA/EMA continuation):**
- val_abupt: **7.3914%** ← merge bar
- surface_pressure: 4.8552%
- wall_shear: 8.3192%
- volume_pressure: 4.3156%
- τ_x: 7.1166%
- τ_y: **9.6123%** (2.63× AB-UPT target of 3.65%)
- τ_z: **11.0573%** (3.05× AB-UPT target of 3.63%)
- W&B run: `pxsnrw36` (group: `yi-round37-swa-staged`)
- test_abupt: 8.7189%

**AB-UPT public reference targets (test):**
- surface_pressure: 3.82%, wall_shear: 7.29%, volume_pressure: 6.08%
- τ_x: 5.35%, τ_y: 3.65%, τ_z: 3.63%

**Full yi SOTA cold-start config (without this PR's penalty flag):**
```bash
cd target/
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 --beta-nll-beta 0.5 --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

## Context

This is a retry of the tangency-enforcement concept from PR #680. That PR used `--use-tangential-wallshear-loss` which projected *training targets* onto the tangent plane at every step, but evaluated against the raw τ_x/y/z ground truth → catastrophic asymmetry. This PR uses a regulariser on *predictions* which preserves target integrity.

Run both arms. Report val_abupt and per-axis τ_y, τ_z. Compare `train/wallshear_pred_normal_rms` across arms — lower = more tangency-aware model.
