### PR TITLE
askeladd: vol-decoder SDF-gate v2 — bounded tanh + input norm (Issue #717)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,91 @@ class Transformer(nn.Module):
         return x
 
 
+class VolDecoderSDFGate(nn.Module):
+    """Bounded affine gate on the volume-decoder output, conditioned on per-case SDF stats.
+
+    8-channel descriptor → 8→16→2 MLP → tanh-bounded (a, b) → ``vol_pred * (1 + a) + b``.
+
+    The tanh bound caps the multiplier at [0.7, 1.3] and the bias at +/-0.05, eliminating
+    the unbounded blow-up failure mode of the v1 design (PR #781). Last-layer zero init
+    means the gate is identity at step 0.
+    """
+
+    DESCRIPTOR_DIM = 8
+
+    def __init__(self, descriptor_dim: int = 8, hidden: int = 16):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(descriptor_dim, hidden),
+            nn.GELU(),
+            nn.Linear(hidden, 2),
+        )
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+        # Hard-coded input normalization for the 8-channel SDF descriptor:
+        # length-scale stats (mean, std, min, max, median) divided by [3, 3, 3, 6, 3];
+        # frac channels (frac<0.05, frac<0.20, frac<0.50) left at 1.0.
+        norm = torch.tensor([3.0, 3.0, 3.0, 6.0, 1.0, 1.0, 1.0, 3.0], dtype=torch.float32)
+        self.register_buffer("input_norm", norm)
+        self._last_a: torch.Tensor | None = None
+        self._last_b: torch.Tensor | None = None
+        self._last_ab_raw: torch.Tensor | None = None
+        self._last_g_sdf: torch.Tensor | None = None
+
+    def forward(self, vol_pred: torch.Tensor, g_sdf: torch.Tensor) -> torch.Tensor:
+        # vol_pred: (B, N, C); g_sdf: (B, 8)
+        g_sdf_norm = g_sdf / self.input_norm.to(dtype=g_sdf.dtype, device=g_sdf.device)
+        ab = self.mlp(g_sdf_norm)  # (B, 2)
+        a = 0.3 * torch.tanh(ab[:, 0:1])  # (B, 1) multiplier in [-0.3, 0.3] => 1+a in [0.7, 1.3]
+        b = 0.05 * torch.tanh(ab[:, 1:2])  # (B, 1) small additive bias in [-0.05, 0.05]
+        self._last_a = a.detach()
+        self._last_b = b.detach()
+        self._last_ab_raw = ab.detach()
+        self._last_g_sdf = g_sdf.detach()
+        return vol_pred * (1.0 + a.unsqueeze(1)) + b.unsqueeze(1)
+
+
+def _compute_sdf_descriptor(
+    sdf: torch.Tensor, mask: torch.Tensor | None
+) -> torch.Tensor:
+    """Compute the 8-channel per-case SDF descriptor used by ``VolDecoderSDFGate``.
+
+    Channels: [mean, std, min, max, frac<0.05, frac<0.20, frac<0.50, median] of |sdf|
+    over each case's valid points (mask=True). Returns ``(B, 8)``.
+    """
+
+    abs_sdf = sdf.abs()
+    if mask is None:
+        valid = torch.ones_like(abs_sdf, dtype=torch.bool)
+    else:
+        valid = mask.to(dtype=torch.bool)
+    valid_f = valid.to(dtype=abs_sdf.dtype)
+    valid_count = valid_f.sum(dim=1).clamp(min=1.0)  # (B,)
+
+    masked_vals = abs_sdf * valid_f
+    mean = masked_vals.sum(dim=1) / valid_count
+    sq_dev = ((abs_sdf - mean.unsqueeze(1)) ** 2) * valid_f
+    std = (sq_dev.sum(dim=1) / valid_count).clamp(min=0.0).sqrt()
+
+    inf_filled = torch.where(valid, abs_sdf, torch.full_like(abs_sdf, float("inf")))
+    sdf_min = inf_filled.amin(dim=1)
+    neg_inf_filled = torch.where(valid, abs_sdf, torch.full_like(abs_sdf, float("-inf")))
+    sdf_max = neg_inf_filled.amax(dim=1)
+
+    frac_005 = ((abs_sdf < 0.05) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+    frac_020 = ((abs_sdf < 0.20) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+    frac_050 = ((abs_sdf < 0.50) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+
+    sorted_vals, _ = inf_filled.sort(dim=1)  # (B, N), invalid -> +inf at the end
+    valid_count_long = valid.to(dtype=torch.long).sum(dim=1).clamp(min=1)
+    mid_idx = ((valid_count_long - 1) // 2).unsqueeze(1)  # (B, 1)
+    median = sorted_vals.gather(1, mid_idx).squeeze(1)
+
+    return torch.stack(
+        [mean, std, sdf_min, sdf_max, frac_005, frac_020, frac_050, median], dim=-1
+    )
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +427,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_decoder_sdf_gating: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +507,15 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.vol_decoder_sdf_gating = vol_decoder_sdf_gating
+        if vol_decoder_sdf_gating:
+            if self.volume_input_dim < 4:
+                raise ValueError(
+                    "vol_decoder_sdf_gating requires volume_input_dim >= 4 (xyz + sdf channel)"
+                )
+            self.vol_decoder_gate = VolDecoderSDFGate()
+        else:
+            self.vol_decoder_gate = None
 
     def _encode_group(
         self,
@@ -513,8 +608,19 @@ class SurfaceTransolver(nn.Module):
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
+        gate_a: torch.Tensor | None = None
+        gate_b: torch.Tensor | None = None
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            volume_preds = self.volume_out(volume_hidden)
+            if self.vol_decoder_gate is not None:
+                # SDF is the 4th input channel (index 3) per data.VOLUME_X_DIM = 4 layout.
+                g_sdf = _compute_sdf_descriptor(
+                    volume_x[:, :, 3], volume_mask
+                )
+                volume_preds = self.vol_decoder_gate(volume_preds, g_sdf)
+                gate_a = self.vol_decoder_gate._last_a
+                gate_b = self.vol_decoder_gate._last_b
+            volume_preds = volume_preds * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
@@ -525,4 +631,6 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "gate_a": gate_a,
+            "gate_b": gate_b,
         }

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    vol_decoder_sdf_gating: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -297,7 +298,43 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_decoder_sdf_gating=config.vol_decoder_sdf_gating,
     )
+
+
+def collect_gate_metrics(model: nn.Module, prefix: str) -> dict[str, float]:
+    """Compute per-step gate stats from the SDF gate's stored tensors.
+
+    Returns a dict keyed under ``{prefix}/scale_*`` and ``{prefix}/bias_*``,
+    plus ``{prefix}/scale_sat_frac`` (fraction of batch items where
+    the raw pre-tanh multiplier output exceeds 0.9 in absolute value).
+    Empty dict if gating is disabled or the gate has not been called yet.
+    """
+
+    gate = getattr(unwrap_model(model), "vol_decoder_gate", None)
+    if gate is None or gate._last_a is None:
+        return {}
+    a = gate._last_a.float().reshape(-1)
+    b = gate._last_b.float().reshape(-1)
+    ab_raw = gate._last_ab_raw.float()  # (B, 2)
+    a_std = float(a.std(unbiased=False).cpu().item()) if a.numel() > 1 else 0.0
+    b_std = float(b.std(unbiased=False).cpu().item()) if b.numel() > 1 else 0.0
+    metrics = {
+        f"{prefix}/scale_mean": float(a.mean().cpu().item()),
+        f"{prefix}/scale_std": a_std,
+        f"{prefix}/scale_min": float(a.min().cpu().item()),
+        f"{prefix}/scale_max": float(a.max().cpu().item()),
+        f"{prefix}/scale_max_abs": float(a.abs().max().cpu().item()),
+        f"{prefix}/bias_mean": float(b.mean().cpu().item()),
+        f"{prefix}/bias_std": b_std,
+        f"{prefix}/bias_min": float(b.min().cpu().item()),
+        f"{prefix}/bias_max": float(b.max().cpu().item()),
+        f"{prefix}/bias_max_abs": float(b.abs().max().cpu().item()),
+        f"{prefix}/scale_sat_frac": float(
+            (ab_raw[:, 0].abs() > 0.9).to(dtype=torch.float32).mean().cpu().item()
+        ),
+    }
+    return metrics
 
 
 def train_loss(
@@ -1050,6 +1087,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if config.vol_decoder_sdf_gating:
+                    train_log.update(collect_gate_metrics(model, prefix="train/gate"))
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
@@ -1240,6 +1279,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if config.vol_decoder_sdf_gating:
+                    primary_val_surface = val_metrics.get("val_surface", {})
+                    for key in (
+                        "gate_scale_mean",
+                        "gate_scale_std",
+                        "gate_scale_min",
+                        "gate_scale_max",
+                        "gate_scale_max_abs",
+                        "gate_bias_mean",
+                        "gate_bias_std",
+                        "gate_bias_min",
+                        "gate_bias_max",
+                        "gate_bias_max_abs",
+                        "gate_scale_sat_frac",
+                    ):
+                        if key in primary_val_surface:
+                            log_metrics[f"val/gate/{key[len('gate_'):]}"] = primary_val_surface[key]
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -905,6 +905,10 @@ class EvalAccumulator:
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
+    # Per-case SDF-gate diagnostics (only populated when the gate is enabled).
+    gate_a_values: list[float] = field(default_factory=list)
+    gate_b_values: list[float] = field(default_factory=list)
+    gate_ab_raw_a_values: list[float] = field(default_factory=list)
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -966,6 +970,13 @@ def accumulate_eval_batch(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+        )
+    gate = getattr(eval_module, "vol_decoder_gate", None)
+    if gate is not None and gate._last_a is not None:
+        accumulator.gate_a_values.extend(gate._last_a.float().reshape(-1).cpu().tolist())
+        accumulator.gate_b_values.extend(gate._last_b.float().reshape(-1).cpu().tolist())
+        accumulator.gate_ab_raw_a_values.extend(
+            gate._last_ab_raw[:, 0].float().reshape(-1).cpu().tolist()
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
@@ -1052,6 +1063,9 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
                 state = merged.case_sums[key].setdefault(case_id, [0.0, 0.0])
                 state[0] += values[0]
                 state[1] += values[1]
+        merged.gate_a_values.extend(accumulator.gate_a_values)
+        merged.gate_b_values.extend(accumulator.gate_b_values)
+        merged.gate_ab_raw_a_values.extend(accumulator.gate_ab_raw_a_values)
     return merged
 
 
@@ -1081,7 +1095,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     loss = (accumulator.surface_loss_sse + accumulator.volume_loss_sse) / max(
         accumulator.surface_loss_count + accumulator.volume_loss_count, 1
     )
-    return {
+    result = {
         "loss": loss,
         "surface_loss": accumulator.surface_loss_sse / max(accumulator.surface_loss_count, 1),
         "volume_loss": accumulator.volume_loss_sse / max(accumulator.volume_loss_count, 1),
@@ -1110,6 +1124,30 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
     }
+    if accumulator.gate_a_values:
+        a_tensor = torch.tensor(accumulator.gate_a_values, dtype=torch.float32)
+        b_tensor = torch.tensor(accumulator.gate_b_values, dtype=torch.float32)
+        ab_raw_a = torch.tensor(accumulator.gate_ab_raw_a_values, dtype=torch.float32)
+        a_std = float(a_tensor.std(unbiased=False).item()) if a_tensor.numel() > 1 else 0.0
+        b_std = float(b_tensor.std(unbiased=False).item()) if b_tensor.numel() > 1 else 0.0
+        result.update(
+            {
+                "gate_scale_mean": float(a_tensor.mean().item()),
+                "gate_scale_std": a_std,
+                "gate_scale_min": float(a_tensor.min().item()),
+                "gate_scale_max": float(a_tensor.max().item()),
+                "gate_scale_max_abs": float(a_tensor.abs().max().item()),
+                "gate_bias_mean": float(b_tensor.mean().item()),
+                "gate_bias_std": b_std,
+                "gate_bias_min": float(b_tensor.min().item()),
+                "gate_bias_max": float(b_tensor.max().item()),
+                "gate_bias_max_abs": float(b_tensor.abs().max().item()),
+                "gate_scale_sat_frac": float(
+                    (ab_raw_a.abs() > 0.9).to(dtype=torch.float32).mean().item()
+                ),
+            }
+        )
+    return result
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Hypothesis

Geometry conditioning of the volume decoder via bounded affine gating on SDF statistics can fix the 4 OOD test cases that account for 92% of test_vol_pressure error. The unbounded affine design in PR #781 was confirmed as structurally fragile — a single outlier training case drove the MLP gate from ~0.0025 to 2.5625 in one step (×1000 spike), reproducing the exact failure mode of FiLM v1 (PR #770). However, the underlying hypothesis — that per-case SDF statistics can calibrate the volume pressure predictor for geometrically-OOD cases — was never tested against validation data.

This PR implements the bounded-affine variant with input normalization:
1. **Bounded gate outputs** via tanh: `a = 0.3 * tanh(...)` and `b = 0.05 * tanh(...)` so multiplier is always in [0.7, 1.3] and bias is always small.
2. **Hard-coded input normalization** of the 8 SDF-stat channels before the MLP — divide length-scale channels by 1m, keep frac stats as-is.
3. **Smaller hidden dimension** — 8→16→2 (was 8→64→2), sufficient for a 2-output gate from 8 inputs.

These three changes together eliminate the structural blow-up mode while preserving the geometry-conditioning hypothesis.

Sister PR to #778 (frieren bounded-FiLM v2 on volume tokens). That PR conditions volume *tokens*; this PR conditions vol_pred *output* — they test different insertion points for the same SDF geometry conditioning signal.

## Instructions

Modify the `VolDecoderSDFGate` module in `model.py` as follows:

### 1. Input normalization (hard-coded scales)

Before the MLP forward pass, apply these hard-coded normalizations to the 8-channel descriptor `g_sdf`:

```python
# Hard-coded input normalization: divide length-scale channels by 1.0 (metres)
# and leave frac channels (already in [0,1]) unchanged.
# Channel layout: [mean, std, min, max, frac<0.05, frac<0.20, frac<0.50, median]
# Length-scale channels: indices 0,1,2,3,7 (mean, std, min, max, median)
# Frac channels: indices 4,5,6 — keep as-is
_NORM = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
                      dtype=g_sdf.dtype, device=g_sdf.device)
# Length-scale stats are already in ~[0, 3] metre range; divide by 3.0 to normalize:
_NORM = torch.tensor([3.0, 3.0, 3.0, 6.0, 1.0, 1.0, 1.0, 3.0],
                      dtype=g_sdf.dtype, device=g_sdf.device)
g_sdf_norm = g_sdf / _NORM
ab = self.mlp(g_sdf_norm)
```

The exact normalization constants: divide `[mean, std, min, max, median]` by `[3.0, 3.0, 3.0, 6.0, 3.0]` and leave frac channels `[frac<0.05, frac<0.20, frac<0.50]` at 1.0. (SDF range spans ~0 to ~6m for the largest DrivAerML geometries; mean/std typically 0.3–1.5m, max up to 6m.)

### 2. Bounded gate outputs via tanh

After the MLP, clamp the output:

```python
ab = self.mlp(g_sdf_norm)  # (B, 2)
a = 0.3 * torch.tanh(ab[:, 0:1])   # multiplier in [0.7, 1.3]
b = 0.05 * torch.tanh(ab[:, 1:2])  # small additive bias
return vol_pred * (1.0 + a) + b
```

### 3. Smaller hidden dimension

Change the MLP from `8→64→2` to `8→16→2`:

```python
class VolDecoderSDFGate(nn.Module):
    def __init__(self, descriptor_dim=8, hidden=16):  # was 64
        super().__init__()
        self.mlp = nn.Sequential(
            nn.Linear(descriptor_dim, hidden),
            nn.GELU(),
            nn.Linear(hidden, 2),
        )
        nn.init.zeros_(self.mlp[-1].weight)
        nn.init.zeros_(self.mlp[-1].bias)
```

This reduces the module from 706 to ~154 params. Still sufficient for a 2-output gate from 8 inputs.

### 4. Kill thresholds (corrected signs from PR #781)

Use the corrected `>` comparison (not `<`) for kill-if-divergent gates:

```
--kill-thresholds "200:train/gate/scale_max_abs>0.6,200:train/gate/bias_max_abs>0.2,10864:val_primary/abupt_axis_mean_rel_l2_pct>32,21728:val_primary/abupt_axis_mean_rel_l2_pct>12"
```

The tanh bound means scale_max_abs should never exceed 0.3 (the tanh scale factor), so 0.6 is a generous safety threshold (2×). If it fires, something is wrong with the bounded impl.

### 5. Logging

Keep the same gate monitoring in W&B:
- `train/gate/scale_{mean,std,min,max,max_abs}` per train step
- `train/gate/bias_{mean,std,min,max,max_abs}` per train step
- `val/gate/...` same at validation

Add one more: `train/gate/scale_sat_frac` = fraction of batch items where `|ab[:,0]| > 0.9` (near tanh saturation). If this fraction grows above 0.5, the gate is saturating and the normalization may need adjustment.

### 6. Same base config as SOTA

Use the identical SOTA baseline config (no other changes):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-decoder-sdf-gating \
  --kill-thresholds "200:train/gate/scale_max_abs>0.6,200:train/gate/bias_max_abs>0.2,10864:val_primary/abupt_axis_mean_rel_l2_pct>32,21728:val_primary/abupt_axis_mean_rel_l2_pct>12" \
  --wandb-group vol-geom-cond --wandb-name askeladd/vol-decoder-sdf-gate-v2
```

Note: The `--vol-decoder-sdf-gating` flag already exists in the codebase from PR #781. You only need to modify the `VolDecoderSDFGate` class internals.

### Pre-launch sanity check

Before the full DDP run, validate on 1 GPU (`--nproc_per_node=1 --batch-size 1`) for 200 steps:
1. Step 0: `(gate_output - vol_pred).abs().max() == 0.0` (identity check)
2. Step 200: `scale_max_abs <= 0.3` (tanh bound check — should be strict)
3. Confirm no NaN in any gate stat over 200 steps

Report the step-0 identity check result and the step-200 max gate value in your first comment.

## Kill gates

| Gate | Step | Threshold |
|------|------|-----------|
| Auto: scale saturation | 200 | `train/gate/scale_max_abs > 0.6` |
| Auto: bias saturation | 200 | `train/gate/bias_max_abs > 0.2` |
| EP1 | 10,864 | `val_abupt > 32%` |
| EP2 | 21,728 | `val_abupt > 12%` |
| EP3 manual | 32,592 | `val_abupt > 8.0%` OR (`val_abupt > 7.0%` AND `val_vol_p > 4.5%`) |

## Baseline to beat

**Single-model SOTA** (PR #592, alphonse, run `4k25s25e`):
- val_abupt = **6.5985%** (EP4, step 43,459)
- val_vol_p = 3.9456% (the target metric for this intervention)
- test_abupt = 7.9915%

**Vol-pressure anchor** (PR #681, run `dc031qpt`):
- test_vol_p = 11.374% (current best on the OOD metric this PR is designed to fix)

**Primary target:** beat val_abupt 6.5985% without regressing val_vol_p.
**Secondary signal:** does test_vol_p improve vs 11.374% anchor?

## Final report fields

Please include in your final results comment:
- best-epoch val_abupt, val_vol_p, val_surface_p, val_tau_x/y/z
- gate stats per epoch: scale_mean, scale_std, scale_max_abs, scale_sat_frac, bias_mean, bias_max_abs
- Comparison table vs SOTA (#592) and unbounded v1 (#781)
- Any saturation observed in the tanh gate
