### PR TITLE
STRING + QK-Norm at lr=5e-5 with staged warmup (2000-step)

### DIFF
--- a/model.py
+++ b/model.py
@@ -185,7 +185,7 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, qk_norm: bool = False):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -194,6 +194,7 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.qk_norm = qk_norm
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -222,6 +223,9 @@ class TransolverAttention(nn.Module):
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        if self.qk_norm:
+            q = F.normalize(q, dim=-1)
+            k = F.normalize(k, dim=-1)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -243,6 +247,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        qk_norm: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -252,6 +257,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            qk_norm=qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -274,6 +280,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        qk_norm: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -284,6 +291,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    qk_norm=qk_norm,
                 )
                 for _ in range(depth)
             ]
@@ -315,6 +323,7 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        qk_norm: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -325,6 +334,7 @@ class SurfaceTransolver(nn.Module):
         self.pe_kind = pe_kind
         self.pe_num_features = pe_num_features
         self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        self.qk_norm = qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -360,6 +370,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            qk_norm=qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -96,6 +96,7 @@ class Config:
     model_pe: str = "sincos"
     pe_num_features: int = 16
     pe_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    model_qk_norm: bool = False
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
@@ -195,6 +196,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        qk_norm=config.model_qk_norm,
     )
 
 


### PR DESCRIPTION
## Hypothesis

L2-normalizing Q and K attention vectors per head (QK-Norm) inside `TransolverAttention.forward` stabilizes attention entropy, which may help the Transolver block better resolve anisotropic features (τ_y/τ_z cross-flow) that dominate the remaining validation gap vs. SOTA.

**Prior evidence:** Pre-wave run `tkiigfmc` showed QK-Norm is not destructive on old stack (test=8.625%). PR #696 tested QK-Norm at lr=1e-4 on the current wave config and showed steady learning (EP13 best=7.593%) but a persistent ~1pp gap to SOTA. The gap is attributed to **two compounding issues**:
1. **LR too high at initialization:** Lion lr=1e-4 combined with QK-Norm produces attention logit spikes at EP8 (+0.12pp uptick), indicating the normalizer is over-constraining gradient flow at high LR. Solution: lr=5e-5 (half of SOTA).
2. **Insufficient warmup:** QK-Norm layers need more gradient warmup steps to normalize before full gradient flow. Solution: `--lr-warmup-steps 2000` (4× default 500).

This experiment directly tests whether the lower-LR + extended-warmup combination eliminates the instability that caused #696 to plateau.

**References:**
- QK-Norm: Henry et al. (2020), "Query-Key Normalization for Transformers" (https://arxiv.org/abs/2010.04245)
- Wortsman et al. (2023), "Replacing softmax with ReLU in Vision Transformers" — attention entropy stabilization benefits

## Code Changes Required

Implement QK-Norm in `model.py` and add the CLI flag to `train.py`. This is a minimal 5-location change — do not touch anything else.

### 1. `model.py` — `TransolverAttention.__init__`

Find `class TransolverAttention` and its `__init__`. Add `qk_norm: bool = False` as a parameter and store it:

```python
# In TransolverAttention.__init__, add parameter:
def __init__(self, ..., qk_norm: bool = False):
    ...
    self.qk_norm = qk_norm
```

### 2. `model.py` — `TransolverAttention.forward`

In the `forward` method, after computing `q` and `k` (before the dot-product / softmax), add:

```python
import torch.nn.functional as F  # (at top of file if not present)

# In TransolverAttention.forward, after q and k are computed:
if self.qk_norm:
    q = F.normalize(q, dim=-1)
    k = F.normalize(k, dim=-1)
```

The normalization is per-head across the head dimension (`dim=-1` when q/k have shape `[B, H, S, D//H]` or equivalent). Verify the shape and adjust `dim` if needed so you normalize along the per-head feature dimension.

### 3. `model.py` — `TransformerBlock.__init__` and `Transformer.__init__`

Plumb `qk_norm` through the call chain:

```python
# TransformerBlock.__init__: accept and forward qk_norm
def __init__(self, ..., qk_norm: bool = False):
    self.attn = TransolverAttention(..., qk_norm=qk_norm)

# Transformer.__init__: accept and forward qk_norm
def __init__(self, ..., qk_norm: bool = False):
    self.blocks = nn.ModuleList([TransformerBlock(..., qk_norm=qk_norm) for _ in range(n_layers)])
```

### 4. `model.py` — `SurfaceTransolver.__init__`

Add `qk_norm: bool = False` to `SurfaceTransolver.__init__` and forward it to `Transformer(...)`:

```python
def __init__(self, ..., qk_norm: bool = False):
    self.transformer = Transformer(..., qk_norm=qk_norm)
```

### 5. `train.py` — `Config` dataclass and argument parser

Add the flag to the `Config` dataclass:

```python
# In Config dataclass:
model_qk_norm: bool = False
```

Add the CLI arg in the `build_argparser()` / `parse_args()` section:

```python
parser.add_argument('--model-qk-norm', action='store_true', default=False,
                    help='Enable QK-Norm (L2-normalize Q and K per attention head)')
```

Wire it through to `SurfaceTransolver(...)`:

```python
# In the model instantiation block:
model = SurfaceTransolver(..., qk_norm=config.model_qk_norm)
```

Log it to W&B config as well so it's visible in the run summary.

## Smoke Test (run first, ~5 min)

Run a 1-epoch smoke test to verify no crashes and reasonable EP1 loss:

```bash
torchrun --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-group string-qknorm-lr5e5 \
  --epochs 1 \
  --lr 5e-5 \
  --optimizer lion \
  --use-ema --ema-decay 0.999 \
  --lr-warmup-steps 2000 \
  --lr-cosine-t-max 50 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-qk-norm \
  --train-surface-points 40000 --eval-surface-points 40000 \
  --train-volume-points 65000 \
  --surface-loss-weight 1.0 \
  --no-compile-model \
  --seed 42
```

**Expected EP1 range:** 13–14% (QK-Norm adds convergence overhead; EP1 at lr=5e-5 with 2000-step warmup will be slower than lr=1e-4). If EP1 > 16%, stop and report — do not proceed to long run.

## Long Run (after smoke passes)

```bash
torchrun --nproc_per_node=8 train.py \
  --agent tanjiro \
  --wandb-group string-qknorm-lr5e5 \
  --epochs 50 \
  --lr 5e-5 \
  --optimizer lion \
  --use-ema --ema-decay 0.999 \
  --lr-warmup-steps 2000 \
  --lr-cosine-t-max 50 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-qk-norm \
  --train-surface-points 40000 --eval-surface-points 40000 \
  --train-volume-points 65000 \
  --surface-loss-weight 1.0 \
  --no-compile-model \
  --seed 42
```

## Kill Gates

| Epoch | Max val_abupt | Action if exceeded |
|-------|--------------|-------------------|
| EP5 | ≤9.0% | Kill and close PR |
| EP10 | ≤8.0% | Kill and close PR |
| EP15 | ≤7.4% | Kill and close PR |
| EP20 | ≤7.0% | Kill and close PR |
| EP50 | Run to completion | Report terminal SENPAI-RESULT |

**Rationale:** Lower LR means slower early convergence — gates are set ~0.5pp higher than SOTA trajectory to account for the warmup overhead. If EP5 > 9.0%, the lower LR alone is not compensating and the mechanism doesn't work.

## Baseline to Beat

| Metric | Target |
|--------|--------|
| `val_primary/abupt_axis_mean_rel_l2_pct` (best-val EMA) | < 6.5281% (SOTA val, PR #599 `sogus8sx`) |
| `test_primary/abupt_axis_mean_rel_l2_pct` | < 7.9303% (SOTA test, PR #599 `sogus8sx`) |

**SOTA run:** `sogus8sx` — STRING PE 5-sigma, Lion lr=1e-4, EMA 0.999, cosine T_max=50, 4L/512d/4H/128S, no-compile, seed=42.

## What to Report

After each epoch, post the val_abupt EMA metric in a PR comment. At EP50 (or at early termination), post a terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Also include the per-component breakdown: `surface_pressure_rel_l2_pct`, `wall_shear_rel_l2_pct`, `volume_pressure_rel_l2_pct`.

**COMPLIANCE NOTE:** Run only the commands above. Do NOT run any unauthorized W&B groups or side experiments without first getting advisor approval via a PR comment. Report every epoch result promptly.
