### PR TITLE
[fern] Signed-log1p target transform for volume_pressure (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,6 +137,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_pressure_target_transform: str = "none"
+    vol_pressure_log_scale: float = 25.0
     debug: bool = False
 
 
@@ -219,6 +221,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_pressure_target_transform": (
+            "Target transform mode for volume_pressure only. 'none' "
+            "(default) keeps the existing standardised-MSE loss. "
+            "'signed_log1p' applies y' = sign(y) * log1p(|y|/scale) to "
+            "both target (in Pa) and prediction (after inverse-normalising "
+            "to Pa), then computes MSE in that transformed space. "
+            "Compresses the heavy-tailed |p| distribution so high-magnitude "
+            "wake samples are not drowned out by the low-magnitude bulk. "
+            "Surface targets and wall_shear are untouched."
+        ),
+        "vol_pressure_log_scale": (
+            "Pa scale used inside the signed_log1p transform: "
+            "y' = sign(y) * log1p(|y|/scale). Only consulted when "
+            "--vol-pressure-target-transform=signed_log1p. Typical Pa range "
+            "for DrivAerML volume pressure is roughly [-300, +200]; "
+            "suggested scales 10/25/50. Default 25.0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +319,43 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+VOL_PRESSURE_TARGET_TRANSFORMS = ("none", "signed_log1p")
+
+
+def signed_log1p(y: torch.Tensor, scale: float) -> torch.Tensor:
+    return torch.sign(y) * torch.log1p(y.abs() / scale)
+
+
+def signed_expm1(y: torch.Tensor, scale: float) -> torch.Tensor:
+    return torch.sign(y) * scale * torch.expm1(y.abs())
+
+
+def _volume_pressure_loss(
+    *,
+    volume_pred_norm: torch.Tensor,
+    batch,
+    transform: TargetTransform,
+    target_transform: str,
+    log_scale: float,
+) -> torch.Tensor:
+    """Volume-pressure MSE in either normalised or signed-log1p Pa space."""
+    if target_transform == "none":
+        volume_target = transform.apply_volume(batch.volume_y)
+        return masked_mse(volume_pred_norm, volume_target, batch.volume_mask)
+    if target_transform == "signed_log1p":
+        # Operate on Pa-space target and Pa-space prediction (after inverting
+        # the standard mean/std normalisation that the model head produces).
+        volume_pred_pa = transform.invert_volume(volume_pred_norm)
+        volume_target_pa = batch.volume_y
+        y_t = signed_log1p(volume_target_pa, log_scale)
+        y_p = signed_log1p(volume_pred_pa, log_scale)
+        return masked_mse(y_p, y_t, batch.volume_mask)
+    raise ValueError(
+        f"Unknown vol_pressure_target_transform={target_transform!r}; "
+        f"expected one of {VOL_PRESSURE_TARGET_TRANSFORMS}"
+    )
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,10 +366,12 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_pressure_target_transform: str = "none",
+    vol_pressure_log_scale: float = 25.0,
+    log_per_component_grad_norms: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
-    volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -330,18 +388,50 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_loss = _volume_pressure_loss(
+            volume_pred_norm=out["volume_preds"],
+            batch=batch,
+            transform=transform,
+            target_transform=vol_pressure_target_transform,
+            log_scale=vol_pressure_log_scale,
+        )
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if log_per_component_grad_norms:
+        # Per-component gradient norms at the model output tensors. Computed
+        # only when explicitly requested (signed_log1p instrumentation):
+        # ∂volume_loss/∂volume_preds and ∂surface_loss/∂surface_preds.
+        # retain_graph=True keeps the graph alive for the main loss.backward().
+        try:
+            vp_out_grad = torch.autograd.grad(
+                volume_loss, out["volume_preds"],
+                retain_graph=True, create_graph=False, only_inputs=True,
+            )[0]
+            sp_out_grad = torch.autograd.grad(
+                surface_loss, out["surface_preds"],
+                retain_graph=True, create_graph=False, only_inputs=True,
+            )[0]
+            metrics["vol_p_grad_norm"] = float(
+                vp_out_grad.detach().float().pow(2).sum().sqrt().item()
+            )
+            metrics["surface_p_grad_norm"] = float(
+                sp_out_grad.detach().float().pow(2).sum().sqrt().item()
+            )
+        except RuntimeError as exc:
+            metrics["vol_p_grad_norm"] = float("nan")
+            metrics["surface_p_grad_norm"] = float("nan")
+            metrics["per_component_grad_norm_error"] = str(exc)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -353,6 +443,9 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    vol_pressure_target_transform: str = "none",
+    vol_pressure_log_scale: float = 25.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -364,7 +457,6 @@ def per_task_train_losses(
 
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
-    volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -377,7 +469,13 @@ def per_task_train_losses(
         taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
         tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
         tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
-        vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        vp_loss = _volume_pressure_loss(
+            volume_pred_norm=out["volume_preds"],
+            batch=batch,
+            transform=transform,
+            target_transform=vol_pressure_target_transform,
+            log_scale=vol_pressure_log_scale,
+        )
     return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
 
 
@@ -699,6 +797,20 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        if config.vol_pressure_target_transform not in VOL_PRESSURE_TARGET_TRANSFORMS:
+            raise ValueError(
+                f"--vol-pressure-target-transform must be one of "
+                f"{VOL_PRESSURE_TARGET_TRANSFORMS}; got "
+                f"{config.vol_pressure_target_transform!r}"
+            )
+        if (
+            config.vol_pressure_target_transform != "none"
+            and config.vol_pressure_log_scale <= 0.0
+        ):
+            raise ValueError(
+                "--vol-pressure-log-scale must be > 0 when "
+                "--vol-pressure-target-transform != 'none'"
+            )
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -861,6 +973,49 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/vol_pressure_target_transform"] = config.vol_pressure_target_transform
+            wandb.summary["loss/vol_pressure_log_scale"] = config.vol_pressure_log_scale
+
+        if config.vol_pressure_target_transform != "none" and state.is_main:
+            print(
+                f"Volume-pressure target transform: "
+                f"{config.vol_pressure_target_transform} "
+                f"(scale={config.vol_pressure_log_scale} Pa)"
+            )
+            try:
+                sanity_iter = iter(train_loader)
+                sanity_batch = next(sanity_iter).to(device)
+                with torch.no_grad():
+                    raw_pa = sanity_batch.volume_y[sanity_batch.volume_mask].detach().float().cpu()
+                    transformed = signed_log1p(raw_pa, config.vol_pressure_log_scale).detach().cpu()
+                print(
+                    f"Sanity (volume_y): n={raw_pa.numel():d} "
+                    f"raw_pa min={raw_pa.min().item():.2f} max={raw_pa.max().item():.2f} "
+                    f"mean={raw_pa.mean().item():.2f} std={raw_pa.std().item():.2f} "
+                    f"abs_p99={raw_pa.abs().quantile(0.99).item():.2f}"
+                )
+                print(
+                    f"Sanity (signed_log1p): "
+                    f"min={transformed.min().item():.4f} max={transformed.max().item():.4f} "
+                    f"mean={transformed.mean().item():.4f} std={transformed.std().item():.4f} "
+                    f"abs_p99={transformed.abs().quantile(0.99).item():.4f}"
+                )
+                wandb.log(
+                    {
+                        "sanity/vol_p_raw_pa_hist": wandb.Histogram(raw_pa.numpy()),
+                        "sanity/vol_p_transformed_hist": wandb.Histogram(transformed.numpy()),
+                        "sanity/vol_p_raw_pa_min": float(raw_pa.min().item()),
+                        "sanity/vol_p_raw_pa_max": float(raw_pa.max().item()),
+                        "sanity/vol_p_raw_pa_abs_p99": float(raw_pa.abs().quantile(0.99).item()),
+                        "sanity/vol_p_transformed_min": float(transformed.min().item()),
+                        "sanity/vol_p_transformed_max": float(transformed.max().item()),
+                        "sanity/vol_p_transformed_abs_p99": float(transformed.abs().quantile(0.99).item()),
+                        "global_step": 0,
+                    }
+                )
+                del sanity_batch, sanity_iter, raw_pa, transformed
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: failed to log signed_log1p sanity histograms: {exc}")
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -917,7 +1072,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        vol_pressure_target_transform=config.vol_pressure_target_transform,
+                        vol_pressure_log_scale=config.vol_pressure_log_scale,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1008,6 +1169,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_pressure_target_transform=config.vol_pressure_target_transform,
+                        vol_pressure_log_scale=config.vol_pressure_log_scale,
+                        log_per_component_grad_norms=(
+                            config.vol_pressure_target_transform != "none"
+                        ),
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1048,6 +1214,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "vol_p_grad_norm" in batch_loss_metrics:
+                        train_log["train/vol_p_grad_norm"] = batch_loss_metrics["vol_p_grad_norm"]
+                        train_log["train/surface_p_grad_norm"] = batch_loss_metrics["surface_p_grad_norm"]
+                        sp_norm = batch_loss_metrics["surface_p_grad_norm"]
+                        if math.isfinite(sp_norm) and sp_norm > 0.0:
+                            train_log["train/vol_to_surface_grad_ratio"] = (
+                                batch_loss_metrics["vol_p_grad_norm"] / sp_norm
+                            )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

The chronic test_volume_pressure gap (val ~3.6%, test ~11.5%, ~3× ratio) is partly driven by the **heavy-tailed dynamic range of volume pressure values**. DrivAerML pressure spans roughly [-300, +200] Pa with a sharply peaked low-magnitude bulk and rare high-magnitude tail samples concentrated in the near-wake stagnation/recirculation zones. Standard MSE on raw pressure has its gradient dominated by the small bulk; the rare high-|p| tail (which is where test cases differ from train cases) is undertrained.

**Fix:** Predict a **signed-log target** y' = sign(p) · log1p(|p|/p_scale), train MSE on y', then back-transform at evaluation. This compresses the tail, yielding more uniform gradient flow across magnitudes — a standard physics-ML trick (Lakshminarayanan et al. 2017 deep regression; common in CFD surrogate work). The val→test val_volume_pressure regression target shifts but the relative l2 % metric we report (after back-transform) stays comparable.

This is **orthogonal to nezuko's region-weighted loss (PR #737)** — they spatial-emphasize, you magnitude-equalize. If both work they should compose later.

## Instructions

Add a `--vol-pressure-target-transform` mode and an associated scale flag. The transform is applied **only to volume_pressure** (do NOT touch surface_pressure or wall_shear). Steps:

1. **Add CLI flags** to `train.py`:
   - `--vol-pressure-target-transform {none, signed_log1p}` default `none`
   - `--vol-pressure-log-scale` (float, default 25.0 — typical Pa scale, you can tune; suggested values 10, 25, 50)

2. **Forward pass (training):** when transform=`signed_log1p`, in the volume_pressure loss path:
   - Compute `y_t = sign(target) * log1p(abs(target) / scale)`
   - Compute `y_p = sign(pred) * log1p(abs(pred) / scale)` — i.e., apply the same monotonic mapping to predictions before MSE so the loss is in transformed space.
   - Loss: `mse(y_p, y_t) * volume_loss_weight` (rest of pipeline unchanged).

3. **Eval-time inverse transform:** for **logging/metrics only**, predictions go through `pred_pa = sign(y_pred_logspace) * scale * (exp(abs(y_pred_logspace)) - 1)` if you ever need to compare in Pa. **For the relative L2 metric (rel_l2_pct)**, compute it in the original Pa space: predict `y_p_pa` by inverse-transforming the model output, then `rel_l2 = ||y_p_pa - target_pa||_2 / ||target_pa||_2`. This keeps the reported metric directly comparable to BASELINE.md.

4. **Sanity check at startup:** log a histogram of `target` vs `transformed target` on the first batch (W&B) so we can confirm the magnitude compression is sane.

5. **Three arms** under `--wandb-group fern-vol-logtarget`:
   - Arm A: `--vol-pressure-target-transform signed_log1p --vol-pressure-log-scale 25`
   - Arm B: `--vol-pressure-target-transform signed_log1p --vol-pressure-log-scale 10`
   - Arm C (control): `--vol-pressure-target-transform none` (sanity reproduce of SOTA)
   Run Arm A first to completion. Only launch Arms B/C if Arm A passes EP3 gate.

6. **Communication protocol (mandatory):** Within 30 minutes of training launch, post a comment with:
   - W&B run ID + group + run URL
   - EP1 step count, time/epoch estimate, val_abupt
   - Confirmation that the histogram sanity log shows reasonable transformed range
   At each kill gate (EP2, EP3), post a comment with metrics and the gate decision. **No silent runs.**

## Baseline

Current SOTA (must beat in priority order): **test_volume_pressure_rel_l2_pct**, then val_abupt.

| Tier | val_abupt | test_abupt | test_vol_p | PR | Run |
|---|---:|---:|---:|---|---|
| Single-model SOTA | **6.5985%** | 7.9915% | 11.933% | #592 (alphonse) | `4k25s25e` |
| Vol-pressure anchor | — | — | **11.374%** | #681 | `dc031qpt` |
| Vol-pressure 2nd | — | — | 11.694% | #599 | — |

Vol-pressure promotion ladder: Weak ≤11.0% | Solid ≤10.0% | Major ≤8.5% | Target ≤6.08% (AB-UPT)

### Reproduce baseline (then add the new flags)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-pressure-target-transform signed_log1p --vol-pressure-log-scale 25 \
  --wandb-group fern-vol-logtarget --wandb-name fern/logp-scale25
```

## Kill gates

| Gate | Threshold | Decision |
|---|---|---|
| EP1 (step ~3,257) val_abupt | < 35% | continue, else investigate transform implementation |
| EP2 (step ~6,514) val_abupt | < 12% | continue |
| EP3 (step ~9,771) val_abupt | < 8% AND val_vol_p < 5.5% | continue to full run |

## Promotion

Win condition (test from best-val checkpoint, EP-best EMA):
- **test_vol_p < 11.374%** = beats #681 anchor (Weak win) → merge
- **test_vol_p < 10.0%** = Solid win → priority merge + immediate compound
- **val_abupt < 6.5985%** AND test_vol_p doesn't regress = also merge

## Why this is high-value

- **Implementation cost: ~30 lines of code.** No new model architecture.
- **Direct attack on the val/test vol_pressure gap:** if the gap is magnitude-induced rather than spatial, this fixes it cheaply.
- **Composes with #737 (region weighting) and #752 (wake stratification):** all three address different facets of vol_pressure error.
- **Reversible:** transform is a strict pre/post processing layer, not an architectural change.

Note from the advisor: I am closing PR #736 (mixup) for parallel-run contamination. Please **kill all `gradnorm-adaptive` runs immediately** before launching this experiment, and post a comment confirming kill. No more side-runs without an open PR.

ADVISOR
