### PR TITLE
Exp 1B: Volume outlier-aware point sampling (Issue #717)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-05 (updated 12:40 UTC)
+- **Date:** 2026-05-05 (updated 15:30 UTC)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -43,8 +43,8 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 2. Optimizer / Training Dynamics (2 PRs in-flight)
 
-- **PR #667** (fern): Weight decay sweep {5e-4 control, 1e-3, 1e-4}. Arm A control complete: val=6.959% (timeout at EP4/13, 2.80× vol val→test gap fully present). Arm B (wd=1e-3) EP2 PASS at 8.670% (slightly worse than control 8.581%, vol_p +0.27pp worse). EP3 gate ETA ~13:35 UTC.
-- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Pre-EP1.
+- **PR #667** (fern): Weight decay sweep {5e-4 ctrl=6.959% test=8.135% vol-ratio 2.80×, 1e-3 final=6.913% test=8.097% vol-ratio 2.85×, 1e-4 running}. **Arm B finalized — WD direction scientifically null on volume val→test gap.** Test_vp essentially flat across WD values; ratio actually widened slightly with stronger WD. Arm C running for completeness.
+- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Silent since 13:20Z receipt; follow-up nudge posted 15:23Z requesting EP1 status.
 
 **Closed (null):**
 - PR #603 (tanjiro): EMA decay sweep — {0.9993, 0.9997, 0.9999} all no improvement.
@@ -57,8 +57,10 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 3. Attention Mechanism (2 PRs in-flight)
 
-- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64); arm-b: heads=2 (dim_head=256). Just assigned, pre-EP1.
-- **PR #665** (frieren): Cross-slice attention — adds global inter-slice MHA layer. Arm A control complete: val=6.9349% (timeout at EP4/13). Arm B (with cross-slice attn, +5.25M params, zero-init proj) EP1 −3.82pp ahead, but EP2 reversed: 10.92% PASS but +2.22pp behind control (wall-shear z +2.75pp regression). EP3 gate at high kill risk (ETA ~13:50 UTC).
+- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64) EP2 PASS 8.5458%; arm-b: heads=2 (dim_head=256) queued. EP3 watch for Arm A.
+
+**Closed (this round):**
+- PR #665 (frieren): Cross-slice attention — direction closed.
 
 **Open question:** Does more diverse (heads=8) or higher-capacity (heads=2) attention improve over SOTA heads=4? Does inter-slice attention capture global geometry correlations? (Early signal from PR #665: cross-slice attn slows late-EP convergence, likely due to +33% params needing more training to escape zero-init.)
 
@@ -73,6 +75,14 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 - L=6/hidden=448/heads=7 (PR #693): CLOSED — 98 min/epoch (heads=7 kills SDPA fast path). Key lesson: heads must be power-of-2 for budget-feasible training.
 
 **Open question:** Does L=6/hidden=384/heads=4 (PR #694) continue the depth scaling trend? Is slices=128 optimal or does smaller/larger over-fragment or under-communicate geometry (PR #690)?
+
+### 4b. Knowledge Distillation (1 PR in-flight)
+
+- **PR #676** (nezuko): K=7 ensemble teacher → student KD with kd_alpha sweep. **Arm A (kd-alpha=0.7) FINAL:** val=7.0153% test=8.2539% — misses merge bar 6.5985% by +0.42pp. **Budget-limited:** KD doubles per-step time (2.37 it/s vs ~5 it/s) → only 4 epochs in 270-min cap; trajectory slope at EP4 still -0.42pp/epoch (would plausibly cross merge bar at ~9 epochs). **Volume val→test ratio narrowed 3.17×→2.78×** — first lever in the round to actually move the chronic surface↔volume gap. Arm B (kd-alpha=0.5) launched 15:10Z. **Open follow-ups documented:** (a) batched KD cache / fused volume KD kernel to halve per-step overhead, (b) channel-selective KD on volume only, (c) T_max=4 cosine fix, (d) scheduled kd_alpha 0.9→0.1.
+
+### 4c. Boundary Condition Encoding (1 PR in-flight)
+
+- **PR #716** (frieren): nn.Embedding(3, 16) for wall=0/inlet=1/outlet=2 injected before Transolver encoder. Primary target: wall_shear_z (SOTA 9.81%). Hypothesis received 15:20Z; data-shape inspection requested.
 
 ### 5. Physics-Informed Loss / Output Formulation
 
@@ -91,22 +101,25 @@ All 8 students running:
 
 | Student | PR | Hypothesis | Status |
 |---|---|---|---|
-| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Just assigned — pre-EP1 |
-| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Just assigned — pre-EP1 |
-| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Just assigned — pre-EP1 |
-| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | Just assigned — pre-EP1 |
-| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Pre-EP1 |
-| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 EP2 PASS, 1e-4 queued} | Arm B EP3 gate ~13:35 UTC |
-| frieren | #665 | Cross-slice attention (Arm A=6.9349%, Arm B EP2 PASS but trailing) | Arm B EP3 gate ~13:50 UTC |
-| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha=0.7) | EP1=28.62%, EP2 gate ~12:56 UTC |
+| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Arm A heads=64 EP1 ~25.87%; EP2 gate watch |
+| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Arm A EP1 ~29.43%; EP2 gate watch |
+| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Arm A heads=8 EP2 PASS 8.5458%; EP3 gate next |
+| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | EP3 PASS 7.3175% (gap closing); EP4 final ETA ~15:43 UTC |
+| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Silent since 13:20Z ADVISOR receipt; follow-up nudge posted 15:23Z |
+| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 final=6.913%, 1e-4 running} | Arm B FINAL: WD direction scientifically null on volume gap; Arm C running |
+| frieren | #716 | BC-type embedding (nn.Embedding(3,16)) — wall_shear_z primary target | Hypothesis received; Arm A control + Arm B BC starting; EP1 watch |
+| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha sweep) | Arm A FINAL: val=7.0153% (misses bar, budget-limited); Arm B kd=0.5 running since 15:10Z |
 
 **Zero idle students. Zero idle GPUs.**
 
-**Upcoming gate actions:**
-- All new PRs (#690, #691, #692, #694, #695): EP1 informational (+ epoch-time gate for #694: kill if > 75 min/epoch), EP2 gate at step ~21,729 — KILL if > 12.0%; EP3 gate — KILL if > 8.0%
-- Fern PR #667 Arm B (wd=1e-3): EP3 gate ~13:35 UTC — KILL if > 8.0%; queue Arm C (wd=1e-4) if Arm B doesn't beat Arm A by ≥0.30pp
-- Frieren PR #665 Arm B (cross-slice attn): EP3 gate ~13:50 UTC — KILL if > 8.0%; high kill risk (needs 2.92pp drop in one epoch vs Arm A's 1.38pp)
-- Nezuko PR #676 Arm A (kd-alpha=0.7): EP2 gate ~12:56 UTC — KILL if > 12.0%
+**Upcoming gate actions (UTC):**
+- thorfinn PR #694: EP4 final ~15:43 — verdict on merge bar < 6.5985% (forecast 6.85–7.05%, tail ≤6.6%)
+- fern PR #667 Arm C (wd=1e-4): EP1 ~15:50 (info), EP2 ~17:05 (kill > 12%), EP3 ~18:20 (kill > 8%), final ~19:08
+- nezuko PR #676 Arm B (kd=0.5): EP2 ~17:30 (kill > 12%), EP3 ~18:45 (kill > 8%), final ~19:40
+- tanjiro PR #692 Arm A (heads=8): EP3 ~16:00 (kill > 8%), final ~16:21
+- askeladd PR #691, alphonse PR #690: EP2 gate watch (kill > 12%)
+- edward PR #695: pending student EP1 status update
+- frieren PR #716: data-shape inspection result + EP1 informational
 
 ---
 

--- a/train.py
+++ b/train.py
@@ -36,6 +36,9 @@ from data import DrivAerMLSurfaceDataset
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
+    CaseImportanceTracker,
+    DistributedWeightedSampler,
+    DrivAerMLEmphasisDataset,
     MetricSlopeTracker,
     TargetTransform,
     autocast_context,
@@ -54,6 +57,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    make_train_loader,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -137,6 +141,14 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_point_emphasis: str = "none"
+    vol_emphasis_ema_beta: float = 0.9
+    vol_emphasis_temperature: float = 0.5
+    vol_emphasis_geo_threshold: float = 0.3
+    vol_emphasis_geo_near_count: int = 1
+    vol_emphasis_geo_far_count: int = 3
+    vol_emphasis_warmup_epochs: int = 1
+    vol_emphasis_strata_cache_size: int = 32
     debug: bool = False
 
 
@@ -219,6 +231,70 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_point_emphasis": (
+            "Volume-point hard-example sampling mode. 'none' (default) uses "
+            "the existing uniform within-case + uniform across-cases "
+            "behaviour. 'ema_residual' (Arm A) maintains an EMA of mean "
+            "|residual| per training case on volume pressure (beta="
+            "--vol-emphasis-ema-beta) and at each epoch start builds a "
+            "DistributedWeightedSampler with case probability = softmax("
+            "importance / --vol-emphasis-temperature). Within each case, "
+            "volume points are still drawn uniformly. 'geometric_distance' "
+            "(Arm B) precomputes near/far strata from |volume_sdf| with "
+            "boundary --vol-emphasis-geo-threshold (metres) and samples "
+            "volume points with a fixed near:far count ratio of "
+            "--vol-emphasis-geo-near-count : --vol-emphasis-geo-far-count "
+            "(defaults 1:3) per case per step."
+        ),
+        "vol_emphasis_ema_beta": (
+            "EMA decay for the per-case volume-residual importance buffer "
+            "in --vol-point-emphasis ema_residual: importance[c] = beta * "
+            "importance[c] + (1-beta) * mean_abs_residual[c]. Default 0.9. "
+            "Only applies when --vol-point-emphasis=ema_residual."
+        ),
+        "vol_emphasis_temperature": (
+            "Softmax temperature for converting per-case importance into "
+            "case sampling probabilities in --vol-point-emphasis "
+            "ema_residual. Lower T concentrates more probability on "
+            "high-residual cases. Default 0.5. Only applies when "
+            "--vol-point-emphasis=ema_residual."
+        ),
+        "vol_emphasis_geo_threshold": (
+            "Distance threshold (metres) used by --vol-point-emphasis "
+            "geometric_distance to split volume points into near (|sdf| <= "
+            "threshold) and far (|sdf| > threshold) strata. Default 0.3. "
+            "Strata are precomputed from each case's volume_sdf.npy on "
+            "first access and cached per worker."
+        ),
+        "vol_emphasis_geo_near_count": (
+            "Near-stratum target count for stratified volume sampling in "
+            "--vol-point-emphasis geometric_distance. Combined with "
+            "--vol-emphasis-geo-far-count to define the near:far ratio. "
+            "With default 1:3 and --train-volume-points N, each case-step "
+            "draws floor(N/4) near points and 3*floor(N/4) far points. "
+            "Falls back gracefully when a stratum is empty or short."
+        ),
+        "vol_emphasis_geo_far_count": (
+            "Far-stratum target count for stratified volume sampling in "
+            "--vol-point-emphasis geometric_distance. See "
+            "--vol-emphasis-geo-near-count. Default 3 (=> 1:3 near:far)."
+        ),
+        "vol_emphasis_warmup_epochs": (
+            "Number of warmup epochs at the start of training during which "
+            "--vol-point-emphasis ema_residual still uses uniform case "
+            "sampling. Importance EMA is collected from epoch 0 but only "
+            "used to bias the sampler from epoch >= warmup_epochs. Default "
+            "1 (uniform for epoch 0, weighted from epoch 1 onwards). Set "
+            "to 0 to bias from the very first epoch."
+        ),
+        "vol_emphasis_strata_cache_size": (
+            "Per-worker LRU cache size (in cases) for the precomputed "
+            "near/far strata used by --vol-point-emphasis "
+            "geometric_distance. Each cached entry uses ~10MB (far) + "
+            "~50MB (near) of int64 indices. Default 32. Lower this if RAM "
+            "is constrained; raise it (or set to 0 for unbounded) if disk "
+            "I/O is the bottleneck."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -230,7 +306,53 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    valid_emphasis = ("none", "ema_residual", "geometric_distance")
+    if config.vol_point_emphasis not in valid_emphasis:
+        raise ValueError(
+            f"--vol-point-emphasis must be one of {valid_emphasis}; "
+            f"got {config.vol_point_emphasis!r}"
+        )
+    if config.vol_emphasis_ema_beta < 0.0 or config.vol_emphasis_ema_beta >= 1.0:
+        raise ValueError(
+            f"--vol-emphasis-ema-beta must be in [0.0, 1.0); "
+            f"got {config.vol_emphasis_ema_beta}"
+        )
+    if config.vol_emphasis_temperature <= 0.0:
+        raise ValueError(
+            f"--vol-emphasis-temperature must be > 0; "
+            f"got {config.vol_emphasis_temperature}"
+        )
+    if config.vol_emphasis_geo_threshold <= 0.0:
+        raise ValueError(
+            f"--vol-emphasis-geo-threshold must be > 0; "
+            f"got {config.vol_emphasis_geo_threshold}"
+        )
+    if config.vol_emphasis_geo_near_count < 0 or config.vol_emphasis_geo_far_count < 0:
+        raise ValueError(
+            "--vol-emphasis-geo-near-count and --vol-emphasis-geo-far-count must be >= 0"
+        )
+    if config.vol_emphasis_geo_near_count + config.vol_emphasis_geo_far_count <= 0:
+        raise ValueError(
+            "Sum of --vol-emphasis-geo-near-count and --vol-emphasis-geo-far-count must be > 0"
+        )
+    if config.vol_emphasis_warmup_epochs < 0:
+        raise ValueError(
+            f"--vol-emphasis-warmup-epochs must be >= 0; "
+            f"got {config.vol_emphasis_warmup_epochs}"
+        )
+    if config.vol_emphasis_strata_cache_size < 0:
+        raise ValueError(
+            f"--vol-emphasis-strata-cache-size must be >= 0; "
+            f"got {config.vol_emphasis_strata_cache_size}"
+        )
+    if config.vol_point_emphasis == "ema_residual" and config.use_gradnorm:
+        raise ValueError(
+            "--vol-point-emphasis ema_residual is not supported alongside "
+            "--use-gradnorm. The gradnorm path computes per-task losses but "
+            "does not surface volume predictions for the residual EMA hook."
+        )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -310,6 +432,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    importance_tracker: CaseImportanceTracker | None = None,
+    distributed_state=None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -335,6 +459,14 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+    if importance_tracker is not None:
+        importance_tracker.collect_batch(
+            volume_pred_norm=out["volume_preds"],
+            volume_target_norm=volume_target,
+            volume_mask=batch.volume_mask,
+            case_ids=batch.case_ids,
+            distributed_state=distributed_state,
+        )
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
@@ -653,45 +785,43 @@ def rebuild_train_loader_with_vol_points(
     old_train_loader: DataLoader,
     n_points: int,
     distributed_state,
-) -> DataLoader:
+) -> tuple[DataLoader, "DistributedSampler | DistributedWeightedSampler | None"]:
     """Rebuild the training DataLoader with a new max_volume_points value.
 
     Reuses the existing ``DrivAerMLCaseStore`` so cached point counts and
     artifact-path resolutions survive the swap. The view list is recomputed
     because ``max_volume_points`` changes the per-case view count, which in
     turn changes the dataset length that the distributed sampler must see.
+
+    Returns the loader and its sampler so the caller can ``set_epoch`` and
+    refresh weighted-sampler weights between epochs.
     """
 
     old_ds = old_train_loader.dataset
     sampling_mode = (
         "train_random" if (config.train_surface_points > 0 or n_points > 0) else "full"
     )
-    train_ds = DrivAerMLSurfaceDataset(
-        old_ds.case_ids,
-        store=old_ds.store,
-        max_surface_points=config.train_surface_points,
-        max_volume_points=n_points,
-        sampling_mode=sampling_mode,
-    )
-    train_sampler = None
-    train_shuffle = True
-    if distributed_state is not None and distributed_state.enabled:
-        train_sampler = DistributedSampler(
-            train_ds,
-            num_replicas=distributed_state.world_size,
-            rank=distributed_state.rank,
-            shuffle=True,
-            drop_last=True,
+    if config.vol_point_emphasis == "geometric_distance":
+        train_ds = DrivAerMLEmphasisDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+            geo_threshold=config.vol_emphasis_geo_threshold,
+            near_count=config.vol_emphasis_geo_near_count,
+            far_count=config.vol_emphasis_geo_far_count,
+            cache_size=config.vol_emphasis_strata_cache_size,
         )
-        train_shuffle = False
-    return DataLoader(
-        train_ds,
-        batch_size=config.batch_size,
-        shuffle=train_shuffle,
-        sampler=train_sampler,
-        drop_last=True,
-        **loader_kwargs(config),
-    )
+    else:
+        train_ds = DrivAerMLSurfaceDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+        )
+    return make_train_loader(config, train_ds, distributed_state)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -728,6 +858,31 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
+        importance_tracker: CaseImportanceTracker | None = None
+        if config.vol_point_emphasis == "ema_residual":
+            importance_tracker = CaseImportanceTracker(
+                train_loader.dataset.case_ids,
+                ema_beta=config.vol_emphasis_ema_beta,
+                temperature=config.vol_emphasis_temperature,
+                device=device,
+            )
+            if state.is_main:
+                print(
+                    f"Volume-point emphasis: ema_residual "
+                    f"(beta={config.vol_emphasis_ema_beta}, "
+                    f"T={config.vol_emphasis_temperature}, "
+                    f"warmup_epochs={config.vol_emphasis_warmup_epochs}, "
+                    f"n_train_cases={len(importance_tracker.case_ids)})"
+                )
+        elif config.vol_point_emphasis == "geometric_distance":
+            if state.is_main:
+                print(
+                    f"Volume-point emphasis: geometric_distance "
+                    f"(threshold={config.vol_emphasis_geo_threshold}m, "
+                    f"near:far ratio={config.vol_emphasis_geo_near_count}:"
+                    f"{config.vol_emphasis_geo_far_count}, "
+                    f"strata cache_size={config.vol_emphasis_strata_cache_size} cases/worker)"
+                )
         transform = TargetTransform(
             surface_y_mean=stats["surface_y_mean"].to(device),
             surface_y_std=stats["surface_y_std"].to(device),
@@ -885,11 +1040,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                             f"(was {current_train_vol_points})"
                         )
                     config.train_volume_points = desired_vol_points
-                    train_loader = rebuild_train_loader_with_vol_points(
+                    train_loader, _ = rebuild_train_loader_with_vol_points(
                         config, train_loader, desired_vol_points, state
                     )
                     current_train_vol_points = desired_vol_points
-            if isinstance(train_loader.sampler, DistributedSampler):
+            if importance_tracker is not None and isinstance(
+                train_loader.sampler, DistributedWeightedSampler
+            ):
+                use_weighted = epoch >= config.vol_emphasis_warmup_epochs
+                if use_weighted:
+                    weights = importance_tracker.case_view_weights(train_loader.dataset)
+                else:
+                    weights = torch.ones(len(train_loader.dataset), dtype=torch.float64)
+                train_loader.sampler.update_weights(weights)
+                train_loader.sampler.set_epoch(epoch)
+            elif isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
             timeout_hit = distributed_any(
                 state,
@@ -1008,6 +1173,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        importance_tracker=importance_tracker,
+                        distributed_state=state,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1160,6 +1327,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }
+            if importance_tracker is not None and state.is_main:
+                tracker_metrics = importance_tracker.diagnostic_metrics()
+                tracker_metrics["vol_emphasis/sampler_weighted_active"] = (
+                    1.0 if epoch >= config.vol_emphasis_warmup_epochs else 0.0
+                )
+                log_metrics.update(tracker_metrics)
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
                 wandb.log(log_metrics)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -23,14 +23,19 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, Sampler
 from torch.utils.data.distributed import DistributedSampler
 
+import numpy as np
+
 from data import (
     SURFACE_TARGET_NAMES,
     SurfaceBatch,
     VOLUME_TARGET_NAMES,
     VOLUME_Y_DIM,
+    DrivAerMLCase,
+    DrivAerMLSurfaceDataset,
     load_data,
     pad_collate,
 )
+from data.loader import _resolve_artifact_path
 
 
 class EMA:
@@ -269,22 +274,453 @@ def full_eval_loaders_from(
     }
 
 
-def make_loaders(
-    config,
-    distributed_state: DistributedState | None = None,
-) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
-    train_ds, val_splits, test_splits, stats = load_data(
-        manifest_path=config.manifest,
-        root=config.data_root or None,
-        train_surface_points=config.train_surface_points,
-        eval_surface_points=config.eval_surface_points,
-        train_volume_points=config.train_volume_points,
-        eval_volume_points=config.eval_volume_points,
-        debug=config.debug,
+class DrivAerMLEmphasisDataset(DrivAerMLSurfaceDataset):
+    """Train dataset variant with stratified volume-point sampling.
+
+    Replaces the uniform volume-point draw with a near/far split based on
+    each volume point's signed distance from the body surface (|sdf|), as
+    used by ``--vol-point-emphasis geometric_distance``. Only the volume
+    sampling is modified; surface sampling, view layout, and eval paths
+    fall back to the parent ``DrivAerMLSurfaceDataset`` behaviour.
+
+    Strata indices for each case are precomputed lazily on first access
+    by reading ``volume_sdf.npy`` once and held in a per-instance LRU
+    cache (``cache_size`` cases). With DataLoader ``num_workers > 0`` each
+    worker maintains its own cache; the OS page cache amortises the
+    ``volume_sdf.npy`` reads across workers.
+    """
+
+    def __init__(
+        self,
+        *args,
+        geo_threshold: float = 0.3,
+        near_count: int = 1,
+        far_count: int = 3,
+        cache_size: int = 32,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if geo_threshold <= 0.0:
+            raise ValueError(f"geo_threshold must be > 0; got {geo_threshold}")
+        if near_count < 0 or far_count < 0:
+            raise ValueError(
+                f"near_count={near_count}, far_count={far_count} must both be >= 0"
+            )
+        if near_count + far_count <= 0:
+            raise ValueError("near_count + far_count must be > 0")
+        self.geo_threshold = float(geo_threshold)
+        self.near_count = int(near_count)
+        self.far_count = int(far_count)
+        self.cache_size = int(cache_size)
+        self._strata_cache: "dict[str, tuple[np.ndarray, np.ndarray]]" = {}
+        self._strata_order: list[str] = []
+
+    def _load_strata(self, case_id: str) -> tuple[np.ndarray, np.ndarray]:
+        cached = self._strata_cache.get(case_id)
+        if cached is not None:
+            if self._strata_order[-1] != case_id:
+                self._strata_order.remove(case_id)
+                self._strata_order.append(case_id)
+            return cached
+        sdf_path = self.store.root / case_id / "volume_sdf.npy"
+        sdf_resolved = _resolve_artifact_path(sdf_path)
+        sdf = np.load(sdf_resolved, mmap_mode="r")
+        sdf_abs = np.abs(np.asarray(sdf, dtype=np.float32).reshape(-1))
+        near_mask = sdf_abs <= self.geo_threshold
+        near_idx = np.flatnonzero(near_mask).astype(np.int64)
+        far_idx = np.flatnonzero(~near_mask).astype(np.int64)
+        entry = (near_idx, far_idx)
+        if self.cache_size > 0:
+            while len(self._strata_order) >= self.cache_size:
+                evict = self._strata_order.pop(0)
+                self._strata_cache.pop(evict, None)
+            self._strata_cache[case_id] = entry
+            self._strata_order.append(case_id)
+        return entry
+
+    def _stratified_volume_indices(
+        self,
+        *,
+        case_id: str,
+        total: int,
+        count: int,
+        view,
+    ) -> torch.Tensor | None:
+        if view.view_index >= view.volume_view_count:
+            return torch.empty(0, dtype=torch.long)
+        if count <= 0 or total <= count:
+            return None if view.view_index == 0 else torch.empty(0, dtype=torch.long)
+        if view.sampling_mode != "train_random":
+            return self._indices(
+                total, count, view, group_view_count=view.volume_view_count
+            )
+
+        near_idx, far_idx = self._load_strata(case_id)
+        ratio_total = self.near_count + self.far_count
+        n_near_target = (count * self.near_count) // ratio_total
+        n_far_target = count - n_near_target
+
+        n_near = min(n_near_target, len(near_idx))
+        n_far = min(n_far_target, len(far_idx))
+        remaining = count - n_near - n_far
+        if remaining > 0:
+            far_slack = len(far_idx) - n_far
+            near_slack = len(near_idx) - n_near
+            if far_slack > 0 and (n_near < n_near_target or near_slack <= 0):
+                take = min(remaining, far_slack)
+                n_far += take
+                remaining -= take
+            if remaining > 0 and near_slack > 0:
+                take = min(remaining, near_slack)
+                n_near += take
+                remaining -= take
+        # Edge case: both strata exhausted of unique points; sample with
+        # replacement from whichever is non-empty to keep the contract that
+        # we always return ``count`` indices when total > count.
+        parts: list[np.ndarray] = []
+        if n_near > 0 and len(near_idx) > 0:
+            sel = torch.randint(len(near_idx), (n_near,), dtype=torch.long).numpy()
+            parts.append(near_idx[sel])
+        if n_far > 0 and len(far_idx) > 0:
+            sel = torch.randint(len(far_idx), (n_far,), dtype=torch.long).numpy()
+            parts.append(far_idx[sel])
+        if remaining > 0:
+            pool = far_idx if len(far_idx) >= len(near_idx) else near_idx
+            if len(pool) == 0:
+                pool = far_idx if len(far_idx) > 0 else near_idx
+            if len(pool) > 0:
+                sel = torch.randint(len(pool), (remaining,), dtype=torch.long).numpy()
+                parts.append(pool[sel])
+        if not parts:
+            return torch.empty(0, dtype=torch.long)
+        result = np.concatenate(parts)
+        result.sort()
+        return torch.from_numpy(result)
+
+    def __getitem__(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        if view.sampling_mode != "train_random":
+            return super().__getitem__(idx)
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+        volume_idx = self._stratified_volume_indices(
+            case_id=view.case_id,
+            total=counts["n_volume"],
+            count=self.max_volume_points,
+            view=view,
+        )
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=None if volume_idx is None else volume_idx.numpy(),
+        )
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = view.sampling_mode + "_geo_strat"
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+
+class DistributedWeightedSampler(Sampler[int]):
+    """DDP-aware weighted random sampler with replacement.
+
+    Each rank seeds the same generator with ``base_seed + epoch`` and
+    draws an identical multinomial sequence of length
+    ``num_samples`` (rounded down to a multiple of ``num_replicas`` for
+    drop-last semantics). Each rank then takes its strided slice. Weights
+    can be refreshed between epochs via ``update_weights`` and the epoch
+    seed advanced via ``set_epoch``.
+    """
+
+    def __init__(
+        self,
+        weights,
+        *,
+        num_replicas: int,
+        rank: int,
+        num_samples: int | None = None,
+        seed: int = 0,
+    ) -> None:
+        if num_replicas < 1:
+            raise ValueError(f"num_replicas must be >= 1; got {num_replicas}")
+        if rank < 0 or rank >= num_replicas:
+            raise ValueError(
+                f"rank must be in [0, {num_replicas}); got {rank}"
+            )
+        self._set_weights(weights)
+        self.num_replicas = int(num_replicas)
+        self.rank = int(rank)
+        self.seed = int(seed)
+        self.epoch = 0
+        if num_samples is None:
+            num_samples = int(self.weights.shape[0])
+        self.total_samples = (int(num_samples) // self.num_replicas) * self.num_replicas
+        if self.total_samples <= 0:
+            raise ValueError(
+                f"DistributedWeightedSampler total_samples is 0 "
+                f"(num_samples={num_samples}, num_replicas={num_replicas})"
+            )
+        self.per_rank = self.total_samples // self.num_replicas
+
+    def _set_weights(self, weights) -> None:
+        tensor = torch.as_tensor(weights, dtype=torch.float64)
+        if tensor.ndim != 1:
+            raise ValueError(
+                f"DistributedWeightedSampler weights must be 1-D; got shape {tensor.shape}"
+            )
+        positive = (tensor > 0).any()
+        if not bool(positive.item()):
+            raise ValueError(
+                "DistributedWeightedSampler requires at least one positive weight"
+            )
+        self.weights = tensor
+
+    def update_weights(self, weights) -> None:
+        new_w = torch.as_tensor(weights, dtype=torch.float64)
+        if new_w.shape != self.weights.shape:
+            raise ValueError(
+                f"Weight shape {tuple(new_w.shape)} != existing {tuple(self.weights.shape)}"
+            )
+        self._set_weights(new_w)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = int(epoch)
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + self.epoch)
+        all_idx = torch.multinomial(
+            self.weights,
+            self.total_samples,
+            replacement=True,
+            generator=generator,
+        )
+        idx = all_idx[self.rank :: self.num_replicas]
+        return iter(int(i) for i in idx.tolist())
+
+    def __len__(self) -> int:
+        return self.per_rank
+
+
+class CaseImportanceTracker:
+    """Per-case EMA of volume-pressure |residual| for emphasis sampling.
+
+    Holds ``importance[c] = beta * importance[c] + (1-beta) * mean |residual_c|``
+    for every training case, where the residual is computed in the
+    transform's normalised volume space (matches the training loss). Only
+    cases that appeared in the most recent global step are updated.
+    Across DDP ranks, per-case sums and counts are all-reduced before the
+    EMA step so every rank holds the same buffer.
+    """
+
+    def __init__(
+        self,
+        case_ids: Iterable[str],
+        *,
+        ema_beta: float,
+        temperature: float,
+        device: torch.device,
+    ) -> None:
+        if not (0.0 <= ema_beta < 1.0):
+            raise ValueError(f"ema_beta must be in [0, 1); got {ema_beta}")
+        if temperature <= 0.0:
+            raise ValueError(f"temperature must be > 0; got {temperature}")
+        self.case_ids: list[str] = list(case_ids)
+        if not self.case_ids:
+            raise ValueError("CaseImportanceTracker requires at least one case_id")
+        self.case_id_to_idx: dict[str, int] = {
+            cid: i for i, cid in enumerate(self.case_ids)
+        }
+        self.ema_beta = float(ema_beta)
+        self.temperature = float(temperature)
+        self.device = device
+        self.importance = torch.ones(len(self.case_ids), device=device, dtype=torch.float32)
+        self.update_count = 0
+        # Diagnostics for logging.
+        self.last_appeared = 0
+        self.last_avg_residual = 0.0
+
+    @torch.no_grad()
+    def collect_batch(
+        self,
+        *,
+        volume_pred_norm: torch.Tensor,
+        volume_target_norm: torch.Tensor,
+        volume_mask: torch.Tensor,
+        case_ids: list[str],
+        distributed_state: DistributedState | None = None,
+    ) -> None:
+        """Update the EMA buffer with the current batch's per-case residuals.
+
+        ``volume_pred_norm`` and ``volume_target_norm`` are expected in the
+        normalised volume-pressure space used by the training loss
+        (``transform.apply_volume`` output).
+        """
+
+        residual = (volume_pred_norm.detach() - volume_target_norm.detach()).abs().float()
+        # Pad mask along channel dim if needed.
+        mask = volume_mask
+        while mask.ndim < residual.ndim:
+            mask = mask.unsqueeze(-1)
+        mask_f = mask.to(dtype=residual.dtype)
+        weighted = residual * mask_f
+        sum_resid = weighted.flatten(1).sum(dim=1)  # [B]
+        count = mask_f.flatten(1).sum(dim=1).clamp(min=1.0)  # [B]
+        per_case_resid = (sum_resid / count).to(self.device)
+
+        n_cases = self.importance.shape[0]
+        sum_buf = torch.zeros(n_cases, device=self.device, dtype=torch.float32)
+        cnt_buf = torch.zeros(n_cases, device=self.device, dtype=torch.float32)
+        for i, cid in enumerate(case_ids):
+            idx = self.case_id_to_idx.get(cid)
+            if idx is None:
+                continue
+            sum_buf[idx] = sum_buf[idx] + per_case_resid[i]
+            cnt_buf[idx] = cnt_buf[idx] + 1.0
+
+        if distributed_state is not None and distributed_state.enabled:
+            dist.all_reduce(sum_buf, op=dist.ReduceOp.SUM)
+            dist.all_reduce(cnt_buf, op=dist.ReduceOp.SUM)
+
+        appeared = cnt_buf > 0
+        avg_resid = sum_buf / cnt_buf.clamp(min=1.0)
+        new_importance = (
+            self.ema_beta * self.importance + (1.0 - self.ema_beta) * avg_resid
+        )
+        self.importance = torch.where(appeared, new_importance, self.importance)
+        self.update_count += 1
+        self.last_appeared = int(appeared.sum().item())
+        if self.last_appeared > 0:
+            self.last_avg_residual = float(avg_resid[appeared].mean().item())
+
+    def case_probabilities(self) -> torch.Tensor:
+        x = self.importance / self.temperature
+        x = x - x.max()
+        w = x.exp()
+        return (w / w.sum().clamp(min=1e-12)).cpu()
+
+    def case_view_weights(self, dataset) -> torch.Tensor:
+        """Build a per-view weight tensor for ``DistributedWeightedSampler``.
+
+        Within a case, weight is split evenly across the case's joint
+        views so that the marginal probability of selecting any view from
+        that case equals ``case_probabilities()[c]``.
+        """
+
+        probs = self.case_probabilities().tolist()
+        weights = torch.empty(len(dataset.views), dtype=torch.float64)
+        for i, view in enumerate(dataset.views):
+            cidx = self.case_id_to_idx.get(view.case_id)
+            if cidx is None:
+                weights[i] = 0.0
+                continue
+            weights[i] = probs[cidx] / float(max(view.view_count, 1))
+        return weights
+
+    @torch.no_grad()
+    def diagnostic_metrics(self) -> dict[str, float]:
+        if self.importance.numel() == 0:
+            return {}
+        probs = self.case_probabilities()
+        imp = self.importance.float().detach().cpu()
+        # Effective number of active cases via Shannon entropy.
+        log_p = torch.log(probs.clamp(min=1e-12))
+        entropy = float(-(probs * log_p).sum().item())
+        max_p = float(probs.max().item())
+        min_p = float(probs.min().item())
+        n = len(self.case_ids)
+        return {
+            "vol_emphasis/importance/mean": float(imp.mean().item()),
+            "vol_emphasis/importance/std": float(imp.std().item()),
+            "vol_emphasis/importance/min": float(imp.min().item()),
+            "vol_emphasis/importance/max": float(imp.max().item()),
+            "vol_emphasis/probability/min": min_p,
+            "vol_emphasis/probability/max": max_p,
+            "vol_emphasis/probability/max_to_uniform_ratio": max_p * n,
+            "vol_emphasis/probability/effective_cases_exp_entropy": math.exp(entropy),
+            "vol_emphasis/update_count": float(self.update_count),
+            "vol_emphasis/last_appeared_cases": float(self.last_appeared),
+            "vol_emphasis/last_avg_residual": float(self.last_avg_residual),
+        }
+
+
+def _build_train_dataset(config, case_ids, store, max_volume_points, sampling_mode):
+    """Construct the training dataset, swapping in the emphasis variant when needed."""
+
+    if config.vol_point_emphasis == "geometric_distance":
+        return DrivAerMLEmphasisDataset(
+            case_ids,
+            store=store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=max_volume_points,
+            sampling_mode=sampling_mode,
+            geo_threshold=config.vol_emphasis_geo_threshold,
+            near_count=config.vol_emphasis_geo_near_count,
+            far_count=config.vol_emphasis_geo_far_count,
+            cache_size=config.vol_emphasis_strata_cache_size,
+        )
+    return DrivAerMLSurfaceDataset(
+        case_ids,
+        store=store,
+        max_surface_points=config.train_surface_points,
+        max_volume_points=max_volume_points,
+        sampling_mode=sampling_mode,
     )
-    train_sampler = None
+
+
+def make_train_loader(
+    config,
+    train_ds,
+    distributed_state: DistributedState | None,
+    *,
+    case_ids: Iterable[str] | None = None,
+    weighted_sampler: "DistributedWeightedSampler | None" = None,
+) -> tuple[DataLoader, "DistributedSampler | DistributedWeightedSampler | None"]:
+    """Wrap the train dataset in the right sampler for the chosen emphasis mode.
+
+    Returns the loader and the sampler so callers can call ``set_epoch`` /
+    ``update_weights`` between epochs.
+    """
+
+    train_sampler: DistributedSampler | DistributedWeightedSampler | None = None
     train_shuffle = True
-    if distributed_state is not None and distributed_state.enabled:
+    use_weighted = config.vol_point_emphasis == "ema_residual"
+    if use_weighted:
+        if distributed_state is None or not distributed_state.enabled:
+            num_replicas, rank = 1, 0
+        else:
+            num_replicas, rank = distributed_state.world_size, distributed_state.rank
+        if weighted_sampler is None:
+            uniform = torch.ones(len(train_ds), dtype=torch.float64)
+            weighted_sampler = DistributedWeightedSampler(
+                uniform,
+                num_replicas=num_replicas,
+                rank=rank,
+                num_samples=len(train_ds),
+            )
+        train_sampler = weighted_sampler
+        train_shuffle = False
+    elif distributed_state is not None and distributed_state.enabled:
         train_sampler = DistributedSampler(
             train_ds,
             num_replicas=distributed_state.world_size,
@@ -300,6 +736,41 @@ def make_loaders(
         sampler=train_sampler,
         drop_last=True,
         **loader_kwargs(config),
+    )
+    return train_loader, train_sampler
+
+
+def make_loaders(
+    config,
+    distributed_state: DistributedState | None = None,
+) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
+    train_ds, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=config.debug,
+    )
+    if config.vol_point_emphasis == "geometric_distance":
+        # Swap in the stratified-volume variant; reuse the loaded store so
+        # cached point counts and artifact-path resolutions survive.
+        train_ds = DrivAerMLEmphasisDataset(
+            train_ds.case_ids,
+            store=train_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=config.train_volume_points,
+            sampling_mode=train_ds.sampling_mode,
+            geo_threshold=config.vol_emphasis_geo_threshold,
+            near_count=config.vol_emphasis_geo_near_count,
+            far_count=config.vol_emphasis_geo_far_count,
+            cache_size=config.vol_emphasis_strata_cache_size,
+        )
+    train_loader, _ = make_train_loader(
+        config,
+        train_ds,
+        distributed_state,
     )
     val_loaders = {
         name: eval_loader_for_dataset(ds, config, distributed_state=distributed_state)


### PR DESCRIPTION
## Hypothesis

The chronic 3× volume_pressure test-vs-val gap (val≈3.9%, test≈11.5%) likely stems from a combination of two factors: (1) the training distribution underrepresents geometrically complex cases (e.g. far-wake vortex shedding regions, underbody diffuser outflow), and (2) the uniform random volume-point sampling during training means difficult high-variance points are seen with the same frequency as easy near-zero-pressure points.

**Exp 1B: Volume Anomaly/Outlier-Aware Sampling** — implement per-case variance-weighted sampling of volume points during training. After each mini-batch forward pass, compute per-point residuals on volume pressure. Maintain a running EMA of per-point loss magnitude across training. Use these per-point importance scores to bias the volume point sampling toward high-loss regions, forcing the model to focus compute budget on hard vortex-dominated far-wake predictions.

This is analogous to the "hard-example mining" approach from metric learning (Schroff et al. 2015, FaceNet) but applied per-point rather than per-image. The key insight: if we consistently sample more points from the high-residual volume regions, the model gets proportionally more gradient signal from the problematic far-wake pressure field.

**Two arms:**
- **Arm A** (`emphasis_mode=ema_residual`): EMA of per-point |residual| used as point sampling probability, temperature-softened with T=0.5
- **Arm B** (`emphasis_mode=geometric_distance`): Use volumetric distance from the car body surface as a proxy for "difficult" regions (far-wake). Points with distance > 0.3m get 3× upsampled probability vs baseline.

Both arms use the same SOTA training config and only modify the volume point sampling distribution.

## Instructions

Add a `--vol-point-emphasis` CLI flag to `target/train.py` (and `trainer_runtime.py` as needed). Implement two modes:

### New CLI flag:
```
--vol-point-emphasis {none,ema_residual,geometric_distance}
```
Default: `none` (identical to current behavior).

### Arm A: `ema_residual` mode

1. After each forward pass on volume points, compute `residuals = (pred_pressure - gt_pressure).abs()` for each volume point in the batch. Shape: `[B, N_vol]`.

2. Maintain a per-sample-per-point EMA buffer. However since per-point buffers are large, maintain a **per-sample importance score** (one scalar per training case) as the mean absolute residual across all its volume points: `importance[case_idx] = ema_beta * importance[case_idx] + (1-ema_beta) * residuals.mean(dim=-1)`. Use `ema_beta=0.9`.

3. At the start of each epoch, convert `importance` to a **case-level sampling probability** (softmax with temperature T=0.5). Use this to construct a `WeightedRandomSampler` for the training DataLoader. Cases with higher volume-pressure error are sampled more frequently within the epoch.

4. Within each batch, volume points are still drawn uniformly at random from each case's volume mesh (existing behavior). Only the case-level sampling distribution changes.

5. Normalize the case sampling weights at the start of each epoch so that the total number of training steps per epoch is unchanged.

### Arm B: `geometric_distance` mode

1. For each training case, precompute the distance of each volume point from the nearest surface mesh point. Cache this on first forward pass.

2. Volume points are split into `near` (distance ≤ 0.3m) and `far` (distance > 0.3m) strata. During training, sample volume points with a 1:3 near-to-far ratio (instead of the current uniform ratio). That is, of the `--train-volume-points N` points sampled per case per step, take floor(N/4) from `near` and 3*floor(N/4) from `far`. If either stratum has fewer points than required, fall back to that stratum's full set and supplement from the other.

3. No change to loss weighting — the emphasis comes purely from the point sampling distribution.

### Common to both arms:
- Add `--vol-point-emphasis` to the argument parser (default `none`).
- When `none`, behavior is identical to current code — no regression risk.
- Log the emphasis mode and parameters to W&B config.
- Use `--wandb-group frieren-vol-emphasis-sweep` for both arms.

### Run commands:

**Arm A (ema_residual):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-point-emphasis ema_residual \
  --wandb-group frieren-vol-emphasis-sweep --wandb-name frieren/vol-emphasis-ema
```

**Arm B (geometric_distance):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-point-emphasis geometric_distance \
  --wandb-group frieren-vol-emphasis-sweep --wandb-name frieren/vol-emphasis-geodist
```

Run Arm A first. Apply standard gates: EP1 epoch-time (kill if > 80min), EP2 kill if val_abupt > 12%, EP3 kill if val_abupt > 8%. If Arm A passes all gates, run Arm B. Report both arm results.

**Key metric to watch:** `val_primary/volume_pressure_rel_l2_pct` — does it drop below 3.9% (current val) or more importantly does the test metric approach below 10.0% (Issue #717 Solid win)?

## Baseline

Current single-model SOTA: PR #592 (alphonse, `alphonse/depth-L5`)
- W&B run: `4k25s25e` (group: `model-depth-sweep`)
- **val_abupt: 6.5985%** (gate — must beat to update SOTA)
- val surface_pressure: 4.3322% | val volume_pressure: 3.9456%
- val wall_shear_x: 6.5420% / wall_shear_y: 8.3631% / wall_shear_z: 9.8099%
- test_abupt: 7.9915% | test vol_pressure: ~11.69%

Issue #717 vol_pressure targets: Weak win ≤ 10.8% | Solid win ≤ 10.0% | Major win ≤ 9.5%

**Hard constraint:** Zero model ensembling. All metrics must be single-model only.
