### PR TITLE
[frieren] Stochastic depth + volume-token dropout for OOD generalization (Issue #717)

### DIFF
--- a/model.py
+++ b/model.py
@@ -256,6 +256,22 @@ class TransolverAttention(nn.Module):
         return _apply_token_mask(out_x, attn_mask)
 
 
+def drop_path(x: torch.Tensor, drop_prob: float, training: bool) -> torch.Tensor:
+    """Stochastic depth: randomly drop entire residual branches during training.
+
+    Huang et al. 2016 "Deep Networks with Stochastic Depth".
+    At inference, all branches are active and no scaling is needed because
+    the kept branches are already rescaled by 1/keep_prob during training.
+    """
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1.0 - drop_prob
+    # Shape: (batch, 1, 1, ...) so each sample in the batch is independently dropped
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+    mask = x.new_empty(shape).bernoulli_(keep_prob).div_(keep_prob)
+    return x * mask
+
+
 class TransformerBlock(nn.Module):
     def __init__(
         self,
@@ -265,6 +281,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -278,12 +295,13 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path_rate = drop_path_rate
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + drop_path(self.attention(self.norm1(x), attn_mask=attn_mask), self.drop_path_rate, self.training)
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + drop_path(self.mlp(self.norm2(x)), self.drop_path_rate, self.training)
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -298,8 +316,11 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_rates: list[float] | None = None,
     ):
         super().__init__()
+        if drop_path_rates is None:
+            drop_path_rates = [0.0] * depth
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -309,8 +330,9 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    drop_path_rate=drop_path_rates[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -342,11 +364,14 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        drop_path_rate: float = 0.0,
+        vol_token_drop_rate: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
+        self.vol_token_drop_rate = vol_token_drop_rate
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
@@ -409,6 +434,11 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        # Linear stochastic-depth schedule: layer 0 is never dropped, layer n_layers-1 is
+        # dropped at drop_path_rate.  For a single-layer model the rate is 0.
+        _dp_rates = [
+            drop_path_rate * i / max(1, n_layers - 1) for i in range(n_layers)
+        ]
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -417,6 +447,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            drop_path_rates=_dp_rates,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -482,18 +513,32 @@ class SurfaceTransolver(nn.Module):
             )
             masks.append(surface_mask)
 
+        vol_token_drop_frac: float | None = None
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    volume_x,
-                    rff=self.volume_rff,
-                    string_sep=self.volume_string_sep,
-                    project_features=self.project_volume_features,
-                    bias=self.volume_bias,
-                    placeholder=self.volume_placeholder,
-                )
+            vol_encoded = self._encode_group(
+                volume_x,
+                rff=self.volume_rff,
+                string_sep=self.volume_string_sep,
+                project_features=self.project_volume_features,
+                bias=self.volume_bias,
+                placeholder=self.volume_placeholder,
             )
+            # Volume-token dropout: per-token Bernoulli mask scaled by 1/(1-rate)
+            # for unbiased forward, AND'd into the pad mask so dropped tokens are
+            # excluded from slice attention (matches PatchDropout, 2208.07220).
+            if self.vol_token_drop_rate > 0.0 and self.training:
+                keep_prob = 1.0 - self.vol_token_drop_rate
+                tok_keep = vol_encoded.new_empty(
+                    vol_encoded.shape[0], vol_encoded.shape[1]
+                ).bernoulli_(keep_prob)
+                vol_encoded = vol_encoded * (tok_keep / keep_prob).unsqueeze(-1)
+                valid_mask_f = volume_mask.to(dtype=tok_keep.dtype)
+                n_valid = valid_mask_f.sum().clamp(min=1.0)
+                n_dropped = ((1.0 - tok_keep) * valid_mask_f).sum()
+                vol_token_drop_frac = float((n_dropped / n_valid).item())
+                volume_mask = volume_mask * tok_keep.to(dtype=volume_mask.dtype)
+            tokens.append(vol_encoded)
             masks.append(volume_mask)
 
         attn_mask = torch.cat(masks, dim=1)
@@ -525,4 +570,5 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "vol_token_drop_frac": vol_token_drop_frac,
         }

--- a/train.py
+++ b/train.py
@@ -137,6 +137,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    drop_path_rate: float = 0.0
+    vol_token_drop_rate: float = 0.0
     debug: bool = False
 
 
@@ -297,6 +299,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        drop_path_rate=config.drop_path_rate,
+        vol_token_drop_rate=config.vol_token_drop_rate,
     )
 
 
@@ -335,13 +339,16 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if out.get("vol_token_drop_frac") is not None:
+        metrics["vol_token_drop_frac"] = float(out["vol_token_drop_frac"])
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -861,6 +868,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/drop_path_rate"] = config.drop_path_rate
+            wandb.summary["model/vol_token_drop_rate"] = config.vol_token_drop_rate
+            # Log per-layer drop-path schedule
+            n_layers = config.model_layers
+            per_layer_dp = [
+                config.drop_path_rate * i / max(1, n_layers - 1) for i in range(n_layers)
+            ]
+            wandb.summary["model/drop_path_per_layer"] = per_layer_dp
+            if state.is_main and config.drop_path_rate > 0.0:
+                print(
+                    f"Stochastic depth: drop_path_rate={config.drop_path_rate}, "
+                    f"per-layer schedule={[round(r, 4) for r in per_layer_dp]}"
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1046,6 +1066,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/vol_token_drop_rate": config.vol_token_drop_rate,
+                            "train/drop_path_rate": config.drop_path_rate,
+                            **({"train/vol_token_drop_actual_frac": batch_loss_metrics["vol_token_drop_frac"]}
+                               if "vol_token_drop_frac" in batch_loss_metrics else {}),
                         }
                     )
                 if gradnorm_metrics:


### PR DESCRIPTION
## Hypothesis

The chronic 3x val/test gap on volume_pressure (val ~3.6%, test ~11.5%), and the 4 catastrophic outlier test cases (109% / 107% / 103% / 102% rel_l2 from PR #734), are consistent with a **distribution-shift / overfitting-on-geometry** failure mode rather than a sampling or loss-shape problem. The model is over-reliant on specific geometry-token feature combinations that exist in the training set but not in the test set.

**Fix:** **Stochastic depth + structured geometry-branch token dropout** — apply Huang et al. 2016 stochastic depth to the transformer blocks (per-block linearly-scaled survival probability) AND apply token-level dropout in the volume-branch input embedding. Both are well-known techniques to push a transformer toward learning robust, distribution-invariant representations rather than memorizing fragile geometry-feature compositions.

This directly attacks the failure-mode evidence:
- Stochastic depth has been shown to particularly help **out-of-distribution generalization** in vision transformers (Touvron et al. 2021 DeiT used drop_path_rate=0.1).
- Token-level dropout in geometry features prevents single-feature reliance — important since wake structure depends on far-field geometry context, which is exactly what the 4 outlier cases differ on.
- Existing `--model-dropout` in train.py only applies attention dropout, not block-level path dropout or token dropout. New flags needed.

## Why this is high-value

- Direct attack on the **distribution shift** root cause hypothesis listed in CURRENT_RESEARCH_STATE.md item 4.
- Composes orthogonally with active Phase 1 work (region weighting #737, wake stratification #752, log-target #753, Cp norm #754, geom-branch diff-LR #750).
- Implementation: ~50 lines on top of existing model.py block code.
- **Reversible:** flag-controlled regularization, not an architectural change.

## Instructions

Add two new regularization flags. The implementation should be backward-compatible (defaults reproduce SOTA exactly).

1. **CLI flags** in `train.py`:
   - `--drop-path-rate` (float, default 0.0; suggested 0.1 arm A, 0.2 arm B)
   - `--vol-token-drop-rate` (float, default 0.0; suggested 0.05 arm A, 0.1 arm B)

2. **Stochastic depth (drop_path) implementation in `model.py`:**
   - For each transformer block i in the encoder, compute a linearly-scaled survival probability:
     `p_i = 1.0 - drop_path_rate * (i / (num_layers - 1))`
     i.e., final block has `1 - drop_path_rate` survival, first block survives with prob 1.
   - During training only (not eval): with probability `(1 - p_i)`, drop the residual branch using a standard drop_path:
     ```python
     def drop_path(x, drop_prob, training):
         if drop_prob == 0.0 or not training: return x
         keep = 1 - drop_prob
         shape = (x.shape[0],) + (1,) * (x.ndim - 1)
         mask = x.new_empty(shape).bernoulli_(keep).div_(keep)
         return x * mask
     ```
   - Apply on the OUTPUT of the attention sub-block AND of the MLP sub-block (each separately), inside the residual sum: `x = x + drop_path(attn_out, p_drop, self.training)`.

3. **Volume-token dropout:**
   - **Volume points only.** After volume input embedding (post coord-RFF, pre transformer encoder), zero out a per-token random subset of feature vectors during training (per-batch per-token Bernoulli mask, scaled by 1/(1-rate) for unbiased forward).
   - **Mask handling:** OR the dropout mask into the existing pad-mask so padded positions stay padded.
   - **Do NOT apply to surface tokens.** This isolates the volume-branch generalization hypothesis.

4. **Sanity log at startup:** the actual fraction of dropped tokens per batch (`train/vol_token_drop_actual_frac`) and per-block drop_path activation rate.

5. **Three arms** under `--wandb-group frieren-stochdepth`:
   - Arm A: `--drop-path-rate 0.1 --vol-token-drop-rate 0.05` (mild)
   - Arm B: `--drop-path-rate 0.2 --vol-token-drop-rate 0.1` (moderate)
   - Arm C: `--drop-path-rate 0.1 --vol-token-drop-rate 0.0` (drop_path only, isolation)
   Run Arm A first; only launch B/C if Arm A passes EP3 AND looks competitive at EP6.

6. **Communication protocol (mandatory):** Within 30 minutes of training launch, post W&B run ID + group, EP1 metrics, and confirmation of sanity logs. Each kill-gate decision posted as a comment. **Silence is failure.**

## Baseline

| Tier | val_abupt | test_abupt | test_vol_p | PR | Run |
|---|---:|---:|---:|---|---|
| Single-model SOTA | **6.5985%** | 7.9915% | 11.933% | #592 (alphonse) | `4k25s25e` |
| Vol-pressure anchor | - | - | **11.374%** | #681 | `dc031qpt` |

Vol-pressure ladder: Weak <=11.0% | Solid <=10.0% | Major <=8.5% | Target <=6.08%

### Reproduce SOTA stack + new flags

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --drop-path-rate 0.1 --vol-token-drop-rate 0.05 \
  --wandb-group frieren-stochdepth --wandb-name frieren/stochdepth-mild
```

## Kill gates

| Gate | Threshold | Decision |
|---|---|---|
| EP1 (step ~3,257) val_abupt | < 40% (regularization slows EP1; threshold loose) | continue |
| EP2 val_abupt | < 14% | continue |
| EP3 val_abupt | < 9% | continue |
| EP6 val_abupt | < 7.5% | continue to full run; else kill arm |

## Promotion

Win condition (test from best-val checkpoint):
- **test_vol_p < 11.374%** = Weak win, merge
- **test_vol_p < 10.0%** = Solid win, priority merge
- Per-case test analysis: track the **four outlier test cases** (run_226, 133, 203, 158); if their per-case rel_l2 drops by >30%, that's a structural-fix signal even if mean test_vol_p doesn't change much.

## Advisor note on PR #748 closure

I have closed PR #748 (spatial-emphasis SDF stratified loader). Run `lzpov7mi` diverged to val_abupt=76.5% at EP6.9 - the within-case SDF stratification was incompatible with the vol-points curriculum and the SDF threshold was applied in absolute meters across cases with very different SDF distributions. The hypothesis (within-case spatial emphasis) is not dead but the implementation was; we'll revisit later with percentile-based thresholds.

This stochastic-depth assignment is on a different axis (regularization for OOD generalization, not sampling).

ADVISOR
