### PR TITLE
Residual correction MLP on frozen SOTA (tau_y/tau_z bias fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1040,6 +1040,91 @@ class SurfaceTransolver(nn.Module):
         return result
 
 
+class CorrectionMLP(nn.Module):
+    """Per-point residual-correction MLP for frozen-SOTA stacking (PR #724).
+
+    Input: concatenation of [surface_hidden (D), surface_xyz (3), frozen_preds (4)].
+    Output: per-point 4-channel residual added to the frozen surface predictions
+    in normalized space. The final layer is zero-initialized so the wrapped model
+    is exactly identity at step 0 (correction=0), preventing immediate degradation.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int = 64, output_dim: int = 4):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class FrozenBackboneWithCorrection(nn.Module):
+    """Wraps a frozen Transolver backbone and a trainable CorrectionMLP head.
+
+    The frozen backbone runs under torch.no_grad() so no autograd graph is built
+    through it. Training-mode toggling is overridden so the backbone always stays
+    in eval() mode (dropout/etc disabled) while the correction MLP follows normal
+    train/eval semantics. Surface predictions are replaced with
+    `frozen_preds + correction(surface_hidden, xyz, frozen_preds)` masked to valid
+    surface points; volume predictions are passed through unchanged.
+    """
+
+    def __init__(
+        self,
+        frozen_model: nn.Module,
+        correction_mlp: nn.Module,
+        *,
+        space_dim: int = 3,
+    ):
+        super().__init__()
+        self.frozen_model = frozen_model
+        self.correction_mlp = correction_mlp
+        self.space_dim = space_dim
+        for param in self.frozen_model.parameters():
+            param.requires_grad_(False)
+        self.frozen_model.eval()
+
+    def train(self, mode: bool = True) -> "FrozenBackboneWithCorrection":
+        super().train(mode)
+        self.correction_mlp.train(mode)
+        self.frozen_model.eval()
+        return self
+
+    def forward(
+        self,
+        *,
+        surface_x: torch.Tensor | None = None,
+        surface_mask: torch.Tensor | None = None,
+        volume_x: torch.Tensor | None = None,
+        volume_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        with torch.no_grad():
+            out = self.frozen_model(
+                surface_x=surface_x,
+                surface_mask=surface_mask,
+                volume_x=volume_x,
+                volume_mask=volume_mask,
+            )
+        if surface_x is None or surface_mask is None:
+            return out
+        surface_xyz = surface_x[..., : self.space_dim]
+        surface_hidden = out["surface_hidden"]
+        frozen_surface_preds = out["surface_preds"]
+        features = torch.cat([surface_hidden, surface_xyz, frozen_surface_preds], dim=-1)
+        correction = self.correction_mlp(features) * surface_mask.unsqueeze(-1)
+        out["surface_preds_frozen"] = frozen_surface_preds
+        out["surface_preds"] = frozen_surface_preds + correction
+        out["correction"] = correction
+        return out
+
+
 class EMA:
     def __init__(self, model: nn.Module, decay: float = 0.999, start_step: int = 0):
         self.decay = decay
@@ -1163,6 +1248,8 @@ class Config:
     swa_lr: float = 5e-6
     swa_anneal_epochs: int = 1
     swa_update_every_steps: int = 500
+    correction_mode: bool = False
+    correction_mlp_hidden: int = 64
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2148,6 +2235,16 @@ def train_loss(
         metrics["film/geom_token_abs_mean"] = float(
             geom_token.abs().mean().cpu().item()
         )
+    if "correction" in out and bool(batch.surface_mask.any()):
+        correction = out["correction"].detach().float()
+        valid = correction[batch.surface_mask]  # [N_valid, 4]
+        if valid.numel() > 0:
+            metrics["correction/abs_mean"] = float(valid.abs().mean().cpu().item())
+            metrics["correction/rms"] = float(valid.square().mean().sqrt().cpu().item())
+            for ch_idx, ch_name in enumerate(("cp", "tau_x", "tau_y", "tau_z")):
+                ch = valid[:, ch_idx]
+                metrics[f"correction/{ch_name}_abs_mean"] = float(ch.abs().mean().cpu().item())
+                metrics[f"correction/{ch_name}_rms"] = float(ch.square().mean().sqrt().cpu().item())
     return loss, metrics
 
 
@@ -2556,11 +2653,35 @@ def main(argv: Iterable[str] | None = None) -> None:
                 f"Resumed model weights from {config.resume_from} "
                 f"(saved at epoch {prev_epoch}, val_abupt={prev_primary_val:.4f}%)"
             )
+    if config.correction_mode:
+        if not config.resume_from:
+            raise ValueError(
+                "--correction-mode requires --resume-from <SOTA checkpoint>"
+            )
+        backbone_hidden_dim = config.model_hidden_dim
+        correction_input_dim = backbone_hidden_dim + 3 + SURFACE_Y_DIM
+        correction_mlp = CorrectionMLP(
+            input_dim=correction_input_dim,
+            hidden_dim=config.correction_mlp_hidden,
+            output_dim=SURFACE_Y_DIM,
+        ).to(device)
+        model = FrozenBackboneWithCorrection(model, correction_mlp).to(device)
+        if is_main:
+            n_correction = sum(p.numel() for p in correction_mlp.parameters())
+            print(
+                f"Correction mode: backbone frozen, "
+                f"CorrectionMLP({correction_input_dim}->{config.correction_mlp_hidden}->{config.correction_mlp_hidden}->{SURFACE_Y_DIM}) "
+                f"with {n_correction:,} trainable params"
+            )
     if config.compile_model:
         model = torch.compile(model)
     n_params = sum(param.numel() for param in model.parameters())
+    n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
     if is_main:
-        print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+        print(
+            f"Model: SurfaceTransolver grouped surface+volume "
+            f"({n_params / 1e6:.2f}M params; {n_trainable / 1e6:.2f}M trainable)"
+        )
 
     if is_distributed:
         train_model = DistributedDataParallel(
@@ -2572,16 +2693,17 @@ def main(argv: Iterable[str] | None = None) -> None:
     else:
         train_model = model
 
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
     optimizer_name = config.optimizer.lower()
     if optimizer_name == "adamw":
         optimizer = torch.optim.AdamW(
-            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+            trainable_params, lr=config.lr, weight_decay=config.weight_decay
         )
     elif optimizer_name == "lion":
         from lion_pytorch import Lion
 
         optimizer = Lion(
-            model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+            trainable_params, lr=config.lr, weight_decay=config.weight_decay
         )
     elif optimizer_name == "muon":
         muon_2d_params = [p for p in model.parameters() if p.requires_grad and p.ndim == 2]
@@ -3033,7 +3155,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema_decay_now is not None:
                 train_log["train/ema_decay"] = ema_decay_now
             for key, value in batch_loss_metrics.items():
-                if key.startswith("film/"):
+                if key.startswith("film/") or key.startswith("correction/"):
                     train_log[f"train/{key}"] = value
             train_log.update(
                 train_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis

The current yi SOTA (val_abupt=7.3767%, W&B run `dc031qpt`) is a near-converged Transolver stack. The remaining per-axis errors are highly structured: τ_y and τ_z are 2.6× and 3.0× above the AB-UPT reference, while surface_p is only 1.27× above. This suggests the SOTA model has a systematic bias for wall-shear components that a lightweight correction head could absorb without retraining the expensive backbone.

**Hypothesis:** A lightweight residual-correction MLP — trained on top of the frozen SOTA checkpoint — can learn to predict the per-point residual error `ŷ_correction = y_true - ŷ_frozen`, yielding a corrected prediction `ŷ_final = ŷ_frozen + ŷ_correction`. This approach has zero risk of catastrophic forgetting (backbone frozen), near-zero GPU budget, and targets the highest-error channels (τ_y, τ_z) directly.

Prior art: Stacking a lightweight neural corrector on a physics/ML solver is a well-established technique in CFD (see Kochkov et al., 2021 "Machine learning–accelerated computational fluid dynamics"; Ren et al., 2022 "PhyCRNet").

## Instructions

The student must implement a two-stage training script based on `target/train.py`. The key idea:

**Stage 1 (this PR):** Load the frozen SOTA checkpoint, add a small correction MLP on top of the backbone output predictions, train *only* the correction MLP for 3–5 epochs.

Implement the following changes in a fork of `train.py` (e.g., `train_correction.py` or by adding flags to `train.py`):

### A. Add `--correction-mode` flag and `--correction-mlp-hidden` flag

```python
parser.add_argument('--correction-mode', action='store_true', default=False,
    help='If set, freeze backbone and train only a correction MLP on top of frozen SOTA predictions.')
parser.add_argument('--correction-mlp-hidden', type=int, default=64,
    help='Hidden dim of per-channel correction MLP (default 64).')
```

### B. CorrectionMLP architecture

Add a `CorrectionMLP` class. The correction network takes as input the frozen model's surface features (the intermediate node representations from the final Transolver layer, shape `[N, D]` where D=512) **concatenated with the coordinates** `[x, y, z]` and **the frozen predictions** `[τ_x, τ_y, τ_z, p]`, and outputs a per-point correction vector of shape `[N, 4]`:

```python
class CorrectionMLP(nn.Module):
    def __init__(self, input_dim: int, hidden_dim: int = 64, output_dim: int = 4):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(input_dim, hidden_dim),
            nn.GELU(),
            nn.Linear(hidden_dim, hidden_dim),
            nn.GELU(),
            nn.Linear(hidden_dim, output_dim),
        )
    
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        return self.net(x)
```

Input dim = 512 (backbone surface features) + 3 (coords) + 4 (frozen predictions) = 519.

### C. Expose intermediate surface features from Transolver

The backbone's `forward()` must return the pre-head surface node features (shape `[N, D]`) in addition to predictions. Add a `return_surface_features=False` kwarg to `Transolver.forward()`. When True, return `(preds, surface_feats)`. When False (default), return `preds` only (no behavior change for existing code).

### D. Freeze backbone, train only correction MLP

When `--correction-mode` is active:

```python
# After loading SOTA checkpoint (--resume-from required)
for param in model.parameters():
    param.requires_grad_(False)  # freeze everything

correction_mlp = CorrectionMLP(input_dim=519, hidden_dim=args.correction_mlp_hidden)
correction_mlp = correction_mlp.to(device)

# Only optimize correction_mlp
optimizer = Lion(correction_mlp.parameters(), lr=args.lr, weight_decay=args.weight_decay)
```

### E. Training loop modification

In the training step, when `--correction-mode` is active:
1. Run frozen `model` with `return_surface_features=True` to get `(preds, surface_feats)`
2. Detach `preds` and `surface_feats` (they're frozen)
3. Concatenate `[surface_feats, surface_coords, preds]` → feed through `correction_mlp`
4. Compute `final_preds = preds + correction_mlp_output` (surface only; volume predictions unchanged)
5. Compute loss as normal on `final_preds`

### F. Training run

Run two arms:

**Arm A — correction MLP hidden_dim=64:**
```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --resume-from /workspace/senpai/target/artifacts/pxsnrw36/checkpoint.pt \
  --agent norman \
  --wandb-group yi-round41-residual-correction \
  --wandb-name norman/correction-mlp-d64-frozen-sota \
  --correction-mode \
  --correction-mlp-hidden 64 \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --lr-warmup-steps 500 \
  --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 5 \
  --kill-thresholds "5400:val_primary/abupt_axis_mean_rel_l2_pct<7.5"
```

**Arm B — correction MLP hidden_dim=128:**
```bash
cd /workspace/senpai/target
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train.py \
  --resume-from /workspace/senpai/target/artifacts/pxsnrw36/checkpoint.pt \
  --agent norman \
  --wandb-group yi-round41-residual-correction \
  --wandb-name norman/correction-mlp-d128-frozen-sota \
  --correction-mode \
  --correction-mlp-hidden 128 \
  --learnable-pe \
  --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --lr-warmup-steps 500 \
  --ema-decay 0.999 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --epochs 5 \
  --kill-thresholds "5400:val_primary/abupt_axis_mean_rel_l2_pct<7.5"
```

Run Arm A first. If it doesn't break the 7.5% kill gate by EP1, close and do Arm B. If neither arm beats 7.3767%, report and close.

**Important:** The `pxsnrw36` checkpoint was trained with `surface_input_dim=4` (no k1_k2 curvature). Do **NOT** add `--surface-curvature-features k1_k2`, `--beta-nll-beta`, or `--grad-ema-alpha` when loading it.

## Kill gate

EP1 kill gate: val_abupt > 7.50% (correction MLP that can't beat the frozen baseline at EP1 is not learning useful residuals — close that arm immediately).

EP3 merge gate: val_abupt < 7.3767% required to beat baseline.

## Baseline

**Current yi SOTA (PR #681, nezuko, terminal LR polish lr=3e-7):**

| Metric | val | test |
|---|---:|---:|
| abupt_axis_mean_rel_l2_pct | **7.3767%** | **8.7015%** |
| surface_pressure_rel_l2_pct | 4.8515% | 4.6236% |
| wall_shear_rel_l2_pct | 8.3016% | 8.3214% |
| volume_pressure_rel_l2_pct | 4.3066% | 11.3738% |
| wall_shear_x_rel_l2_pct (τ_x) | 7.1045% | 7.1753% |
| wall_shear_y_rel_l2_pct (τ_y) | **9.5832%** | 9.5964% |
| wall_shear_z_rel_l2_pct (τ_z) | **11.0377%** | 10.7383% |

W&B baseline run: `dc031qpt` · Resumed from: `pxsnrw36` (PR #658)

**AB-UPT reference targets (test):**
- τ_y: 3.65% (yi is 2.6× above)
- τ_z: 3.63% (yi is 3.0× above)
- surface_p: 3.82% (yi is 1.21× above)

## Expected outcome

If the hypothesis is correct, the correction MLP should absorb the systematic τ_y/τ_z bias. Expected improvement: 0.1–0.5pp on val_abupt, concentrated on wall_shear_y and wall_shear_z. If no improvement at EP1, the residual structure may be too complex for a shallow MLP given the backbone features — report and close.

## Terminal result format

Post a single-line `SENPAI-RESULT` JSON with the best arm's metrics once both arms are complete (or after kill gate fires on the losing arm):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-run-id>","<arm-b-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<best_test>}}
```
