### PR TITLE
BC-type feature embedding for surface boundary disambiguation

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_bc_type_embedding: bool = False,
+        bc_type_embedding_dim: int = 16,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +356,8 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_bc_type_embedding = use_bc_type_embedding
+        self.bc_type_embedding_dim = bc_type_embedding_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -399,7 +403,19 @@ class SurfaceTransolver(nn.Module):
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
 
-        surface_proj_in = surface_extra_dim + rff_out_dim
+        if use_bc_type_embedding:
+            # BC-type categorical embedding for surface points only.
+            # 3 zones (wall=0, low-z=1, high-z=2) inferred geometrically from
+            # per-batch z 5th/95th percentile (DrivAerML lacks explicit BC labels;
+            # this is a coarse geometric segmentation of the car body).
+            # Default normal(0,1) init breaks symmetry from step 0.
+            self.bc_type_embedding = nn.Embedding(3, bc_type_embedding_dim)
+            surface_bc_extra = bc_type_embedding_dim
+        else:
+            self.bc_type_embedding = None
+            surface_bc_extra = 0
+
+        surface_proj_in = surface_extra_dim + rff_out_dim + surface_bc_extra
         volume_proj_in = volume_extra_dim + rff_out_dim
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
@@ -422,6 +438,38 @@ class SurfaceTransolver(nn.Module):
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
+    def _compute_bc_labels(
+        self,
+        pos: torch.Tensor,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Per-case z-percentile BC zones: 0=wall (default), 1=low-z, 2=high-z.
+
+        DrivAerML surface arrays do not carry explicit zone IDs, so labels are
+        derived geometrically from the per-case z (vertical) distribution:
+        low-z 5% (wheels/underbody) and high-z 5% (roof) get distinct labels;
+        the remaining ~90% (main car body) stays at 0. Padding tokens are
+        excluded from the percentile via NaN masking and labelled 0 (they are
+        masked out downstream anyway).
+        """
+        if pos.shape[1] == 0:
+            return pos.new_zeros(pos.shape[0], 0, dtype=torch.long)
+        z = pos[..., 2].float()
+        if mask is not None:
+            valid = mask.to(dtype=torch.bool)
+            z_for_quantile = torch.where(valid, z, torch.full_like(z, float("nan")))
+            z_lo = torch.nanquantile(z_for_quantile, 0.05, dim=1, keepdim=True)
+            z_hi = torch.nanquantile(z_for_quantile, 0.95, dim=1, keepdim=True)
+        else:
+            z_lo = torch.quantile(z, 0.05, dim=1, keepdim=True)
+            z_hi = torch.quantile(z, 0.95, dim=1, keepdim=True)
+        bc = torch.zeros_like(z, dtype=torch.long)
+        bc = torch.where(z < z_lo, torch.ones_like(bc), bc)
+        bc = torch.where(z > z_hi, torch.full_like(bc, 2), bc)
+        if mask is not None:
+            bc = torch.where(mask.to(dtype=torch.bool), bc, torch.zeros_like(bc))
+        return bc
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -431,6 +479,8 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        bc_type_embedding: nn.Embedding | None = None,
+        mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
@@ -441,6 +491,10 @@ class SurfaceTransolver(nn.Module):
             feature_parts.append(string_sep(pos))
         elif rff is not None:
             feature_parts.append(rff(pos))
+        if bc_type_embedding is not None:
+            bc_labels = self._compute_bc_labels(pos, mask)
+            bc_emb = bc_type_embedding(bc_labels).to(dtype=hidden.dtype)
+            feature_parts.append(bc_emb)
         if project_features is not None and feature_parts:
             features = (
                 feature_parts[0] if len(feature_parts) == 1 else torch.cat(feature_parts, dim=-1)
@@ -478,6 +532,8 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    bc_type_embedding=self.bc_type_embedding,
+                    mask=surface_mask,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -102,6 +102,8 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_bc_type_embedding: bool = False
+    bc_type_embedding_dim: int = 16
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -219,6 +221,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_bc_type_embedding": (
+            "Add a 3-way categorical BC-type embedding to surface points. "
+            "DrivAerML lacks explicit zone IDs, so labels are derived "
+            "geometrically per-case from z (vertical): bottom 5%% (=>1), "
+            "top 5%% (=>2), middle 90%% (=>0=wall). Embedding "
+            "(nn.Embedding(3, --bc-type-embedding-dim)) is concatenated with "
+            "existing surface features before the first projection. Default "
+            "normal(0,1) init breaks symmetry from step 0. Adds "
+            "3 * embedding_dim parameters."
+        ),
+        "bc_type_embedding_dim": (
+            "Embedding dimensionality for --use-bc-type-embedding. "
+            "Default 16 keeps the added parameter count tiny."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -297,6 +313,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_bc_type_embedding=config.use_bc_type_embedding,
+        bc_type_embedding_dim=config.bc_type_embedding_dim,
     )
 
 
@@ -829,6 +847,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print(
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                )
+            if config.use_bc_type_embedding:
+                bc_emb = getattr(base_model, "bc_type_embedding", None)
+                bc_added_params = bc_emb.weight.numel() if bc_emb is not None else 0
+                print(
+                    f"BC-type embedding enabled: 3 zones x dim={config.bc_type_embedding_dim} "
+                    f"(+{bc_added_params} params). Geometric labels (per-batch z 5th/95th "
+                    f"percentile): 0=wall (mid 90%), 1=low-z (bottom 5%), 2=high-z (top 5%)."
                 )
 
         run = init_wandb_run(


### PR DESCRIPTION
## Hypothesis

Surface point features currently only encode geometry (position, normals, RFF embeddings). The model has no explicit signal about what *type* of surface boundary a point lies on — inlet, outlet, or wall. These three boundary condition (BC) types have fundamentally different physics:

- **Inlet**: prescribed velocity profile, known turbulence intensity — uniform pressure gradient
- **Outlet**: zero-gradient or fixed-pressure condition — flow exits
- **Wall (car body)**: no-slip condition, adverse pressure gradients, flow separation, boundary layer development

The model must currently infer BC type from geometry alone (position/shape cues). Explicitly encoding BC type as a learnable categorical embedding should help the encoder specialise surface representations per BC type, potentially reducing wall_shear errors (currently the dominant per-channel error at ~9.8%).

This follows from classical CFD: the numerical solver treats each BC zone with different discretisation schemes. The surrogate should mirror this.

**Reference:** DrivAerML dataset stores per-point BC labels (`bc_type` or equivalent zone identifiers); these are available in the `.vtp` / `.npy` surface data files.

## Instructions

Add a BC-type categorical embedding to the surface point features, injected before the Transolver encoder. Implement a 2-arm sweep:

### Arm A — Control (SOTA baseline, no change)

Run the standard SOTA configuration for reference:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group frieren-bc-type-sweep --wandb-name frieren/arm-a-control
```

### Arm B — BC-type learned embedding

Add a new CLI flag `--use-bc-type-embedding` (boolean, default False) and implement the following:

1. **Load BC-type labels:** Read the per-point boundary condition zone labels from the dataset (the integer zone/patch IDs assigned to surface points). Map them to 3 canonical categories: `wall=0`, `inlet=1`, `outlet=2`. Store as an integer tensor per surface point.

2. **Learnable embedding table:** Add an `nn.Embedding(num_embeddings=3, embedding_dim=16)` in the surface encoder. This produces a 16-d vector per BC category. (16-d keeps the added parameter budget tiny — 48 new params.)

3. **Feature injection:** Concatenate the BC-type embedding with the existing surface point features before the first linear projection of the Transolver encoder. If the current surface feature dimension is `D_in`, the new input dimension becomes `D_in + 16`. Adjust the first linear layer accordingly.

4. **Initialisation:** Use default `nn.Embedding` init (normal(0, 1)), NOT zero-init. BC types are clearly distinct; the embedding should break symmetry from the start.

5. **Add `--use-bc-type-embedding` flag** to `train.py` argument parser (default=False, action=store_true).

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-bc-type-embedding \
  --wandb-group frieren-bc-type-sweep --wandb-name frieren/arm-b-bc-embed
```

### First check the data

Before implementing, inspect the dataset to confirm BC zone labels exist and how they are stored:

```python
import numpy as np, os
# Look at a sample surface file from the training set
data = np.load("target/data/train/case_001/surface.npz")
print(list(data.keys()))  # Look for zone_id, bc_type, patch_id, or similar
```

If BC labels are stored per-face (not per-point), apply majority-vote or nearest-neighbor to map to surface points.

If no explicit BC labels exist in the .npz files, check whether inlet/outlet/wall can be identified from position: inlet and outlet patches typically have a small number of points at a fixed z-plane (front/back), wall points form the main car body. As a fallback, implement a simple geometric classifier: assign `inlet` to points with z < z_5th_percentile, `outlet` to z > z_95th_percentile, `wall` to everything else — and use that as the BC-type label.

### Kill gates

- **EP1 (informational):** Report val_abupt for both arms; no kill unless > 20%.
- **EP2 gate:** Kill any arm with val_abupt > 12.0% at step ~21,729.
- **EP3 gate:** Kill any arm with val_abupt > 8.0% at step ~32,594.
- If Arm A diverges from SOTA by > 0.3pp at EP3, something is wrong — report immediately.

### What to report

In your PR comment, include:
- val_abupt for both arms at each epoch (table format)
- Per-channel breakdown at final/best epoch: surface_pressure, volume_pressure, wall_shear_x, wall_shear_y, wall_shear_z
- Whether Arm B shows improvement on wall_shear channels specifically
- W&B run IDs for both arms

## Baseline

**Single-model SOTA:** PR #592 (alphonse), W&B run `4k25s25e`

| Metric | SOTA val | SOTA test |
|---|---|---|
| val_abupt | **6.5985%** | 7.9915% |
| surface_pressure | 4.3322% | — |
| volume_pressure | 3.9456% | — |
| wall_shear_x | 6.5420% | — |
| wall_shear_y | 8.3631% | — |
| wall_shear_z | **9.8099%** | — |

**Gate:** Beat val_abupt < 6.5985% to set a new single-model SOTA.

**Known weakness:** wall_shear_z at 9.8% is the worst channel. BC-type encoding is specifically motivated by the no-slip / boundary-layer physics at wall surfaces — this channel is the primary target for improvement.

**Ensemble SOTA:** PR #612 (nezuko), val_abupt=6.1751%, test_abupt=7.5347%
