### PR TITLE
fern: No-slice Anchor-STRING transformer (AB-UPT-lite, stabilized) — Issue #618 Exp 3

### DIFF
--- a/model.py
+++ b/model.py
@@ -271,11 +271,12 @@ class AnchorStringAttention(nn.Module):
       2. Cross-attention from points (queries+coords) to anchors (keys/values
          +coords), with RoPE rotated by point and anchor coords respectively.
 
-    Anchor selection during training is randperm shared across the batch
-    (PR #765 v1 simplification). Evaluation uses evenly-spaced indices for
-    deterministic forward passes. Padded points may be selected as anchors;
-    with the SOTA point-view sizes (65k+65k) the padding fraction is
-    typically zero, so we accept this for v1.
+    Anchor selection: caller passes ``anchor_idx`` sampled once per forward
+    at the encoder level so all blocks attend to the same K anchor positions.
+    Random sampling is used in both training and eval to keep the model's
+    train/eval distribution consistent. Padded points may be selected as
+    anchors; with the SOTA point-view sizes (65k+65k) the padding fraction
+    is typically zero, so we accept this for v1.
 
     Returns the attention delta (not residual'd). The caller (TransformerBlock)
     is responsible for the outer residual connection so this module slots in
@@ -323,16 +324,13 @@ class AnchorStringAttention(nn.Module):
         self,
         x: torch.Tensor,
         coords: torch.Tensor,
-        deterministic: bool,
+        anchor_idx: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        B, N, _ = x.shape
-        K = min(self.num_anchors, N)
-        if deterministic:
-            stride = max(1, N // K)
-            idx = torch.arange(0, K * stride, stride, device=x.device, dtype=torch.long)[:K]
-        else:
-            idx = torch.randperm(N, device=x.device, dtype=torch.long)[:K]
-        return x.index_select(1, idx), coords.index_select(1, idx)
+        if anchor_idx is None:
+            B, N, _ = x.shape
+            K = min(self.num_anchors, N)
+            anchor_idx = torch.randperm(N, device=x.device, dtype=torch.long)[:K]
+        return x.index_select(1, anchor_idx), coords.index_select(1, anchor_idx)
 
     def _split_heads(self, x: torch.Tensor) -> torch.Tensor:
         B, T, _ = x.shape
@@ -347,9 +345,9 @@ class AnchorStringAttention(nn.Module):
         x: torch.Tensor,
         coords: torch.Tensor,
         attn_mask: torch.Tensor | None = None,
+        anchor_idx: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        deterministic = not self.training
-        a, ac = self.select_anchors(x, coords, deterministic=deterministic)
+        a, ac = self.select_anchors(x, coords, anchor_idx=anchor_idx)
 
         q_a = self._split_heads(self.q_self(a))
         k_a = self._split_heads(self.k_self(a))
@@ -489,13 +487,16 @@ class TransformerBlock(nn.Module):
         x: torch.Tensor,
         attn_mask: torch.Tensor | None = None,
         coords: torch.Tensor | None = None,
+        anchor_idx: torch.Tensor | None = None,
     ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
         x_norm = self.norm1(x)
         if self.attn_mode == "anchor_string":
             if coords is None:
                 raise ValueError("coords are required for attn_mode='anchor_string'")
-            attn_out = self.attention(x_norm, coords=coords, attn_mask=attn_mask)
+            attn_out = self.attention(
+                x_norm, coords=coords, attn_mask=attn_mask, anchor_idx=anchor_idx
+            )
         else:
             attn_out = self.attention(x_norm, attn_mask=attn_mask)
         x = x + attn_out
@@ -520,6 +521,7 @@ class Transformer(nn.Module):
     ):
         super().__init__()
         self.attn_mode = attn_mode
+        self.num_anchors = num_anchors
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -542,8 +544,13 @@ class Transformer(nn.Module):
         attn_mask: torch.Tensor | None = None,
         coords: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        anchor_idx: torch.Tensor | None = None
+        if self.attn_mode == "anchor_string":
+            N = x.shape[1]
+            K = min(self.num_anchors, N)
+            anchor_idx = torch.randperm(N, device=x.device, dtype=torch.long)[:K]
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask, coords=coords)
+            x = block(x, attn_mask=attn_mask, coords=coords, anchor_idx=anchor_idx)
         return x
 
 

--- a/model.py
+++ b/model.py
@@ -188,6 +188,199 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class LearnableCoordinateRoPE(nn.Module):
+    """Learnable per-axis rotary position encoding for 3D continuous coords.
+
+    Splits ``head_dim // 2`` rotation pairs across ``ndim`` axes; the first
+    ``(head_dim // 2) % ndim`` axes get one extra pair so the full
+    ``head_dim`` is consumed. ``log_freq`` is initialised round-robin from
+    ``init_sigmas`` (matching :class:`StringSeparableEncoding`'s multi-sigma
+    pattern). ``phase`` initialises to zero. Both are learnable so the
+    network can specialise per-axis frequency content during training.
+    Issue #618 Experiment 3.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        ndim: int = 3,
+        init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+    ):
+        super().__init__()
+        if head_dim % 2 != 0:
+            raise ValueError(f"head_dim must be even; got {head_dim}")
+        self.head_dim = head_dim
+        self.ndim = ndim
+        total_pairs = head_dim // 2
+        base = total_pairs // ndim
+        extra = total_pairs % ndim
+        self.pairs_per_axis: list[int] = [base + (1 if a < extra else 0) for a in range(ndim)]
+        self.rot_dim = 2 * sum(self.pairs_per_axis)
+        max_pairs = max(self.pairs_per_axis)
+
+        log_freq_init = torch.zeros(ndim, max_pairs)
+        for axis in range(ndim):
+            for f in range(self.pairs_per_axis[axis]):
+                log_freq_init[axis, f] = math.log(init_sigmas[f % len(init_sigmas)])
+        self.log_freq = nn.Parameter(log_freq_init)
+        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
+
+    def angles(self, coords: torch.Tensor) -> torch.Tensor:
+        # coords: [..., ndim] -> theta: [..., total_pairs]
+        parts: list[torch.Tensor] = []
+        for axis in range(self.ndim):
+            pairs = self.pairs_per_axis[axis]
+            f = self.log_freq[axis, :pairs].exp().to(dtype=coords.dtype)
+            p = self.phase[axis, :pairs].to(dtype=coords.dtype)
+            theta = coords[..., axis : axis + 1] * f + p
+            parts.append(theta)
+        return torch.cat(parts, dim=-1)
+
+    def rotate(self, qk: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        # qk: [B, H, T, head_dim], theta: [B, T, total_pairs]
+        rot_dim = self.rot_dim
+        if rot_dim == 0:
+            return qk
+        cos = theta.cos().to(dtype=qk.dtype).unsqueeze(1)
+        sin = theta.sin().to(dtype=qk.dtype).unsqueeze(1)
+        rotated = qk[..., :rot_dim]
+        passthrough = qk[..., rot_dim:]
+        rotated = rotated.view(*rotated.shape[:-1], -1, 2)
+        x_a = rotated[..., 0]
+        x_b = rotated[..., 1]
+        out_a = x_a * cos - x_b * sin
+        out_b = x_a * sin + x_b * cos
+        out = torch.stack([out_a, out_b], dim=-1)
+        out = out.flatten(start_dim=-2)
+        if passthrough.shape[-1] > 0:
+            out = torch.cat([out, passthrough], dim=-1)
+        return out
+
+    def forward(self, qk: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        theta = self.angles(coords)
+        return self.rotate(qk, theta)
+
+
+class AnchorStringAttention(nn.Module):
+    """No-slice attention: K coordinate-bearing anchors with STRING-RoPE on Q/K.
+
+    Replaces Transolver's slice-token bottleneck with K=``num_anchors``
+    anchor tokens that participate in attention via :class:`LearnableCoordinateRoPE`
+    on Q/K. Two sub-blocks per attention call:
+      1. Anchor self-attention with RoPE rotated by anchor coords.
+      2. Cross-attention from points (queries+coords) to anchors (keys/values
+         +coords), with RoPE rotated by point and anchor coords respectively.
+
+    Anchor selection during training is randperm shared across the batch
+    (PR #765 v1 simplification). Evaluation uses evenly-spaced indices for
+    deterministic forward passes. Padded points may be selected as anchors;
+    with the SOTA point-view sizes (65k+65k) the padding fraction is
+    typically zero, so we accept this for v1.
+
+    Returns the attention delta (not residual'd). The caller (TransformerBlock)
+    is responsible for the outer residual connection so this module slots in
+    place of TransolverAttention without changing block semantics.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_anchors: int = 1024,
+        dropout: float = 0.0,
+        use_qk_norm: bool = True,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.num_anchors = num_anchors
+        self.dropout = dropout
+        self.use_qk_norm = use_qk_norm
+
+        self.q_self = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.k_self = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.v_self = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.out_self = LinearProjection(hidden_dim, hidden_dim)
+
+        self.q_cross = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.k_cross = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.v_cross = LinearProjection(hidden_dim, hidden_dim, bias=False)
+        self.out_cross = LinearProjection(hidden_dim, hidden_dim)
+        self.proj_dropout = nn.Dropout(dropout)
+
+        self.rope = LearnableCoordinateRoPE(self.head_dim, ndim=3)
+        if use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+            self.k_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+        else:
+            self.q_norm = None
+            self.k_norm = None
+
+    def select_anchors(
+        self,
+        x: torch.Tensor,
+        coords: torch.Tensor,
+        deterministic: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        B, N, _ = x.shape
+        K = min(self.num_anchors, N)
+        if deterministic:
+            stride = max(1, N // K)
+            idx = torch.arange(0, K * stride, stride, device=x.device, dtype=torch.long)[:K]
+        else:
+            idx = torch.randperm(N, device=x.device, dtype=torch.long)[:K]
+        return x.index_select(1, idx), coords.index_select(1, idx)
+
+    def _split_heads(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, _ = x.shape
+        return x.view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+
+    def _merge_heads(self, x: torch.Tensor) -> torch.Tensor:
+        B, H, T, _ = x.shape
+        return x.transpose(1, 2).contiguous().view(B, T, H * self.head_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        coords: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        deterministic = not self.training
+        a, ac = self.select_anchors(x, coords, deterministic=deterministic)
+
+        q_a = self._split_heads(self.q_self(a))
+        k_a = self._split_heads(self.k_self(a))
+        v_a = self._split_heads(self.v_self(a))
+        if self.q_norm is not None:
+            q_a = self.q_norm(q_a)
+            k_a = self.k_norm(k_a)
+        q_a = self.rope(q_a, ac)
+        k_a = self.rope(k_a, ac)
+        attn_a = F.scaled_dot_product_attention(
+            q_a, k_a, v_a, dropout_p=self.dropout if self.training else 0.0
+        )
+        a = a + self.out_self(self._merge_heads(attn_a))
+
+        q_x = self._split_heads(self.q_cross(x))
+        k_x = self._split_heads(self.k_cross(a))
+        v_x = self._split_heads(self.v_cross(a))
+        if self.q_norm is not None:
+            q_x = self.q_norm(q_x)
+            k_x = self.k_norm(k_x)
+        q_x = self.rope(q_x, coords)
+        k_x = self.rope(k_x, ac)
+        attn_x = F.scaled_dot_product_attention(
+            q_x, k_x, v_x, dropout_p=self.dropout if self.training else 0.0
+        )
+        out = self._merge_heads(attn_x)
+        out = _apply_token_mask(out, attn_mask)
+        out = self.proj_dropout(self.out_cross(out))
+        return _apply_token_mask(out, attn_mask)
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -265,23 +458,47 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        attn_mode: str = "transolver",
+        num_anchors: int = 1024,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
+        self.attn_mode = attn_mode
         self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.attention = TransolverAttention(
-            hidden_dim=hidden_dim,
-            num_heads=num_heads,
-            num_slices=num_slices,
-            dropout=dropout,
-            use_qk_norm=use_qk_norm,
-        )
+        if attn_mode == "anchor_string":
+            self.attention = AnchorStringAttention(
+                hidden_dim=hidden_dim,
+                num_heads=num_heads,
+                num_anchors=num_anchors,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+        else:
+            self.attention = TransolverAttention(
+                hidden_dim=hidden_dim,
+                num_heads=num_heads,
+                num_slices=num_slices,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x_norm = self.norm1(x)
+        if self.attn_mode == "anchor_string":
+            if coords is None:
+                raise ValueError("coords are required for attn_mode='anchor_string'")
+            attn_out = self.attention(x_norm, coords=coords, attn_mask=attn_mask)
+        else:
+            attn_out = self.attention(x_norm, attn_mask=attn_mask)
+        x = x + attn_out
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -298,8 +515,11 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        attn_mode: str = "transolver",
+        num_anchors: int = 1024,
     ):
         super().__init__()
+        self.attn_mode = attn_mode
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -309,14 +529,21 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    attn_mode=attn_mode,
+                    num_anchors=num_anchors,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, coords=coords)
         return x
 
 
@@ -342,6 +569,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        attn_mode: str = "transolver",
+        num_anchors: int = 1024,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +583,8 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.attn_mode = attn_mode
+        self.num_anchors = num_anchors
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -417,6 +648,8 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            attn_mode=attn_mode,
+            num_anchors=num_anchors,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -465,6 +698,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -481,6 +715,7 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -495,10 +730,12 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        coords = torch.cat(coords_list, dim=1) if self.attn_mode == "anchor_string" else None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, coords=coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
-from model import SurfaceTransolver
+from model import AnchorStringAttention, SurfaceTransolver
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
@@ -102,6 +102,9 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    attn_mode: str = "transolver"
+    num_anchors: int = 1024
+    new_module_lr_mult: float = 0.1
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -233,20 +236,47 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def collect_new_module_param_ids(model: nn.Module) -> set[int]:
+    """IDs of params under :class:`AnchorStringAttention` modules.
+
+    Includes the embedded ``LearnableCoordinateRoPE`` because it sits inside
+    AnchorStringAttention; iterating its parameters with ``recurse=True``
+    captures both. Used to build a separate optimizer param group with a
+    reduced LR for the new modules (PR #765 stability rail).
+    """
+
+    seen: set[int] = set()
+    for _, module in model.named_modules():
+        if isinstance(module, AnchorStringAttention):
+            for p in module.parameters(recurse=True):
+                seen.add(id(p))
+    return seen
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    new_param_ids = (
+        collect_new_module_param_ids(model)
+        if config.attn_mode == "anchor_string"
+        else set()
+    )
+    if new_param_ids:
+        new_params = [p for p in model.parameters() if id(p) in new_param_ids]
+        base_params = [p for p in model.parameters() if id(p) not in new_param_ids]
+        new_lr = config.lr * config.new_module_lr_mult
+        param_groups = [
+            {"params": base_params, "lr": config.lr, "name": "base"},
+            {"params": new_params, "lr": new_lr, "name": "new_modules"},
+        ]
+    else:
+        param_groups = [{"params": list(model.parameters()), "lr": config.lr, "name": "base"}]
     if optimizer_name == "adamw":
-        return torch.optim.AdamW(
-            model.parameters(),
-            lr=config.lr,
-            weight_decay=config.weight_decay,
-        )
+        return torch.optim.AdamW(param_groups, weight_decay=config.weight_decay)
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
-            lr=config.lr,
+            param_groups,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
             use_triton=False,
@@ -284,6 +314,49 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_anchor_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block log_freq diagnostics for the anchor-STRING RoPE.
+
+    Aggregates across blocks (mean/std/min/max + per-axis mean) and emits
+    one set per block so divergence can be localised.
+    """
+
+    metrics: dict[str, float] = {}
+    blocks = getattr(getattr(model, "backbone", None), "blocks", None)
+    if blocks is None:
+        return metrics
+    all_log_freqs: list[torch.Tensor] = []
+    for block_idx, block in enumerate(blocks):
+        attention = getattr(block, "attention", None)
+        if attention is None or not isinstance(attention, AnchorStringAttention):
+            continue
+        rope = getattr(attention, "rope", None)
+        if rope is None:
+            continue
+        log_freq = rope.log_freq.detach().float()
+        phase = rope.phase.detach().float()
+        prefix = f"anchor_rope/block_{block_idx}"
+        metrics[f"{prefix}/log_freq_mean"] = float(log_freq.mean().item())
+        metrics[f"{prefix}/log_freq_std"] = float(log_freq.std().item())
+        metrics[f"{prefix}/log_freq_min"] = float(log_freq.min().item())
+        metrics[f"{prefix}/log_freq_max"] = float(log_freq.max().item())
+        metrics[f"{prefix}/phase_abs_mean"] = float(phase.abs().mean().item())
+        for axis in range(log_freq.shape[0]):
+            pairs = rope.pairs_per_axis[axis]
+            axis_log_freq = log_freq[axis, :pairs]
+            metrics[f"{prefix}/log_freq_axis_{axis}_mean"] = float(axis_log_freq.mean().item())
+            metrics[f"{prefix}/log_freq_axis_{axis}_max"] = float(axis_log_freq.max().item())
+        all_log_freqs.append(log_freq.flatten())
+    if all_log_freqs:
+        cat = torch.cat(all_log_freqs)
+        metrics["anchor_rope/all/log_freq_mean"] = float(cat.mean().item())
+        metrics["anchor_rope/all/log_freq_std"] = float(cat.std().item())
+        metrics["anchor_rope/all/log_freq_min"] = float(cat.min().item())
+        metrics["anchor_rope/all/log_freq_max"] = float(cat.max().item())
+        metrics["anchor_rope/all/freq_max"] = float(cat.exp().max().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +370,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        attn_mode=config.attn_mode,
+        num_anchors=config.num_anchors,
     )
 
 
@@ -759,6 +834,21 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
+        if state.is_main:
+            for group in optimizer.param_groups:
+                group_name = group.get("name", "default")
+                group_params = group.get("params", [])
+                group_n = sum(p.numel() for p in group_params)
+                group_lr = group.get("lr", 0.0)
+                print(
+                    f"Optimizer group '{group_name}': "
+                    f"{len(group_params)} tensors, {group_n:,d} params, lr={group_lr:.2e}"
+                )
+            if config.attn_mode == "anchor_string":
+                print(
+                    f"Anchor-STRING attention enabled: K={config.num_anchors} anchors, "
+                    f"new-module LR mult={config.new_module_lr_mult}"
+                )
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
@@ -861,6 +951,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            for group in optimizer.param_groups:
+                group_name = group.get("name", "default")
+                group_params = group.get("params", [])
+                wandb.summary[f"optimizer/group_{group_name}/num_params"] = sum(
+                    p.numel() for p in group_params
+                )
+                wandb.summary[f"optimizer/group_{group_name}/num_tensors"] = len(group_params)
+                wandb.summary[f"optimizer/group_{group_name}/lr"] = group.get("lr", 0.0)
+            if config.attn_mode == "anchor_string":
+                wandb.summary["model/attn_mode"] = config.attn_mode
+                wandb.summary["model/num_anchors"] = config.num_anchors
+                wandb.summary["model/new_module_lr_mult"] = config.new_module_lr_mult
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1240,6 +1342,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_anchor_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**No-slice Anchor-STRING transformer (AB-UPT-lite, stabilized).** Replace Transolver's learned slice bottleneck with K=1024 coordinate-bearing anchor tokens that participate in attention via *true* learnable per-axis STRING-RoPE applied to Q/K. The current SOTA (PR #592 alphonse, val_abupt=6.5985%, test_abupt=7.9915%) uses STRING-separable encoding *additively at the input* — the encoding is consumed by the input MLP and exact (x,y,z) coordinates disappear before slice tokens form Q/K. AB-UPT shows that rotating Q/K with coordinate-dependent group action (true RoPE on real coordinates) is materially stronger when tokens carry coordinates throughout the stack. Issue #618 lays out four experiments to close this gap; this PR implements **Experiment 3** with stability rails (differential LR for new modules, conservative frequency init, grad-clip) so a coordinate-bearing transformer can train end-to-end without diverging.

If anchor-STRING beats baseline (val_abupt < 6.5985%), this would be a structural unlock — coordinate identity preserved through the full attention stack rather than collapsed into a learned slice basis. Even a flat result on val_abupt with a clear vol_pressure improvement would be evidence the architecture is the right direction (current vol_p val approx 3.6%, test approx 11.5%, ~3x gap is the chronic blocker).

## Baseline to beat

From `target/BASELINE.md`:

| Metric | Single-model SOTA (PR #592 alphonse `4k25s25e`, EP4) |
|---|---|
| **val_abupt_axis_mean_rel_l2_pct** | **6.5985%** (gate) |
| test_abupt_axis_mean_rel_l2_pct | 7.9915% |
| val surf_p / vol_p / tau_x / tau_y / tau_z | 3.59 / 3.61 / 4.27 / 13.21 / 7.30 |
| test surf_p / vol_p / tau_x / tau_y / tau_z | 4.65 / 11.47 / 5.55 / 11.83 / 6.45 |

Architecture: L=5, hidden=512, heads=4, slices=128, ~15.9M params, ~52GB VRAM, Lion lr=9e-5 wd=5e-4, EMA=0.999, QK-norm, STRING-separable input encoding (rff_features=16, sigmas=0.25/0.5/1/2/4).

## What to build

### A. New module: `LearnableCoordinateRoPE` (in `model.py`)

Per-axis learnable rotary frequencies that act on Q/K inside attention. Reference scaffold from Issue #618:

```python
class LearnableCoordinateRoPE(nn.Module):
    """Rotates Q/K by coordinate-dependent angles. ndim=3 axes, head_dim split into ndim*2 chunks."""
    def __init__(self, head_dim: int, ndim: int = 3, num_freqs_per_axis: int | None = None,
                 init_sigmas=(0.5, 1.0, 2.0)):
        super().__init__()
        assert head_dim % (2 * ndim) == 0, "head_dim must be divisible by 2*ndim"
        self.ndim = ndim
        self.num_freqs = num_freqs_per_axis or (head_dim // (2 * ndim))
        # Conservative init: log_freq spread in [log(0.1), log(10.0)] across sigmas
        log_freq = torch.empty(ndim, self.num_freqs)
        for a in range(ndim):
            sigma = init_sigmas[a % len(init_sigmas)]
            log_freq[a] = torch.linspace(math.log(0.1), math.log(10.0), self.num_freqs) + 0.1 * torch.randn(self.num_freqs)
        self.log_freq = nn.Parameter(log_freq)              # [ndim, num_freqs]
        self.phase    = nn.Parameter(torch.zeros(ndim, self.num_freqs))

    def forward(self, qk: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
        # qk: [B, H, N, head_dim], coords: [B, N, ndim]
        B, H, N, D = qk.shape
        freqs = torch.exp(self.log_freq)                    # [ndim, F]
        angles = coords.unsqueeze(-1) * freqs.unsqueeze(0).unsqueeze(0) + self.phase.unsqueeze(0).unsqueeze(0)
        # angles: [B, N, ndim, F]  ->  rotate pairs
        cos, sin = angles.cos(), angles.sin()               # [B, N, ndim, F]
        cos = cos.reshape(B, N, -1).unsqueeze(1)            # [B, 1, N, ndim*F]
        sin = sin.reshape(B, N, -1).unsqueeze(1)
        qk_a, qk_b = qk[..., 0::2], qk[..., 1::2]           # split halves of head_dim
        rot_a = qk_a * cos - qk_b * sin
        rot_b = qk_a * sin + qk_b * cos
        out = torch.empty_like(qk)
        out[..., 0::2] = rot_a
        out[..., 1::2] = rot_b
        return out
```

### B. New module: `AnchorStringAttention` (in `model.py`)

Replaces Transolver attention. Three sub-blocks:

1. **Anchor selection.** Sample K anchor indices per sample from concatenated [surface, volume] points. Stratified random (half from surface, half from volume) is acceptable for the first run. Anchors carry their (x,y,z) coords and corresponding token features.
2. **Anchor self-attention** with `LearnableCoordinateRoPE` applied to Q/K using anchor coords.
3. **Cross-attention** from all point tokens (Q from points + point coords) to anchors (K/V from anchors + anchor coords). Both sides rotated.

```python
class AnchorStringAttention(nn.Module):
    def __init__(self, dim, heads, num_anchors=1024, head_dim=None):
        super().__init__()
        self.heads = heads
        self.head_dim = head_dim or (dim // heads)
        self.num_anchors = num_anchors
        self.q_self  = nn.Linear(dim, dim);  self.k_self  = nn.Linear(dim, dim);  self.v_self  = nn.Linear(dim, dim)
        self.q_cross = nn.Linear(dim, dim);  self.k_cross = nn.Linear(dim, dim);  self.v_cross = nn.Linear(dim, dim)
        self.out_self  = nn.Linear(dim, dim)
        self.out_cross = nn.Linear(dim, dim)
        self.rope = LearnableCoordinateRoPE(self.head_dim, ndim=3)
        self.qk_norm_q = nn.LayerNorm(self.head_dim)
        self.qk_norm_k = nn.LayerNorm(self.head_dim)

    def select_anchors(self, x, coords):
        # Stratified random for v1: share idx across batch.
        B, N, _ = x.shape
        idx = torch.randperm(N, device=x.device)[: self.num_anchors]
        return x[:, idx, :], coords[:, idx, :]

    def forward(self, x, coords):
        B, N, D = x.shape
        a, ac = self.select_anchors(x, coords)
        # anchor self-attention with RoPE
        q = self.q_self(a).view(B, -1, self.heads, self.head_dim).transpose(1, 2)
        k = self.k_self(a).view(B, -1, self.heads, self.head_dim).transpose(1, 2)
        v = self.v_self(a).view(B, -1, self.heads, self.head_dim).transpose(1, 2)
        q = self.qk_norm_q(q); k = self.qk_norm_k(k)
        q = self.rope(q, ac); k = self.rope(k, ac)
        a2 = torch.nn.functional.scaled_dot_product_attention(q, k, v)
        a2 = a2.transpose(1, 2).contiguous().view(B, -1, D)
        a  = a + self.out_self(a2)
        # cross-attention: points -> anchors with RoPE on both sides
        q = self.q_cross(x).view(B, N, self.heads, self.head_dim).transpose(1, 2)
        k = self.k_cross(a).view(B, -1, self.heads, self.head_dim).transpose(1, 2)
        v = self.v_cross(a).view(B, -1, self.heads, self.head_dim).transpose(1, 2)
        q = self.qk_norm_q(q); k = self.qk_norm_k(k)
        q = self.rope(q, coords); k = self.rope(k, ac)
        x2 = torch.nn.functional.scaled_dot_product_attention(q, k, v)
        x2 = x2.transpose(1, 2).contiguous().view(B, N, D)
        return x + self.out_cross(x2)
```

### C. Wire it into the model

- Add `--attn-mode {transolver,anchor_string}` flag (default `transolver` so SOTA stays untouched).
- When `anchor_string`: replace `TransolverAttention` blocks with `AnchorStringAttention`. Keep input MLP, FFN, residual structure identical.
- Keep input STRING-separable encoding ON by default — anchor-STRING is *additional*, not a replacement at the input. We test the architecture, not a feature ablation.
- Plumb the coord tensor through to each attention block alongside `x`.
- Add `--num-anchors` flag (default 1024). Allow 2048 as a follow-up.

### D. Stability rails (the "stabilized" half)

Coordinate RoPE on real-world meters can blow up gradients early. Three measures:

1. **Differential LR.** New parameters (`AnchorStringAttention.*`, `LearnableCoordinateRoPE.*`) get **0.1x base LR**. Two optimizer param groups: existing params at lr=9e-5, new modules at lr=9e-6.
2. **Conservative freq init.** `log_freq` spread linearly in `[log(0.1), log(10.0)]` plus 0.1 stdev jitter. Phases zero. (In scaffold above.)
3. **Grad clip kept at 0.5.** Verify it actually triggers in early epochs (log grad norm to W&B).

### E. Plumbing: optimizer param groups

In `train.py`, after model construction, build the optimizer with two groups:

```python
new_module_names = ("anchor_attn", "rope")
new_params  = [p for n, p in model.named_parameters() if any(t in n for t in new_module_names)]
base_params = [p for n, p in model.named_parameters() if not any(t in n for t in new_module_names)]
optimizer = Lion([
    {"params": base_params, "lr": args.lr},
    {"params": new_params,  "lr": args.lr * 0.1},
], weight_decay=args.weight_decay)
```

Print param counts per group at startup for sanity.

## Run plan

**Run 1 — primary (K=1024 anchors, conservative init):**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --attn-mode anchor_string --num-anchors 1024 \
  --wandb-group anchor-string-618 --wandb-name fern/anchor-string-K1024
```

**Run 2 — K=2048 if Run 1 trains stably and is within 0.3pp of baseline:**

Same as Run 1 but `--num-anchors 2048` and `--wandb-name fern/anchor-string-K2048`. Skip if Run 1 diverges.

**Run 3 — diagnostic if Run 1 diverges (NaN, val_abupt > 8%):**

Drop new-module LR multiplier from 0.1 to 0.05, narrow init range to `[log(0.5), log(5.0)]`, `--wandb-name fern/anchor-string-K1024-tighter`. Single attempt; if this also diverges, mark the experiment a stability failure and report.

You have 8 GPUs and ~2h45m budget — Run 1 then Run 2 (or Run 3) sequentially is the expected utilization pattern.

## Decision rule

- **Beat baseline:** val_abupt < 6.5985% on EMA model → ready for review, this is a merge.
- **Within 0.3pp + clear vol_pressure improvement (test vol_p < 11.0%):** ready for review with explicit ask for a follow-up at K=2048.
- **Worse by >0.5pp or unstable:** mark ready with diagnosis (loss curves, grad norms, attention sparsity) so we can decide if Experiment 1 (slice-centroid RoPE) on the same stack is the next swing.

## Files you should touch

- `target/model.py` — add `LearnableCoordinateRoPE`, `AnchorStringAttention`, wire `--attn-mode`.
- `target/train.py` — add `--attn-mode`, `--num-anchors` flags; build two-group optimizer when `attn-mode=anchor_string`.
- Do **not** modify the loss, EMA, schedule, or input STRING-separable encoding — those are SOTA-defining and orthogonal here.

## Reporting

Post a comment on this PR with:
1. Run IDs and W&B group link.
2. Per-channel val + test metrics for each run (surf_p, vol_p, tau_x, tau_y, tau_z, abupt mean) at best-val epoch.
3. Param counts per optimizer group (base vs new-module).
4. Mean grad norm per epoch for the new modules vs base.
5. Any stability events (NaN, loss spikes, EMA divergence) with epoch numbers.

References: Issue #618 (Experiment 3); `target/BASELINE.md`; AB-UPT paper (`RopeFrequency(dim=head_dim, ndim=3)` + `DotProductAttention`). Prior PR #545 attempted slice-centroid RoPE on yi without learnable per-axis params and lost — that's why this PR uses anchor tokens (preserve real coords) and learnable per-axis RoPE.
