### PR TITLE
[frieren] Dedicated 2-layer volume head on shared encoder (Issue #717)

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_head_layers: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +355,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.vol_head_layers = int(vol_head_layers)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -421,6 +423,26 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # Optional dedicated volume decoder head (Issue #717 capacity-additive
+        # path). When `vol_head_layers == 0` the model is bitwise identical to
+        # the prior shared-head SOTA; when > 0, volume tokens pass through
+        # `vol_head_layers` additional Transolver blocks (same hidden_dim,
+        # heads, slices, mlp_ratio, dropout, qk-norm as the shared encoder)
+        # before the final norm + linear projection. Surface/wall-shear path
+        # is unchanged.
+        if self.vol_head_layers > 0:
+            self.vol_head_blocks = Transformer(
+                depth=self.vol_head_layers,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_expansion_factor=mlp_ratio,
+                num_slices=slice_num,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+        else:
+            self.vol_head_blocks = None
 
     def _encode_group(
         self,
@@ -500,6 +522,14 @@ class SurfaceTransolver(nn.Module):
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
         hidden = self.backbone(hidden, attn_mask=attn_mask)
         hidden = _apply_token_mask(hidden, attn_mask)
+
+        if self.vol_head_blocks is not None and volume_tokens > 0:
+            surface_part = hidden[:, :surface_tokens]
+            volume_part = hidden[:, surface_tokens:]
+            volume_part = self.vol_head_blocks(volume_part, attn_mask=volume_mask)
+            hidden = torch.cat([surface_part, volume_part], dim=1)
+            hidden = _apply_token_mask(hidden, attn_mask)
+
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
         cursor = 0

--- a/train.py
+++ b/train.py
@@ -137,6 +137,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_head_layers: int = 0
     debug: bool = False
 
 
@@ -219,6 +220,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_head_layers": (
+            "Number of additional Transolver decoder blocks applied to the "
+            "volume tokens after the shared encoder, before the final norm "
+            "and linear projection. The new blocks reuse the encoder's "
+            "hidden_dim/heads/slices/mlp_ratio/dropout/qk-norm. Surface and "
+            "wall-shear paths are unchanged. Default 0 reproduces the "
+            "shared-head SOTA bitwise. PR #761 (Issue #717 Exp 1C) sets "
+            "this to 2 to test whether dedicated volume capacity closes "
+            "the val/test volume_pressure gap."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -297,6 +308,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_head_layers=config.vol_head_layers,
     )
 
 
@@ -756,7 +768,22 @@ def main(argv: Iterable[str] | None = None) -> None:
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
-            print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+            vol_head_blocks_for_print = getattr(base_model, "vol_head_blocks", None)
+            vol_head_param_count = (
+                sum(p.numel() for p in vol_head_blocks_for_print.parameters())
+                if vol_head_blocks_for_print is not None
+                else 0
+            )
+            vol_head_msg = (
+                f", vol_head_layers={config.vol_head_layers} "
+                f"({vol_head_param_count / 1e6:.2f}M)"
+                if config.vol_head_layers > 0
+                else ""
+            )
+            print(
+                f"Model: SurfaceTransolver grouped surface+volume "
+                f"({n_params / 1e6:.2f}M params){vol_head_msg}"
+            )
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
@@ -861,6 +888,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/total_params"] = int(n_params)
+            wandb.summary["model/vol_head_layers"] = int(config.vol_head_layers)
+            vol_head_blocks = getattr(base_model, "vol_head_blocks", None)
+            vol_head_params = (
+                sum(p.numel() for p in vol_head_blocks.parameters())
+                if vol_head_blocks is not None
+                else 0
+            )
+            wandb.summary["model/vol_head_params"] = int(vol_head_params)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

**Issue #717 Exp 1C-priority-6 (capacity-additive): dedicated 2-layer volume head on shared encoder.**

PR #755 (your own stochastic-depth experiment) just produced a key diagnostic: regularization made val WORSE on volume_pressure (12.48% → 14.14%) while every non-volume metric improved. That falsifies the "memorize-and-fail-OOD" framing of the val/test gap and points to a different conclusion: **the volume branch is capacity-limited on this 5-block, 13-epoch budget**.

This experiment adds capacity exactly where the data says it is needed: a **dedicated 2-layer Transolver decoder head exclusively for volume queries**, branching off the shared encoder. Surface and wall-shear heads remain unchanged and continue to share the encoder output. This is the capacity-additive answer to the regularization-hurt-val finding.

This is **NOT a dual-tower** (PR #722 closed null). The encoder is fully shared — only the volume decoder gets extra capacity. The hypothesis is that two extra Transolver blocks on the volume path will give the model the representational room it currently lacks for the operating-regime shifts that test cases exhibit (different wake intensities, off-distribution geometry envelopes), without hurting surface/wall-shear which are already near AB-UPT.

**Mechanism (precise):**

1. Inside `model.py`, after the shared encoder produces token embeddings, the existing volume head is a small projection. Replace it with:
   - 2 additional Transolver blocks (same `hidden_dim=512`, `heads=4`, `slices=128` as the encoder) operating only on volume query tokens, with their own RMSNorm + MLP.
   - Final linear projection to scalar `volume_pressure`.
2. The surface and wall-shear heads stay exactly as they are (small linear projections off the shared encoder output).
3. Add CLI flag `--vol-head-layers` (int, default 0; this PR uses 2). When 0, the model is identical to current SOTA bitwise.

**Expected param/VRAM impact:**
- 2 extra blocks at hidden=512, heads=4, slices=128 → ~3.6M extra params (vs current ~15.9M total). New total ~19.5M.
- VRAM: encoder forward unchanged; 2 extra block forwards on volume tokens (65k tokens @ EP9). Estimate +6-8 GB peak vs SOTA's ~52 GB → ~58-60 GB / 96 GB available. Comfortable margin.

**Why this should help:**
- Surface and wall-shear are already near or beating AB-UPT (4.33%/7.33% test vs AB-UPT 3.82%/7.29%). They don't need capacity.
- Volume is the primary gap (test 11.5% vs AB-UPT 6.08%). The shared head can't simultaneously serve all three output heads' optimal feature transforms — Pareto fronts always stretch.
- A dedicated volume head with two additional self-attention/slice-attention rounds gives the model a chance to refine volume-specific features (wake separation, far-field decay) without dragging the surface representation.
- This is **orthogonal** to all in-flight Issue #717 work (#737 region weighting, #752 wake stratification, #753 log-target, #756 EMA schedule, #757 k-NN ∇p, #758 GradNorm sweep, #729 KD, #728 outlier sampling, #734 distance feature). Composes cleanly later.

**Differences from PR #722 (closed null dual-tower):**
- #722 split the ENCODER (separate volume + surface encoders with cross-attention). It regressed val by +0.87pp because the surface and volume tasks share substantial low-level structure (geometry, slicing, RFF features) that benefits from a unified encoder.
- This PR shares the entire encoder; only the head splits. Cheap, low-risk, capacity-aligned.

## Issue #717 frozen anchors (must report against)

| Run | PR | Test volume_p | Test wall_shear | Test tau_y | Test tau_z |
|---|---:|---:|---:|---:|---:|
| `sogus8sx` | #599 | 11.694 | 7.299 | 7.941 | 9.535 |
| `4k25s25e` | #592 | 11.933 | 7.334 | 8.145 | 9.298 |
| `dc031qpt` | #681 | 11.374 | 8.321 | 9.596 | 10.738 |

**Single-model val SOTA gate:** val_abupt < **6.5985%** (PR #592)

## Promotion ladder (Issue #717 vol-pressure)

- Weak win: test_volume_pressure < 11.0% — merge.
- Solid win: test_volume_pressure ≤ 10.0% — priority merge.
- Major win: test_volume_pressure ≤ 8.5%.
- Target: test_volume_pressure ≤ 6.08% (AB-UPT).

**Also a win**: val_abupt < 6.5985% (single-model SOTA) — merge as new SOTA stack baseline even if test_volume only mildly improves.

## Implementation sketch

You will need to make code changes in `target/`:

1. **`target/model.py`:** Identify where the shared encoder output flows into the surface/volume/wall-shear heads. Add a `VolumeHead` module with `n_layers=vol_head_layers` Transolver blocks (use the same `TransformerBlock` class already in the file — instantiate `nn.ModuleList` of length 2). The block's slice-attention should use the same slices as the encoder (read from the encoder's slice tokens; do not re-slice from scratch).
2. **`target/train.py`:** Add `--vol-head-layers` (int, default 0). Default=0 reproduces SOTA exactly. This PR runs with default value 2 in the command below.
3. **Sanity log at startup:** log `model/vol_head_layers`, `model/total_params`, `model/vol_head_params` to W&B summary.
4. **Initialization:** the new blocks should use the same init as the encoder blocks (likely already covered by your `_init_weights` if you use the same `TransformerBlock` class).

## Training command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-head-layers 2 \
  --wandb-group frieren-vol-head --wandb-name frieren/vol-head-2L
```

## Gates

- **EP1 time gate:** kill if epoch_time > 80 min (extra 2 blocks add ~10-15% per epoch; SOTA is ~38 min/epoch; expect ~45 min).
- **EP2 (step ~21,729):** kill if val_abupt > 12%.
- **EP3 (step ~32,594):** kill if val_abupt > 8%.
- **EP6 (step ~65,188):** kill if val_abupt > 7.5%.

## Required reporting (Issue #717 9-column table)

After training, post the SENPAI-RESULT comment with:

1. W&B run ID + group + URL.
2. Best-val-abupt checkpoint metrics (val and test, all 7 channels including aggregate).
3. Best-val-volume_pressure checkpoint metrics.
4. Final-epoch checkpoint metrics.
5. Per-case test volume diagnostics: top 10 worst test cases by `volume_pressure_rel_l2_pct`.
6. Per-region test volume error (slabs along x: front/cabin/wake; bands by distance-to-surface: 0-0.1m / 0.1-0.5m / 0.5-2m / 2m+).
7. Statement: did val volume gain transfer to test volume? Did the extra capacity help or just overfit?
8. Required 9-col table (rows: #599 anchor, #592 anchor, #681 anchor, candidate-best-aggregate, candidate-best-volume, candidate-final).

## Closure rules

- **Solid/major win on test_volume_pressure (≤10.0%):** mark `status:review`.
- **Weak win (<11.0%) and val ≤ 6.5985%:** mark `status:review`, this is potentially a stack-update win.
- **Val beats SOTA (<6.5985%) but test_volume regresses:** mark `status:review`, advisor will weigh.
- **Both val and test miss:** post SENPAI-RESULT, leave open for advisor close.
- **Crash/divergence/OOM:** report root cause clearly.

## Communication protocol

- Within 30 minutes of training launch, post: W&B run ID + group, EP1 metrics + sanity logs (`model/vol_head_layers`, `model/total_params`).
- Each kill-gate decision posted as a comment.
- Silence is failure.

ADVISOR
