### PR TITLE
askeladd: vol-decoder SDF-gate v3 — lower cap + gate LR warmup + gate WD

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,87 @@ class Transformer(nn.Module):
         return x
 
 
+class VolDecoderSDFGate(nn.Module):
+    """Bounded affine gate on the volume-decoder output, conditioned on per-case SDF stats.
+
+    8-channel descriptor -> 8->16->2 MLP -> tanh-bounded (a, b) -> ``vol_pred * (1 + a) + b``.
+
+    v3: tanh cap is 0.15 (multiplier in [0.85, 1.15]) and bias cap is 0.03; smaller
+    range than v2 so the gradient signal into the gate MLP is reduced and the gate
+    is less vulnerable to LR perturbations during the EP1->EP2 LR jump.
+    """
+
+    DESCRIPTOR_DIM = 8
+
+    def __init__(self, descriptor_dim: int = 8, hidden: int = 16):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(descriptor_dim, hidden),
+            nn.GELU(),
+            nn.Linear(hidden, 2),
+        )
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+        norm = torch.tensor([3.0, 3.0, 3.0, 6.0, 1.0, 1.0, 1.0, 3.0], dtype=torch.float32)
+        self.register_buffer("input_norm", norm)
+        self._last_a: torch.Tensor | None = None
+        self._last_b: torch.Tensor | None = None
+        self._last_ab_raw: torch.Tensor | None = None
+        self._last_g_sdf: torch.Tensor | None = None
+
+    def forward(self, vol_pred: torch.Tensor, g_sdf: torch.Tensor) -> torch.Tensor:
+        g_sdf_norm = g_sdf / self.input_norm.to(dtype=g_sdf.dtype, device=g_sdf.device)
+        ab = self.mlp(g_sdf_norm)  # (B, 2)
+        a = 0.15 * torch.tanh(ab[:, 0:1])  # multiplier in [-0.15, 0.15] => 1+a in [0.85, 1.15]
+        b = 0.03 * torch.tanh(ab[:, 1:2])  # additive bias in [-0.03, 0.03]
+        self._last_a = a.detach()
+        self._last_b = b.detach()
+        self._last_ab_raw = ab.detach()
+        self._last_g_sdf = g_sdf.detach()
+        return vol_pred * (1.0 + a.unsqueeze(1)) + b.unsqueeze(1)
+
+
+def _compute_sdf_descriptor(
+    sdf: torch.Tensor, mask: torch.Tensor | None
+) -> torch.Tensor:
+    """Compute the 8-channel per-case SDF descriptor for ``VolDecoderSDFGate``.
+
+    Channels: [mean, std, min, max, frac<0.05, frac<0.20, frac<0.50, median] of |sdf|
+    over each case's valid points (mask=True). Returns ``(B, 8)``.
+    """
+
+    abs_sdf = sdf.abs()
+    if mask is None:
+        valid = torch.ones_like(abs_sdf, dtype=torch.bool)
+    else:
+        valid = mask.to(dtype=torch.bool)
+    valid_f = valid.to(dtype=abs_sdf.dtype)
+    valid_count = valid_f.sum(dim=1).clamp(min=1.0)
+
+    masked_vals = abs_sdf * valid_f
+    mean = masked_vals.sum(dim=1) / valid_count
+    sq_dev = ((abs_sdf - mean.unsqueeze(1)) ** 2) * valid_f
+    std = (sq_dev.sum(dim=1) / valid_count).clamp(min=0.0).sqrt()
+
+    inf_filled = torch.where(valid, abs_sdf, torch.full_like(abs_sdf, float("inf")))
+    sdf_min = inf_filled.amin(dim=1)
+    neg_inf_filled = torch.where(valid, abs_sdf, torch.full_like(abs_sdf, float("-inf")))
+    sdf_max = neg_inf_filled.amax(dim=1)
+
+    frac_005 = ((abs_sdf < 0.05) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+    frac_020 = ((abs_sdf < 0.20) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+    frac_050 = ((abs_sdf < 0.50) & valid).to(dtype=abs_sdf.dtype).sum(dim=1) / valid_count
+
+    sorted_vals, _ = inf_filled.sort(dim=1)
+    valid_count_long = valid.to(dtype=torch.long).sum(dim=1).clamp(min=1)
+    mid_idx = ((valid_count_long - 1) // 2).unsqueeze(1)
+    median = sorted_vals.gather(1, mid_idx).squeeze(1)
+
+    return torch.stack(
+        [mean, std, sdf_min, sdf_max, frac_005, frac_020, frac_050, median], dim=-1
+    )
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +423,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_decoder_sdf_gating: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +503,15 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.vol_decoder_sdf_gating = vol_decoder_sdf_gating
+        if vol_decoder_sdf_gating:
+            if self.volume_input_dim < 4:
+                raise ValueError(
+                    "vol_decoder_sdf_gating requires volume_input_dim >= 4 (xyz + sdf channel)"
+                )
+            self.vol_decoder_gate = VolDecoderSDFGate()
+        else:
+            self.vol_decoder_gate = None
 
     def _encode_group(
         self,
@@ -513,8 +604,17 @@ class SurfaceTransolver(nn.Module):
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
+        gate_a: torch.Tensor | None = None
+        gate_b: torch.Tensor | None = None
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            volume_preds = self.volume_out(volume_hidden)
+            if self.vol_decoder_gate is not None:
+                # SDF is the 4th input channel (index 3) per data.VOLUME_X_DIM = 4 layout.
+                g_sdf = _compute_sdf_descriptor(volume_x[:, :, 3], volume_mask)
+                volume_preds = self.vol_decoder_gate(volume_preds, g_sdf)
+                gate_a = self.vol_decoder_gate._last_a
+                gate_b = self.vol_decoder_gate._last_b
+            volume_preds = volume_preds * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
@@ -525,4 +625,6 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "gate_a": gate_a,
+            "gate_b": gate_b,
         }

--- a/train.py
+++ b/train.py
@@ -102,6 +102,9 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    vol_decoder_sdf_gating: bool = False
+    gate_weight_decay: float = 5e-3
+    gate_warmup_epochs: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -235,9 +238,33 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    # When the SDF gate is enabled, split the gate MLP params into their own
+    # group so we can apply v3's stronger weight decay and an independent
+    # per-step LR warmup (see gate-LR override in main()).
+    gate_module = getattr(unwrap_model(model), "vol_decoder_gate", None)
+    if config.vol_decoder_sdf_gating and gate_module is not None:
+        gate_params = list(gate_module.mlp.parameters())
+        gate_param_ids = {id(p) for p in gate_params}
+        backbone_params = [
+            p for p in model.parameters() if id(p) not in gate_param_ids and p.requires_grad
+        ]
+    else:
+        gate_params = []
+        backbone_params = [p for p in model.parameters() if p.requires_grad]
+
+    def _build_param_groups(backbone_wd: float, gate_wd: float) -> list[dict]:
+        groups = [
+            {"params": backbone_params, "lr": config.lr, "weight_decay": backbone_wd},
+        ]
+        if gate_params:
+            groups.append(
+                {"params": gate_params, "lr": config.lr, "weight_decay": gate_wd}
+            )
+        return groups
+
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
-            model.parameters(),
+            _build_param_groups(config.weight_decay, config.gate_weight_decay),
             lr=config.lr,
             weight_decay=config.weight_decay,
         )
@@ -245,7 +272,7 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
+            _build_param_groups(config.weight_decay, config.gate_weight_decay),
             lr=config.lr,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
@@ -297,7 +324,41 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_decoder_sdf_gating=config.vol_decoder_sdf_gating,
     )
+
+
+def collect_gate_metrics(model: nn.Module, prefix: str) -> dict[str, float]:
+    """Per-step gate health metrics from the most recent forward pass.
+
+    Returns scale_{mean,std,min,max,max_abs}, scale_range, sat_frac (fraction
+    of cases with |scale| > 0.9 * tanh_cap), and bias_max_abs. Empty dict if
+    the gate is disabled or hasn't been called yet.
+    """
+
+    gate = getattr(unwrap_model(model), "vol_decoder_gate", None)
+    if gate is None or gate._last_a is None:
+        return {}
+    a = gate._last_a.float().reshape(-1)
+    b = gate._last_b.float().reshape(-1)
+    a_std = float(a.std(unbiased=False).cpu().item()) if a.numel() > 1 else 0.0
+    a_min = float(a.min().cpu().item())
+    a_max = float(a.max().cpu().item())
+    # tanh cap on the multiplier is 0.15 in v3; saturated = |a| > 0.9 * 0.15 = 0.135.
+    sat_thresh = 0.9 * 0.15
+    return {
+        f"{prefix}/scale_mean": float(a.mean().cpu().item()),
+        f"{prefix}/scale_std": a_std,
+        f"{prefix}/scale_min": a_min,
+        f"{prefix}/scale_max": a_max,
+        f"{prefix}/scale_max_abs": float(a.abs().max().cpu().item()),
+        f"{prefix}/scale_range": a_max - a_min,
+        f"{prefix}/sat_frac": float(
+            (a.abs() > sat_thresh).to(dtype=torch.float32).mean().cpu().item()
+        ),
+        f"{prefix}/bias_mean": float(b.mean().cpu().item()),
+        f"{prefix}/bias_max_abs": float(b.abs().max().cpu().item()),
+    }
 
 
 def train_loss(
@@ -762,6 +823,30 @@ def main(argv: Iterable[str] | None = None) -> None:
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
+        # Gate-specific independent LR warmup (v3): the gate MLP param group
+        # gets its own per-step linear warmup over `gate_warmup_epochs` epochs,
+        # using `len(train_loader)` at construction time as the steps/epoch
+        # estimate. This is intentionally smoother than the per-epoch backbone
+        # SequentialLR warmup so the EP1->EP2 LR jump cannot saturate the gate.
+        gate_param_group_idx: int | None = None
+        gate_warmup_steps: int = 0
+        if config.vol_decoder_sdf_gating and len(optimizer.param_groups) > 1:
+            gate_param_group_idx = 1
+            gate_warmup_steps = max(
+                1, config.gate_warmup_epochs * max(len(train_loader), 1)
+            )
+            if state.is_main:
+                gate_param_count = sum(
+                    p.numel() for p in optimizer.param_groups[gate_param_group_idx]["params"]
+                )
+                print(
+                    f"VolDecoderSDFGate v3 enabled: tanh_cap=0.15 bias_cap=0.03 "
+                    f"gate_params={gate_param_count} "
+                    f"gate_warmup_epochs={config.gate_warmup_epochs} "
+                    f"gate_warmup_steps={gate_warmup_steps} "
+                    f"gate_weight_decay={config.gate_weight_decay}"
+                )
+
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
         if config.use_gradnorm:
@@ -1012,6 +1097,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
+                # v3: gate MLP gets its own per-step linear warmup, scaling
+                # the scheduler-set LR by global_step / gate_warmup_steps for
+                # the first gate_warmup_epochs epochs. Backbone is unaffected.
+                gate_lr_log = current_lr
+                if gate_param_group_idx is not None and global_step <= gate_warmup_steps:
+                    scheduled_gate_lr = scheduler.get_last_lr()[gate_param_group_idx]
+                    gate_factor = global_step / float(gate_warmup_steps)
+                    gate_lr = scheduled_gate_lr * gate_factor
+                    optimizer.param_groups[gate_param_group_idx]["lr"] = gate_lr
+                    gate_lr_log = gate_lr
+                elif gate_param_group_idx is not None:
+                    gate_lr_log = optimizer.param_groups[gate_param_group_idx]["lr"]
                 loss_is_nonfinite = not bool(torch.isfinite(loss.detach()).item())
                 skip_step = distributed_any(state, loss_is_nonfinite, device)
                 should_log_model_telemetry = (
@@ -1050,6 +1147,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if config.vol_decoder_sdf_gating:
+                    train_log.update(collect_gate_metrics(model, prefix="train/gate"))
+                    if gate_param_group_idx is not None:
+                        train_log["train/gate/lr"] = gate_lr_log
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
@@ -1240,6 +1341,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if config.vol_decoder_sdf_gating:
+                    primary_val_surface = val_metrics.get("val_surface", {})
+                    for key in (
+                        "gate_scale_mean",
+                        "gate_scale_std",
+                        "gate_scale_min",
+                        "gate_scale_max",
+                        "gate_scale_max_abs",
+                        "gate_scale_range",
+                        "gate_scale_sat_frac",
+                        "gate_bias_mean",
+                        "gate_bias_max_abs",
+                    ):
+                        if key in primary_val_surface:
+                            log_metrics[f"val/gate/{key[len('gate_'):]}"] = primary_val_surface[key]
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -905,6 +905,9 @@ class EvalAccumulator:
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
+    # Per-case SDF-gate diagnostics (only populated when the gate is enabled).
+    gate_a_values: list[float] = field(default_factory=list)
+    gate_b_values: list[float] = field(default_factory=list)
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -967,6 +970,10 @@ def accumulate_eval_batch(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+    gate = getattr(eval_module, "vol_decoder_gate", None)
+    if gate is not None and gate._last_a is not None:
+        accumulator.gate_a_values.extend(gate._last_a.float().reshape(-1).cpu().tolist())
+        accumulator.gate_b_values.extend(gate._last_b.float().reshape(-1).cpu().tolist())
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
@@ -1052,6 +1059,8 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
                 state = merged.case_sums[key].setdefault(case_id, [0.0, 0.0])
                 state[0] += values[0]
                 state[1] += values[1]
+        merged.gate_a_values.extend(accumulator.gate_a_values)
+        merged.gate_b_values.extend(accumulator.gate_b_values)
     return merged
 
 
@@ -1081,7 +1090,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     loss = (accumulator.surface_loss_sse + accumulator.volume_loss_sse) / max(
         accumulator.surface_loss_count + accumulator.volume_loss_count, 1
     )
-    return {
+    result = {
         "loss": loss,
         "surface_loss": accumulator.surface_loss_sse / max(accumulator.surface_loss_count, 1),
         "volume_loss": accumulator.volume_loss_sse / max(accumulator.volume_loss_count, 1),
@@ -1110,6 +1119,29 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
     }
+    if accumulator.gate_a_values:
+        a_tensor = torch.tensor(accumulator.gate_a_values, dtype=torch.float32)
+        b_tensor = torch.tensor(accumulator.gate_b_values, dtype=torch.float32)
+        a_std = float(a_tensor.std(unbiased=False).item()) if a_tensor.numel() > 1 else 0.0
+        a_min = float(a_tensor.min().item())
+        a_max = float(a_tensor.max().item())
+        sat_thresh = 0.9 * 0.15  # v3 tanh cap = 0.15
+        result.update(
+            {
+                "gate_scale_mean": float(a_tensor.mean().item()),
+                "gate_scale_std": a_std,
+                "gate_scale_min": a_min,
+                "gate_scale_max": a_max,
+                "gate_scale_max_abs": float(a_tensor.abs().max().item()),
+                "gate_scale_range": a_max - a_min,
+                "gate_scale_sat_frac": float(
+                    (a_tensor.abs() > sat_thresh).to(dtype=torch.float32).mean().item()
+                ),
+                "gate_bias_mean": float(b_tensor.mean().item()),
+                "gate_bias_max_abs": float(b_tensor.abs().max().item()),
+            }
+        )
+    return result
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Hypothesis

**VolDecoderSDFGate v3: lower tanh cap (0.15) + 2-epoch gate-specific LR warmup + gate weight decay 5e-3**

PRs #781 (unbounded) and #785 (bounded-tanh v2, cap=0.3) both failed via gate saturation. In v2, the 20× LR jump at the EP1→EP2 boundary (4.5e-6 → 9e-5 from `--lr-warmup-epochs 1`) triggered a 30× vol_loss spike, driving the gate MLP monotonically to full negative saturation (scale=-0.301, sat_frac=1.0) within ~2k steps. Geometry conditioning was never active during steady-state training.

**v3 fixes three independent levers:**
1. **Lower tanh cap 0.3 → 0.15**: Scale range shrinks from (−0.3, 0.3) to (−0.15, 0.15). Smaller gradient signal into the gate MLP — less vulnerable to LR perturbation.
2. **Gate-specific 2-epoch LR warmup**: Gate MLP gets its own independent linear warmup from 0 → base_lr over 2 epochs (21,728 steps). At the EP1→EP2 boundary where v2 saturated, gate LR is only at 50% — the spike is structurally blocked.
3. **Gate weight decay 5e-3**: 10× stronger regularization on gate MLP (vs backbone 5e-4) applies constant pull toward zero weights, resisting monotone drift.

The 4 OOD test cases (run_133/226/203/158) account for 92% of test_vol_p deviation. The hypothesis — that per-case SDF statistics can calibrate vol_pred for OOD geometries via a stable post-decoder gate — is still untested at steady state.

## Instructions

**Start from your PR #785 code** (the `VolDecoderSDFGate` module). Apply three changes:

### Change 1: Lower tanh cap

In `VolDecoderSDFGate.forward()`:
```python
# v3:
a = 0.15 * torch.tanh(ab[:, 0:1])  # scale ∈ (−0.15, 0.15) → multiplier ∈ (0.85, 1.15)
b = 0.03 * torch.tanh(ab[:, 1:2])  # additive bias ∈ (−0.03, 0.03)
```

Keep the same hidden dim (8→16→2), zero-init output layer, and input normalization (`_NORM = [3.0, 3.0, 3.0, 6.0, 1.0, 1.0, 1.0, 3.0]`).

### Change 2 + 3: Gate param group with independent warmup and higher weight decay

In the optimizer setup, separate gate MLP params into their own param group:

```python
gate_params = list(model.vol_decoder_gate.mlp.parameters())
gate_param_ids = {id(p) for p in gate_params}
backbone_params = [p for p in model.parameters() if id(p) not in gate_param_ids]

optimizer = Lion([
    {"params": backbone_params, "lr": 9e-5, "weight_decay": 5e-4},
    {"params": gate_params,     "lr": 9e-5, "weight_decay": 5e-3},  # 10× stronger WD
], betas=(0.9, 0.99))
```

Then in the per-step LR update: apply 2-epoch linear warmup ONLY to the gate param group:
```python
# steps_per_epoch ≈ 10,864 for 13 epochs on this dataset
gate_warmup_steps = 2 * steps_per_epoch  # 21,728 steps
if global_step < gate_warmup_steps:
    gate_scale = global_step / gate_warmup_steps
    optimizer.param_groups[1]["lr"] = 9e-5 * gate_scale
# After gate_warmup_steps, the gate follows the same cosine schedule as backbone
```

The main backbone uses the existing `--lr-warmup-epochs 1` (1-epoch warmup).

### Gate health metrics to log every step:
- `train/gate/scale_mean`, `train/gate/scale_std`, `train/gate/scale_min`, `train/gate/scale_max`
- `train/gate/scale_max_abs` (= max abs per-case scale value)
- `train/gate/scale_range` (= scale_max − scale_min; → 0 means saturated)
- `train/gate/sat_frac` (= fraction of cases with |scale| > 0.9 × 0.15 = 0.135)
- `train/gate/bias_max_abs`

### Run a 200-step single-GPU sanity check before DDP launch. Report:
- scale_range at step 200 (should be > 0.0 if gate is activating)
- Any kill threshold fires

### Launch command (after 200-step sanity passes):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --no-compile-model --agent askeladd \
  --wandb-group vol-geom-cond \
  --wandb-name askeladd/vol-decoder-sdf-gate-v3 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --surface-loss-weight 2.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable --use-qk-norm \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --validation-every 1 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<32,21728:val_primary/abupt_axis_mean_rel_l2_pct<12"
```

Note: the gate-specific LR warmup and weight decay are implemented directly in optimizer setup code, not via CLI flags. The kill thresholds use `<VALUE` semantics: kill if the observed metric does NOT satisfy `< VALUE` at that step (i.e., kill if val_abupt ≥ 32% at EP1, ≥ 12% at EP2). Also kill manually if `scale_range < 0.002` at step 200 (gate saturated to constant).

## Gates

- **200-step sanity check** (single GPU): scale_range > 0.002 AND no unexpected crashes → launch DDP
- **EP1** (step 10,864): val_abupt < 32% AND scale_range > 0.002 → continue
- **EP2** (step 21,728): val_abupt < 12% AND scale_range > 0.002 → continue
- **Final**: test_vol_p < 11.374% (vol-pressure anchor PR #681) — primary win condition

## Baseline

**Single-model SOTA:** PR #592 (alphonse, depth-L5, run `4k25s25e`, EP4) — val_abupt=6.5985% / test_abupt=7.9915%
**Vol-pressure anchor:** PR #681 (run `dc031qpt`) — test_vol_p=11.374%
**Val per-channel (SOTA):** surface_pressure=4.3322%, volume_pressure=3.9456%, wall_shear_x=6.542%, tau_y=8.363%, tau_z=9.810%
**Test per-channel (SOTA):** surface_pressure=4.22%, volume_pressure=11.933%, wall_shear=7.49%, tau_y=8.23%, tau_z=9.55%

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
**Single-model training gate:** val_abupt < 6.5985%
