### PR TITLE
Exp 1A: dual-tower volume/surface cross-attention probe

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,10 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        dual_tower: bool = False,
+        dual_tower_surface_layers: int = 3,
+        dual_tower_volume_layers: int = 3,
+        dual_tower_cross_attn_heads: int = 4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +358,10 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.dual_tower = dual_tower
+        self.dual_tower_surface_layers = dual_tower_surface_layers
+        self.dual_tower_volume_layers = dual_tower_volume_layers
+        self.dual_tower_cross_attn_heads = dual_tower_cross_attn_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -409,15 +417,57 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
-        self.backbone = Transformer(
-            depth=n_layers,
-            hidden_dim=n_hidden,
-            num_heads=n_head,
-            mlp_expansion_factor=mlp_ratio,
-            num_slices=slice_num,
-            dropout=dropout,
-            use_qk_norm=use_qk_norm,
-        )
+        if dual_tower:
+            self.backbone = None
+            self.surface_backbone = Transformer(
+                depth=dual_tower_surface_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+            self.volume_backbone = Transformer(
+                depth=dual_tower_volume_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+            # Volume queries attend to surface keys/values. Pre-norm both
+            # streams so the bridge sees calibrated activations and remains
+            # stable as the towers update independently.
+            self.cross_attn_q_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.cross_attn_kv_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.cross_attn = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=dual_tower_cross_attn_heads,
+                dropout=dropout,
+                batch_first=True,
+            )
+            # Tanh-gated residual: tanh(0)=0 keeps the bridge as identity at
+            # init so the towers train independently first, and the gate
+            # learns when to open. Standard pattern from OpenFlamingo.
+            self.cross_attn_gate = nn.Parameter(torch.zeros(1))
+        else:
+            self.surface_backbone = None
+            self.volume_backbone = None
+            self.cross_attn_q_norm = None
+            self.cross_attn_kv_norm = None
+            self.cross_attn = None
+            self.cross_attn_gate = None
+            self.backbone = Transformer(
+                depth=n_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
@@ -462,6 +512,14 @@ class SurfaceTransolver(nn.Module):
             raise ValueError("SurfaceTransolver requires surface_mask when surface_x is provided")
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
+
+        if self.dual_tower:
+            return self._forward_dual_tower(
+                surface_x=surface_x,
+                surface_mask=surface_mask,
+                volume_x=volume_x,
+                volume_mask=volume_mask,
+            )
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
@@ -525,4 +583,124 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+        }
+
+    def _forward_dual_tower(
+        self,
+        *,
+        surface_x: torch.Tensor | None,
+        surface_mask: torch.Tensor | None,
+        volume_x: torch.Tensor | None,
+        volume_mask: torch.Tensor | None,
+    ) -> dict[str, torch.Tensor]:
+        # The data loader can hand a rank a batch where the surface views are
+        # exhausted but volume views remain (or vice versa) — in that case the
+        # absent modality arrives as a zero-token tensor. Cross-attention is
+        # undefined with an empty key/value sequence, so we treat zero-token
+        # inputs as "modality absent" for the bridge.
+        surface_present = surface_x is not None and surface_x.shape[1] > 0
+        volume_present = volume_x is not None and volume_x.shape[1] > 0
+
+        if surface_present:
+            surface_hidden_in = self._encode_group(
+                surface_x,
+                rff=self.surface_rff,
+                string_sep=self.surface_string_sep,
+                project_features=self.project_surface_features,
+                bias=self.surface_bias,
+                placeholder=self.surface_placeholder,
+            )
+            surface_hidden_in = _apply_token_mask(surface_hidden_in, surface_mask)
+            surface_backbone_out = self.surface_backbone(
+                surface_hidden_in, attn_mask=surface_mask
+            )
+            surface_backbone_out = _apply_token_mask(surface_backbone_out, surface_mask)
+        else:
+            surface_backbone_out = None
+
+        if volume_present:
+            volume_hidden_in = self._encode_group(
+                volume_x,
+                rff=self.volume_rff,
+                string_sep=self.volume_string_sep,
+                project_features=self.project_volume_features,
+                bias=self.volume_bias,
+                placeholder=self.volume_placeholder,
+            )
+            volume_hidden_in = _apply_token_mask(volume_hidden_in, volume_mask)
+            volume_backbone_out = self.volume_backbone(
+                volume_hidden_in, attn_mask=volume_mask
+            )
+            volume_backbone_out = _apply_token_mask(volume_backbone_out, volume_mask)
+        else:
+            volume_backbone_out = None
+
+        # Cross-attention bridge: volume queries pull surface context. Skip if
+        # either modality is empty, OR if any sample has all-padded surface
+        # tokens — F.multi_head_attention_forward NaNs on an all-True
+        # key_padding_mask row.
+        run_cross_attn = (
+            surface_backbone_out is not None
+            and volume_backbone_out is not None
+            and bool((surface_mask.sum(dim=1) > 0).all().item())
+        )
+        if run_cross_attn:
+            q = self.cross_attn_q_norm(volume_backbone_out)
+            kv = self.cross_attn_kv_norm(surface_backbone_out)
+            # nn.MultiheadAttention treats key_padding_mask True as "ignore".
+            key_padding_mask = ~surface_mask.bool()
+            vol_ctx, _ = self.cross_attn(
+                query=q,
+                key=kv,
+                value=kv,
+                key_padding_mask=key_padding_mask,
+                need_weights=False,
+            )
+            vol_ctx = _apply_token_mask(vol_ctx, volume_mask)
+            volume_backbone_out = volume_backbone_out + torch.tanh(self.cross_attn_gate) * vol_ctx
+            volume_backbone_out = _apply_token_mask(volume_backbone_out, volume_mask)
+
+        # Reference tensor for batch_size/device/dtype when a tower output
+        # is missing. Either surface_x or volume_x is guaranteed non-None
+        # by the caller.
+        ref = surface_x if surface_x is not None else volume_x
+        batch_size = ref.shape[0]
+
+        if surface_backbone_out is not None:
+            surface_hidden = surface_backbone_out
+            surface_hidden_norm = _apply_token_mask(
+                self.norm(surface_hidden), surface_mask
+            )
+            surface_preds = self.surface_out(surface_hidden_norm) * surface_mask.unsqueeze(-1)
+        else:
+            surface_hidden = ref.new_zeros(batch_size, 0, self.norm.normalized_shape[0])
+            surface_hidden_norm = surface_hidden
+            surface_preds = ref.new_zeros(batch_size, 0, self.surface_output_dim)
+
+        if volume_backbone_out is not None:
+            volume_hidden = volume_backbone_out
+            volume_hidden_norm = _apply_token_mask(
+                self.norm(volume_hidden), volume_mask
+            )
+            volume_preds = self.volume_out(volume_hidden_norm) * volume_mask.unsqueeze(-1)
+        else:
+            volume_hidden = ref.new_zeros(batch_size, 0, self.norm.normalized_shape[0])
+            volume_hidden_norm = volume_hidden
+            volume_preds = ref.new_zeros(batch_size, 0, self.volume_output_dim)
+
+        # Recreate the joint hidden tensor for telemetry consumers that
+        # expect the concatenated representation.
+        if surface_hidden.shape[1] > 0 and volume_hidden.shape[1] > 0:
+            hidden = torch.cat([surface_hidden, volume_hidden], dim=1)
+        elif surface_hidden.shape[1] > 0:
+            hidden = surface_hidden
+        else:
+            hidden = volume_hidden
+
+        return {
+            "surface_preds": surface_preds,
+            "volume_preds": volume_preds,
+            "hidden": hidden,
+            "surface_hidden": surface_hidden_norm,
+            "volume_hidden": volume_hidden_norm,
         }

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-05 (updated 12:40 UTC)
+- **Date:** 2026-05-05 (updated 15:30 UTC)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -43,8 +43,8 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 2. Optimizer / Training Dynamics (2 PRs in-flight)
 
-- **PR #667** (fern): Weight decay sweep {5e-4 control, 1e-3, 1e-4}. Arm A control complete: val=6.959% (timeout at EP4/13, 2.80× vol val→test gap fully present). Arm B (wd=1e-3) EP2 PASS at 8.670% (slightly worse than control 8.581%, vol_p +0.27pp worse). EP3 gate ETA ~13:35 UTC.
-- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Pre-EP1.
+- **PR #667** (fern): Weight decay sweep {5e-4 ctrl=6.959% test=8.135% vol-ratio 2.80×, 1e-3 final=6.913% test=8.097% vol-ratio 2.85×, 1e-4 running}. **Arm B finalized — WD direction scientifically null on volume val→test gap.** Test_vp essentially flat across WD values; ratio actually widened slightly with stronger WD. Arm C running for completeness.
+- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Silent since 13:20Z receipt; follow-up nudge posted 15:23Z requesting EP1 status.
 
 **Closed (null):**
 - PR #603 (tanjiro): EMA decay sweep — {0.9993, 0.9997, 0.9999} all no improvement.
@@ -57,8 +57,10 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 3. Attention Mechanism (2 PRs in-flight)
 
-- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64); arm-b: heads=2 (dim_head=256). Just assigned, pre-EP1.
-- **PR #665** (frieren): Cross-slice attention — adds global inter-slice MHA layer. Arm A control complete: val=6.9349% (timeout at EP4/13). Arm B (with cross-slice attn, +5.25M params, zero-init proj) EP1 −3.82pp ahead, but EP2 reversed: 10.92% PASS but +2.22pp behind control (wall-shear z +2.75pp regression). EP3 gate at high kill risk (ETA ~13:50 UTC).
+- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64) EP2 PASS 8.5458%; arm-b: heads=2 (dim_head=256) queued. EP3 watch for Arm A.
+
+**Closed (this round):**
+- PR #665 (frieren): Cross-slice attention — direction closed.
 
 **Open question:** Does more diverse (heads=8) or higher-capacity (heads=2) attention improve over SOTA heads=4? Does inter-slice attention capture global geometry correlations? (Early signal from PR #665: cross-slice attn slows late-EP convergence, likely due to +33% params needing more training to escape zero-init.)
 
@@ -73,6 +75,14 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 - L=6/hidden=448/heads=7 (PR #693): CLOSED — 98 min/epoch (heads=7 kills SDPA fast path). Key lesson: heads must be power-of-2 for budget-feasible training.
 
 **Open question:** Does L=6/hidden=384/heads=4 (PR #694) continue the depth scaling trend? Is slices=128 optimal or does smaller/larger over-fragment or under-communicate geometry (PR #690)?
+
+### 4b. Knowledge Distillation (1 PR in-flight)
+
+- **PR #676** (nezuko): K=7 ensemble teacher → student KD with kd_alpha sweep. **Arm A (kd-alpha=0.7) FINAL:** val=7.0153% test=8.2539% — misses merge bar 6.5985% by +0.42pp. **Budget-limited:** KD doubles per-step time (2.37 it/s vs ~5 it/s) → only 4 epochs in 270-min cap; trajectory slope at EP4 still -0.42pp/epoch (would plausibly cross merge bar at ~9 epochs). **Volume val→test ratio narrowed 3.17×→2.78×** — first lever in the round to actually move the chronic surface↔volume gap. Arm B (kd-alpha=0.5) launched 15:10Z. **Open follow-ups documented:** (a) batched KD cache / fused volume KD kernel to halve per-step overhead, (b) channel-selective KD on volume only, (c) T_max=4 cosine fix, (d) scheduled kd_alpha 0.9→0.1.
+
+### 4c. Boundary Condition Encoding (1 PR in-flight)
+
+- **PR #716** (frieren): nn.Embedding(3, 16) for wall=0/inlet=1/outlet=2 injected before Transolver encoder. Primary target: wall_shear_z (SOTA 9.81%). Hypothesis received 15:20Z; data-shape inspection requested.
 
 ### 5. Physics-Informed Loss / Output Formulation
 
@@ -91,22 +101,25 @@ All 8 students running:
 
 | Student | PR | Hypothesis | Status |
 |---|---|---|---|
-| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Just assigned — pre-EP1 |
-| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Just assigned — pre-EP1 |
-| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Just assigned — pre-EP1 |
-| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | Just assigned — pre-EP1 |
-| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Pre-EP1 |
-| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 EP2 PASS, 1e-4 queued} | Arm B EP3 gate ~13:35 UTC |
-| frieren | #665 | Cross-slice attention (Arm A=6.9349%, Arm B EP2 PASS but trailing) | Arm B EP3 gate ~13:50 UTC |
-| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha=0.7) | EP1=28.62%, EP2 gate ~12:56 UTC |
+| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Arm A heads=64 EP1 ~25.87%; EP2 gate watch |
+| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Arm A EP1 ~29.43%; EP2 gate watch |
+| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Arm A heads=8 EP2 PASS 8.5458%; EP3 gate next |
+| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | EP3 PASS 7.3175% (gap closing); EP4 final ETA ~15:43 UTC |
+| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Silent since 13:20Z ADVISOR receipt; follow-up nudge posted 15:23Z |
+| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 final=6.913%, 1e-4 running} | Arm B FINAL: WD direction scientifically null on volume gap; Arm C running |
+| frieren | #716 | BC-type embedding (nn.Embedding(3,16)) — wall_shear_z primary target | Hypothesis received; Arm A control + Arm B BC starting; EP1 watch |
+| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha sweep) | Arm A FINAL: val=7.0153% (misses bar, budget-limited); Arm B kd=0.5 running since 15:10Z |
 
 **Zero idle students. Zero idle GPUs.**
 
-**Upcoming gate actions:**
-- All new PRs (#690, #691, #692, #694, #695): EP1 informational (+ epoch-time gate for #694: kill if > 75 min/epoch), EP2 gate at step ~21,729 — KILL if > 12.0%; EP3 gate — KILL if > 8.0%
-- Fern PR #667 Arm B (wd=1e-3): EP3 gate ~13:35 UTC — KILL if > 8.0%; queue Arm C (wd=1e-4) if Arm B doesn't beat Arm A by ≥0.30pp
-- Frieren PR #665 Arm B (cross-slice attn): EP3 gate ~13:50 UTC — KILL if > 8.0%; high kill risk (needs 2.92pp drop in one epoch vs Arm A's 1.38pp)
-- Nezuko PR #676 Arm A (kd-alpha=0.7): EP2 gate ~12:56 UTC — KILL if > 12.0%
+**Upcoming gate actions (UTC):**
+- thorfinn PR #694: EP4 final ~15:43 — verdict on merge bar < 6.5985% (forecast 6.85–7.05%, tail ≤6.6%)
+- fern PR #667 Arm C (wd=1e-4): EP1 ~15:50 (info), EP2 ~17:05 (kill > 12%), EP3 ~18:20 (kill > 8%), final ~19:08
+- nezuko PR #676 Arm B (kd=0.5): EP2 ~17:30 (kill > 12%), EP3 ~18:45 (kill > 8%), final ~19:40
+- tanjiro PR #692 Arm A (heads=8): EP3 ~16:00 (kill > 8%), final ~16:21
+- askeladd PR #691, alphonse PR #690: EP2 gate watch (kill > 12%)
+- edward PR #695: pending student EP1 status update
+- frieren PR #716: data-shape inspection result + EP1 informational
 
 ---
 

--- a/train.py
+++ b/train.py
@@ -102,6 +102,10 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    dual_tower: bool = False
+    dual_tower_surface_layers: int = 3
+    dual_tower_volume_layers: int = 3
+    dual_tower_cross_attn_heads: int = 4
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -297,6 +301,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        dual_tower=config.dual_tower,
+        dual_tower_surface_layers=config.dual_tower_surface_layers,
+        dual_tower_volume_layers=config.dual_tower_volume_layers,
+        dual_tower_cross_attn_heads=config.dual_tower_cross_attn_heads,
     )
 
 
@@ -753,6 +761,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            # Dual-tower can skip the cross-attention bridge on batches where
+            # one modality has zero tokens, leaving the bridge's parameters
+            # unused on that step — DDP fails reduction without this flag.
+            if config.dual_tower:
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:

--- a/train.py
+++ b/train.py
@@ -57,6 +57,7 @@ from trainer_runtime import (
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
+    numeric_metric_items,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -106,6 +107,8 @@ class Config:
     dual_tower_surface_layers: int = 3
     dual_tower_volume_layers: int = 3
     dual_tower_cross_attn_heads: int = 4
+    save_epoch_snapshots: str = ""
+    track_best_volp: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -860,7 +863,14 @@ def main(argv: Iterable[str] | None = None) -> None:
         output_dir = Path(config.output_dir) / f"run-{run.id}"
         output_dir.mkdir(parents=True, exist_ok=True)
         model_path = output_dir / "checkpoint.pt"
+        volp_model_path = output_dir / "checkpoint_best_volp.pt"
         config_path = output_dir / "config.yaml"
+        snapshot_epochs: set[int] = set()
+        if config.save_epoch_snapshots.strip():
+            for tok in config.save_epoch_snapshots.split(","):
+                tok = tok.strip()
+                if tok:
+                    snapshot_epochs.add(int(tok))
         with config_path.open("w") as f:
             yaml.safe_dump(asdict(config), f)
 
@@ -877,6 +887,9 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
+        best_volp_val = float("inf")
+        best_volp_metrics: dict[str, float] = {}
+        snapshot_records: list[dict[str, object]] = []
         best_checkpoint_source = "ema" if ema is not None else "raw"
         global_step = 0
         early_stop_reason: str | None = None
@@ -1285,6 +1298,49 @@ def main(argv: Iterable[str] | None = None) -> None:
                         },
                         model_path,
                     )
+                # Track best-val-volume_pressure separately so we can harvest
+                # test metrics from a checkpoint that minimises volume error
+                # (the primary target of Issue #717), not just abupt aggregate.
+                if config.track_best_volp:
+                    volp_val = float(val_metrics["val_surface"].get("volume_pressure_rel_l2_pct", float("inf")))
+                    volp_improved = should_update_best_checkpoint(volp_val, best_volp_val)
+                    if volp_improved:
+                        best_volp_val = volp_val
+                        best_volp_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}
+                        torch.save(
+                            {
+                                "model": base_model.state_dict(),
+                                "config": asdict(config),
+                                "epoch": epoch + 1,
+                                "val_metrics": val_metrics,
+                                "checkpoint_source": best_checkpoint_source,
+                                "selection_metric": "val_primary/volume_pressure_rel_l2_pct",
+                            },
+                            volp_model_path,
+                        )
+                    log_metrics["best_volp_checkpoint/updated"] = 1.0 if volp_improved else 0.0
+                # Save per-epoch EMA snapshot at requested epochs for separate
+                # post-training test eval.
+                if (epoch + 1) in snapshot_epochs:
+                    snap_path = output_dir / f"snapshot_ep{epoch + 1}.pt"
+                    torch.save(
+                        {
+                            "model": base_model.state_dict(),
+                            "config": asdict(config),
+                            "epoch": epoch + 1,
+                            "val_metrics": val_metrics,
+                            "checkpoint_source": best_checkpoint_source,
+                            "selection_metric": f"snapshot_ep{epoch + 1}",
+                        },
+                        snap_path,
+                    )
+                    snapshot_records.append(
+                        {
+                            "epoch": epoch + 1,
+                            "path": snap_path,
+                            "val_metrics": dict(val_metrics["val_surface"]),
+                        }
+                    )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
                 wandb.log(log_metrics)
@@ -1359,6 +1415,60 @@ def main(argv: Iterable[str] | None = None) -> None:
             global_step=global_step,
             total_minutes=total_minutes,
         )
+
+        # Post-training: load each per-epoch snapshot and the best-val-volp
+        # checkpoint, run full_val + test eval on each, log under namespaced
+        # W&B summary keys so the PR comment can compare checkpoints.
+        extra_checkpoints: list[tuple[str, Path, dict[str, float]]] = []
+        if config.track_best_volp and best_volp_metrics:
+            extra_checkpoints.append(
+                ("best_volp", volp_model_path, best_volp_metrics)
+            )
+        for record in snapshot_records:
+            ep = int(record["epoch"])
+            extra_checkpoints.append(
+                (
+                    f"snapshot_ep{ep}",
+                    Path(record["path"]),
+                    dict(record["val_metrics"]),
+                )
+            )
+        for label, path, val_record in extra_checkpoints:
+            if not path.exists():
+                continue
+            try:
+                ckpt = torch.load(path, map_location=device, weights_only=True)
+                base_model.load_state_dict(ckpt["model"])
+            except Exception as exc:  # pragma: no cover - defensive
+                print(f"[{label}] failed to load {path}: {exc}")
+                continue
+            full_val_metrics = {
+                name: evaluate_split(base_model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in final_val_loaders.items()
+            }
+            test_metrics = {
+                name: evaluate_split(base_model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in final_test_loaders.items()
+            }
+            extra_log: dict[str, object] = {"global_step": global_step}
+            full_val_log = primary_metric_log(
+                f"{label}/full_val_primary", full_val_metrics["val_surface"]
+            )
+            test_log = primary_metric_log(
+                f"{label}/test_primary", test_metrics["test_surface"]
+            )
+            extra_log.update(full_val_log)
+            extra_log.update(test_log)
+            for split_name, metrics in full_val_metrics.items():
+                extra_log.update(metric_namespace(f"{label}/full_val", split_name, metrics))
+            for split_name, metrics in test_metrics.items():
+                extra_log.update(metric_namespace(f"{label}/test", split_name, metrics))
+            extra_log[f"{label}/checkpoint_epoch"] = float(val_record.get("epoch", 0))
+            wandb.log(extra_log)
+            wandb.summary.update(numeric_metric_items(extra_log))
+            print(f"\n=== {label} (epoch {int(val_record.get('epoch', 0))}) ===")
+            print_metrics(f"{label}/test_surface", test_metrics["test_surface"])
+
         wandb.finish()
     finally:
         cleanup_distributed(state)


### PR DESCRIPTION
## Hypothesis

The chronic volume_pressure test-vs-val gap (~3×: val≈3.9%, test≈11.5%) suggests the model lacks a dedicated representation pathway for volumetric pressure fields. The current architecture processes surface and volume points through a single shared Transolver stack, forcing volume pressure to compete with surface features for attention capacity.

**Experiment 1A from Issue #717**: A dual-tower architecture gives volume pressure its own encoder path, with cross-attention providing geometric grounding from the surface mesh. Volume queries attend to surface keys/values, letting the volume encoder selectively pull in relevant surface context (pressure gradients, boundary layer separation zones) rather than passively sharing mixed representations.

Reference: PR #654 (yi branch) sketched a similar DualTowerTransolver. This experiment adapts that concept to the tay branch architecture.

## Instructions

Implement a dual-tower variant of the current Transolver in `target/train.py`. This is a **short probe** — run to the budget limit, harvest test metrics early (EP3, EP5, EP7, EP10), and report the per-channel test breakdown.

### Architecture

Add a `DualTowerTransolver` class alongside the existing `Transolver`. The design:

```
SurfaceEncoder: Transolver(layers=3, hidden=512, heads=4, slices=128)
VolumeEncoder:  Transolver(layers=3, hidden=512, heads=4, slices=128)
CrossAttn:      nn.MultiheadAttention(embed_dim=512, num_heads=4, batch_first=True)

forward(surface_x, surface_pos, volume_x, volume_pos):
    surf_tokens = SurfaceEncoder(surface_x, surface_pos)   # [B, Ns, 512]
    vol_tokens  = VolumeEncoder(volume_x, volume_pos)      # [B, Nv, 512]
    # Volume queries attend to surface keys/values
    vol_ctx, _  = CrossAttn(query=vol_tokens, key=surf_tokens, value=surf_tokens)
    vol_tokens  = vol_tokens + vol_ctx   # residual connection
    return surf_tokens, vol_tokens       # decoded separately via existing output heads
```

Keep the same input/output projections and loss formulation as the baseline. The 3+3 layer split keeps total param count similar to the L=5 baseline (~16M); add a `--dual-tower` flag (boolean, default False) to enable this path. When `--dual-tower` is False, the model falls back to standard Transolver (single-tower) for a fair comparison.

### Training command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --dual-tower \
  --batch-size 4 --validation-every 1 \
  --wandb-group vol-pressure-dual-tower \
  --wandb-name tanjiro/dual-tower-cross-attn
```

### EP gates

- **EP1**: Log epoch time. If > 80 min/epoch, kill immediately (budget infeasible).
- **EP2** (~step 10,865): KILL if val_abupt > 12.0%
- **EP3** (~step 16,298): KILL if val_abupt > 8.0%; **Harvest test metrics at this checkpoint regardless.**
- **EP5**: Harvest test metrics.
- **EP7**: Harvest test metrics.
- **Best-val-abupt checkpoint**: Harvest test metrics.
- **Best-val-volume_pressure checkpoint**: Also harvest test metrics from this checkpoint separately.

### Required reporting

In your PR comment, report a table comparing all harvested checkpoints vs the three Issue #717 baseline anchors:

| Checkpoint | val_abupt | test_abupt | test vol_pressure | test wall_shear | test tau_y | test tau_z |
|---|---|---|---|---|---|---|
| sogus8sx (#599) baseline | — | — | 11.694% | 7.299% | 7.941% | 9.535% |
| 4k25s25e (#592) SOTA     | 6.598% | 7.991% | 11.933% | 7.334% | 8.145% | 9.298% |
| dc031qpt (#681) baseline | — | — | 11.374% | 8.321% | 9.596% | 10.738% |
| dual-tower EP3 | | | | | | |
| dual-tower EP5 | | | | | | |
| dual-tower best-val-abupt | | | | | | |
| dual-tower best-val-volp  | | | | | | |

**Promotion gates (Issue #717):**
- Weak win: test vol_pressure ≤ 10.8% (without harming test_abupt)
- Solid win: test vol_pressure ≤ 10.0%
- Major win: test vol_pressure ≤ 9.5%
- Target: test vol_pressure ≤ 6.08%

## Baseline

- **Single-model SOTA**: PR #592, run `4k25s25e` — val_abupt = 6.5985%, test_abupt = 7.9915%, test vol_pressure = 11.933%
- **Ensemble SOTA**: PR #612, run `5veexq8r` — val_abupt = 6.1751%, test_abupt = 7.5347%
- **Single-model gate**: val_abupt < 6.5985% to update SOTA

```bash
# Baseline reproduce (PR #592):
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --wandb-group model-depth-sweep --wandb-name alphonse/depth-L5
```

See Issue #717 for the full volume_pressure improvement programme and promotion ladder.
