### PR TITLE
Fix PR #772 unit-mismatch: learnable affine anchor for vol_p OOD gap

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,64 @@ class Transformer(nn.Module):
         return x
 
 
+class LearnableScaleAnchor(nn.Module):
+    """Learnable affine surface->volume anchor for ``volume_pressure``.
+
+    For each volume query point, finds the nearest unmasked surface point via
+    chunked ``cdist``, gathers that surface point's predicted pressure, and
+    returns ``alpha * surf_p_norm + beta`` as a correction added to the
+    normalized volume pressure prediction.
+
+    ``alpha`` and ``beta`` are initialised to zero so the network starts
+    identical to the no-anchor baseline (PR #775; analogous to ReZero /
+    LayerScale zero-init). The expected steady-state value of ``alpha`` in
+    normalized space is ~rho/2 V**2 * std_cp / std_volp ≈ 1.23 for DrivAerML
+    (V_inf=38 m/s, rho=1.225, std_cp≈0.356, std_volp≈255.9 Pa).
+
+    Padded surface points (mask=False) are excluded from the nearest-neighbor
+    search; padded volume points have their anchor forced to zero so they
+    contribute nothing to the masked loss.
+    """
+
+    def __init__(self, chunk_size: int = 4096):
+        super().__init__()
+        self.alpha = nn.Parameter(torch.zeros(1))
+        self.beta = nn.Parameter(torch.zeros(1))
+        self.chunk_size = int(chunk_size)
+
+    def forward(
+        self,
+        vol_xyz: torch.Tensor,        # (B, Nv, 3)
+        surf_xyz: torch.Tensor,       # (B, Ns, 3)
+        surf_p_norm: torch.Tensor,    # (B, Ns, 1) — normalized predicted Cp
+        surf_mask: torch.Tensor,      # (B, Ns) bool
+        vol_mask: torch.Tensor,       # (B, Nv) bool
+    ) -> torch.Tensor:                # (B, Nv, 1)
+        B, Nv, _ = vol_xyz.shape
+        Ns = surf_xyz.shape[1]
+        out = surf_p_norm.new_zeros(B, Nv, surf_p_norm.shape[-1])
+        if Ns == 0 or Nv == 0:
+            return self.alpha * out + self.beta * vol_mask.unsqueeze(-1).to(out.dtype)
+        for b in range(B):
+            sm_b = surf_mask[b]
+            if not bool(sm_b.any()):
+                continue
+            sp_b = surf_xyz[b]
+            sc_b = surf_p_norm[b]
+            vp_b = vol_xyz[b]
+            for start in range(0, Nv, self.chunk_size):
+                end = min(start + self.chunk_size, Nv)
+                vp_chunk = vp_b[start:end]
+                with torch.no_grad():
+                    d = torch.cdist(vp_chunk.unsqueeze(0), sp_b.unsqueeze(0))[0]
+                    d = d.masked_fill(~sm_b.unsqueeze(0), float("inf"))
+                    idx = d.argmin(dim=1)
+                out[b, start:end] = sc_b[idx]
+        anchor = self.alpha * out + self.beta
+        anchor = anchor * vol_mask.unsqueeze(-1).to(anchor.dtype)
+        return anchor
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +400,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_surface_anchor: bool = False,
+        surface_anchor_chunk_size: int = 4096,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +481,16 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.use_surface_anchor = use_surface_anchor
+        self.surface_anchor_chunk_size = surface_anchor_chunk_size
+        if use_surface_anchor:
+            if self.volume_output_dim != 1:
+                raise ValueError(
+                    "LearnableScaleAnchor expects volume_output_dim=1 (volume_pressure)"
+                )
+            self.surface_anchor = LearnableScaleAnchor(chunk_size=surface_anchor_chunk_size)
+        else:
+            self.surface_anchor = None
 
     def _encode_group(
         self,
@@ -518,6 +588,23 @@ class SurfaceTransolver(nn.Module):
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+
+        if (
+            self.surface_anchor is not None
+            and volume_x is not None
+            and surface_x is not None
+        ):
+            vol_xyz = volume_x[..., : self.space_dim].to(volume_preds.dtype)
+            surf_xyz = surface_x[..., : self.space_dim].to(volume_preds.dtype)
+            surf_p_pred_norm = surface_preds[..., 0:1]
+            anchor = self.surface_anchor(
+                vol_xyz=vol_xyz,
+                surf_xyz=surf_xyz,
+                surf_p_norm=surf_p_pred_norm,
+                surf_mask=surface_mask,
+                vol_mask=volume_mask,
+            )
+            volume_preds = (volume_preds + anchor) * volume_mask.unsqueeze(-1)
 
         return {
             "surface_preds": surface_preds,

--- a/run_pr775_arms.sh
+++ b/run_pr775_arms.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -u
+cd /workspace/senpai/target
+
+COMMON_ARGS="--agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
+  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
+  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
+  --pos-encoding-mode string_separable --use-qk-norm \
+  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
+  --lr-cosine-t-max 13 --epochs 13 \
+  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
+  --no-compile-model \
+  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
+  --batch-size 4 --validation-every 1 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --use-surface-anchor --surface-anchor-chunk-size 4096 \
+  --kill-thresholds 21729:val_primary/abupt_axis_mean_rel_l2_pct<32 \
+  --wandb-group surf-anchor-learnable-scale-tay"
+
+echo "===== Arm A: shared learnable affine anchor (alpha, beta scalar) ====="
+date -u +%FT%TZ
+torchrun --standalone --nproc_per_node=8 train.py $COMMON_ARGS \
+  --wandb-name nezuko/anchor-arm-a \
+  > logs/pr775/arm_a.log 2>&1
+echo "Arm A exit: $?"
+date -u +%FT%TZ
+
+echo "===== Arm B: same architecture, second seed (verify alpha convergence) ====="
+date -u +%FT%TZ
+torchrun --standalone --nproc_per_node=8 train.py $COMMON_ARGS \
+  --wandb-name nezuko/anchor-arm-b \
+  > logs/pr775/arm_b.log 2>&1
+echo "Arm B exit: $?"
+date -u +%FT%TZ
+
+echo "===== ALL PR775 ARMS DONE ====="
+date -u +%FT%TZ

--- a/train.py
+++ b/train.py
@@ -102,6 +102,8 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_surface_anchor: bool = False
+    surface_anchor_chunk_size: int = 4096
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -266,6 +268,16 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_surface_anchor_metrics(model: nn.Module) -> dict[str, float]:
+    anchor = getattr(model, "surface_anchor", None)
+    if anchor is None:
+        return {}
+    return {
+        "anchor/alpha": float(anchor.alpha.detach().float().item()),
+        "anchor/beta": float(anchor.beta.detach().float().item()),
+    }
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -297,6 +309,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_surface_anchor=config.use_surface_anchor,
+        surface_anchor_chunk_size=config.surface_anchor_chunk_size,
     )
 
 
@@ -1104,6 +1118,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        train_log.update(collect_surface_anchor_metrics(base_model))
 
                 train_log.update(
                     train_slope_tracker.update(
@@ -1240,6 +1255,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_surface_anchor_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Learnable affine scale on surface-anchor for volume_pressure** — Fix the unit-mismatch root cause from PR #772.

PR #772 showed the right geometric idea (nearest-surface-point lookup as a soft anchor for vol_p) but failed because `surface_cp` (dimensionless Cp, mean≈−0.304, std≈0.356) was used directly as a target for `volume_pressure` (absolute Pa, mean≈−205.8, std≈255.9). The anchor added ≈200 Pa of constant bias noise to every prediction.

This PR fixes that by introducing a **learnable affine transform** on the surface anchor:

```
vol_p_anchor = alpha * surf_p_norm + beta
vol_p_pred   = vol_p_pred_base + vol_p_anchor
```

where:
- `surf_p_norm` = nearest-surface Cp value (same chunked-cdist lookup as PR #772, O(N·M/chunk) memory)
- `alpha` = learnable scalar, **initialized to 0** → training starts in pure-absolute mode (identical to SOTA at step 0), and the model learns the scale relationship from data only when it's beneficial
- `beta` = learnable scalar, **initialized to 0**
- The alpha=0 init is critical: it means the model cannot degrade below SOTA at initialization — the anchor starts as a zero correction and grows only if the gradient signal supports it

This approach is architecturally distinct from PR #771 (askeladd, surface latent scalar offset via cross-attention aggregation) — here there is no cross-attention or learned feature aggregation; it is a pure geometric lookup with a learnable affine.

## Rationale — why this matters for val→test OOD gap

The 4 OOD test cases (run_133, run_226, run_203, run_158) have body geometries with `surface_cp` distributions that are physically correlated with their vol_p fields. A model that learns `alpha ≈ 255.9/0.356 ≈ 718` (the Pa/Cp scale) can exploit this correlation for free during inference, improving generalization. The anchor doesn't change what the model can predict in-distribution — it adds a geometric inductive bias that should extrapolate better OOD.

## Current SOTA (single-model baseline to beat)

| Metric | Value |
|--------|-------|
| val_abupt | **6.5985%** |
| val_surface_pressure | 4.3322% |
| val_volume_pressure | 3.9456% |
| val_wall_shear_x | 6.5420% |
| val_wall_shear_y | 8.3631% |
| val_wall_shear_z | 9.8099% |
| test_abupt | 7.9915% |
| test_vol_pressure | ~11.7% |

W&B run: `4k25s25e` (group: `model-depth-sweep`, name: `alphonse/depth-L5`)

**Single-model gate: val_abupt < 6.5985%**

## Implementation Instructions

### Step 1 — Add `LearnableScaleAnchor` module

In `target/model.py` (or a new file `target/surface_anchor.py`), add:

```python
import torch
import torch.nn as nn

class LearnableScaleAnchor(nn.Module):
    """
    Geometric nearest-surface-point lookup with a learnable affine transform.
    Initialized to zero correction (alpha=0, beta=0) so training starts
    identical to the no-anchor baseline.
    """
    def __init__(self, chunk_size: int = 4096):
        super().__init__()
        self.alpha = nn.Parameter(torch.zeros(1))   # scale, init=0
        self.beta  = nn.Parameter(torch.zeros(1))   # bias,  init=0
        self.chunk_size = chunk_size

    def forward(
        self,
        vol_xyz:  torch.Tensor,   # (B, Nv, 3) volume query points
        surf_xyz: torch.Tensor,   # (B, Ns, 3) surface points
        surf_cp:  torch.Tensor,   # (B, Ns, 1) surface Cp values
    ) -> torch.Tensor:            # (B, Nv, 1) anchor correction
        B, Nv, _ = vol_xyz.shape
        corrections = []
        for b in range(B):
            vp = vol_xyz[b]    # (Nv, 3)
            sp = surf_xyz[b]   # (Ns, 3)
            sc = surf_cp[b]    # (Ns, 1)
            # Chunked cdist to avoid OOM at Nv=65536, Ns=65536
            nn_vals = []
            for start in range(0, Nv, self.chunk_size):
                end = min(start + self.chunk_size, Nv)
                d = torch.cdist(vp[start:end].unsqueeze(0), sp.unsqueeze(0))[0]  # (chunk, Ns)
                idx = d.argmin(dim=1)   # (chunk,)
                nn_vals.append(sc[idx])  # (chunk, 1)
            nn_cp = torch.cat(nn_vals, dim=0)  # (Nv, 1)
            corrections.append(nn_cp)
        nn_cp_batch = torch.stack(corrections, dim=0)  # (B, Nv, 1)
        return self.alpha * nn_cp_batch + self.beta
```

### Step 2 — Wire into the volume pressure prediction path

In `target/trainer_runtime.py` (or wherever vol_p predictions are assembled), instantiate the anchor module and add its output to the vol_p prediction **after** the main model forward pass:

```python
# In __init__ or model setup:
self.surf_anchor = LearnableScaleAnchor(chunk_size=4096).to(device)

# In training forward pass (inside compute_loss or equivalent):
# Assume `vol_p_pred` is the model's raw volume pressure prediction (B, Nv, 1)
# Assume `surf_xyz`, `surf_cp` are available from the batch
anchor_correction = self.surf_anchor(vol_xyz, surf_xyz, surf_cp)  # (B, Nv, 1)
vol_p_pred = vol_p_pred + anchor_correction
```

Make sure the anchor module's parameters are included in the optimizer. If using a separate parameter group, match the main model's learning rate and weight decay.

### Step 3 — Expose as CLI flag

Add a `--use-surface-anchor` flag (default: `False`) so the anchor can be toggled without code changes:

```python
parser.add_argument("--use-surface-anchor", action="store_true", default=False,
                    help="Add learnable affine surface anchor to vol_p prediction")
```

Wire it: only instantiate `LearnableScaleAnchor` when `args.use_surface_anchor is True`.

### Step 4 — Run two arms

Run **two arms** in a single PR to test sensitivity:

**Arm A — shared scalar (alpha, beta are global scalars):**
The implementation above. One alpha and one beta for all points.

**Arm B — per-feature scalar (alpha, beta shaped (1, 1, 1), identical init):**
Architecturally identical to Arm A but explicitly check the log: does `alpha` converge to a physically meaningful value (~718 Pa/Cp)?

Use the same W&B group for both arms: `--wandb-group surf-anchor-learnable-scale-tay`

### Reproduce commands

**Arm A — shared learnable affine anchor:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surface-anchor \
  --wandb-group surf-anchor-learnable-scale-tay --wandb-name nezuko/anchor-arm-a
```

**Arm B — verify alpha convergence (same flags, different run name):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surface-anchor \
  --wandb-group surf-anchor-learnable-scale-tay --wandb-name nezuko/anchor-arm-b
```

(Arm B is architecturally identical to Arm A for scalar shape; the distinction is to check alpha's learned value and confirm gradient flow through the anchor path. If you add a `--anchor-per-channel` flag, Arm B can test that variant.)

### Kill gate

EP1 gate: **val_abupt < 32%** at step ~2700. Kill both arms if either fails the gate.

### What to log / report

In the PR comment, please report:
1. `val_abupt` at each epoch for both arms
2. `val_volume_pressure` trajectory (primary OOD target)
3. The **learned value of `alpha`** at end of training (log it via W&B: `wandb.log({"anchor/alpha": self.surf_anchor.alpha.item()})`)
4. W&B run IDs for both arms
5. Any gradient norm or loss spike at the alpha parameter

## References

- PR #772 (nezuko): original surface-anchor attempt — failed due to unit mismatch
- PR #771 (askeladd): surface latent scalar offset via cross-attention — in-flight, distinct approach
- Issue #717: vol_p OOD gap root-cause tracking
