### PR TITLE
[fern] Anchor-STRING RoPE v2: true coord Q/K rotation (Issue #618 Exp 3 Redux)

### DIFF
--- a/model.py
+++ b/model.py
@@ -136,6 +136,139 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class AnchorStringRoPE(nn.Module):
+    """Learnable per-axis rotary encoding on actual 3D point coordinates.
+
+    Performs a sub-sampled cross-attention pass: queries come from all N
+    points, keys/values come from K=n_anchors uniformly strided anchors.
+    Per-axis log-frequencies rotate Q and K with their own coordinates,
+    yielding spatial relative-position dependence on `(coord_q - coord_k)`.
+
+    Designed for Issue #618 Exp 3 Redux (PR #774): bypasses the Transolver
+    slice bottleneck by operating directly on raw [x, y, z] coordinates and
+    is added residually to existing volume features. Output projection is
+    zero-init so the residual starts as identity pass-through.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        n_heads: int,
+        n_anchors: int = 512,
+        ndim: int = 3,
+    ):
+        super().__init__()
+        if hidden_dim % n_heads != 0:
+            raise ValueError("hidden_dim must be divisible by n_heads")
+        self.hidden_dim = hidden_dim
+        self.n_heads = n_heads
+        self.n_anchors = n_anchors
+        self.ndim = ndim
+        self.head_dim = hidden_dim // n_heads
+        # freqs_per_axis: number of frequency pairs per spatial axis. The
+        # remaining (head_dim - ndim*2*freqs_per_axis) dims are passthrough.
+        self.freqs_per_axis = self.head_dim // (2 * ndim)
+        if self.freqs_per_axis <= 0:
+            raise ValueError(
+                f"head_dim={self.head_dim} too small for ndim={ndim} (need head_dim>=2*ndim)"
+            )
+        self.rope_dim_per_head = self.freqs_per_axis * 2 * ndim
+
+        # Log-spaced 0.1..10.0 Hz per axis; matched to DrivAerML coord scale
+        # ~[-2, 2] m. NLP defaults (theta=10000) are wrong for spatial inputs.
+        log_freqs_init = torch.linspace(
+            math.log(0.1), math.log(10.0), self.freqs_per_axis
+        )
+        self.log_freqs = nn.Parameter(
+            log_freqs_init.unsqueeze(0).expand(ndim, -1).clone()
+        )
+
+        # Independent QKV/output projections for the residual branch.
+        self.qkv = nn.Linear(hidden_dim, 3 * hidden_dim, bias=False)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        nn.init.trunc_normal_(self.qkv.weight, std=0.02)
+        nn.init.zeros_(self.out_proj.weight)
+
+    def _apply_rope_to_qk(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        coords_q: torch.Tensor,
+        coords_k: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # q, k:                [B, H, seq_len, head_dim]
+        # coords_q, coords_k:  [B, seq_len, ndim]
+        freqs = self.log_freqs.exp()  # [ndim, freqs_per_axis]
+        fpa = self.freqs_per_axis
+        D_head = q.shape[-1]
+
+        def rotate_single(tensor: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+            parts: list[torch.Tensor] = []
+            coords_f = coords.to(dtype=tensor.dtype)
+            for ax in range(self.ndim):
+                c = coords_f[:, :, ax]
+                f = freqs[ax].to(dtype=tensor.dtype)
+                angles = c.unsqueeze(-1) * f.unsqueeze(0).unsqueeze(0)
+                cos_a = angles.cos().unsqueeze(1)
+                sin_a = angles.sin().unsqueeze(1)
+                start = ax * 2 * fpa
+                sl = tensor[..., start:start + 2 * fpa]
+                sl_l, sl_r = sl[..., :fpa], sl[..., fpa:]
+                rot = torch.cat(
+                    [sl_l * cos_a - sl_r * sin_a, sl_r * cos_a + sl_l * sin_a],
+                    dim=-1,
+                )
+                parts.append(rot)
+            if self.rope_dim_per_head < D_head:
+                parts.append(tensor[..., self.rope_dim_per_head:])
+            return torch.cat(parts, dim=-1)
+
+        return rotate_single(q, coords_q), rotate_single(k, coords_k)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # features: [B, N, hidden_dim]
+        # coords:   [B, N, ndim]  raw 3D positions
+        # mask:     [B, N] optional, 1 for valid tokens, 0 for padded
+        B, N, D = features.shape
+        H, hd = self.n_heads, self.head_dim
+        K = min(self.n_anchors, N)
+
+        # Uniform-stride sub-sampling of anchors.
+        stride = max(1, N // K)
+        anchor_idx = torch.arange(0, N, stride, device=features.device)[:K]
+        anchor_feats = features.index_select(1, anchor_idx)
+        anchor_coords = coords.index_select(1, anchor_idx)
+
+        qkv_all = self.qkv(features)
+        qkv_anc = self.qkv(anchor_feats)
+        q = qkv_all[:, :, :D]
+        k = qkv_anc[:, :, D:2 * D]
+        v = qkv_anc[:, :, 2 * D:]
+
+        q = q.view(B, N, H, hd).transpose(1, 2)
+        k = k.view(B, K, H, hd).transpose(1, 2)
+        v = v.view(B, K, H, hd).transpose(1, 2)
+
+        q_rot, k_rot = self._apply_rope_to_qk(q, k, coords, anchor_coords)
+
+        attn_mask = None
+        if mask is not None:
+            anchor_mask = mask.index_select(1, anchor_idx)
+            attn_mask = anchor_mask.bool().view(B, 1, 1, K)
+
+        out = F.scaled_dot_product_attention(q_rot, k_rot, v, attn_mask=attn_mask)
+        out = out.transpose(1, 2).reshape(B, N, D)
+        out = self.out_proj(out)
+        if mask is not None:
+            out = out * mask.unsqueeze(-1).to(dtype=out.dtype)
+        return out
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -357,10 +490,12 @@ class SurfaceTransolver(nn.Module):
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        if pos_encoding_mode == "string_separable":
+        if pos_encoding_mode in ("string_separable", "anchor_string_rope"):
             # STRING-separable: learnable per-axis log_freq + phase,
-            # replaces fixed isotropic Gaussian RFF.
-            # num_features defaults to rff_num_features if provided, else 32.
+            # replaces fixed isotropic Gaussian RFF. Shared between
+            # `string_separable` and `anchor_string_rope` modes — the
+            # anchor-RoPE branch only adds a residual cross-attention
+            # over actual 3D coords on the volume path.
             string_sep_features = rff_num_features if rff_num_features > 0 else 32
             self.surface_string_sep = StringSeparableEncoding(
                 in_dim=space_dim,
@@ -409,6 +544,15 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        if pos_encoding_mode == "anchor_string_rope":
+            self.anchor_rope_vol = AnchorStringRoPE(
+                hidden_dim=n_hidden,
+                n_heads=n_head,
+                n_anchors=512,
+                ndim=space_dim,
+            )
+        else:
+            self.anchor_rope_vol = None
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -506,6 +650,13 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.anchor_rope_vol is not None and volume_x is not None:
+            vol_coords_xyz = volume_x[:, :, : self.space_dim]
+            rope_delta = self.anchor_rope_vol(
+                volume_hidden, vol_coords_xyz, mask=volume_mask
+            )
+            volume_hidden = volume_hidden + rope_delta
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -233,9 +233,45 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _split_anchor_rope_freq_params(
+    model: nn.Module,
+) -> tuple[list[nn.Parameter], list[nn.Parameter]]:
+    """Return (main_params, rope_freq_params) where the second group is
+    the per-axis log-frequency tensor for AnchorStringRoPE. The frequency
+    parameter rotates Q/K phase across all heads at once, so it gets a
+    smaller LR (PR #774 differential-LR fix from PR #769 divergence)."""
+    rope_freq_params: list[nn.Parameter] = []
+    main_params: list[nn.Parameter] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.endswith("anchor_rope_vol.log_freqs"):
+            rope_freq_params.append(param)
+        else:
+            main_params.append(param)
+    return main_params, rope_freq_params
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    main_params, rope_freq_params = _split_anchor_rope_freq_params(model)
+    use_param_groups = bool(rope_freq_params)
     if optimizer_name == "adamw":
+        if use_param_groups:
+            return torch.optim.AdamW(
+                [
+                    {
+                        "params": main_params,
+                        "lr": config.lr,
+                        "weight_decay": config.weight_decay,
+                    },
+                    {
+                        "params": rope_freq_params,
+                        "lr": config.lr * 0.1,
+                        "weight_decay": 0.0,
+                    },
+                ],
+            )
         return torch.optim.AdamW(
             model.parameters(),
             lr=config.lr,
@@ -244,6 +280,23 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
+        if use_param_groups:
+            return Lion(
+                [
+                    {
+                        "params": main_params,
+                        "lr": config.lr,
+                        "weight_decay": config.weight_decay,
+                    },
+                    {
+                        "params": rope_freq_params,
+                        "lr": config.lr * 0.1,
+                        "weight_decay": 0.0,
+                    },
+                ],
+                betas=(config.lion_beta1, config.lion_beta2),
+                use_triton=False,
+            )
         return Lion(
             model.parameters(),
             lr=config.lr,
@@ -281,6 +334,34 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
         for axis in range(log_freq.shape[0]):
             metrics[f"{prefix}/freq_axis_{axis}_mean"] = float(log_freq[axis].mean().item())
             metrics[f"{prefix}/freq_axis_{axis}_std"] = float(log_freq[axis].std().item())
+    return metrics
+
+
+def collect_anchor_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-axis log-frequency diagnostics for AnchorStringRoPE.
+
+    PR #774 EP1 kill-gate watches `anchor_rope/log_freqs_mean` and
+    `anchor_rope/log_freqs_max_hz` to detect runaway/freezing of the
+    learnable frequency parameters (the failure mode of PR #769)."""
+
+    module = getattr(model, "anchor_rope_vol", None)
+    if module is None:
+        return {}
+    log_freqs = module.log_freqs.detach().float()
+    freqs_hz = log_freqs.exp()
+    prefix = "anchor_rope"
+    metrics: dict[str, float] = {
+        f"{prefix}/log_freqs_mean": float(log_freqs.mean().item()),
+        f"{prefix}/log_freqs_std": float(log_freqs.std().item()),
+        f"{prefix}/log_freqs_min": float(log_freqs.min().item()),
+        f"{prefix}/log_freqs_max": float(log_freqs.max().item()),
+        f"{prefix}/freqs_hz_min": float(freqs_hz.min().item()),
+        f"{prefix}/freqs_hz_max": float(freqs_hz.max().item()),
+        f"{prefix}/freqs_hz_mean": float(freqs_hz.mean().item()),
+    }
+    for axis in range(log_freqs.shape[0]):
+        metrics[f"{prefix}/log_freqs_axis_{axis}_mean"] = float(log_freqs[axis].mean().item())
+        metrics[f"{prefix}/log_freqs_axis_{axis}_max"] = float(log_freqs[axis].max().item())
     return metrics
 
 
@@ -1240,6 +1321,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_anchor_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The Transolver's slice-token bottleneck prevents true coordinate-dependent Q/K attention — slice centroids are abstract learned features, not spatial positions, so applying RoPE on them is architecturally unsound (confirmed by PR #769 failure: log_freq desensitized, val_abupt stuck at 26.59% = 3× SOTA at EP2, zero improvement EP1→EP2).

The correct implementation of positional encoding in attention is **Anchor-STRING**: bypass the slice bottleneck by applying learnable per-axis rotary encoding directly to actual 3D point coordinates in a sub-sampled attention pass. This is architecturally identical to AB-UPT's `RopeFrequency(dim=head_dim, ndim=3)` + `DotProductAttention` with explicit coordinates — the model that defines our target metric.

**Root cause fixes from PR #769 divergence:**
1. **Differential LR**: 0.1× for RoPE frequency parameters (prevent large gradient steps on coordinate-scale params)
2. **Conservative freq init**: log-spaced between 0.1–10.0 Hz, matched to DrivAerML spatial scale ~[-2,2]m (not NLP defaults)
3. **No slice bottleneck in the new path**: attention operates on actual 3D points (K=512 sub-sampled anchors), not abstract slice tokens
4. **Residual connection**: anchor-RoPE output is added residually to existing volume features (after Transolver backbone), so even if the RoPE signal is weak initially, the backbone retains its performance

**Expected signal**: if the architecture can learn spatial attention via coordinate-dependent Q/K, volume_pressure generalization should improve (the 4 OOD geometry test cases should become more distinguishable). Watch `val_vol_pressure` closely — this is the primary diagnostic metric.

## Background: What Exp 4 (PR #626) Showed

The AB-UPT geometry branch in Exp 4 **compressed the vol_pressure val→test gap from 3.17× to 2.07×** (−35%) even though headline val_abupt regressed. This is a strong signal that coordinate-aware attention helps with geometry-OOD robustness. The problem was training efficiency — the geometry branch competed poorly with the warm backbone. This experiment fixes that with residual addition and differential LR.

References: [AB-UPT paper](https://arxiv.org/abs/2402.12969), Issue #618, Issue #717

## Instructions

This requires modifying `target/model.py` to add a new `pos_encoding_mode = "anchor_string_rope"` path. **Do NOT modify the existing `string_separable` path** — keep it untouched.

### Step 1: Add `AnchorStringRoPE` module to `model.py`

Add this new class (insert after `StringSeparableEncoding`):

```python
import math

class AnchorStringRoPE(nn.Module):
    """
    Learnable per-axis rotary encoding on actual 3D point coordinates.
    Sub-samples K anchor points, computes attention between all N points
    and K anchors with coordinate-dependent Q/K rotation.
    
    Freq init: log-spaced 0.1..10.0 Hz — matched to DrivAerML scale ~[-2,2]m.
    Residual: output is added back to input features.
    """
    def __init__(self, hidden_dim: int, n_heads: int, n_anchors: int = 512, ndim: int = 3):
        super().__init__()
        self.hidden_dim = hidden_dim
        self.n_heads = n_heads
        self.n_anchors = n_anchors
        self.ndim = ndim
        self.head_dim = hidden_dim // n_heads
        
        # freqs_per_axis: how many frequency pairs per spatial axis
        # remaining head_dim dims are passthrough (no rotation)
        self.freqs_per_axis = self.head_dim // (2 * ndim)  # floor division
        self.rope_dim_per_head = self.freqs_per_axis * 2 * ndim
        
        # Log-frequencies init: log-spaced 0.1..10.0 Hz per axis
        log_freqs_init = torch.linspace(
            math.log(0.1), math.log(10.0), self.freqs_per_axis
        )  # [freqs_per_axis]
        self.log_freqs = nn.Parameter(
            log_freqs_init.unsqueeze(0).expand(ndim, -1).clone()
        )  # [ndim, freqs_per_axis] — each axis independently learnable
        
        # Separate QKV and output projections (independent of backbone)
        self.qkv = nn.Linear(hidden_dim, 3 * hidden_dim, bias=False)
        self.out_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
        # Init output projection to zero so residual starts as identity
        nn.init.zeros_(self.out_proj.weight)
    
    def _apply_rope_to_qk(self, q, k, coords_q, coords_k):
        """
        q: [B, H, N, head_dim], k: [B, H, K, head_dim]
        coords_q: [B, N, ndim], coords_k: [B, K, ndim]
        Returns q_rot, k_rot with same shapes.
        """
        B, H, N, D = q.shape
        freqs = self.log_freqs.exp()  # [ndim, freqs_per_axis]
        fpa = self.freqs_per_axis  # abbreviation
        
        def rotate_single(tensor, coords):
            # tensor: [B, H, seq_len, D]
            # coords: [B, seq_len, ndim]
            parts = []
            for ax in range(self.ndim):
                c = coords[:, :, ax]  # [B, seq_len]
                f = freqs[ax]         # [fpa]
                angles = c.unsqueeze(-1) * f.unsqueeze(0).unsqueeze(0)  # [B, seq_len, fpa]
                cos_a = angles.cos().unsqueeze(1)  # [B, 1, seq_len, fpa]
                sin_a = angles.sin().unsqueeze(1)
                start = ax * 2 * fpa
                sl = tensor[..., start:start + 2*fpa]
                sl_l, sl_r = sl[..., :fpa], sl[..., fpa:]
                rot = torch.cat([sl_l * cos_a - sl_r * sin_a,
                                  sl_r * cos_a + sl_l * sin_a], dim=-1)
                parts.append(rot)
            # Passthrough for remaining dims
            if self.rope_dim_per_head < D:
                parts.append(tensor[..., self.rope_dim_per_head:])
            return torch.cat(parts, dim=-1)
        
        return rotate_single(q, coords_q), rotate_single(k, coords_k)
    
    def forward(self, features, coords):
        """
        features: [B, N, hidden_dim]
        coords:   [B, N, 3]  — actual 3D point positions
        Returns:  [B, N, hidden_dim]  — residual delta
        """
        B, N, D = features.shape
        H, hd = self.n_heads, self.head_dim
        K = min(self.n_anchors, N)
        
        # Sub-sample anchors: uniform stride
        stride = max(1, N // K)
        anchor_idx = torch.arange(0, N, stride, device=features.device)[:K]
        anchor_feats = features[:, anchor_idx]   # [B, K, D]
        anchor_coords = coords[:, anchor_idx]     # [B, K, 3]
        
        # Project all points to Q; anchors to K and V
        qkv_all = self.qkv(features)         # [B, N, 3D]
        qkv_anc = self.qkv(anchor_feats)     # [B, K, 3D]
        q = qkv_all[:, :, :D]               # [B, N, D]
        k = qkv_anc[:, :, D:2*D]            # [B, K, D]
        v = qkv_anc[:, :, 2*D:]             # [B, K, D]
        
        # Reshape to multi-head
        q = q.view(B, N, H, hd).transpose(1, 2)   # [B, H, N, hd]
        k = k.view(B, K, H, hd).transpose(1, 2)   # [B, H, K, hd]
        v = v.view(B, K, H, hd).transpose(1, 2)
        
        # Apply RoPE with actual 3D coordinates
        q_rot, k_rot = self._apply_rope_to_qk(q, k, coords, anchor_coords)
        
        # Scaled dot-product attention
        out = F.scaled_dot_product_attention(q_rot, k_rot, v)  # [B, H, N, hd]
        out = out.transpose(1, 2).reshape(B, N, D)
        return self.out_proj(out)
```

### Step 2: Integrate into `SurfaceTransolver.__init__`

When `pos_encoding_mode == "anchor_string_rope"`:
- Use the same input encoding as `string_separable` (STRING-sep for input features)
- Plus add `AnchorStringRoPE` for the volume path

```python
if pos_encoding_mode in ("string_separable", "anchor_string_rope"):
    string_sep_features = rff_num_features if rff_num_features > 0 else 32
    self.surface_string_sep = StringSeparableEncoding(
        in_dim=space_dim, num_features=string_sep_features,
        sigma=rff_sigma, init_sigmas=self.rff_init_sigmas,
    )
    self.volume_string_sep = StringSeparableEncoding(
        in_dim=space_dim, num_features=string_sep_features,
        sigma=rff_sigma, init_sigmas=self.rff_init_sigmas,
    )
    string_sep_out_dim = self.surface_string_sep.output_dim
    self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)
    self.surface_rff = None
    self.volume_rff = None
    rff_out_dim = string_sep_out_dim
    
    if pos_encoding_mode == "anchor_string_rope":
        self.anchor_rope_vol = AnchorStringRoPE(
            hidden_dim=n_hidden,
            n_heads=n_head,
            n_anchors=512,
            ndim=3,
        )
    else:
        self.anchor_rope_vol = None
```

### Step 3: Apply in `SurfaceTransolver.forward`

After the backbone Transolver pass, before the volume output head, add:

```python
if self.anchor_rope_vol is not None:
    # vol_features: [B, N_vol, D], vol_coords: [B, N_vol, 3]
    # coords should be the raw 3D coordinates (x, y, z), NOT the encoded features
    rope_delta = self.anchor_rope_vol(vol_features, vol_coords_xyz)
    vol_features = vol_features + rope_delta  # residual addition
```

Where `vol_coords_xyz` is the raw 3D coordinates tensor (first 3 dims of volume input, before any encoding).

### Step 4: Differential LR for frequency parameters

In `train.py`, build the optimizer with separate param groups:

```python
rope_freq_params = [p for n, p in model.named_parameters() 
                    if 'anchor_rope_vol.log_freqs' in n]
main_params = [p for n, p in model.named_parameters() 
               if 'anchor_rope_vol.log_freqs' not in n]
# Lion optimizer with 0.1× LR for RoPE frequency params
optimizer = Lion([
    {'params': main_params, 'lr': config.lr, 'weight_decay': config.weight_decay},
    {'params': rope_freq_params, 'lr': config.lr * 0.1, 'weight_decay': 0.0},
], betas=(0.9, 0.99))
```

### Step 5: Diagnostic W&B logging

Add these logs in the training loop (every 100 steps):
```python
if hasattr(model, 'anchor_rope_vol') and model.anchor_rope_vol is not None:
    with torch.no_grad():
        lf = model.anchor_rope_vol.log_freqs
        wandb.log({
            'anchor_rope/log_freqs_mean': lf.mean().item(),
            'anchor_rope/log_freqs_min': lf.min().item(),
            'anchor_rope/log_freqs_max': lf.max().item(),
        })
        if lf.grad is not None:
            wandb.log({'anchor_rope/log_freqs_grad_norm': lf.grad.norm().item()})
```

### Training command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode anchor_string_rope \
  --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group fern-anchor-string-rope-v2
```

### Kill gates
- **EP1**: val_abupt > 35% → kill. Check `anchor_rope/log_freqs_mean` — should be near 0.0 (log space of initial ~1.0 Hz)
- **EP2**: val_abupt > 12% → kill
- **EP3**: val_abupt > 8.5% → kill
- **Success signal**: val_vol_pressure < 4.0% while val_abupt < 8.0% → this experiment is working

## Baseline

Current single-model SOTA: **PR #592** (alphonse, depth-L5, Lion+STRING-sep+QK-norm)
- **val_abupt = 6.5985%** (EP4, step 43,459, W&B run `4k25s25e`)
- val_vol_pressure = 3.9456%, test_vol_pressure ≈ 11.9%
- test_abupt = 7.9915%

Gate: val_abupt < **6.5985%** to beat single-model SOTA.
