### PR TITLE
Exp 1C P4: x-slab wake stratified vol sampling (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -38,6 +38,7 @@ from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
     TargetTransform,
+    apply_wake_oversample,
     autocast_context,
     build_lr_scheduler,
     check_kill_thresholds,
@@ -129,6 +130,7 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    vol_wake_oversample: float = 1.0
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -159,6 +161,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "vol_wake_oversample": (
+            "Wake-region oversampling factor for training-time volume point "
+            "sampling. Splits volume points into 3 x-slabs using "
+            "`volume_x[..., 0]` (raw metres): front (x<1.0), cabin "
+            "(1.0<=x<4.0), wake (x>=4.0). Each batch's loaded volume points "
+            "are resampled with replacement using weights [1.0, 1.0, FACTOR] "
+            "via torch.multinomial, then fed to the model unchanged. "
+            "FACTOR=1.0 (default) is a no-op = current uniform sampling. "
+            "FACTOR>1.0 makes wake points proportionally more likely. Eval "
+            "sampling is unaffected — deterministic strided chunks remain."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -310,8 +323,11 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_wake_oversample: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    if vol_wake_oversample != 1.0:
+        batch = apply_wake_oversample(batch, vol_wake_oversample)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -353,6 +369,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    vol_wake_oversample: float = 1.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -363,6 +381,8 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    if vol_wake_oversample != 1.0:
+        batch = apply_wake_oversample(batch, vol_wake_oversample)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -917,7 +937,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model, batch, transform, device, config.amp_mode,
+                        vol_wake_oversample=config.vol_wake_oversample,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1008,6 +1029,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_wake_oversample=config.vol_wake_oversample,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/train.py
+++ b/train.py
@@ -131,6 +131,7 @@ class Config:
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
     vol_wake_oversample: float = 1.0
+    vol_wake_mode: str = "far"
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -171,7 +172,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "via torch.multinomial, then fed to the model unchanged. "
             "FACTOR=1.0 (default) is a no-op = current uniform sampling. "
             "FACTOR>1.0 makes wake points proportionally more likely. Eval "
-            "sampling is unaffected — deterministic strided chunks remain."
+            "sampling is unaffected — deterministic strided chunks remain. "
+            "Use --vol-wake-mode to choose which slab is treated as 'wake'."
+        ),
+        "vol_wake_mode": (
+            "Which x-slab to oversample when --vol-wake-oversample > 1.0. "
+            "'far' (default): oversample x >= 4.0 (far-wake / downstream "
+            "slab). 'near': oversample 1.0 <= x < 4.0 (immediate wake "
+            "corridor behind the body where turbulent separation dominates). "
+            "Has no effect when --vol-wake-oversample == 1.0."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -324,10 +333,11 @@ def train_loss(
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
     vol_wake_oversample: float = 1.0,
+    vol_wake_mode: str = "far",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     if vol_wake_oversample != 1.0:
-        batch = apply_wake_oversample(batch, vol_wake_oversample)
+        batch = apply_wake_oversample(batch, vol_wake_oversample, mode=vol_wake_mode)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -371,6 +381,7 @@ def per_task_train_losses(
     amp_mode: str,
     *,
     vol_wake_oversample: float = 1.0,
+    vol_wake_mode: str = "far",
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -382,7 +393,7 @@ def per_task_train_losses(
 
     batch = batch.to(device)
     if vol_wake_oversample != 1.0:
-        batch = apply_wake_oversample(batch, vol_wake_oversample)
+        batch = apply_wake_oversample(batch, vol_wake_oversample, mode=vol_wake_mode)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -939,6 +950,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode,
                         vol_wake_oversample=config.vol_wake_oversample,
+                        vol_wake_mode=config.vol_wake_mode,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1042,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
                         vol_wake_oversample=config.vol_wake_oversample,
+                        vol_wake_mode=config.vol_wake_mode,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -817,6 +817,82 @@ def check_kill_thresholds(
     return None
 
 
+def apply_wake_oversample(
+    batch: SurfaceBatch,
+    factor: float,
+    *,
+    x_low: float = 1.0,
+    x_high: float = 4.0,
+) -> SurfaceBatch:
+    """Spatially stratify volume points by x-coordinate (wake oversampling).
+
+    Splits each case's volume points into 3 x-slabs using ``volume_x[..., 0]``
+    (raw metres):
+        - front:  x < x_low      -> weight 1.0
+        - cabin:  x_low <= x < x_high -> weight 1.0
+        - wake:   x >= x_high    -> weight ``factor``
+    Resamples ``N`` points per case with replacement using a fully batched
+    ``torch.multinomial`` over those weights, then reassembles the batch.
+    Padding tokens (``volume_mask=False``) get weight 0 so they are never
+    sampled; the resampled mask preserves each case's original valid count
+    so padding semantics are unchanged. Implementation is sync-free (no
+    ``.item()`` calls) so it adds negligible overhead per training step.
+
+    No-op when ``factor <= 0`` or ``factor == 1.0`` (uniform baseline).
+    Train-only — eval batches must not call this helper because eval relies
+    on deterministic strided chunks.
+    """
+
+    if not (factor > 0.0) or abs(factor - 1.0) < 1e-12:
+        return batch
+    volume_x = batch.volume_x
+    if volume_x.numel() == 0 or volume_x.shape[1] == 0:
+        return batch
+    volume_y = batch.volume_y
+    volume_mask = batch.volume_mask
+    B, N, _ = volume_x.shape
+
+    x_coord = volume_x[..., 0]
+    factor_t = torch.as_tensor(float(factor), device=volume_x.device, dtype=torch.float32)
+    one_t = torch.as_tensor(1.0, device=volume_x.device, dtype=torch.float32)
+    weights = torch.where(x_coord >= x_high, factor_t, one_t)
+    valid = volume_mask.to(torch.float32)
+    weights = weights * valid
+
+    # Guard against all-zero rows (entire batch padded out): fall back to
+    # uniform-over-valid weights so multinomial does not raise. The safety
+    # tensor is cheap and shape-preserving.
+    row_sum = weights.sum(dim=-1, keepdim=True)
+    fallback_uniform = valid + (1.0 - valid.amax(dim=-1, keepdim=True))
+    weights = torch.where(row_sum > 0, weights, fallback_uniform)
+
+    sampled_idx = torch.multinomial(weights, N, replacement=True)  # [B, N]
+
+    gather_x = sampled_idx.unsqueeze(-1).expand(-1, -1, volume_x.shape[-1])
+    gather_y = sampled_idx.unsqueeze(-1).expand(-1, -1, volume_y.shape[-1])
+    new_volume_x = torch.gather(volume_x, 1, gather_x)
+    new_volume_y = torch.gather(volume_y, 1, gather_y)
+    # Preserve original per-case valid counts: keep mask=True for the first
+    # ``valid_n`` slots of each row (the original ordering had valid first
+    # then padding, so a per-row count cap reproduces that semantic without
+    # a CPU sync). All sampled indices already point into the valid region
+    # because padded weights are zero.
+    valid_counts = volume_mask.sum(dim=-1, keepdim=True)
+    positions = torch.arange(N, device=volume_x.device).unsqueeze(0).expand(B, -1)
+    new_volume_mask = positions < valid_counts
+
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=batch.surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=new_volume_x,
+        volume_y=new_volume_y,
+        volume_mask=new_volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
 def masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     expanded_mask = mask
     while expanded_mask.ndim < values.ndim:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -823,14 +823,17 @@ def apply_wake_oversample(
     *,
     x_low: float = 1.0,
     x_high: float = 4.0,
+    mode: str = "far",
 ) -> SurfaceBatch:
     """Spatially stratify volume points by x-coordinate (wake oversampling).
 
     Splits each case's volume points into 3 x-slabs using ``volume_x[..., 0]``
-    (raw metres):
-        - front:  x < x_low      -> weight 1.0
-        - cabin:  x_low <= x < x_high -> weight 1.0
-        - wake:   x >= x_high    -> weight ``factor``
+    (raw metres) and oversamples one slab by ``factor`` per ``mode``:
+        - mode="far"  (default): wake = x >= x_high gets weight ``factor``;
+          everything else weight 1.0. Targets the far-downstream slab.
+        - mode="near": near-wake = x_low <= x < x_high gets weight ``factor``;
+          everything else weight 1.0. Targets the immediate wake corridor
+          behind the body where turbulent separation dominates.
     Resamples ``N`` points per case with replacement using a fully batched
     ``torch.multinomial`` over those weights, then reassembles the batch.
     Padding tokens (``volume_mask=False``) get weight 0 so they are never
@@ -845,6 +848,8 @@ def apply_wake_oversample(
 
     if not (factor > 0.0) or abs(factor - 1.0) < 1e-12:
         return batch
+    if mode not in ("far", "near"):
+        raise ValueError(f"apply_wake_oversample: unknown mode={mode!r} (expected 'far' or 'near')")
     volume_x = batch.volume_x
     if volume_x.numel() == 0 or volume_x.shape[1] == 0:
         return batch
@@ -855,7 +860,11 @@ def apply_wake_oversample(
     x_coord = volume_x[..., 0]
     factor_t = torch.as_tensor(float(factor), device=volume_x.device, dtype=torch.float32)
     one_t = torch.as_tensor(1.0, device=volume_x.device, dtype=torch.float32)
-    weights = torch.where(x_coord >= x_high, factor_t, one_t)
+    if mode == "far":
+        oversample_region = x_coord >= x_high
+    else:
+        oversample_region = (x_coord >= x_low) & (x_coord < x_high)
+    weights = torch.where(oversample_region, factor_t, one_t)
     valid = volume_mask.to(torch.float32)
     weights = weights * valid
 


### PR DESCRIPTION
## Hypothesis

The chronic 3× volume_pressure test-vs-val gap (val≈3.6%, test≈11.5%) is driven by a small number of catastrophic wake failures, not diffuse geometry generalization. Per-case diagnostics from PR #734 (askeladd) identified 4 outlier test cases (run_226=109.85%, run_133=107.71%, run_203=103.84%, run_158=102.04% rel_l2) that each contribute ~2pp to the test mean. Per-region analysis showed the wake slab (x≥4m) has 80–102% rel_l2 across all SDF-distance bands, while containing only 6.8% of volume points.

**Hypothesis:** During training, the model almost never trains on wake-region volume points because they are underrepresented in random sampling (6.8% of 65k = ~4.4k wake points per batch). By stratifying volume point sampling to oversample the wake region (x≥4m) at training time, the model will see more wake supervision per step and learn better generalizable wake structure. This is distinct from frieren's PR #728 which stratifies by SDF-distance-to-surface — here we stratify by x-coordinate slab (spatial wake location).

The x-coordinate discriminator was identified as the key failure axis in PR #734's per-region table: wake (x≥4m) fails at 80–102% while front (x<1m) and cabin (1≤x<4m) achieve 3–8% rel_l2. SDF distance had zero discriminating power — all SDF bands fail equally in the wake slab.

## Instructions

Implement a new `--vol-wake-oversample` flag in `target/train.py` and `trainer_runtime.py` that spatially stratifies volume point sampling by x-coordinate during training. Leave eval sampling unchanged (deterministic strided chunks).

### Implementation

In `trainer_runtime.py` (or wherever volume point sampling is done during training), add a stratified sampler that:

1. Splits volume points into **3 x-slabs** using the precomputed x-coordinate (channel 0 of `volume_x`, i.e. `volume_x[..., 0]`):
   - **Front:** x < 1.0m  
   - **Cabin:** 1.0 ≤ x < 4.0m  
   - **Wake:** x ≥ 4.0m

2. Assigns **per-slab sampling weights**:
   - Front: 1.0× (uniform baseline)
   - Cabin: 1.0× (uniform baseline)  
   - Wake: `--vol-wake-oversample` factor (float, default=1.0 = no change)

3. Uses these weights to build a probability distribution over all volume points, then samples `train_volume_points` points from it **with replacement** (same as current random sampling). This is a pure sampling change — no change to the model, loss function, or architecture.

4. The flag `--vol-wake-oversample FACTOR` controls the wake oversampling multiplier. FACTOR=3.0 means wake points are 3× more likely to be sampled than front/cabin points.

### Experiment arms

Run **two arms** under `--wandb-group vol-wake-stratified`:

**Arm A — wake oversample factor=3.0:**
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --vol-wake-oversample 3.0 \
  --wandb-group vol-wake-stratified
```

**Arm B — wake oversample factor=5.0:**
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --vol-wake-oversample 5.0 \
  --wandb-group vol-wake-stratified
```

### Kill gates (applied to each arm independently)

- **EP2 val_abupt ≥ 12%** → kill arm (convergence failure)
- **EP3 val_abupt ≥ 8.0%** → kill arm (no improvement over baseline trajectory)

Run Arm A first. If it passes EP3, continue to completion and launch Arm B. If Arm A is killed, skip Arm B.

### Diagnostics to log

In the PR comment results, please include:
1. Standard metrics table (val_abupt, val_vol_pressure, test_abupt, test_vol_pressure at best epoch)
2. Per-arm W&B run IDs
3. If possible: val_vol_pressure comparison between baseline and your best run — this is the primary signal

## Baseline

Current single-model SOTA (PR #592, alphonse, W&B run `4k25s25e`):

| Metric | val | test |
|--------|-----|------|
| **abupt_axis_mean_rel_l2_pct** | **6.5985%** | **7.9915%** |
| vol_pressure | ~3.6% | 11.9335% |
| surface_pressure | ~4.4% | — |

**Vol-pressure promotion ladder (test_vol_pressure):**
- Weak: ≤11.0% | Solid: ≤10.0% | Major: ≤8.5% | Target: ≤6.08%

Frozen anchors (vol_pressure test): PR #681=11.374%, PR #599=11.694%, PR #592=11.9335%

Beat target: **test_vol_pressure < 11.374%** (weakest frozen anchor) for any signal; **val_abupt < 6.5985%** for SOTA beat.

W&B project: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
