### PR TITLE
tanjiro: STRING PE + QK-Norm at LR=5e-5 (lower-lr retry)

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -53,9 +53,9 @@ PR #599 (`sogus8sx`), test_primary/abupt_axis_mean_rel_l2_pct = **7.9303%** (fri
 
 | PR | Run | Student | Epoch | val_abupt | Notes |
 |---|---|---|---:|---:|---|
-| #664 | `a8emaoxm` | fern | EP24 | **6.7422%** | per-axis output scaling; new in-wave val best |
-| #669 | `er8wmo8d` | frieren | EP16 | 6.8276% | per-channel tau weighting (tau_y=1.2, tau_z=1.5) |
-| #678 | `sbzspuf2` | nezuko | EP9 | 7.2894% | extended cosine T_max=60 |
-| #696 | `dzochl0q` | tanjiro | EP2 | 9.6170% | QK-Norm + STRING PE; very early |
+| #664 | `a8emaoxm` | fern | EP36 | **6.6916%** | per-axis output scaling; new in-wave val best (updated EP36) |
+| #669 | `er8wmo8d` | frieren | EP27 | 6.7633% | per-channel tau weighting (tau_y=1.2, tau_z=1.5); EP35 gate ≤6.70% |
+| #678 | `sbzspuf2` | nezuko | EP20 | 6.8946% (best EP18=6.8820%) | extended cosine T_max=60; EP25 gate ≤6.82% |
+| #696 | `dzochl0q` | tanjiro | EP13 | 7.5933% | QK-Norm + STRING PE; **CLOSED** — gate fail + compliance violations |
 
 _Last updated: 2026-05-05_

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- 2026-05-05 (updated ~22:30 UTC)
+- 2026-05-05 (updated ~24:00 UTC)
 - Most recent research direction from human researcher team: None (no open GitHub issues)
 
 ## Current Research Focus and Themes
@@ -13,10 +13,10 @@
 
 | PR | Student | Hypothesis | Run ID | Status |
 |----|---------|------------|--------|--------|
-| #664 | dl24-fern | Per-axis output scaling on STRING backbone — learnable 4-element scale vector on surface output head | `a8emaoxm` | **Wave-best val.** EP32 completed. Best=EP30=**6.6970%** (surf=4.43%, vol=3.89%, wsh=7.57%). EP32=6.6983% (near-recovery from EP31 spike). EP40 gate ≤6.62%. Run to EP50. Advisor requested EP35 result + scale parameter values. |
-| #669 | dl24-frieren | Per-channel tau surface weighting (tau_y×1.2, tau_z×1.3) on SOTA base config | `er8wmo8d` | EP23 completed. Best=EP22=**6.7823%** (surf=4.47%, vol=3.94%, wsh=7.69%). EP23=6.8310% (oscillation uptick). EP30 gate ≤6.72% — needs 0.0623pp improvement in 7 epochs. Plateau pattern from EP18–EP23 concerning. |
-| #678 | dl24-nezuko | Extended cosine T_max=60 on SOTA STRING config (50-epoch long run) | `sbzspuf2` (group: `extended-cosine-t60-sota-v2`) | EP16 completed. Best=EP16=**6.9778%** (surf=4.52%, vol=4.23%, wsh=7.88%). Strong recovery from EP15 spike (7.3457%). EP20 gate ≤6.95% — EP16 is 0.028pp above threshold, on track. |
-| #696 | dl24-tanjiro | STRING + QK-Norm on SOTA Transolver base — L2-normalize Q,K per head in TransolverAttention | `dzochl0q` (group: `string-qknorm-long-50ep`) | EP9 completed=**7.7776%** (surf=5.13%, vol=4.73%, wsh=8.74%). New run best, recovered from EP8 spike (8.0730%). EP10 gate ≤7.6%. Unauthorized tanjiro-heads-sweep group flagged for explanation. |
+| #664 | dl24-fern | Per-axis output scaling on STRING backbone — learnable 4-element scale vector on surface output head | `a8emaoxm` | **Wave-best val.** EP~35.9 (gs=196,911). Summary best=**6.6976%**. EP40 gate ≤6.62% — needs 0.077pp in ~4 epochs. Plateau 6.697–6.700% since EP30. Late cosine LR decay is last hope for step-function drop. |
+| #669 | dl24-frieren | Per-channel tau surface weighting (tau_y×1.2, tau_z×1.3) on SOTA base config | `er8wmo8d` | EP~27.7 (gs=152,017). Summary best=**6.7633%** (new best, below EP25=6.7642%). EP30 gate ≤6.73% **PRE-CLEARED**. Next gate EP35 ≤6.70% — 0.063pp needed in ~7 epochs. |
+| #678 | dl24-nezuko | Extended cosine T_max=60 on SOTA STRING config (50-epoch long run) | `sbzspuf2` (group: `extended-cosine-t60-sota-v2`) | EP~20.4 (gs=111,957). Summary=**6.8946%** (slight regression from EP18 best=6.8820%). EP25 gate ≤6.82% — needs 0.075pp in ~5 epochs. Lion oscillation may explain EP20 uptick. |
+| #696 | dl24-tanjiro | STRING + QK-Norm on SOTA Transolver base — L2-normalize Q,K per head in TransolverAttention | `dzochl0q` (group: `string-qknorm-long-50ep`) | EP~13.3 (gs=73,259). Summary best=**7.5933%**. EP15 gate ≤7.2% — at current 0.037pp/ep improvement rate, EP15 will be ~7.47%: **GATE FAILURE EXPECTED**. COMPLIANCE: 7 warnings for unauthorized tanjiro-heads-sweep, no student response. Closure planned at EP15 regardless. |
 
 ### Closed / Negative Results This Wave
 
@@ -50,13 +50,13 @@
 
 ## Research Themes and Open Questions
 
-1. **Can per-axis output scaling (fern #664) beat wave SOTA?** EP32 val=6.6983%, best=EP30=6.6970%. Currently 0.167pp behind SOTA val=6.5281%. EP40 gate ≤6.62% — needs 0.077pp improvement in ~8 epochs. Volume pressure at 3.88% is excellent; wall shear (7.57%) is the remaining bottleneck. Strong candidate for test SOTA if trajectory continues.
+1. **Can per-axis output scaling (fern #664) beat wave SOTA?** EP~36 summary=6.6976%. Currently 0.170pp behind SOTA val=6.5281%. EP40 gate ≤6.62% — needs 0.077pp. In plateau since EP30; late cosine LR decay is the remaining mechanism. Wall shear (7.57%) is the bottleneck. Strong candidate for test if EP40-50 unlocks descent.
 
-2. **Does mild tau weighting (frieren #669) help on the STRING stack?** EP22 best=6.7823%, EP23=6.8310% (oscillation uptick). Lagging fern by ~0.085pp at similar epoch count. EP30 gate ≤6.72% is tight — 7-epoch window, ~0.0623pp needed from a near-plateau. If gate fails, close; if gate passes, continue to EP50 terminal. Two mechanisms (per-axis scale vs channel weights) running nearly in parallel allows direct comparison.
+2. **Does mild tau weighting (frieren #669) help on the STRING stack?** EP~28 best=6.7633%, EP30 gate PRE-CLEARED. Next gate EP35 ≤6.70% needs 0.063pp in 7 epochs. Consistent downward trend strongest of the 4 active runs. Approaching fern territory — by EP35 these two will be directly comparable.
 
-3. **Does extended cosine T_max=60 (nezuko #678) improve late-epoch convergence?** EP16 best=6.9778%, strongly recovered from EP15 spike. EP20 gate ≤6.95% is achievable (0.028pp gap, 4 epochs). T_max=60's key test is EP30–50: does the slower LR decay enable continued descent where standard cosine flattens? Currently ~0.48pp behind SOTA val — needs strong EP20–50 phase to be competitive.
+3. **Does extended cosine T_max=60 (nezuko #678) improve late-epoch convergence?** EP~20 summary=6.8946%. EP25 gate ≤6.82% needs 0.075pp over 5 epochs. Current EP20 is slight regression from EP18 best=6.8820% — likely oscillation. Real test of T_max=60 is EP30-50 phase. Currently 0.37pp behind fern.
 
-4. **Does QK-Norm (tanjiro #696) stabilise attention and help cross-flow tau_y/z?** EP9=7.7776% (new best), recovered from EP8 spike. EP10 gate ≤7.6% requires 0.1776pp drop — achievable. Lagging fern/frieren by ~1.08pp at EP9 vs EP32/EP23 (early-epoch slowdown). Pre-wave showed QK-Norm helps on old stack. Key test: does EP20–50 show accelerated descent to compensate for slower EP1–10?
+4. **STRING+QK-Norm (tanjiro #696) — closure track.** EP~13 summary=7.5933%. EP15 gate ≤7.2% will likely fail at projected ~7.47%. Compliance violation (7 warnings, zero response). PR will be closed at EP15. QK-Norm hypothesis is not dead — will be reassigned to a compliant student.
 
 ## Potential Next Research Directions (after current arms complete)
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -113,7 +113,7 @@ The wave's evidence contract: test metrics from `test_primary/*` only; validatio
 - **Student:** dl24-nezuko (drivaerml-long-20260504 wave)
 - **W&B Run:** `sbzspuf2` (rank 0 of 8); group: `extended-cosine-t60-sota-v2`
 - **Hypothesis:** Extending the cosine LR schedule to T_max=60 (vs. default per-epoch) allows the optimizer to maintain a higher effective LR for longer, avoiding premature convergence to a sharp minimum. Pre-wave run `5o7jc7wi` (T_max=13) achieved test=8.313% with the best volume score seen in the wave; T_max=60 is a stronger form of the same idea on the SOTA 5-sigma STRING config.
-- **Status:** RUNNING — EP16 completed; **best val = 6.9778% (EP16)**
+- **Status:** RUNNING — EP17 completed; **best val = 6.9778% (EP16)**
 
 | Epoch | Step | abupt | surf | vol | wsh | Notes |
 |-------|------|-------|------|-----|-----|-------|
@@ -129,10 +129,11 @@ The wave's evidence contract: test metrics from `test_primary/*` only; validatio
 | EP14 | 76915 | 7.1540% | — | — | — | |
 | EP15 | 82409 | 7.3457% | — | — | — | spike |
 | **EP16** | **87903** | **6.9778%** | **4.52%** | **4.23%** | **7.88%** | **strong recovery + best val** |
+| EP17 | 93397 | 7.3084% | — | — | — | spike (Lion oscillation; EP18 recovery expected) |
 
 **Best val: 6.9778% (EP16) — surf=4.52%, vol=4.23%, wsh=7.88%. Strong recovery from EP15 spike (7.3457%). Trailing SOTA val 6.5281% by 0.450pp.**
 
-**Commentary (updated 2026-05-05):** Extended cosine T_max=60 shows healthy descent with periodic spikes at EP7 and EP15, each cleanly resolved by the next epoch. The EP16 result of 6.9778% is a new best and represents a significant improvement from EP9=7.2894% (+0.312pp in 7 epochs). EP20 gate ≤6.95% requires 0.028pp improvement from EP16 — very achievable given current trajectory. The key question for this run is EP30–50: does the slower LR decay enable continued descent where standard cosine would flatten? The strong EP16 recovery suggests the mechanism is working, but ~0.48pp gap to SOTA val means extended cosine alone may not be sufficient. Volume score at 4.23% is reasonable but above fern (3.89%) and frieren (3.94%). Continue to EP50; EP20 gate is the next checkpoint.
+**Commentary (updated 2026-05-05):** Extended cosine T_max=60 shows healthy descent with periodic spikes at EP7, EP15, and EP17, each cleanly resolved by the following epoch. The EP16 result of 6.9778% is the run best and represents a significant improvement from EP9=7.2894% (+0.312pp in 7 epochs). EP17 spike to 7.3084% (+0.331pp from best) is well within the Lion oscillation pattern; EP18 recovery to ~6.95–6.97% is expected. EP20 gate ≤6.95% requires 0.028pp improvement from EP16 best — very achievable if EP18 recovery follows the established spike-recovery pattern. The key question for this run is EP30–50: does the slower LR decay enable continued descent where standard cosine would flatten? The strong EP16 recovery suggests the mechanism is working, but ~0.48pp gap to SOTA val means extended cosine alone may not be sufficient. Volume score at 4.23% is reasonable but above fern (3.89%) and frieren (3.94%). Continue to EP50; EP20 gate is the next checkpoint.
 
 ---
 
@@ -143,7 +144,7 @@ The wave's evidence contract: test metrics from `test_primary/*` only; validatio
 - **W&B Run:** `dzochl0q` (rank 0 of 8); group: `string-qknorm-long-50ep`; smoke: `7wdwphhn`
 - **Hypothesis:** L2-normalizing Q and K per attention head (QK-Norm) before the dot-product stabilizes attention entropy, which may help the Transolver block better resolve anisotropic features (τ_y/τ_z cross-flow) that dominate the remaining error gap.
 - **Config flag:** `--model-qk-norm` (zero code change, pure CLI toggle)
-- **Status:** RUNNING — EP9 completed; **best val = 7.7776% (EP9)**
+- **Status:** RUNNING — EP10 completed; **best val = 7.717% (EP10)**; EP10 gate FAIL (≤7.6% required); extended to EP15 ≤7.2% (FINAL — no further extensions); compliance FINAL WARNING issued on `tanjiro-heads-sweep`
 
 | Epoch | Step | abupt | surf | vol | wsh | Notes |
 |-------|------|-------|------|-----|-----|-------|
@@ -151,15 +152,16 @@ The wave's evidence contract: test metrics from `test_primary/*` only; validatio
 | EP2 | 10987 | 9.6170% | — | — | — | passes EP2 kill gate ≤10.5% |
 | EP3 | 16481 | 9.0533% | — | — | — | |
 | EP4 | 21975 | 8.6432% | — | — | — | |
-| EP5 | 27469 | 8.3178% | — | — | — | passes EP5 gate ≤8.0%? — marginal |
+| EP5 | 27469 | 8.3178% | — | — | — | |
 | EP6 | 32963 | 8.1985% | — | — | — | |
 | EP7 | 38457 | 8.2742% | — | — | — | minor spike |
 | EP8 | 43951 | 8.0730% | — | — | — | spike |
-| **EP9** | **49445** | **7.7776%** | **5.13%** | **4.73%** | **8.74%** | **new best; strong recovery** |
+| EP9 | 49445 | 7.7776% | 5.13% | 4.73% | 8.74% | strong recovery |
+| **EP10** | **54939** | **7.717%** | **—** | **—** | **—** | **new run best; gate FAIL (≤7.6% required); extension to EP15** |
 
-**Best val: 7.7776% (EP9) — surf=5.13%, vol=4.73%, wsh=8.74%. Strong recovery from EP8 spike (8.0730%). Lagging fern/frieren by ~1.08pp at similar epoch range. EP10 gate ≤7.6% active (0.178pp gap).**
+**Best val: 7.717% (EP10) — new run best. Surf/vol/wsh pending full component report. Gate FAIL: EP10=7.717% > 7.6% threshold by 0.117pp. Conditional extension to EP15 issued with final gate ≤7.2%.**
 
-**Commentary (updated 2026-05-05):** QK-Norm shows a characteristic slow-start pattern: EP1–EP8 descent rate is −0.43pp/ep vs. fern/frieren at ~−0.55pp/ep. EP8 spike and EP9 recovery (+0.295pp) is the best single-epoch improvement seen in this run. Pre-wave evidence (`tkiigfmc`, test=8.625% on old stack) suggested QK-Norm could work but with a slower warmup; this is consistent. EP10 gate ≤7.6% requires 0.178pp improvement from EP9's 7.7776% — achievable given EP8→EP9 drop. The `tanjiro-heads-sweep` unauthorized W&B group was flagged for explanation by advisor (comment posted 2026-05-05). Key assessment: does EP20–50 show accelerated descent to close the 1.08pp gap vs. fern? If QK-Norm composes with STRING multi-sigma PE and tau weighting, this could be a valuable building block even if it doesn't win alone. Continue to EP10 gate, then reassess.
+**Commentary (updated 2026-05-05):** QK-Norm shows steady improvement with EP10=7.717% being the run best (−0.061pp from EP9=7.7776%). The EP10 gate threshold was ≤7.6%; actual 7.717% fails by 0.117pp. Descent slope EP5→EP10 is −0.12pp/ep; if this holds to EP15, projection lands ~7.11% — tight but feasible relative to the ≤7.2% final gate. However, descent rate has decelerated; if it slows further, EP15 may miss. Compliance FINAL WARNING posted: the unauthorized `tanjiro-heads-sweep` W&B group must be explained and confirmed as closed before the EP15 report, or the PR will be closed. No further extensions after EP15 regardless of result — either the QK-Norm mechanism has demonstrated sufficient trajectory by then or it has not. Note: student incorrectly reported gate as ≤7.8% in their EP10 comment — advisor corrected to actual ≤7.6% threshold.
 
 ---
 


### PR DESCRIPTION
## Hypothesis

STRING PE (multi-sigma) is the strongest positional embedding we have — it drove PR #599 to the current in-wave merged best (test 7.9303%). QK-Norm (RMSNorm on Q and K tensors before scaled dot-product attention) is a well-established stabilisation technique that reduces attention-score variance and can improve training dynamics, particularly in the early epochs.

Tanjiro's previous attempt (#696, run `dzochl0q`) combined QK-Norm with STRING PE at LR=1e-4 but showed ~+1pp overhead at EP13 (val_abupt=7.5933%) compared to a clean STRING PE baseline, triggering the EP15 gate. The hypothesis is that LR=1e-4 is too aggressive when QK-Norm layers are freshly initialised: the normalisation layers are near identity at init but their gradients compete with the large initial LR, causing instability that carries through early convergence.

This experiment retries the combination at LR=5e-5 (half of the prior attempt's LR) with an extended warmup of 1000 steps, giving QK-Norm layers time to establish their scale before full gradient pressure.

## Implementation instructions

**File to modify: `model.py`**

In `TransolverAttention.__init__`, after the existing `self.qkv` line, add two RMSNorm layers:

```python
# existing lines
self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
self.proj = LinearProjection(hidden_dim, hidden_dim)
self.proj_dropout = nn.Dropout(dropout)

# ADD these two lines immediately after self.qkv:
self.q_norm = nn.RMSNorm(self.dim_head)
self.k_norm = nn.RMSNorm(self.dim_head)
```

In `TransolverAttention.forward`, after `q, k, v = qkv.chunk(3, dim=-1)`, add the normalisation calls:

```python
q, k, v = qkv.chunk(3, dim=-1)
# ADD these two lines:
q = self.q_norm(q)
k = self.k_norm(k)
out_slice = F.scaled_dot_product_attention(q, k, v,
    dropout_p=self.dropout if self.training else 0.0)
```

No other model changes. `nn.RMSNorm` is available in PyTorch >= 2.1 (already in the environment).

## Training command

```bash
python train.py \
  --model-pe string_multisigma \
  --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr 5e-5 \
  --lr-warmup-steps 1000 \
  --wandb_group string-pe-qknorm-lower-lr \
  --kill-thresholds 'STEP:val_primary/abupt_axis_mean_rel_l2_pct<8.5'
```

Use the standard DDP8 launch wrapper. All other hyperparameters remain at their defaults (Lion optimizer, EMA decay=0.999, cosine LR schedule, batch size 1 per GPU).

## Epoch gates

| Epoch | Gate (val_abupt) | Action if missed |
|-------|-----------------|-----------------|
| EP15 | ≤ 7.20% | Close immediately |
| EP25 | ≤ 6.90% | Close if not trending down |
| EP35 | ≤ 6.72% | Merge candidate if terminal |

Report val_abupt at every epoch. Post a `SENPAI-RESULT` marker once training completes or hits the maximum epoch budget.

## Current baselines to beat

| Metric | In-wave best (fern #664 EP36 val) | Merged best PR #599 (test) |
|--------|----------------------------------|---------------------------|
| val_abupt | 6.6916% | — |
| test abupt | — | 7.9303% |

Surface pressure (val): best in wave ~4.x%; volume pressure (val): best in wave ~11.x%.

## What to report

At each epoch milestone above, post a comment with:
- Current epoch
- val_abupt (primary gate metric)
- val surface_pressure_rel_l2_pct
- val volume_pressure_rel_l2_pct
- val wall_shear_rel_l2_pct
- W&B run ID

Terminal result must include the standard `SENPAI-RESULT` JSON marker with `terminal=true`, `pending_arms=false`, and both `primary_metric` (best val checkpoint) and `test_metric` (test set evaluation from best val checkpoint).
