### PR TITLE
askeladd: volume decoder SDF-statistics geometry gating (Issue #717)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,89 @@ class Transformer(nn.Module):
         return x
 
 
+class VolDecoderSDFGate(nn.Module):
+    """Per-case affine output gate for volume pressure conditioned on SDF stats.
+
+    Computes 8 mask-aware SDF distribution statistics over the volume cloud
+    (mean, std, min, max, frac<0.05m, frac<0.20m, frac<0.50m, median), feeds
+    them through a two-layer MLP, and returns affine modulation parameters
+    ``(a, b)`` so the volume prediction becomes ``vol_pred * (1 + a) + b``.
+
+    The final linear is zero-initialised so ``(a, b) = (0, 0)`` at step 0
+    and the gate is identity from initialisation. The kill-gate watchdog
+    monitors ``a.abs().max()`` (logged as ``gate/scale_max_abs``).
+    """
+
+    DESCRIPTOR_DIM = 8
+
+    def __init__(self, hidden_dim: int = 64):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.mlp = nn.Sequential(
+            nn.Linear(self.DESCRIPTOR_DIM, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, 2),
+        )
+        nn.init.trunc_normal_(self.mlp[0].weight, std=0.02)
+        nn.init.zeros_(self.mlp[0].bias)
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+        self.last_a: torch.Tensor | None = None
+        self.last_b: torch.Tensor | None = None
+
+    @staticmethod
+    def compute_descriptor(sdf: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """Compute the 8-dim per-case SDF descriptor.
+
+        ``sdf``  is ``[B, V]`` raw SDF values in metres; ``mask`` is ``[B, V]``
+        bool with True for valid (non-padded) points. Computation is in
+        float32 to keep min/max/median stable under bf16 autocast.
+        """
+
+        sdf = sdf.float()
+        m = mask.to(dtype=sdf.dtype)
+        m_sum = m.sum(dim=1).clamp(min=1.0)
+        mean = (sdf * m).sum(dim=1) / m_sum
+        sq = ((sdf * sdf) * m).sum(dim=1) / m_sum
+        var = (sq - mean * mean).clamp(min=0.0)
+        std = var.sqrt()
+        big = sdf.new_full(sdf.shape, float("inf"))
+        small = sdf.new_full(sdf.shape, float("-inf"))
+        sdf_for_min = torch.where(mask, sdf, big)
+        sdf_for_max = torch.where(mask, sdf, small)
+        smin = sdf_for_min.amin(dim=1)
+        smax = sdf_for_max.amax(dim=1)
+        below_5 = ((sdf < 0.05) & mask).to(sdf.dtype).sum(dim=1) / m_sum
+        below_20 = ((sdf < 0.20) & mask).to(sdf.dtype).sum(dim=1) / m_sum
+        below_50 = ((sdf < 0.50) & mask).to(sdf.dtype).sum(dim=1) / m_sum
+        # Median over valid entries: pad to +inf then take floor((n_valid-1)/2).
+        sorted_vals, _ = sdf_for_min.sort(dim=1)
+        valid_count = mask.sum(dim=1).clamp(min=1)
+        mid_idx = ((valid_count - 1) // 2).long().unsqueeze(1)
+        median = sorted_vals.gather(1, mid_idx).squeeze(1)
+        return torch.stack(
+            [mean, std, smin, smax, below_5, below_20, below_50, median],
+            dim=-1,
+        )
+
+    def forward(
+        self,
+        vol_pred: torch.Tensor,
+        sdf: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        descriptor = self.compute_descriptor(sdf, mask)
+        ab = self.mlp(descriptor.to(vol_pred.dtype))
+        a = ab[:, 0:1]
+        b = ab[:, 1:2]
+        with torch.no_grad():
+            self.last_a = a.detach().float()
+            self.last_b = b.detach().float()
+        a_b = a.unsqueeze(-1)
+        b_b = b.unsqueeze(-1)
+        return vol_pred * (1.0 + a_b) + b_b
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +425,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_decoder_sdf_gating: bool = False,
+        vol_decoder_sdf_gating_hidden: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +506,11 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.vol_decoder_sdf_gate = (
+            VolDecoderSDFGate(hidden_dim=vol_decoder_sdf_gating_hidden)
+            if vol_decoder_sdf_gating
+            else None
+        )
 
     def _encode_group(
         self,
@@ -514,7 +604,16 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            volume_preds = self.volume_out(volume_hidden)
+            if (
+                self.vol_decoder_sdf_gate is not None
+                and self.volume_input_dim > self.space_dim
+            ):
+                sdf_channel = volume_x[..., self.space_dim]
+                volume_preds = self.vol_decoder_sdf_gate(
+                    volume_preds, sdf_channel, volume_mask
+                )
+            volume_preds = volume_preds * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/train.py
+++ b/train.py
@@ -137,6 +137,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_decoder_sdf_gating: bool = False
+    vol_decoder_sdf_gating_hidden: int = 64
     debug: bool = False
 
 
@@ -297,7 +299,44 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_decoder_sdf_gating=config.vol_decoder_sdf_gating,
+        vol_decoder_sdf_gating_hidden=config.vol_decoder_sdf_gating_hidden,
     )
+
+
+def collect_gate_metrics(model: nn.Module, prefix: str) -> dict[str, float]:
+    """Read the most recent ``(a, b)`` stash from the SDF gate.
+
+    Returns an empty dict if gating is off or the gate has not been called
+    yet on this rank. Stats are computed over the per-case scalars from
+    the most recent forward pass.
+    """
+
+    base = unwrap_model(model)
+    gate = getattr(base, "vol_decoder_sdf_gate", None)
+    if gate is None or gate.last_a is None or gate.last_b is None:
+        return {}
+    a = gate.last_a.flatten()
+    b = gate.last_b.flatten()
+    n = int(a.numel())
+    metrics = {
+        f"{prefix}/scale_mean": float(a.mean().cpu().item()),
+        f"{prefix}/scale_min": float(a.min().cpu().item()),
+        f"{prefix}/scale_max": float(a.max().cpu().item()),
+        f"{prefix}/scale_max_abs": float(a.abs().max().cpu().item()),
+        f"{prefix}/bias_mean": float(b.mean().cpu().item()),
+        f"{prefix}/bias_min": float(b.min().cpu().item()),
+        f"{prefix}/bias_max": float(b.max().cpu().item()),
+        f"{prefix}/bias_max_abs": float(b.abs().max().cpu().item()),
+        f"{prefix}/n_cases": float(n),
+    }
+    if n > 1:
+        metrics[f"{prefix}/scale_std"] = float(a.std(unbiased=False).cpu().item())
+        metrics[f"{prefix}/bias_std"] = float(b.std(unbiased=False).cpu().item())
+    else:
+        metrics[f"{prefix}/scale_std"] = 0.0
+        metrics[f"{prefix}/bias_std"] = 0.0
+    return metrics
 
 
 def train_loss(
@@ -1050,6 +1089,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if config.vol_decoder_sdf_gating:
+                    train_log.update(collect_gate_metrics(model, "train/gate"))
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
@@ -1240,6 +1281,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if config.vol_decoder_sdf_gating:
+                    log_metrics.update(collect_gate_metrics(model, "val/gate"))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
# Volume decoder SDF-statistics geometry gating (Issue #717 Phase 1)

## Hypothesis

The chronic 3× val→test gap on `vol_pressure` is **case-dominated**: 4 geometrically-OOD test cases (run_133, run_226, run_203, run_158) produce ~92% of squared test_vol_p deviation (PR #767 confirmed). The volume decoder fails specifically on these cases — surface encoder generalises fine.

The SDF channel is **already** the 4th volume input feature (channel 4 of `VOLUME_X_DIM=4`), but it currently flows through the decoder as a passive per-point coordinate-like input. We hypothesize that **per-case SDF statistics** form a compact, training-data-cheap geometry descriptor that distinguishes OOD geometries from the training manifold, and that **gating the volume decoder output on this descriptor** lets the model learn case-conditional volume pressure corrections without paying the cost of full FiLM modulation across all decoder layers (which blew up structurally in PR #770).

This is *distinct* from your closed PR #771 (surface-latent scalar offset): #771 conditioned on **surface slice tokens** (mean-pooled S), which capture body shape but not the volume support distribution. SDF-stat conditioning captures the *envelope of the sampled volume cloud relative to the body* — a different and more directly geometry-OOD-aligned signal. Different conditioning source, different test of the geometry-conditioning hypothesis.

## Concrete design

### 1. Geometry descriptor (per case, per forward pass)

From the volume input tensor `vol_x` of shape `(B, V, 4)` where channel 3 is precomputed SDF (in metres):

```python
sdf = vol_x[..., 3]                              # (B, V)
g_sdf = torch.stack([
    sdf.mean(dim=1),                             # mean SDF
    sdf.std(dim=1),                              # std SDF
    sdf.amin(dim=1),                             # closest point to body
    sdf.amax(dim=1),                             # farthest point
    (sdf < 0.05).float().mean(dim=1),            # frac near-body  (5cm)
    (sdf < 0.20).float().mean(dim=1),            # frac mid-shell  (20cm)
    (sdf < 0.50).float().mean(dim=1),            # frac far-shell  (50cm)
    sdf.median(dim=1).values,                    # median SDF
], dim=-1)                                       # (B, 8)
```

Eight scalars per case. No-op at fixed sampling, but encodes how the volume cloud distributes around *this specific body*.

### 2. Gating module

```python
class VolDecoderSDFGate(nn.Module):
    def __init__(self, descriptor_dim=8, hidden=64):
        super().__init__()
        self.mlp = nn.Sequential(
            nn.Linear(descriptor_dim, hidden),
            nn.GELU(),
            nn.Linear(hidden, 2),                # (gate_scale, gate_bias)
        )
        # Zero-init final layer so gate ≡ identity at init (no degradation)
        nn.init.zeros_(self.mlp[-1].weight)
        nn.init.zeros_(self.mlp[-1].bias)

    def forward(self, vol_p_pred, g_sdf):
        # vol_p_pred: (B, V) raw pressure prediction
        # g_sdf:     (B, 8) descriptor
        ab = self.mlp(g_sdf)                     # (B, 2)
        a, b = ab[:, 0:1], ab[:, 1:2]            # (B,1) each
        return vol_p_pred * (1.0 + a) + b        # (B, V)
```

Affine modulation: `pred' = (1 + a(g)) * pred + b(g)`. Zero-initialized → identity at step 0 → guaranteed no-degradation start. ~600 params total.

### 3. CLI flag

Add `--vol-decoder-sdf-gating` (default off). When set:
- Compute `g_sdf` from `vol_x` channel 3 inside the model forward
- Apply `VolDecoderSDFGate` to the volume pressure head output before loss computation
- Log `gate_scale_mean`, `gate_bias_mean`, `gate_scale_std`, `gate_bias_std` per validation step (W&B custom metrics) so we can monitor the gate magnitude and confirm it doesn't blow up like PR #770's FiLM did

### 4. Where to wire it

In `target/train.py` model wrapper / volume head: after the existing volume pressure prediction `vol_p_pred` is computed, **before** loss computation. Search for where `volume_pressure` prediction is produced and apply gate there. The exact site depends on the model structure — your call where to slot it in cleanly.

## Why this might work where #771 didn't

| Aspect | #771 (closed) | #779 (this PR) |
|---|---|---|
| Source of geometry signal | Surface slice tokens, mean-pooled | Volume SDF distribution |
| What it captures | Body shape (already encoded by surface enc) | Volume cloud envelope around body |
| Form | Scalar offset `b(g)` only | Affine `(1+a)*pred + b` |
| Init | Zero-init Linear(D→1) | Zero-init MLP, identity at step 0 |
| Params | 513 | ~600 |
| OOD targeting | Indirect (surface → guess vol shift) | Direct (volume support → vol shift) |

PR #771 final result: val_abupt 7.006%, val_vol_p 4.30% — clearly some signal, but the conditioning source was wrong. SDF stats are computed *over the same volume cloud where the loss lives*, so the gradient signal aligns with the geometry-OOD failure mode.

## Acceptance / kill gates

| Gate | Action |
|---|---|
| EP1 val_abupt > 8.0% | KILL — gate has structurally broken something |
| EP2 val_abupt > 7.5% | KILL — no signal |
| `gate_scale.abs().max()` > 2.0 at any val step | KILL — same blow-up failure mode as PR #770 FiLM |
| EP3 val_abupt > 7.0% AND val_vol_p > 4.5% | KILL — performing worse than #771 |
| EP6 val_abupt < 6.7% | continue, push to full 13-epoch budget |
| Final val_abupt < SOTA 6.5985% | win — merge candidate |
| Final val_abupt < SOTA AND test_vol_p < 11.374% (anchor) | major win — geometry conditioning hypothesis confirmed |

## Reproduce command (full SOTA base + new flag)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-decoder-sdf-gating \
  --wandb-group vol-geom-cond --wandb-name askeladd/vol-decoder-sdf-gating-v1
```

## Baselines to beat

| Tier | val_abupt | test_abupt | test_vol_pressure |
|---|---|---|---|
| Single-model SOTA (PR #592) | **6.5985%** | 7.9915% | 11.933% |
| Vol-pressure anchor (PR #681) | — | — | 11.374% |
| Ensemble SOTA (PR #612, K=7) | 6.1751% | 7.5347% | 11.4652% |
| AB-UPT reference | — | — | 6.08% (target floor) |
| Your prior #771 | 7.006% | — | — |

Primary metric: **val_abupt** (lower better). Secondary watch: **val_vol_p** must not regress >0.05pp vs SOTA 3.946%.

## Protocol reminders (from #771 review)

1. **Post a startup W&B comment within 5 min of training start** — include W&B run URL, run id, group, name, config delta vs SOTA, and "training started, awaiting EP1 results"
2. **Honor kill gates immediately.** PR #771 kept training past two kill orders. If a kill gate fires, kill the run, post a comment, and `mark_ready_for_review` for analysis.
3. **One hypothesis, one PR.** Don't bundle additional changes.
4. **Final report must include:** best-EP val_abupt, val_vol_p, val_surface_p, val_tau_x/y/z, gate_scale stats per epoch, and the full training command used.

## References

- Issue #717 (vol_pressure gap diagnosis)
- PR #767 (Phase 0 case-decomposition: 92% squared deviation from 4 cases)
- PR #771 (your prior closed scalar-offset attempt — different conditioning source)
- PR #770 (FiLM unbounded blow-up — why we use bounded zero-init affine)
- PR #778 (frieren FiLM v2 with bounded tanh — sister approach, different conditioning surface)
