### PR TITLE
[edward] Per-case Cp target normalization for volume_pressure (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -44,6 +44,8 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    compute_cp_space_target_stats,
+    compute_per_case_q_k,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -62,6 +64,7 @@ from trainer_runtime import (
     print_metrics,
     run_final_evaluation,
     should_update_best_checkpoint,
+    summarize_q_k_distribution,
     timeout_budget_minutes,
     unwrap_model,
 )
@@ -137,6 +140,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    target_cp_normalization: str = "none"
+    cp_norm_eps: float = 1e-3
     debug: bool = False
 
 
@@ -218,6 +223,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "target_cp_normalization": (
+            "Per-case pressure-coefficient (Cp) target normalization for "
+            "surface_pressure (channel 0) and volume_pressure. With "
+            "'per_case_surface_max', q_k = max(|surface_cp|) is computed "
+            "once per case at startup over the FULL on-disk array; targets "
+            "are then divided by q_k before standardization, predictions "
+            "are multiplied back at evaluation so reported "
+            "rel_l2 stays comparable to Pa-space. wall_shear is NOT "
+            "rescaled. Default 'none' preserves the legacy pipeline. "
+            "Modes: {none, per_case_surface_max}."
+        ),
+        "cp_norm_eps": (
+            "Numerical floor for q_k to avoid div-by-zero on degenerate "
+            "cases. Each per-case q_k is clamped to max(q_k, eps) before "
+            "scaling. Default 1e-3."
         ),
     }
     for field in fields(Config):
@@ -312,8 +333,8 @@ def train_loss(
     surface_channel_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
-    surface_target = transform.apply_surface(batch.surface_y)
-    volume_target = transform.apply_volume(batch.volume_y)
+    surface_target = transform.apply_surface(batch.surface_y, batch.case_ids)
+    volume_target = transform.apply_volume(batch.volume_y, batch.case_ids)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -363,8 +384,8 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
-    surface_target = transform.apply_surface(batch.surface_y)
-    volume_target = transform.apply_volume(batch.volume_y)
+    surface_target = transform.apply_surface(batch.surface_y, batch.case_ids)
+    volume_target = transform.apply_volume(batch.volume_y, batch.case_ids)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -694,6 +715,95 @@ def rebuild_train_loader_with_vol_points(
     )
 
 
+def _log_q_k_artifacts(
+    *,
+    store,
+    q_k_by_case: dict[str, float],
+    case_ids_by_split: dict[str, list[str]],
+    output_dir: Path,
+) -> None:
+    """Write a per-case q_k CSV and log distribution histograms to W&B."""
+
+    import numpy as np
+    from data.loader import _resolve_artifact_path
+
+    csv_path = output_dir / "q_k_per_case.csv"
+    case_to_split: dict[str, str] = {}
+    for split_name, ids in case_ids_by_split.items():
+        for cid in ids:
+            case_to_split[cid] = split_name
+    rows = [
+        (cid, case_to_split.get(cid, "unknown"), float(q_k_by_case[cid]))
+        for cid in sorted(q_k_by_case.keys())
+    ]
+    with csv_path.open("w") as f:
+        f.write("case_id,split,q_k\n")
+        for cid, split_name, q_k in rows:
+            f.write(f"{cid},{split_name},{q_k:.6f}\n")
+    wandb.save(str(csv_path), policy="now")
+
+    table = wandb.Table(columns=["case_id", "split", "q_k"])
+    for cid, split_name, q_k in rows:
+        table.add_data(cid, split_name, q_k)
+
+    log_payload: dict[str, object] = {
+        "global_step": 0,
+        "cp_norm/q_k_per_case_table": table,
+    }
+    for split_name, ids in case_ids_by_split.items():
+        values = np.asarray(
+            [float(q_k_by_case[cid]) for cid in ids if cid in q_k_by_case],
+            dtype=np.float32,
+        )
+        if values.size == 0:
+            continue
+        log_payload[f"cp_norm/q_k_hist/{split_name}"] = wandb.Histogram(values)
+
+    train_ids = case_ids_by_split.get("train", [])
+    if train_ids:
+        # Sample ~24 train cases, draw up to 50k points each, log scaled-target histograms.
+        stride = max(1, len(train_ids) // 24)
+        sample_cases = train_ids[::stride][:24]
+        sp_samples: list[np.ndarray] = []
+        vp_samples: list[np.ndarray] = []
+        rng = np.random.default_rng(0)
+        for cid in sample_cases:
+            q_k = float(q_k_by_case[cid])
+            try:
+                cp_path = _resolve_artifact_path(store.root / cid / "surface_cp.npy")
+                cp = np.load(cp_path, mmap_mode="r")
+                cp_arr = np.asarray(cp, dtype=np.float32).reshape(-1) / q_k
+                if cp_arr.size > 50_000:
+                    cp_arr = rng.choice(cp_arr, 50_000, replace=False)
+                sp_samples.append(cp_arr)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                vp_path = _resolve_artifact_path(store.root / cid / "volume_pressure.npy")
+                vp = np.load(vp_path, mmap_mode="r")
+                vp_arr = np.asarray(vp, dtype=np.float32).reshape(-1) / q_k
+                if vp_arr.size > 50_000:
+                    vp_arr = rng.choice(vp_arr, 50_000, replace=False)
+                vp_samples.append(vp_arr)
+            except Exception:  # noqa: BLE001
+                pass
+        if sp_samples:
+            sp_concat = np.concatenate(sp_samples)
+            log_payload["cp_norm/scaled_surface_p_hist_train"] = wandb.Histogram(sp_concat)
+            log_payload["cp_norm/scaled_surface_p_min"] = float(sp_concat.min())
+            log_payload["cp_norm/scaled_surface_p_max"] = float(sp_concat.max())
+            log_payload["cp_norm/scaled_surface_p_mean"] = float(sp_concat.mean())
+            log_payload["cp_norm/scaled_surface_p_std"] = float(sp_concat.std())
+        if vp_samples:
+            vp_concat = np.concatenate(vp_samples)
+            log_payload["cp_norm/scaled_volume_p_hist_train"] = wandb.Histogram(vp_concat)
+            log_payload["cp_norm/scaled_volume_p_min"] = float(vp_concat.min())
+            log_payload["cp_norm/scaled_volume_p_max"] = float(vp_concat.max())
+            log_payload["cp_norm/scaled_volume_p_mean"] = float(vp_concat.mean())
+            log_payload["cp_norm/scaled_volume_p_std"] = float(vp_concat.std())
+    wandb.log(log_payload)
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     state = init_distributed()
     run = None
@@ -728,11 +838,96 @@ def main(argv: Iterable[str] | None = None) -> None:
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
+
+        cp_norm_active = config.target_cp_normalization != "none"
+        q_k_by_case: dict[str, float] = {}
+        case_ids_by_split: dict[str, list[str]] = {}
+        cp_norm_logs: dict[str, object] = {}
+        surface_y_mean = stats["surface_y_mean"].clone()
+        surface_y_std = stats["surface_y_std"].clone()
+        volume_y_mean = stats["volume_y_mean"].clone()
+        volume_y_std = stats["volume_y_std"].clone()
+        if cp_norm_active:
+            store = train_loader.dataset.store
+            train_case_ids = list(train_loader.dataset.case_ids)
+            val_case_ids = sorted({
+                cid for ds in val_loaders.values() for cid in ds.dataset.case_ids
+            })
+            test_case_ids = sorted({
+                cid for ds in test_loaders.values() for cid in ds.dataset.case_ids
+            })
+            case_ids_by_split = {
+                "train": train_case_ids,
+                "val": val_case_ids,
+                "test": test_case_ids,
+            }
+            if state.is_main:
+                print(
+                    f"Cp normalization mode={config.target_cp_normalization!r}; "
+                    f"computing q_k for {sum(len(v) for v in case_ids_by_split.values())} cases..."
+                )
+            q_k_by_case = compute_per_case_q_k(
+                store,
+                case_ids_by_split,
+                mode=config.target_cp_normalization,
+                eps=config.cp_norm_eps,
+                progress_print=state.is_main,
+            )
+            if state.is_main:
+                print("Cp normalization: computing Cp-space mean/std on train set...")
+            cp_stats = compute_cp_space_target_stats(
+                store,
+                train_case_ids,
+                q_k_by_case,
+                progress_print=state.is_main,
+            )
+            surface_y_mean[0] = cp_stats["cp_surface_pressure_mean"][0]
+            surface_y_std[0] = cp_stats["cp_surface_pressure_std"][0]
+            volume_y_mean[0] = cp_stats["cp_volume_pressure_mean"][0]
+            volume_y_std[0] = cp_stats["cp_volume_pressure_std"][0]
+            q_k_summary = summarize_q_k_distribution(q_k_by_case, case_ids_by_split)
+            if state.is_main:
+                for split_name, summary in q_k_summary.items():
+                    print(
+                        f"  q_k[{split_name}]: count={int(summary['count'])} "
+                        f"mean={summary['mean']:.4f} std={summary['std']:.4f} "
+                        f"min={summary['min']:.4f} median={summary['median']:.4f} "
+                        f"max={summary['max']:.4f}"
+                    )
+                print(
+                    "  Cp-space surface_pressure stats: "
+                    f"mean={float(cp_stats['cp_surface_pressure_mean'][0]):.6f} "
+                    f"std={float(cp_stats['cp_surface_pressure_std'][0]):.6f}"
+                )
+                print(
+                    "  Cp-space volume_pressure stats: "
+                    f"mean={float(cp_stats['cp_volume_pressure_mean'][0]):.6f} "
+                    f"std={float(cp_stats['cp_volume_pressure_std'][0]):.6f}"
+                )
+            for split_name, summary in q_k_summary.items():
+                for stat_name, value in summary.items():
+                    cp_norm_logs[f"cp_norm/q_k_{split_name}_{stat_name}"] = float(value)
+            cp_norm_logs["cp_norm/cp_surface_pressure_mean"] = float(
+                cp_stats["cp_surface_pressure_mean"][0]
+            )
+            cp_norm_logs["cp_norm/cp_surface_pressure_std"] = float(
+                cp_stats["cp_surface_pressure_std"][0]
+            )
+            cp_norm_logs["cp_norm/cp_volume_pressure_mean"] = float(
+                cp_stats["cp_volume_pressure_mean"][0]
+            )
+            cp_norm_logs["cp_norm/cp_volume_pressure_std"] = float(
+                cp_stats["cp_volume_pressure_std"][0]
+            )
+
         transform = TargetTransform(
-            surface_y_mean=stats["surface_y_mean"].to(device),
-            surface_y_std=stats["surface_y_std"].to(device),
-            volume_y_mean=stats["volume_y_mean"].to(device),
-            volume_y_std=stats["volume_y_std"].to(device),
+            surface_y_mean=surface_y_mean.to(device),
+            surface_y_std=surface_y_std.to(device),
+            volume_y_mean=volume_y_mean.to(device),
+            volume_y_std=volume_y_std.to(device),
+            cp_norm_mode=config.target_cp_normalization,
+            q_k_by_case=q_k_by_case,
+            cp_norm_eps=config.cp_norm_eps,
         )
 
         model: nn.Module = build_model(config).to(device)
@@ -861,6 +1056,17 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if cp_norm_active:
+                wandb.summary["cp_norm/mode"] = config.target_cp_normalization
+                wandb.summary["cp_norm/eps"] = config.cp_norm_eps
+                wandb.summary.update(cp_norm_logs)
+                wandb.log({"global_step": 0, **cp_norm_logs})
+                _log_q_k_artifacts(
+                    store=train_loader.dataset.store,
+                    q_k_by_case=q_k_by_case,
+                    case_ids_by_split=case_ids_by_split,
+                    output_dir=output_dir,
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -170,6 +170,9 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        cp_norm_mode: str = "none",
+        q_k_by_case: dict[str, float] | None = None,
+        cp_norm_eps: float = 1e-3,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -187,6 +190,24 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        self.cp_norm_mode = cp_norm_mode
+        self.cp_norm_eps = float(cp_norm_eps)
+        self.q_k_by_case = dict(q_k_by_case) if q_k_by_case is not None else {}
+        if self.cp_norm_mode != "none" and not self.q_k_by_case:
+            raise ValueError(
+                "TargetTransform: cp_norm_mode is enabled but q_k_by_case is empty"
+            )
+
+    @property
+    def cp_normalization_active(self) -> bool:
+        return self.cp_norm_mode != "none"
+
+    def _q_k_tensor(self, case_ids: list[str], device: torch.device) -> torch.Tensor:
+        values = [
+            max(float(self.q_k_by_case.get(cid, 1.0)), self.cp_norm_eps)
+            for cid in case_ids
+        ]
+        return torch.tensor(values, dtype=torch.float32, device=device)
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -194,17 +215,65 @@ class TargetTransform:
     def invert(self, y: torch.Tensor) -> torch.Tensor:
         return self.invert_surface(y)
 
-    def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+    def apply_surface(
+        self, y: torch.Tensor, case_ids: list[str] | None = None
+    ) -> torch.Tensor:
+        scaled = y
+        if self.cp_normalization_active:
+            if case_ids is None:
+                raise ValueError(
+                    "TargetTransform.apply_surface requires case_ids when "
+                    "cp_norm_mode != 'none'"
+                )
+            q_k = self._q_k_tensor(case_ids, y.device).view(-1, 1, 1)
+            scaled = y.clone()
+            scaled[..., 0:1] = scaled[..., 0:1] / q_k
+        return (scaled - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
 
-    def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+    def invert_surface(
+        self, y: torch.Tensor, case_ids: list[str] | None = None
+    ) -> torch.Tensor:
+        unscaled = y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
+        if self.cp_normalization_active:
+            if case_ids is None:
+                raise ValueError(
+                    "TargetTransform.invert_surface requires case_ids when "
+                    "cp_norm_mode != 'none'"
+                )
+            q_k = self._q_k_tensor(case_ids, y.device).view(-1, 1, 1)
+            unscaled = unscaled.clone()
+            unscaled[..., 0:1] = unscaled[..., 0:1] * q_k
+        return unscaled
 
-    def apply_volume(self, y: torch.Tensor) -> torch.Tensor:
-        return (y - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)
+    def apply_volume(
+        self, y: torch.Tensor, case_ids: list[str] | None = None
+    ) -> torch.Tensor:
+        scaled = y
+        if self.cp_normalization_active:
+            if case_ids is None:
+                raise ValueError(
+                    "TargetTransform.apply_volume requires case_ids when "
+                    "cp_norm_mode != 'none'"
+                )
+            q_k = self._q_k_tensor(case_ids, y.device).view(-1, 1, 1)
+            scaled = y.clone()
+            scaled[..., 0:1] = scaled[..., 0:1] / q_k
+        return (scaled - self.volume_y_mean.to(y.device)) / self.volume_y_std.to(y.device)
 
-    def invert_volume(self, y: torch.Tensor) -> torch.Tensor:
-        return y * self.volume_y_std.to(y.device) + self.volume_y_mean.to(y.device)
+    def invert_volume(
+        self, y: torch.Tensor, case_ids: list[str] | None = None
+    ) -> torch.Tensor:
+        unscaled = y * self.volume_y_std.to(y.device) + self.volume_y_mean.to(y.device)
+        if self.cp_normalization_active:
+            if case_ids is None:
+                raise ValueError(
+                    "TargetTransform.invert_volume requires case_ids when "
+                    "cp_norm_mode != 'none'"
+                )
+            q_k = self._q_k_tensor(case_ids, y.device).view(-1, 1, 1)
+            unscaled = unscaled.clone()
+            unscaled[..., 0:1] = unscaled[..., 0:1] * q_k
+        return unscaled
 
 
 def autocast_context(device: torch.device, amp_mode: str):
@@ -267,6 +336,145 @@ def full_eval_loaders_from(
         name: eval_loader_for_dataset(loader.dataset, config, distributed_state=None)
         for name, loader in loaders.items()
     }
+
+
+def compute_per_case_q_k(
+    store,
+    case_ids_by_split: Mapping[str, Iterable[str]],
+    *,
+    mode: str = "per_case_surface_max",
+    eps: float = 1e-3,
+    progress_print: bool = False,
+) -> dict[str, float]:
+    """Walk each case once and compute the per-case scaling factor q_k.
+
+    For mode='per_case_surface_max', q_k = max(|surface_cp|) using the FULL
+    on-disk surface pressure array (not a sub-sampled view). This single
+    init-time pass per rank is cached after the first read because the
+    underlying loader's `_resolve_artifact_path` uses functools.lru_cache.
+    """
+
+    if mode != "per_case_surface_max":
+        raise ValueError(
+            f"compute_per_case_q_k: unsupported mode {mode!r}; "
+            "expected 'per_case_surface_max'"
+        )
+    import numpy as np
+    from data.loader import _resolve_artifact_path
+
+    q_k: dict[str, float] = {}
+    seen: set[str] = set()
+    all_case_ids = []
+    for split_name, ids in case_ids_by_split.items():
+        for cid in ids:
+            if cid in seen:
+                continue
+            seen.add(cid)
+            all_case_ids.append(cid)
+
+    for i, case_id in enumerate(all_case_ids):
+        cp_path = store.root / case_id / "surface_cp.npy"
+        resolved = _resolve_artifact_path(cp_path)
+        cp = np.load(resolved, mmap_mode="r")
+        abs_max = float(np.abs(np.asarray(cp, dtype=np.float64)).max())
+        q_k[case_id] = max(abs_max, eps)
+        if progress_print and (i + 1) % 100 == 0:
+            print(
+                f"  Cp normalization: q_k computed for {i + 1}/{len(all_case_ids)} cases",
+                flush=True,
+            )
+    return q_k
+
+
+def compute_cp_space_target_stats(
+    store,
+    train_case_ids: Iterable[str],
+    q_k_by_case: Mapping[str, float],
+    *,
+    progress_print: bool = False,
+) -> dict[str, torch.Tensor]:
+    """Compute mean/std of (surface_cp / q_k) and (volume_pressure / q_k) over train.
+
+    Used as the standardization stats for the channels that are Cp-scaled.
+    Returns a dict with `cp_surface_pressure_mean`, `cp_surface_pressure_std`,
+    `cp_volume_pressure_mean`, `cp_volume_pressure_std`, each a 1D tensor of
+    length 1.
+    """
+
+    import numpy as np
+    from data.loader import _resolve_artifact_path
+
+    surface_n = 0
+    surface_sum = 0.0
+    surface_sum_sq = 0.0
+    volume_n = 0
+    volume_sum = 0.0
+    volume_sum_sq = 0.0
+
+    train_ids = list(train_case_ids)
+    for i, case_id in enumerate(train_ids):
+        q_k = max(float(q_k_by_case.get(case_id, 1.0)), 1e-12)
+
+        cp_path = store.root / case_id / "surface_cp.npy"
+        cp = np.load(_resolve_artifact_path(cp_path), mmap_mode="r")
+        cp_arr = np.asarray(cp, dtype=np.float64).reshape(-1) / q_k
+        surface_n += int(cp_arr.size)
+        surface_sum += float(cp_arr.sum())
+        surface_sum_sq += float(np.square(cp_arr).sum())
+
+        vp_path = store.root / case_id / "volume_pressure.npy"
+        vp = np.load(_resolve_artifact_path(vp_path), mmap_mode="r")
+        vp_arr = np.asarray(vp, dtype=np.float64).reshape(-1) / q_k
+        volume_n += int(vp_arr.size)
+        volume_sum += float(vp_arr.sum())
+        volume_sum_sq += float(np.square(vp_arr).sum())
+
+        if progress_print and (i + 1) % 50 == 0:
+            print(
+                f"  Cp normalization: stats accumulated for {i + 1}/{len(train_ids)} train cases",
+                flush=True,
+            )
+
+    surface_mean = surface_sum / max(surface_n, 1)
+    surface_var = max(surface_sum_sq / max(surface_n, 1) - surface_mean ** 2, 0.0)
+    surface_std = math.sqrt(surface_var) if surface_var > 0 else 1.0
+
+    volume_mean = volume_sum / max(volume_n, 1)
+    volume_var = max(volume_sum_sq / max(volume_n, 1) - volume_mean ** 2, 0.0)
+    volume_std = math.sqrt(volume_var) if volume_var > 0 else 1.0
+
+    return {
+        "cp_surface_pressure_mean": torch.tensor([surface_mean], dtype=torch.float32),
+        "cp_surface_pressure_std": torch.tensor([max(surface_std, 1e-6)], dtype=torch.float32),
+        "cp_volume_pressure_mean": torch.tensor([volume_mean], dtype=torch.float32),
+        "cp_volume_pressure_std": torch.tensor([max(volume_std, 1e-6)], dtype=torch.float32),
+    }
+
+
+def summarize_q_k_distribution(
+    q_k_by_case: Mapping[str, float],
+    case_ids_by_split: Mapping[str, Iterable[str]],
+) -> dict[str, dict[str, float]]:
+    """Compute summary stats (mean/std/min/max/median) per split."""
+    summary: dict[str, dict[str, float]] = {}
+    for split_name, ids in case_ids_by_split.items():
+        values = [float(q_k_by_case[cid]) for cid in ids if cid in q_k_by_case]
+        if not values:
+            continue
+        sorted_v = sorted(values)
+        n = len(sorted_v)
+        median = sorted_v[n // 2] if n % 2 == 1 else 0.5 * (sorted_v[n // 2 - 1] + sorted_v[n // 2])
+        mean = sum(sorted_v) / n
+        var = sum((v - mean) ** 2 for v in sorted_v) / n
+        summary[split_name] = {
+            "count": float(n),
+            "mean": mean,
+            "std": math.sqrt(var),
+            "min": sorted_v[0],
+            "max": sorted_v[-1],
+            "median": median,
+        }
+    return summary
 
 
 def make_loaders(
@@ -957,8 +1165,8 @@ def accumulate_eval_batch(
     amp_mode: str,
 ) -> None:
     batch = batch.to(device)
-    surface_target_norm = transform.apply_surface(batch.surface_y)
-    volume_target_norm = transform.apply_volume(batch.volume_y)
+    surface_target_norm = transform.apply_surface(batch.surface_y, batch.case_ids)
+    volume_target_norm = transform.apply_volume(batch.volume_y, batch.case_ids)
     eval_module = unwrap_model(model)
     with autocast_context(device, amp_mode):
         out = eval_module(
@@ -975,8 +1183,8 @@ def accumulate_eval_batch(
     accumulator.surface_loss_count += surface_count
     accumulator.volume_loss_sse += volume_sse
     accumulator.volume_loss_count += volume_count
-    surface_pred = transform.invert_surface(surface_pred_norm)
-    volume_pred = transform.invert_volume(volume_pred_norm)
+    surface_pred = transform.invert_surface(surface_pred_norm, batch.case_ids)
+    volume_pred = transform.invert_volume(volume_pred_norm, batch.case_ids)
 
     if bool(batch.surface_mask.any()):
         surface_abs = (surface_pred - batch.surface_y).abs()
@@ -1140,6 +1348,52 @@ def evaluate_split(
             return {}
         accumulator = merge_eval_accumulators(acc for acc in gathered if acc is not None)
     return finalize_eval_accumulator(accumulator)
+
+
+def per_case_rel_l2_pct(accumulator: EvalAccumulator) -> dict[str, dict[str, float]]:
+    """Return per-case rel_l2 percent for each EVAL_KEY metric.
+
+    Output: {case_id: {metric_name: rel_l2_pct, ...}, ...}
+    """
+    per_case: dict[str, dict[str, float]] = {}
+    for key in EVAL_KEYS:
+        for case_id, (error_sq, target_sq) in accumulator.case_sums[key].items():
+            if target_sq <= 0.0:
+                continue
+            rel_l2_pct = math.sqrt(error_sq / target_sq) * 100.0
+            per_case.setdefault(case_id, {})[key] = rel_l2_pct
+    return per_case
+
+
+@torch.no_grad()
+def evaluate_split_with_accumulator(
+    model: nn.Module,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    *,
+    amp_mode: str = "none",
+    distributed_state: DistributedState | None = None,
+) -> tuple[dict[str, float], EvalAccumulator]:
+    """Like evaluate_split but also returns the merged accumulator."""
+    model.eval()
+    accumulator = EvalAccumulator()
+    for batch in loader:
+        accumulate_eval_batch(
+            accumulator,
+            model=model,
+            batch=batch,
+            transform=transform,
+            device=device,
+            amp_mode=amp_mode,
+        )
+    if distributed_state is not None and distributed_state.enabled:
+        gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
+        dist.all_gather_object(gathered, accumulator)
+        if not distributed_state.is_main:
+            return {}, EvalAccumulator()
+        accumulator = merge_eval_accumulators(acc for acc in gathered if acc is not None)
+    return finalize_eval_accumulator(accumulator), accumulator
 
 
 def _sanitize_artifact_token(value: str) -> str:
@@ -1485,10 +1739,14 @@ def run_final_evaluation(
     wandb.summary.update(numeric_metric_items(full_val_log))
     print_metrics("full_val", full_val_metrics["val_surface"])
 
-    test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
-        for name, loader in final_test_loaders.items()
-    }
+    test_metrics: dict[str, dict[str, float]] = {}
+    test_per_case: dict[str, dict[str, dict[str, float]]] = {}
+    for name, loader in final_test_loaders.items():
+        metrics, accumulator = evaluate_split_with_accumulator(
+            model, loader, transform, device, amp_mode=config.amp_mode
+        )
+        test_metrics[name] = metrics
+        test_per_case[name] = per_case_rel_l2_pct(accumulator)
     test_log: dict[str, object] = {
         "global_step": global_step,
         **primary_metric_log("test_primary", test_metrics["test_surface"]),
@@ -1505,6 +1763,8 @@ def run_final_evaluation(
     wandb.summary.update(numeric_metric_items(test_log))
     print_metrics("test_surface", test_metrics["test_surface"])
 
+    _log_per_case_test_table(test_per_case, global_step=global_step)
+
     log_model_artifact(
         run=run,
         model_path=model_path,
@@ -1514,3 +1774,54 @@ def run_final_evaluation(
         test_metrics=test_metrics,
         n_params=n_params,
     )
+
+
+def _log_per_case_test_table(
+    per_case_metrics: dict[str, dict[str, dict[str, float]]],
+    *,
+    global_step: int,
+) -> None:
+    """Log per-case test rel_l2 percentages as a W&B table."""
+    columns = [
+        "case_id",
+        "split_name",
+        "surface_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+    ]
+    table = wandb.Table(columns=columns)
+    outliers_of_interest = {"run_226", "run_133", "run_203", "run_158"}
+    outlier_log: dict[str, float] = {}
+    for split_name, cases in per_case_metrics.items():
+        for case_id in sorted(cases.keys()):
+            entry = cases[case_id]
+            row = [case_id, split_name]
+            for key in (
+                "surface_pressure",
+                "wall_shear",
+                "wall_shear_x",
+                "wall_shear_y",
+                "wall_shear_z",
+                "volume_pressure",
+            ):
+                value = entry.get(key, float("nan"))
+                row.append(float(value))
+            table.add_data(*row)
+            if case_id in outliers_of_interest:
+                outlier_log[
+                    f"test_outliers/{case_id}/volume_pressure_rel_l2_pct"
+                ] = float(entry.get("volume_pressure", float("nan")))
+                outlier_log[
+                    f"test_outliers/{case_id}/surface_pressure_rel_l2_pct"
+                ] = float(entry.get("surface_pressure", float("nan")))
+    log_payload: dict[str, object] = {
+        "global_step": global_step,
+        "test/per_case_rel_l2_pct": table,
+    }
+    if outlier_log:
+        log_payload.update(outlier_log)
+        wandb.summary.update(outlier_log)
+    wandb.log(log_payload)


### PR DESCRIPTION
## Hypothesis

The chronic test_volume_pressure gap (val ~3.6%, test ~11.5%) and the **four catastrophic test outliers** identified in PR #734 (run_226=109.85%, run_133=107.71%, run_203=103.84%, run_158=102.04%) point at a **dimensional inconsistency** between train and test cases: each car case has a different effective dynamic pressure q_inf = ½ρU∞², because while the freestream nominally is fixed, simulation cases vary in operating condition encoding (geometry-induced pressure scale changes from frontal area, wake length, wheel rotation amplitude). The model, trained on raw absolute pressure (Pa), implicitly memorizes a per-case pressure scale that does not transfer to test cases with different effective q_inf.

**Fix:** Per-case **pressure coefficient normalization** — divide all pressure targets (surface AND volume) by a case-level scaling constant derived from the training-time surface pressure stagnation peak. Define for each case k:

    q_k = max(|p_surf_k|)   (a per-case proxy for ½ρU∞² + geometry-induced scale)

Train the model to predict the dimensionless field Cp = p / q_k, then de-scale at evaluation by multiplying by the held-out case's q_k (which the data loader can extract on the fly because `surface_p` is the input target observed by the model during training and its stagnation magnitude is geometry-determined; at val/test time we still have access to the surface_p target via the loader).

Actually — cleanly: q_k is computed **once per case at dataset-build time** using the full surface pressure ground truth (read once, cached). It is NOT data leakage into the model: the model never sees q_k, it only sees the standardized targets and predicts standardized outputs.

This is the **non-dimensionalization trick that turns CFD targets into Cp** — standard practice in turbomachinery and external aerodynamics ML, and the natural target for any aerodynamic surrogate (see Beck & Kurz 2021; Vinuesa & Brunton 2022). Never tried on this dataset.

## Why this is high-value

- **Directly attacks the val/test outlier issue.** If the four catastrophic test cases (109% rel_l2!) have q_k far outside the train q_k distribution, raw-Pa training cannot generalize. Cp training removes that dimension.
- **Composes orthogonally with all in-flight Phase 1 work** (nezuko region weighting #737, askeladd wake stratification #752, fern log-target #753, alphonse geom branch #750).
- **Implementation: ~80 lines.** Modify the dataset preprocessor or the loader to compute and cache q_k per case, scale targets at load time, store q_k in the batch metadata, multiply predictions back to Pa for the rel_l2 metric computation at eval.
- **Reversible.** Just a target transform. No architecture changes.

## Instructions

Add a `--target-cp-normalization` mode that wraps the existing target pipeline.

1. **CLI flag** in `train.py`:
   - `--target-cp-normalization {none, per_case_surface_max}` default `none`
   - Optional: `--cp-norm-eps 1e-3` (avoids div-by-zero on degenerate cases)

2. **Per-case scaling factor computation** — at dataset construction time, walk every case once and compute `q_k = max(abs(surface_p_k))` (using the FULL surface pressure ground truth, not a sub-sampled view). Cache `q_k` in the case metadata dict. This is a one-time cost per case, ~seconds total.

3. **At training time (`__getitem__` in the dataset)** when mode=`per_case_surface_max`:
   - Divide `surface_y` (surface_pressure channel only) by `q_k` → `surface_p / q_k`
   - Divide `volume_y` (volume_pressure channel only) by `q_k` → `volume_p / q_k`
   - **Do NOT scale wall_shear** — wall_shear has units of stress (Pa) but its scaling with q_inf is already approximately captured by the dimensionless skin-friction coefficient relationship; rescaling only pressure isolates the hypothesis.
   - Pass `q_k` along in the batch (e.g., `batch.q_inf` shape `[B]`) so the loss/eval can de-normalize for reporting.

4. **At evaluation time:**
   - Model predicts `Cp_pred` (dimensionless)
   - For the rel_l2_pct metric, compute in **physical Pa space**: `pred_pa = Cp_pred * q_k`, then `rel_l2 = ||pred_pa - target_pa||_2 / ||target_pa||_2`. **This keeps the reported metrics directly comparable to BASELINE.md**.
   - Log both `val_primary/volume_pressure_rel_l2_pct` (Pa-space, comparable) and a new `val_aux/volume_pressure_cp_rel_l2_pct` (Cp-space, for diagnostics).

5. **Sanity logs at startup:**
   - Distribution of `q_k` across train/val/test (mean, std, min, max). If train q_k range does not bracket val/test range, the hypothesis is partially supported even before training.
   - Histogram of train surface_p / q_k and volume_p / q_k after scaling — these should be in roughly [-1.5, 0.5] range for both.

6. **Two arms** under `--wandb-group edward-cp-normalization`:
   - Arm A: `--target-cp-normalization per_case_surface_max`
   - Arm B (control): `--target-cp-normalization none` reproducing SOTA on the same code path (sanity check that the new code path doesn't regress when disabled)
   Run Arm A first.

7. **Communication protocol (mandatory):** Post a startup comment within 30 minutes of launch with W&B run ID + group, EP1 progress, and confirmation that q_k distribution is logged. Post EP1, EP2, EP3 kill-gate decisions as comments. **Silence is treated as failure.**

## Baseline

| Tier | val_abupt | test_abupt | test_vol_p | PR | Run |
|---|---:|---:|---:|---|---|
| Single-model SOTA | **6.5985%** | 7.9915% | 11.933% | #592 (alphonse) | `4k25s25e` |
| Vol-pressure anchor | — | — | **11.374%** | #681 | `dc031qpt` |

Vol-pressure promotion ladder: Weak ≤11.0% | Solid ≤10.0% | Major ≤8.5% | Target ≤6.08% (AB-UPT)

### Reproduce SOTA stack + new flag

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --target-cp-normalization per_case_surface_max \
  --wandb-group edward-cp-normalization --wandb-name edward/cp-norm
```

## Kill gates

| Gate | Threshold | Decision |
|---|---|---|
| EP1 (step ~3,257) val_abupt | < 35% | continue |
| EP2 (step ~6,514) val_abupt | < 12% | continue |
| EP3 (step ~9,771) val_abupt | < 8% | continue to full run |

## Promotion

Win condition (test from best-val checkpoint):
- **test_vol_p < 11.374%** = Weak win → merge
- **test_vol_p < 10.0%** = Solid win → priority merge
- Special: if the **four outlier test cases** (run_226, 133, 203, 158) drop below 50% rel_l2 (currently ~100%+), even if mean test_vol_p doesn't change much, that is still a structural fix worth merging — log per-case test rel_l2 as a table at end-of-run.

## Note from advisor on PR #735 closure

I have closed your PR #735 (TTA Y-mirror + jitter). Both arms were negative results (Arm A test_vol_p 13.48% > 11.93% SOTA worse; Arm B trained-mirror best-val test_vol_p 12.24% > SOTA, +0.31pp regression on the primary metric). Y-mirror exploits a symmetry the model can't actually use given STRING-separable PE.

The Cp normalization hypothesis here is much higher-leverage. Please proceed.

ADVISOR
