### PR TITLE
thorfinn: Exp 3 Redux (Issue #618) — Anchor-STRING stabilized (diff-LR + RoPE clip)

### DIFF
--- a/model.py
+++ b/model.py
@@ -136,6 +136,458 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class StringRoPE(nn.Module):
+    """STRING-style RoPE: learnable per-axis frequencies and phases for 3D RoPE.
+
+    Applies rotary position embeddings to Q/K tensors given 3D coordinates.
+    Each head dimension pair (2f, 2f+1) is rotated by an angle derived from
+    the coordinate along axis d:
+
+        theta_{d,f}(x_d) = exp(log_freq[d, f]) * 2pi * x_d + phase[d, f]
+
+    The rotation is applied as a complex-number multiply: (q_r + i*q_i) *
+    exp(i*theta) = (q_r*cos - q_i*sin) + i*(q_r*sin + q_i*cos).
+
+    Axes are combined additively: theta = sum_d theta_{d,f}.  This allows
+    smooth factorisation across stream (x), span (y) and vertical (z).
+
+    Parameters
+    ----------
+    num_heads : int
+        Number of attention heads.
+    head_dim : int
+        Dimension per head.  Must be even.
+    num_axes : int
+        Number of spatial axes (3 for 3-D point clouds).
+    init_sigmas : list[float] | None
+        Scale sigmas for log-spaced init: log_freq[d, f] = log(2*pi / sigma_f).
+        Round-robin across features.  If None, defaults to sigma=1.0 for all.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_dim: int,
+        num_axes: int = 3,
+        init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        if head_dim % 2 != 0:
+            raise ValueError(f"head_dim must be even for RoPE; got {head_dim}")
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.num_axes = num_axes
+        num_freq_pairs = head_dim // 2
+
+        # log_freq[num_axes, num_freq_pairs]: learnable log-frequency
+        if init_sigmas and len(init_sigmas) >= 1:
+            log_freq_vals = torch.tensor(
+                [math.log(2.0 * math.pi / init_sigmas[f % len(init_sigmas)]) for f in range(num_freq_pairs)],
+                dtype=torch.float32,
+            )
+            log_freq_init = log_freq_vals.unsqueeze(0).expand(num_axes, num_freq_pairs).clone()
+        else:
+            log_freq_init = torch.zeros(num_axes, num_freq_pairs)
+        self.log_freq = nn.Parameter(log_freq_init)
+
+        # phase[num_axes, num_freq_pairs]: learnable phase offset
+        self.phase = nn.Parameter(torch.zeros(num_axes, num_freq_pairs))
+
+    def _compute_angles(self, coords: torch.Tensor) -> torch.Tensor:
+        """Compute rotation angles from coordinates.
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            Shape ``[B, N, num_axes]``.
+
+        Returns
+        -------
+        angles : torch.Tensor
+            Shape ``[B, N, num_freq_pairs]``.
+        """
+        freq = torch.exp(self.log_freq.to(dtype=coords.dtype))   # [num_axes, F]
+        phase = self.phase.to(dtype=coords.dtype)                  # [num_axes, F]
+        # coords: [B, N, num_axes] -> [B, N, num_axes, 1] * [num_axes, F] -> [B, N, num_axes, F]
+        angles = coords.unsqueeze(-1) * freq + phase               # [B, N, num_axes, F]
+        # Sum across axes (additive factorisation) -> [B, N, F]
+        return angles.sum(dim=-2)
+
+    @staticmethod
+    def _rotate(x: torch.Tensor, angles: torch.Tensor) -> torch.Tensor:
+        """Apply RoPE rotation.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``[B, H, N, head_dim]``.
+        angles : torch.Tensor
+            Shape ``[B, N, F]`` where F = head_dim // 2.
+
+        Returns
+        -------
+        rotated : torch.Tensor
+            Same shape as x.
+        """
+        B, H, N, D = x.shape
+        F = D // 2
+        # angles: [B, N, F] -> [B, 1, N, F] broadcast over heads
+        cos_a = torch.cos(angles).unsqueeze(1)  # [B, 1, N, F]
+        sin_a = torch.sin(angles).unsqueeze(1)  # [B, 1, N, F]
+        # Split x into pairs
+        x_r = x[..., :F]  # real part  [B, H, N, F]
+        x_i = x[..., F:]  # imaginary part  [B, H, N, F]
+        out_r = x_r * cos_a - x_i * sin_a
+        out_i = x_r * sin_a + x_i * cos_a
+        return torch.cat([out_r, out_i], dim=-1)
+
+    def apply_self(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        coords: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE for self-attention (both Q and K use the same coords).
+
+        Parameters
+        ----------
+        q, k : torch.Tensor
+            Shape ``[B, H, N, head_dim]``.
+        coords : torch.Tensor
+            Shape ``[B, N, num_axes]``.
+        """
+        angles = self._compute_angles(coords)
+        return self._rotate(q, angles), self._rotate(k, angles)
+
+    def apply_cross(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        q_coords: torch.Tensor,
+        k_coords: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE for cross-attention (Q and K use different coords).
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            Shape ``[B, H, Nq, head_dim]``.
+        k : torch.Tensor
+            Shape ``[B, H, Nk, head_dim]``.
+        q_coords : torch.Tensor
+            Shape ``[B, Nq, num_axes]``.
+        k_coords : torch.Tensor
+            Shape ``[B, Nk, num_axes]``.
+        """
+        q_angles = self._compute_angles(q_coords)
+        k_angles = self._compute_angles(k_coords)
+        return self._rotate(q, q_angles), self._rotate(k, k_angles)
+
+
+class AnchorStringAttention(nn.Module):
+    """Anchor-STRING attention backbone.
+
+    Replaces the Transolver backbone with a two-stage attention mechanism:
+
+    1. Stride-select K anchor points from the N input tokens.
+    2. Run ``depth`` layers of anchor self-attention with STRING-RoPE on the
+       anchor tokens (K x K attention — cheap).
+    3. Run a single round of point-to-anchor cross-attention (N x K) so every
+       point token attends to the refined anchor representation.
+
+    This gives O(K^2 * D) anchor self-attention + O(N*K*D) cross-attend cost
+    vs. O(N^2*D) full attention.  For N=65k, K=1024, this is ~4000x cheaper
+    for the self-attention stage.
+
+    Parameters
+    ----------
+    depth : int
+        Number of anchor self-attention layers.
+    hidden_dim : int
+        Token / hidden dimension.
+    num_heads : int
+        Attention heads.
+    mlp_expansion_factor : int | float
+        MLP hidden = hidden_dim * mlp_expansion_factor.
+    anchor_tokens : int
+        K, number of anchors.
+    init_sigmas : list[float] | None
+        Init sigmas for STRING-RoPE log_freq.
+    dropout : float
+        Dropout rate.
+    use_qk_norm : bool
+        If True, apply RMSNorm to Q and K in both anchor self-attn and
+        point→anchor cross-attn (matches the SOTA TransolverAttention stack).
+    coord_scale : list[float] | None
+        Per-axis scales used to normalise coordinates before STRING-RoPE.
+        Coords are divided by these values so the resulting normalised
+        coordinates fit roughly in ``[-2, 2]`` per axis. This prevents the
+        STRING-RoPE rotation angles from aliasing chaotically across the
+        wide DrivAerML volume domain (raw x reaches +71 m, y reaches -22 m).
+        Defaults to ``[35.0, 18.0, 12.0]`` — half-extents observed in the
+        diagnostic run; passing ``None`` disables normalisation.
+    """
+
+    def __init__(
+        self,
+        *,
+        depth: int,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_expansion_factor: int | float,
+        anchor_tokens: int = 1024,
+        init_sigmas: list[float] | None = None,
+        dropout: float = 0.0,
+        use_qk_norm: bool = False,
+        coord_scale: list[float] | None = None,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.depth = depth
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.anchor_tokens = anchor_tokens
+        self.dropout = dropout
+        self.use_qk_norm = use_qk_norm
+
+        # Per-axis coordinate scale buffer for STRING-RoPE input. Raw DrivAerML
+        # volume coords reach 70 m+, which makes any sigma <= 10 m alias many
+        # rotations between Q and K — diagnosed root cause of the EP1
+        # divergence in PR #647 / first attempt of #742. Dividing by half-extent
+        # brings coords into roughly [-2, 2] per axis where the PR-spec sigmas
+        # [0.1, 0.3, 1.0, 3.0, 10.0] are appropriate.
+        if coord_scale is None:
+            coord_scale_vec = torch.tensor([35.0, 18.0, 12.0], dtype=torch.float32)
+        else:
+            if len(coord_scale) != 3:
+                raise ValueError(
+                    f"coord_scale must have 3 entries, got {len(coord_scale)}"
+                )
+            coord_scale_vec = torch.tensor(coord_scale, dtype=torch.float32)
+        if (coord_scale_vec <= 0).any():
+            raise ValueError(f"coord_scale entries must be positive: {coord_scale}")
+        self.register_buffer("coord_scale", coord_scale_vec)
+
+        # STRING-RoPE: shared between anchor self-attn and point→anchor cross-attn
+        self.string_rope = StringRoPE(
+            num_heads=num_heads,
+            head_dim=self.head_dim,
+            num_axes=3,
+            init_sigmas=init_sigmas,
+        )
+
+        # Anchor self-attention layers (reuse TransformerBlock for pre-LN + MLP)
+        # TransformerBlock uses TransolverAttention internally (slice-based),
+        # but we want standard multi-head attention for anchors.
+        # Use explicit QKV + sdpa layers instead.
+        self.anchor_norms1 = nn.ModuleList(
+            [nn.LayerNorm(hidden_dim, eps=1e-6) for _ in range(depth)]
+        )
+        self.anchor_qkv = nn.ModuleList(
+            [nn.Linear(hidden_dim, 3 * hidden_dim, bias=False) for _ in range(depth)]
+        )
+        self.anchor_proj = nn.ModuleList(
+            [nn.Linear(hidden_dim, hidden_dim) for _ in range(depth)]
+        )
+        self.anchor_norms2 = nn.ModuleList(
+            [nn.LayerNorm(hidden_dim, eps=1e-6) for _ in range(depth)]
+        )
+        if use_qk_norm:
+            self.anchor_q_norms = nn.ModuleList(
+                [nn.RMSNorm(self.head_dim, elementwise_affine=True) for _ in range(depth)]
+            )
+            self.anchor_k_norms = nn.ModuleList(
+                [nn.RMSNorm(self.head_dim, elementwise_affine=True) for _ in range(depth)]
+            )
+        else:
+            self.anchor_q_norms = None
+            self.anchor_k_norms = None
+        mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
+        self.anchor_mlps = nn.ModuleList(
+            [UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim) for _ in range(depth)]
+        )
+        self.anchor_dropout = nn.Dropout(dropout)
+
+        # Point-to-anchor cross-attention (single layer)
+        self.cross_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.cross_q = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.cross_kv = nn.Linear(hidden_dim, 2 * hidden_dim, bias=False)
+        self.cross_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.cross_dropout = nn.Dropout(dropout)
+        if use_qk_norm:
+            self.cross_q_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+            self.cross_k_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+        else:
+            self.cross_q_norm = None
+            self.cross_k_norm = None
+
+        # Diagnostic: last selected anchor coords (eval-time only). Captured by
+        # forward() so collect_anchor_rope_metrics can compute coord spread.
+        self._last_anchor_coords: torch.Tensor | None = None
+
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        for name, p in self.named_parameters():
+            if name.startswith("string_rope."):
+                continue
+            if p.dim() >= 2:
+                nn.init.trunc_normal_(p, std=0.02)
+            elif "bias" in name:
+                nn.init.zeros_(p)
+
+    def _select_anchors(
+        self,
+        hidden: torch.Tensor,
+        coords: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Stride-select K anchor tokens, mask-aware when ``attn_mask`` is given.
+
+        With ``attn_mask`` the K anchors are sampled at evenly-spaced positions
+        among the valid (non-padding) tokens of each batch row, so anchors
+        never land on a zero-coord, zero-hidden padding token. Without a mask
+        we fall back to a single shared stride along ``[0, N)``.
+
+        Parameters
+        ----------
+        hidden : torch.Tensor
+            Shape ``[B, N, D]``.
+        coords : torch.Tensor
+            Shape ``[B, N, 3]``.
+        attn_mask : torch.Tensor | None
+            Optional ``[B, N]`` boolean / 0-1 validity mask.
+
+        Returns
+        -------
+        anchor_hidden : torch.Tensor
+            Shape ``[B, K, D]``.
+        anchor_coords : torch.Tensor
+            Shape ``[B, K, 3]``.
+        anchor_idx : torch.Tensor
+            Shape ``[B, K]`` (mask-aware path) or ``[K]`` (no-mask path).
+        """
+        B, N, D = hidden.shape
+        K = min(self.anchor_tokens, N)
+        if attn_mask is None:
+            stride = max(1, N // K)
+            anchor_idx = torch.arange(0, N, stride, device=hidden.device)[:K]
+            return hidden[:, anchor_idx], coords[:, anchor_idx], anchor_idx
+        # Mask-aware vectorised stride selection.
+        valid_cumsum = attn_mask.long().cumsum(dim=-1)  # [B, N]
+        n_valid = valid_cumsum[:, -1]  # [B]
+        k_range = torch.arange(K, device=hidden.device, dtype=torch.float32).unsqueeze(0)
+        n_valid_f = n_valid.float().unsqueeze(1).clamp(min=1.0)
+        target = (k_range * n_valid_f / float(K)).long() + 1  # [B, K], 1-based
+        target = torch.minimum(target, n_valid.long().unsqueeze(1).clamp(min=1))
+        anchor_idx = torch.searchsorted(valid_cumsum, target).clamp(max=N - 1)  # [B, K]
+        idx_h = anchor_idx.unsqueeze(-1).expand(B, K, D)
+        anchor_hidden = torch.gather(hidden, dim=1, index=idx_h)
+        idx_c = anchor_idx.unsqueeze(-1).expand(B, K, coords.shape[-1])
+        anchor_coords = torch.gather(coords, dim=1, index=idx_c)
+        return anchor_hidden, anchor_coords, anchor_idx
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        coords: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        hidden : torch.Tensor
+            Shape ``[B, N, D]``.
+        coords : torch.Tensor
+            Shape ``[B, N, 3]``.
+        attn_mask : torch.Tensor | None
+            Optional token validity mask ``[B, N]``.
+
+        Returns
+        -------
+        out : torch.Tensor
+            Shape ``[B, N, D]``.
+        """
+        B, N, D = hidden.shape
+        H = self.num_heads
+        Hd = self.head_dim
+
+        # Normalise raw coords by the registered per-axis scale so STRING-RoPE
+        # operates on coords in roughly [-2, 2] per axis (avoids many-rotation
+        # aliasing for far-field volume points).
+        coord_scale = self.coord_scale.to(dtype=coords.dtype, device=coords.device)
+        coords_rope = coords / coord_scale
+
+        # --- Select anchors (mask-aware so we skip padded tokens) ---
+        anchor_h, anchor_coords_raw, _ = self._select_anchors(hidden, coords, attn_mask)
+        anchor_coords_rope = anchor_coords_raw / coord_scale
+        K = anchor_h.shape[1]
+        if not self.training:
+            # Diagnostic snapshot for collect_anchor_rope_metrics — keep the raw
+            # coords here so the wandb metrics keep their original physical units.
+            self._last_anchor_coords = anchor_coords_raw.detach()
+
+        # --- Anchor self-attention layers with STRING-RoPE ---
+        for i in range(self.depth):
+            # Pre-LN
+            a_normed = self.anchor_norms1[i](anchor_h)
+            # QKV projection
+            qkv = self.anchor_qkv[i](a_normed)
+            q, k, v = qkv.chunk(3, dim=-1)
+            # Reshape to [B, H, K, Hd]
+            q = q.view(B, K, H, Hd).permute(0, 2, 1, 3)
+            k = k.view(B, K, H, Hd).permute(0, 2, 1, 3)
+            v = v.view(B, K, H, Hd).permute(0, 2, 1, 3)
+            if self.anchor_q_norms is not None:
+                q = self.anchor_q_norms[i](q)
+                k = self.anchor_k_norms[i](k)
+            # Apply STRING-RoPE (self-attention: same coords for Q and K)
+            q, k = self.string_rope.apply_self(q, k, anchor_coords_rope)
+            # Scaled dot-product attention
+            attn_out = F.scaled_dot_product_attention(
+                q, k, v,
+                dropout_p=self.dropout if self.training else 0.0,
+            )
+            # [B, H, K, Hd] -> [B, K, D]
+            attn_out = attn_out.permute(0, 2, 1, 3).contiguous().view(B, K, D)
+            attn_out = self.anchor_dropout(self.anchor_proj[i](attn_out))
+            anchor_h = anchor_h + attn_out
+
+            # MLP block
+            anchor_h = anchor_h + self.anchor_mlps[i](self.anchor_norms2[i](anchor_h))
+
+        # --- Point-to-anchor cross-attention ---
+        # Q from points, K/V from anchors
+        h_normed = self.cross_norm(hidden)
+        q = self.cross_q(h_normed).view(B, N, H, Hd).permute(0, 2, 1, 3)  # [B, H, N, Hd]
+        kv = self.cross_kv(anchor_h)
+        k, v = kv.chunk(2, dim=-1)
+        k = k.view(B, K, H, Hd).permute(0, 2, 1, 3)  # [B, H, K, Hd]
+        v = v.view(B, K, H, Hd).permute(0, 2, 1, 3)  # [B, H, K, Hd]
+        if self.cross_q_norm is not None:
+            q = self.cross_q_norm(q)
+            k = self.cross_k_norm(k)
+        # Apply STRING-RoPE cross-attention
+        q, k = self.string_rope.apply_cross(q, k, coords_rope, anchor_coords_rope)
+        # Compute cross-attention
+        cross_out = F.scaled_dot_product_attention(
+            q, k, v,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        # [B, H, N, Hd] -> [B, N, D]
+        cross_out = cross_out.permute(0, 2, 1, 3).contiguous().view(B, N, D)
+        cross_out = self.cross_dropout(self.cross_proj(cross_out))
+        hidden = hidden + cross_out
+
+        if attn_mask is not None:
+            hidden = _apply_token_mask(hidden, attn_mask)
+
+        return hidden
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -342,6 +794,11 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        backbone_kind: str = "transolver",
+        anchor_tokens: int = 1024,
+        anchor_selection: str = "stride",
+        anchor_string_init_sigmas: list[float] | None = None,
+        anchor_string_coord_scale: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +811,13 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.backbone_kind = backbone_kind
+        self.anchor_tokens = anchor_tokens
+        self.anchor_selection = anchor_selection
+        self.anchor_string_init_sigmas = list(anchor_string_init_sigmas) if anchor_string_init_sigmas else None
+        self.anchor_string_coord_scale = (
+            list(anchor_string_coord_scale) if anchor_string_coord_scale else None
+        )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -409,15 +873,28 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
-        self.backbone = Transformer(
-            depth=n_layers,
-            hidden_dim=n_hidden,
-            num_heads=n_head,
-            mlp_expansion_factor=mlp_ratio,
-            num_slices=slice_num,
-            dropout=dropout,
-            use_qk_norm=use_qk_norm,
-        )
+        if backbone_kind == "anchor_string":
+            self.backbone = AnchorStringAttention(
+                depth=n_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                anchor_tokens=anchor_tokens,
+                init_sigmas=anchor_string_init_sigmas,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+                coord_scale=anchor_string_coord_scale,
+            )
+        else:
+            self.backbone = Transformer(
+                depth=n_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
@@ -498,7 +975,18 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        if self.backbone_kind == "anchor_string":
+            # Build per-token xyz coords for STRING-RoPE.  Coords are the first
+            # space_dim columns of the raw input tensors (before any feature projection).
+            coord_parts: list[torch.Tensor] = []
+            if surface_x is not None:
+                coord_parts.append(surface_x[:, :, : self.space_dim])
+            if volume_x is not None:
+                coord_parts.append(volume_x[:, :, : self.space_dim])
+            coords = torch.cat(coord_parts, dim=1)  # [B, N_total, 3]
+            hidden = self.backbone(hidden, coords, attn_mask=attn_mask)
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -138,6 +138,13 @@ class Config:
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
     debug: bool = False
+    backbone_kind: str = "transolver"
+    anchor_tokens: int = 1024
+    anchor_selection: str = "stride"
+    anchor_string_init_sigmas: str = ""
+    anchor_string_coord_scale: str = "35.0,18.0,12.0"
+    rope_lr_scale: float = 1.0
+    rope_grad_clip: float = 0.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -233,19 +240,64 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _get_rope_params(model: nn.Module) -> tuple[list[nn.Parameter], set[int]]:
+    """Return RoPE parameters and their id-set for AnchorStringAttention backbone."""
+    rope_params: list[nn.Parameter] = []
+    rope_param_ids: set[int] = set()
+    # Access the unwrapped base model when DDP-wrapped
+    base = getattr(model, "module", model)
+    backbone = getattr(base, "backbone", None)
+    if backbone is not None:
+        string_rope = getattr(backbone, "string_rope", None)
+        if string_rope is not None:
+            for p in string_rope.parameters():
+                rope_params.append(p)
+                rope_param_ids.add(id(p))
+    return rope_params, rope_param_ids
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    use_rope_group = (
+        config.backbone_kind == "anchor_string"
+        and config.rope_lr_scale != 1.0
+    )
+    if use_rope_group:
+        rope_params, rope_param_ids = _get_rope_params(model)
+        main_params = [p for p in model.parameters() if id(p) not in rope_param_ids]
+        rope_lr = config.lr * config.rope_lr_scale
+    else:
+        main_params = list(model.parameters())
+        rope_params = []
+        rope_lr = config.lr
+
     if optimizer_name == "adamw":
+        if use_rope_group and rope_params:
+            param_groups = [
+                {"params": main_params, "lr": config.lr, "weight_decay": config.weight_decay},
+                {"params": rope_params, "lr": rope_lr, "weight_decay": config.weight_decay},
+            ]
+            return torch.optim.AdamW(param_groups)
         return torch.optim.AdamW(
-            model.parameters(),
+            main_params,
             lr=config.lr,
             weight_decay=config.weight_decay,
         )
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
+        if use_rope_group and rope_params:
+            param_groups = [
+                {"params": main_params, "lr": config.lr, "weight_decay": config.weight_decay},
+                {"params": rope_params, "lr": rope_lr, "weight_decay": config.weight_decay},
+            ]
+            return Lion(
+                param_groups,
+                betas=(config.lion_beta1, config.lion_beta2),
+                use_triton=False,
+            )
         return Lion(
-            model.parameters(),
+            main_params,
             lr=config.lr,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
@@ -284,6 +336,90 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def parse_anchor_string_init_sigmas(spec: str) -> list[float] | None:
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    sigmas = [float(token.strip()) for token in spec.split(",") if token.strip()]
+    if not sigmas:
+        return None
+    if any(s <= 0.0 for s in sigmas):
+        raise ValueError(f"--anchor-string-init-sigmas must be positive: {spec!r}")
+    return sigmas
+
+
+def parse_anchor_string_coord_scale(spec: str) -> list[float] | None:
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    scales = [float(token.strip()) for token in spec.split(",") if token.strip()]
+    if not scales:
+        return None
+    if len(scales) != 3:
+        raise ValueError(
+            f"--anchor-string-coord-scale needs 3 comma-separated values "
+            f"(x,y,z), got {len(scales)}: {spec!r}"
+        )
+    if any(s <= 0.0 for s in scales):
+        raise ValueError(f"--anchor-string-coord-scale entries must be positive: {spec!r}")
+    return scales
+
+
+def collect_anchor_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Collect per-axis RoPE freq / phase diagnostics and anchor coord spread.
+
+    Logged once per epoch under keys:
+      rope/log_freq_axis_{0,1,2}_{mean,std,min,max}
+      rope/phase_axis_{0,1,2}_{mean,std}
+      anchor/coord_spread_xyz  (max-min per axis, mean over axes)
+    The coord_spread metric is static (depends only on the last batch's anchor
+    coords), but surfacing it confirms anchors are covering the mesh.
+    """
+    metrics: dict[str, float] = {}
+    base = getattr(model, "module", model)
+    backbone = getattr(base, "backbone", None)
+    if backbone is None:
+        return metrics
+    string_rope = getattr(backbone, "string_rope", None)
+    if string_rope is None:
+        return metrics
+
+    log_freq = string_rope.log_freq.detach().float()  # [num_axes, F]
+    phase = string_rope.phase.detach().float()         # [num_axes, F]
+    num_axes = log_freq.shape[0]
+    axis_names = ["x", "y", "z"]
+    for axis in range(min(num_axes, 3)):
+        ax_lf = log_freq[axis]
+        ax_ph = phase[axis]
+        metrics[f"rope/log_freq_axis_{axis}_mean"] = float(ax_lf.mean().item())
+        metrics[f"rope/log_freq_axis_{axis}_std"] = float(ax_lf.std().item())
+        metrics[f"rope/log_freq_axis_{axis}_min"] = float(ax_lf.min().item())
+        metrics[f"rope/log_freq_axis_{axis}_max"] = float(ax_lf.max().item())
+        metrics[f"rope/phase_axis_{axis}_mean"] = float(ax_ph.mean().item())
+        metrics[f"rope/phase_axis_{axis}_std"] = float(ax_ph.std().item())
+    metrics["rope/log_freq_global_mean"] = float(log_freq.mean().item())
+    metrics["rope/log_freq_global_min"] = float(log_freq.min().item())
+    metrics["rope/log_freq_global_max"] = float(log_freq.max().item())
+    # Anchor coord spread from the most recent (eval-time) forward pass.
+    last_anchor_coords = getattr(backbone, "_last_anchor_coords", None)
+    if last_anchor_coords is not None and last_anchor_coords.numel() > 0:
+        coords_f = last_anchor_coords.float()  # [B, K, 3]
+        per_axis_std: list[float] = []
+        for axis in range(min(coords_f.shape[-1], 3)):
+            ax = axis_names[axis] if axis < len(axis_names) else str(axis)
+            std_val = float(coords_f[..., axis].reshape(-1).std().item())
+            min_val = float(coords_f[..., axis].reshape(-1).min().item())
+            max_val = float(coords_f[..., axis].reshape(-1).max().item())
+            metrics[f"anchor/coord_spread_{ax}"] = std_val
+            metrics[f"anchor/coord_min_{ax}"] = min_val
+            metrics[f"anchor/coord_max_{ax}"] = max_val
+            per_axis_std.append(std_val)
+        if per_axis_std:
+            metrics["anchor/coord_spread_xyz"] = float(sum(per_axis_std) / len(per_axis_std))
+        metrics["anchor/num_anchors"] = float(coords_f.shape[1])
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +433,11 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        backbone_kind=config.backbone_kind,
+        anchor_tokens=config.anchor_tokens,
+        anchor_selection=config.anchor_selection,
+        anchor_string_init_sigmas=parse_anchor_string_init_sigmas(config.anchor_string_init_sigmas),
+        anchor_string_coord_scale=parse_anchor_string_coord_scale(config.anchor_string_coord_scale),
     )
 
 
@@ -861,6 +1002,26 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            # Log rope LR at step 0 for anchor_string experiments
+            if config.backbone_kind == "anchor_string":
+                rope_lr_val = config.lr * config.rope_lr_scale
+                wandb.summary["optim/rope_lr"] = rope_lr_val
+                # Per-axis coord_scale buffer used to normalise coords before STRING-RoPE.
+                backbone_mod = getattr(base_model, "backbone", None)
+                if backbone_mod is not None:
+                    coord_scale = getattr(backbone_mod, "coord_scale", None)
+                    if coord_scale is not None:
+                        cs = coord_scale.detach().float().cpu().tolist()
+                        for axis_idx, axis_name in enumerate(("x", "y", "z")):
+                            if axis_idx < len(cs):
+                                wandb.summary[f"rope/coord_scale_{axis_name}"] = cs[axis_idx]
+                    string_rope = getattr(backbone_mod, "string_rope", None)
+                    if string_rope is not None and hasattr(string_rope, "log_freq"):
+                        lf = string_rope.log_freq.detach().float()
+                        wandb.summary["rope/init_log_freq_min"] = float(lf.min().item())
+                        wandb.summary["rope/init_log_freq_max"] = float(lf.max().item())
+                        wandb.summary["rope/init_log_freq_mean"] = float(lf.mean().item())
+                        wandb.summary["rope/use_qk_norm"] = bool(config.use_qk_norm)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1055,13 +1216,68 @@ def main(argv: Iterable[str] | None = None) -> None:
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
-                    if config.grad_clip_norm > 0.0:
-                        grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
-                            base_model.parameters(),
-                            max_norm=config.grad_clip_norm,
-                        )
+                    # Fix 4: RoPE frequency warmup — zero log_freq grads for step < 500
+                    # This prevents log_freq from diverging before the main backbone has
+                    # warmed up, giving RoPE a stable signal to start learning from.
+                    if config.backbone_kind == "anchor_string" and global_step < 500:
+                        backbone_mod = getattr(base_model, "backbone", None)
+                        if backbone_mod is not None:
+                            string_rope_mod = getattr(backbone_mod, "string_rope", None)
+                            if string_rope_mod is not None and hasattr(string_rope_mod, "log_freq"):
+                                if string_rope_mod.log_freq.grad is not None:
+                                    string_rope_mod.log_freq.grad.zero_()
+
+                    # Fix 2: For anchor_string, exclude RoPE params from the global
+                    # clip so the subsequent per-group RoPE clip (rope_grad_clip) is
+                    # not vacuous (the prior PR applied the global clip first, making
+                    # the secondary clip a no-op).
+                    use_rope_clip = (
+                        config.backbone_kind == "anchor_string"
+                        and config.rope_grad_clip > 0.0
+                    )
+                    if use_rope_clip:
+                        rope_params_clip, rope_param_ids_clip = _get_rope_params(base_model)
+                        main_params_clip = [
+                            p for p in base_model.parameters()
+                            if id(p) not in rope_param_ids_clip
+                        ]
+                        # Compute and log RoPE grad norm before its clip
+                        if rope_params_clip:
+                            rope_grad_norm_pre = torch.nn.utils.clip_grad_norm_(
+                                rope_params_clip,
+                                max_norm=float("inf"),  # measure-only pass
+                            )
+                            rope_grad_norm_pre_val = float(rope_grad_norm_pre.detach().cpu().item())
+                            torch.nn.utils.clip_grad_norm_(
+                                rope_params_clip,
+                                max_norm=config.rope_grad_clip,
+                            )
+                            rope_grad_norm_post = torch.nn.utils.clip_grad_norm_(
+                                rope_params_clip,
+                                max_norm=float("inf"),  # measure post-clip norm
+                            )
+                            rope_grad_norm_post_val = float(rope_grad_norm_post.detach().cpu().item())
+                            train_log["rope/grad_norm_pre_clip"] = rope_grad_norm_pre_val
+                            train_log["rope/grad_norm_post_clip"] = rope_grad_norm_post_val
+                        else:
+                            main_params_clip = list(base_model.parameters())
+
+                        # Global clip applies only to non-RoPE params
+                        if config.grad_clip_norm > 0.0:
+                            grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
+                                main_params_clip,
+                                max_norm=config.grad_clip_norm,
+                            )
+                        else:
+                            grad_norm_tensor = global_grad_norm(main_params_clip, device)
                     else:
-                        grad_norm_tensor = global_grad_norm(base_model.parameters(), device)
+                        if config.grad_clip_norm > 0.0:
+                            grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
+                                base_model.parameters(),
+                                max_norm=config.grad_clip_norm,
+                            )
+                        else:
+                            grad_norm_tensor = global_grad_norm(base_model.parameters(), device)
                     grad_norm_pre_clip = float(grad_norm_tensor.detach().cpu().item())
                     grad_is_nonfinite = not math.isfinite(grad_norm_pre_clip)
                     skip_step = distributed_any(state, grad_is_nonfinite, device)
@@ -1240,6 +1456,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_anchor_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis (Issue #618 Exp 3 Redux — Anchor-STRING Stabilized)

PR #647 (frieren) implemented the Anchor-STRING / no-slice AB-UPT-lite architecture but **diverged at EP1 with val_abupt=48.27%**. Inspection suggests the architecture is sound but training is destabilized by the joint optimization of geometric RoPE frequency parameters and the main backbone. We hypothesize three targeted fixes will stabilize training and unlock the geometry-conditioned attention path:

1. **Differential learning rate (0.1×)** for RoPE frequency parameters relative to the main model. RoPE log-frequencies sit in a different scale regime than backbone weights — when both share the Lion lr=9e-5, frequency drift in EP1 catastrophically perturbs the rotation phases applied to Q/K.
2. **Gradient clipping on the RoPE path at 1.0**, separate from the global grad-clip=0.5. RoPE backprop produces large gradients early in training when frequencies are wide; clipping the RoPE-path gradients independently prevents them from saturating Lion's update direction.
3. **Conservative log-spaced frequency init in [0.1, 10.0]** rather than the wider sigma set used in PR #647. DrivAerML point-cloud coords sit in roughly [-2, 2] m; frequencies above ~10 cycles/m alias trivially and are the most likely source of EP1 instability.

If all three fixes land, we expect **EP1 val to be in a sane 9–20% range** (vs PR #647's 48.27%) and the run to train through EP3 cleanly. The geometry-conditioned attention should then reduce the volume_pressure val→test gap (PR #626 demonstrated this with a 3.17×→2.07× compression even on a regressed val), targeting the **Issue #717 vol-test ladder** at the weak threshold (test vol_pressure < 11.0%).

This is the **highest-priority Issue #618 re-attempt** per the human researcher directive. References:
- PR #647 (original Exp 3, diverged): https://github.com/morganmcg1/DrivAerML/pull/647
- PR #626 (Exp 4 AB-UPT, val regression but vol gap compressed): https://github.com/morganmcg1/DrivAerML/pull/626
- Issue #618 advisor comment with the full Exp 3 Redux spec.

## Instructions

Re-implement the Anchor-STRING attention path from PR #647 on top of the current `tay` SOTA stack, with the three stabilization fixes. Reproduce frieren's `AnchorStringAttention` module and the `--backbone-kind anchor_string` plumbing exactly, then add:

### Code changes

1. **Differential LR for RoPE params.** Tag every parameter that is part of the RoPE frequency / phase tables (`log_freq`, `phase`, anchor-STRING init sigma buffers if learnable) into a separate Lion param group with **lr = 0.1 × base_lr = 9e-6**. Keep β2=0.99 and weight_decay=5e-4 on this group. Confirm via `wandb.summary['optim/rope_lr']` at step 0.

2. **Separate RoPE-path gradient clip.** After `loss.backward()` and before global `clip_grad_norm_(model.parameters(), 0.5)`, do an extra `clip_grad_norm_(rope_params, 1.0)`. Log per-step `rope/grad_norm_pre_clip` and `rope/grad_norm_post_clip` to W&B (every step is fine — they're scalars).

3. **Conservative frequency init.** Pass `--anchor-string-init-sigmas "0.1,0.3,1.0,3.0,10.0"` (log-spaced 0.1–10.0, 5 sigma values matching the established RFF count). Init `log_freq` from `log(2π / sigma)` so the period is sigma metres along each axis. Verify in EP0 with `wandb.summary['rope/init_log_freq_min/max/mean']`.

### CLI flags (add only the three new ones)

```
--backbone-kind anchor_string \
--anchor-tokens 1024 \
--anchor-selection stride \
--anchor-string-init-sigmas "0.1,0.3,1.0,3.0,10.0" \
--rope-lr-scale 0.1 \
--rope-grad-clip 1.0
```

Keep all other SOTA hyperparameters identical to PR #592: Lion lr=9e-5, β2=0.99, wd=5e-4, EMA=0.999, slices=128 (the slice path is the fallback if `--backbone-kind anchor_string` is not active; here it is, so slicing is bypassed inside Anchor-STRING blocks), L=5, hidden=512, heads=4, RFF=16, vol-points-curriculum 16k→65k, grad-clip global=0.5, lr-warmup 1ep, cosine T_max=13.

### W&B logging additions (required)

Per Issue #618 advisor directive:

- `rope/grad_norm` (pre + post clip, per step)
- `rope/log_freq_axis_{0,1,2}_{mean,std,min,max}` per epoch
- `rope/phase_axis_{0,1,2}_{mean,std}` per epoch
- `anchor/coord_spread_xyz` (std of selected anchor coords per axis) per epoch — diagnostic for anchor selection drift
- Standard val_abupt + per-channel val (surface_pressure, volume_pressure, wall_shear, tau_x, tau_y, tau_z)

Use `--wandb_group thorfinn-exp3-redux-string-rope`.

### Kill gates (operational)

- **EP1 time gate**: kill if epoch_time > 80 min.
- **EP1 stability gate**: kill if val_abupt > 25% (PR #647 hit 48% — this catches a re-divergence early).
- **EP2 (step ~21,729)**: kill if val_abupt > 12.0%.
- **EP3 (step ~32,594)**: kill if val_abupt > 8.0%.

### Final SENPAI-RESULT requirements

- 9-column Issue #717 table (best EMA val_abupt, best EMA test_abupt, per-channel val + test for surface_pressure / volume_pressure / wall_shear / tau_y / tau_z) with comparison to all three frozen anchors `sogus8sx` (#599), `4k25s25e` (#592), `dc031qpt` (#681).
- Per-region test volume_pressure breakdown.
- Per-case top-10 worst test volume_pressure cases.
- val→test transfer ratio for volume_pressure (target: compress toward PR #626's 2.07× from the SOTA 3.17×).
- RoPE frequency drift summary: did `log_freq` move materially over training? If yes, by how much per axis?

## Baseline

**Single-model SOTA** (this is your gate):

| Metric | Value | Source |
|---|---:|---|
| val_abupt (EMA, full) | **6.5985%** | PR #592 (alphonse, run `4k25s25e`) |
| test_abupt | 7.9915% | PR #592 |
| test volume_pressure | 11.933% | PR #592 |

**Issue #717 frozen anchors** (also report against these):

| Run | PR | Test vol_p | Test wall_shear | Test tau_y | Test tau_z |
|---|---:|---:|---:|---:|---:|
| `sogus8sx` | #599 | 11.694 | 7.299 | 7.941 | 9.535 |
| `4k25s25e` | #592 | 11.933 | 7.334 | 8.145 | 9.298 |
| `dc031qpt` | #681 | 11.374 | 8.321 | 9.596 | 10.738 |

**Promotion ladder for Issue #717 vol-test:** weak < 11.0%, solid ≤ 10.0%, major ≤ 8.5%, target ≤ 6.08%.

### Reproduce command

```bash
cd target && torchrun --nproc_per_node=8 train.py \
  --backbone-kind anchor_string \
  --anchor-tokens 1024 \
  --anchor-selection stride \
  --anchor-string-init-sigmas "0.1,0.3,1.0,3.0,10.0" \
  --rope-lr-scale 0.1 \
  --rope-grad-clip 1.0 \
  --depth 5 --hidden 512 --heads 4 --slices 128 \
  --rff-num-features 16 \
  --rff-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 9e-5 --beta2 0.99 --weight-decay 5e-4 \
  --grad-clip 0.5 \
  --ema-decay 0.999 \
  --vol-points-curriculum "16384:0,32768:3,65536:6" \
  --warmup-epochs 1 --cosine-tmax 13 \
  --loss-weights "tau_y=1.5,tau_z=2.0,surface=2.0,volume=1.0" \
  --epochs 13 \
  --wandb_group thorfinn-exp3-redux-string-rope
```

Confirm `python train.py --help` flag spellings before launching — adjust to match the actual flag names if any differ. **Do not concurrently run two `torchrun --nproc_per_node=8` jobs on the same 8 GPUs** (PR #716 lesson — doubles epoch time).
