### PR TITLE
Exp 1D: Single-model KD from K=7 ensemble (Issue #717)

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -40,8 +40,10 @@ import torch.nn as nn
 import wandb
 import yaml
 
-from data import load_data, pad_collate
-from data.loader import SurfaceBatch
+import numpy as np
+
+from data import DrivAerMLSurfaceDataset, load_data, pad_collate
+from data.loader import DrivAerMLCaseStore, SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EvalAccumulator,
@@ -663,9 +665,13 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--split",
         nargs="+",
-        choices=["val", "test"],
+        choices=["train", "val", "test"],
         default=["val", "test"],
-        help="Which splits to evaluate the ensemble on.",
+        help=(
+            "Which splits to evaluate the ensemble on. 'train' is only "
+            "supported with --build-kd-cache (full-fidelity per-case averaged "
+            "predictions for offline knowledge distillation)."
+        ),
     )
     parser.add_argument("--eval-surface-points", type=int, default=65536)
     parser.add_argument("--eval-volume-points", type=int, default=65536)
@@ -760,13 +766,74 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
             "then exit. Used for distributing inference across GPUs."
         ),
     )
+    parser.add_argument(
+        "--build-kd-cache",
+        type=str,
+        default="",
+        help=(
+            "Output directory for the per-case averaged ensemble predictions "
+            "used as soft targets in knowledge distillation. When set, the "
+            "tool runs in build-kd-cache mode: it loads the K members listed "
+            "via --candidate-run-ids (or --run-ids), iterates each requested "
+            "split (train/val/test) with deterministic eval_chunk sampling, "
+            "averages predictions across the K members, and writes per-case "
+            "full arrays as float16 .npy files at "
+            "<dir>/<split>/<case_id>/{surface_pred,volume_pred}.npy. Idempotent: "
+            "cases whose files already exist are skipped, so runs can be split "
+            "across multiple processes."
+        ),
+    )
+    parser.add_argument(
+        "--kd-cache-channels",
+        type=str,
+        default="all",
+        choices=["all", "vol_only"],
+        help=(
+            "Which channels to cache when --build-kd-cache is set. 'vol_only' "
+            "writes only the volume_pressure soft targets (~14GB total across "
+            "all splits). Default 'all' caches both surface (4 channels) and "
+            "volume (1 channel) in case the experiment widens to all-channel KD."
+        ),
+    )
+    parser.add_argument(
+        "--kd-cache-case-stride",
+        type=int,
+        default=1,
+        help=(
+            "Process every k-th case for --build-kd-cache. Combined with "
+            "--kd-cache-case-offset, this lets multiple worker processes "
+            "(each pinned to a different GPU via CUDA_VISIBLE_DEVICES) cover "
+            "disjoint case slices in parallel."
+        ),
+    )
+    parser.add_argument(
+        "--kd-cache-case-offset",
+        type=int,
+        default=0,
+        help="Start offset for --kd-cache-case-stride sharding (default 0).",
+    )
     args = parser.parse_args(argv)
-    if args.greedy:
+    if args.build_kd_cache:
+        ids_set = bool(args.run_ids) or bool(args.candidate_run_ids.strip())
+        if not ids_set:
+            parser.error(
+                "--build-kd-cache requires --run-ids or --candidate-run-ids "
+                "(comma-separated)."
+            )
+    elif args.greedy:
         if not args.candidate_run_ids.strip():
             parser.error("--greedy requires --candidate-run-ids")
+        if "train" in args.split:
+            parser.error(
+                "--split train is only supported alongside --build-kd-cache."
+            )
     else:
         if not args.run_ids:
             parser.error("--run-ids is required when --greedy is not set")
+        if "train" in args.split:
+            parser.error(
+                "--split train is only supported alongside --build-kd-cache."
+            )
     return args
 
 
@@ -1135,8 +1202,323 @@ def main_greedy(args: argparse.Namespace) -> None:
         wandb.finish()
 
 
+def kd_cache_paths(output_dir: Path, split: str, case_id: str) -> dict[str, Path]:
+    case_dir = output_dir / split / case_id
+    return {
+        "case_dir": case_dir,
+        "surface_pred": case_dir / "surface_pred.npy",
+        "volume_pred": case_dir / "volume_pred.npy",
+        "_done": case_dir / "_done",
+    }
+
+
+@torch.no_grad()
+def _ensemble_average_batch(
+    members: list[SurfaceTransolver],
+    batch,
+    device: torch.device,
+    amp_mode: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run K members forward, return averaged surface/volume normalized preds."""
+
+    sum_surf: torch.Tensor | None = None
+    sum_vol: torch.Tensor | None = None
+    for model in members:
+        with autocast_context(device, amp_mode):
+            out = model(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+        sp = out["surface_preds"].float()
+        vp = out["volume_preds"].float()
+        sum_surf = sp if sum_surf is None else sum_surf + sp
+        sum_vol = vp if sum_vol is None else sum_vol + vp
+    k = float(len(members))
+    return sum_surf / k, sum_vol / k
+
+
+def _strided_indices(view_index: int, total: int, view_count: int) -> np.ndarray:
+    """Mirror loader's eval_chunk indexing: torch.arange(view_index, total, view_count)."""
+
+    return np.arange(view_index, total, view_count, dtype=np.int64)
+
+
+def build_kd_cache_for_split(
+    members: list[SurfaceTransolver],
+    *,
+    split: str,
+    case_ids: list[str],
+    store: DrivAerMLCaseStore,
+    eval_surface_points: int,
+    eval_volume_points: int,
+    output_dir: Path,
+    device: torch.device,
+    amp_mode: str,
+    save_surface: bool,
+    save_volume: bool,
+    case_stride: int = 1,
+    case_offset: int = 0,
+    num_workers: int = 4,
+    batch_size: int = 1,
+) -> int:
+    """Cache K-averaged ensemble predictions per case for one split.
+
+    For each requested case, build a single-case ``eval_chunk`` dataset/loader,
+    run the K members on every chunk, average the normalized predictions
+    across members, and place each chunk's predictions at the strided rows of
+    a per-case full-size buffer. Once all chunks are processed, write the full
+    buffer to ``<output_dir>/<split>/<case_id>/{surface_pred,volume_pred}.npy``
+    in float16. The function is idempotent: cases with an existing
+    ``_done`` sentinel file are skipped, so multiple workers can safely
+    process disjoint shards (via ``case_stride`` / ``case_offset``).
+    """
+
+    if not save_surface and not save_volume:
+        raise ValueError("build_kd_cache_for_split requires save_surface or save_volume")
+
+    selected_case_ids = case_ids[case_offset::case_stride]
+    print(
+        f"[build_kd_cache] split={split} cases_total={len(case_ids)} "
+        f"selected={len(selected_case_ids)} "
+        f"(stride={case_stride} offset={case_offset}); "
+        f"save surface={save_surface} volume={save_volume}"
+    )
+    cached_count = 0
+    started_at = time.time()
+
+    for case_idx, case_id in enumerate(selected_case_ids):
+        paths = kd_cache_paths(output_dir, split, case_id)
+        if paths["_done"].exists():
+            cached_count += 1
+            continue
+        paths["case_dir"].mkdir(parents=True, exist_ok=True)
+
+        counts = store.case_point_counts(case_id)
+        n_surface = int(counts["n_surface"])
+        n_volume = int(counts["n_volume"])
+
+        single_ds = DrivAerMLSurfaceDataset(
+            [case_id],
+            store=store,
+            max_surface_points=eval_surface_points,
+            max_volume_points=eval_volume_points,
+            sampling_mode="eval_chunk",
+        )
+        loader = torch.utils.data.DataLoader(
+            single_ds,
+            batch_size=batch_size,
+            shuffle=False,
+            sampler=None,
+            collate_fn=pad_collate,
+            num_workers=num_workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=False,
+        )
+
+        surface_buf = (
+            np.zeros((n_surface, 4), dtype=np.float32) if save_surface else None
+        )
+        volume_buf = (
+            np.zeros((n_volume, 1), dtype=np.float32) if save_volume else None
+        )
+        surface_filled = np.zeros(n_surface, dtype=bool) if save_surface else None
+        volume_filled = np.zeros(n_volume, dtype=bool) if save_volume else None
+
+        case_t0 = time.time()
+        for batch in loader:
+            batch = batch.to(device)
+            avg_surf, avg_vol = _ensemble_average_batch(
+                members, batch, device, amp_mode
+            )
+            avg_surf_cpu = avg_surf.detach().cpu().float().numpy()
+            avg_vol_cpu = avg_vol.detach().cpu().float().numpy()
+
+            for item_idx, item_meta in enumerate(batch.metadata):
+                if save_surface:
+                    surface_view_index = int(item_meta["surface_view_index"])
+                    surface_view_count = int(item_meta["surface_view_count"])
+                    n_surface_loaded = int(item_meta["n_surface_loaded"])
+                    if n_surface_loaded > 0 and surface_view_index < surface_view_count:
+                        if n_surface <= eval_surface_points:
+                            rows = np.arange(n_surface, dtype=np.int64)
+                        else:
+                            rows = _strided_indices(
+                                surface_view_index, n_surface, surface_view_count
+                            )
+                        if rows.size != n_surface_loaded:
+                            raise RuntimeError(
+                                f"Surface view shape mismatch for {case_id} "
+                                f"view {surface_view_index}/{surface_view_count}: "
+                                f"loader gave {n_surface_loaded} rows, "
+                                f"strided slice has {rows.size}."
+                            )
+                        surface_buf[rows] = avg_surf_cpu[item_idx, :n_surface_loaded, :]
+                        surface_filled[rows] = True
+                if save_volume:
+                    volume_view_index = int(item_meta["volume_view_index"])
+                    volume_view_count = int(item_meta["volume_view_count"])
+                    n_volume_loaded = int(item_meta["n_volume_loaded"])
+                    if n_volume_loaded > 0 and volume_view_index < volume_view_count:
+                        if n_volume <= eval_volume_points:
+                            rows = np.arange(n_volume, dtype=np.int64)
+                        else:
+                            rows = _strided_indices(
+                                volume_view_index, n_volume, volume_view_count
+                            )
+                        if rows.size != n_volume_loaded:
+                            raise RuntimeError(
+                                f"Volume view shape mismatch for {case_id} "
+                                f"view {volume_view_index}/{volume_view_count}: "
+                                f"loader gave {n_volume_loaded} rows, "
+                                f"strided slice has {rows.size}."
+                            )
+                        volume_buf[rows] = avg_vol_cpu[item_idx, :n_volume_loaded, :]
+                        volume_filled[rows] = True
+
+        if save_surface:
+            unfilled = int((~surface_filled).sum())
+            if unfilled > 0:
+                raise RuntimeError(
+                    f"Surface buffer for {case_id} has {unfilled} unfilled rows "
+                    f"after iterating eval_chunk loader."
+                )
+        if save_volume:
+            unfilled = int((~volume_filled).sum())
+            if unfilled > 0:
+                raise RuntimeError(
+                    f"Volume buffer for {case_id} has {unfilled} unfilled rows "
+                    f"after iterating eval_chunk loader."
+                )
+
+        if save_surface:
+            np.save(paths["surface_pred"], surface_buf.astype(np.float16))
+        if save_volume:
+            np.save(paths["volume_pred"], volume_buf.astype(np.float16))
+        paths["_done"].touch()
+        cached_count += 1
+        case_dt = time.time() - case_t0
+
+        if (case_idx + 1) % 5 == 0 or case_idx == 0 or case_idx == len(selected_case_ids) - 1:
+            elapsed = time.time() - started_at
+            avg_per_case = elapsed / max(case_idx + 1, 1)
+            remaining = avg_per_case * (len(selected_case_ids) - case_idx - 1)
+            print(
+                f"  [{case_idx + 1}/{len(selected_case_ids)}] {case_id}: "
+                f"{case_dt:.1f}s (elapsed={elapsed:.0f}s, "
+                f"~{remaining:.0f}s remaining); n_surface={n_surface} n_volume={n_volume}"
+            )
+    return cached_count
+
+
+def main_build_kd_cache(args: argparse.Namespace) -> None:
+    """Build per-case averaged ensemble predictions for offline KD."""
+
+    entity = os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    project = os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+
+    raw_ids = (
+        args.run_ids
+        if args.run_ids
+        else [rid.strip() for rid in args.candidate_run_ids.split(",") if rid.strip()]
+    )
+    if not raw_ids:
+        raise ValueError("No run IDs provided for --build-kd-cache")
+
+    output_dir = Path(args.build_kd_cache).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"KD cache output: {output_dir}")
+    print(f"Members (K={len(raw_ids)}): {raw_ids}")
+
+    cache_root = Path(args.cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    api = wandb.Api()
+
+    members: list[SurfaceTransolver] = []
+    for run_id in raw_ids:
+        print(f"Fetching artifact for member {run_id}...")
+        member_dir = download_checkpoint(api, entity, project, run_id, cache_root)
+        model, _cfg = load_member(run_id, member_dir, device)
+        members.append(model)
+    print(f"Loaded {len(members)} members on {device}")
+
+    save_surface = args.kd_cache_channels in {"all", "surface_only"}
+    save_volume = args.kd_cache_channels in {"all", "vol_only"}
+    if not (save_surface or save_volume):
+        raise ValueError("--kd-cache-channels gives no channels to save")
+
+    store = DrivAerMLCaseStore(
+        manifest_path=args.manifest, root=args.data_root or None
+    )
+
+    # Manifest summary so we know the cache covers the expected splits.
+    manifest_summary = {
+        "train": store.case_ids("train"),
+        "val": store.case_ids("val"),
+        "test": store.case_ids("test"),
+    }
+    print(
+        "Split case counts: "
+        + ", ".join(f"{k}={len(v)}" for k, v in manifest_summary.items())
+    )
+    splits_requested = list(args.split)
+    print(f"Splits to cache: {splits_requested}")
+
+    metadata_path = output_dir / "kd_cache_metadata.json"
+    if not metadata_path.exists():
+        import json
+
+        metadata = {
+            "members": list(raw_ids),
+            "k": len(raw_ids),
+            "eval_surface_points": int(args.eval_surface_points),
+            "eval_volume_points": int(args.eval_volume_points),
+            "channels": args.kd_cache_channels,
+            "amp_mode": args.amp_mode,
+            "manifest_path": str(args.manifest),
+        }
+        with metadata_path.open("w") as fh:
+            json.dump(metadata, fh, indent=2)
+        print(f"Wrote KD cache metadata to {metadata_path}")
+
+    total_cached = 0
+    for split in splits_requested:
+        ids = manifest_summary[split]
+        n_cached = build_kd_cache_for_split(
+            members,
+            split=split,
+            case_ids=ids,
+            store=store,
+            eval_surface_points=args.eval_surface_points,
+            eval_volume_points=args.eval_volume_points,
+            output_dir=output_dir,
+            device=device,
+            amp_mode=args.amp_mode,
+            save_surface=save_surface,
+            save_volume=save_volume,
+            case_stride=max(1, int(args.kd_cache_case_stride)),
+            case_offset=max(0, int(args.kd_cache_case_offset)),
+            num_workers=int(args.num_workers),
+            batch_size=int(args.batch_size),
+        )
+        total_cached += n_cached
+        print(f"[build_kd_cache] split={split} cached_or_skipped={n_cached}")
+
+    if torch.cuda.is_available():
+        peak_gb = torch.cuda.max_memory_allocated(device) / 1e9
+        print(f"Peak GPU memory: {peak_gb:.2f} GB")
+    print(f"Done. Total cases cached/skipped: {total_cached}")
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     args = parse_args(argv)
+    if args.build_kd_cache:
+        main_build_kd_cache(args)
+        return
     if args.greedy:
         main_greedy(args)
         return

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-05 (updated 12:40 UTC)
+- **Date:** 2026-05-05 (updated 15:30 UTC)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -43,8 +43,8 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 2. Optimizer / Training Dynamics (2 PRs in-flight)
 
-- **PR #667** (fern): Weight decay sweep {5e-4 control, 1e-3, 1e-4}. Arm A control complete: val=6.959% (timeout at EP4/13, 2.80× vol val→test gap fully present). Arm B (wd=1e-3) EP2 PASS at 8.670% (slightly worse than control 8.581%, vol_p +0.27pp worse). EP3 gate ETA ~13:35 UTC.
-- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Pre-EP1.
+- **PR #667** (fern): Weight decay sweep {5e-4 ctrl=6.959% test=8.135% vol-ratio 2.80×, 1e-3 final=6.913% test=8.097% vol-ratio 2.85×, 1e-4 running}. **Arm B finalized — WD direction scientifically null on volume val→test gap.** Test_vp essentially flat across WD values; ratio actually widened slightly with stronger WD. Arm C running for completeness.
+- **PR #695** (edward): RFF num_features=32 (doubled from 16) for tau_y/tau_z. Silent since 13:20Z receipt; follow-up nudge posted 15:23Z requesting EP1 status.
 
 **Closed (null):**
 - PR #603 (tanjiro): EMA decay sweep — {0.9993, 0.9997, 0.9999} all no improvement.
@@ -57,8 +57,10 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 
 ### 3. Attention Mechanism (2 PRs in-flight)
 
-- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64); arm-b: heads=2 (dim_head=256). Just assigned, pre-EP1.
-- **PR #665** (frieren): Cross-slice attention — adds global inter-slice MHA layer. Arm A control complete: val=6.9349% (timeout at EP4/13). Arm B (with cross-slice attn, +5.25M params, zero-init proj) EP1 −3.82pp ahead, but EP2 reversed: 10.92% PASS but +2.22pp behind control (wall-shear z +2.75pp regression). EP3 gate at high kill risk (ETA ~13:50 UTC).
+- **PR #692** (tanjiro): Attention heads sweep — arm-a: heads=8 (dim_head=64) EP2 PASS 8.5458%; arm-b: heads=2 (dim_head=256) queued. EP3 watch for Arm A.
+
+**Closed (this round):**
+- PR #665 (frieren): Cross-slice attention — direction closed.
 
 **Open question:** Does more diverse (heads=8) or higher-capacity (heads=2) attention improve over SOTA heads=4? Does inter-slice attention capture global geometry correlations? (Early signal from PR #665: cross-slice attn slows late-EP convergence, likely due to +33% params needing more training to escape zero-init.)
 
@@ -73,6 +75,14 @@ No new directives from the human research team. Issue #618 (STRING/RoPE queue) a
 - L=6/hidden=448/heads=7 (PR #693): CLOSED — 98 min/epoch (heads=7 kills SDPA fast path). Key lesson: heads must be power-of-2 for budget-feasible training.
 
 **Open question:** Does L=6/hidden=384/heads=4 (PR #694) continue the depth scaling trend? Is slices=128 optimal or does smaller/larger over-fragment or under-communicate geometry (PR #690)?
+
+### 4b. Knowledge Distillation (1 PR in-flight)
+
+- **PR #676** (nezuko): K=7 ensemble teacher → student KD with kd_alpha sweep. **Arm A (kd-alpha=0.7) FINAL:** val=7.0153% test=8.2539% — misses merge bar 6.5985% by +0.42pp. **Budget-limited:** KD doubles per-step time (2.37 it/s vs ~5 it/s) → only 4 epochs in 270-min cap; trajectory slope at EP4 still -0.42pp/epoch (would plausibly cross merge bar at ~9 epochs). **Volume val→test ratio narrowed 3.17×→2.78×** — first lever in the round to actually move the chronic surface↔volume gap. Arm B (kd-alpha=0.5) launched 15:10Z. **Open follow-ups documented:** (a) batched KD cache / fused volume KD kernel to halve per-step overhead, (b) channel-selective KD on volume only, (c) T_max=4 cosine fix, (d) scheduled kd_alpha 0.9→0.1.
+
+### 4c. Boundary Condition Encoding (1 PR in-flight)
+
+- **PR #716** (frieren): nn.Embedding(3, 16) for wall=0/inlet=1/outlet=2 injected before Transolver encoder. Primary target: wall_shear_z (SOTA 9.81%). Hypothesis received 15:20Z; data-shape inspection requested.
 
 ### 5. Physics-Informed Loss / Output Formulation
 
@@ -91,22 +101,25 @@ All 8 students running:
 
 | Student | PR | Hypothesis | Status |
 |---|---|---|---|
-| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Just assigned — pre-EP1 |
-| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Just assigned — pre-EP1 |
-| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Just assigned — pre-EP1 |
-| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | Just assigned — pre-EP1 |
-| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Pre-EP1 |
-| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 EP2 PASS, 1e-4 queued} | Arm B EP3 gate ~13:35 UTC |
-| frieren | #665 | Cross-slice attention (Arm A=6.9349%, Arm B EP2 PASS but trailing) | Arm B EP3 gate ~13:50 UTC |
-| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha=0.7) | EP1=28.62%, EP2 gate ~12:56 UTC |
+| alphonse | #690 | Slice count sweep {64, 192, 256} vs SOTA 128 | Arm A heads=64 EP1 ~25.87%; EP2 gate watch |
+| askeladd | #691 | RFF sigma expansion {7-wide, 6-low-ext} | Arm A EP1 ~29.43%; EP2 gate watch |
+| tanjiro | #692 | Heads sweep {8, 2} vs SOTA heads=4 | Arm A heads=8 EP2 PASS 8.5458%; EP3 gate next |
+| thorfinn | #694 | Depth L=6 hidden=384 heads=4 (budget-safe) | EP3 PASS 7.3175% (gap closing); EP4 final ETA ~15:43 UTC |
+| edward | #695 | RFF num_features=32 (doubled) for tau_y/tau_z | Silent since 13:20Z ADVISOR receipt; follow-up nudge posted 15:23Z |
+| fern | #667 | Weight decay sweep {5e-4 ctrl=6.959%, 1e-3 final=6.913%, 1e-4 running} | Arm B FINAL: WD direction scientifically null on volume gap; Arm C running |
+| frieren | #716 | BC-type embedding (nn.Embedding(3,16)) — wall_shear_z primary target | Hypothesis received; Arm A control + Arm B BC starting; EP1 watch |
+| nezuko | #676 | Ensemble K=7 distillation teacher (kd-alpha sweep) | Arm A FINAL: val=7.0153% (misses bar, budget-limited); Arm B kd=0.5 running since 15:10Z |
 
 **Zero idle students. Zero idle GPUs.**
 
-**Upcoming gate actions:**
-- All new PRs (#690, #691, #692, #694, #695): EP1 informational (+ epoch-time gate for #694: kill if > 75 min/epoch), EP2 gate at step ~21,729 — KILL if > 12.0%; EP3 gate — KILL if > 8.0%
-- Fern PR #667 Arm B (wd=1e-3): EP3 gate ~13:35 UTC — KILL if > 8.0%; queue Arm C (wd=1e-4) if Arm B doesn't beat Arm A by ≥0.30pp
-- Frieren PR #665 Arm B (cross-slice attn): EP3 gate ~13:50 UTC — KILL if > 8.0%; high kill risk (needs 2.92pp drop in one epoch vs Arm A's 1.38pp)
-- Nezuko PR #676 Arm A (kd-alpha=0.7): EP2 gate ~12:56 UTC — KILL if > 12.0%
+**Upcoming gate actions (UTC):**
+- thorfinn PR #694: EP4 final ~15:43 — verdict on merge bar < 6.5985% (forecast 6.85–7.05%, tail ≤6.6%)
+- fern PR #667 Arm C (wd=1e-4): EP1 ~15:50 (info), EP2 ~17:05 (kill > 12%), EP3 ~18:20 (kill > 8%), final ~19:08
+- nezuko PR #676 Arm B (kd=0.5): EP2 ~17:30 (kill > 12%), EP3 ~18:45 (kill > 8%), final ~19:40
+- tanjiro PR #692 Arm A (heads=8): EP3 ~16:00 (kill > 8%), final ~16:21
+- askeladd PR #691, alphonse PR #690: EP2 gate watch (kill > 12%)
+- edward PR #695: pending student EP1 status update
+- frieren PR #716: data-shape inspection result + EP1 informational
 
 ---
 

--- a/train.py
+++ b/train.py
@@ -32,7 +32,10 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+import numpy as np
+
 from data import DrivAerMLSurfaceDataset
+from data.loader import DrivAerMLCase
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -137,6 +140,10 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    kd_ensemble_cache_dir: str = ""
+    kd_alpha: float = 0.5
+    kd_channels: str = "vol_only"
+    kd_warmup_epochs: int = 0
     debug: bool = False
 
 
@@ -219,6 +226,31 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "kd_ensemble_cache_dir": (
+            "Path to a per-case averaged ensemble prediction directory "
+            "produced by `ensemble_eval.py --build-kd-cache <dir>`. When set, "
+            "the trainer adds an MSE knowledge-distillation term against the "
+            "cached soft targets at the points sampled by the loader. Empty "
+            "(default) disables KD."
+        ),
+        "kd_alpha": (
+            "Mixing weight for the KD loss term. Final per-channel loss = "
+            "(1 - alpha) * L_gt + alpha * L_kd. Default 0.5. Only used when "
+            "--kd-ensemble-cache-dir is set."
+        ),
+        "kd_channels": (
+            "Which channels to apply KD on: 'vol_only' (default; only "
+            "volume_pressure uses soft targets) or 'all' (all 4 surface "
+            "channels + volume_pressure use soft targets). Surface arm: "
+            "applies the same alpha to surface_pressure and the three "
+            "wall-shear axes."
+        ),
+        "kd_warmup_epochs": (
+            "Linearly ramp the KD alpha from 0 to --kd-alpha over the first "
+            "N epochs (default 0 = full alpha from epoch 0). Useful when the "
+            "student is initially producing very large prediction errors and "
+            "the soft-target gradient could overwhelm the GT gradient."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +332,202 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+class IndexedDrivAerMLDataset(DrivAerMLSurfaceDataset):
+    """DrivAerML dataset that exposes sampled row indices in metadata.
+
+    Identical sampling to ``DrivAerMLSurfaceDataset`` but additionally stores
+    ``surface_row_indices`` and ``volume_row_indices`` (long tensors of row
+    positions in the case's full point arrays) on each ``DrivAerMLCase``'s
+    metadata dict. Downstream KD code uses these indices to slice into the
+    pre-cached per-case ensemble soft-target arrays.
+    """
+
+    def __getitem__(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+        volume_idx = self._indices(
+            counts["n_volume"],
+            self.max_volume_points,
+            view,
+            group_view_count=view.volume_view_count,
+        )
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=None if volume_idx is None else volume_idx.numpy(),
+        )
+        metadata = dict(case.metadata)
+        if surface_idx is None:
+            metadata["surface_row_indices"] = torch.arange(
+                counts["n_surface"], dtype=torch.long
+            )
+        else:
+            metadata["surface_row_indices"] = surface_idx.detach().clone().long()
+        if volume_idx is None:
+            metadata["volume_row_indices"] = torch.arange(
+                counts["n_volume"], dtype=torch.long
+            )
+        else:
+            metadata["volume_row_indices"] = volume_idx.detach().clone().long()
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = view.sampling_mode
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+
+class KDEnsembleCache:
+    """Lazy mmap-backed reader for per-case averaged ensemble predictions.
+
+    Files are produced by ``ensemble_eval.py --build-kd-cache``. Layout:
+
+        <root>/<split>/<case_id>/{surface_pred,volume_pred}.npy  # float16
+
+    This class memory-maps each requested .npy file on first access and
+    caches the mmap handle in a per-process LRU dict. The training loop
+    only reads small slices (the rows sampled by the loader for the current
+    batch), so cumulative I/O per step is small (<~1 MB).
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        load_surface: bool,
+        load_volume: bool,
+    ):
+        self.root = Path(root)
+        if not self.root.exists():
+            raise FileNotFoundError(
+                f"KD ensemble cache directory does not exist: {self.root}"
+            )
+        self.load_surface = load_surface
+        self.load_volume = load_volume
+        self._surface: dict[str, np.ndarray] = {}
+        self._volume: dict[str, np.ndarray] = {}
+
+    def _resolve(self, split: str, case_id: str) -> Path:
+        return self.root / split / case_id
+
+    def _maybe_load(
+        self,
+        cache: dict[str, np.ndarray],
+        split: str,
+        case_id: str,
+        filename: str,
+    ) -> np.ndarray:
+        if case_id in cache:
+            return cache[case_id]
+        path = self._resolve(split, case_id) / filename
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Missing KD prediction cache for case {case_id} ({split}): {path}"
+            )
+        arr = np.load(path, mmap_mode="r")
+        cache[case_id] = arr
+        return arr
+
+    def get_surface(self, split: str, case_id: str) -> np.ndarray:
+        if not self.load_surface:
+            raise RuntimeError("KDEnsembleCache configured with load_surface=False")
+        return self._maybe_load(self._surface, split, case_id, "surface_pred.npy")
+
+    def get_volume(self, split: str, case_id: str) -> np.ndarray:
+        if not self.load_volume:
+            raise RuntimeError("KDEnsembleCache configured with load_volume=False")
+        return self._maybe_load(self._volume, split, case_id, "volume_pred.npy")
+
+    def has_case(self, split: str, case_id: str) -> bool:
+        case_dir = self._resolve(split, case_id)
+        if not case_dir.exists():
+            return False
+        if self.load_surface and not (case_dir / "surface_pred.npy").exists():
+            return False
+        if self.load_volume and not (case_dir / "volume_pred.npy").exists():
+            return False
+        return True
+
+
+def gather_kd_targets_from_batch(
+    batch,
+    *,
+    cache: KDEnsembleCache,
+    split: str,
+    device: torch.device,
+    n_surface_dim: int,
+    n_volume_dim: int,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Build per-batch teacher target tensors aligned to the loader output.
+
+    For each item in ``batch``, look up the cached full-case averaged
+    predictions and gather the rows at the indices stored in metadata. Pad
+    to the batch's max-N dimensions so the result lines up with
+    ``out['surface_preds']`` and ``out['volume_preds']``. Returns
+    ``(surface_teacher, volume_teacher)``; either may be ``None`` when the
+    cache is configured to skip that channel family.
+    """
+
+    batch_size = len(batch.case_ids)
+    surface_max = batch.surface_x.shape[1] if cache.load_surface else 0
+    volume_max = batch.volume_x.shape[1] if cache.load_volume else 0
+    surface_teacher = (
+        torch.zeros((batch_size, surface_max, n_surface_dim), dtype=torch.float32)
+        if cache.load_surface
+        else None
+    )
+    volume_teacher = (
+        torch.zeros((batch_size, volume_max, n_volume_dim), dtype=torch.float32)
+        if cache.load_volume
+        else None
+    )
+    for item_idx, (case_id, item_meta) in enumerate(zip(batch.case_ids, batch.metadata)):
+        if cache.load_surface:
+            surface_indices = item_meta["surface_row_indices"]
+            n_surface_loaded = int(item_meta["n_surface_loaded"])
+            if n_surface_loaded > 0:
+                full = cache.get_surface(split, case_id)
+                rows = surface_indices[:n_surface_loaded].cpu().numpy().astype(np.int64)
+                sliced = np.asarray(full[rows], dtype=np.float32)
+                surface_teacher[item_idx, :n_surface_loaded, :] = torch.from_numpy(
+                    sliced
+                )
+        if cache.load_volume:
+            volume_indices = item_meta["volume_row_indices"]
+            n_volume_loaded = int(item_meta["n_volume_loaded"])
+            if n_volume_loaded > 0:
+                full = cache.get_volume(split, case_id)
+                rows = volume_indices[:n_volume_loaded].cpu().numpy().astype(np.int64)
+                sliced = np.asarray(full[rows], dtype=np.float32)
+                volume_teacher[item_idx, :n_volume_loaded, :] = torch.from_numpy(
+                    sliced
+                )
+    if surface_teacher is not None:
+        surface_teacher = surface_teacher.to(device, non_blocking=True)
+    if volume_teacher is not None:
+        volume_teacher = volume_teacher.to(device, non_blocking=True)
+    return surface_teacher, volume_teacher
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,6 +538,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    kd_alpha_effective: float = 0.0,
+    kd_channels: str = "vol_only",
+    kd_surface_teacher: torch.Tensor | None = None,
+    kd_volume_teacher: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -322,26 +554,80 @@ def train_loss(
             volume_mask=batch.volume_mask,
         )
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
+            surface_loss_gt = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
-        weighted_volume_loss = volume_loss_weight * volume_loss
+            surface_loss_gt = masked_mse(
+                out["surface_preds"], surface_target, batch.surface_mask
+            )
+        volume_loss_gt = masked_mse(
+            out["volume_preds"], volume_target, batch.volume_mask
+        )
+
+        kd_active = kd_alpha_effective > 0.0
+        apply_kd_volume = kd_active and (kd_volume_teacher is not None)
+        apply_kd_surface = (
+            kd_active
+            and kd_channels == "all"
+            and (kd_surface_teacher is not None)
+        )
+
+        if apply_kd_volume:
+            volume_loss_kd = masked_mse(
+                out["volume_preds"], kd_volume_teacher, batch.volume_mask
+            )
+            volume_loss_total = (
+                (1.0 - kd_alpha_effective) * volume_loss_gt
+                + kd_alpha_effective * volume_loss_kd
+            )
+        else:
+            volume_loss_kd = volume_loss_gt.detach()
+            volume_loss_total = volume_loss_gt
+
+        if apply_kd_surface:
+            if surface_channel_weights is not None:
+                surface_loss_kd = weighted_channel_mse(
+                    out["surface_preds"],
+                    kd_surface_teacher,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+            else:
+                surface_loss_kd = masked_mse(
+                    out["surface_preds"], kd_surface_teacher, batch.surface_mask
+                )
+            surface_loss_total = (
+                (1.0 - kd_alpha_effective) * surface_loss_gt
+                + kd_alpha_effective * surface_loss_kd
+            )
+        else:
+            surface_loss_kd = surface_loss_gt.detach()
+            surface_loss_total = surface_loss_gt
+
+        weighted_surface_loss = surface_loss_weight * surface_loss_total
+        weighted_volume_loss = volume_loss_weight * volume_loss_total
         loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        base_mse_loss = surface_loss_gt + volume_loss_gt
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
-        "surface_loss": float(surface_loss.detach().cpu().item()),
-        "volume_loss": float(volume_loss.detach().cpu().item()),
+        "surface_loss": float(surface_loss_gt.detach().cpu().item()),
+        "volume_loss": float(volume_loss_gt.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if apply_kd_volume:
+        metrics["kd/volume_loss_gt"] = float(volume_loss_gt.detach().cpu().item())
+        metrics["kd/volume_loss_kd"] = float(volume_loss_kd.detach().cpu().item())
+        metrics["kd/volume_loss_total"] = float(volume_loss_total.detach().cpu().item())
+    if apply_kd_surface:
+        metrics["kd/surface_loss_gt"] = float(surface_loss_gt.detach().cpu().item())
+        metrics["kd/surface_loss_kd"] = float(surface_loss_kd.detach().cpu().item())
+        metrics["kd/surface_loss_total"] = float(surface_loss_total.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -666,7 +952,12 @@ def rebuild_train_loader_with_vol_points(
     sampling_mode = (
         "train_random" if (config.train_surface_points > 0 or n_points > 0) else "full"
     )
-    train_ds = DrivAerMLSurfaceDataset(
+    dataset_cls = (
+        IndexedDrivAerMLDataset
+        if isinstance(old_ds, IndexedDrivAerMLDataset)
+        else DrivAerMLSurfaceDataset
+    )
+    train_ds = dataset_cls(
         old_ds.case_ids,
         store=old_ds.store,
         max_surface_points=config.train_surface_points,
@@ -694,6 +985,70 @@ def rebuild_train_loader_with_vol_points(
     )
 
 
+def make_indexed_train_loader(
+    train_loader: DataLoader,
+    config: Config,
+    distributed_state,
+) -> DataLoader:
+    """Swap a train DataLoader's dataset for ``IndexedDrivAerMLDataset``.
+
+    Preserves the train sampling mode, points-per-view limits, and the case
+    list while replacing the dataset class so each ``__getitem__`` call
+    surfaces the sampled row indices via metadata. The DataLoader itself is
+    rebuilt because the (sampler, dataset) binding does not survive a
+    dataset swap. The reference uses ``rebuild_train_loader_with_vol_points``
+    with the current ``train_volume_points`` value to drive the rebuild
+    machinery.
+    """
+
+    old_ds = train_loader.dataset
+    if isinstance(old_ds, IndexedDrivAerMLDataset):
+        return train_loader
+    sampling_mode = (
+        "train_random"
+        if (config.train_surface_points > 0 or config.train_volume_points > 0)
+        else "full"
+    )
+    indexed_ds = IndexedDrivAerMLDataset(
+        old_ds.case_ids,
+        store=old_ds.store,
+        max_surface_points=config.train_surface_points,
+        max_volume_points=config.train_volume_points,
+        sampling_mode=sampling_mode,
+    )
+    train_sampler = None
+    train_shuffle = True
+    if distributed_state is not None and distributed_state.enabled:
+        train_sampler = DistributedSampler(
+            indexed_ds,
+            num_replicas=distributed_state.world_size,
+            rank=distributed_state.rank,
+            shuffle=True,
+            drop_last=True,
+        )
+        train_shuffle = False
+    return DataLoader(
+        indexed_ds,
+        batch_size=config.batch_size,
+        shuffle=train_shuffle,
+        sampler=train_sampler,
+        drop_last=True,
+        **loader_kwargs(config),
+    )
+
+
+def kd_alpha_for_epoch(epoch: int, target_alpha: float, warmup_epochs: int) -> float:
+    """Linear warmup from 0 to ``target_alpha`` over ``warmup_epochs`` epochs."""
+
+    if target_alpha <= 0.0:
+        return 0.0
+    if warmup_epochs <= 0:
+        return target_alpha
+    if epoch >= warmup_epochs:
+        return target_alpha
+    return target_alpha * (float(epoch) / float(warmup_epochs))
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     state = init_distributed()
     run = None
@@ -701,6 +1056,22 @@ def main(argv: Iterable[str] | None = None) -> None:
         config = parse_args(argv)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
+        kd_enabled = bool(config.kd_ensemble_cache_dir)
+        if kd_enabled:
+            if config.kd_channels not in {"all", "vol_only"}:
+                raise ValueError(
+                    f"--kd-channels must be 'all' or 'vol_only'; got "
+                    f"{config.kd_channels!r}"
+                )
+            if not 0.0 <= config.kd_alpha <= 1.0:
+                raise ValueError(
+                    f"--kd-alpha must be in [0, 1]; got {config.kd_alpha}"
+                )
+            if config.use_gradnorm:
+                raise ValueError(
+                    "Knowledge distillation is incompatible with --use-gradnorm "
+                    "in this iteration; pick one."
+                )
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
             requested_epochs = min(requested_epochs, int(os.environ["SENPAI_MAX_EPOCHS"]))
@@ -726,6 +1097,32 @@ def main(argv: Iterable[str] | None = None) -> None:
         current_train_vol_points = config.train_volume_points
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        kd_cache: KDEnsembleCache | None = None
+        if kd_enabled:
+            train_loader = make_indexed_train_loader(train_loader, config, state)
+            kd_cache = KDEnsembleCache(
+                config.kd_ensemble_cache_dir,
+                load_surface=(config.kd_channels == "all"),
+                load_volume=True,
+            )
+            cache_train_ids = train_loader.dataset.case_ids
+            missing_train = [
+                cid for cid in cache_train_ids
+                if not kd_cache.has_case("train", cid)
+            ]
+            if missing_train:
+                raise FileNotFoundError(
+                    f"KD ensemble cache is missing {len(missing_train)} train "
+                    f"cases under {config.kd_ensemble_cache_dir}/train/. "
+                    f"First few: {missing_train[:5]}. Run "
+                    f"`ensemble_eval.py --build-kd-cache` to populate them."
+                )
+            if state.is_main:
+                print(
+                    f"KD enabled: alpha={config.kd_alpha} channels={config.kd_channels} "
+                    f"cache_dir={config.kd_ensemble_cache_dir} "
+                    f"(verified {len(cache_train_ids)} train cases present)"
+                )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(
@@ -999,6 +1396,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    kd_alpha_effective = kd_alpha_for_epoch(
+                        epoch, config.kd_alpha, config.kd_warmup_epochs
+                    ) if kd_enabled else 0.0
+                    kd_surface_teacher: torch.Tensor | None = None
+                    kd_volume_teacher: torch.Tensor | None = None
+                    if kd_enabled and kd_alpha_effective > 0.0:
+                        kd_surface_teacher, kd_volume_teacher = gather_kd_targets_from_batch(
+                            batch,
+                            cache=kd_cache,
+                            split="train",
+                            device=device,
+                            n_surface_dim=batch.surface_y.shape[-1],
+                            n_volume_dim=batch.volume_y.shape[-1],
+                        )
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1008,7 +1419,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        kd_alpha_effective=kd_alpha_effective,
+                        kd_channels=config.kd_channels,
+                        kd_surface_teacher=kd_surface_teacher,
+                        kd_volume_teacher=kd_volume_teacher,
                     )
+                    if kd_enabled:
+                        batch_loss_metrics["kd/alpha_effective"] = float(kd_alpha_effective)
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1048,6 +1465,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    kd_log_extras = {
+                        f"train/{k}": v
+                        for k, v in batch_loss_metrics.items()
+                        if k.startswith("kd/")
+                    }
+                    if kd_log_extras:
+                        train_log.update(kd_log_extras)
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Exp 1D: Single-Model Knowledge Distillation from K=7 Ensemble**

The K=7 greedy ensemble (PR #612, val_abupt=6.1751%) outperforms the best single model (PR #592, val_abupt=6.5985%) by 0.399pp. The ensemble's superiority is especially stark on volume_pressure (val: ensemble=3.61% vs single=3.95%). However the ensemble cannot be used as our primary submission metric due to the hard no-ensembling constraint (Issue #717).

This experiment tests whether the K=7 ensemble's knowledge can be **distilled** into a single L=5 model via soft-target training. If successful, the distilled student could exceed the single-model SOTA without ensembling at inference.

**Mechanism:** Standard soft-label knowledge distillation (Hinton et al. 2015). For each training sample, pre-compute the K=7 ensemble's predictions and use them as soft targets for the student's loss function. The student learns to match the ensemble's smooth output distribution rather than fitting raw ground-truth labels.

**Why this might help:** The ensemble averages out per-model noise, especially in the far-wake volume pressure where individual models disagree. The ensemble predictions serve as a "denoised" training signal that regularizes the student's volume pressure predictions.

**Key question:** Can a single L=5 student trained on ensemble soft-targets beat val_abupt=6.5985% and particularly reduce the chronic 3× vol_pressure test-vs-val gap?

## Instructions

This experiment requires adding ensemble distillation support to `target/train.py`. Use the existing `target/ensemble_eval.py` as a reference for how to load ensemble member predictions.

### Phase 1: Pre-cache ensemble predictions (offline, before training)

Use `ensemble_eval.py` to cache predictions from the K=7 ensemble on the **training set** (in addition to val/test). Add support to `ensemble_eval.py` for caching training set predictions if not already present:

```bash
cd target/
uv run python ensemble_eval.py \
  --greedy \
  --candidate-run-ids d777epep nh96x7m4 5o7jc7wi wyz68o8r 9mm3sz7x 49aimdiz 19qf6di1 \
  --cache-only \
  --pred-cache-dir /tmp/kd_ensemble_cache \
  --split train val test
```

The K=7 ensemble members are: `d777epep, nh96x7m4, 5o7jc7wi, wyz68o8r, 9mm3sz7x, 49aimdiz, 19qf6di1` (from PR #612).

### Phase 2: Add KD loss to train.py

Add the following CLI flags to `target/train.py`:
```
--kd-ensemble-cache-dir PATH   Path to pre-cached ensemble predictions directory
--kd-alpha FLOAT               KD loss weight (0.0 = pure GT, 1.0 = pure ensemble soft targets)
                               Default: 0.5
--kd-channels {all,vol_only}   Which channels to apply KD on. Default: vol_only
```

**Loss formulation:** When `--kd-ensemble-cache-dir` is set:

1. Load cached ensemble predictions for the current training case (keyed by case ID).
2. Compute two losses:
   - `L_gt`: standard MSE against ground truth (existing loss)
   - `L_kd`: MSE against cached ensemble predictions (soft target loss)
3. Final loss: `L = (1 - alpha) * L_gt + alpha * L_kd`
4. When `--kd-channels vol_only`, apply KD only to the volume_pressure channel; surface pressure and wall shear channels use `L_gt` only.

Start with `--kd-alpha 0.5 --kd-channels vol_only` as the main arm. This applies soft supervision on the channel where the ensemble advantage is largest (val vol_pressure: 3.61% ensemble vs 3.95% single-model).

### Run command:

**Arm A (KD alpha=0.5, vol-only):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --kd-ensemble-cache-dir /tmp/kd_ensemble_cache \
  --kd-alpha 0.5 --kd-channels vol_only \
  --wandb-group alphonse-kd-ensemble --wandb-name alphonse/kd-alpha05-vol
```

**Arm B (KD alpha=0.5, all channels) — only if Arm A shows positive signal:**
```bash
  # same as Arm A but with --kd-channels all --wandb-name alphonse/kd-alpha05-all
```

**Kill gates:** EP1 epoch-time gate (kill if > 80min), EP2 kill if val_abupt > 12%, EP3 kill if val_abupt > 8%.

**Success metric:** val_abupt < 6.5985% AND/OR test vol_pressure < 11.5% (any reduction in the chronic gap).

**If caching training set predictions is infeasible** (memory or time): fall back to `--kd-channels val` approach — run KD only on the validation set as a regularization signal via an auxiliary loss on the EMA model predictions. Report which approach was used.

## Baseline

Current single-model SOTA: PR #592 (alphonse, `alphonse/depth-L5`)
- W&B run: `4k25s25e` (group: `model-depth-sweep`)
- **val_abupt: 6.5985%** (EP4, step 43,459)
- val surface_pressure: 4.3322% | val volume_pressure: 3.9456%
- val wall_shear_x: 6.5420% / wall_shear_y: 8.3631% / wall_shear_z: 9.8099%
- test_abupt: 7.9915% | test vol_pressure: ~11.69%

Ensemble SOTA K=7 (PR #612, run `5veexq8r`): val_abupt=6.1751%, val vol_pressure=3.61%
K=7 members: `d777epep, nh96x7m4, 5o7jc7wi, wyz68o8r, 9mm3sz7x, 49aimdiz, 19qf6di1`

Issue #717 vol_pressure targets: Weak ≤ 10.8% | Solid ≤ 10.0% | Major ≤ 9.5%

**Hard constraint (Issue #717):** Zero model ensembling at inference. The KD cache is generated offline from the ensemble, but inference uses only the single distilled student.
