### PR TITLE
[nezuko] Upstream-region supervised attention for vol_pressure (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,6 +137,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_loss_w_upstream: float = 1.0
+    vol_loss_w_rest: float = 1.0
+    vol_loss_upstream_x_hi: float = 0.5
     debug: bool = False
 
 
@@ -219,6 +222,28 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_loss_w_upstream": (
+            "Per-point loss weight applied to volume points in the "
+            "upstream zone (x_rel <= --vol-loss-upstream-x-hi). The "
+            "upstream zone has 92%% of points and dominates the "
+            "test_volume_p L2 contribution; upweighting concentrates "
+            "training signal on the structural-error-dominant region. "
+            "Default 1.0 = no reweighting (uniform per-point loss)."
+        ),
+        "vol_loss_w_rest": (
+            "Per-point loss weight applied to volume points outside the "
+            "upstream zone (x_rel > --vol-loss-upstream-x-hi). Default "
+            "1.0 = uniform; setting < 1.0 down-weights wake regions."
+        ),
+        "vol_loss_upstream_x_hi": (
+            "Upper bound on x_rel for the upstream mask. Default 0.5 "
+            "captures everything from inflow to mid-vehicle (car body "
+            "spans x_rel in [-0.5, +0.5] with cx as midpoint). On "
+            "DrivAerML this covers ~92%% of volume points. Coordinates "
+            "use the dataset-mean reference frame (cx=1.5046, "
+            "s_ref=4.6720) so that view-only volumes without surface "
+            "data still classify correctly."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +325,103 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+# DrivAerML dataset-mean surface bbox stats over 50 train cases:
+#   cx=1.5046+/-0.0805, cz=0.3942+/-0.0286, s_ref=4.6720+/-0.1369.
+# View-splitting in train_random mode produces volume-only views (no surface)
+# at small train_volume_points. Use the dataset-mean reference frame for those
+# elements rather than collapsing the region mask to zero.
+DRIVAERML_FALLBACK_CX = 1.5046
+DRIVAERML_FALLBACK_CZ = 0.3942
+DRIVAERML_FALLBACK_S_REF = 4.6720
+
+
+def compute_volume_upstream_weights(
+    volume_x: torch.Tensor,
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    *,
+    upstream_x_hi: float,
+    w_upstream: float,
+    w_rest: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-point loss weights upweighting the upstream zone (x_rel <= upstream_x_hi).
+
+    Returns (weights, upstream_mask_float) of shape ``[B, N_volume]``.
+    Coordinates are normalized as ``x_rel = (vx - cx) / s_ref``, with
+    ``(cx, s_ref)`` taken from the per-element surface bbox when available
+    and falling back to dataset-mean stats otherwise (volume-only views or
+    masked-out surface).
+    """
+    batch_size, num_volume_points = volume_x.shape[0], volume_x.shape[1]
+    device = volume_x.device
+    if num_volume_points == 0:
+        empty_w = torch.full(
+            (batch_size, num_volume_points),
+            float(w_rest),
+            device=device,
+            dtype=torch.float32,
+        )
+        empty_m = torch.zeros_like(empty_w)
+        return empty_w, empty_m
+
+    fallback_cx = torch.full(
+        (batch_size, 1), DRIVAERML_FALLBACK_CX, device=device, dtype=torch.float32
+    )
+    fallback_s_ref = torch.full(
+        (batch_size, 1), DRIVAERML_FALLBACK_S_REF, device=device, dtype=torch.float32
+    )
+
+    if surface_x.shape[1] == 0:
+        cx, s_ref = fallback_cx, fallback_s_ref
+    else:
+        valid = surface_mask.bool()
+        has_surface = valid.any(dim=1, keepdim=True)
+        surface_xyz = surface_x[..., :3].float()
+        big = torch.finfo(surface_xyz.dtype).max
+        surf_x_for_min = surface_xyz[..., 0].masked_fill(~valid, big)
+        surf_x_for_max = surface_xyz[..., 0].masked_fill(~valid, -big)
+        surf_x_min = surf_x_for_min.min(dim=1, keepdim=True).values
+        surf_x_max = surf_x_for_max.max(dim=1, keepdim=True).values
+        per_elem_cx = 0.5 * (surf_x_min + surf_x_max)
+        per_elem_s_ref = (surf_x_max - surf_x_min).clamp_min(1e-6)
+        cx = torch.where(has_surface, per_elem_cx, fallback_cx)
+        s_ref = torch.where(has_surface, per_elem_s_ref, fallback_s_ref)
+
+    volume_xyz = volume_x[..., :3].float()
+    x_rel = (volume_xyz[..., 0] - cx) / s_ref
+    upstream_mask_bool = x_rel <= float(upstream_x_hi)
+    upstream_mask = upstream_mask_bool.float()
+    weights = upstream_mask * (float(w_upstream) - float(w_rest)) + float(w_rest)
+    return weights, upstream_mask
+
+
+def weighted_masked_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    point_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Per-point weighted masked MSE.
+
+    pred / target: [B, N, C]; mask: [B, N]; point_weights: [B, N].
+    Returns the weighted mean of the squared error over (valid points x channels)
+    where each point's squared error is multiplied by ``point_weights``. Mean
+    is computed over the unweighted valid count to keep gradient magnitude
+    comparable to ``masked_mse`` for the reference w=1 case.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype)
+    point_w = point_weights.to(device=pred.device, dtype=pred.dtype)
+    sq_err = (pred - target).square().sum(dim=-1)  # [B, N]
+    weighted = sq_err * point_w * mask_dev
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,10 +432,17 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_loss_w_upstream: float = 1.0,
+    vol_loss_w_rest: float = 1.0,
+    vol_loss_upstream_x_hi: float = 0.5,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    use_vol_weights = bool(
+        (vol_loss_w_upstream != 1.0) or (vol_loss_w_rest != 1.0)
+    )
+    upstream_mask_frac = float("nan")
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -330,7 +459,33 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        if use_vol_weights:
+            volume_point_weights, upstream_mask = compute_volume_upstream_weights(
+                batch.volume_x,
+                batch.surface_x,
+                batch.surface_mask,
+                upstream_x_hi=vol_loss_upstream_x_hi,
+                w_upstream=vol_loss_w_upstream,
+                w_rest=vol_loss_w_rest,
+            )
+            volume_loss = weighted_masked_mse(
+                out["volume_preds"], volume_target, batch.volume_mask, volume_point_weights
+            )
+            mask_dev = batch.volume_mask.to(
+                device=upstream_mask.device, dtype=upstream_mask.dtype
+            )
+            valid_count = mask_dev.sum()
+            if bool(valid_count.detach().cpu().item() > 0):
+                upstream_mask_frac = float(
+                    ((upstream_mask * mask_dev).sum() / valid_count.clamp_min(1.0))
+                    .detach()
+                    .cpu()
+                    .item()
+                )
+            else:
+                upstream_mask_frac = 0.0
+        else:
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -341,6 +496,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "vol_upstream_mask_frac": upstream_mask_frac,
     }
 
 
@@ -747,6 +903,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        use_vol_upstream_weights = bool(
+            (config.vol_loss_w_upstream != 1.0) or (config.vol_loss_w_rest != 1.0)
+        )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -829,6 +988,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print(
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                )
+            if use_vol_upstream_weights:
+                print(
+                    f"Volume upstream loss weights: w_upstream="
+                    f"{config.vol_loss_w_upstream} w_rest={config.vol_loss_w_rest} "
+                    f"upstream_x_hi={config.vol_loss_upstream_x_hi}"
                 )
 
         run = init_wandb_run(
@@ -1008,6 +1173,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_loss_w_upstream=config.vol_loss_w_upstream,
+                        vol_loss_w_rest=config.vol_loss_w_rest,
+                        vol_loss_upstream_x_hi=config.vol_loss_upstream_x_hi,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1048,6 +1216,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if (
+                        use_vol_upstream_weights
+                        and "vol_upstream_mask_frac" in batch_loss_metrics
+                        and math.isfinite(batch_loss_metrics["vol_upstream_mask_frac"])
+                    ):
+                        train_log["train/vol_upstream_mask_frac"] = batch_loss_metrics[
+                            "vol_upstream_mask_frac"
+                        ]
+                        train_log["train/vol_loss_w_upstream"] = config.vol_loss_w_upstream
+                        train_log["train/vol_loss_w_rest"] = config.vol_loss_w_rest
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -892,6 +892,98 @@ EVAL_KEYS = (
 )
 
 
+# Volume eval-time region partition (matches PR #737 / PR #763 spec).
+# upstream: x_rel <= VOLUME_REGION_X_LO  (~92% of points)
+# near:     VOLUME_REGION_X_LO < x_rel < VOLUME_REGION_X_HI AND |z_rel| < VOLUME_REGION_Z_ABS
+# far:      x_rel >= VOLUME_REGION_X_HI
+# These are mutually exclusive and cover every volume point. The boundary at
+# 0.5 captures everything from the inflow up through mid-vehicle (cars span
+# x_rel in [-0.5, +0.5] with cx as midpoint).
+VOLUME_REGION_KEYS = ("upstream", "near", "far")
+VOLUME_REGION_X_LO = 0.5
+VOLUME_REGION_X_HI = 3.0
+VOLUME_REGION_Z_ABS = 1.5
+# Dataset-mean fallback (matches DRIVAERML_FALLBACK_* in train.py); needed for
+# views from the multi-view sampler that have no valid surface points.
+VOLUME_REGION_FALLBACK_CX = 1.5046
+VOLUME_REGION_FALLBACK_CZ = 0.3942
+VOLUME_REGION_FALLBACK_S_REF = 4.6720
+
+
+def _volume_region_masks(
+    volume_x: torch.Tensor,
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Classify volume points into (near, far, upstream) regions.
+
+    Inputs are batched tensors:
+      volume_x:     [B, N_volume, >=3]
+      surface_x:    [B, N_surface, >=3]
+      surface_mask: [B, N_surface]   (True = valid)
+
+    Returns three [B, N_volume] bool tensors. The classification is based on
+    a per-batch surface bbox (cx, cz, s_ref), with dataset-mean fallback for
+    elements that lack any valid surface points.
+    """
+    batch_size, num_volume_points = volume_x.shape[0], volume_x.shape[1]
+    device = volume_x.device
+    empty_bool = torch.zeros(
+        (batch_size, num_volume_points), device=device, dtype=torch.bool
+    )
+    if num_volume_points == 0:
+        return empty_bool, empty_bool, empty_bool
+
+    fallback_cx = torch.full(
+        (batch_size, 1), VOLUME_REGION_FALLBACK_CX, device=device, dtype=torch.float32
+    )
+    fallback_cz = torch.full(
+        (batch_size, 1), VOLUME_REGION_FALLBACK_CZ, device=device, dtype=torch.float32
+    )
+    fallback_s_ref = torch.full(
+        (batch_size, 1), VOLUME_REGION_FALLBACK_S_REF, device=device, dtype=torch.float32
+    )
+
+    if surface_x.shape[1] == 0:
+        cx, cz, s_ref = fallback_cx, fallback_cz, fallback_s_ref
+    else:
+        valid = surface_mask.bool()
+        has_surface = valid.any(dim=1, keepdim=True)
+        surface_xyz = surface_x[..., :3].float()
+        big = torch.finfo(surface_xyz.dtype).max
+        surf_x_for_min = surface_xyz[..., 0].masked_fill(~valid, big)
+        surf_x_for_max = surface_xyz[..., 0].masked_fill(~valid, -big)
+        surf_z_for_min = surface_xyz[..., 2].masked_fill(~valid, big)
+        surf_z_for_max = surface_xyz[..., 2].masked_fill(~valid, -big)
+        surf_x_min = surf_x_for_min.min(dim=1, keepdim=True).values
+        surf_x_max = surf_x_for_max.max(dim=1, keepdim=True).values
+        surf_z_min = surf_z_for_min.min(dim=1, keepdim=True).values
+        surf_z_max = surf_z_for_max.max(dim=1, keepdim=True).values
+        per_elem_cx = 0.5 * (surf_x_min + surf_x_max)
+        per_elem_cz = 0.5 * (surf_z_min + surf_z_max)
+        per_elem_s_ref = (surf_x_max - surf_x_min).clamp_min(1e-6)
+        cx = torch.where(has_surface, per_elem_cx, fallback_cx)
+        cz = torch.where(has_surface, per_elem_cz, fallback_cz)
+        s_ref = torch.where(has_surface, per_elem_s_ref, fallback_s_ref)
+
+    volume_xyz = volume_x[..., :3].float()
+    x_rel = (volume_xyz[..., 0] - cx) / s_ref
+    z_rel = (volume_xyz[..., 2] - cz) / s_ref
+    near = (
+        (x_rel > VOLUME_REGION_X_LO)
+        & (x_rel < VOLUME_REGION_X_HI)
+        & (z_rel > -VOLUME_REGION_Z_ABS)
+        & (z_rel < VOLUME_REGION_Z_ABS)
+    )
+    far = x_rel >= VOLUME_REGION_X_HI
+    upstream = x_rel <= VOLUME_REGION_X_LO
+    return near, far, upstream
+
+
+def _volume_region_keyed_keys() -> tuple[str, ...]:
+    return tuple(f"volume_pressure_{region}" for region in VOLUME_REGION_KEYS)
+
+
 @dataclass
 class EvalAccumulator:
     surface_loss_sse: float = 0.0
@@ -905,6 +997,13 @@ class EvalAccumulator:
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
+    volume_region_case_sums: dict[str, dict[str, list[float]]] = field(
+        default_factory=lambda: {region: {} for region in VOLUME_REGION_KEYS}
+    )
+    volume_region_point_counts: dict[str, int] = field(
+        default_factory=lambda: {region: 0 for region in VOLUME_REGION_KEYS}
+    )
+    volume_region_total_points: int = 0
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -1002,6 +1101,15 @@ def accumulate_eval_batch(
         accumulator.abs_sums["volume_pressure"] += float(volume_abs[:, 0].sum().detach().cpu().item())
         accumulator.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
 
+    near_mask, far_mask, upstream_mask = _volume_region_masks(
+        batch.volume_x, batch.surface_x, batch.surface_mask
+    )
+    region_masks = {
+        "upstream": upstream_mask,
+        "near": near_mask,
+        "far": far_mask,
+    }
+
     for case_idx, case_id in enumerate(batch.case_ids):
         surface_valid = batch.surface_mask[case_idx].bool()
         if bool(surface_valid.any()):
@@ -1034,6 +1142,20 @@ def accumulate_eval_batch(
                 pred=volume_pred[case_idx][volume_valid],
                 target=batch.volume_y[case_idx][volume_valid],
             )
+            valid_count = int(volume_valid.sum().detach().cpu().item())
+            accumulator.volume_region_total_points += valid_count
+            for region_name, region_mask in region_masks.items():
+                region_valid = region_mask[case_idx].bool() & volume_valid
+                region_count = int(region_valid.sum().detach().cpu().item())
+                accumulator.volume_region_point_counts[region_name] += region_count
+                if region_count == 0:
+                    continue
+                _accumulate_case_rel_l2(
+                    accumulator.volume_region_case_sums[region_name],
+                    case_id=case_id,
+                    pred=volume_pred[case_idx][region_valid],
+                    target=batch.volume_y[case_idx][region_valid],
+                )
 
 
 def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccumulator:
@@ -1050,6 +1172,15 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
             merged.abs_counts[key] += accumulator.abs_counts[key]
             for case_id, values in accumulator.case_sums[key].items():
                 state = merged.case_sums[key].setdefault(case_id, [0.0, 0.0])
+                state[0] += values[0]
+                state[1] += values[1]
+        merged.volume_region_total_points += accumulator.volume_region_total_points
+        for region in VOLUME_REGION_KEYS:
+            merged.volume_region_point_counts[region] += (
+                accumulator.volume_region_point_counts[region]
+            )
+            for case_id, values in accumulator.volume_region_case_sums[region].items():
+                state = merged.volume_region_case_sums[region].setdefault(case_id, [0.0, 0.0])
                 state[0] += values[0]
                 state[1] += values[1]
     return merged
@@ -1081,7 +1212,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     loss = (accumulator.surface_loss_sse + accumulator.volume_loss_sse) / max(
         accumulator.surface_loss_count + accumulator.volume_loss_count, 1
     )
-    return {
+    out = {
         "loss": loss,
         "surface_loss": accumulator.surface_loss_sse / max(accumulator.surface_loss_count, 1),
         "volume_loss": accumulator.volume_loss_sse / max(accumulator.volume_loss_count, 1),
@@ -1110,6 +1241,20 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
     }
+    total_volume_points = max(accumulator.volume_region_total_points, 1)
+    for region in VOLUME_REGION_KEYS:
+        region_rel_l2, region_cases = _rel_l2(
+            accumulator.volume_region_case_sums[region]
+        )
+        out[f"volume_pressure_{region}_rel_l2"] = region_rel_l2
+        out[f"volume_pressure_{region}_rel_l2_pct"] = region_rel_l2 * 100.0
+        out[f"volume_pressure_{region}_cases"] = region_cases
+        point_count = accumulator.volume_region_point_counts[region]
+        out[f"volume_pressure_{region}_point_count"] = float(point_count)
+        out[f"volume_pressure_{region}_point_frac"] = (
+            point_count / total_volume_points
+        )
+    return out
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Hypothesis

The chronic ~3× volume_pressure test-vs-val gap is owned by the **upstream region** (x_rel ≤ 0.5), not the near-wake. Your own #737 diagnostic established this empirically:

| Region | Point share | val rel_l2 | test rel_l2 | val→test ratio | L2 contribution |
|---|---:|---:|---:|---:|---:|
| **upstream (x_rel ≤ 0.5)** | **92.43%** | 4.32% | **11.93%** | **2.76×** | ~138 (~4× of near) |
| near (0.5 < x_rel < 3.0, |z_rel|<1.5) | 7.34% | 13.81% | 21.58% | 1.56× | ~32 |
| far (x_rel ≥ 3.0) | 0.23% | 70.31% | 78.69% | 1.12× | ~14 |

The upstream zone — between front of vehicle, around the wheels, under-body, A-pillars — has 92% of points but a 2.76× val→test gap. This is where the aggregate test_volume_p error lives. Static near-wake upweighting (#737) cannot move the aggregate; even Arm B's marginal improvement came from upstream val→test transfer (2.76× vs 2.93×) as a *side effect*.

This experiment tests whether **direct upstream-region supervision** — per-point loss reweighting that explicitly upweights the x_rel ≤ 0.5 zone — improves test_volume_p by attacking the dominant L2 contribution head-on.

The intuition for why upstream needs more supervision (not less, despite being 92% of points): the upstream pressure field has **complex geometric blocking effects** (stagnation pressure, wheel/wheelhouse vortices, under-body tunnel, A-pillar suction) that vary sharply across cases. Uniform loss weighting effectively gives this zone the *same* per-point weight as far-wake but the *much harder* prediction problem. Upweighting upstream concentrates training signal on the structural-error-dominant zone.

## Implementation

You already implemented the region-loss machinery in #737 (`compute_volume_region_weights`, `_volume_region_masks`, dataset-mean bbox fallback at commit `a4c516e`). Re-implement that same machinery on the fresh `tay` branch (it was deleted with #737), then add an **upstream** weight knob. Specifically:

### 1. Region loss weights (`Config` in `train.py`)

Add three CLI flags:

- `--vol-loss-w-upstream` (default 1.0) — weight applied to `x_rel ≤ vol_loss_upstream_x_hi`.
- `--vol-loss-upstream-x-hi` (default 0.5) — upper-x boundary for upstream zone (in normalized x_rel coords; ≤ 0.5 captures everything from the inflow up to mid-vehicle).
- `--vol-loss-w-rest` (default 1.0) — weight applied everywhere else (near-wake band + far-wake combined). Keep the implementation simple: just upstream vs not-upstream. We'll add finer regions if needed.

Reuse the dataset-mean bbox fallback (cx=1.5046, cz=0.3942, s_ref=4.6720) and the `& has_surface` removal from the v3 fix. **Verify mask coverage logging** (`train/vol_upstream_mask_frac`) is in the 80–95% range (upstream is the majority region).

### 2. Eval-time per-region classifier (`trainer_runtime.py`)

Reuse the same `_volume_region_masks` pattern from your v3. The eval-time region classifier should report per-region rel_l2 (upstream / near / far) at every val step so we can track whether upstream supervision actually closes the val→test ratio in the targeted zone.

### 3. Three-arm sweep on the SOTA stack

Run sequentially on the same 8 GPUs (per #716 lesson; no concurrent torchrun):

| Arm | w_upstream | w_rest | Hypothesis |
|---|---:|---:|---|
| **A** | **1.5** | 1.0 | Mild upstream upweight, mirror the magnitude that worked in #737 Arm A on near |
| **B** | **2.0** | 1.0 | Stronger upweight to test the dose-response |
| **C** | **3.0** | 1.0 | Aggressive — does the test improvement saturate or reverse? |

Run **Arm A first to completion**. If it shows **clear improvement in upstream val rel_l2** at EP3 (target: upstream val < 4.0%, vs Arm A #737's 4.16%) AND the test_vol_p projects to <11.694% at EP4, then proceed with Arm B. Otherwise stop and report — the directional effect on this lever needs to be characterized first.

### 4. Reproduce command (Arm A)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --kill-thresholds "21729:val_primary/abupt_axis_mean_rel_l2_pct<12;32594:val_primary/abupt_axis_mean_rel_l2_pct<8" \
  --vol-loss-upstream-x-hi 0.5 \
  --vol-loss-w-upstream 1.5 --vol-loss-w-rest 1.0 \
  --wandb-group nezuko-upstream-region-vp-loss \
  --wandb-name nezuko/upstream-A-w1.5
```

Arm B: `--vol-loss-w-upstream 2.0 --wandb-name nezuko/upstream-B-w2.0`
Arm C: `--vol-loss-w-upstream 3.0 --wandb-name nezuko/upstream-C-w3.0`

### 5. Reporting

Required outputs (mirror #737):
- 9-column results table (val_abupt, surface_p, volume_p, wall_shear, tau_x, tau_y, tau_z) at best-val checkpoint, with test eval from best-val.
- Per-region (upstream / near / far / overall) rel_l2 at val and test for both arms.
- val→test ratio per region — this is the diagnostic. The hypothesis succeeds if **upstream val→test ratio drops below 2.5×** under upweighting, and fails if it stays at ~2.7× or worsens.
- Mask coverage stats (`train/vol_upstream_mask_frac` mean/min/max, zero-coverage step count).

## Baseline

| Tier | val_abupt | test_abupt | test_vol_p | Source |
|---|---:|---:|---:|---|
| Single-model SOTA | **6.5985%** | **7.9915%** | 11.933% | #592 (`4k25s25e`) |
| Vol-anchor | — | — | **11.374%** | #681 (`dc031qpt`) |
| Issue #717 weak gate | — | — | ≤ 11.0% | promotion ladder |
| #737 Arm B (closed neg) | 7.005% | 8.228% | 11.952% | reference upper bound |

**Win conditions:**
- **Solid win**: test_vol_p ≤ 10.0% (Issue #717 solid gate)
- **Weak win**: test_vol_p ≤ 11.0% (weak gate)
- **At-minimum diagnostic win**: upstream val→test ratio < 2.5× (down from 2.76× in #737 Arm B)

## Issue
Issue #717 (vol_pressure gap, Phase 1/Phase 2 wave). Direct continuation of #737 closure follow-up #1.

## Notes from #737 closure (advisor)

- Reuse the `a4c516e` dataset-mean bbox fallback. It's the only pattern that gives 0/37k+ zero-coverage steps. Per-case std on cx/cz/s_ref is <8% so the approximation is sound.
- Keep the per-region eval logging — it was the most diagnostic output of #737 and should remain in the eval loop for all future runs.
- Mind the train-cap budget. With vol-points schedule, EP4 lands at ~270 min (best=EP4 in #737 both arms). Plan reporting around EP3 gate + final EP4 best.
