### PR TITLE
SDF-FiLM: volume SDF stats → affine conditioning on vol tokens (geometry OOD fix)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,71 @@ class Transformer(nn.Module):
         return x
 
 
+class SDFFiLM(nn.Module):
+    """SDF-statistic FiLM conditioning of the volume token hidden representation.
+
+    Geometry-OOD attack: PR #767 diagnostic showed the val→test vol_pressure gap is
+    case-dominated (4 OOD geometries drive 92% of squared deviation). SDF is already
+    a precomputed input channel; here we route per-case SDF order statistics
+    (mean/std/min/max) through a small MLP that produces FiLM (Perez et al. 2018)
+    affine parameters γ, β applied per-token to the volume hidden representation.
+
+    Bounded scale: γ = 1 + tanh(γ_raw) ∈ (0, 2) prevents blow-up.
+    Final-layer zero-init => γ=1, β=0 at startup, so the module is the identity
+    at init (no degradation guarantee).
+    """
+
+    def __init__(self, sdf_dim: int, hidden_dim: int, mlp_hidden: int = 64):
+        super().__init__()
+        self.fc1 = nn.Linear(sdf_dim, mlp_hidden)
+        self.act = nn.SiLU()
+        self.fc2 = nn.Linear(mlp_hidden, 2 * hidden_dim)
+        nn.init.trunc_normal_(self.fc1.weight, std=0.02)
+        nn.init.zeros_(self.fc1.bias)
+        nn.init.zeros_(self.fc2.weight)
+        nn.init.zeros_(self.fc2.bias)
+        # Buffer for W&B telemetry: [γ_mean, γ_std, γ_max_abs_dev, β_mean, β_std, β_max_abs]
+        self.register_buffer("last_stats", torch.zeros(6))
+
+    def forward(self, sdf_desc: torch.Tensor, vol_tokens: torch.Tensor) -> torch.Tensor:
+        params = self.fc2(self.act(self.fc1(sdf_desc.to(dtype=vol_tokens.dtype))))
+        gamma_raw, beta = params.chunk(2, dim=-1)  # each [B, D]
+        gamma = 1.0 + torch.tanh(gamma_raw)  # γ ∈ (0, 2)
+        with torch.no_grad():
+            gamma_f = gamma.detach().float()
+            beta_f = beta.detach().float()
+            self.last_stats[0] = gamma_f.mean()
+            self.last_stats[1] = gamma_f.std()
+            self.last_stats[2] = (gamma_f - 1.0).abs().max()
+            self.last_stats[3] = beta_f.mean()
+            self.last_stats[4] = beta_f.std()
+            self.last_stats[5] = beta_f.abs().max()
+        return vol_tokens * gamma.unsqueeze(1) + beta.unsqueeze(1)
+
+
+def _masked_sdf_descriptor(volume_x: torch.Tensor, volume_mask: torch.Tensor) -> torch.Tensor:
+    """Compute [B, 4] per-case SDF descriptor (mean, std, min, max) over non-padded volume points.
+
+    ``volume_x`` is ``[B, N, 4]`` with channels (x, y, z, sdf). Padded rows are zero-filled
+    by the loader, so we mask them out — for the SOTA dataset the mask is usually all ones,
+    but eval-time strided sampling can produce ragged batches.
+    """
+    sdf = volume_x[..., 3]  # [B, N]
+    mask = volume_mask.to(device=sdf.device, dtype=sdf.dtype)
+    eps = 1e-6
+    valid = mask.sum(dim=1, keepdim=True).clamp(min=eps)  # [B, 1]
+    sdf_masked = sdf * mask
+    sdf_mean = sdf_masked.sum(dim=1, keepdim=True) / valid
+    diff = (sdf - sdf_mean) * mask
+    sdf_var = diff.pow(2).sum(dim=1, keepdim=True) / valid
+    sdf_std = sdf_var.clamp(min=0.0).sqrt()
+    pos_inf = torch.full_like(sdf, float("inf"))
+    neg_inf = torch.full_like(sdf, float("-inf"))
+    sdf_min = torch.where(mask > 0, sdf, pos_inf).min(dim=1, keepdim=True).values
+    sdf_max = torch.where(mask > 0, sdf, neg_inf).max(dim=1, keepdim=True).values
+    return torch.cat([sdf_mean, sdf_std, sdf_min, sdf_max], dim=-1)  # [B, 4]
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +407,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        sdf_film_conditioning: bool = False,
+        sdf_film_active_threshold: int = 49152,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +488,18 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.sdf_film_conditioning = sdf_film_conditioning
+        self.sdf_film_active_threshold = sdf_film_active_threshold
+        if sdf_film_conditioning:
+            volume_sdf_dim = max(0, self.volume_input_dim - space_dim)
+            if volume_sdf_dim < 1:
+                raise ValueError(
+                    "SDF-FiLM conditioning requires volume_input_dim > space_dim "
+                    "(SDF channel must be present in volume_x)."
+                )
+            self.sdf_film = SDFFiLM(sdf_dim=4, hidden_dim=n_hidden)
+        else:
+            self.sdf_film = None
 
     def _encode_group(
         self,
@@ -514,6 +593,25 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
+            if self.sdf_film is not None:
+                # Delayed-onset: at EP1-5 (vol_points<49152) the FiLM stays dormant by
+                # zero-multiplying its output. Always active in eval (N_vol=65536 there).
+                # We invoke FiLM unconditionally so DDP sees its parameters in the
+                # autograd graph (grad=0 in dormant epochs) — avoids needing
+                # find_unused_parameters=True.
+                apply_full = (
+                    not self.training
+                    or volume_x.shape[1] >= self.sdf_film_active_threshold
+                )
+                sdf_desc = _masked_sdf_descriptor(volume_x, volume_mask)  # [B, 4]
+                film_out = self.sdf_film(sdf_desc, volume_hidden)
+                if apply_full:
+                    volume_hidden = film_out
+                else:
+                    # Mathematically identity (volume_hidden + 0*film_out = volume_hidden),
+                    # but the autograd graph still touches FiLM params with grad=0.
+                    volume_hidden = volume_hidden + 0.0 * film_out
+                volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -102,6 +102,8 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    sdf_film_conditioning: bool = False
+    sdf_film_active_threshold: int = 49152
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -297,7 +299,29 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        sdf_film_conditioning=config.sdf_film_conditioning,
+        sdf_film_active_threshold=config.sdf_film_active_threshold,
     )
+
+
+def collect_sdf_film_metrics(model: nn.Module) -> dict[str, float]:
+    """Read the buffer-cached γ/β stats from the SDFFiLM module (rank-0 only).
+
+    The buffer is updated in-place each forward; with DDP `broadcast_buffers=True`
+    (default) we end up logging rank 0's most recent forward — fine for monitoring.
+    """
+    film = getattr(model, "sdf_film", None)
+    if film is None:
+        return {}
+    s = film.last_stats.detach().cpu()
+    return {
+        "sdf_film/gamma_mean": float(s[0]),
+        "sdf_film/gamma_std": float(s[1]),
+        "sdf_film/gamma_max_abs_dev": float(s[2]),
+        "sdf_film/beta_mean": float(s[3]),
+        "sdf_film/beta_std": float(s[4]),
+        "sdf_film/beta_max_abs": float(s[5]),
+    }
 
 
 def train_loss(
@@ -830,6 +854,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if getattr(base_model, "sdf_film", None) is not None:
+                film_param_count = sum(p.numel() for p in base_model.sdf_film.parameters())
+                print(
+                    f"SDF-FiLM conditioning ENABLED: sdf_dim=4 -> 64 -> 2*{config.model_hidden_dim} "
+                    f"({film_param_count:,d} params); zero-init final layer (identity at start); "
+                    f"γ ∈ (0, 2) via 1+tanh; gated for train_vol_points >= "
+                    f"{config.sdf_film_active_threshold}; always active in eval"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -861,6 +893,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/sdf_film_conditioning"] = bool(config.sdf_film_conditioning)
+            wandb.summary["model/sdf_film_active_threshold"] = int(config.sdf_film_active_threshold)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1240,6 +1274,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_sdf_film_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The vol_pressure val→test gap is **case-dominated**: 4 geometrically-OOD test cases (run_133, run_226, run_203, run_158) account for **92%** of squared test_vol_p deviation (PR #767 diagnostic). The upstream region (x≤0.5m, 92% of volume points) is where the gap lives.

SDF (signed distance function) is already computed and stored as the 4th volume input channel (`VOLUME_X_DIM=4`, channels: x, y, z, sdf). The current model uses it as just another positional feature fed into the volume token encoder — but it is never explicitly used to **condition the volume decoder** at the geometry level.

**Hypothesis:** Using SDF statistics (mean, std, min, max computed per-case from the sampled volume points) as a compact geometry descriptor to condition the volume decoder via a learned affine transformation (FiLM-style: scale+bias) will reduce the val→test generalisation gap for vol_pressure. Cases with anomalous SDF distributions (the 4 OOD cases) have distinctly different SDF signatures that a conditioned decoder can learn to handle.

This is orthogonal to and lighter-weight than the global FiLM v2 approach (#778 frieren), which derives conditioning from the full surface encoder latent. Here we derive conditioning directly from the volume SDF statistics — a more compact and directly geometry-relevant signal.

Key difference from askeladd's scalar-offset approach (#781): that PR uses a surface-latent-derived scalar offset on the final vol_pressure head. This PR derives conditioning from **volume-side SDF statistics**, uses a **full affine (scale + bias)** applied to the intermediate volume token representations (not just the output), and targets a different pathway.

## Instructions

All changes go in `target/train.py`. The SOTA config (single-model gate: val_abupt < **6.5985%**) is your baseline.

### Step 1 — Compute per-case SDF statistics as geometry descriptor

In the forward pass, before the volume decoder processes volume tokens, extract SDF statistics from the volume input:

```python
# volume_x shape: [B, N_vol, 4]  — channels: (x, y, z, sdf)
sdf_vals = volume_x[..., 3]  # [B, N_vol]  — 4th channel is SDF

# Compute per-case summary statistics (mean, std, min, max)
sdf_mean = sdf_vals.mean(dim=1, keepdim=True)   # [B, 1]
sdf_std  = sdf_vals.std(dim=1, keepdim=True)    # [B, 1]
sdf_min  = sdf_vals.min(dim=1).values.unsqueeze(1)  # [B, 1]
sdf_max  = sdf_vals.max(dim=1).values.unsqueeze(1)  # [B, 1]

sdf_desc = torch.cat([sdf_mean, sdf_std, sdf_min, sdf_max], dim=-1)  # [B, 4]
```

### Step 2 — Add SDF-FiLM conditioning module to the model

Add a lightweight FiLM (Feature-wise Linear Modulation) module that maps the 4-dim SDF descriptor to scale+bias for the volume token hidden dimension:

```python
class SDFFiLM(nn.Module):
    def __init__(self, sdf_dim: int, hidden_dim: int):
        super().__init__()
        # Two-layer MLP: 4 → 64 → 2*hidden_dim
        self.net = nn.Sequential(
            nn.Linear(sdf_dim, 64),
            nn.SiLU(),
            nn.Linear(64, 2 * hidden_dim),
        )
        # Zero-init final layer so scale=1, bias=0 at init (no degradation guarantee)
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)

    def forward(self, sdf_desc: torch.Tensor, vol_tokens: torch.Tensor):
        # sdf_desc: [B, 4]; vol_tokens: [B, N_vol, D]
        params = self.net(sdf_desc)          # [B, 2D]
        gamma_raw, beta = params.chunk(2, dim=-1)  # each [B, D]
        # Bounded scale: γ ∈ (0, 2) via tanh — prevents blow-up
        gamma = 1.0 + torch.tanh(gamma_raw)  # [B, D]
        # Apply per-token: broadcast over N_vol
        return vol_tokens * gamma.unsqueeze(1) + beta.unsqueeze(1)
```

Instantiate as `self.sdf_film = SDFFiLM(sdf_dim=4, hidden_dim=hidden_dim)` in the model `__init__`.

### Step 3 — Apply conditioning with delayed onset (EP6+)

Apply the SDF-FiLM modulation to the volume tokens after the volume encoder but **before** the final volume prediction head. Use delayed onset (active only when training volume points ≥ 49152, i.e. curriculum stage 3 / EP6+) to ensure the volume decoder is established before geometry conditioning kicks in:

```python
# In the forward pass, after volume token encoding:
if self.training and current_vol_points < 49152:
    # Before EP6: identity (no conditioning)
    pass
else:
    # EP6+: apply SDF-FiLM conditioning
    vol_tokens = self.sdf_film(sdf_desc, vol_tokens)
```

During validation/inference, always apply the conditioning (no gate needed — eval is always at full N_vol=65536).

### Step 4 — CLI flag

Add `--sdf-film-conditioning` boolean flag (default: True for this run). Use `--wandb-group sdf-film-vol-geometry` and `--wandb-name edward/sdf-film-v1`.

### Complete reproduce command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --sdf-film-conditioning \
  --wandb-group sdf-film-vol-geometry --wandb-name edward/sdf-film-v1
```

### Monitoring guidance

- **EP1-5:** SDF-FiLM is gated off (conditioning dormant). Metrics should match SOTA closely.
- **EP6+ (curriculum stage 3, N_vol=49152):** FiLM activates. Watch `val_vol_p` — we expect improvement here. Also watch `gamma` norms (should stay in (0,2) range due to tanh bound).
- Log per-epoch `gamma_mean`, `gamma_std`, `beta_mean` via W&B to confirm conditioning is engaging.
- **Kill criterion:** If val_abupt > 8.5% at EP4, abort — something structural is wrong.

## Baseline

**Single-model SOTA:** PR #592 (alphonse), W&B run `4k25s25e`
- val_abupt = **6.5985%** (EP4, step 43,459)
- test_abupt = **7.9915%**
- val_vol_pressure = 3.9456%
- test_vol_pressure ≈ 11.933% (3× gap, caused by 4 OOD cases)
- val_surface_pressure = 4.3322%
- val_wall_shear_x = 6.5420%, val_wall_shear_y = 8.3631%, val_wall_shear_z = 9.8099%

**Gate to beat:** val_abupt < 6.5985%
**Primary vol-pressure target:** test_vol_pressure ≤ 11.0% (Weak tier), ≤ 10.0% (Solid), ≤ 8.5% (Major)

**Ensemble SOTA:** PR #612 (nezuko), val_abupt=6.1751%, test_abupt=7.5347%, W&B run `5veexq8r`

## Context

**Why this matters:** PR #767 diagnostic confirmed the entire vol_pressure gap is case-dominated — 4 OOD test geometries drive 92% of squared deviation. The upstream region (x≤0.5m) is the failure zone. SDF is already available as a precomputed input; this experiment tests whether routing SDF-derived geometry statistics into the volume decoder as a conditioning signal allows the decoder to adapt its predictions per geometry.

**Related in-flight PRs (do NOT duplicate):**
- #778 frieren: FiLM from surface-latent (uses surface encoder output, not SDF stats)
- #781 askeladd: scalar offset from surface-latent on output head (not volume token FiLM)
- #777 alphonse: gc-loss delayed start (loss-side, not architecture)
- #771 askeladd: minimal scalar offset (different signal source)

**This PR is distinct:** Volume-side SDF statistics → full affine FiLM on volume tokens (not surface latent, not output head, not loss weighting).
