### PR TITLE
GradNorm adaptive loss balancing on SOTA Lion+STRING config

### DIFF
--- a/train.py
+++ b/train.py
@@ -129,6 +129,9 @@ class Config:
     y_symmetry_aug_prob: float = 0.5
     eval_only: bool = False
     eval_checkpoint: str = ""
+    use_gradnorm: bool = False
+    gradnorm_alpha: float = 1.0
+    gradnorm_lr: float = 1e-3
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -186,6 +189,39 @@ def parse_pe_init_sigmas(spec: str) -> list[float] | None:
         return None
     sigmas = [float(s) for s in spec.split(",") if s.strip()]
     return sigmas or None
+
+
+class GradNormWeights(nn.Module):
+    """Learnable per-task GradNorm weights (Chen et al. 2018, arXiv:1711.02257).
+
+    Stores log-weights so the multiplicative weight ``w = exp(log_w)`` is
+    always positive. Weights are renormalised externally to satisfy
+    ``sum(w) = n_tasks``.
+    """
+
+    def __init__(self, n_tasks: int):
+        super().__init__()
+        self.n_tasks = n_tasks
+        self.log_weights = nn.Parameter(torch.zeros(n_tasks))
+
+    @property
+    def weights(self) -> torch.Tensor:
+        return torch.exp(self.log_weights)
+
+
+def per_channel_masked_mse(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Per-channel masked MSE. Returns a [C] tensor (one scalar per output channel).
+
+    The denominator is the spatial mask count, so summing the per-channel MSEs
+    and dividing by ``C`` recovers the full ``masked_mse`` value.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    diff_sq = (pred - target).square()  # [B, N, C]
+    weighted = diff_sq * mask_f  # broadcast [B, N, C]
+    denom = mask_f.sum().clamp_min(1.0)
+    return weighted.sum(dim=(0, 1)) / denom  # [C]
 
 
 def build_model(config: Config) -> SurfaceTransolver:
@@ -264,7 +300,8 @@ def train_loss(
     use_y_symmetry_aug: bool = False,
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
-) -> tuple[torch.Tensor, dict[str, float]]:
+    gradnorm_weights: GradNormWeights | None = None,
+) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
         flip_mask = apply_y_symmetry_aug(batch, y_symmetry_aug_prob)
@@ -282,9 +319,23 @@ def train_loss(
         )
         surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
-        weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        if gradnorm_weights is not None:
+            surface_per_ch = per_channel_masked_mse(
+                out["surface_preds"], surface_target, batch.surface_mask
+            )  # [4]: cp, tau_x, tau_y, tau_z
+            volume_per_ch = per_channel_masked_mse(
+                out["volume_preds"], volume_target, batch.volume_mask
+            )  # [1]: vol_p
+            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
+            w_detached = gradnorm_weights.weights.detach()
+            loss = (w_detached * task_losses).sum()
+            weighted_surface_loss = (w_detached[:4] * surface_per_ch).sum()
+            weighted_volume_loss = w_detached[4] * volume_per_ch[0]
+        else:
+            task_losses = None
+            weighted_surface_loss = surface_loss_weight * surface_loss
+            weighted_volume_loss = volume_loss_weight * volume_loss
+            loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
@@ -292,7 +343,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }
+    }, task_losses
 
 
 def run_eval_only(config: Config, state) -> None:
@@ -425,6 +476,22 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+
+        gradnorm_weights: GradNormWeights | None = None
+        gradnorm_opt: torch.optim.Optimizer | None = None
+        gradnorm_L0: torch.Tensor | None = None
+        gradnorm_n_tasks = 5  # cp, tau_x, tau_y, tau_z, vol_p
+        gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z", "vol_p")
+        if config.use_gradnorm:
+            gradnorm_weights = GradNormWeights(n_tasks=gradnorm_n_tasks).to(device)
+            gradnorm_opt = torch.optim.Adam(
+                gradnorm_weights.parameters(), lr=config.gradnorm_lr
+            )
+            if state.is_main:
+                print(
+                    f"GradNorm enabled: alpha={config.gradnorm_alpha}, "
+                    f"n_tasks={gradnorm_n_tasks}, lr={config.gradnorm_lr}"
+                )
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
         if kill_thresholds and state.is_main:
             print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
@@ -504,7 +571,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 aug_log: dict[str, int] = {}
-                loss, batch_loss_metrics = train_loss(
+                loss, batch_loss_metrics, task_losses = train_loss(
                     model,
                     batch,
                     transform,
@@ -515,6 +582,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     use_y_symmetry_aug=config.use_y_symmetry_aug,
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
+                    gradnorm_weights=gradnorm_weights,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -581,6 +649,98 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
                 else:
+                    gradnorm_log: dict[str, float] = {}
+                    if (
+                        gradnorm_weights is not None
+                        and gradnorm_opt is not None
+                        and task_losses is not None
+                    ):
+                        task_losses_finite = bool(
+                            torch.isfinite(task_losses.detach()).all().item()
+                        )
+                        if task_losses_finite:
+                            if gradnorm_L0 is None:
+                                gradnorm_L0 = task_losses.detach().clone()
+                            shared_param = base_model.norm.weight
+                            c_per_task: list[torch.Tensor] = []
+                            for i in range(gradnorm_n_tasks):
+                                g_i = torch.autograd.grad(
+                                    task_losses[i],
+                                    shared_param,
+                                    retain_graph=True,
+                                    allow_unused=True,
+                                )[0]
+                                if g_i is None:
+                                    c_per_task.append(
+                                        torch.zeros((), device=device, dtype=torch.float32)
+                                    )
+                                else:
+                                    c_per_task.append(g_i.detach().float().norm(2))
+                            c_tensor = torch.stack(c_per_task)  # [n_tasks]
+                            with torch.no_grad():
+                                w_now = gradnorm_weights.weights
+                                G_per_task = w_now * c_tensor  # [n_tasks]
+                                G_bar = G_per_task.mean()
+                                L_ratio = (
+                                    task_losses.detach().float()
+                                    / gradnorm_L0.float().clamp_min(1e-12)
+                                )
+                                r = L_ratio / L_ratio.mean().clamp_min(1e-12)
+                                target = G_bar * r.pow(config.gradnorm_alpha)
+                                diff = G_per_task - target
+                                # d L_grad / d log_w_i = sign(diff_i) * G_per_task_i
+                                log_w_grad = torch.sign(diff) * G_per_task
+                                # safety: zero out non-finite components
+                                log_w_grad = torch.where(
+                                    torch.isfinite(log_w_grad),
+                                    log_w_grad,
+                                    torch.zeros_like(log_w_grad),
+                                )
+                            gradnorm_opt.zero_grad(set_to_none=True)
+                            gradnorm_weights.log_weights.grad = log_w_grad
+                            gradnorm_opt.step()
+                            with torch.no_grad():
+                                # renormalise so weights sum to n_tasks
+                                lw = gradnorm_weights.log_weights.data
+                                lw_norm = lw - torch.logsumexp(lw, dim=0) + math.log(
+                                    float(gradnorm_n_tasks)
+                                )
+                                gradnorm_weights.log_weights.data.copy_(lw_norm)
+                                # DDP: average log_weights across ranks for sync
+                                if state.enabled:
+                                    torch.distributed.all_reduce(
+                                        gradnorm_weights.log_weights.data,
+                                        op=torch.distributed.ReduceOp.SUM,
+                                    )
+                                    gradnorm_weights.log_weights.data.div_(
+                                        state.world_size
+                                    )
+                                w_post = gradnorm_weights.weights.detach().cpu()
+                                c_cpu = c_tensor.detach().cpu()
+                                G_cpu = G_per_task.detach().cpu()
+                                tl_cpu = task_losses.detach().float().cpu()
+                                r_cpu = r.detach().cpu()
+                                for ti, name in enumerate(gradnorm_task_names):
+                                    gradnorm_log[f"gradnorm/w_{name}"] = float(
+                                        w_post[ti].item()
+                                    )
+                                    gradnorm_log[f"gradnorm/grad_norm_{name}"] = float(
+                                        c_cpu[ti].item()
+                                    )
+                                    gradnorm_log[f"gradnorm/G_{name}"] = float(
+                                        G_cpu[ti].item()
+                                    )
+                                    gradnorm_log[f"gradnorm/task_loss_{name}"] = float(
+                                        tl_cpu[ti].item()
+                                    )
+                                    gradnorm_log[f"gradnorm/r_{name}"] = float(
+                                        r_cpu[ti].item()
+                                    )
+                                gradnorm_log["gradnorm/G_bar"] = float(
+                                    G_bar.detach().cpu().item()
+                                )
+                    if gradnorm_log:
+                        train_log.update(gradnorm_log)
                     loss.backward()
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(


### PR DESCRIPTION
## Hypothesis

GradNorm (Chen et al., 2018) is an adaptive multi-task loss balancing method that learns per-task loss weights dynamically to equalize gradient magnitudes across tasks. Our model jointly optimizes surface pressure (`cp`), wall shear vector (`tau_x/y/z`), and volume pressure (`p_v`), which have very different gradient scales. The current loss is a fixed-weight sum — surface gets 1.0× and volume gets 1.0× with no per-channel balancing.

Pre-wave run `341czkol` tested GradNorm α=1.0 on an older config (test=8.243%) and showed improvement over unweighted baselines on that config. That configuration is now superseded by the SOTA Lion+STRING PE setup. This experiment tests GradNorm on the current SOTA config — which is the correct scientific comparison: does GradNorm help when the base config is already strong?

**The mechanism:** GradNorm maintains a single learnable weight per output channel that rescales each task's gradient contribution. The `α` hyperparameter controls how aggressively to equalize: α=1.0 drives weights toward equalizing gradient norms; α=0.5 is more conservative (run `wyz68o8r` tested EMA-proxy GradNorm α=0.5, test=8.236%). This experiment tests α=1.0 (more aggressive equalization) and α=0.5 as a comparison arm.

Reference: [GradNorm: Gradient Normalization for Adaptive Loss Balancing in Deep Multitask Networks (Chen et al., NeurIPS 2018)](https://arxiv.org/abs/1711.02257)

## Instructions

Implement GradNorm adaptive loss weighting in `train.py`. The key idea: replace the fixed `surface_loss_weight` / `volume_loss_weight` scalars with *learned* per-channel weights that are updated each step by the GradNorm update rule.

### Implementation

1. **Add a `GradNormWeights` module** to `train.py`:

```python
class GradNormWeights(nn.Module):
    """Learnable per-channel GradNorm weights (Chen et al. 2018)."""
    def __init__(self, n_tasks: int):
        super().__init__()
        self.log_weights = nn.Parameter(torch.zeros(n_tasks))

    @property
    def weights(self):
        return torch.exp(self.log_weights)
```

2. **Add CLI flags** (add to `Config` dataclass and `build_arg_parser`):

```python
# Config dataclass
use_gradnorm: bool = False
gradnorm_alpha: float = 1.0

# build_arg_parser  
parser.add_argument("--use-gradnorm", action="store_true", default=False)
parser.add_argument("--no-use-gradnorm", dest="use_gradnorm", action="store_false")
parser.add_argument("--gradnorm-alpha", type=float, default=1.0)
```

3. **Instantiate and initialize** after the model is built (in the training setup section):

```python
# Tasks: surface_cp, wall_tau_x, wall_tau_y, wall_tau_z, volume_p — 5 tasks
gradnorm_weights = None
if cfg.use_gradnorm:
    gradnorm_weights = GradNormWeights(n_tasks=5).to(device)
    gradnorm_opt = torch.optim.Adam(gradnorm_weights.parameters(), lr=1e-3)
    # Store initial L0 task losses (will be set after first forward pass)
    L0 = None
```

4. **Compute per-task losses** in the training step. Where the current code computes combined loss, split it into per-task components before combining:

```python
if cfg.use_gradnorm and gradnorm_weights is not None:
    # Per-task losses (unweighted)
    loss_cp = surface_loss_cp   # surface pressure rel L2
    loss_tau_x = wall_loss_x
    loss_tau_y = wall_loss_y
    loss_tau_z = wall_loss_z
    loss_vol = volume_loss_p
    task_losses = torch.stack([loss_cp, loss_tau_x, loss_tau_y, loss_tau_z, loss_vol])
    
    # Initialize L0 on first step
    if L0 is None:
        L0 = task_losses.detach().clone()
    
    # Weighted sum
    w = gradnorm_weights.weights
    loss = (w * task_losses).sum()
    
    # GradNorm update: compute gradient of weighted sum w.r.t. shared params
    # using last shared layer weights as proxy
    shared_params = list(model.parameters())[-2]  # last shared layer param
    G_w = torch.autograd.grad(
        (w * task_losses).sum(), shared_params,
        retain_graph=True, allow_unused=True
    )[0]
    if G_w is not None:
        G_bar = G_w.norm(2)
        # Per-task gradient norms
        G_i = []
        for i, tl in enumerate(task_losses):
            g = torch.autograd.grad(
                w[i] * tl, shared_params,
                retain_graph=True, allow_unused=True
            )[0]
            G_i.append(g.norm(2) if g is not None else torch.zeros(1, device=device))
        G_i = torch.stack(G_i)
        
        # Relative inverse training rate
        r_i = (task_losses.detach() / L0) / ((task_losses.detach() / L0).mean())
        
        # GradNorm loss
        gradnorm_loss = (G_i - G_bar * r_i.pow(cfg.gradnorm_alpha)).abs().sum()
        
        gradnorm_opt.zero_grad()
        gradnorm_loss.backward(retain_graph=True)
        gradnorm_opt.step()
        
        # Renormalize weights so they sum to n_tasks
        with torch.no_grad():
            gradnorm_weights.log_weights.data = torch.log(
                gradnorm_weights.weights / gradnorm_weights.weights.sum() * 5
            )
else:
    loss = cfg.surface_loss_weight * surface_loss + cfg.volume_loss_weight * volume_loss
```

5. **Log GradNorm weights** to W&B each step:
```python
if cfg.use_gradnorm and gradnorm_weights is not None:
    w = gradnorm_weights.weights.detach()
    wandb.log({
        "gradnorm/w_cp": w[0].item(),
        "gradnorm/w_tau_x": w[1].item(),
        "gradnorm/w_tau_y": w[2].item(),
        "gradnorm/w_tau_z": w[3].item(),
        "gradnorm/w_vol": w[4].item(),
    }, step=global_step)
```

### Run two arms

**Arm A — α=1.0 (aggressive equalization):**
```bash
torchrun --nproc_per_node=8 train.py \
  --agent fern \
  --wandb-group gradnorm-adaptive \
  --epochs 50 \
  --lr 1e-4 \
  --optimizer lion \
  --use-ema \
  --ema-decay 0.999 \
  --lr-cosine-t-max 50 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --train-surface-points 65536 \
  --train-volume-points 16384 \
  --eval-surface-points 40000 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --use-gradnorm \
  --gradnorm-alpha 1.0 \
  --no-compile-model \
  --seed 42
```

**Arm B — α=0.5 (conservative equalization):**
Same command with `--gradnorm-alpha 0.5`.

Run both arms concurrently — use 4 GPUs each (`--nproc_per_node=4`) if running simultaneously on a single 8-GPU node, or run on separate nodes. **Start with Arm A; launch Arm B only after Arm A smoke test (EP1) confirms no NaN.**

### Kill gates (val_primary/abupt_axis_mean_rel_l2_pct)

| Epoch | Gate |
|-------|------|
| EP5 | ≤9.0% |
| EP10 | ≤8.0% |
| EP20 | ≤7.2% |
| EP50 | terminal |

Kill if diverged (loss > 1.0 after EP3) or gate exceeded.

### Smoke test (before full run)
```bash
torchrun --nproc_per_node=8 train.py \
  --agent fern \
  --wandb-group gradnorm-adaptive \
  --epochs 1 \
  --lr 1e-4 \
  --optimizer lion \
  --use-ema \
  --ema-decay 0.999 \
  --lr-cosine-t-max 50 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --train-surface-points 65536 \
  --train-volume-points 16384 \
  --eval-surface-points 40000 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --use-gradnorm \
  --gradnorm-alpha 1.0 \
  --no-compile-model \
  --seed 42
```

After EP1, post the smoke test val_primary/abupt_axis_mean_rel_l2_pct, all 6 axis metrics, and confirm no NaN anywhere. If EP1 > 16%, flag it before continuing.

## Baseline

Current in-wave single-model SOTA (merged PR #599, run `sogus8sx`):
- `test_primary/abupt_axis_mean_rel_l2_pct` = **7.9303%**

Active val tracking (not yet merged):
- fern PR #664 `a8emaoxm`: best val=6.6970% @ EP30 (CLOSED at EP40 gate fail)
- frieren PR #669 `er8wmo8d`: best val=6.7488% @ EP31 (ongoing)

Public AB-UPT targets (lower is better):
- `surface_pressure_rel_l2_pct` ≤ 3.82%
- `wall_shear_rel_l2_pct` ≤ 7.29%
- `volume_pressure_rel_l2_pct` ≤ 6.08%
- `wall_shear_x_rel_l2_pct` ≤ 5.35%
- `wall_shear_y_rel_l2_pct` ≤ 3.65%
- `wall_shear_z_rel_l2_pct` ≤ 3.63%

Val target to beat: **6.6916%** (current in-wave best across all active runs).

Pre-wave GradNorm evidence (different config):
- `341czkol`: GradNorm α=1.0, test=8.243% (improved over then-SOTA)
- `wyz68o8r`: EMA-proxy GradNorm α=0.5, test=8.236%

## Expected outcome

GradNorm should dynamically up-weight the channels with high gradient norms (tau_y, tau_z — the hardest channels from prior runs) and down-weight the easier channels (surface cp), reducing the overall abupt_axis_mean. The α=1.0 arm pushes harder toward equal gradient training rates; α=0.5 is more conservative. We expect α=1.0 to show more improvement on the tau components at the risk of slightly higher surface error.
