### PR TITLE
alphonse: Anchor-STRING RoPE stabilized — diff LR + grad clip + freq init

### DIFF
--- a/model.py
+++ b/model.py
@@ -194,6 +194,13 @@ class AnchorStringRoPE(nn.Module):
             self.out_proj.weight.mul_(0.01)
         self.phase: nn.Parameter | None = None
 
+    def init_sigmas(self) -> list[float]:
+        return torch.logspace(
+            math.log10(self.init_min_freq),
+            math.log10(self.init_max_freq),
+            self.freqs_per_axis,
+        ).tolist()
+
     def _apply_rope_to_qk(
         self,
         q: torch.Tensor,

--- a/model.py
+++ b/model.py
@@ -136,6 +136,138 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class AnchorStringRoPE(nn.Module):
+    """Learnable per-axis rotary encoding on actual 3D point coordinates.
+
+    Performs a sub-sampled cross-attention pass: queries come from all N
+    points, keys/values come from K=n_anchors uniformly strided anchors.
+    Per-axis log-frequencies rotate Q and K with their own coordinates,
+    yielding spatial relative-position dependence on (coord_q - coord_k).
+
+    Originally landed as PR #774 v2 (zero-init out_proj) and PR #786 v3
+    (Xavier x 0.01 out_proj init). PR #801 adds an `init_max_freq` knob to
+    let the caller tighten the log-spaced frequency init range.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        n_heads: int,
+        n_anchors: int = 1024,
+        ndim: int = 3,
+        init_max_freq: float = 10.0,
+        init_min_freq: float = 0.1,
+    ):
+        super().__init__()
+        if hidden_dim % n_heads != 0:
+            raise ValueError("hidden_dim must be divisible by n_heads")
+        if init_max_freq <= init_min_freq:
+            raise ValueError(
+                f"init_max_freq={init_max_freq} must be > init_min_freq={init_min_freq}"
+            )
+        self.hidden_dim = hidden_dim
+        self.n_heads = n_heads
+        self.n_anchors = n_anchors
+        self.ndim = ndim
+        self.head_dim = hidden_dim // n_heads
+        self.init_max_freq = init_max_freq
+        self.init_min_freq = init_min_freq
+        self.freqs_per_axis = self.head_dim // (2 * ndim)
+        if self.freqs_per_axis <= 0:
+            raise ValueError(
+                f"head_dim={self.head_dim} too small for ndim={ndim} (need head_dim>=2*ndim)"
+            )
+        self.rope_dim_per_head = self.freqs_per_axis * 2 * ndim
+
+        log_freqs_init = torch.linspace(
+            math.log(init_min_freq), math.log(init_max_freq), self.freqs_per_axis
+        )
+        self.log_freqs = nn.Parameter(
+            log_freqs_init.unsqueeze(0).expand(ndim, -1).clone()
+        )
+
+        self.qkv = nn.Linear(hidden_dim, 3 * hidden_dim, bias=False)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        nn.init.trunc_normal_(self.qkv.weight, std=0.02)
+        nn.init.xavier_uniform_(self.out_proj.weight)
+        with torch.no_grad():
+            self.out_proj.weight.mul_(0.01)
+        self.phase: nn.Parameter | None = None
+
+    def _apply_rope_to_qk(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        coords_q: torch.Tensor,
+        coords_k: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        freqs = self.log_freqs.exp()
+        fpa = self.freqs_per_axis
+        D_head = q.shape[-1]
+
+        def rotate_single(tensor: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+            parts: list[torch.Tensor] = []
+            coords_f = coords.to(dtype=tensor.dtype)
+            for ax in range(self.ndim):
+                c = coords_f[:, :, ax]
+                f = freqs[ax].to(dtype=tensor.dtype)
+                angles = c.unsqueeze(-1) * f.unsqueeze(0).unsqueeze(0)
+                cos_a = angles.cos().unsqueeze(1)
+                sin_a = angles.sin().unsqueeze(1)
+                start = ax * 2 * fpa
+                sl = tensor[..., start:start + 2 * fpa]
+                sl_l, sl_r = sl[..., :fpa], sl[..., fpa:]
+                rot = torch.cat(
+                    [sl_l * cos_a - sl_r * sin_a, sl_r * cos_a + sl_l * sin_a],
+                    dim=-1,
+                )
+                parts.append(rot)
+            if self.rope_dim_per_head < D_head:
+                parts.append(tensor[..., self.rope_dim_per_head:])
+            return torch.cat(parts, dim=-1)
+
+        return rotate_single(q, coords_q), rotate_single(k, coords_k)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, D = features.shape
+        H, hd = self.n_heads, self.head_dim
+        K = min(self.n_anchors, N)
+
+        stride = max(1, N // K)
+        anchor_idx = torch.arange(0, N, stride, device=features.device)[:K]
+        anchor_feats = features.index_select(1, anchor_idx)
+        anchor_coords = coords.index_select(1, anchor_idx)
+
+        qkv_all = self.qkv(features)
+        qkv_anc = self.qkv(anchor_feats)
+        q = qkv_all[:, :, :D]
+        k = qkv_anc[:, :, D:2 * D]
+        v = qkv_anc[:, :, 2 * D:]
+
+        q = q.view(B, N, H, hd).transpose(1, 2)
+        k = k.view(B, K, H, hd).transpose(1, 2)
+        v = v.view(B, K, H, hd).transpose(1, 2)
+
+        q_rot, k_rot = self._apply_rope_to_qk(q, k, coords, anchor_coords)
+
+        attn_mask = None
+        if mask is not None:
+            anchor_mask = mask.index_select(1, anchor_idx)
+            attn_mask = anchor_mask.bool().view(B, 1, 1, K)
+
+        out = F.scaled_dot_product_attention(q_rot, k_rot, v, attn_mask=attn_mask)
+        out = out.transpose(1, 2).reshape(B, N, D)
+        out = self.out_proj(out)
+        if mask is not None:
+            out = out * mask.unsqueeze(-1).to(dtype=out.dtype)
+        return out
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -342,6 +474,10 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_anchor_string_rope: bool = False,
+        anchor_string_rope_n_anchors: int = 1024,
+        anchor_rope_init_max_freq: float = 10.0,
+        anchor_rope_init_min_freq: float = 0.1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +490,10 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_anchor_string_rope = use_anchor_string_rope
+        self.anchor_string_rope_n_anchors = anchor_string_rope_n_anchors
+        self.anchor_rope_init_max_freq = anchor_rope_init_max_freq
+        self.anchor_rope_init_min_freq = anchor_rope_init_min_freq
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -409,6 +549,17 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        if use_anchor_string_rope:
+            self.anchor_rope_vol = AnchorStringRoPE(
+                hidden_dim=n_hidden,
+                n_heads=n_head,
+                n_anchors=anchor_string_rope_n_anchors,
+                ndim=space_dim,
+                init_max_freq=anchor_rope_init_max_freq,
+                init_min_freq=anchor_rope_init_min_freq,
+            )
+        else:
+            self.anchor_rope_vol = None
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -506,6 +657,13 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.anchor_rope_vol is not None and volume_x is not None:
+            vol_coords_xyz = volume_x[:, :, : self.space_dim]
+            rope_delta = self.anchor_rope_vol(
+                volume_hidden, vol_coords_xyz, mask=volume_mask
+            )
+            volume_hidden = volume_hidden + rope_delta
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -102,6 +102,11 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_anchor_string_rope: bool = False
+    anchor_string_rope_n_anchors: int = 1024
+    anchor_rope_lr_scale: float = 1.0
+    anchor_rope_grad_clip: float = 0.0
+    anchor_rope_init_max_freq: float = 10.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -233,11 +238,39 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _build_param_groups(model: nn.Module, config: Config) -> list[dict]:
+    """Split parameters so anchor-rope log_freqs/phase get a separate LR group.
+
+    The anchor-rope log_freqs/phase live on a more curved (periodic) loss
+    surface than the rest of the network. When ``--anchor-rope-lr-scale != 1``
+    they receive their own optimizer group at ``lr * anchor_rope_lr_scale`` to
+    prevent premature frequency lock-in. With ``anchor_rope_lr_scale == 1`` we
+    keep a single group so the optimizer is byte-identical to the legacy path.
+    """
+    rope_params: list[nn.Parameter] = []
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        if "anchor_rope" in name and ("log_freqs" in name or "phase" in name):
+            rope_params.append(p)
+    if not rope_params or config.anchor_rope_lr_scale == 1.0:
+        return [{"params": [p for p in model.parameters() if p.requires_grad], "lr": config.lr}]
+    rope_param_ids = {id(p) for p in rope_params}
+    other_params = [
+        p for p in model.parameters() if p.requires_grad and id(p) not in rope_param_ids
+    ]
+    return [
+        {"params": other_params, "lr": config.lr},
+        {"params": rope_params, "lr": config.lr * config.anchor_rope_lr_scale},
+    ]
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    param_groups = _build_param_groups(model, config)
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
-            model.parameters(),
+            param_groups,
             lr=config.lr,
             weight_decay=config.weight_decay,
         )
@@ -245,7 +278,7 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
+            param_groups,
             lr=config.lr,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
@@ -284,6 +317,80 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_anchor_rope_metrics(
+    model: nn.Module, *, rope_param_lr: float | None = None
+) -> dict[str, float]:
+    """Gather per-validation anchor-rope frequency / out_proj diagnostics."""
+    module = getattr(model, "anchor_rope_vol", None)
+    if module is None:
+        return {}
+    metrics: dict[str, float] = {}
+    log_freqs = module.log_freqs.detach().float()
+    metrics["anchor_rope/log_freqs_mean"] = float(log_freqs.mean().item())
+    metrics["anchor_rope/log_freqs_std"] = float(log_freqs.std().item())
+    metrics["anchor_rope/log_freqs_min"] = float(log_freqs.min().item())
+    metrics["anchor_rope/log_freqs_max"] = float(log_freqs.max().item())
+    freqs_hz = log_freqs.exp()
+    metrics["anchor_rope/freqs_hz_min"] = float(freqs_hz.min().item())
+    metrics["anchor_rope/freqs_hz_max"] = float(freqs_hz.max().item())
+    metrics["anchor_rope/freqs_hz_mean"] = float(freqs_hz.mean().item())
+    for axis in range(log_freqs.shape[0]):
+        metrics[f"anchor_rope/log_freqs_axis_{axis}_mean"] = float(log_freqs[axis].mean().item())
+        metrics[f"anchor_rope/log_freqs_axis_{axis}_max"] = float(log_freqs[axis].max().item())
+    out_w = module.out_proj.weight.detach().float()
+    metrics["anchor_rope/out_proj_weight_rms"] = float(out_w.pow(2).mean().sqrt().item())
+    metrics["anchor_rope/out_proj_weight_max_abs"] = float(out_w.abs().max().item())
+    if module.phase is not None:
+        phase = module.phase.detach().float()
+        metrics["anchor_rope/phase_mean"] = float(phase.mean().item())
+        metrics["anchor_rope/phase_std"] = float(phase.std().item())
+        metrics["anchor_rope/phase_max_abs"] = float(phase.abs().max().item())
+    if rope_param_lr is not None:
+        metrics["anchor_rope/rope_param_lr"] = float(rope_param_lr)
+    return metrics
+
+
+def anchor_rope_named_params(model: nn.Module) -> list[tuple[str, nn.Parameter]]:
+    """All anchor-rope parameters (qkv, out_proj, log_freqs, phase, etc.)."""
+    return [
+        (name, p)
+        for name, p in model.named_parameters()
+        if "anchor_rope" in name and p.requires_grad
+    ]
+
+
+def anchor_rope_grad_norm(
+    named_params: list[tuple[str, nn.Parameter]], device: torch.device
+) -> torch.Tensor:
+    total = torch.zeros((), device=device, dtype=torch.float32)
+    for _, p in named_params:
+        if p.grad is None:
+            continue
+        total = total + p.grad.detach().float().square().sum()
+    return total.sqrt()
+
+
+def current_rope_lr(
+    optimizer: torch.optim.Optimizer,
+    anchor_rope_params: list[tuple[str, nn.Parameter]],
+) -> float:
+    """Find the live LR of the optimizer group that owns the first rope param."""
+    if not anchor_rope_params:
+        return float("nan")
+    # log_freqs/phase live in the rope group when --anchor-rope-lr-scale != 1.0;
+    # otherwise they share the only group with the rest of the model.
+    rope_lr_param_ids = {
+        id(p)
+        for name, p in anchor_rope_params
+        if "log_freqs" in name or "phase" in name
+    }
+    target_ids = rope_lr_param_ids or {id(p) for _, p in anchor_rope_params}
+    for group in optimizer.param_groups:
+        if any(id(p) in target_ids for p in group["params"]):
+            return float(group["lr"])
+    return float(optimizer.param_groups[0]["lr"])
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -297,6 +404,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_anchor_string_rope=config.use_anchor_string_rope,
+        anchor_string_rope_n_anchors=config.anchor_string_rope_n_anchors,
+        anchor_rope_init_max_freq=config.anchor_rope_init_max_freq,
     )
 
 
@@ -761,6 +871,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+        anchor_rope_params = anchor_rope_named_params(base_model)
+        rope_param_lr_base = config.lr * config.anchor_rope_lr_scale
+        if anchor_rope_params and state.is_main:
+            print(
+                f"AnchorStringRoPE active: "
+                f"params={sum(p.numel() for _, p in anchor_rope_params):,d}, "
+                f"lr_scale={config.anchor_rope_lr_scale}, "
+                f"grad_clip={config.anchor_rope_grad_clip}, "
+                f"init_max_freq={config.anchor_rope_init_max_freq}, "
+                f"n_anchors={config.anchor_string_rope_n_anchors}"
+            )
 
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
@@ -861,6 +982,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            ar_module = getattr(base_model, "anchor_rope_vol", None)
+            if ar_module is not None:
+                wandb.summary["anchor_rope/init_sigmas"] = ar_module.init_sigmas()
+                wandb.summary["anchor_rope/init_max_freq"] = config.anchor_rope_init_max_freq
+                wandb.summary["anchor_rope/n_anchors"] = config.anchor_string_rope_n_anchors
+                wandb.summary["anchor_rope/lr_scale"] = config.anchor_rope_lr_scale
+                wandb.summary["anchor_rope/grad_clip"] = config.anchor_rope_grad_clip
+                wandb.summary["anchor_rope/rope_param_lr_base"] = rope_param_lr_base
+                wandb.summary["model/use_anchor_string_rope"] = 1.0
+                wandb.summary["model/anchor_string_rope_n_anchors"] = (
+                    config.anchor_string_rope_n_anchors
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1027,6 +1160,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                should_log_anchor_rope_grad = (
+                    should_log_gradients and bool(anchor_rope_params)
+                )
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
@@ -1078,6 +1214,39 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/step_skipped": 1.0 if skip_step else 0.0,
                         }
                     )
+                    if (
+                        not skip_step
+                        and anchor_rope_params
+                        and config.anchor_rope_grad_clip > 0.0
+                    ):
+                        if should_log_anchor_rope_grad:
+                            ar_norm_before = float(
+                                anchor_rope_grad_norm(anchor_rope_params, device).detach().cpu().item()
+                            )
+                            train_log["anchor_rope/grad_norm_before_clip"] = ar_norm_before
+                        torch.nn.utils.clip_grad_norm_(
+                            [p for _, p in anchor_rope_params],
+                            max_norm=config.anchor_rope_grad_clip,
+                        )
+                        if should_log_anchor_rope_grad:
+                            ar_norm_after = float(
+                                anchor_rope_grad_norm(anchor_rope_params, device).detach().cpu().item()
+                            )
+                            train_log["anchor_rope/grad_norm_after_clip"] = ar_norm_after
+                            train_log["anchor_rope/grad_clip_active"] = (
+                                1.0 if ar_norm_before > config.anchor_rope_grad_clip else 0.0
+                            )
+                    elif (
+                        not skip_step
+                        and anchor_rope_params
+                        and should_log_anchor_rope_grad
+                    ):
+                        ar_norm_before = float(
+                            anchor_rope_grad_norm(anchor_rope_params, device).detach().cpu().item()
+                        )
+                        train_log["anchor_rope/grad_norm_before_clip"] = ar_norm_before
+                        train_log["anchor_rope/grad_norm_after_clip"] = ar_norm_before
+                        train_log["anchor_rope/grad_clip_active"] = 0.0
                     gradient_metrics = (
                         collect_gradient_metrics(
                             model,
@@ -1240,6 +1409,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if anchor_rope_params:
+                    log_metrics.update(
+                        collect_anchor_rope_metrics(
+                            base_model,
+                            rope_param_lr=current_rope_lr(optimizer, anchor_rope_params),
+                        )
+                    )
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Anchor-STRING RoPE Stabilized: Exp 3 Redux (Issue #618)**

The Anchor-STRING RoPE architecture (per-axis learned frequency rotation on Q/K via K=1024 spatial anchors) ran as PR #786 (v3) but was CLOSED INCONCLUSIVE — reaching only 4 effective epochs due to the 270-min training budget, with val_abupt=6.92% at EP4 cutoff. The architecture is fundamentally sound (v2 PR #774 showed 1.05× gap-closure per epoch from 7.13% at EP1). However, two diagnostics from the gradient logs point to a stabilization problem we should fix before the next full-budget run:

1. **The RoPE frequency params have high relative LR vs the main backbone** — the anchor-frequency path receives the same LR (9e-5) as all other parameters, but its gradient landscape is more curved (rotary functions are periodic, not linear). Reducing the effective LR for `log_freq` params prevents premature frequency lock-in in early epochs.

2. **Gradient clipping on the rotary path is too loose** — the global `--grad-clip-norm 0.5` clips the L2 norm of the entire parameter gradient, so a large local gradient spike in the anchor-rope module may pass through without triggering the clip (the rest of the network is flat at that step). Dedicated per-module clipping at 1.0 on the anchor-rope module would have caught the val instabilities observed in v3 EP2.

3. **Frequency initialization may be too aggressive** — the default `init_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0)` were tuned for the input-level STRING-sep encoding. For per-head per-anchor Q/K rotation, the effective frequency after rotary application needs to match the spatial scale of the DrivAerML geometry (~[-3, 3] meters). Log-spaced init from 0.1 to 10.0 better covers this range.

This PR implements these three targeted fixes on the exact SOTA stack used in PR #786, and runs the full 13-epoch budget. We expect EP7+ clarity on whether the architecture can beat the single-model SOTA (val_abupt=6.5985%).

**Reference: Issue #618 — Exp 3 (Anchor-STRING stabilized)**

---

## Instructions

### Code changes required

You are working from the `tay` branch. The `--use-anchor-string-rope` and `--anchor-string-rope-n-anchors` flags already exist (merged from PR #783). This experiment requires three targeted modifications to `train.py` and/or `model.py`:

#### 1. Differential LR for anchor-rope frequency parameters

In `build_optimizer` in `train.py`, split parameters into two groups: anchor-rope `log_freq` + `phase` parameters at `0.1 × lr` (i.e., `lr * 0.1 = 9e-6`), and all other parameters at the default `lr = 9e-5`.

```python
# In build_optimizer (or before optimizer construction in main())
base_model = model.module if hasattr(model, 'module') else model
rope_params = [p for name, p in base_model.named_parameters() 
               if ('anchor_rope' in name or 'string_rope' in name) 
               and ('log_freq' in name or 'phase' in name) and p.requires_grad]
rope_param_ids = {id(p) for p in rope_params}
other_params = [p for p in base_model.parameters() 
                if id(p) not in rope_param_ids and p.requires_grad]
param_groups = [
    {'params': other_params, 'lr': config.lr},
    {'params': rope_params, 'lr': config.lr * config.anchor_rope_lr_scale},
]
# Use param_groups instead of model.parameters() when constructing the optimizer
```

Add a new CLI flag: `--anchor-rope-lr-scale 0.1` (float, default=1.0 so it's a no-op when not used).

Log `anchor_rope/rope_param_lr` per epoch to W&B.

#### 2. Per-module gradient clipping on the anchor-rope path

After `loss.backward()` and before `optimizer.step()`, apply an additional per-module clip specifically to the anchor-rope submodule parameters:

```python
# After global clip, before optimizer.step()
if config.anchor_rope_grad_clip > 0 and hasattr(base_model, 'backbone'):
    rope_modules = [m for name, m in base_model.named_modules() 
                    if 'anchor_rope' in name or 'string_rope' in name]
    rope_params_list = [p for m in rope_modules for p in m.parameters() if p.grad is not None]
    if rope_params_list:
        torch.nn.utils.clip_grad_norm_(rope_params_list, config.anchor_rope_grad_clip)
```

Add a new CLI flag: `--anchor-rope-grad-clip 1.0` (float, default=0.0 = disabled).

Log `anchor_rope/grad_norm_before_clip` and `anchor_rope/grad_norm_after_clip` per training step (log every `config.gradient_log_every` steps).

#### 3. Conservative frequency initialization

Add a new CLI flag: `--anchor-rope-init-max-freq 10.0` (float, default uses current `rff_init_sigmas` range). When set, override the `init_sigmas` used for the anchor-rope module specifically with log-spaced values between `0.1` and `anchor_rope_init_max_freq`:

```python
# In model.py AnchorStringRoPE or equivalent, when anchor_rope_init_max_freq is set:
import numpy as np
n_octaves = len(init_sigmas)  # e.g., 5
conservative_sigmas = np.logspace(np.log10(0.1), np.log10(config.anchor_rope_init_max_freq), n_octaves).tolist()
# Use conservative_sigmas instead of config.rff_init_sigmas for anchor-rope init
```

Log `anchor_rope/init_sigmas` as a W&B config field (not a metric) so we can compare runs.

### Run command

After implementing the three changes above, run:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-anchor-string-rope \
  --anchor-string-rope-n-anchors 1024 \
  --anchor-rope-lr-scale 0.1 \
  --anchor-rope-grad-clip 1.0 \
  --anchor-rope-init-max-freq 10.0 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>35,21728:val_primary/abupt_axis_mean_rel_l2_pct>12,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5" \
  --wandb-group anchor-string-rope-stabilized \
  --wandb-name alphonse/anchor-rope-stabilized
```

### W&B logging requirements

Per validation epoch, log:
- `anchor_rope/log_freqs_mean`, `anchor_rope/log_freqs_std`, `anchor_rope/log_freqs_min`, `anchor_rope/log_freqs_max`
- `anchor_rope/out_proj_weight_rms`, `anchor_rope/out_proj_weight_max_abs`
- `anchor_rope/rope_param_lr` (the effective LR applied to rope params)
- `anchor_rope/init_sigmas` (as config, once at run start)

Per `gradient_log_every` training steps:
- `anchor_rope/grad_norm_before_clip` (L2 norm of anchor-rope params gradients before module clip)
- `anchor_rope/grad_norm_after_clip`

---

## Kill Gates

| Gate | Step | Threshold | Notes |
|------|------|-----------|-------|
| EP1 | 10,864 | val_abupt > 35% | Catastrophic divergence check |
| EP2 | 21,728 | val_abupt > 12% | Basic convergence check |
| EP3 | 32,592 | val_abupt > 8.5% | Architecture viability check |

These gates are generous (same as PR #786). If EP1 passes at ~25-28% and EP2 at ~9-11%, we are on track.

---

## Baseline to beat

**Single-model SOTA** (PR #592, alphonse, run `4k25s25e`):
- val_abupt = **6.5985%** (EP4)
- test_abupt = **7.9915%**
- val_vol_p = 3.9456%, val_surface_p = 4.3322%

**Prior Anchor-STRING RoPE v3 trajectory** (PR #786, CLOSED INCONCLUSIVE, budget limited):
- EP4 val_abupt = 6.92% (270-min cutoff)
- out_proj_weight_rms = 0.0464 at EP4 (Xavier×0.01 init worked as designed)
- Architecture was converging at cutoff — no indication of divergence

---

## Final report fields

Please include in your results comment:
- Per-epoch table: display_ep, val_abupt, val_vol_p, val_surface_p, val_wall_shear (ws_x / ws_y / ws_z)
- Anchor-rope diagnostics per epoch: log_freqs_mean, out_proj_weight_rms, rope_param_lr
- Gradient diagnostics: grad_norm_before_clip and grad_norm_after_clip per epoch (avg over steps)
- Final test metrics (test_abupt, test_vol_p, test_surface_p, test_wall_shear) from best-val checkpoint
- Comparison to PR #786 v3 EP4 baseline (6.92%)
- Whether the stabilization fixes (differential LR / grad clip / freq init) measurably changed the learning dynamics vs PR #786

**Reference:** Issue #618
