### PR TITLE
Exp 1B-2: Spatial within-case volume point emphasis (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -37,13 +37,16 @@ from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
+    StratifiedVolumeDataset,
     TargetTransform,
+    VOL_POINT_EMPHASIS_MODES,
     autocast_context,
     build_lr_scheduler,
     check_kill_thresholds,
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    compute_train_split_sdf_stats,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -129,6 +132,9 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    vol_point_emphasis: str = "none"
+    vol_emphasis_near_frac: float = 0.25
+    vol_emphasis_near_thresh: float = 0.30
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -159,6 +165,33 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "vol_point_emphasis": (
+            "Volume-point sampling emphasis mode for training. 'none' "
+            "(default) is uniform-random sampling over each case's full "
+            "volume mesh. 'geometric_distance' partitions volume points "
+            "into 'near' (sdf<=near_thresh) and 'far' strata using the "
+            "precomputed `volume_sdf.npy` channel and draws "
+            "round(N*near_frac) from near + remainder from far without "
+            "replacement. The DrivAerML watertight CFD mesh is heavily "
+            "concentrated near the surface (~91%% of points within 0.30m), "
+            "so loader-level stratification is required to actually "
+            "achieve the desired near/far ratio (batch-level stratifying "
+            "after a uniform 65k loader sample would degenerate to "
+            "uniform). Eval/test sampling is unchanged."
+        ),
+        "vol_emphasis_near_frac": (
+            "Fraction of volume points to draw from the near stratum "
+            "(sdf<=near_thresh) when --vol-point-emphasis is "
+            "'geometric_distance'. Default 0.25 => 25%% near / 75%% far per "
+            "case per view. Ignored when --vol-point-emphasis is 'none'."
+        ),
+        "vol_emphasis_near_thresh": (
+            "SDF threshold (m) defining the near/far split when "
+            "--vol-point-emphasis is 'geometric_distance'. Negative SDF "
+            "values are clamped to 0 (interior points are treated as "
+            "at the surface). Default 0.30. Ignored when "
+            "--vol-point-emphasis is 'none'."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -230,7 +263,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    if config.vol_point_emphasis not in VOL_POINT_EMPHASIS_MODES:
+        raise ValueError(
+            f"--vol-point-emphasis must be one of {VOL_POINT_EMPHASIS_MODES}; "
+            f"got {config.vol_point_emphasis!r}"
+        )
+    if config.vol_point_emphasis == "geometric_distance":
+        if not (0.0 < config.vol_emphasis_near_frac < 1.0):
+            raise ValueError(
+                "--vol-emphasis-near-frac must be in (0, 1); got "
+                f"{config.vol_emphasis_near_frac}"
+            )
+        if config.vol_emphasis_near_thresh <= 0.0:
+            raise ValueError(
+                "--vol-emphasis-near-thresh must be positive; got "
+                f"{config.vol_emphasis_near_thresh}"
+            )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -594,6 +644,33 @@ def synced_per_task_tensor(
     return stacked
 
 
+def compute_vol_emphasis_diagnostics(
+    batch,
+    *,
+    near_thresh: float,
+) -> dict[str, float]:
+    """Per-step diagnostics on the loaded batch's SDF distribution."""
+    sdf_vals = batch.volume_x[..., 3].clamp(min=0.0)
+    valid_mask = batch.volume_mask.bool()
+    sdf_valid = sdf_vals[valid_mask].detach().float()
+    if sdf_valid.numel() == 0:
+        return {}
+    near_count = int((sdf_valid <= near_thresh).sum().item())
+    far_count = int(sdf_valid.numel()) - near_count
+    total = max(near_count + far_count, 1)
+    p50 = float(sdf_valid.quantile(0.5).item())
+    p95 = float(sdf_valid.quantile(0.95).item())
+    return {
+        "vol_emphasis/near_count": float(near_count),
+        "vol_emphasis/far_count": float(far_count),
+        "vol_emphasis/near_frac_actual": float(near_count) / float(total),
+        "vol_emphasis/sdf_min": float(sdf_valid.min().item()),
+        "vol_emphasis/sdf_max": float(sdf_valid.max().item()),
+        "vol_emphasis/sdf_p50": p50,
+        "vol_emphasis/sdf_p95": p95,
+    }
+
+
 def parse_vol_points_schedule(text: str) -> list[tuple[int, int]]:
     if not text:
         return []
@@ -666,13 +743,24 @@ def rebuild_train_loader_with_vol_points(
     sampling_mode = (
         "train_random" if (config.train_surface_points > 0 or n_points > 0) else "full"
     )
-    train_ds = DrivAerMLSurfaceDataset(
-        old_ds.case_ids,
-        store=old_ds.store,
-        max_surface_points=config.train_surface_points,
-        max_volume_points=n_points,
-        sampling_mode=sampling_mode,
-    )
+    if config.vol_point_emphasis == "geometric_distance":
+        train_ds = StratifiedVolumeDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+            near_thresh=config.vol_emphasis_near_thresh,
+            near_frac=config.vol_emphasis_near_frac,
+        )
+    else:
+        train_ds = DrivAerMLSurfaceDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+        )
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:
@@ -861,6 +949,21 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.vol_point_emphasis == "geometric_distance":
+                try:
+                    sdf_stats = compute_train_split_sdf_stats(
+                        train_loader.dataset.store,
+                        near_thresh=config.vol_emphasis_near_thresh,
+                        sample_cases=10,
+                    )
+                    for key, value in sdf_stats.items():
+                        wandb.summary[key] = value
+                    print(
+                        f"SDF startup stats (10 cases, near_thresh={config.vol_emphasis_near_thresh}): "
+                        + ", ".join(f"{k}={v:.4g}" for k, v in sdf_stats.items())
+                    )
+                except Exception as exc:
+                    print(f"SDF startup stats failed: {exc}")
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1035,6 +1138,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                 }
+                if (
+                    config.vol_point_emphasis == "geometric_distance"
+                    and state.is_main
+                    and global_step % 100 == 0
+                ):
+                    train_log.update(
+                        compute_vol_emphasis_diagnostics(
+                            batch, near_thresh=config.vol_emphasis_near_thresh
+                        )
+                    )
                 if not loss_is_nonfinite:
                     train_log.update(
                         {

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -23,14 +23,20 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, Sampler
 from torch.utils.data.distributed import DistributedSampler
 
+import numpy as np
+
 from data import (
     SURFACE_TARGET_NAMES,
+    DrivAerMLCase,
+    DrivAerMLCaseStore,
+    DrivAerMLSurfaceDataset,
     SurfaceBatch,
     VOLUME_TARGET_NAMES,
     VOLUME_Y_DIM,
     load_data,
     pad_collate,
 )
+from data.loader import _resolve_artifact_path
 
 
 class EMA:
@@ -269,6 +275,208 @@ def full_eval_loaders_from(
     }
 
 
+VOL_POINT_EMPHASIS_MODES = ("none", "geometric_distance")
+
+
+class StratifiedVolumeDataset(DrivAerMLSurfaceDataset):
+    """Train-only dataset that stratifies volume points by signed-distance.
+
+    For each case, partitions the full ~10M volume points into a "near"
+    stratum (sdf <= near_thresh) and a "far" stratum (sdf > near_thresh)
+    using the precomputed `volume_sdf.npy` channel. Per-view sampling
+    draws ``round(N * near_frac)`` indices from near + the remainder from
+    far without replacement.
+
+    Loader-level stratification is required because the watertight CFD
+    mesh is heavily concentrated near the surface (~91% of points within
+    0.30m for DrivAerML), so a uniform 65k-point batch carries fewer than
+    10% far points — not enough to fill a 75% far quota. Sampling at the
+    full-mesh level is the natural place where every stratum has plenty
+    of points to draw from.
+
+    Eval/test datasets are NOT wrapped — uniform deterministic chunks on
+    the full mesh remain unchanged.
+    """
+
+    def __init__(
+        self,
+        case_ids,
+        *,
+        store: DrivAerMLCaseStore | None = None,
+        manifest_path=None,
+        root=None,
+        max_surface_points: int = 0,
+        max_volume_points: int = 0,
+        sampling_mode: str = "train_random",
+        near_thresh: float,
+        near_frac: float,
+    ):
+        kwargs = {
+            "store": store,
+            "max_surface_points": max_surface_points,
+            "max_volume_points": max_volume_points,
+            "sampling_mode": sampling_mode,
+        }
+        if manifest_path is not None:
+            kwargs["manifest_path"] = manifest_path
+        if root is not None:
+            kwargs["root"] = root
+        super().__init__(case_ids, **kwargs)
+        self.near_thresh = float(near_thresh)
+        self.near_frac = float(near_frac)
+        self._sdf_split_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+    def _sdf_split_indices(self, case_id: str) -> tuple[np.ndarray, np.ndarray]:
+        cached = self._sdf_split_cache.get(case_id)
+        if cached is not None:
+            return cached
+        case_dir = self.store.root / case_id
+        sdf_path = _resolve_artifact_path(case_dir / "volume_sdf.npy")
+        sdf = np.asarray(np.load(sdf_path, mmap_mode="r"), dtype=np.float32).reshape(-1)
+        sdf_clamped = np.maximum(sdf, 0.0)
+        near_mask = sdf_clamped <= self.near_thresh
+        # Use int32 to halve memory cost of the cached splits; counts well
+        # under 2^31 per case so int32 is safe.
+        near_idx = np.flatnonzero(near_mask).astype(np.int32, copy=False)
+        far_idx = np.flatnonzero(~near_mask).astype(np.int32, copy=False)
+        self._sdf_split_cache[case_id] = (near_idx, far_idx)
+        return near_idx, far_idx
+
+    def _stratified_volume_indices(self, case_id: str, count: int) -> torch.Tensor:
+        near_idx_np, far_idx_np = self._sdf_split_indices(case_id)
+        near_idx = torch.from_numpy(near_idx_np.astype(np.int64, copy=False))
+        far_idx = torch.from_numpy(far_idx_np.astype(np.int64, copy=False))
+
+        n_near_target = int(round(count * self.near_frac))
+        n_far_target = max(0, count - n_near_target)
+        n_near_avail = int(near_idx.numel())
+        n_far_avail = int(far_idx.numel())
+
+        def _draw(idx_pool: torch.Tensor, k: int, n_avail: int) -> torch.Tensor:
+            if k <= 0 or n_avail <= 0:
+                return torch.empty(0, dtype=torch.long)
+            if k <= n_avail:
+                # Without replacement
+                pick = torch.randperm(n_avail)[:k]
+            else:
+                # Fallback within stratum: with replacement
+                pick = torch.randint(0, n_avail, (k,), dtype=torch.long)
+            return idx_pool[pick]
+
+        if n_near_avail >= n_near_target and n_far_avail >= n_far_target:
+            near_picked = _draw(near_idx, n_near_target, n_near_avail)
+            far_picked = _draw(far_idx, n_far_target, n_far_avail)
+        elif n_near_avail < n_near_target:
+            # Take all of near, top up far with the deficit
+            near_picked = near_idx.clone()
+            adjusted_far = count - n_near_avail
+            far_picked = _draw(far_idx, adjusted_far, n_far_avail)
+        else:
+            # Take all of far, top up near with the deficit
+            far_picked = far_idx.clone()
+            adjusted_near = count - n_far_avail
+            near_picked = _draw(near_idx, adjusted_near, n_near_avail)
+
+        combined = torch.cat([near_picked, far_picked])
+        combined, _ = combined.sort()
+        return combined
+
+    def __getitem__(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+
+        use_stratified = (
+            view.sampling_mode == "train_random"
+            and self.max_volume_points > 0
+            and counts["n_volume"] > self.max_volume_points
+            and view.view_index < view.volume_view_count
+        )
+        if use_stratified:
+            volume_idx = self._stratified_volume_indices(
+                view.case_id, self.max_volume_points
+            )
+        else:
+            volume_idx = self._indices(
+                counts["n_volume"],
+                self.max_volume_points,
+                view,
+                group_view_count=view.volume_view_count,
+            )
+
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=None if volume_idx is None else volume_idx.numpy(),
+        )
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = view.sampling_mode
+        metadata["joint_view_count"] = int(view.view_count)
+        metadata["volume_stratified"] = bool(use_stratified)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+
+def compute_train_split_sdf_stats(
+    store: DrivAerMLCaseStore,
+    *,
+    near_thresh: float,
+    sample_cases: int = 10,
+) -> dict[str, float]:
+    """Compute SDF distribution diagnostics across a sample of train cases."""
+    case_ids = store.case_ids("train")[:sample_cases]
+    if not case_ids:
+        return {}
+    sdf_min = math.inf
+    sdf_max = -math.inf
+    p50_vals: list[float] = []
+    p95_vals: list[float] = []
+    near_fracs: list[float] = []
+    total_points = 0
+    for cid in case_ids:
+        case_dir = store.root / cid
+        sdf_path = _resolve_artifact_path(case_dir / "volume_sdf.npy")
+        sdf = np.asarray(np.load(sdf_path, mmap_mode="r"), dtype=np.float32).reshape(-1)
+        sdf_clamped = np.maximum(sdf, 0.0)
+        sdf_min = min(sdf_min, float(sdf.min()))
+        sdf_max = max(sdf_max, float(sdf.max()))
+        p50_vals.append(float(np.median(sdf_clamped)))
+        p95_vals.append(float(np.percentile(sdf_clamped, 95)))
+        near_fracs.append(float(np.mean(sdf_clamped <= near_thresh)))
+        total_points += int(sdf.size)
+    return {
+        "vol_emphasis/startup_sample_cases": float(len(case_ids)),
+        "vol_emphasis/startup_sample_points": float(total_points),
+        "vol_emphasis/startup_sdf_min": sdf_min,
+        "vol_emphasis/startup_sdf_max": sdf_max,
+        "vol_emphasis/startup_sdf_p50_mean": float(np.mean(p50_vals)),
+        "vol_emphasis/startup_sdf_p95_mean": float(np.mean(p95_vals)),
+        f"vol_emphasis/startup_near_frac_thresh_{near_thresh:g}": float(
+            np.mean(near_fracs)
+        ),
+    }
+
+
 def make_loaders(
     config,
     distributed_state: DistributedState | None = None,
@@ -282,6 +490,7 @@ def make_loaders(
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
     )
+    train_ds = _maybe_wrap_train_dataset(train_ds, config)
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:
@@ -310,6 +519,29 @@ def make_loaders(
         for name, ds in test_splits.items()
     }
     return train_loader, val_loaders, test_loaders, stats
+
+
+def _maybe_wrap_train_dataset(
+    train_ds: DrivAerMLSurfaceDataset,
+    config,
+) -> DrivAerMLSurfaceDataset:
+    """Swap a plain DrivAerMLSurfaceDataset for a stratified one if requested."""
+    mode = getattr(config, "vol_point_emphasis", "none")
+    if mode == "none":
+        return train_ds
+    if mode != "geometric_distance":
+        raise ValueError(
+            f"Unknown --vol-point-emphasis '{mode}'. Supported: {VOL_POINT_EMPHASIS_MODES}."
+        )
+    return StratifiedVolumeDataset(
+        train_ds.case_ids,
+        store=train_ds.store,
+        max_surface_points=train_ds.max_surface_points,
+        max_volume_points=train_ds.max_volume_points,
+        sampling_mode=train_ds.sampling_mode,
+        near_thresh=config.vol_emphasis_near_thresh,
+        near_frac=config.vol_emphasis_near_frac,
+    )
 
 
 def _metric_path(name: str) -> str:
@@ -1366,6 +1598,7 @@ def define_wandb_metrics() -> None:
         "train/weight_type/*",
         "train/weight_hist/*",
         "train/weight_hist_param/*",
+        "vol_emphasis/*",
         "lr",
     ):
         wandb.define_metric(metric_prefix, step_metric="global_step")


### PR DESCRIPTION
## Hypothesis

The chronic 3x volume_pressure test-vs-val gap (val ~3.9%, test ~11.5%) is dominated by specific spatial regions present in essentially every case (far wake, vortex shedding, underbody outflow). PR #728 Arm A (per-case EMA emphasis) verified the mechanism but confirmed that per-case granularity is too coarse — within each case, points are still sampled uniformly, so the model never gets concentrated gradient signal from the hard regions.

**This experiment: spatial-distance-weighted point sampling (within each case).** Stratify volume points by distance from the car body surface. Up-sample far-wake / far-volume points so the model sees more gradient signal from the regions where it currently fails on test.

**Critical infrastructure simplification:** The volume input already carries a precomputed signed distance scalar at `volume_x[..., 3:4]` (see `data/loader.py:40` — `VOLUME_X_DIM = 4 # xyz(3) + sdf(1)`). This is a true watertight-mesh SDF, not a sampled cdist proxy. Use it directly — no cache step, no precompute pass, no `cdist` to surface points. This is also the channel askeladd is using in PR #734, so it's been independently validated as a clean and reliable signal.

## Instructions

Add a `--vol-point-emphasis` CLI flag with mode `geometric_distance` to `target/train.py` and `trainer_runtime.py`. Implement spatial stratification of volume points using the precomputed SDF channel.

### New CLI flag
```
--vol-point-emphasis {none, geometric_distance}     # default: none
--vol-emphasis-near-frac    float    default: 0.25  # frac of points sampled from "near" stratum
--vol-emphasis-near-thresh  float    default: 0.30  # SDF threshold (m) for near vs far split
```

When `none`, behavior is identical to current code — no regression risk.

### Implementation

In the training-volume-point sampler, for each case in the batch:

1. Read the SDF scalar from `volume_x[..., 3]` (already precomputed; clamp negatives to 0 — interior points are treated as "at the surface").
2. Build a near-mask: `near = sdf <= near_thresh` (default 0.30 m).
3. Of the `N = train_volume_points` points to sample per case:
   - `n_near = round(N * near_frac)` from the near stratum
   - `n_far  = N - n_near` from the far stratum
4. Sample without replacement within each stratum.
5. Fallback: if either stratum has fewer points than required (rare but possible at low vol-points-schedule values), draw the full stratum and top up from the other stratum.
6. **Eval is unchanged.** Eval-time volume sampling stays uniform — we are changing only the training distribution.

This is **inverse-density emphasis**: under uniform sampling, near-surface points dominate because they are densely packed in the watertight mesh; far-wake points are under-sampled. With `near_frac=0.25` the per-batch allocation is 25% near / 75% far, redistributing gradient signal toward the regions the test split fails on.

Why `near_frac=0.25` and `near_thresh=0.30 m`:
- Frieren's PR #728 spec used a 1:3 near:far ratio with 0.30m threshold. Use that as Arm A.
- Arm B (only if Arm A passes EP3 gate): more aggressive `near_frac=0.15`, `near_thresh=0.50 m` to push further into the wake.

### Logging

Log per-step (rank-0, every 100 steps):
- `vol_emphasis/near_count`  — actual near points drawn
- `vol_emphasis/far_count`   — actual far points drawn
- `vol_emphasis/near_frac_actual` — `near_count / (near_count + far_count)`
- `vol_emphasis/sdf_min, sdf_max, sdf_p50, sdf_p95` — distribution diagnostics on a single batch's SDF

Log to W&B config the SDF-channel sanity at startup: min, max, fraction-with-sdf-le-0.30 across the train split.

### Run commands

**Arm A (near_frac=0.25, near_thresh=0.30 m):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-point-emphasis geometric_distance \
  --vol-emphasis-near-frac 0.25 --vol-emphasis-near-thresh 0.30 \
  --kill-thresholds "21729:val_primary/abupt_axis_mean_rel_l2_pct<12.0,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0" \
  --wandb-group frieren-vol-spatial-emphasis --wandb-name frieren/spatial-emphasis-arm-a
```

**Arm B (near_frac=0.15, near_thresh=0.50 m), only if Arm A passes EP3 gate:**
```bash
... --vol-emphasis-near-frac 0.15 --vol-emphasis-near-thresh 0.50 \
... --wandb-name frieren/spatial-emphasis-arm-b
```

### Kill gates (informed by PR #728 trajectory; ref `4k25s25e`)
- EP1 epoch time: kill if > 85 min (baseline ~76 min)
- EP1 kill: val_abupt > 30% at step 10,864 (matches SOTA early-epoch range)
- EP2 kill: val_abupt > 12% at step 21,729
- EP3 kill: val_abupt > 8% at step 32,594

Standard reproduce + 4-epoch wall-clock window.

### Why this should work where Arm A did not

PR #728 Arm A redistributed across cases — but every case has both easy near-surface and hard far-wake regions, so weighting case A vs case B by total residual does not help. This experiment redistributes **within** each case: every batch now sees the hard regions over-represented. This is the actual mechanism that should close the test gap.

## Baseline

Current single-model SOTA: PR #592 (alphonse, `alphonse/depth-L5`)
- W&B run: `4k25s25e` (group: `model-depth-sweep`)
- **val_abupt: 6.5985%** (gate — must beat to update SOTA)
- val surface_pressure: 4.3322% | val volume_pressure: 3.9456%
- val wall_shear_x: 6.5420% / wall_shear_y: 8.3631% / wall_shear_z: 9.8099%
- test_abupt: 7.9915% | test vol_pressure: ~11.69%

Issue #717 vol_pressure test targets: Weak win ≤ 10.8% | Solid win ≤ 10.0% | Major win ≤ 9.5%

**Hard constraint:** Zero model ensembling. All metrics must be single-model only.

## Suggested follow-ups (not part of this PR)
- Per-spatial-bin emphasis (32^3 voxel grid, per-bin EMA residual) — finer granularity than the binary near/far split
- RHO-LOSS-style reducible-loss filtering using an early checkpoint as reference
- Combine spatial emphasis with region-weighted loss (nezuko's PR #737 direction) — orthogonal mechanisms

