### PR TITLE
FiLM v3: compressed vol-points schedule for max FiLM-active epochs

### DIFF
--- a/model.py
+++ b/model.py
@@ -324,9 +324,16 @@ class VolGeomFilm(nn.Module):
     """FiLM modulation for volume tokens conditioned on a global surface latent.
 
     Applies ``vol' = gamma(g) * vol + beta(g)`` where ``g`` is a B x D global
-    surface geometry embedding. Initialised to identity (gamma=1, beta=0) so
-    that the first-step output equals the input and the model can recover the
-    baseline at any time during optimisation.
+    surface geometry embedding.
+
+    v2 — bounded tanh modulation:
+      gamma = 1 + tanh(gamma_proj(g))  in (0, 2)
+      beta  = tanh(beta_proj(g))        in (-1, 1)
+
+    Both projections are fully zero-initialised (weight and bias). Since
+    tanh(0) = 0, at initialisation gamma = 1 and beta = 0, preserving the
+    identity transform without requiring a bias=1 hack. The tanh bounds prevent
+    the unbounded gamma deviation seen in v1 (±4.7× by epoch 1).
 
     Reference: Perez et al. 2018, "FiLM: Visual Reasoning with a General
     Conditioning Layer" (https://arxiv.org/abs/1709.07871).
@@ -337,16 +344,18 @@ class VolGeomFilm(nn.Module):
         self.hidden_dim = hidden_dim
         self.gamma_proj = nn.Linear(hidden_dim, hidden_dim)
         self.beta_proj = nn.Linear(hidden_dim, hidden_dim)
+        # Full zero-init: tanh(0)=0 => gamma=1+0=1, beta=0 at step 0 (identity).
         nn.init.zeros_(self.gamma_proj.weight)
-        nn.init.ones_(self.gamma_proj.bias)
+        nn.init.zeros_(self.gamma_proj.bias)
         nn.init.zeros_(self.beta_proj.weight)
         nn.init.zeros_(self.beta_proj.bias)
 
     def forward(
         self, vol_tokens: torch.Tensor, g: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        gamma = self.gamma_proj(g).unsqueeze(1)
-        beta = self.beta_proj(g).unsqueeze(1)
+        # gamma in (0, 2); beta in (-1, 1)
+        gamma = 1.0 + torch.tanh(self.gamma_proj(g).unsqueeze(1))  # B × 1 × D
+        beta = torch.tanh(self.beta_proj(g).unsqueeze(1))            # B × 1 × D
         out = gamma * vol_tokens + beta
         return out, gamma.squeeze(1), beta.squeeze(1)
 
@@ -374,6 +383,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         vol_geom_film: bool = False,
+        vol_geom_film_start_epoch: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -456,6 +466,10 @@ class SurfaceTransolver(nn.Module):
         self.n_hidden = n_hidden
         self.vol_geom_film_enabled = vol_geom_film
         self.vol_geom_film = VolGeomFilm(n_hidden) if vol_geom_film else None
+        self.vol_geom_film_start_epoch = vol_geom_film_start_epoch
+        # Set by the training loop at the start of each epoch via
+        # ``base_model._current_epoch = epoch``. Used to gate delayed FiLM onset.
+        self._current_epoch: int = 0
 
     def _encode_group(
         self,
@@ -545,14 +559,21 @@ class SurfaceTransolver(nn.Module):
 
         diagnostics: dict[str, torch.Tensor] = {}
         surface_g_out: torch.Tensor | None = None
-        # Always run FiLM when volume tokens are present so that gamma/beta
-        # parameters are exercised on every iteration (DDP requires this with
-        # find_unused_parameters=False; without an unconditional path the
-        # FiLM proj weights become stale on volume-only batches).
+        # Delayed FiLM onset: bypass FiLM entirely (identity passthrough) for
+        # epochs before vol_geom_film_start_epoch. This lets the backbone
+        # stabilise during the low-volume-point early curriculum epochs (0-5)
+        # and fires FiLM only when the 49k-point representation is available
+        # (epoch 6+ per the default vol-points schedule).
+        film_active = self._current_epoch >= self.vol_geom_film_start_epoch
+        if self.vol_geom_film is not None and volume_x is not None and volume_tokens > 0:
+            diagnostics["vol_geom_film/film_active"] = torch.tensor(
+                1.0 if film_active else 0.0
+            )
         if (
             self.vol_geom_film is not None
             and volume_x is not None
             and volume_tokens > 0
+            and film_active
         ):
             # Resolution order: live surface latent (with grads back to surface
             # encoder) -> cached g_override (no grads) -> zero fallback (cold

--- a/model.py
+++ b/model.py
@@ -605,8 +605,14 @@ class SurfaceTransolver(nn.Module):
                     diagnostics["vol_geom_film/g_std"] = g32.std(dim=0, unbiased=False).mean()
                 diagnostics["vol_geom_film/gamma_dev_from_one_mean_abs"] = (gamma32 - 1.0).abs().mean()
                 diagnostics["vol_geom_film/gamma_dev_from_one_max_abs"] = (gamma32 - 1.0).abs().max()
+                # sat_frac: fraction of γ entries within 0.1 of saturation (γ<0.1 or γ>1.9).
+                gamma_sat = ((gamma32 < 0.1) | (gamma32 > 1.9)).to(dtype=torch.float32)
+                diagnostics["vol_geom_film/gamma_sat_frac"] = gamma_sat.mean()
                 diagnostics["vol_geom_film/beta_mean_abs"] = beta32.abs().mean()
                 diagnostics["vol_geom_film/beta_max_abs"] = beta32.abs().max()
+                # beta_sat_frac: fraction of β entries within 0.1 of saturation (|β|>0.9).
+                beta_sat = (beta32.abs() > 0.9).to(dtype=torch.float32)
+                diagnostics["vol_geom_film/beta_sat_frac"] = beta_sat.mean()
                 diagnostics["vol_geom_film/g_is_live"] = torch.tensor(1.0 if g_source == "live" else 0.0)
                 diagnostics["vol_geom_film/g_is_override"] = torch.tensor(1.0 if g_source == "override" else 0.0)
                 diagnostics["vol_geom_film/g_is_zeros"] = torch.tensor(1.0 if g_source == "zeros" else 0.0)

--- a/model.py
+++ b/model.py
@@ -320,6 +320,37 @@ class Transformer(nn.Module):
         return x
 
 
+class VolGeomFilm(nn.Module):
+    """FiLM modulation for volume tokens conditioned on a global surface latent.
+
+    Applies ``vol' = gamma(g) * vol + beta(g)`` where ``g`` is a B x D global
+    surface geometry embedding. Initialised to identity (gamma=1, beta=0) so
+    that the first-step output equals the input and the model can recover the
+    baseline at any time during optimisation.
+
+    Reference: Perez et al. 2018, "FiLM: Visual Reasoning with a General
+    Conditioning Layer" (https://arxiv.org/abs/1709.07871).
+    """
+
+    def __init__(self, hidden_dim: int):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.gamma_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.beta_proj = nn.Linear(hidden_dim, hidden_dim)
+        nn.init.zeros_(self.gamma_proj.weight)
+        nn.init.ones_(self.gamma_proj.bias)
+        nn.init.zeros_(self.beta_proj.weight)
+        nn.init.zeros_(self.beta_proj.bias)
+
+    def forward(
+        self, vol_tokens: torch.Tensor, g: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        gamma = self.gamma_proj(g).unsqueeze(1)
+        beta = self.beta_proj(g).unsqueeze(1)
+        out = gamma * vol_tokens + beta
+        return out, gamma.squeeze(1), beta.squeeze(1)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +373,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_geom_film: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +453,9 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.n_hidden = n_hidden
+        self.vol_geom_film_enabled = vol_geom_film
+        self.vol_geom_film = VolGeomFilm(n_hidden) if vol_geom_film else None
 
     def _encode_group(
         self,
@@ -455,6 +490,7 @@ class SurfaceTransolver(nn.Module):
         surface_mask: torch.Tensor | None = None,
         volume_x: torch.Tensor | None = None,
         volume_mask: torch.Tensor | None = None,
+        g_override: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         if surface_x is None and volume_x is None:
             raise ValueError("SurfaceTransolver requires surface_x or volume_x")
@@ -507,6 +543,57 @@ class SurfaceTransolver(nn.Module):
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
+        diagnostics: dict[str, torch.Tensor] = {}
+        surface_g_out: torch.Tensor | None = None
+        # Always run FiLM when volume tokens are present so that gamma/beta
+        # parameters are exercised on every iteration (DDP requires this with
+        # find_unused_parameters=False; without an unconditional path the
+        # FiLM proj weights become stale on volume-only batches).
+        if (
+            self.vol_geom_film is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            # Resolution order: live surface latent (with grads back to surface
+            # encoder) -> cached g_override (no grads) -> zero fallback (cold
+            # start). Zero g preserves identity (gamma=1, beta=0) since the
+            # FiLM projections are zero-initialised on the weight matrix.
+            g_source = "zeros"
+            if surface_x is not None and surface_tokens > 0:
+                mask_f = surface_mask.unsqueeze(-1).to(dtype=surface_hidden.dtype)
+                masked_sum = (surface_hidden * mask_f).sum(dim=1)
+                masked_count = mask_f.sum(dim=1).clamp(min=1.0)
+                g = masked_sum / masked_count
+                surface_g_out = g.detach()
+                g_source = "live"
+            elif g_override is not None:
+                g = g_override.to(device=volume_hidden.device, dtype=volume_hidden.dtype)
+                g_source = "override"
+            else:
+                g = volume_hidden.new_zeros(volume_hidden.shape[0], self.n_hidden)
+            volume_hidden, gamma, beta = self.vol_geom_film(volume_hidden, g)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+            with torch.no_grad():
+                g32 = g.detach().float()
+                gamma32 = gamma.detach().float()
+                beta32 = beta.detach().float()
+                diagnostics["vol_geom_film/g_mean"] = g32.mean()
+                diagnostics["vol_geom_film/g_mean_abs"] = g32.abs().mean()
+                diagnostics["vol_geom_film/g_norm_mean"] = g32.norm(dim=-1).mean()
+                if g32.shape[0] > 1:
+                    diagnostics["vol_geom_film/g_std"] = g32.std(dim=0, unbiased=False).mean()
+                diagnostics["vol_geom_film/gamma_dev_from_one_mean_abs"] = (gamma32 - 1.0).abs().mean()
+                diagnostics["vol_geom_film/gamma_dev_from_one_max_abs"] = (gamma32 - 1.0).abs().max()
+                diagnostics["vol_geom_film/beta_mean_abs"] = beta32.abs().mean()
+                diagnostics["vol_geom_film/beta_max_abs"] = beta32.abs().max()
+                diagnostics["vol_geom_film/g_is_live"] = torch.tensor(1.0 if g_source == "live" else 0.0)
+                diagnostics["vol_geom_film/g_is_override"] = torch.tensor(1.0 if g_source == "override" else 0.0)
+                diagnostics["vol_geom_film/g_is_zeros"] = torch.tensor(1.0 if g_source == "zeros" else 0.0)
+                if surface_tokens > 0:
+                    surface_token_norm = surface_hidden.detach().float().norm(dim=-1)
+                    if surface_token_norm.numel() > 0:
+                        diagnostics["vol_geom_film/surface_hidden_token_norm_max"] = surface_token_norm.max()
+
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
@@ -525,4 +612,6 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "diagnostics": diagnostics,
+            "surface_g": surface_g_out,
         }

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    vol_geom_film: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -284,6 +285,45 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def _build_g_override_from_cache(
+    case_ids: list[str],
+    g_cache: dict[str, torch.Tensor],
+    n_hidden: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Assemble a B x D g_override tensor from the per-case g cache.
+
+    Cache misses (cold start) become zero rows, which yields the FiLM
+    identity (gamma=1, beta=0) thanks to the zero-init weight matrix.
+    """
+    rows: list[torch.Tensor] = []
+    for case_id in case_ids:
+        cached = g_cache.get(case_id)
+        if cached is None:
+            rows.append(torch.zeros(n_hidden, dtype=torch.float32))
+        else:
+            rows.append(cached.to(dtype=torch.float32))
+    return torch.stack(rows, dim=0).to(device=device, dtype=torch.float32)
+
+
+def _update_g_cache_from_out(
+    out: dict[str, object],
+    batch,
+    g_cache: dict[str, torch.Tensor],
+) -> None:
+    """Refresh per-case g cache when a surface-present batch produced a live g."""
+    surface_g = out.get("surface_g") if isinstance(out, dict) else None
+    if surface_g is None:
+        return
+    if not torch.is_tensor(surface_g):
+        return
+    sg = surface_g.detach().to(device="cpu", dtype=torch.float32)
+    surface_mask = batch.surface_mask
+    for i, case_id in enumerate(batch.case_ids):
+        if bool(surface_mask[i].any()):
+            g_cache[case_id] = sg[i].clone()
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +337,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_geom_film=config.vol_geom_film,
     )
 
 
@@ -310,7 +351,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, dict[str, float]]:
+    g_override: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, float], dict[str, object]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -320,6 +362,7 @@ def train_loss(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            g_override=g_override,
         )
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
@@ -335,13 +378,16 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    for key, value in out.get("diagnostics", {}).items():
+        metrics[key] = float(value.detach().cpu().item()) if torch.is_tensor(value) else float(value)
+    return loss, metrics, out
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -353,13 +399,14 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
-) -> list[torch.Tensor]:
+    *,
+    g_override: torch.Tensor | None = None,
+) -> tuple[list[torch.Tensor], dict[str, object]]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
-    Returns scalar tensors in order: [sp, tau_x, tau_y, tau_z, vp].
-    All five share the same forward graph so the GradNorm balancer can
-    extract per-task gradient norms via ``torch.autograd.grad`` with
-    ``retain_graph=True``.
+    Returns the per-task losses [sp, tau_x, tau_y, tau_z, vp] and the
+    forward output dict (so the caller can pull out e.g. ``surface_g`` for
+    the FiLM g-cache).
     """
 
     batch = batch.to(device)
@@ -371,6 +418,7 @@ def per_task_train_losses(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            g_override=g_override,
         )
         surface_pred = out["surface_preds"]
         sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
@@ -378,7 +426,7 @@ def per_task_train_losses(
         tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
         tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
+    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss], out
 
 
 GRADNORM_MODES = ("full", "ema_proxy")
@@ -753,6 +801,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            if config.vol_geom_film:
+                # Volume-only training views skip the live surface encoder path,
+                # so the FiLM projections are always exercised but only depend on
+                # g_override (no surface_hidden grad path) — keep DDP happy by
+                # tolerating the changing autograd graph shape.
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
@@ -870,6 +924,14 @@ def main(argv: Iterable[str] | None = None) -> None:
         timeout_hit = False
         train_start = time.time()
 
+        # Per-case g cache for FiLM volume conditioning. Populated on the fly
+        # by surface-present training batches (rare in DrivAerML — ~2.4% of
+        # train views — so most batches consult the cache as g_override).
+        # Each rank maintains its own cache; values stay on CPU to avoid
+        # GPU-RAM bloat at 400 train cases x n_hidden floats.
+        train_g_cache: dict[str, torch.Tensor] = {}
+        n_hidden_cache = config.model_hidden_dim
+
         for epoch in range(max_epochs):
             if vol_points_schedule:
                 desired_vol_points = vol_points_for_epoch(
@@ -915,9 +977,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                if config.vol_geom_film:
+                    g_override = _build_g_override_from_cache(
+                        batch.case_ids,
+                        train_g_cache,
+                        n_hidden_cache,
+                        device,
+                    )
+                else:
+                    g_override = None
                 if balancer is not None:
-                    per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                    per_task_losses, last_out = per_task_train_losses(
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        g_override=g_override,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -999,7 +1075,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
-                    loss, batch_loss_metrics = train_loss(
+                    loss, batch_loss_metrics, last_out = train_loss(
                         model,
                         batch,
                         transform,
@@ -1008,7 +1084,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        g_override=g_override,
                     )
+                if config.vol_geom_film:
+                    _update_g_cache_from_out(last_out, batch, train_g_cache)
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1048,6 +1127,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for key, value in batch_loss_metrics.items():
+                        if "/" in key:
+                            train_log[key] = value
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     vol_geom_film: bool = False
+    vol_geom_film_start_epoch: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -338,6 +339,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         vol_geom_film=config.vol_geom_film,
+        vol_geom_film_start_epoch=config.vol_geom_film_start_epoch,
     )
 
 
@@ -933,6 +935,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_hidden_cache = config.model_hidden_dim
 
         for epoch in range(max_epochs):
+            # Propagate current epoch to base_model for delayed FiLM onset gating.
+            if config.vol_geom_film:
+                base_model._current_epoch = epoch
             if vol_points_schedule:
                 desired_vol_points = vol_points_for_epoch(
                     vol_points_schedule, epoch, config.train_volume_points

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -955,17 +955,30 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    g_cache: dict[str, torch.Tensor] | None = None,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
     volume_target_norm = transform.apply_volume(batch.volume_y)
     eval_module = unwrap_model(model)
+    g_override = None
+    if g_cache and getattr(eval_module, "vol_geom_film_enabled", False):
+        n_hidden = getattr(eval_module, "n_hidden")
+        g_list: list[torch.Tensor] = []
+        for case_id in batch.case_ids:
+            cached = g_cache.get(case_id)
+            if cached is not None:
+                g_list.append(cached.to(device=device, dtype=torch.float32))
+            else:
+                g_list.append(torch.zeros(n_hidden, device=device, dtype=torch.float32))
+        g_override = torch.stack(g_list, dim=0)
     with autocast_context(device, amp_mode):
         out = eval_module(
             surface_x=batch.surface_x,
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            g_override=g_override,
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
@@ -1113,6 +1126,85 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
 
 
 @torch.no_grad()
+def compute_eval_g_cache(
+    model: nn.Module,
+    loader,
+    device: torch.device,
+    *,
+    amp_mode: str = "none",
+    distributed_state: DistributedState | None = None,
+) -> dict[str, torch.Tensor]:
+    """Pre-compute per-case surface latent g for FiLM-conditioned eval.
+
+    During eval, most volume chunks have empty surface tensors (because
+    DrivAerML cases have ~30M volume points vs ~700k surface points, so
+    volume_views >> surface_views). Without this pre-pass, ~98% of volume
+    eval predictions would skip FiLM and use the unconditioned baseline,
+    causing a train/eval mismatch.
+
+    This helper iterates the loader once, runs surface-only forwards on
+    surface-present batches, computes g via masked mean pool over
+    surface_hidden, and accumulates a running mean per case_id. Cross-rank
+    aggregation guarantees every rank ends up with the same complete cache.
+    """
+    eval_module = unwrap_model(model)
+    if not getattr(eval_module, "vol_geom_film_enabled", False):
+        return {}
+    model.eval()
+    g_sum: dict[str, torch.Tensor] = {}
+    g_count: dict[str, int] = {}
+    for batch in loader:
+        if batch.surface_x.shape[1] == 0 or not bool(batch.surface_mask.any()):
+            continue
+        batch = batch.to(device)
+        with autocast_context(device, amp_mode):
+            out = eval_module(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+        surface_hidden = out["surface_hidden"].float()
+        mask_f = batch.surface_mask.unsqueeze(-1).float()
+        masked_sum = (surface_hidden * mask_f).sum(dim=1)
+        masked_count = mask_f.sum(dim=1).clamp(min=1.0)
+        g = (masked_sum / masked_count).detach().cpu()
+        for i, case_id in enumerate(batch.case_ids):
+            if not bool(batch.surface_mask[i].any()):
+                continue
+            if case_id not in g_sum:
+                g_sum[case_id] = g[i].clone()
+                g_count[case_id] = 1
+            else:
+                g_sum[case_id] = g_sum[case_id] + g[i]
+                g_count[case_id] = g_count[case_id] + 1
+    if distributed_state is not None and distributed_state.enabled:
+        gathered: list[tuple[dict[str, torch.Tensor], dict[str, int]] | None] = [
+            None for _ in range(distributed_state.world_size)
+        ]
+        dist.all_gather_object(gathered, (g_sum, g_count))
+        merged_sum: dict[str, torch.Tensor] = {}
+        merged_count: dict[str, int] = {}
+        for partial in gathered:
+            if partial is None:
+                continue
+            ps, pc = partial
+            for case_id, value in ps.items():
+                if case_id not in merged_sum:
+                    merged_sum[case_id] = value.clone()
+                    merged_count[case_id] = pc[case_id]
+                else:
+                    merged_sum[case_id] = merged_sum[case_id] + value
+                    merged_count[case_id] = merged_count[case_id] + pc[case_id]
+        g_sum = merged_sum
+        g_count = merged_count
+    return {
+        case_id: g_sum[case_id] / max(g_count[case_id], 1)
+        for case_id in g_sum
+    }
+
+
+@torch.no_grad()
 def evaluate_split(
     model: nn.Module,
     loader,
@@ -1122,6 +1214,13 @@ def evaluate_split(
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
 ) -> dict[str, float]:
+    g_cache = compute_eval_g_cache(
+        model,
+        loader,
+        device,
+        amp_mode=amp_mode,
+        distributed_state=distributed_state,
+    )
     model.eval()
     accumulator = EvalAccumulator()
     for batch in loader:
@@ -1132,6 +1231,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            g_cache=g_cache,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]


### PR DESCRIPTION
## Hypothesis

**Vol decoder FiLM conditioning v3: compressed vol-points schedule to maximize FiLM-active training time**

PR #778 (FiLM v2) validated that bounded tanh γ∈(0,2) works correctly — FiLM-active epoch was cleanly the best checkpoint across all 4 channels, with no blow-up. However, the run **timed out at step 36720 (mid display Epoch 4/13)**, meaning only ~4127 FiLM-active steps were executed (FiLM fired at EP3, but training ended at EP4 onset). The curriculum never reached V=49k or V=65k, where vol_pressure signal is strongest.

**Root cause:** `--vol-geom-film-start-epoch 6` combined with the standard schedule `0:16384:3:32768:6:49152:9:65536` means FiLM doesn't fire until EP6 = step 87296. With a 270-min budget (~40,000 usable steps), EP6 arrives just 2 epochs before timeout. Even at EP3 in the run (when `--vol-geom-film-start-epoch 3` was used in the actual run), only 1 FiLM-active epoch was completed.

**Fix: Compress the vol-points schedule + early FiLM onset.**

Move to V=65k by EP2 (instead of EP9) so the model trains the majority of epochs at full resolution with FiLM active:

```
0:16384:1:32768:2:49152:3:65536
```

This reaches V=65k by EP3, giving 10+ FiLM-active epochs within the 270-min budget. Pair with `--vol-geom-film-start-epoch 2` so FiLM fires from EP2 onward, at the start of V≥49k.

**Expected benefit:** ~10× more FiLM-active training steps compared to v2. The mechanism is proven; this PR tests whether sufficient FiLM training time translates to metric improvement.

## Instructions

**Branch your code from `tay`** (NOT from the closed `frieren/vol-geom-film-v2-bounded` branch — the human has merged v3 code fixes into `tay` already).

Check that your `VolGeomFilm` class in the code on `tay` already includes the bounded tanh design from PR #778:
- `gamma = 1.0 + torch.tanh(self.gamma_proj(g)).unsqueeze(1)` → γ∈(0,2)
- `beta = torch.tanh(self.beta_proj(g)).unsqueeze(1)` → β∈(−1,1)
- Zero-weight init for all gamma_proj and beta_proj weights and biases

If not present, re-apply the bounded tanh design from PR #778 (see PR body for exact code).

**The only change vs v2 is the training command:**

### Reproduce command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --no-compile-model --agent frieren \
  --wandb-group vol-film-v3-compressed-curriculum \
  --wandb-name frieren/vol-film-v3-compressed-curriculum \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --surface-loss-weight 2.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --validation-every 1 \
  --use-vol-geom-film \
  --vol-geom-film-start-epoch 2
```

**Key changes vs v2:**
1. `--vol-points-schedule "0:16384:1:32768:2:49152:3:65536"` — reach V=65k by EP3 (was EP9)
2. `--vol-geom-film-start-epoch 2` — FiLM fires at EP2 (was EP6)

### Diagnostics to log in results comment

Report at each gate epoch:
- `max|γ−1|` (max deviation of γ from identity) at EP2 (FiLM onset), EP5, EP9, EP13
- `sat_frac` (fraction of samples where γ saturates near 0 or 2) at EP13
- val_vol_p trend after EP2 onset vs EP1 (does FiLM improve vol_pressure?)
- Per-channel test metrics at best-val checkpoint

## Gates

- **EP1:** val_abupt < 32% → continue (V=32k, FiLM not yet active)
- **EP3:** val_abupt < 12% → continue (V=65k, 1 FiLM-active epoch complete)
- **EP6:** val_abupt < 8.0% → continue (4 FiLM-active epochs complete)
- **Final win conditions:**
  - Primary: test_vol_p < 11.374% (vol-pressure anchor PR #681)
  - Secondary: val_abupt < 6.5985% (single-model SOTA PR #592)

## Baseline

| Metric | Value | Source |
|---|---|---|
| val_abupt (single SOTA) | 6.5985% | PR #592 alphonse |
| test_abupt (single SOTA) | 7.9915% | PR #592 alphonse |
| test_vol_p (anchor) | 11.374% | PR #681 dc031qpt |
| val_abupt (ensemble SOTA) | 6.1751% | PR #612 nezuko K=7 |
| test_abupt (ensemble SOTA) | 7.5347% | PR #612 nezuko K=7 |

**PR #778 (FiLM v2 baseline for this PR):**
- val_abupt: 6.8991% (best EP: display EP4 = code EP3, first FiLM-active epoch)
- test_vol_p: 12.1104% (only ~4127 FiLM-active steps — severely undertrained)
- FiLM γ deviation: bounded and stable (max~0.4 at EP3)

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

