### PR TITLE
[thorfinn] Cosine-annealed EMA decay schedule (0.99 -> 0.9999)

### DIFF
--- a/train.py
+++ b/train.py
@@ -112,6 +112,9 @@ class Config:
     use_ema: bool = True
     ema_decay: float = 0.999
     ema_start_step: int = 50
+    ema_decay_schedule: str = "fixed"
+    ema_decay_start: float = 0.99
+    ema_decay_end: float = 0.9999
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
@@ -150,6 +153,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "separate checks. STEP is a global optimizer step and METRIC must match "
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
+        ),
+        "ema_decay_schedule": (
+            "EMA decay scheduling mode. 'fixed' (default) uses --ema-decay "
+            "as a constant for the whole run, preserving previous behavior. "
+            "'cosine_anneal' interpolates from --ema-decay-start at step 0 "
+            "to --ema-decay-end at the final step using a cosine ramp: "
+            "ema_decay_t = end + 0.5 * (start - end) * (1 + cos(pi * t)) "
+            "with t = clamp(global_step / (epochs * steps_per_epoch), 0, 1). "
+            "Cai et al. 2021 / Karras et al. 2024 motivation: low decay "
+            "early (track moving weights) -> high decay late (Polyak-style "
+            "averaging). When 'cosine_anneal', --ema-decay is ignored."
+        ),
+        "ema_decay_start": (
+            "Initial EMA decay at training step 0 when "
+            "--ema-decay-schedule=cosine_anneal. Default 0.99 = aggressive "
+            "tracking of fast-moving early weights."
+        ),
+        "ema_decay_end": (
+            "Final EMA decay at the last training step when "
+            "--ema-decay-schedule=cosine_anneal. Default 0.9999 = long "
+            "Polyak-style averaging window for late-stage refinement."
         ),
         "vol_points_schedule": (
             "Optional epoch-based curriculum for the train-volume-points view "
@@ -230,7 +254,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    if config.ema_decay_schedule not in EMA_DECAY_SCHEDULES:
+        raise ValueError(
+            f"--ema-decay-schedule must be one of {EMA_DECAY_SCHEDULES}, "
+            f"got {config.ema_decay_schedule!r}."
+        )
+    if config.ema_decay_schedule == "cosine_anneal":
+        if not 0.0 < config.ema_decay_start < 1.0:
+            raise ValueError(
+                f"--ema-decay-start must be in (0, 1), got {config.ema_decay_start}."
+            )
+        if not 0.0 < config.ema_decay_end < 1.0:
+            raise ValueError(
+                f"--ema-decay-end must be in (0, 1), got {config.ema_decay_end}."
+            )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -382,6 +421,23 @@ def per_task_train_losses(
 
 
 GRADNORM_MODES = ("full", "ema_proxy")
+
+
+EMA_DECAY_SCHEDULES = ("fixed", "cosine_anneal")
+
+
+def cosine_anneal_ema_decay(
+    global_step: int, total_steps: int, decay_start: float, decay_end: float
+) -> float:
+    """Cosine ramp from `decay_start` (t=0) to `decay_end` (t=1).
+
+    ema_decay_t = decay_end + 0.5 * (decay_start - decay_end) * (1 + cos(pi * t))
+    t = clamp(global_step / total_steps, 0, 1).
+    """
+    if total_steps <= 0:
+        return float(decay_end)
+    t = max(0.0, min(1.0, float(global_step) / float(total_steps)))
+    return float(decay_end + 0.5 * (decay_start - decay_end) * (1.0 + math.cos(math.pi * t)))
 
 
 class GradNormBalancer:
@@ -761,6 +817,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+        if state.is_main and config.use_ema:
+            if config.ema_decay_schedule == "cosine_anneal":
+                print(
+                    f"EMA decay schedule=cosine_anneal: "
+                    f"start={config.ema_decay_start} -> end={config.ema_decay_end} "
+                    f"over total_steps=epochs*steps_per_epoch (--ema-decay ignored)."
+                )
+            else:
+                print(f"EMA decay schedule=fixed at {config.ema_decay}.")
 
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
@@ -1027,6 +1092,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                if config.use_ema and config.ema_decay_schedule == "cosine_anneal":
+                    ema_decay_current = cosine_anneal_ema_decay(
+                        global_step=global_step,
+                        total_steps=total_estimated_steps,
+                        decay_start=config.ema_decay_start,
+                        decay_end=config.ema_decay_end,
+                    )
+                else:
+                    ema_decay_current = float(config.ema_decay)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
@@ -1034,6 +1108,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/ema_decay_current": ema_decay_current,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(
@@ -1091,6 +1166,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     else:
                         optimizer.step()
                         if ema is not None:
+                            ema.decay = ema_decay_current
                             ema.update(base_model)
                         weight_metrics = (
                             collect_weight_metrics(


### PR DESCRIPTION
## Hypothesis

EMA decay 0.999 was confirmed optimal in PR #603. But that ablation used a fixed value across all of training. **Cosine-annealed EMA decay** (from 0.99 in early training -> 0.9999 in late training) has been shown in vision (Cai et al. 2021, Karras et al. 2024) to combine the best of both regimes:
- Early training (high model variance, large parameter movement): low EMA decay 0.99 keeps the EMA close to current weights, so EMA evaluation tracks the rapidly-moving training trajectory and doesn't lag.
- Late training (small parameter movement, fine refinement): high EMA decay 0.9999 averages over a longer window, smoothing out late-stage step-noise and recovering Polyak-style asymptotic optimality.

We currently use 0.999 fixed, which is a compromise across both regimes. A cosine-annealed schedule should improve both EP1-EP3 convergence (lower decay = less lag) and EP10-EP13 fine refinement (higher decay = more averaging). This translates directly into a better best-val EMA checkpoint, which is the checkpoint we use for test evaluation.

This is a **stabilization experiment** in your wheelhouse (gradnorm #523, gradclip #309, EMA tuning lineage). Low implementation cost, high upside.

## Why this is high-value

- **Implementation cost: ~15 lines.** Replace the fixed `--ema-decay` constant with a per-step value driven by the existing `lr_cosine_t_max` schedule.
- **Composes with all current Phase 1 work**: it's purely an EMA bookkeeping change, doesn't touch the loss, sampler, or model.
- **Known good evidence base** in vision (DeiT-III, EDM2). Never tried in this project.
- **Direct path to compounding gain**: better best-val EMA -> better test from best-val checkpoint.

## Instructions

1. **CLI flags** in `train.py`:
   - `--ema-decay-schedule {fixed, cosine_anneal}` default `fixed` (preserves current behavior)
   - `--ema-decay-start` (float, default 0.99) - early-training value
   - `--ema-decay-end` (float, default 0.9999) - late-training value
   - The existing `--ema-decay` flag should still work; when `--ema-decay-schedule fixed`, use it as today. When `cosine_anneal`, ignore `--ema-decay` and interpolate `--ema-decay-start` -> `--ema-decay-end`.

2. **Schedule formula** (per global step):
   ```
   total_steps = epochs * steps_per_epoch
   t = min(1.0, current_step / total_steps)
   d_start = ema_decay_start  # e.g., 0.99
   d_end   = ema_decay_end    # e.g., 0.9999
   # Cosine ramp from d_start -> d_end (so ramp is concave)
   ema_decay_t = d_end + 0.5 * (d_start - d_end) * (1 + cos(pi * t))
   ```
   At t=0: ema_decay=d_start (0.99). At t=1: ema_decay=d_end (0.9999).

3. **Where to apply:** in the EMA update path (find where `--ema-decay` is currently consumed - probably a single multiplier in the EMA model update step). Replace the constant with `ema_decay_t` computed from the global step.

4. **Sanity logs:** every step, log `train/ema_decay_current` to W&B so we can confirm the schedule executed correctly. Plot will show concave 0.99 -> 0.9999 ramp.

5. **Three arms** under `--wandb-group thorfinn-ema-anneal`:
   - Arm A: `--ema-decay-schedule cosine_anneal --ema-decay-start 0.99 --ema-decay-end 0.9999`
   - Arm B: `--ema-decay-schedule cosine_anneal --ema-decay-start 0.99 --ema-decay-end 0.999` (less aggressive late phase)
   - Arm C: `--ema-decay-schedule cosine_anneal --ema-decay-start 0.995 --ema-decay-end 0.9999` (less aggressive early phase)
   Run Arm A first to completion. Only launch B/C if Arm A passes EP3 and looks competitive at EP6.

6. **Communication protocol (mandatory, this is non-negotiable):** I closed PR #751 partly because no comments were ever posted. The protocol is:
   - **Within 30 minutes of training launch:** post a comment with W&B run ID + group + URL, EP1 step count, time/epoch, val_abupt, and confirmation `train/ema_decay_current` is logged.
   - **At each kill gate** (EP1, EP2, EP3, EP6, end): post a comment with metrics and the gate decision.
   - **If the run crashes or exits early:** post a comment immediately with the error log and your diagnosis.
   - **Silence will be treated as failure and the PR will be closed.**

## Baseline

| Tier | val_abupt | test_abupt | test_vol_p | PR | Run |
|---|---:|---:|---:|---|---|
| Single-model SOTA | **6.5985%** | 7.9915% | 11.933% | #592 (alphonse) | `4k25s25e` |
| Vol-pressure anchor | - | - | **11.374%** | #681 | `dc031qpt` |

### Reproduce SOTA stack + new flags

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay-schedule cosine_anneal --ema-decay-start 0.99 --ema-decay-end 0.9999 \
  --wandb-group thorfinn-ema-anneal --wandb-name thorfinn/ema-anneal-099-09999
```

## Kill gates

| Gate | Threshold | Decision |
|---|---|---|
| EP1 (step ~3,257) val_abupt | < 35% | continue, post heartbeat comment |
| EP2 (step ~6,514) val_abupt | < 12% | continue, post comment |
| EP3 (step ~9,771) val_abupt | < 8% | continue to full run |
| EP6 val_abupt | < 7.0% | continue to full run; else kill arm |
| End (EP13) | best-val EMA val_abupt | post final results table |

## Promotion

Win condition (test from best-val EMA checkpoint, EP-best):
- **val_abupt < 6.5985%** AND test_vol_p does not regress = beats single-model SOTA, merge
- **test_vol_p < 11.374%** = vol-pressure Weak win, merge
- Even if neither: if EMA-decay schedule clearly improves the val_abupt convergence trajectory at any single epoch (>=0.3pp better than fixed-0.999 SOTA at the same epoch), that's a useful signal that should inform future EMA tuning.

## Advisor note on PR #751 closure

I have closed PR #751 (Issue #618 AnchorString clean). The W&B run ended at step 21,729 (EP9.5) after only 35 minutes - either an auto-kill triggered or a process crash, but no comments were posted to explain. val_abupt landed at 23.17%, val_vol_p 15.50%, both far from competitive.

The Issue #618 STRING/RoPE direction is being kept alive via alphonse's PR #750 (Geometry-Branch redux). Once that lands a result, we will revisit STRING/RoPE variants. For now, this EMA-anneal experiment is a tighter, lower-risk experiment that gives you a chance to demonstrate clean execution and communication.

ADVISOR
