### PR TITLE
[fern] Slice-centroid Learnable-STRING-RoPE on Transolver Q/K — Issue #618 Exp 1

### DIFF
--- a/model.py
+++ b/model.py
@@ -188,6 +188,81 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class LearnableCoordinateRoPE(nn.Module):
+    """Learnable per-axis rotary position encoding for 3D continuous coords.
+
+    Issue #618 / PR #769. Splits ``head_dim // 2`` rotation pairs across
+    ``ndim`` axes; the first ``(head_dim // 2) % ndim`` axes get one extra
+    pair so the full ``head_dim`` is consumed. ``log_freq`` is initialised
+    round-robin from ``init_sigmas`` (matching :class:`StringSeparableEncoding`'s
+    multi-sigma pattern). ``phase`` initialises to zero. Both are learnable
+    so the network can specialise per-axis frequency content during training.
+    The angle formula matches the input-level STRING-separable encoding:
+    ``theta = 2*pi * coord * exp(log_freq) + phase``.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        ndim: int = 3,
+        init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+    ):
+        super().__init__()
+        if head_dim % 2 != 0:
+            raise ValueError(f"head_dim must be even; got {head_dim}")
+        self.head_dim = head_dim
+        self.ndim = ndim
+        total_pairs = head_dim // 2
+        base = total_pairs // ndim
+        extra = total_pairs % ndim
+        self.pairs_per_axis: list[int] = [base + (1 if a < extra else 0) for a in range(ndim)]
+        self.rot_dim = 2 * sum(self.pairs_per_axis)
+        max_pairs = max(self.pairs_per_axis)
+
+        log_freq_init = torch.zeros(ndim, max_pairs)
+        for axis in range(ndim):
+            for f in range(self.pairs_per_axis[axis]):
+                log_freq_init[axis, f] = math.log(init_sigmas[f % len(init_sigmas)])
+        self.log_freq = nn.Parameter(log_freq_init)
+        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
+
+    def angles(self, coords: torch.Tensor) -> torch.Tensor:
+        # coords: [..., ndim] -> theta: [..., total_pairs]
+        # Matches StringSeparableEncoding: theta = 2*pi * coord * exp(log_freq) + phase
+        parts: list[torch.Tensor] = []
+        for axis in range(self.ndim):
+            pairs = self.pairs_per_axis[axis]
+            f = self.log_freq[axis, :pairs].exp().to(dtype=coords.dtype)
+            p = self.phase[axis, :pairs].to(dtype=coords.dtype)
+            theta = 2.0 * math.pi * coords[..., axis : axis + 1] * f + p
+            parts.append(theta)
+        return torch.cat(parts, dim=-1)
+
+    def rotate(self, qk: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        # qk: [B, H, S, head_dim], theta: [B, H, S, total_pairs]
+        rot_dim = self.rot_dim
+        if rot_dim == 0:
+            return qk
+        cos = theta.cos().to(dtype=qk.dtype)
+        sin = theta.sin().to(dtype=qk.dtype)
+        rotated = qk[..., :rot_dim]
+        passthrough = qk[..., rot_dim:]
+        rotated = rotated.view(*rotated.shape[:-1], -1, 2)
+        x_a = rotated[..., 0]
+        x_b = rotated[..., 1]
+        out_a = x_a * cos - x_b * sin
+        out_b = x_a * sin + x_b * cos
+        out = torch.stack([out_a, out_b], dim=-1)
+        out = out.flatten(start_dim=-2)
+        if passthrough.shape[-1] > 0:
+            out = torch.cat([out, passthrough], dim=-1)
+        return out
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, coords: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        theta = self.angles(coords)
+        return self.rotate(q, theta), self.rotate(k, theta)
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -196,6 +271,10 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
+        ndim: int = 3,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -206,6 +285,8 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.slice_string_rope_after_qk_norm = slice_string_rope_after_qk_norm
+        self.ndim = ndim
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -220,6 +301,14 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+        if slice_string_rope:
+            self.slice_string_rope = LearnableCoordinateRoPE(
+                head_dim=self.dim_head,
+                ndim=ndim,
+                init_sigmas=tuple(slice_string_rope_init_sigmas),
+            )
+        else:
+            self.slice_string_rope = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -236,13 +325,30 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        # If RoPE is enabled and we want pre-QK-norm rotation, apply it here.
+        if self.slice_string_rope is not None and not self.slice_string_rope_after_qk_norm:
+            if point_coords is None:
+                raise ValueError("point_coords required when slice_string_rope is enabled")
+            centroids = self._slice_centroids(slice_weights, point_coords)
+            q, k = self.slice_string_rope(q, k, centroids)
         if self.q_norm is not None:
             q = self.q_norm(q)
             k = self.k_norm(k)
+        # Default ordering (Arm B): RoPE after QK-norm so RoPE rotates already-normalised Q/K.
+        if self.slice_string_rope is not None and self.slice_string_rope_after_qk_norm:
+            if point_coords is None:
+                raise ValueError("point_coords required when slice_string_rope is enabled")
+            centroids = self._slice_centroids(slice_weights, point_coords)
+            q, k = self.slice_string_rope(q, k, centroids)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -255,6 +361,16 @@ class TransolverAttention(nn.Module):
         out_x = self.proj_dropout(self.proj(out_x))
         return _apply_token_mask(out_x, attn_mask)
 
+    @staticmethod
+    def _slice_centroids(slice_weights: torch.Tensor, point_coords: torch.Tensor) -> torch.Tensor:
+        # slice_weights: [B, H, N, S]; point_coords: [B, N, ndim]
+        # centroids: [B, H, S, ndim]
+        sw = slice_weights.float()
+        coords = point_coords.float()
+        weighted = torch.einsum("bhns,bnd->bhsd", sw, coords)
+        denom = sw.sum(dim=2).unsqueeze(-1).clamp_min(1e-8)
+        return weighted / denom
+
 
 class TransformerBlock(nn.Module):
     def __init__(
@@ -265,6 +381,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -275,13 +394,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            slice_string_rope=slice_string_rope,
+            slice_string_rope_init_sigmas=slice_string_rope_init_sigmas,
+            slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, point_coords=point_coords)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -298,6 +425,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -309,14 +439,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    slice_string_rope=slice_string_rope,
+                    slice_string_rope_init_sigmas=slice_string_rope_init_sigmas,
+                    slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, point_coords=point_coords)
         return x
 
 
@@ -342,6 +480,9 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] | list[float] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +495,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.slice_string_rope_enabled = slice_string_rope
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -417,6 +559,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            slice_string_rope=slice_string_rope,
+            slice_string_rope_init_sigmas=slice_string_rope_init_sigmas,
+            slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -465,6 +610,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -481,6 +627,7 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -495,10 +642,14 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        point_coords = (
+            torch.cat(coords_list, dim=1) if self.slice_string_rope_enabled else None
+        )
+        hidden = self.backbone(hidden, attn_mask=attn_mask, point_coords=point_coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
-from model import SurfaceTransolver
+from model import LearnableCoordinateRoPE, SurfaceTransolver
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
@@ -102,6 +102,10 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    slice_string_rope: bool = False
+    slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    slice_string_rope_after_qk_norm: bool = True
+    slice_string_rope_lr_mult: float = 0.5
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -233,20 +237,44 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def collect_slice_rope_param_ids(model: nn.Module) -> set[int]:
+    """IDs of params under :class:`LearnableCoordinateRoPE` modules.
+
+    Used to build a separate optimizer param group with a reduced LR for the
+    new slice-centroid RoPE module (PR #769). PR #765 froze new modules at
+    0.1x and the RoPE never trained — 0.5x is the chosen default here.
+    """
+
+    seen: set[int] = set()
+    for _, module in model.named_modules():
+        if isinstance(module, LearnableCoordinateRoPE):
+            for p in module.parameters(recurse=True):
+                seen.add(id(p))
+    return seen
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    new_param_ids = (
+        collect_slice_rope_param_ids(model) if config.slice_string_rope else set()
+    )
+    if new_param_ids:
+        new_params = [p for p in model.parameters() if id(p) in new_param_ids]
+        base_params = [p for p in model.parameters() if id(p) not in new_param_ids]
+        new_lr = config.lr * config.slice_string_rope_lr_mult
+        param_groups = [
+            {"params": base_params, "lr": config.lr, "name": "base"},
+            {"params": new_params, "lr": new_lr, "name": "slice_string_rope"},
+        ]
+    else:
+        param_groups = [{"params": list(model.parameters()), "lr": config.lr, "name": "base"}]
     if optimizer_name == "adamw":
-        return torch.optim.AdamW(
-            model.parameters(),
-            lr=config.lr,
-            weight_decay=config.weight_decay,
-        )
+        return torch.optim.AdamW(param_groups, weight_decay=config.weight_decay)
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
-            lr=config.lr,
+            param_groups,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
             use_triton=False,
@@ -284,6 +312,70 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_slice_string_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block log_freq and phase diagnostics for slice-centroid RoPE.
+
+    Issue #618 / PR #769. PR #765's RoPE froze under 0.1x LR (log_freq norm
+    barely moved). The aggregate `all/log_freq_*` keys plus per-axis
+    `axis_*_mean` keys make it cheap to verify the module is actually
+    differentiating per-axis frequencies during training.
+    """
+
+    metrics: dict[str, float] = {}
+    blocks = getattr(getattr(model, "backbone", None), "blocks", None)
+    if blocks is None:
+        return metrics
+    all_log_freqs: list[torch.Tensor] = []
+    all_phases: list[torch.Tensor] = []
+    rope_modules: list[tuple[int, LearnableCoordinateRoPE]] = []
+    for block_idx, block in enumerate(blocks):
+        attention = getattr(block, "attention", None)
+        if attention is None:
+            continue
+        rope = getattr(attention, "slice_string_rope", None)
+        if rope is None:
+            continue
+        rope_modules.append((block_idx, rope))
+    for block_idx, rope in rope_modules:
+        log_freq = rope.log_freq.detach().float()
+        phase = rope.phase.detach().float()
+        prefix = f"slice_string_rope/block_{block_idx}"
+        metrics[f"{prefix}/log_freq_mean"] = float(log_freq.mean().item())
+        metrics[f"{prefix}/log_freq_std"] = float(log_freq.std().item())
+        metrics[f"{prefix}/log_freq_min"] = float(log_freq.min().item())
+        metrics[f"{prefix}/log_freq_max"] = float(log_freq.max().item())
+        metrics[f"{prefix}/phase_abs_mean"] = float(phase.abs().mean().item())
+        for axis in range(log_freq.shape[0]):
+            pairs = rope.pairs_per_axis[axis]
+            axis_log_freq = log_freq[axis, :pairs]
+            metrics[f"{prefix}/log_freq_axis_{axis}_mean"] = float(axis_log_freq.mean().item())
+            metrics[f"{prefix}/log_freq_axis_{axis}_max"] = float(axis_log_freq.max().item())
+        all_log_freqs.append(log_freq.flatten())
+        all_phases.append(phase.flatten())
+        if rope.log_freq.grad is not None:
+            param_norm = rope.log_freq.detach().float().norm().clamp_min(1e-12)
+            grad_norm = rope.log_freq.grad.detach().float().norm()
+            metrics[f"{prefix}/log_freq_grad_to_param"] = float(
+                (grad_norm / param_norm).item()
+            )
+        if rope.phase.grad is not None:
+            param_norm = rope.phase.detach().float().norm().clamp_min(1e-12)
+            grad_norm = rope.phase.grad.detach().float().norm()
+            metrics[f"{prefix}/phase_grad_to_param"] = float(
+                (grad_norm / param_norm).item()
+            )
+    if all_log_freqs:
+        cat = torch.cat(all_log_freqs)
+        metrics["slice_string_rope/all/log_freq_mean"] = float(cat.mean().item())
+        metrics["slice_string_rope/all/log_freq_std"] = float(cat.std().item())
+        metrics["slice_string_rope/all/log_freq_min"] = float(cat.min().item())
+        metrics["slice_string_rope/all/log_freq_max"] = float(cat.max().item())
+        metrics["slice_string_rope/all/freq_max"] = float(cat.exp().max().item())
+        ph = torch.cat(all_phases)
+        metrics["slice_string_rope/all/phase_abs_mean"] = float(ph.abs().mean().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,7 +389,24 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        slice_string_rope=config.slice_string_rope,
+        slice_string_rope_init_sigmas=parse_slice_string_rope_init_sigmas(
+            config.slice_string_rope_init_sigmas
+        ),
+        slice_string_rope_after_qk_norm=config.slice_string_rope_after_qk_norm,
     )
+
+
+def parse_slice_string_rope_init_sigmas(spec: str) -> tuple[float, ...]:
+    spec = (spec or "").strip()
+    if not spec:
+        return (0.25, 0.5, 1.0, 2.0, 4.0)
+    sigmas = [float(token.strip()) for token in spec.split(",") if token.strip()]
+    if not sigmas:
+        return (0.25, 0.5, 1.0, 2.0, 4.0)
+    if any(s <= 0.0 for s in sigmas):
+        raise ValueError(f"--slice-string-rope-init-sigmas must be positive: {spec!r}")
+    return tuple(sigmas)
 
 
 def train_loss(
@@ -759,6 +868,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
+        if state.is_main:
+            for group in optimizer.param_groups:
+                group_name = group.get("name", "default")
+                group_params = group.get("params", [])
+                group_n = sum(p.numel() for p in group_params)
+                group_lr = group.get("lr", 0.0)
+                print(
+                    f"Optimizer group '{group_name}': "
+                    f"{len(group_params)} tensors, {group_n:,d} params, lr={group_lr:.2e}"
+                )
+            if config.slice_string_rope:
+                print(
+                    f"Slice-centroid STRING-RoPE enabled: after_qk_norm="
+                    f"{config.slice_string_rope_after_qk_norm}, "
+                    f"init_sigmas={config.slice_string_rope_init_sigmas}, "
+                    f"lr_mult={config.slice_string_rope_lr_mult}"
+                )
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
@@ -861,6 +987,25 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            for group in optimizer.param_groups:
+                group_name = group.get("name", "default")
+                group_params = group.get("params", [])
+                wandb.summary[f"optimizer/group_{group_name}/num_params"] = sum(
+                    p.numel() for p in group_params
+                )
+                wandb.summary[f"optimizer/group_{group_name}/num_tensors"] = len(group_params)
+                wandb.summary[f"optimizer/group_{group_name}/lr"] = group.get("lr", 0.0)
+            if config.slice_string_rope:
+                wandb.summary["model/slice_string_rope"] = True
+                wandb.summary["model/slice_string_rope_after_qk_norm"] = (
+                    config.slice_string_rope_after_qk_norm
+                )
+                wandb.summary["model/slice_string_rope_init_sigmas"] = (
+                    config.slice_string_rope_init_sigmas
+                )
+                wandb.summary["model/slice_string_rope_lr_mult"] = (
+                    config.slice_string_rope_lr_mult
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1240,6 +1385,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_slice_string_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Slice-centroid Learnable-STRING-RoPE inside Transolver attention** — Issue #618 Experiment 1. Keep the proven Transolver slice mechanism intact (it learns geometry-aware aggregation) and inject true coordinate-dependent group action at the only place inside Transolver where attention is actually computed: the slice-token Q/K. The slice tokens carry differentiable centroids of the points that select into them, so we can compute centroids on-the-fly from `slice_weights @ point_coords` and rotate slice Q/K with `LearnableCoordinateRoPE` indexed by those centroid coordinates.

This is the minimal next step after PR #765 (Experiment 3, AnchorSTRING) closed negative. Lessons retained from #765:
- The `LearnableCoordinateRoPE` module itself is sound (per-axis log_freq + phase, multi-sigma init).
- The 0.1× LR rail on new modules effectively *froze* the RoPE (log_freq norm barely moved). Drop to **0.5× multiplier** or **same LR** for this experiment.
- Random anchor sparsity (1024/131k) was the architectural killer in #765 — slice centroids do not have that pathology since they are dense, learned, and consistent across layers.

This is explicitly *not* a repeat of PR #545 (fixed slice-centroid RoPE on `yi`):
- learnable per-axis `log_freq` + `phase` (matches our successful `StringSeparableEncoding` parameterization)
- multi-sigma init `0.25,0.5,1.0,2.0,4.0` (PR #488 showed multi-sigma is critical for vol_pressure)
- runs on current `tay` SOTA stack (STRING-separable input encoding, QK-norm, Lion, EMA=0.999)
- keeps existing input-level STRING/sincos features (PR #333 confirmed removing those is bad)

## Why this is the right next swing

Current `tay` SOTA single-model is val_abupt=6.5985% (PR #592 alphonse). Input-level STRING-sep delivered the big tay wins (#311, #358, #488), but it is *additive* coordinate features at the input MLP — exact `(x,y,z)` are absorbed into the latent before any attention computes Q/K. AB-UPT shows that attention-level coordinate group action (RoPE on Q/K with real coordinates) is materially stronger when tokens carry coordinates throughout. Transolver's slice bottleneck makes a faithful AB-UPT port disruptive (Exp 3 confirmed), but slice centroids are a free, dense, geometrically-meaningful coordinate the slice tokens already implicitly carry. Adding rotary Q/K on slice centroids tests the attention-level STRING hypothesis with a single targeted change to `TransolverAttention`.

Even a flat val_abupt with a sizeable vol_pressure improvement (chronic test/val gap ~3×: val≈3.6%, test≈11.5%) would be a structural signal worth following.

## Baseline to beat

From `target/BASELINE.md`:

| Metric | Single-model SOTA (PR #592 alphonse `4k25s25e`, EP4) |
|---|---|
| **val_abupt_axis_mean_rel_l2_pct** | **6.5985%** (gate to beat) |
| test_abupt_axis_mean_rel_l2_pct | 7.9915% |
| val surf_p / vol_p / tau_x / tau_y / tau_z | 3.59 / 3.61 / 4.27 / 13.21 / 7.30 |
| test surf_p / vol_p / tau_x / tau_y / tau_z | 4.65 / 11.47 / 5.55 / 11.83 / 6.45 |

**Ensemble SOTA** (for context, not your gate): nezuko PR #612 K=7 pool-24, val_abupt=6.1751%, test_abupt=7.5347%. Single-model improvements feed the ensemble pool.

Architecture: L=5, hidden=512, heads=4, slices=128, ~15.9M params, ~52GB VRAM, Lion lr=9e-5 wd=5e-4, EMA=0.999, QK-norm, STRING-sep input (rff=16, sigmas=0.25/0.5/1/2/4).

## What to build

### A. `LearnableCoordinateRoPE` in `target/model.py`

The module is already drafted in PR #765 (commits on `fern/anchor-string`). **Cherry-pick it forward** — the module itself is sound. Verify the implementation matches Issue #618 (per-axis `log_freq [ndim, F]` + `phase [ndim, F]`, multi-sigma init, applied as 2D rotation on consecutive Q/K pairs).

If you re-implement from scratch:

```python
class LearnableCoordinateRoPE(nn.Module):
    def __init__(self, head_dim, ndim=3, init_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0)):
        super().__init__()
        self.head_dim = head_dim
        self.ndim = ndim
        total_pairs = head_dim // 2
        base = total_pairs // ndim
        extra = total_pairs % ndim
        self.pairs_per_axis = [base + (axis < extra) for axis in range(ndim)]
        max_pairs = max(self.pairs_per_axis)
        self.log_freq = nn.Parameter(torch.zeros(ndim, max_pairs))
        self.phase   = nn.Parameter(torch.zeros(ndim, max_pairs))
        for axis, pairs in enumerate(self.pairs_per_axis):
            for i in range(pairs):
                self.log_freq.data[axis, i] = math.log(init_sigmas[i % len(init_sigmas)])

    def angles(self, coords):  # coords: [..., 3]
        parts = []
        for axis, pairs in enumerate(self.pairs_per_axis):
            freq  = self.log_freq[axis, :pairs].exp().to(coords.dtype)
            phase = self.phase[axis, :pairs].to(coords.dtype)
            theta = 2.0 * math.pi * coords[..., axis:axis+1] * freq + phase
            parts.append(theta)
        return torch.cat(parts, dim=-1)

    def rotate(self, x, theta):
        rot_dim = theta.shape[-1] * 2
        x_rot = x[..., :rot_dim].float().reshape(*x.shape[:-1], theta.shape[-1], 2)
        cos, sin = theta.cos().unsqueeze(-1), theta.sin().unsqueeze(-1)
        x0, x1 = x_rot[..., 0:1], x_rot[..., 1:2]
        y = torch.cat([x0*cos - x1*sin, x0*sin + x1*cos], dim=-1).flatten(-2).to(x.dtype)
        return torch.cat([y, x[..., rot_dim:]], dim=-1) if rot_dim < x.shape[-1] else y

    def forward(self, q, k, coords):
        theta = self.angles(coords)
        return self.rotate(q, theta), self.rotate(k, theta)
```

### B. Thread `point_coords` through Transolver to slice attention

```python
# SurfaceTransolver.forward
coords_list = [surface_x[:, :, :self.space_dim], volume_x[:, :, :self.space_dim]]
point_coords = torch.cat(coords_list, dim=1)  # [B, N, 3]
hidden = self.backbone(hidden, attn_mask=attn_mask, point_coords=point_coords)
```

`Transformer.forward` and `TransformerBlock.forward` accept and forward `point_coords` to `TransolverAttention`.

### C. Slice-centroid rotation in `TransolverAttention.forward`

```python
slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
qkv = self.qkv(slice_tokens)
q, k, v = qkv.chunk(3, dim=-1)
# QK-norm here (existing)
q = self.q_norm(q); k = self.k_norm(k)

if self.slice_string_rope is not None:
    # slice_weights: [B, H, N, S], point_coords: [B, N, 3]
    sw = slice_weights.float()
    centroids = torch.einsum("bhns,bnd->bhsd", sw, point_coords.float())
    centroids = centroids / sw.sum(dim=2).unsqueeze(-1).clamp_min(1e-8)
    # centroids: [B, H, S, 3] — same shape as q,k slice axis
    q, k = self.slice_string_rope(q, k, centroids)

out_slice = F.scaled_dot_product_attention(q, k, v, ...)
```

Place rotation **after QK-norm** by default (Arm B) — QK-norm normalizes magnitudes, then RoPE rotates the angle.

### D. `train.py` config flags

```python
slice_string_rope: bool = False
slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
slice_string_rope_after_qk_norm: bool = True
```

CLI: `--slice-string-rope`, `--slice-string-rope-init-sigmas`, `--no-slice-string-rope-after-qk-norm`.

### E. Optimizer LR rail (NOT 0.1×)

PR #765 froze new modules at 0.1× LR; `log_freq` norm barely changed and the RoPE never differentiated per-axis frequencies. **Use 0.5× multiplier** for this experiment (still conservative vs base, but actually trainable). Param group:

```python
new_module_names = ("slice_string_rope",)
new_params  = [p for n,p in model.named_parameters() if any(t in n for t in new_module_names)]
base_params = [p for n,p in model.named_parameters() if not any(t in n for t in new_module_names)]
optimizer = Lion([
    {"params": base_params, "lr": args.lr},
    {"params": new_params,  "lr": args.lr * 0.5},
], weight_decay=args.weight_decay)
```

If Arm B clears EP3 cleanly, also try Arm D with same LR (1.0×) — see run plan.

## Run plan

Use `--wandb_group fern-slice-string-rope-v1` so all arms group together.

| Arm | Config | LR multiplier on RoPE | Purpose |
|---|---|---|---|
| **A** | control (no flag) | — | matched-config baseline |
| **B** | `--slice-string-rope` (after QK-norm) | 0.5× | primary candidate |
| **C** | `--slice-string-rope --no-slice-string-rope-after-qk-norm` | 0.5× | rotate-before-QKnorm ablation |
| **D** | `--slice-string-rope` (after QK-norm) | 1.0× (no diff LR) | trainability check if B is healthy but underwhelming |

You have 8 GPUs — run A, B, C in parallel first (3 GPUs), then if at least one of B/C looks alive at EP2 launch D. Reserve remaining GPUs for one repeat seed of the best arm.

### Reproduce command (Arm B, primary)

```bash
cd target/
python train.py \
  --pos_encoding_mode string_separable \
  --string_sep_rff_features 16 \
  --string_sep_init_sigmas 0.25,0.5,1.0,2.0,4.0 \
  --qk_norm \
  --hidden_dim 512 --num_layers 5 --num_heads 4 --num_slices 128 \
  --optimizer lion --lr 9e-5 --weight_decay 5e-4 \
  --ema_decay 0.999 --grad_clip 0.5 \
  --slice-string-rope --slice-string-rope-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --slice-string-rope-after-qk-norm \
  --wandb_group fern-slice-string-rope-v1 \
  --wandb_name slice-rope-armB-seed0
```

(Confirm exact flag spellings via `python train.py --help`.)

## Logging requirements

Per-step / per-epoch metrics to push to W&B:

- `slice_string_rope/centroid_spread_mean` (mean ‖centroid − case_centroid‖ across slices)
- `slice_string_rope/log_freq_axis_{0,1,2}_{mean,std}` — confirm RoPE actually differentiates per-axis (this is the diagnostic that PR #765 was missing)
- `slice_string_rope/grad_to_param_norm` for `log_freq` and `phase` — confirm they are training (target: not <1e-3 like #765)
- standard val/test per-channel: `surface_pressure`, `volume_pressure`, `wall_shear`, `tau_x`, `tau_y`, `tau_z`, plus `abupt`
- `nonfinite_count`, `grad_norm` (stability rails)

## Decision rule

- **Merge candidate**: any arm beats single-model SOTA val_abupt < 6.5985%.
- **Promising / send back**: matched control beaten by ≥0.15pp val_abupt, OR vol_pressure val improves materially (≥0.2pp absolute) without aggregate damage. Try Arm D, FPS-style centroid-coord noise, or extend to 6 layers.
- **Close**: all arms underperform matched control by >0.5pp, OR `log_freq` does not differentiate per-axis (RoPE not training) — revisit whether 0.5× LR is still wrong.

## Kill gates

- EP1 val_abupt > 35% → kill immediately (training broken)
- EP2 val_abupt > 12% → kill (will not recover)
- EP3 val_abupt > 8% → kill (will not beat SOTA)

## Notes on what failed in PR #765 (avoid)

1. **Per-step random anchor resampling** broke gradient signal. Slice centroids are dense and consistent across layers — no equivalent pathology here, but make sure `slice_weights` is recomputed per layer (it already is in current Transolver) and the centroid einsum is run **inside** each `TransolverAttention.forward`, not cached.
2. **0.1× LR multiplier** silently froze the new module. We use 0.5× here, and Arm D tests no diff LR at all.
3. **QK-norm + RoPE ordering** matters. Default after QK-norm; Arm C ablates the alternative.

Good luck — this is the smallest, cleanest test of attention-level coordinate-dependent group action on the current SOTA stack.
