### PR TITLE
Multigrid hierarchical volume attention for vol_p val/test gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -3239,7 +3239,24 @@ def main(argv: Iterable[str] | None = None) -> None:
     resume_info: dict[str, float | str | int] = {}
     if config.resume_from:
         ckpt = torch.load(config.resume_from, map_location=device, weights_only=True)
-        model.load_state_dict(ckpt["model"], strict=True)
+        # Allow newly-added zero-init blocks (e.g. multigrid for PR #725) to be
+        # missing from the checkpoint while keeping unexpected-key checks strict.
+        load_strict = config.volume_multigrid_coarse_ratio <= 0.0
+        if load_strict:
+            model.load_state_dict(ckpt["model"], strict=True)
+        else:
+            missing, unexpected = model.load_state_dict(ckpt["model"], strict=False)
+            allowed_missing_prefix = ("volume_multigrid.",)
+            stray_missing = [k for k in missing if not k.startswith(allowed_missing_prefix)]
+            if stray_missing or unexpected:
+                raise RuntimeError(
+                    f"Resume state_dict mismatch: missing={stray_missing} unexpected={unexpected}"
+                )
+            if is_main:
+                print(
+                    f"Resumed with non-strict load: {len(missing)} multigrid keys "
+                    "initialized fresh (zero-init residual)"
+                )
         prev_epoch = ckpt.get("epoch", -1)
         prev_val_metrics = ckpt.get("val_metrics", {}) or {}
         prev_primary_val = float(

--- a/train.py
+++ b/train.py
@@ -848,6 +848,120 @@ class Transformer(nn.Module):
         return x
 
 
+class MultigridVolumeBlock(nn.Module):
+    """Hierarchical multigrid attention for the volume branch (PR #725).
+
+    Coarse-to-fine V-cycle: pick K = ratio * N coarse anchor points, run
+    self-attention on the coarse subset for global mixing (full K x K), then
+    cross-attend from all N volume features (queries) to the coarse tokens
+    (keys/values). The result is added as a zero-initialized residual to the
+    volume features, keeping the block as a no-op at step 0 and letting the
+    network learn to use it gradually.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        coarse_ratio: float,
+        coarse_attn_layers: int,
+        cross_heads: int,
+        mlp_ratio: int = 4,
+    ):
+        super().__init__()
+        if hidden_dim % cross_heads != 0:
+            raise ValueError("hidden_dim must be divisible by cross_heads")
+        self.hidden_dim = hidden_dim
+        self.coarse_ratio = float(coarse_ratio)
+        self.coarse_attn_layers_n = int(coarse_attn_layers)
+        self.cross_heads = int(cross_heads)
+        self.cross_head_dim = hidden_dim // cross_heads
+
+        self.coarse_attn_layers = nn.ModuleList(
+            [
+                nn.TransformerEncoderLayer(
+                    d_model=hidden_dim,
+                    nhead=num_heads,
+                    dim_feedforward=mlp_ratio * hidden_dim,
+                    dropout=0.0,
+                    activation="gelu",
+                    batch_first=True,
+                    norm_first=True,
+                )
+                for _ in range(coarse_attn_layers)
+            ]
+        )
+
+        self.cross_norm_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.cross_norm_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.cross_q_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.cross_k_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.cross_v_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.cross_out_proj = nn.Linear(hidden_dim, hidden_dim, bias=True)
+
+        nn.init.trunc_normal_(self.cross_q_proj.weight, std=0.02)
+        nn.init.trunc_normal_(self.cross_k_proj.weight, std=0.02)
+        nn.init.trunc_normal_(self.cross_v_proj.weight, std=0.02)
+        nn.init.zeros_(self.cross_out_proj.weight)
+        nn.init.zeros_(self.cross_out_proj.bias)
+
+    def select_coarse_indices(
+        self, num_points: int, device: torch.device
+    ) -> torch.Tensor:
+        K = max(64, int(num_points * self.coarse_ratio))
+        K = min(K, num_points)
+        if self.training:
+            return torch.randperm(num_points, device=device)[:K]
+        return torch.linspace(0, num_points - 1, K, device=device).long()
+
+    def forward(
+        self,
+        volume_features: torch.Tensor,
+        volume_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if self.coarse_ratio <= 0.0:
+            return volume_features
+
+        B, N, D = volume_features.shape
+        idx = self.select_coarse_indices(N, volume_features.device)
+        coarse = volume_features.index_select(1, idx)
+
+        coarse_kp_mask: torch.Tensor | None = None
+        if volume_mask is not None:
+            coarse_mask = volume_mask.index_select(1, idx)
+            coarse_kp_mask = ~coarse_mask.bool()
+            if coarse_kp_mask.all():
+                return volume_features
+
+        for layer in self.coarse_attn_layers:
+            coarse = layer(coarse, src_key_padding_mask=coarse_kp_mask)
+
+        q = self.cross_q_proj(self.cross_norm_q(volume_features))
+        kv = self.cross_norm_kv(coarse)
+        k = self.cross_k_proj(kv)
+        v = self.cross_v_proj(kv)
+
+        K = coarse.shape[1]
+        H, hd = self.cross_heads, self.cross_head_dim
+        q = q.view(B, N, H, hd).transpose(1, 2)
+        k = k.view(B, K, H, hd).transpose(1, 2)
+        v = v.view(B, K, H, hd).transpose(1, 2)
+
+        attn_mask: torch.Tensor | None = None
+        if coarse_kp_mask is not None:
+            attn_mask = torch.zeros(B, 1, 1, K, device=q.device, dtype=q.dtype)
+            attn_mask = attn_mask.masked_fill(
+                coarse_kp_mask[:, None, None, :], float("-inf")
+            )
+
+        out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+        out = out.transpose(1, 2).contiguous().view(B, N, D)
+        out = self.cross_out_proj(out)
+
+        return volume_features + out
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -871,6 +985,9 @@ class SurfaceTransolver(nn.Module):
         pos_max_wavelength: int = 1000,
         learnable_pe: bool = False,
         beta_nll: bool = False,
+        volume_multigrid_coarse_ratio: float = 0.0,
+        volume_multigrid_attn_layers: int = 2,
+        volume_multigrid_cross_heads: int = 8,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -918,6 +1035,18 @@ class SurfaceTransolver(nn.Module):
             film_geom_dim=film_encoder_dim if use_film else 0,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        self.volume_multigrid_coarse_ratio = float(volume_multigrid_coarse_ratio)
+        if self.volume_multigrid_coarse_ratio > 0.0:
+            self.volume_multigrid = MultigridVolumeBlock(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                coarse_ratio=volume_multigrid_coarse_ratio,
+                coarse_attn_layers=volume_multigrid_attn_layers,
+                cross_heads=volume_multigrid_cross_heads,
+                mlp_ratio=mlp_ratio,
+            )
+        else:
+            self.volume_multigrid = None
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
         if self.beta_nll:
@@ -1010,6 +1139,8 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
+            if self.volume_multigrid is not None:
+                volume_hidden = self.volume_multigrid(volume_hidden, volume_mask)
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
@@ -1251,6 +1382,9 @@ class Config:
     correction_mode: bool = False
     correction_mlp_hidden: int = 64
     ensemble_checkpoints: str = ""
+    volume_multigrid_coarse_ratio: float = 0.0
+    volume_multigrid_attn_layers: int = 2
+    volume_multigrid_cross_heads: int = 8
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -1458,6 +1592,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         learnable_pe=config.learnable_pe,
         surface_input_dim=surface_input_dim,
         beta_nll=config.beta_nll_beta >= 0.0,
+        volume_multigrid_coarse_ratio=config.volume_multigrid_coarse_ratio,
+        volume_multigrid_attn_layers=config.volume_multigrid_attn_layers,
+        volume_multigrid_cross_heads=config.volume_multigrid_cross_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Volume pressure in CFD is governed by an elliptic PDE (Laplace/Poisson). The biggest unexplained anomaly in the yi SOTA is the **volume_pressure val/test gap: 4.31% val vs 11.46% test** — a 2.66× split suggesting the model's single-resolution attention cannot resolve the long-range pressure correlations needed to generalize to unseen test geometries.

Multigrid methods (the canonical solver for elliptic PDEs) use coarse-to-fine resolution hierarchy: a coarse grid removes low-frequency errors cheaply, then a fine grid resolves high-frequency residuals. Adding an intra-volume hierarchical attention block — coarse global context via self-attention on a 10% point subset, then cross-attention from full-resolution points to the coarse tokens — should propagate global pressure gradients more efficiently and improve test generalization.

**Distinct from active work:**
- Emma's #654 (dual-tower): *cross-modal* surface↔volume. This is *intra-volume* hierarchical resolution — orthogonal mechanism, can compose later.
- Kohaku's #719 (SDF-stratified norm): fixes the gap via normalization. Multigrid fixes it via receptive field structure — orthogonal.

**Mathematical grounding:** Coarse attention (N_coarse = 6553, 10% of 65536) captures global elliptic pressure field structure (wake, stagnation zone, far-field). Fine cross-attention (N_fine = 65536) broadcasts that context to all volume points — exactly the "prolongation" step of multigrid. The coarse-fine separation decouples low-frequency global from high-frequency local modes.

## Implementation

Add a multigrid block in the **volume branch only**, inserted AFTER Transolver layers and BEFORE the final prediction MLP. No surface changes.

### Step 1 — CLI flags

```python
parser.add_argument('--volume-multigrid-coarse-ratio', type=float, default=0.0,
                    help='Fraction of volume points for coarse global context (0=disabled, e.g. 0.1)')
parser.add_argument('--volume-multigrid-attn-layers', type=int, default=2,
                    help='Number of self-attention layers on coarse subset')
parser.add_argument('--volume-multigrid-cross-heads', type=int, default=8,
                    help='Heads in fine→coarse cross-attention')
```

### Step 2 — Coarse subset selection

```python
def select_coarse(volume_feats, ratio, training: bool):
    N = volume_feats.size(1)
    K = max(64, int(N * ratio))
    if training:
        idx = torch.randperm(N, device=volume_feats.device)[:K]
    else:
        # Deterministic stride for consistent val/test evaluation
        idx = torch.linspace(0, N-1, K, device=volume_feats.device).long()
    return volume_feats[:, idx], idx
```

### Step 3 — Multigrid block

In `build_model` or the model class, when `volume_multigrid_coarse_ratio > 0`, initialize:

```python
self.coarse_attn_layers = nn.ModuleList([
    nn.TransformerEncoderLayer(d_model=n_hidden, nhead=n_heads,
                                dim_feedforward=4*n_hidden, batch_first=True,
                                norm_first=True)
    for _ in range(args.volume_multigrid_attn_layers)
])
self.cross_attn = nn.MultiheadAttention(
    embed_dim=n_hidden,
    num_heads=args.volume_multigrid_cross_heads,
    batch_first=True
)
```

Insert after Transolver volume encode, before prediction MLP:

```python
if self.volume_multigrid_coarse_ratio > 0:
    coarse, _ = select_coarse(volume_features, self.volume_multigrid_coarse_ratio, self.training)
    for layer in self.coarse_attn_layers:
        coarse = layer(coarse)
    attended, _ = self.cross_attn(query=volume_features, key=coarse, value=coarse)
    volume_features = volume_features + attended
```

### Step 4 — Param budget

- Coarse self-attn (2 layers, hidden 512, heads 8): ~3.2M extra params
- Cross-attn (512d, 8h): ~1.05M extra params  
- Total: ~4.3M extra (33% over 12.7M base)

If OOM at bs=4 → drop `--volume-multigrid-coarse-ratio` to 0.05 first (3277 points) before reducing batch size.

## Reproduce command — Arm A (cold-start, full yi SOTA stack + multigrid)

```bash
cd /workspace/senpai/target
torchrun --standalone --nproc_per_node=4 train.py \
  --agent violet \
  --wandb-group yi-round41-multigrid-volume \
  --wandb-name violet/multigrid-coarse010-fullstack \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 \
  --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 1 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --volume-multigrid-coarse-ratio 0.10 \
  --volume-multigrid-attn-layers 2 \
  --volume-multigrid-cross-heads 8 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --epochs 8
```

## Baseline — PR #681 nezuko, W&B run `dc031qpt`

| Metric | yi SOTA val | yi SOTA test | AB-UPT target |
|---|---:|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **7.3767%** | **8.7015%** | — |
| `surface_pressure_rel_l2_pct` | 4.8515% | 4.6236% | 3.82% |
| `wall_shear_rel_l2_pct` | 8.3016% | 8.3214% | 7.29% |
| `volume_pressure_rel_l2_pct` | **4.3066%** | **11.3738%** | 6.08% |
| `wall_shear_x_rel_l2_pct` | 7.1045% | 7.1753% | 5.35% |
| `wall_shear_y_rel_l2_pct` | 9.5832% | 9.5964% | 3.65% |
| `wall_shear_z_rel_l2_pct` | 11.0377% | 10.7383% | 3.63% |

**Primary merge criterion:** `val_primary/abupt_axis_mean_rel_l2_pct` < 7.3767%.

**Secondary diagnostic (novel for this experiment):** `test_primary/volume_pressure_rel_l2_pct` < 11.37% (target ≤9.0% for a strong result). This is the main mechanistic signal — even if val_abupt doesn't beat baseline, a large test_vp improvement would justify a continuation run.

## EP gates

- **EP1 gate**: val_abupt ≤ 20% → continue (cold-start + extra params = slower early convergence)
- **EP3 gate**: val_abupt ≤ 10.5% AND val_vp ≤ 5.5% → continue to full run
- **Terminal**: If val_vp shows ≥15% relative improvement vs baseline (4.31% → ≤3.66%) even without beating val_abupt bar, post results and flag as PROMISING for longer run

## Arm B (conditional on Arm A EP3)

If Arm A passes EP3, queue Arm B at `--volume-multigrid-coarse-ratio 0.05` (half the coarse tokens) to test robustness. Do NOT run Arms A and B in parallel.

## Result reporting

Report per-channel breakdown at EP1, EP3, and terminal. Include param count and VRAM. Headline metric is `test_primary/volume_pressure_rel_l2_pct` — report it prominently.

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"abupt_axis_mean_rel_l2_pct","value":<val_abupt>},"test_metric":{"name":"abupt_axis_mean_rel_l2_pct","value":<test_abupt>}}
```
