### PR TITLE
Y-flip training augmentation for τ_y equivariance (50% prob)

### DIFF
--- a/launch_pr746_armA.sh
+++ b/launch_pr746_armA.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PR #746 - Y-flip training augmentation - Arm A (--y-flip-prob 0.5)
+set -uo pipefail
+cd /workspace/senpai/target
+mkdir -p logs_haku
+LOG=logs_haku/pr746_armA_yflip_p050_$(date +%Y%m%d_%H%M%S).log
+echo "Logging to: $LOG"
+echo "Started at: $(date -u)" > "$LOG"
+nohup torchrun --standalone --nproc_per_node=4 train.py \
+  --agent haku \
+  --wandb-group yi-round42-haku-yflip-aug \
+  --wandb-name haku/yflip-aug-p050 \
+  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
+  --grad-ema-alpha 0.5 \
+  --surface-curvature-features k1_k2 \
+  --beta-nll-beta 0.5 \
+  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
+  --batch-size 4 --validation-every 2 --no-compile-model \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --y-flip-prob 0.5 \
+  --ema-decay 0.999 --lr-warmup-epochs 1 \
+  --kill-thresholds '5442:val_primary/abupt_axis_mean_rel_l2_pct<50,16326:val_primary/abupt_axis_mean_rel_l2_pct<12,54420:val_primary/abupt_axis_mean_rel_l2_pct<9,108840:val_primary/abupt_axis_mean_rel_l2_pct<8.0' \
+  --epochs 30 \
+  >> "$LOG" 2>&1 &
+PID=$!
+echo "Launched PID $PID"
+echo "PID $PID" >> "$LOG"
+echo "$PID" > logs_haku/pr746_armA.pid
+echo "$LOG" > logs_haku/pr746_armA.logpath

--- a/test_y_flip.py
+++ b/test_y_flip.py
@@ -1,0 +1,115 @@
+"""Unit tests for y_flip_batch — verifies the bilateral-symmetry transform."""
+import sys
+import torch
+
+sys.path.insert(0, "/workspace/senpai/target")
+
+from train import y_flip_batch
+from data.loader import SurfaceBatch
+
+
+def make_batch(B=2, N_surf=8, N_vol=6, surf_x_dim=7):
+    torch.manual_seed(0)
+    surface_x = torch.randn(B, N_surf, surf_x_dim)
+    surface_y = torch.randn(B, N_surf, 4)  # cp, ws_x, ws_y, ws_z
+    surface_mask = torch.ones(B, N_surf, dtype=torch.bool)
+    volume_x = torch.randn(B, N_vol, 4)  # x, y, z, sdf
+    volume_y = torch.randn(B, N_vol, 1)
+    volume_mask = torch.ones(B, N_vol, dtype=torch.bool)
+    return SurfaceBatch(
+        case_ids=["c0", "c1"],
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=surface_mask,
+        volume_x=volume_x,
+        volume_y=volume_y,
+        volume_mask=volume_mask,
+        metadata=[{}, {}],
+    )
+
+
+def test_double_flip_identity():
+    batch = make_batch()
+    flipped = y_flip_batch(batch)
+    twice = y_flip_batch(flipped)
+    assert torch.allclose(twice.surface_x, batch.surface_x, atol=1e-6), "surface_x roundtrip"
+    assert torch.allclose(twice.surface_y, batch.surface_y, atol=1e-6), "surface_y roundtrip"
+    assert torch.allclose(twice.volume_x, batch.volume_x, atol=1e-6), "volume_x roundtrip"
+    assert torch.allclose(twice.volume_y, batch.volume_y, atol=1e-6), "volume_y roundtrip"
+    print("PASS: double-flip identity")
+
+
+def test_no_mutation():
+    batch = make_batch()
+    surface_x_before = batch.surface_x.clone()
+    surface_y_before = batch.surface_y.clone()
+    volume_x_before = batch.volume_x.clone()
+    volume_y_before = batch.volume_y.clone()
+    _ = y_flip_batch(batch)
+    assert torch.equal(batch.surface_x, surface_x_before), "surface_x mutated"
+    assert torch.equal(batch.surface_y, surface_y_before), "surface_y mutated"
+    assert torch.equal(batch.volume_x, volume_x_before), "volume_x mutated"
+    assert torch.equal(batch.volume_y, volume_y_before), "volume_y mutated"
+    print("PASS: no in-place mutation of input batch")
+
+
+def test_sign_flip():
+    """Single-point sanity: flip flips y/n_y/ws_y, preserves x/z/n_x/n_z/area/cp/ws_x/ws_z."""
+    surface_x = torch.tensor([[[1.0, 2.0, 3.0, 0.4, 0.5, 0.6, 0.7]]])  # B=1, N=1, 7 chs
+    surface_y = torch.tensor([[[10.0, 20.0, 30.0, 40.0]]])  # cp, ws_x, ws_y, ws_z
+    volume_x = torch.tensor([[[5.0, 6.0, 7.0, 0.1]]])
+    volume_y = torch.tensor([[[100.0]]])
+    batch = SurfaceBatch(
+        case_ids=["c0"],
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=torch.ones(1, 1, dtype=torch.bool),
+        volume_x=volume_x,
+        volume_y=volume_y,
+        volume_mask=torch.ones(1, 1, dtype=torch.bool),
+        metadata=[{}],
+    )
+    flipped = y_flip_batch(batch)
+    expected_sx = torch.tensor([[[1.0, -2.0, 3.0, 0.4, -0.5, 0.6, 0.7]]])
+    expected_sy = torch.tensor([[[10.0, 20.0, -30.0, 40.0]]])
+    expected_vx = torch.tensor([[[5.0, -6.0, 7.0, 0.1]]])
+    assert torch.equal(flipped.surface_x, expected_sx), f"surface_x got {flipped.surface_x}"
+    assert torch.equal(flipped.surface_y, expected_sy), f"surface_y got {flipped.surface_y}"
+    assert torch.equal(flipped.volume_x, expected_vx), f"volume_x got {flipped.volume_x}"
+    assert torch.equal(flipped.volume_y, volume_y), f"volume_y must be EVEN"
+    print("PASS: single-point sign-flip semantics")
+
+
+def test_curvature_channels_preserved():
+    """With curvature features (k1_k2 — channels 7,8), they should remain EVEN under flip."""
+    surface_x = torch.randn(1, 4, 9)  # 9 channels — base 7 + 2 curvature
+    base = SurfaceBatch(
+        case_ids=["c0"],
+        surface_x=surface_x,
+        surface_y=torch.randn(1, 4, 4),
+        surface_mask=torch.ones(1, 4, dtype=torch.bool),
+        volume_x=torch.randn(1, 3, 4),
+        volume_y=torch.randn(1, 3, 1),
+        volume_mask=torch.ones(1, 3, dtype=torch.bool),
+        metadata=[{}],
+    )
+    flipped = y_flip_batch(base)
+    # Curvature columns 7,8 must be unchanged
+    assert torch.equal(flipped.surface_x[..., 7:], base.surface_x[..., 7:]), "curvature changed"
+    # Area column 6 must be unchanged
+    assert torch.equal(flipped.surface_x[..., 6], base.surface_x[..., 6]), "area changed"
+    # x,z position cols (0,2) and n_x,n_z normal cols (3,5) unchanged
+    for c in (0, 2, 3, 5):
+        assert torch.equal(flipped.surface_x[..., c], base.surface_x[..., c]), f"col {c} changed"
+    # y position (1) and n_y (4) flipped
+    assert torch.equal(flipped.surface_x[..., 1], -base.surface_x[..., 1]), "y not flipped"
+    assert torch.equal(flipped.surface_x[..., 4], -base.surface_x[..., 4]), "n_y not flipped"
+    print("PASS: curvature channels preserved, signs flip on correct cols")
+
+
+if __name__ == "__main__":
+    test_double_flip_identity()
+    test_no_mutation()
+    test_sign_flip()
+    test_curvature_channels_preserved()
+    print("\nAll y_flip_batch tests passed.")

--- a/train.py
+++ b/train.py
@@ -416,6 +416,35 @@ def pad_collate_dynamic(samples: list[DrivAerMLCase]) -> SurfaceBatch:
     )
 
 
+def y_flip_batch(batch: SurfaceBatch) -> SurfaceBatch:
+    """Reflect a batch about the y=0 plane — exploits DrivAerML bilateral symmetry.
+
+    Surface_x layout [x, y, z, nx, ny, nz, area, *curvature]:
+      cols 1 (y) and 4 (n_y) are ODD; positions, normals, area, curvature otherwise EVEN.
+    Surface_y layout [cp, ws_x, ws_y, ws_z]:
+      col 2 (ws_y) is ODD; cp/ws_x/ws_z EVEN.
+    Volume_x layout [x, y, z, sdf]: col 1 (y) is ODD; sdf EVEN.
+    Volume_y is volume_pressure (scalar, EVEN).
+    """
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = -surface_x[..., 1]
+    surface_x[..., 4] = -surface_x[..., 4]
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = -surface_y[..., 2]
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = -volume_x[..., 1]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Muon optimizer (Newton-Schulz orthogonalized momentum)
 # Reference: https://github.com/KellerJordan/Muon  (Keller Jordan, 2024)
@@ -1163,6 +1192,7 @@ class Config:
     swa_lr: float = 5e-6
     swa_anneal_epochs: int = 1
     swa_update_every_steps: int = 500
+    y_flip_prob: float = 0.0
 
 
 NONFINITE_SKIP_ABORT = 200
@@ -2781,6 +2811,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     if config.grad_ema_alpha > 0 and is_main:
         print(f"Gradient EMA smoothing: alpha={config.grad_ema_alpha}")
 
+    y_flip_count = 0
+    y_flip_steps = 0
+    if config.y_flip_prob > 0 and is_main:
+        print(f"Y-flip augmentation: prob={config.y_flip_prob}")
+
     for epoch in range(max_epochs):
         if (time.time() - train_start) / 60.0 >= timeout_minutes:
             if is_main:
@@ -2820,6 +2855,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 train_loader, desc=f"Epoch {epoch + 1}/{max_epochs}", leave=False
             )
         for batch in train_iter:
+            y_flip_applied = 0
+            if config.y_flip_prob > 0 and torch.rand(1).item() < config.y_flip_prob:
+                batch = y_flip_batch(batch)
+                y_flip_applied = 1
+            y_flip_count += y_flip_applied
+            y_flip_steps += 1
             loss, batch_loss_metrics = train_loss(
                 train_model,
                 batch,
@@ -3013,6 +3054,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 **grad_ema_metrics,
                 **weight_metrics,
             }
+            if config.y_flip_prob > 0:
+                train_log["train/y_flip_applied"] = float(y_flip_applied)
+                train_log["train/y_flip_running_avg"] = (
+                    y_flip_count / max(1, y_flip_steps)
+                )
             if "wallshear_pred_normal_rms" in batch_loss_metrics:
                 train_log["train/wallshear_pred_normal_rms"] = batch_loss_metrics[
                     "wallshear_pred_normal_rms"


### PR DESCRIPTION
## Hypothesis

The DrivAerML car geometry is **bilaterally symmetric about the y=0 plane**. In a symmetric flow field over a symmetric car, the surface fields obey exact reflection symmetry: `surface_p(x,y,z) = surface_p(x,-y,z)` (even), `τ_x(x,y,z) = τ_x(x,-y,z)` (even), **`τ_y(x,y,z) = -τ_y(x,-y,z)` (ODD — sign flips)**, `τ_z(x,y,z) = τ_z(x,-y,z)` (even), `vol_p(x,y,z) = vol_p(x,-y,z)` (even).

The current yi SOTA (PR #681, dc031qpt) is **NOT y-equivariant** — proven by alphonse's PR #718: inference-time y-flip TTA gave +12.3% τ_y regression because the model makes inconsistent predictions on flipped inputs. The structural fix is **training-time augmentation**: at each training step, with probability 0.5, y-flip the batch BEFORE the forward pass, forcing the model to learn the symmetry as part of the learned function.

Key distinction vs alphonse #718 (closed null): TTA assumes the model is approximately equivariant — it isn't. Training-time aug builds equivariance into the learned function — it doesn't assume it exists. This is also NOT data-mixing (#727 haku closed null) — it exploits a guaranteed exact physics symmetry of the same car (data-doubling under a known group action).

**Predicted gain:** 0.10–0.30pp on val_abupt, concentrated on τ_y (the ODD axis, currently 2.6× above AB-UPT). If equivariance is the bottleneck, τ_y should improve 0.5–1.5pp — more than the overall headline metric change.

## Instructions

### Step 1 — Add CLI flags

```python
parser.add_argument('--y-flip-prob', type=float, default=0.0,
                    help='Probability of y-flipping each batch (0=disabled, 0.5=50%)')
```

### Step 2 — Implement y_flip_batch

Before the model forward pass in the training loop, add this function and apply it with probability `config.y_flip_prob`:

```python
def y_flip_batch(batch: dict) -> dict:
    """Apply y-axis reflection — exploits bilateral symmetry of DrivAerML cars."""
    out = dict(batch)
    # Coordinates: y → -y
    for key in ('surface_positions', 'volume_positions'):
        if key in out:
            t = out[key].clone()
            t[..., 1] = -t[..., 1]
            out[key] = t
    # Surface normals: n_y → -n_y
    if 'surface_normals' in out:
        t = out['surface_normals'].clone()
        t[..., 1] = -t[..., 1]
        out['surface_normals'] = t
    # Wall shear: τ_y is ODD under y-reflection; τ_x, τ_z are EVEN
    if 'wall_shear' in out:
        t = out['wall_shear'].clone()
        t[..., 1] = -t[..., 1]
        out['wall_shear'] = t
    # surface_pressure, volume_pressure, curvatures, area: EVEN (no change)
    # vol_velocity: v_y is ODD; flip if present
    if 'volume_velocity' in out:
        t = out['volume_velocity'].clone()
        t[..., 1] = -t[..., 1]
        out['volume_velocity'] = t
    return out
```

Apply in training loop:
```python
if config.y_flip_prob > 0 and torch.rand(1).item() < config.y_flip_prob:
    batch = y_flip_batch(batch)
```

Log `train/y_flip_running_avg` (rolling mean of whether each step was flipped, should stabilize near 0.5).

### Step 3 — Verify with unit tests before training

1. **Double-flip identity**: `y_flip_batch(y_flip_batch(b))` must equal `b` for all fields (tolerance 1e-6).
2. **No mutation test**: confirm `b['surface_positions']` is unchanged after `y_flip_batch(b)` (clone, not in-place).
3. **Sign test**: a single surface point with `wall_shear = [0.1, 0.2, 0.3]` should become `[0.1, -0.2, 0.3]` after flip.

### Step 4 — Training runs

**Arm A (primary test):** `--y-flip-prob 0.5` — 50% flip probability (canonical y-equivariance training)

**Arm B (secondary — skip if Arm A beats SOTA):** `--y-flip-prob 0.25` — weaker aug to compare

Both arms: cold-start from scratch (NOT polish), standard yi SOTA stack. The non-equivariant dc031qpt SOTA cannot be polished into equivariance — must train from scratch.

### Reproduce command — Arm A

```bash
cd /workspace/senpai/target
torchrun --standalone --nproc_per_node=4 train.py \
  --agent haku \
  --wandb-group yi-round42-haku-yflip-aug \
  --wandb-name haku/yflip-aug-p050 \
  --learnable-pe --optimizer lion --lr 1e-4 --weight-decay 5e-4 --clip-grad-norm 0.5 \
  --grad-ema-alpha 0.5 \
  --surface-curvature-features k1_k2 \
  --beta-nll-beta 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-slices 128 \
  --batch-size 4 --validation-every 2 --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --y-flip-prob 0.5 \
  --ema-decay 0.999 --lr-warmup-epochs 1 \
  --kill-thresholds '5442:val_primary/abupt_axis_mean_rel_l2_pct<50,16326:val_primary/abupt_axis_mean_rel_l2_pct<12,54420:val_primary/abupt_axis_mean_rel_l2_pct<9,108840:val_primary/abupt_axis_mean_rel_l2_pct<8.0' \
  --epochs 30
```

(Arm B: identical, replace `--y-flip-prob 0.5` with `--y-flip-prob 0.25` and `haku/yflip-aug-p025` for the name.)

### Kill gates (canonical operator: passes(observed) → True ⇒ continue)

| Step | Threshold | Rationale |
|------|---|---|
| 5442 (EP1) | val_abupt < 50% | y-flip should never destabilize above random-init noise |
| 16326 (EP3) | val_abupt < 12% | cold-start should be well into descent by EP3 |
| 54420 (EP10) | val_abupt < 9% | must be below 9% by EP10 (un-augmented SOTA track) |
| 108840 (EP20) | val_abupt < 8.0% | must be closing in on SOTA by EP20 |

Late-run divergence override: if val_abupt slope > +0.05pp/1k steps after EP15, kill and report best-checkpoint val (Lion-EMA divergence seen in long runs).

### Success criteria

- **Strong success**: val_abupt ≤ 7.20% (beat SOTA by ≥0.18pp) — clear win, merge candidate
- **Moderate success**: ≤ 7.30% — merge candidate
- **Modest success**: < 7.3767% by any margin — mergeable; focus on τ_y per-axis
- **Null**: 7.37%–8.0% — didn't hurt but didn't help; structural equivariance achieved but capacity bottleneck
- **Regression**: > 8.0% — augmentation hurt; investigate sign error in flip or capacity mismatch

### What to report

Per-channel breakdown for Arm A (and B if run) on **both validation and test**:

| Config | val_abupt | test_abupt | τ_y val | τ_y test | τ_z val | τ_z test | sp val | sp test | vp val | vp test |
|---|---|---|---|---|---|---|---|---|---|---|

Also report `train/y_flip_running_avg` at end of training (should be ~0.5), and the per-epoch val_abupt trajectory. The **critical diagnostic is τ_y improvement specifically** — the hypothesis predicts τ_y will improve 0.5–1.5pp (more than the headline metric).

## Baseline

Current yi SOTA (merge bar):
- **val_abupt = 7.3767%** (PR #681 nezuko, W&B `dc031qpt`, terminal-LR polish lr=3e-7)
- **test_abupt = 8.7015%**
- Per-axis val: τ_y=9.5832%, τ_z=11.0377%, surface_p=4.8515%, vol_p=4.31%
- Aspirational target: val_abupt ~7.0% (tay branch SOTA PR #511, `5o7jc7wi`)

**Hot in-flight lead:** Norman #724 residual MLP (run `u7obwlh7`) finished at val 7.3588% (-0.0179pp, just above SOTA), pending merge. Y-flip aug is **cold-start, orthogonal** — if both win, they may compose.

Post terminal `SENPAI-RESULT` with val+test metrics after your best arm completes. If Arm A clears SOTA, you do not need to run Arm B.
