### PR TITLE
Exp 1C: coordinate normalization for vol-pressure geometry

### DIFF
--- a/model.py
+++ b/model.py
@@ -33,6 +33,62 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+def _normalize_coords_with_mask(
+    pos: torch.Tensor,
+    mask: torch.Tensor,
+    mode: str,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Per-sample coordinate normalization that respects the token mask.
+
+    Parameters
+    ----------
+    pos: ``[B, N, 3]`` xyz coordinates (padded tokens may carry arbitrary values).
+    mask: ``[B, N]`` boolean/float token mask (1 = valid, 0 = padding).
+    mode: one of ``'none'``, ``'centroid_scale'``, ``'centroid_rms'``.
+
+    Returns
+    -------
+    (pos_normalized, log_scale)
+        ``pos_normalized`` matches ``pos`` shape; ``log_scale`` is ``[B, 1]``
+        when normalization is active and ``None`` otherwise.
+    """
+    if mode == "none":
+        return pos, None
+    if pos.shape[-2] == 0:
+        # Empty view (e.g. trailing modality after curriculum exhaustion).
+        # Skip normalization; downstream code already tolerates N=0.
+        log_scale = pos.new_zeros((pos.shape[0], 1))
+        return pos, log_scale
+    orig_dtype = pos.dtype
+    pos_f = pos.to(dtype=torch.float32)
+    mask_f = mask.to(dtype=torch.float32)
+    mask_exp = mask_f.unsqueeze(-1)
+    raw_valid_count = mask_f.sum(dim=-1, keepdim=True)
+    valid_count = raw_valid_count.clamp(min=1.0)
+    has_valid = (raw_valid_count.squeeze(-1) > 0)  # [B]
+    centroid = (pos_f * mask_exp).sum(dim=-2) / valid_count
+    centered = pos_f - centroid.unsqueeze(-2)
+    invalid_mask = (mask_f == 0).unsqueeze(-1)
+    if mode == "centroid_scale":
+        masked_for_max = centered.masked_fill(invalid_mask, float("-inf"))
+        masked_for_min = centered.masked_fill(invalid_mask, float("inf"))
+        bbox_max = masked_for_max.max(dim=-2).values
+        bbox_min = masked_for_min.min(dim=-2).values
+        scale = (bbox_max - bbox_min).max(dim=-1).values
+    elif mode == "centroid_rms":
+        sq = (centered ** 2).sum(dim=-1) * mask_f
+        ms = sq.sum(dim=-1) / valid_count.squeeze(-1)
+        scale = ms.sqrt()
+    else:
+        raise ValueError(f"Unknown coord_norm_mode: {mode!r}")
+    # Samples with no valid tokens get a unit scale so we don't divide by zero
+    # or take log(0); their centered positions are already zero (centroid 0).
+    scale = torch.where(has_valid, scale, torch.ones_like(scale)).clamp(min=1e-6)
+    pos_normalized = (centered / scale.view(-1, 1, 1)).to(dtype=orig_dtype)
+    log_scale = scale.log().unsqueeze(-1).to(dtype=orig_dtype)
+    return pos_normalized, log_scale
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -342,6 +398,9 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        coord_norm_mode: str = "none",
+        coord_norm_inject_log_scale: bool = False,
+        coord_norm_log_scale_init_std: float = 1e-4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,8 +413,20 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        if coord_norm_mode not in ("none", "centroid_scale", "centroid_rms"):
+            raise ValueError(
+                f"coord_norm_mode must be 'none', 'centroid_scale', or 'centroid_rms'; got {coord_norm_mode!r}"
+            )
+        self.coord_norm_mode = coord_norm_mode
+        self.coord_norm_inject_log_scale = (
+            coord_norm_inject_log_scale and coord_norm_mode != "none"
+        )
+        self.coord_norm_log_scale_init_std = coord_norm_log_scale_init_std
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+        if self.coord_norm_inject_log_scale:
+            surface_extra_dim += 1
+            volume_extra_dim += 1
 
         if pos_encoding_mode == "string_separable":
             # STRING-separable: learnable per-axis log_freq + phase,
@@ -407,6 +478,20 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if self.coord_norm_inject_log_scale:
+            # Log-scale lives at index `surface_extra_orig` of the feature
+            # vector for the surface branch (we appended it after the existing
+            # extras), and at index `volume_extra_orig` for the volume branch.
+            # Initialise that input column with a tiny std so the model starts
+            # from a coord-norm-only baseline (no log-scale signal).
+            with torch.no_grad():
+                std = self.coord_norm_log_scale_init_std
+                if self.project_surface_features is not None:
+                    surf_log_col = max(0, self.surface_input_dim - space_dim)
+                    self.project_surface_features.project.weight[:, surf_log_col].normal_(0.0, std)
+                if self.project_volume_features is not None:
+                    vol_log_col = max(0, self.volume_input_dim - space_dim)
+                    self.project_volume_features.project.weight[:, vol_log_col].normal_(0.0, std)
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -425,6 +510,7 @@ class SurfaceTransolver(nn.Module):
     def _encode_group(
         self,
         x: torch.Tensor,
+        mask: torch.Tensor,
         *,
         rff: nn.Module | None,
         string_sep: nn.Module | None,
@@ -433,10 +519,20 @@ class SurfaceTransolver(nn.Module):
         placeholder: torch.Tensor,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
+        if self.coord_norm_mode != "none":
+            pos, log_scale = _normalize_coords_with_mask(pos, mask, self.coord_norm_mode)
+        else:
+            log_scale = None
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if self.coord_norm_inject_log_scale and log_scale is not None:
+            # log_scale: [B, 1] -> broadcast to [B, N, 1]
+            num_tokens = pos.shape[-2]
+            feature_parts.append(
+                log_scale.unsqueeze(-2).expand(-1, num_tokens, -1).to(dtype=pos.dtype)
+            )
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -473,6 +569,7 @@ class SurfaceTransolver(nn.Module):
             tokens.append(
                 self._encode_group(
                     surface_x,
+                    surface_mask,
                     rff=self.surface_rff,
                     string_sep=self.surface_string_sep,
                     project_features=self.project_surface_features,
@@ -487,6 +584,7 @@ class SurfaceTransolver(nn.Module):
             tokens.append(
                 self._encode_group(
                     volume_x,
+                    volume_mask,
                     rff=self.volume_rff,
                     string_sep=self.volume_string_sep,
                     project_features=self.project_volume_features,

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-05 (updated 12:40 UTC)
+- **Date:** 2026-05-05 (updated 15:30 UTC)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -43,8 +43,8 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 2. Optimizer / Training Dynamics (2 PRs in-flight)
 
-- **PR #667** (fern): Weight decay sweep {5e-4 control, 1e-3, 1e-4}. Arm A control complete: val=6.959% (timeout at EP4/13, 2.80× vol val→test gap fully present). Arm B (wd=1e-3) EP2 PASS at 8.670% (slightly worse than control 8.581%, vol_p +0.27pp worse). EP3 gate ETA ~13:35 UTC.
-- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Pre-EP1.
+- **PR #667** (fern): Weight decay sweep {5e-4 ctrl=6.959% test=8.135% vol-ratio 2.80×, 1e-3 final=6.913% test=8.097% vol-ratio 2.85×, 1e-4 running}. **Arm B finalized — WD direction scientifically null on volume val→test gap.** Test_vp essentially flat across WD values; ratio actually widened slightly with stronger WD. Arm C running for completeness.
+- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Silent since 13:20Z receipt; follow-up nudge posted 15:23Z requesting EP1 status.
 
 **Closed (null):**
 - PR #603 (tanjiro): EMA decay sweep — {0.9993, 0.9997, 0.9999} all no improvement.
@@ -57,8 +57,10 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 3. Attention Mechanism (2 PRs in-flight)
 
-- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64); arm-b: heads=2 (dim_head=256). Just assigned, pre-EP1.
-- **PR #665** (frieren): Cross-slice attention — adds global inter-slice MHA layer. Arm A control complete: val=6.9349% (timeout at EP4/13). Arm B (with cross-slice attn, +5.25M params, zero-init proj) EP1 −3.82pp ahead, but EP2 reversed: 10.92% PASS but +2.22pp behind control (wall-shear z +2.75pp regression). EP3 gate at high kill risk (ETA ~13:50 UTC).
+- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64) EP2 PASS 8.5458%; arm-b: heads=2 (dim_head=256) queued. EP3 watch for Arm A.
+
+**Closed (this round):**
+- PR #665 (frieren): Cross-slice attention — direction closed.
 
 **Open question:** Does more diverse (heads=8) or higher-capacity (heads=2) attention improve over SOTA heads=4? Does inter-slice attention capture global geometry correlations? (Early signal from PR #665: cross-slice attn slows late-EP convergence, likely due to +33% params needing more training to escape zero-init.)
 
@@ -73,6 +75,14 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 - L=6/hidden=448/heads=7 (PR #693): CLOSED — 98 min/epoch (heads=7 kills SDPA fast path). Key lesson: heads must be power-of-2 for budget-feasible training.
 
 **Open question:** Does L=6/hidden=384/heads=4 (PR #694) continue the depth scaling trend? Is slices=128 optimal or does smaller/larger over-fragment or under-communicate geometry (PR #690)?
+
+### 4b. Knowledge Distillation (1 PR in-flight)
+
+- **PR #676** (nezuko): K=7 ensemble teacher → student KD with kd_alpha sweep. **Arm A (kd-alpha=0.7) FINAL:** val=7.0153% test=8.2539% — misses merge bar 6.5985% by +0.42pp. **Budget-limited:** KD doubles per-step time (2.37 it/s vs ~5 it/s) → only 4 epochs in 270-min cap; trajectory slope at EP4 still -0.42pp/epoch (would plausibly cross merge bar at ~9 epochs). **Volume val→test ratio narrowed 3.17×→2.78×** — first lever in the round to actually move the chronic surface↔volume gap. Arm B (kd-alpha=0.5) launched 15:10Z. **Open follow-ups documented:** (a) batched KD cache / fused volume KD kernel to halve per-step overhead, (b) channel-selective KD on volume only, (c) T_max=4 cosine fix, (d) scheduled kd_alpha 0.9→0.1.
+
+### 4c. Boundary Condition Encoding (1 PR in-flight)
+
+- **PR #716** (frieren): nn.Embedding(3, 16) for wall=0/inlet=1/outlet=2 injected before Transolver encoder. Primary target: wall_shear_z (SOTA 9.81%). Hypothesis received 15:20Z; data-shape inspection requested.
 
 ### 5. Physics-Informed Loss / Output Formulation
 
@@ -91,22 +101,25 @@ All 8 students running:
 
 | Student | PR | Hypothesis | Status |
 |---|---|---|---|
-| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Just assigned — pre-EP1 |
-| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Just assigned — pre-EP1 |
-| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Just assigned — pre-EP1 |
-| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | Just assigned — pre-EP1 |
-| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Pre-EP1 |
-| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 EP2 PASS, 1e-4 queued} | Arm B EP3 gate ~13:35 UTC |
-| frieren | #665 | Cross-slice attention (Arm A=6.9349%, Arm B EP2 PASS but trailing) | Arm B EP3 gate ~13:50 UTC |
-| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha=0.7) | EP1=28.62%, EP2 gate ~12:56 UTC |
+| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Arm A heads=64 EP1 ~25.87%; EP2 gate watch |
+| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Arm A EP1 ~29.43%; EP2 gate watch |
+| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Arm A heads=8 EP2 PASS 8.5458%; EP3 gate next |
+| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | EP3 PASS 7.3175% (gap closing); EP4 final ETA ~15:43 UTC |
+| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Silent since 13:20Z ADVISOR receipt; follow-up nudge posted 15:23Z |
+| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 final=6.913%, 1e-4 running} | Arm B FINAL: WD direction scientifically null on volume gap; Arm C running |
+| frieren | #716 | BC-type embedding (nn.Embedding(3,16)) — wall_shear_z primary target | Hypothesis received; Arm A control + Arm B BC starting; EP1 watch |
+| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha sweep) | Arm A FINAL: val=7.0153% (misses bar, budget-limited); Arm B kd=0.5 running since 15:10Z |
 
 **Zero idle students. Zero idle GPUs.**
 
-**Upcoming gate actions:**
-- All new PRs (#690, #691, #692, #694, #695): EP1 informational (+ epoch-time gate for #694: kill if > 75 min/epoch), EP2 gate at step ~21,729 — KILL if > 12.0%; EP3 gate — KILL if > 8.0%
-- Fern PR #667 Arm B (wd=1e-3): EP3 gate ~13:35 UTC — KILL if > 8.0%; queue Arm C (wd=1e-4) if Arm B doesn't beat Arm A by ≥0.30pp
-- Frieren PR #665 Arm B (cross-slice attn): EP3 gate ~13:50 UTC — KILL if > 8.0%; high kill risk (needs 2.92pp drop in one epoch vs Arm A's 1.38pp)
-- Nezuko PR #676 Arm A (kd-alpha=0.7): EP2 gate ~12:56 UTC — KILL if > 12.0%
+**Upcoming gate actions (UTC):**
+- thorfinn PR #694: EP4 final ~15:43 — verdict on merge bar < 6.5985% (forecast 6.85–7.05%, tail ≤6.6%)
+- fern PR #667 Arm C (wd=1e-4): EP1 ~15:50 (info), EP2 ~17:05 (kill > 12%), EP3 ~18:20 (kill > 8%), final ~19:08
+- nezuko PR #676 Arm B (kd=0.5): EP2 ~17:30 (kill > 12%), EP3 ~18:45 (kill > 8%), final ~19:40
+- tanjiro PR #692 Arm A (heads=8): EP3 ~16:00 (kill > 8%), final ~16:21
+- askeladd PR #691, alphonse PR #690: EP2 gate watch (kill > 12%)
+- edward PR #695: pending student EP1 status update
+- frieren PR #716: data-shape inspection result + EP1 informational
 
 ---
 

--- a/train.py
+++ b/train.py
@@ -137,6 +137,11 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    coord_norm_mode: str = "none"
+    coord_norm_inject_log_scale: bool = False
+    coord_norm_log_scale_init_std: float = 1e-4
+    save_snapshot_epochs: str = ""
+    track_best_volp_checkpoint: bool = False
     debug: bool = False
 
 
@@ -219,6 +224,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "save_snapshot_epochs": (
+            "Optional comma-separated list of 1-indexed epoch numbers at which "
+            "to save an extra snapshot checkpoint (regardless of val "
+            "improvement). After training, run_final_evaluation runs test eval "
+            "on each saved snapshot and logs metrics under "
+            "test_ep<N>_primary/* and test_ep<N>/test_surface/*. Empty "
+            "string disables snapshot saving. Example: '3,5,7'."
+        ),
+        "track_best_volp_checkpoint": (
+            "Track and save a separate best-val volume_pressure checkpoint at "
+            "output_dir/checkpoint_volp.pt, in addition to the standard "
+            "best-val abupt checkpoint. After training, run_final_evaluation "
+            "runs test eval on this checkpoint and logs metrics under "
+            "test_volp_primary/* and test_volp/test_surface/*."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -297,6 +317,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        coord_norm_mode=config.coord_norm_mode,
+        coord_norm_inject_log_scale=config.coord_norm_inject_log_scale,
+        coord_norm_log_scale_init_std=config.coord_norm_log_scale_init_std,
     )
 
 
@@ -865,6 +888,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
         best_checkpoint_source = "ema" if ema is not None else "raw"
+        snapshot_epochs: set[int] = {
+            int(e.strip())
+            for e in config.save_snapshot_epochs.split(",")
+            if e.strip()
+        }
+        snapshot_checkpoints: dict[str, Path] = {}
+        best_val_volp = float("inf")
+        best_volp_metrics: dict[str, float] = {}
+        volp_checkpoint_path = output_dir / "checkpoint_volp.pt"
         global_step = 0
         early_stop_reason: str | None = None
         timeout_hit = False
@@ -1274,6 +1306,52 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+
+                primary_volp = float(
+                    val_metrics["val_surface"].get(
+                        "volume_pressure_rel_l2_pct", float("nan")
+                    )
+                )
+                if config.track_best_volp_checkpoint:
+                    volp_improved = should_update_best_checkpoint(primary_volp, best_val_volp)
+                    if volp_improved:
+                        best_val_volp = primary_volp
+                        best_volp_metrics = {
+                            "epoch": float(epoch + 1),
+                            **val_metrics["val_surface"],
+                        }
+                        torch.save(
+                            {
+                                "model": base_model.state_dict(),
+                                "config": asdict(config),
+                                "epoch": epoch + 1,
+                                "val_metrics": val_metrics,
+                                "checkpoint_source": best_checkpoint_source,
+                                "selection_metric": "val_primary/volume_pressure_rel_l2_pct",
+                            },
+                            volp_checkpoint_path,
+                        )
+                    log_metrics["best_volp_checkpoint/updated"] = 1.0 if volp_improved else 0.0
+                    log_metrics["best_volp_checkpoint/valid_primary"] = (
+                        1.0 if is_valid_primary_metric(primary_volp) else 0.0
+                    )
+
+                if (epoch + 1) in snapshot_epochs:
+                    snapshot_path = output_dir / f"checkpoint_ep{epoch + 1}.pt"
+                    torch.save(
+                        {
+                            "model": base_model.state_dict(),
+                            "config": asdict(config),
+                            "epoch": epoch + 1,
+                            "val_metrics": val_metrics,
+                            "checkpoint_source": best_checkpoint_source,
+                            "selection_metric": f"epoch_snapshot_ep{epoch + 1}",
+                        },
+                        snapshot_path,
+                    )
+                    snapshot_checkpoints[f"ep{epoch + 1}"] = snapshot_path
+                    log_metrics[f"snapshot_checkpoint/ep{epoch + 1}_saved"] = 1.0
+
                 wandb.log(log_metrics)
                 tag = " *" if improved else ""
                 print(
@@ -1330,6 +1408,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.finish()
             return
 
+        extra_checkpoints: dict[str, Path] = {}
+        if config.track_best_volp_checkpoint and volp_checkpoint_path.exists():
+            extra_checkpoints["volp"] = volp_checkpoint_path
+        for tag, path in snapshot_checkpoints.items():
+            extra_checkpoints[tag] = path
+
         run_final_evaluation(
             run=run,
             model=base_model,
@@ -1345,6 +1429,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             n_params=n_params,
             global_step=global_step,
             total_minutes=total_minutes,
+            extra_checkpoints=extra_checkpoints,
         )
         wandb.finish()
     finally:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1445,6 +1445,7 @@ def run_final_evaluation(
     n_params: int,
     global_step: int,
     total_minutes: float,
+    extra_checkpoints: dict[str, Path] | None = None,
 ) -> None:
     checkpoint = torch.load(model_path, map_location=device, weights_only=True)
     model.load_state_dict(checkpoint["model"])
@@ -1514,3 +1515,51 @@ def run_final_evaluation(
         test_metrics=test_metrics,
         n_params=n_params,
     )
+
+    if extra_checkpoints:
+        for tag, ckpt_path in extra_checkpoints.items():
+            if not Path(ckpt_path).exists():
+                print(f"[extra_eval] Skipping '{tag}': checkpoint missing at {ckpt_path}")
+                continue
+            try:
+                extra_ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
+                model.load_state_dict(extra_ckpt["model"])
+            except Exception as exc:
+                print(f"[extra_eval] Failed to load '{tag}' checkpoint at {ckpt_path}: {exc}")
+                continue
+            extra_epoch = int(extra_ckpt.get("epoch", -1))
+            extra_selection = str(extra_ckpt.get("selection_metric", tag))
+            print(f"[extra_eval] Evaluating '{tag}' (epoch={extra_epoch}, selection={extra_selection})")
+
+            extra_val_metrics = {
+                name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in final_val_loaders.items()
+            }
+            extra_val_log: dict[str, object] = {
+                "global_step": global_step,
+                **primary_metric_log(f"full_val_{tag}_primary", extra_val_metrics["val_surface"]),
+            }
+            for split_name, metrics in extra_val_metrics.items():
+                extra_val_log.update(metric_namespace(f"full_val_{tag}", split_name, metrics))
+            wandb.log(extra_val_log)
+            wandb.summary.update(numeric_metric_items(extra_val_log))
+
+            extra_test_metrics = {
+                name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+                for name, loader in final_test_loaders.items()
+            }
+            extra_test_log: dict[str, object] = {
+                "global_step": global_step,
+                **primary_metric_log(f"test_{tag}_primary", extra_test_metrics["test_surface"]),
+            }
+            for split_name, metrics in extra_test_metrics.items():
+                extra_test_log.update(metric_namespace(f"test_{tag}", split_name, metrics))
+            extra_test_log[f"test_{tag}/source_epoch"] = float(extra_epoch)
+            wandb.log(extra_test_log)
+            wandb.summary.update(numeric_metric_items(extra_test_log))
+            print_metrics(f"test_{tag}", extra_test_metrics["test_surface"])
+
+        # Reload the primary best-val-abupt checkpoint so any downstream code
+        # sees the model in its canonical state.
+        primary_ckpt = torch.load(model_path, map_location=device, weights_only=True)
+        model.load_state_dict(primary_ckpt["model"])


### PR DESCRIPTION
## Hypothesis

The chronic volume_pressure test-vs-val gap (~3×: val≈3.9%, test≈11.5%) may be partially driven by poor coordinate conditioning in the volume encoder. Volume pressure in DrivAerML is governed by global pressure gradients that span the entire vehicle wake (~5–10 body lengths). The current model receives raw (x, y, z) coordinates with no normalization — meaning the volume encoder sees coordinates in different absolute ranges for different cars, making it harder to learn consistent pressure field geometry.

**Experiment 1C (Priority 1) from Issue #717**: Add per-sample coordinate normalization before feeding geometry into the positional encoder. Specifically:

1. **Centroid-subtraction + scale normalization**: For each sample, compute the centroid `(cx, cy, cz)` and characteristic scale `s` (e.g. max bounding-box side length or RMS distance from centroid), then transform `pos_normalized = (pos - centroid) / s`. This makes geometry representation translation- and scale-invariant within a sample.

2. **Coordinate scale as an auxiliary feature**: Concatenate the log-scale `log(s)` as an extra scalar feature to the input feature vector. This tells the model how "big" the geometry is without losing that information via normalization.

The RFF-based STRING-separable encoding currently maps raw coordinates → Fourier features. After normalization, the fixed sigmas {0.25, 0.5, 1.0, 2.0, 4.0} will align with physically meaningful length scales in normalized space (e.g. sigma=1.0 covers the full vehicle body), rather than mapping to arbitrary absolute distances. This should improve volume pressure encoding particularly in the far-field wake region.

Reference: PR #409 (geometry conditioning via coordinate normalization) on this branch. Issue #717 Phase 1, Experiment 1C.

## Instructions

This is a **short probe** targeting specifically `test_primary/volume_pressure_rel_l2_pct`. Run to budget, harvest test metrics at EP3/EP5/EP7/best-val-abupt/best-val-volp, and report per-channel breakdown.

### Changes to `target/train.py`

Add a coordinate normalization preprocessing step applied to position tensors before they enter the model. Add a flag `--coord-norm-mode` with options: `none` (default, baseline), `centroid_scale` (normalize by centroid + bounding-box scale), `centroid_rms` (normalize by centroid + RMS radius).

For this experiment, use `--coord-norm-mode centroid_scale`:

```python
def normalize_coords(pos, mode="centroid_scale"):
    """
    pos: [B, N, 3] or [N, 3] tensor of (x, y, z) coordinates
    Returns: (pos_normalized, scale_log_feature)
      pos_normalized: [B, N, 3] zero-centered, unit-scale coords
      scale_log_feature: [B, 1] log of scale factor (to concat into input features)
    """
    if mode == "none":
        return pos, None
    centroid = pos.mean(dim=-2, keepdim=True)  # [B, 1, 3]
    centered = pos - centroid                   # [B, N, 3]
    if mode == "centroid_scale":
        # Scale by max bounding-box side length
        bbox_max = centered.max(dim=-2).values  # [B, 3]
        bbox_min = centered.min(dim=-2).values  # [B, 3]
        scale = (bbox_max - bbox_min).max(dim=-1).values.clamp(min=1e-6)  # [B]
    elif mode == "centroid_rms":
        scale = centered.norm(dim=-1).mean(dim=-1).clamp(min=1e-6)  # [B]
    pos_normalized = centered / scale.unsqueeze(-1).unsqueeze(-1)
    scale_log = scale.log().unsqueeze(-1)  # [B, 1]
    return pos_normalized, scale_log
```

Apply `normalize_coords` to both surface and volume position tensors. When `scale_log_feature` is not None, broadcast it to `[B, N, 1]` and concatenate it as an extra input feature dimension (requires adjusting the first linear projection layer's `in_features` by +1). Initialize this extra weight column to near-zero (e.g. `nn.init.normal_(weight[:, -1:], std=1e-4)`) so training starts from the pretrained-equivalent baseline.

Run **two arms** under `--wandb-group vol-pressure-coord-norm`:

**Arm A** — centroid+scale norm, log-scale feature injected:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --coord-norm-mode centroid_scale \
  --batch-size 4 --validation-every 1 \
  --wandb-group vol-pressure-coord-norm \
  --wandb-name thorfinn/coord-norm-arm-a
```

**Arm B** — centroid+RMS norm (alternative scale), no log-scale feature (ablation):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --coord-norm-mode centroid_rms \
  --batch-size 4 --validation-every 1 \
  --wandb-group vol-pressure-coord-norm \
  --wandb-name thorfinn/coord-norm-arm-b
```

Run Arm A first; if EP2 kills Arm A (val > 12%), abort Arm B and report. If Arm A survives EP2, launch Arm B in parallel.

### EP gates

- **EP1**: Log epoch time. Kill if > 80 min/epoch.
- **EP2** (~step 10,865): KILL if val_abupt > 12.0%
- **EP3** (~step 16,298): KILL if val_abupt > 8.0%; **Harvest test metrics at this checkpoint regardless.**
- **EP5**: Harvest test metrics.
- **EP7**: Harvest test metrics.
- **Best-val-abupt checkpoint**: Harvest test metrics.
- **Best-val-volume_pressure checkpoint**: Harvest test metrics from this checkpoint separately.

### Required reporting

Report a table comparing all harvested checkpoints vs the three Issue #717 baseline anchors:

| Checkpoint | val_abupt | test_abupt | test vol_pressure | test wall_shear | test tau_y | test tau_z |
|---|---|---|---|---|---|---|
| sogus8sx (#599) baseline | — | — | 11.694% | 7.299% | 7.941% | 9.535% |
| 4k25s25e (#592) SOTA     | 6.598% | 7.991% | 11.933% | 7.334% | 8.145% | 9.298% |
| dc031qpt (#681) baseline | — | — | 11.374% | 8.321% | 9.596% | 10.738% |
| Arm A EP3 | | | | | | |
| Arm A EP5 | | | | | | |
| Arm A best-val-abupt | | | | | | |
| Arm A best-val-volp  | | | | | | |
| Arm B best-val-abupt | | | | | | |
| Arm B best-val-volp  | | | | | | |

**Promotion gates (Issue #717):**
- Weak win: test vol_pressure ≤ 10.8% (without harming test_abupt)
- Solid win: test vol_pressure ≤ 10.0%
- Major win: test vol_pressure ≤ 9.5%
- Target: test vol_pressure ≤ 6.08%

## Baseline

- **Single-model SOTA**: PR #592, run `4k25s25e` — val_abupt = 6.5985%, test_abupt = 7.9915%, test vol_pressure = 11.933%
- **Ensemble SOTA**: PR #612, run `5veexq8r` — val_abupt = 6.1751%, test_abupt = 7.5347%
- **Single-model gate**: val_abupt < 6.5985% to update SOTA

```bash
# Baseline reproduce (PR #592):
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --wandb-group model-depth-sweep --wandb-name alphonse/depth-L5
```

See Issue #717 for the full volume_pressure improvement programme and promotion ladder.
