### PR TITLE
[nezuko] Surface-anchored residual vol_pressure decoder (Issue #717)

### DIFF
--- a/train.py
+++ b/train.py
@@ -44,6 +44,7 @@ from trainer_runtime import (
     cleanup_distributed,
     collect_gradient_metrics,
     collect_weight_metrics,
+    compute_surface_anchor,
     distributed_any,
     distributed_barrier,
     evaluate_split,
@@ -137,6 +138,10 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_surface_anchor_residual: bool = False
+    vol_surface_anchor_use_ema: bool = False
+    vol_surface_anchor_dist_decay: float = 0.0
+    vol_surface_anchor_chunk_size: int = 4096
     debug: bool = False
 
 
@@ -219,6 +224,34 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_surface_anchor_residual": (
+            "Decompose the volume_pressure prediction as a per-point residual "
+            "from the nearest predicted surface pressure: "
+            "vol_p_pred(x) = surf_p_anchor(x) + decoder(x), where the anchor "
+            "is gathered from the predicted surface pressure at the nearest "
+            "(k=1, L2) surface point. The decoder is then trained on the "
+            "residual target (vol_target - anchor); at inference the anchor "
+            "is added back to recover absolute pressure. The anchor path is "
+            "no-grad — gradients do not flow back into the surface decoder."
+        ),
+        "vol_surface_anchor_use_ema": (
+            "Source the anchor surface pressure from a separate forward pass "
+            "with EMA weights (more stable than the online model's surf_p "
+            "during early training). Doubles per-step forward cost. At "
+            "validation/test the EMA weights are already swapped in by the "
+            "trainer, so the eval-time anchor is naturally EMA-smoothed "
+            "regardless of this flag."
+        ),
+        "vol_surface_anchor_dist_decay": (
+            "If > 0, multiply the anchor by exp(-nn_dist / decay) so far-field "
+            "volume points relax toward 0 (freestream in normalized space). "
+            "Default 0.0 disables decay (full anchor at all distances)."
+        ),
+        "vol_surface_anchor_chunk_size": (
+            "Surface-axis chunk size for the chunked nearest-neighbor scan. "
+            "Caps peak memory at O(B * N_vol * chunk_size * 4 bytes). Lower "
+            "to reduce VRAM pressure if needed."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -300,6 +333,49 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def _resolve_anchor_target(
+    *,
+    batch,
+    surface_pred: torch.Tensor,
+    volume_target: torch.Tensor,
+    vol_anchor_cfg: dict | None,
+    surface_pred_for_anchor: torch.Tensor | None,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Adjust volume target into residual space (absolute - anchor) when enabled.
+
+    Returns the (possibly residual-shifted) volume_target tensor and a small
+    diagnostics dict (anchor mean / std / mean abs distance — recorded as
+    floats only if the anchor is actually applied).
+    """
+    diagnostics: dict[str, float] = {}
+    if vol_anchor_cfg is None or not vol_anchor_cfg.get("enabled", False):
+        return volume_target, diagnostics
+    anchor_src = (
+        surface_pred_for_anchor
+        if surface_pred_for_anchor is not None
+        else surface_pred[..., 0:1].detach().float()
+    )
+    anchor_p, nn_dist = compute_surface_anchor(
+        vol_coords=batch.volume_x[..., :3],
+        surf_coords=batch.surface_x[..., :3],
+        surf_pressure_pred=anchor_src,
+        surf_mask=batch.surface_mask,
+        chunk_size=int(vol_anchor_cfg.get("chunk_size", 4096)),
+        dist_decay=float(vol_anchor_cfg.get("dist_decay", 0.0)),
+    )
+    anchor_p = anchor_p.to(dtype=volume_target.dtype)
+    if bool(batch.volume_mask.any()):
+        valid = batch.volume_mask.bool()
+        anchor_valid = anchor_p[..., 0][valid]
+        dist_valid = nn_dist[valid]
+        diagnostics["vol_anchor/anchor_mean"] = float(anchor_valid.mean().detach().cpu().item())
+        diagnostics["vol_anchor/anchor_std"] = float(anchor_valid.std().detach().cpu().item())
+        diagnostics["vol_anchor/nn_dist_mean"] = float(dist_valid.mean().detach().cpu().item())
+        diagnostics["vol_anchor/nn_dist_max"] = float(dist_valid.max().detach().cpu().item())
+    residual_target = volume_target - anchor_p
+    return residual_target, diagnostics
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,6 +386,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_anchor_cfg: dict | None = None,
+    surface_pred_for_anchor: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -330,18 +408,27 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_target_eff, anchor_diag = _resolve_anchor_target(
+            batch=batch,
+            surface_pred=out["surface_preds"],
+            volume_target=volume_target,
+            vol_anchor_cfg=vol_anchor_cfg,
+            surface_pred_for_anchor=surface_pred_for_anchor,
+        )
+        volume_loss = masked_mse(out["volume_preds"], volume_target_eff, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(anchor_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -353,6 +440,9 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    vol_anchor_cfg: dict | None = None,
+    surface_pred_for_anchor: torch.Tensor | None = None,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -377,7 +467,14 @@ def per_task_train_losses(
         taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
         tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
         tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
-        vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_target_eff, _ = _resolve_anchor_target(
+            batch=batch,
+            surface_pred=surface_pred,
+            volume_target=volume_target,
+            vol_anchor_cfg=vol_anchor_cfg,
+            surface_pred_for_anchor=surface_pred_for_anchor,
+        )
+        vp_loss = masked_mse(out["volume_preds"], volume_target_eff, batch.volume_mask)
     return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
 
 
@@ -575,6 +672,49 @@ class GradNormBalancer:
         with torch.no_grad():
             self.log_weights.clamp_(-self.log_clip, self.log_clip)
         return gradnorm_loss.detach()
+
+
+def compute_ema_anchor_surface_p(
+    *,
+    model: nn.Module,
+    base_model: nn.Module,
+    ema: "EMA",
+    batch,
+    device: torch.device,
+    amp_mode: str,
+) -> torch.Tensor:
+    """Forward pass with EMA weights swapped in to source the anchor.
+
+    Returns the EMA model's surface pressure prediction (channel 0) for the
+    given batch in normalized space, shape ``[B, N_surf, 1]``. Online weights
+    are restored before return so the rest of the training step uses the
+    in-progress optimizer state. The forward is no-grad and runs in eval mode
+    to skip any train-only stochasticity (e.g. dropout).
+    """
+    if ema is None:
+        raise ValueError(
+            "compute_ema_anchor_surface_p called without an EMA tracker; "
+            "--vol-surface-anchor-use-ema requires --use-ema (default)."
+        )
+    ema.store(base_model)
+    ema.copy_to(base_model)
+    was_training = model.training
+    model.eval()
+    try:
+        with torch.no_grad():
+            with autocast_context(device, amp_mode):
+                out = model(
+                    surface_x=batch.surface_x,
+                    surface_mask=batch.surface_mask,
+                    volume_x=batch.volume_x,
+                    volume_mask=batch.volume_mask,
+                )
+        surf_p_ema = out["surface_preds"][..., 0:1].detach().float()
+    finally:
+        if was_training:
+            model.train()
+        ema.restore(base_model)
+    return surf_p_ema
 
 
 def synced_per_task_tensor(
@@ -810,6 +950,29 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"min_weight={config.gradnorm_min_weight}; "
                         f"closed-form weights from r_i = ema_loss_i / initial_loss_i"
                     )
+        if config.vol_surface_anchor_residual:
+            vol_anchor_cfg: dict | None = {
+                "enabled": True,
+                "chunk_size": int(config.vol_surface_anchor_chunk_size),
+                "dist_decay": float(config.vol_surface_anchor_dist_decay),
+                "use_ema": bool(config.vol_surface_anchor_use_ema),
+            }
+            if config.vol_surface_anchor_use_ema and ema is None:
+                raise ValueError(
+                    "--vol-surface-anchor-use-ema requires --use-ema (default true). "
+                    "EMA tracker is None — re-enable EMA or drop the flag."
+                )
+            if state.is_main:
+                print(
+                    "Vol surface-anchor residual ENABLED: "
+                    f"use_ema={vol_anchor_cfg['use_ema']} "
+                    f"dist_decay={vol_anchor_cfg['dist_decay']} "
+                    f"chunk_size={vol_anchor_cfg['chunk_size']} "
+                    "(decoder learns Δ = vol_target - nearest_surface_p)"
+                )
+        else:
+            vol_anchor_cfg = None
+
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
         if kill_thresholds and state.is_main:
             print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
@@ -915,9 +1078,33 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                # Optionally source the anchor surface_p from a separate
+                # forward with EMA weights (Arm B). Computed once per batch
+                # and reused by both the GradNorm and standard loss paths.
+                surface_pred_for_anchor: torch.Tensor | None = None
+                if (
+                    vol_anchor_cfg is not None
+                    and bool(vol_anchor_cfg.get("use_ema", False))
+                    and ema is not None
+                ):
+                    batch_dev = batch.to(device)
+                    surface_pred_for_anchor = compute_ema_anchor_surface_p(
+                        model=model,
+                        base_model=base_model,
+                        ema=ema,
+                        batch=batch_dev,
+                        device=device,
+                        amp_mode=config.amp_mode,
+                    )
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        vol_anchor_cfg=vol_anchor_cfg,
+                        surface_pred_for_anchor=surface_pred_for_anchor,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1008,6 +1195,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_anchor_cfg=vol_anchor_cfg,
+                        surface_pred_for_anchor=surface_pred_for_anchor,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1048,6 +1237,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for k, v in batch_loss_metrics.items():
+                        if k.startswith("vol_anchor/"):
+                            train_log[f"train/{k}"] = v
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1211,6 +1403,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        vol_anchor_cfg=vol_anchor_cfg,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1225,6 +1418,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    vol_anchor_cfg=vol_anchor_cfg,
                 )
                 for name, loader in val_loaders.items()
             }
@@ -1345,6 +1539,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             n_params=n_params,
             global_step=global_step,
             total_minutes=total_minutes,
+            vol_anchor_cfg=vol_anchor_cfg,
         )
         wandb.finish()
     finally:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -865,6 +865,110 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+@torch.no_grad()
+def compute_surface_anchor(
+    vol_coords: torch.Tensor,
+    surf_coords: torch.Tensor,
+    surf_pressure_pred: torch.Tensor,
+    *,
+    surf_mask: torch.Tensor | None = None,
+    chunk_size: int = 4096,
+    dist_decay: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-volume-point surface-pressure anchor via chunked nearest-neighbor.
+
+    For each volume point, finds the nearest valid surface point (k=1, L2)
+    and gathers its predicted surface pressure as the anchor value. The
+    chunked scan over surface points keeps peak memory at
+    ``O(B * N_vol * chunk_size)`` instead of the ``O(B * N_vol * N_surf)``
+    a single cdist call would allocate.
+
+    Inputs:
+        vol_coords:          ``[B, N_vol, 3]`` raw-meter coordinates
+        surf_coords:         ``[B, N_surf, 3]`` raw-meter coordinates
+        surf_pressure_pred:  ``[B, N_surf, 1]`` predicted surface pressure
+                             (already detached/no-grad — gradients are not
+                             expected to flow through the anchor path)
+        surf_mask:           optional ``[B, N_surf]`` bool, ``True`` = valid.
+                             Padded points are excluded from NN selection by
+                             setting their distance to ``+inf``.
+        chunk_size:          surface-axis chunk for the cdist scan
+        dist_decay:          if > 0, scales the anchor by
+                             ``exp(-dist / dist_decay)`` so far-field volume
+                             points relax toward 0 (freestream in normalized
+                             space). 0 disables the decay.
+
+    Returns:
+        anchor_p: ``[B, N_vol, 1]`` per-volume-point anchor pressure
+        nn_dist:  ``[B, N_vol]`` L2 distance to nearest surface point
+    """
+    if vol_coords.shape[0] != surf_coords.shape[0]:
+        raise ValueError("vol_coords and surf_coords must share batch dim")
+    if surf_pressure_pred.shape[:2] != surf_coords.shape[:2]:
+        raise ValueError(
+            f"surf_pressure_pred shape {tuple(surf_pressure_pred.shape)} must "
+            f"match surf_coords first two dims {tuple(surf_coords.shape[:2])}"
+        )
+    if surf_pressure_pred.shape[-1] != 1:
+        raise ValueError(
+            f"surf_pressure_pred last dim must be 1, got {surf_pressure_pred.shape[-1]}"
+        )
+    surf_pressure_pred = surf_pressure_pred.detach()
+
+    B, N_vol, _ = vol_coords.shape
+    N_surf = surf_coords.shape[1]
+    device = vol_coords.device
+    chunk_size = max(1, int(chunk_size))
+
+    # Loader-driven edge cases: surface- or volume-empty batches arise
+    # whenever a case's modality view count differs (per program.md). With
+    # no surface points there is nothing to anchor on; with no volume
+    # points there is nothing to anchor for. In both cases the
+    # downstream volume loss is masked anyway, so a zero-anchor fallback
+    # leaves the standard absolute-mode loss path intact for the batch.
+    if N_surf == 0 or N_vol == 0:
+        anchor_p = torch.zeros((B, N_vol, 1), device=device, dtype=torch.float32)
+        nn_dist = torch.full((B, N_vol), float("inf"), device=device, dtype=torch.float32)
+        return anchor_p, nn_dist
+
+    # Run NN scan in fp32 with autocast disabled — cdist + min are
+    # geometry-only and don't benefit from bf16, and downstream gather
+    # needs a fully materialised contiguous source.
+    with torch.amp.autocast(device_type=device.type, enabled=False):
+        vol_f = vol_coords.detach().float().contiguous()
+        surf_f = surf_coords.detach().float().contiguous()
+        surf_p_f = surf_pressure_pred.float().contiguous()
+
+        best_dist = vol_f.new_full((B, N_vol), float("inf"))
+        best_idx = torch.zeros((B, N_vol), dtype=torch.long, device=device)
+
+        for start in range(0, N_surf, chunk_size):
+            end = min(start + chunk_size, N_surf)
+            surf_chunk = surf_f[:, start:end, :].contiguous()
+            dists = torch.cdist(vol_f, surf_chunk, p=2)
+            if surf_mask is not None:
+                chunk_mask = surf_mask[:, start:end].to(device=device).bool()
+                dists = dists.masked_fill(~chunk_mask.unsqueeze(1), float("inf"))
+            chunk_min, chunk_argmin = dists.min(dim=-1)
+            chunk_argmin_global = chunk_argmin + start
+            update = chunk_min < best_dist
+            best_dist = torch.where(update, chunk_min, best_dist)
+            best_idx = torch.where(update, chunk_argmin_global, best_idx)
+
+        # Advanced indexing avoids a Blackwell torch.gather kernel quirk
+        # that surfaces a "storage of size 0" error on the [B, N_vol, 1]
+        # output shape. surf_p_f is [B, N_surf, 1]; the indexed result is
+        # [B, N_vol, 1] (last dim preserved by integer-array indexing).
+        batch_idx = torch.arange(B, device=device).unsqueeze(-1).expand(B, N_vol)
+        anchor_p = surf_p_f[batch_idx, best_idx]
+
+        if dist_decay > 0.0:
+            decay_w = torch.exp(-best_dist / float(dist_decay)).unsqueeze(-1)
+            anchor_p = decay_w * anchor_p
+
+    return anchor_p.detach(), best_dist.detach()
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -955,6 +1059,7 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    vol_anchor_cfg: Mapping[str, object] | None = None,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -969,6 +1074,18 @@ def accumulate_eval_batch(
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
+    if vol_anchor_cfg is not None and bool(vol_anchor_cfg.get("enabled", False)):
+        anchor_p_norm, _ = compute_surface_anchor(
+            vol_coords=batch.volume_x[..., :3],
+            surf_coords=batch.surface_x[..., :3],
+            surf_pressure_pred=surface_pred_norm[..., 0:1],
+            surf_mask=batch.surface_mask,
+            chunk_size=int(vol_anchor_cfg.get("chunk_size", 4096)),
+            dist_decay=float(vol_anchor_cfg.get("dist_decay", 0.0)),
+        )
+        # Decoder output is interpreted as a residual; reconstruct absolute
+        # volume pressure prediction in normalized space before metrics.
+        volume_pred_norm = volume_pred_norm + anchor_p_norm
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
     volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     accumulator.surface_loss_sse += surface_sse
@@ -1121,6 +1238,7 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    vol_anchor_cfg: Mapping[str, object] | None = None,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1132,6 +1250,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            vol_anchor_cfg=vol_anchor_cfg,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1445,6 +1564,7 @@ def run_final_evaluation(
     n_params: int,
     global_step: int,
     total_minutes: float,
+    vol_anchor_cfg: Mapping[str, object] | None = None,
 ) -> None:
     checkpoint = torch.load(model_path, map_location=device, weights_only=True)
     model.load_state_dict(checkpoint["model"])
@@ -1466,7 +1586,14 @@ def run_final_evaluation(
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            vol_anchor_cfg=vol_anchor_cfg,
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1486,7 +1613,14 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            vol_anchor_cfg=vol_anchor_cfg,
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

**Issue #717 — Per-point surface-anchored residual decoder for vol_pressure (physical prior + OOD conditioning)**

**Context:** Three converging loss-mass negatives (#752, #737, #763) confirm the test_vol_p gap is NOT addressable via point-density or loss-mass manipulation. Askeladd PR #767 (Phase 0 diagnostic) confirmed the gap is case-dominated — a small number of geometrically-OOD test cases (run_133, run_226, run_203, run_158) account for ~92% of the squared test_vol_p deviation. PRs #771 (askeladd, global scalar offset) and #770 (frieren, FiLM block-wise) are pursuing global and block-wise geometry conditioning. This PR tests a **physically-motivated per-point** conditioning approach.

**Core idea:** Instead of predicting vol_pressure absolutely (predicting pressure from scratch for each volume point), decompose the prediction as:

```
vol_p_pred(x) = surface_p_anchor(x) + Δ(x)
```

Where:
- `surface_p_anchor(x)` = the surface pressure prediction at the nearest surface point to volume point x
- `Δ(x)` = the residual pressure change predicted by the model (what it currently predicts, now re-interpreted as a deviation from the surface anchor)

**Physical justification:** Volume pressure is NOT independent of surface pressure — pressure diffuses from the car surface into the flow field. The near-field volume pressure should be close to the surface pressure at the nearest surface point. Far-field points (far from the car) should relax toward freestream. By anchoring on surface_p predictions (which transfer well, val→test ratio <1×), the volume decoder only needs to learn the local pressure deviation, which has much lower geometric variance than absolute volume pressure. If the model learns `Δ ≈ 0` for near-surface points, the volume prediction inherits the well-conditioned surface encoder.

**Why this is different from #771 (askeladd global scalar offset):**
- #771 learns a global per-case scalar bias from the surface latent — one number per case
- This PR: per-point anchor from the nearest predicted surface pressure — fully local, no learned parameters beyond the existing decoder
- If #771 works: global geometry conditioning is the fix → merge and consider per-point refinement
- If #771 fails but this works: local surface-pressure anchoring is the correct primitive

**Implementation:** The anchor lookup is efficient — the surface points are already predicted in the forward pass. The k-NN query (k=1, surface→volume) can be precomputed or done online at low cost.

**Expected effect:** For the 4 OOD test cases where vol_p is severely under-predicted, the surface_p on those cases is already predicted well. If the residual `Δ(x)` is smaller in magnitude and more geometry-invariant than the absolute pressure, the model should generalize better to OOD test geometries.

## Instructions

Implement `--vol-surface-anchor-residual` flag (boolean, default False) in `target/train.py`.

### Architecture change

The surface and volume decoders run in sequence in the forward pass. After surface prediction, perform a nearest-neighbor lookup of the predicted surface pressure values to generate per-volume-point anchors, then decompose the volume pressure target into the residual.

**Step 1 — Nearest-surface lookup module**

Add a `SurfaceAnchorLookup` helper (no learnable parameters):

```python
class SurfaceAnchorLookup(nn.Module):
    """
    For each volume point, find the nearest surface point (k=1) and
    return that surface point's predicted pressure as the anchor value.
    
    Uses a simple L2 nearest-neighbor — no learned parameters.
    All tensors must be on the same device.
    """
    def __init__(self):
        super().__init__()
    
    @torch.no_grad()
    def forward(
        self,
        vol_coords: torch.Tensor,      # B × N_vol × 3
        surf_coords: torch.Tensor,     # B × N_surf × 3
        surf_pressure_pred: torch.Tensor,  # B × N_surf × 1
    ) -> torch.Tensor:
        """Returns B × N_vol × 1 anchor pressures (from nearest surface point)."""
        B, N_vol, _ = vol_coords.shape
        N_surf = surf_coords.shape[1]
        
        # Pairwise distances: B × N_vol × N_surf
        # Use torch.cdist for efficiency
        dists = torch.cdist(vol_coords, surf_coords, p=2)  # B × N_vol × N_surf
        
        # Nearest surface point index for each volume point
        nn_idx = dists.argmin(dim=-1)  # B × N_vol
        
        # Gather surface pressures at nearest indices
        # surf_pressure_pred: B × N_surf × 1 → B × N_vol × 1
        nn_idx_exp = nn_idx.unsqueeze(-1)  # B × N_vol × 1
        anchor_p = torch.gather(surf_pressure_pred, dim=1, index=nn_idx_exp)
        
        return anchor_p  # B × N_vol × 1
```

**Step 2 — Modify the forward/loss computation**

When `--vol-surface-anchor-residual` is active:

1. After computing `surf_pred` (surface pressure predictions, B × N_surf × C_surf, where channel 0 = pressure), extract the surface pressure channel: `surf_p_pred = surf_pred[..., 0:1]` (shape B × N_surf × 1).

2. Compute per-volume-point anchors using `SurfaceAnchorLookup`:
   ```python
   vol_p_anchor = self.surf_anchor_lookup(
       vol_coords=batch_vol_coords,    # B × N_vol × 3
       surf_coords=batch_surf_coords,  # B × N_surf × 3
       surf_pressure_pred=surf_p_pred, # B × N_surf × 1
   )  # B × N_vol × 1
   ```

3. At loss computation time, compute the anchor-adjusted volume pressure loss:
   - Volume pressure ground truth is `vol_target[..., 0:1]` (shape B × N_vol × 1)
   - Volume pressure prediction (pre-anchor) is `vol_pred[..., 0:1]` (shape B × N_vol × 1)
   - Residual target: `vol_p_residual_target = vol_target[..., 0:1] - vol_p_anchor`
   - Residual prediction: `vol_p_residual_pred = vol_pred[..., 0:1] - vol_p_anchor`
   - Use the residual formulation for the vol_pressure loss term only; other channels (tau_x, tau_y, tau_z) are unaffected.

4. **At evaluation/inference time**, convert back to absolute predictions before computing metrics:
   ```python
   vol_pred_abs[..., 0:1] = vol_pred_residual[..., 0:1] + vol_p_anchor
   ```
   Metrics must be reported in absolute space (the standard rel-L2 metrics in `trainer_runtime.py`).

**Important implementation notes:**
- `torch.cdist` on B × 65536 × 3 vs B × 65536 × 3 allocates a B × 65536 × 65536 × 4 bytes tensor which is ~64GB for B=1 — this is too large. Use chunked or approximated NN instead:
  - Option A (recommended): Chunked scan over N_surf in blocks of 4096 to keep peak memory O(N_vol × 4096) ≈ 1GB
  - Option B: Use only a **spatial grid hash** subset — the 1024 nearest surface points by coarse x-z bucket (~100× faster)
  - Option C: Precompute surface→volume NN mapping once per case at first epoch and cache on disk (fastest at training time, requires cache management)
  
  **Use Option A (chunked) by default** — it's the simplest and guaranteed correct. Add flag `--vol-surface-anchor-chunk-size 4096` for tuning.

- The `@torch.no_grad()` decorator on `SurfaceAnchorLookup.forward` ensures gradients don't flow through the anchor path — the anchor is treated as a detached reference, not a second optimization target. This is intentional: we don't want the surface decoder to be "corrected" by its impact on volume anchor quality. The surface decoder should optimize surface metrics alone; the volume residual decoder optimizes the residual.

- **Zero-init residual:** At initialization, if the volume decoder was trained on absolute pressure (the existing SOTA checkpoint), the residual `Δ(x) = vol_pred(x) - anchor(x)` will initially be a mix of signal and noise. The model will adapt to predict the correct residual within 1–2 epochs. No special initialization is needed.

### Kill gates

- EP1: val_abupt < 32.0%, val_vol_p < 18.0%
- EP2: val_abupt < 12.0%, val_vol_p < 6.0%
- EP3: val_abupt < 8.5%, val_vol_p < 5.5%

### Experiment arms

Run a **3-arm sweep** in parallel (3 GPUs × 8 = 24 GPUs total; or 8 GPUs per arm if resource-constrained, run Arm A first):

**Arm A — anchor on raw predicted surf_p (standard)**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --kill-thresholds "21729:val_primary/abupt_axis_mean_rel_l2_pct<12;32594:val_primary/abupt_axis_mean_rel_l2_pct<8" \
  --vol-surface-anchor-residual \
  --vol-surface-anchor-chunk-size 4096 \
  --wandb-group nezuko-surf-anchor-residual \
  --wandb-name nezuko/surf-anchor-A-raw-pred
```

**Arm B — anchor on EMA-smoothed surf_p (more stable anchor)**

Same as Arm A but add `--vol-surface-anchor-use-ema` flag which uses the EMA model's surface pressure as the anchor (more stable than the online model's surf_p during early training):

```bash
  # (same flags as Arm A, change --wandb-name)
  --vol-surface-anchor-residual \
  --vol-surface-anchor-use-ema \
  --vol-surface-anchor-chunk-size 4096 \
  --wandb-group nezuko-surf-anchor-residual \
  --wandb-name nezuko/surf-anchor-B-ema-anchor
```

**Arm C — ablation: anchor weight decay (stronger near-surface, weaker far-field)**

Add `--vol-surface-anchor-dist-decay 0.5` flag: anchor contribution is `exp(-dist/0.5) * anchor_p + (1 - exp(-dist/0.5)) * 0.0`, so far-field volume points (far from car surface) are anchored weakly toward 0 (freestream) instead of toward the nearest surface point:

```bash
  # (same flags as Arm A, change --wandb-name and add --vol-surface-anchor-dist-decay)
  --vol-surface-anchor-residual \
  --vol-surface-anchor-dist-decay 0.5 \
  --vol-surface-anchor-chunk-size 4096 \
  --wandb-group nezuko-surf-anchor-residual \
  --wandb-name nezuko/surf-anchor-C-dist-decay
```

**Gating:** Run Arm A first. If EP3 val_vol_p ≥ 4.5% OR val_abupt ≥ 8.0% → cancel Arm B & C; post results. If Arm A clears EP3 gates, run Arm B and C.

### Additional diagnostics to log (for all arms)

Add per-region vol_pressure logging to trainer_runtime.py (reuse existing `compute_volume_region_weights` from PR #763/#737):

```python
# Log per-region vol_p metrics (same regions as #763)
# val/test: vol_p_upstream, vol_p_near, vol_p_far
# Log upstream val→test ratio as a derived metric
```

This is a 3-line addition to `evaluate_split`. The upstream val→test ratio is the key diagnostic for whether surface anchoring is addressing the OOD gap.

## Baseline

Current single-model SOTA:
- **W&B run:** `4k25s25e` (alphonse DDP8, PR #592)
- val_abupt = **6.5985%** (gate: must beat this to merge)
- val_vol_p = 3.9456%
- val surface_pressure = 4.3322%
- val wall_shear_x = 6.5420%, wall_shear_y = 8.3631%, wall_shear_z = 9.8099%
- test_abupt = 7.9915%
- test_vol_p = **11.694%** (PR #681, vol-anchor SOTA — key target for vol_p gap research)
- test_vol_p upstream val→test ratio = ~2.76× (PR #737, near-wake-weighting)

**Vol_p gap diagnostic baseline (PR #767 Phase 0 confirmed):**
- Top-4 OOD cases (run_133, run_226, run_203, run_158) account for ~92% of squared test_vol_p deviation
- Surface_p and wall_shear transfer with val→test ratio <1× — only vol_p suffers

**Decision gates:**
- Merge: val_abupt < 6.5985% (single-model SOTA gate)
- Strong success on vol_p target: test_vol_p < 11.374% (PR #681 anchor) AND upstream val→test ratio < 2.5×
- Promising (send back for iteration): val_vol_p improves by ≥0.15pp relative to baseline 3.9456%, or upstream val→test ratio < 2.3×, without aggregate regression
- Close: EP3 gate fail OR val_vol_p regression ≥ 0.3pp vs baseline

