### PR TITLE
Annealed per-axis wallshear loss weighting for τ_y/τ_z gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -1114,6 +1114,7 @@ class Config:
     use_tangential_wallshear_loss: bool = False
     wallshear_y_weight: float = 1.0
     wallshear_z_weight: float = 1.0
+    wallshear_weight_anneal_epochs: int = 0
     wallshear_huber_delta: float = 0.0
     beta_nll_beta: float = -1.0
     manifest: str = "data/split_manifest.json"
@@ -2814,6 +2815,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loss_sum = 0.0
         n_batches = 0
 
+        if config.wallshear_weight_anneal_epochs > 0:
+            anneal_epochs = config.wallshear_weight_anneal_epochs
+            ramp = min(epoch + 1, anneal_epochs) / anneal_epochs
+            current_wy = 1.0 + (config.wallshear_y_weight - 1.0) * ramp
+            current_wz = 1.0 + (config.wallshear_z_weight - 1.0) * ramp
+        else:
+            current_wy = config.wallshear_y_weight
+            current_wz = config.wallshear_z_weight
+
         train_iter = train_loader
         if is_main:
             train_iter = tqdm(
@@ -2830,8 +2840,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 volume_loss_weight=config.volume_loss_weight,
                 aux_rel_l2_weight=config.aux_rel_l2_weight,
                 use_tangential_wallshear_loss=config.use_tangential_wallshear_loss,
-                wallshear_y_weight=config.wallshear_y_weight,
-                wallshear_z_weight=config.wallshear_z_weight,
+                wallshear_y_weight=current_wy,
+                wallshear_z_weight=current_wz,
                 wallshear_huber_delta=config.wallshear_huber_delta,
                 beta_nll_beta=config.beta_nll_beta,
             )
@@ -3080,6 +3090,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             "global_step": global_step,
             "swa/active": int(swa_active),
             "swa/n_updates": swa_n_updates,
+            "train/wallshear_y_weight": float(current_wy),
+            "train/wallshear_z_weight": float(current_wz),
         }
         if early_stop_reason is not None:
             log_metrics["early_stop/triggered"] = 1.0


### PR DESCRIPTION
## Hypothesis

τ_y and τ_z are the primary failure modes in the current yi SOTA (val: 9.61% and 11.06% vs AB-UPT targets of 3.65% and 3.63% — 2.6× and 3.0× off target). The model allocates equal loss weight across all output channels, so the harder-to-learn tangential shear components are undertrained relative to their importance.

Hypothesis: **Gradually annealing up the per-axis wallshear loss weights for τ_y and τ_z** will focus training capacity on these underperforming channels without destabilising early training (where uniform weighting helps establish a good initialisation). Starting at 1.0 and ramping to a higher weight over epochs 1–5 combines a stable warm start with targeted capacity allocation.

Unlike static upweighting (which risks divergence from epoch 0), annealed weighting is gentle: the model sees normal gradients early and only amplifies the τ_y/τ_z signal once representations are established.

## Instructions

Two arms — ramp target weight `W_target=3.0` (Arm A) and `W_target=6.0` (Arm B). Full yi SOTA stack in both arms.

Add `--wallshear-y-weight` and `--wallshear-z-weight` flags (default=1.0). Apply linear annealing over epochs 1–5: weight at epoch `e` = `1.0 + (W_target - 1.0) * min(e, 5) / 5`. After epoch 5, hold at `W_target`.

In the β-NLL loss, scale the per-channel loss contributions for τ_y and τ_z by the current weight before summing.

**Arm A — W_target=3.0** (moderate emphasis):
```bash
SENPAI_TIMEOUT_MINUTES=540 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wallshear-y-weight 3.0 --wallshear-z-weight 3.0 \
  --wallshear-weight-anneal-epochs 5 \
  --wandb-group yi-round38-wallshear-axis-annealed \
  --kill-thresholds '2720:val_primary/abupt_axis_mean_rel_l2_pct>=50'
```

**Arm B — W_target=6.0** (strong emphasis):
```bash
SENPAI_TIMEOUT_MINUTES=540 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --beta-nll-beta 0.5 \
  --ema-decay 0.999 \
  --lr-warmup-epochs 1 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wallshear-y-weight 6.0 --wallshear-z-weight 6.0 \
  --wallshear-weight-anneal-epochs 5 \
  --wandb-group yi-round38-wallshear-axis-annealed \
  --kill-thresholds '2720:val_primary/abupt_axis_mean_rel_l2_pct>=50'
```

**Implementation note on annealing**: The linear ramp should apply at the start of each epoch. Store `initial_wy = args.wallshear_y_weight` and `initial_wz = args.wallshear_z_weight`. At epoch `e` (0-indexed):
```python
anneal_epochs = args.wallshear_weight_anneal_epochs  # default=5
ramp = min(e + 1, anneal_epochs) / anneal_epochs
wy = 1.0 + (initial_wy - 1.0) * ramp
wz = 1.0 + (initial_wz - 1.0) * ramp
```

**Diagnostic logging**: Log `train/wallshear_y_weight` and `train/wallshear_z_weight` each epoch so we can see the ramp in W&B.

**Early stopping gates** (terminate and report if not met):
- EP3: val_abupt ≤ 25%
- EP8: val_abupt ≤ 13%
- EP15: val_abupt ≤ 9%

Run both arms sequentially on your 4 GPUs — Arm A first, then Arm B.

## Baseline

PR #658 (nezuko), W&B run `pxsnrw36`:
- val_abupt = **7.3914%**
- surface_pressure = 3.3854%
- τ_x = 5.8050%, τ_y = **9.6123%**, τ_z = **11.0573%**
- volume_pressure = 6.9971%

AB-UPT reference targets: surface_pressure=3.82%, τ_x=5.35%, τ_y=3.65%, τ_z=3.63%, volume_pressure=6.08%

**Key gap**: τ_y at 2.6× and τ_z at 3.0× above AB-UPT target — these are the primary improvement targets.

## Expected Outcome

Success: val_abupt < 7.39% with τ_y < 8.5% and τ_z < 9.5% (meaningful reduction in the dominant gap). Arm B is expected to show sharper τ_y/τ_z improvement but may harm surface_pressure and volume_pressure if the weight is too aggressive — report all per-channel metrics so we can tune the weight.
