### PR TITLE
fern: Anchor-STRING RoPE v3 full 13-epoch run (Issue #618)

### DIFF
--- a/model.py
+++ b/model.py
@@ -136,6 +136,144 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class AnchorStringRoPE(nn.Module):
+    """Learnable per-axis rotary encoding on actual 3D point coordinates.
+
+    Performs a sub-sampled cross-attention pass: queries come from all N
+    points, keys/values come from K=n_anchors uniformly strided anchors.
+    Per-axis log-frequencies rotate Q and K with their own coordinates,
+    yielding spatial relative-position dependence on `(coord_q - coord_k)`.
+
+    Designed for Issue #618 Exp 3 Redux (PR #774): bypasses the Transolver
+    slice bottleneck by operating directly on raw [x, y, z] coordinates and
+    is added residually to existing volume features. Output projection is
+    zero-init so the residual starts as identity pass-through.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        n_heads: int,
+        n_anchors: int = 512,
+        ndim: int = 3,
+    ):
+        super().__init__()
+        if hidden_dim % n_heads != 0:
+            raise ValueError("hidden_dim must be divisible by n_heads")
+        self.hidden_dim = hidden_dim
+        self.n_heads = n_heads
+        self.n_anchors = n_anchors
+        self.ndim = ndim
+        self.head_dim = hidden_dim // n_heads
+        # freqs_per_axis: number of frequency pairs per spatial axis. The
+        # remaining (head_dim - ndim*2*freqs_per_axis) dims are passthrough.
+        self.freqs_per_axis = self.head_dim // (2 * ndim)
+        if self.freqs_per_axis <= 0:
+            raise ValueError(
+                f"head_dim={self.head_dim} too small for ndim={ndim} (need head_dim>=2*ndim)"
+            )
+        self.rope_dim_per_head = self.freqs_per_axis * 2 * ndim
+
+        # Log-spaced 0.1..10.0 Hz per axis; matched to DrivAerML coord scale
+        # ~[-2, 2] m. NLP defaults (theta=10000) are wrong for spatial inputs.
+        log_freqs_init = torch.linspace(
+            math.log(0.1), math.log(10.0), self.freqs_per_axis
+        )
+        self.log_freqs = nn.Parameter(
+            log_freqs_init.unsqueeze(0).expand(ndim, -1).clone()
+        )
+
+        # Independent QKV/output projections for the residual branch.
+        # PR #786 v3 init: Xavier × 0.01 on out_proj (was zero in v2). Small
+        # non-zero residual breaks symmetry from EP1 instead of waiting for
+        # gradients to escape the all-zero output basin.
+        self.qkv = nn.Linear(hidden_dim, 3 * hidden_dim, bias=False)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        nn.init.trunc_normal_(self.qkv.weight, std=0.02)
+        nn.init.xavier_uniform_(self.out_proj.weight)
+        with torch.no_grad():
+            self.out_proj.weight.mul_(0.01)
+
+    def _apply_rope_to_qk(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        coords_q: torch.Tensor,
+        coords_k: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # q, k:                [B, H, seq_len, head_dim]
+        # coords_q, coords_k:  [B, seq_len, ndim]
+        freqs = self.log_freqs.exp()  # [ndim, freqs_per_axis]
+        fpa = self.freqs_per_axis
+        D_head = q.shape[-1]
+
+        def rotate_single(tensor: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+            parts: list[torch.Tensor] = []
+            coords_f = coords.to(dtype=tensor.dtype)
+            for ax in range(self.ndim):
+                c = coords_f[:, :, ax]
+                f = freqs[ax].to(dtype=tensor.dtype)
+                angles = c.unsqueeze(-1) * f.unsqueeze(0).unsqueeze(0)
+                cos_a = angles.cos().unsqueeze(1)
+                sin_a = angles.sin().unsqueeze(1)
+                start = ax * 2 * fpa
+                sl = tensor[..., start:start + 2 * fpa]
+                sl_l, sl_r = sl[..., :fpa], sl[..., fpa:]
+                rot = torch.cat(
+                    [sl_l * cos_a - sl_r * sin_a, sl_r * cos_a + sl_l * sin_a],
+                    dim=-1,
+                )
+                parts.append(rot)
+            if self.rope_dim_per_head < D_head:
+                parts.append(tensor[..., self.rope_dim_per_head:])
+            return torch.cat(parts, dim=-1)
+
+        return rotate_single(q, coords_q), rotate_single(k, coords_k)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # features: [B, N, hidden_dim]
+        # coords:   [B, N, ndim]  raw 3D positions
+        # mask:     [B, N] optional, 1 for valid tokens, 0 for padded
+        B, N, D = features.shape
+        H, hd = self.n_heads, self.head_dim
+        K = min(self.n_anchors, N)
+
+        # Uniform-stride sub-sampling of anchors.
+        stride = max(1, N // K)
+        anchor_idx = torch.arange(0, N, stride, device=features.device)[:K]
+        anchor_feats = features.index_select(1, anchor_idx)
+        anchor_coords = coords.index_select(1, anchor_idx)
+
+        qkv_all = self.qkv(features)
+        qkv_anc = self.qkv(anchor_feats)
+        q = qkv_all[:, :, :D]
+        k = qkv_anc[:, :, D:2 * D]
+        v = qkv_anc[:, :, 2 * D:]
+
+        q = q.view(B, N, H, hd).transpose(1, 2)
+        k = k.view(B, K, H, hd).transpose(1, 2)
+        v = v.view(B, K, H, hd).transpose(1, 2)
+
+        q_rot, k_rot = self._apply_rope_to_qk(q, k, coords, anchor_coords)
+
+        attn_mask = None
+        if mask is not None:
+            anchor_mask = mask.index_select(1, anchor_idx)
+            attn_mask = anchor_mask.bool().view(B, 1, 1, K)
+
+        out = F.scaled_dot_product_attention(q_rot, k_rot, v, attn_mask=attn_mask)
+        out = out.transpose(1, 2).reshape(B, N, D)
+        out = self.out_proj(out)
+        if mask is not None:
+            out = out * mask.unsqueeze(-1).to(dtype=out.dtype)
+        return out
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -342,6 +480,8 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_anchor_string_rope: bool = False,
+        anchor_string_rope_n_anchors: int = 1024,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,13 +494,16 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_anchor_string_rope = use_anchor_string_rope
+        self.anchor_string_rope_n_anchors = anchor_string_rope_n_anchors
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_separable":
             # STRING-separable: learnable per-axis log_freq + phase,
-            # replaces fixed isotropic Gaussian RFF.
-            # num_features defaults to rff_num_features if provided, else 32.
+            # replaces fixed isotropic Gaussian RFF. The optional anchor-RoPE
+            # residual on the volume path layers on independently via the
+            # `use_anchor_string_rope` flag (see `anchor_rope_vol` below).
             string_sep_features = rff_num_features if rff_num_features > 0 else 32
             self.surface_string_sep = StringSeparableEncoding(
                 in_dim=space_dim,
@@ -409,6 +552,15 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        if use_anchor_string_rope:
+            self.anchor_rope_vol = AnchorStringRoPE(
+                hidden_dim=n_hidden,
+                n_heads=n_head,
+                n_anchors=anchor_string_rope_n_anchors,
+                ndim=space_dim,
+            )
+        else:
+            self.anchor_rope_vol = None
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -506,6 +658,13 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.anchor_rope_vol is not None and volume_x is not None:
+            vol_coords_xyz = volume_x[:, :, : self.space_dim]
+            rope_delta = self.anchor_rope_vol(
+                volume_hidden, vol_coords_xyz, mask=volume_mask
+            )
+            volume_hidden = volume_hidden + rope_delta
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -364,6 +364,11 @@ def collect_anchor_rope_metrics(model: nn.Module) -> dict[str, float]:
     for axis in range(log_freqs.shape[0]):
         metrics[f"{prefix}/log_freqs_axis_{axis}_mean"] = float(log_freqs[axis].mean().item())
         metrics[f"{prefix}/log_freqs_axis_{axis}_max"] = float(log_freqs[axis].max().item())
+    # PR #786 v3: track residual branch activation speed. v2 zero-init had
+    # rms=0 at EP1; Xavier×0.01 init should start ~0.01 and grow.
+    out_proj_w = module.out_proj.weight.detach().float()
+    metrics[f"{prefix}/out_proj_weight_rms"] = float(out_proj_w.pow(2).mean().sqrt().item())
+    metrics[f"{prefix}/out_proj_weight_max_abs"] = float(out_proj_w.abs().max().item())
     return metrics
 
 

--- a/train.py
+++ b/train.py
@@ -102,6 +102,8 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_anchor_string_rope: bool = False
+    anchor_string_rope_n_anchors: int = 1024
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -233,9 +235,45 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _split_anchor_rope_freq_params(
+    model: nn.Module,
+) -> tuple[list[nn.Parameter], list[nn.Parameter]]:
+    """Return (main_params, rope_freq_params) where the second group is
+    the per-axis log-frequency tensor for AnchorStringRoPE. The frequency
+    parameter rotates Q/K phase across all heads at once, so it gets a
+    smaller LR (PR #774 differential-LR fix from PR #769 divergence)."""
+    rope_freq_params: list[nn.Parameter] = []
+    main_params: list[nn.Parameter] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.endswith("anchor_rope_vol.log_freqs"):
+            rope_freq_params.append(param)
+        else:
+            main_params.append(param)
+    return main_params, rope_freq_params
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    main_params, rope_freq_params = _split_anchor_rope_freq_params(model)
+    use_param_groups = bool(rope_freq_params)
     if optimizer_name == "adamw":
+        if use_param_groups:
+            return torch.optim.AdamW(
+                [
+                    {
+                        "params": main_params,
+                        "lr": config.lr,
+                        "weight_decay": config.weight_decay,
+                    },
+                    {
+                        "params": rope_freq_params,
+                        "lr": config.lr * 0.1,
+                        "weight_decay": 0.0,
+                    },
+                ],
+            )
         return torch.optim.AdamW(
             model.parameters(),
             lr=config.lr,
@@ -244,6 +282,23 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
+        if use_param_groups:
+            return Lion(
+                [
+                    {
+                        "params": main_params,
+                        "lr": config.lr,
+                        "weight_decay": config.weight_decay,
+                    },
+                    {
+                        "params": rope_freq_params,
+                        "lr": config.lr * 0.1,
+                        "weight_decay": 0.0,
+                    },
+                ],
+                betas=(config.lion_beta1, config.lion_beta2),
+                use_triton=False,
+            )
         return Lion(
             model.parameters(),
             lr=config.lr,
@@ -284,6 +339,34 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_anchor_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-axis log-frequency diagnostics for AnchorStringRoPE.
+
+    PR #774 EP1 kill-gate watches `anchor_rope/log_freqs_mean` and
+    `anchor_rope/log_freqs_max_hz` to detect runaway/freezing of the
+    learnable frequency parameters (the failure mode of PR #769)."""
+
+    module = getattr(model, "anchor_rope_vol", None)
+    if module is None:
+        return {}
+    log_freqs = module.log_freqs.detach().float()
+    freqs_hz = log_freqs.exp()
+    prefix = "anchor_rope"
+    metrics: dict[str, float] = {
+        f"{prefix}/log_freqs_mean": float(log_freqs.mean().item()),
+        f"{prefix}/log_freqs_std": float(log_freqs.std().item()),
+        f"{prefix}/log_freqs_min": float(log_freqs.min().item()),
+        f"{prefix}/log_freqs_max": float(log_freqs.max().item()),
+        f"{prefix}/freqs_hz_min": float(freqs_hz.min().item()),
+        f"{prefix}/freqs_hz_max": float(freqs_hz.max().item()),
+        f"{prefix}/freqs_hz_mean": float(freqs_hz.mean().item()),
+    }
+    for axis in range(log_freqs.shape[0]):
+        metrics[f"{prefix}/log_freqs_axis_{axis}_mean"] = float(log_freqs[axis].mean().item())
+        metrics[f"{prefix}/log_freqs_axis_{axis}_max"] = float(log_freqs[axis].max().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +380,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_anchor_string_rope=config.use_anchor_string_rope,
+        anchor_string_rope_n_anchors=config.anchor_string_rope_n_anchors,
     )
 
 
@@ -1240,6 +1325,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_anchor_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Anchor-STRING RoPE v3 full-budget run** (Issue #618 — Exp 3, definitive test)

The Anchor-STRING RoPE architecture (per-axis learned frequency rotation on Q/K in Transolver attention, interpolated from K=1024 spatial anchors) has shown a strongly closing trajectory across three prior runs:

- PR #774 (v2): EP4 val_abupt=6.9088% — closing gap to SOTA at 1.05× per epoch
- The architecture is sound; the prior runs were limited to 4 epochs by cluster slowdown

Two code improvements are now merged into `tay` from PR #783:
1. **LR cosine schedule matched to actual budget** (`--lr-cosine-t-max 13` instead of 5) — ensures the cosine tail runs over the actual training window
2. **Non-zero `out_proj` init** (`Xavier × 0.01` instead of all-zeros) — allows the RoPE residual to contribute from EP1 rather than waiting to break symmetry from zero

This PR runs the full 13-epoch budget with these fixes to determine definitively whether Anchor-STRING RoPE can beat the SOTA L=5 baseline.

**Key question:** With a full 13-epoch budget and corrected cosine schedule, does the 1.05×/epoch gap closure from v2 extrapolate to beat SOTA (6.5985%) by EP7-EP10?

**Background:** Anchor-STRING embeds learned per-axis frequency rotation (RoPE) into Transolver's Q/K matrices via K=1024 spatial anchors. Each anchor stores a log-frequency vector (3 axes × N_freqs dims). Point RoPE phases are computed by interpolating from the K nearest anchors, then applying standard complex rotation to Q/K. At init, `out_proj.weight=0` means the RoPE contribution is zero — the model is equivalent to the standard STRING-sep baseline. Frequencies are learned from scratch via gradient descent.

Reference: [RoFormer: Enhanced Transformer with Rotary Position Embedding](https://arxiv.org/abs/2104.09864)

## Instructions

The code changes from PR #783 are already merged into `tay`. Use `--use-anchor-string-rope` and `--anchor-string-rope-n-anchors 1024` flags.

The key changes vs PR #774 (v2) are:
- `--lr-cosine-t-max 13` (was 5 in v2 — mismatched to cluster's actual 4-epoch cap; now aligned to full 13-epoch budget)
- Xavier × 0.01 initialization for `out_proj.weight` (was zero; now gives small non-zero residual from EP1)

Run the following command exactly:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-anchor-string-rope \
  --anchor-string-rope-n-anchors 1024 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>35,21728:val_primary/abupt_axis_mean_rel_l2_pct>12,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5" \
  --wandb-group fern-anchor-string-rope-v3 \
  --wandb-name fern/anchor-string-rope-v3-fullrun
```

### W&B logging to include (carry forward from PR #774)

Per validation epoch:
- `anchor_rope/log_freqs_{mean,std,min,max}` — shows if frequencies are learning
- `anchor_rope/freqs_hz_{min,max,mean}` — readable frequency range
- `anchor_rope/log_freqs_axis_{0,1,2}_{mean,max}` — per-axis frequency activity
- `anchor_rope/out_proj_weight_{rms,max_abs}` — residual branch activation speed

Key diagnostic: the `out_proj_weight_rms` should be non-zero from EP1 (due to Xavier×0.01 init) and should grow. In v2 it was zero at EP1 and reached 0.042 by EP4 — with the new init it should start at ~0.01 and grow faster.

### Kill gates

| Gate | Step | Threshold |
|------|------|-----------|
| EP1 | 10,864 | val_abupt > 35% |
| EP2 | 21,728 | val_abupt > 12% |
| EP3 | 32,592 | val_abupt > 8.5% |

These are generous gates — EP3 of 8.5% allows the RoPE architecture extra room since it starts with a more constrained residual. If EP3 clears 8.5%, continue to EP13.

## Baseline to beat

**Single-model SOTA** (PR #592, alphonse, run `4k25s25e`):
- val_abupt = **6.5985%** (EP4, step 43,459)
- val_vol_p = 3.9456%
- val_surface_p = 4.3322%
- test_abupt = 7.9915%

**Prior Anchor-STRING RoPE v2 trajectory** (PR #774, run `dajkq7m8`):
- EP4 val_abupt = 6.9088%
- EP4 test_abupt = 8.249%
- Gap-to-SOTA ratio: 1.05× at EP4 (closing from 1.16× at EP1)
- out_proj_weight rms = 0.042 at EP4

## Final report fields

Please include in your results comment:
- Per-epoch table: val_abupt, val_vol_p, val_surface_p, val_wall_shear at each epoch
- Anchor-rope diagnostics per epoch: log_freqs_mean, out_proj_weight_rms
- Best val epoch and metric
- Comparison table vs SOTA (#592) and vs RoPE v2 (#774) at matched epochs
- W&B run ID (rank 0) and group link
