### PR TITLE
Y-axis symmetry augmentation on SOTA Lion+STRING config

### DIFF
--- a/train.py
+++ b/train.py
@@ -125,6 +125,8 @@ class Config:
     nonfinite_skip_abort: int = 200
     compile_model: bool = False
     debug: bool = False
+    use_y_symmetry_aug: bool = False
+    y_symmetry_aug_prob: float = 0.5
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -221,6 +223,33 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     )
 
 
+def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
+    """Reflect a random subset of batch items through the y=0 plane.
+
+    DrivAerML car geometry is bilaterally symmetric about y=0. Under y-reflection
+    (x, y, z) -> (x, -y, z) the surface point coordinate y, the surface normal
+    component n_y, the wall-shear y-component tau_y, and the volume point
+    coordinate y all negate. cp, surface area, sdf, tau_x, tau_z, and volume
+    pressure are invariant. This in-place transform is applied per-sample with
+    probability `prob`. Returns the boolean mask used (for diagnostic logging).
+
+    Channel layout (verified):
+    - surface_x: [x, y, z, nx, ny, nz, area]  -> negate idx 1 and idx 4
+    - surface_y: [cp, tau_x, tau_y, tau_z]    -> negate idx 2
+    - volume_x:  [x, y, z, sdf]               -> negate idx 1
+    - volume_y:  [pressure]                   -> invariant
+    """
+    B = batch.surface_x.shape[0]
+    flip_mask = torch.rand(B, device=batch.surface_x.device) < prob
+    if flip_mask.any():
+        idx = flip_mask.nonzero(as_tuple=True)[0]
+        batch.surface_x[idx, :, 1] = -batch.surface_x[idx, :, 1]
+        batch.surface_x[idx, :, 4] = -batch.surface_x[idx, :, 4]
+        batch.surface_y[idx, :, 2] = -batch.surface_y[idx, :, 2]
+        batch.volume_x[idx, :, 1] = -batch.volume_x[idx, :, 1]
+    return flip_mask
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -230,8 +259,16 @@ def train_loss(
     *,
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
+    use_y_symmetry_aug: bool = False,
+    y_symmetry_aug_prob: float = 0.5,
+    aug_log: dict | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    if use_y_symmetry_aug:
+        flip_mask = apply_y_symmetry_aug(batch, y_symmetry_aug_prob)
+        if aug_log is not None:
+            aug_log["n_flipped"] = int(flip_mask.sum().item())
+            aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -378,6 +415,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                aug_log: dict[str, int] = {}
                 loss, batch_loss_metrics = train_loss(
                     model,
                     batch,
@@ -386,7 +424,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                     config.amp_mode,
                     surface_loss_weight=config.surface_loss_weight,
                     volume_loss_weight=config.volume_loss_weight,
+                    use_y_symmetry_aug=config.use_y_symmetry_aug,
+                    y_symmetry_aug_prob=config.y_symmetry_aug_prob,
+                    aug_log=aug_log,
                 )
+                if (
+                    config.use_y_symmetry_aug
+                    and state.is_main
+                    and epoch == 0
+                    and global_step == 0
+                ):
+                    print(
+                        f"[aug debug] EP0 step0 (rank0): "
+                        f"{aug_log.get('n_flipped', 0)}/{aug_log.get('batch_size', 0)} "
+                        f"samples y-flipped"
+                    )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 scheduled_lr = scheduler.get_last_lr()[0]
@@ -425,6 +477,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
+                    )
+                if config.use_y_symmetry_aug and aug_log:
+                    bs = max(1, aug_log.get("batch_size", 0))
+                    train_log["train/aug/y_symmetry_flip_rate"] = (
+                        aug_log.get("n_flipped", 0) / bs
+                    )
+                    train_log["train/aug/y_symmetry_n_flipped"] = aug_log.get(
+                        "n_flipped", 0
+                    )
+                    train_log["train/aug/y_symmetry_batch_size"] = aug_log.get(
+                        "batch_size", 0
                     )
 
                 if skip_step:

--- a/train.py
+++ b/train.py
@@ -127,6 +127,8 @@ class Config:
     debug: bool = False
     use_y_symmetry_aug: bool = False
     y_symmetry_aug_prob: float = 0.5
+    eval_only: bool = False
+    eval_checkpoint: str = ""
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -293,11 +295,97 @@ def train_loss(
     }
 
 
+def run_eval_only(config: Config, state) -> None:
+    """Load a saved checkpoint and run full val + test evaluation."""
+    if config.seed >= 0:
+        seed_everything(config.seed)
+    device = state.device
+    if state.is_main:
+        ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
+        print(f"[eval-only] Device: {device}{ddp_suffix}")
+        print(f"[eval-only] Checkpoint: {config.eval_checkpoint}")
+
+    train_loader, val_loaders, test_loaders, stats = make_loaders(
+        config, distributed_state=state
+    )
+    final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
+    final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model: nn.Module = build_model(config).to(device)
+    n_params = sum(param.numel() for param in model.parameters())
+    if state.enabled:
+        ddp_kwargs = {}
+        if device.type == "cuda":
+            ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+        model = DistributedDataParallel(model, **ddp_kwargs)
+    base_model = unwrap_model(model)
+
+    run = init_wandb_run(
+        config=config,
+        state=state,
+        n_params=n_params,
+        train_loader=train_loader,
+        val_loaders=val_loaders,
+        test_loaders=test_loaders,
+        total_estimated_steps=1,
+        max_epochs=0,
+        train_timeout_minutes=0.0,
+        val_budget_minutes=0.0,
+    )
+
+    distributed_barrier(state)
+    if not state.is_main:
+        wandb.finish()
+        return
+
+    ckpt_path = Path(config.eval_checkpoint)
+    checkpoint = torch.load(ckpt_path, map_location=device, weights_only=True)
+    val_metrics = checkpoint["val_metrics"]["val_surface"]
+    best_metrics = {
+        "epoch": float(checkpoint["epoch"]),
+        "abupt_axis_mean_rel_l2_pct": val_metrics["abupt_axis_mean_rel_l2_pct"],
+        "surface_pressure_mae": val_metrics["surface_pressure_mae"],
+        "wall_shear_mae": val_metrics["wall_shear_mae"],
+        "volume_pressure_mae": val_metrics["volume_pressure_mae"],
+    }
+    config_path = ckpt_path.parent / "config.yaml"
+    if not config_path.exists():
+        with config_path.open("w") as f:
+            yaml.safe_dump(asdict(config), f)
+
+    run_final_evaluation(
+        run=run,
+        model=base_model,
+        model_path=ckpt_path,
+        config_path=config_path,
+        config=config,
+        transform=transform,
+        device=device,
+        final_val_loaders=final_val_loaders,
+        final_test_loaders=final_test_loaders,
+        best_metrics=best_metrics,
+        best_checkpoint_source=checkpoint.get("checkpoint_source", "eval-only"),
+        n_params=n_params,
+        global_step=int(checkpoint["epoch"]),
+        total_minutes=0.0,
+    )
+    wandb.finish()
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     state = init_distributed()
     run = None
     try:
         config = parse_args(argv)
+        if config.eval_only:
+            run_eval_only(config, state)
+            return
         if config.seed >= 0:
             seed_everything(config.seed)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)


### PR DESCRIPTION
## Hypothesis

The DrivAerML car geometry is bilaterally symmetric about the y=0 plane. This is an exact physical symmetry: for every training sample, reflecting the mesh coordinates through y=0 and negating `tau_y` (and keeping `cp`, `tau_x`, `tau_z`, `p_v` unchanged) produces a physically valid second training sample. This doubles the effective dataset size from 500 to 1000 samples for free, with zero model change.

The key physics:
- Under y-reflection (x → x, y → -y, z → z): surface pressure `cp` is invariant (scalar), volume pressure `p_v` is invariant, wall shear `tau_x` is invariant (x-component unchanged), wall shear `tau_y` **negates** (y-component flips sign), wall shear `tau_z` is invariant.

Pre-wave run `wgvvevb9` tested per-axis output scaling on an old config and yielded test=8.618%. The current val plateau across all recent experiments (fern #664 at ~6.69%, frieren #669 at ~6.75%) suggests the model is data-limited — adding 2× the samples via exact symmetry augmentation addresses this directly. Symmetry augmentation is a standard technique in physics-aware ML (e.g., [Meshgraphnets](https://arxiv.org/abs/2010.03409), geometric deep learning literature) and is well-motivated for car aerodynamics.

This is a **data augmentation change only** — no model or loss change. The baseline config (Lion+STRING PE) is unchanged.

## Instructions

Add y-axis reflection augmentation in `train.py` at the dataset/dataloader level. The simplest correct implementation is to augment each batch on-the-fly during training (not at eval time).

### Implementation

1. **Add CLI flag** to `Config` dataclass and `build_arg_parser`:

```python
# Config dataclass
use_y_symmetry_aug: bool = False

# build_arg_parser
parser.add_argument("--use-y-symmetry-aug", action="store_true", default=False)
parser.add_argument("--no-use-y-symmetry-aug", dest="use_y_symmetry_aug", action="store_false")
```

2. **Locate where surface and volume batches are formed** in the training loop. This is typically where `surface_coords`, `surface_targets`, `volume_coords`, `volume_targets` are extracted from the batch. After extracting but before the forward pass, apply augmentation with 50% probability per sample in the batch:

```python
if cfg.use_y_symmetry_aug:
    B = surface_coords.shape[0]
    flip_mask = torch.rand(B, device=device) < 0.5  # which samples to flip
    
    if flip_mask.any():
        # Flip y-coordinate (dim 1 of xyz) for surface and volume points
        # surface_coords: [B, N_surf, 3] — negate index 1
        surface_coords_aug = surface_coords.clone()
        surface_coords_aug[flip_mask, :, 1] = -surface_coords_aug[flip_mask, :, 1]
        
        # surface_targets layout: [B, N_surf, C] where C = [cp, tau_x, tau_y, tau_z]
        # tau_y is index 2 — negate it
        surface_targets_aug = surface_targets.clone()
        surface_targets_aug[flip_mask, :, 2] = -surface_targets_aug[flip_mask, :, 2]
        
        # volume_coords: [B, N_vol, 3] — negate y
        volume_coords_aug = volume_coords.clone()
        volume_coords_aug[flip_mask, :, 1] = -volume_coords_aug[flip_mask, :, 1]
        
        # volume_targets: [B, N_vol, 1] — pressure is invariant, no sign flip
        
        surface_coords = surface_coords_aug
        surface_targets = surface_targets_aug
        volume_coords = volume_coords_aug
        # volume_targets unchanged
```

**CRITICAL:** Check the actual channel ordering in `surface_targets` before implementing. Add a one-time debug log at EP1 step 1 to print channel names/indices. If the ordering is `[cp, tau_x, tau_z, tau_y]` or different from `[cp, tau_x, tau_y, tau_z]`, adjust the index accordingly. Negate only `tau_y` — the y-component of wall shear. Negating the wrong channel will corrupt training.

3. **Do NOT augment at eval time.** The flip should only apply during the training loop, not during validation/test.

4. **Log augmentation stats** at EP1 to confirm it's working:
```python
if epoch == 0 and step == 0 and cfg.use_y_symmetry_aug:
    n_flipped = flip_mask.sum().item()
    print(f"[aug debug] EP0 step0: {n_flipped}/{B} samples y-flipped")
```

### Run command (single arm)

```bash
torchrun --nproc_per_node=8 train.py \
  --agent nezuko \
  --wandb-group y-symmetry-aug \
  --epochs 50 \
  --lr 1e-4 \
  --optimizer lion \
  --use-ema \
  --ema-decay 0.999 \
  --lr-cosine-t-max 50 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --train-surface-points 65536 \
  --train-volume-points 16384 \
  --eval-surface-points 40000 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --use-y-symmetry-aug \
  --no-compile-model \
  --seed 42
```

### Smoke test (run first, 1 epoch)

Same command with `--epochs 1`. After EP1:
- Confirm no NaN in any metric
- Confirm aug debug log shows ~50% flip rate
- Report val_primary/abupt_axis_mean_rel_l2_pct and all 6 axis metrics
- Confirm tau_y val metric is not anomalously worse than the baseline (which would indicate the y-flip sign is applied to the wrong channel)

### Kill gates (val_primary/abupt_axis_mean_rel_l2_pct)

| Epoch | Gate |
|-------|------|
| EP5  | ≤9.0% |
| EP10 | ≤8.0% |
| EP20 | ≤7.2% |
| EP50 | terminal |

## Baseline

Current in-wave single-model SOTA (merged PR #599, run `sogus8sx`):
- `test_primary/abupt_axis_mean_rel_l2_pct` = **7.9303%**

Active val tracking (not yet merged):
- frieren PR #669 `er8wmo8d`: best val=6.7488% @ EP31 (ongoing)
- tanjiro PR #732: QK-Norm + warmup, EP5 gate pending

Val target to beat: **6.6916%** (fern #664 peak before gate-fail, current in-wave best across all active/closed runs).

Public AB-UPT targets:
- `surface_pressure_rel_l2_pct` ≤ 3.82%
- `wall_shear_rel_l2_pct` ≤ 7.29%
- `volume_pressure_rel_l2_pct` ≤ 6.08%
- `wall_shear_x_rel_l2_pct` ≤ 5.35%
- `wall_shear_y_rel_l2_pct` ≤ 3.65%
- `wall_shear_z_rel_l2_pct` ≤ 3.63%

## Expected outcome

The y-symmetry doubles effective training data with exact physics, requiring no model change. We expect:
- Improvement in `tau_y` — the component most directly affected by y-augmentation
- Reduction in the val→test generalization gap (augmentation reduces overfitting)
- vol pressure `p_v` improvement since volume coords are also augmented

If val at EP20 is not below 7.0%, the augmentation alone is insufficient and we should consider combining it with loss reweighting (tau_y × 1.2) in a follow-up.
