### PR TITLE
frieren: AB-UPT geom branch v2 — freeze + diff LR + vol_p warmup weight

### DIFF
--- a/model.py
+++ b/model.py
@@ -188,6 +188,463 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SwiGLU(nn.Module):
+    """SwiGLU feed-forward block (Shazeer 2020)."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w3 = nn.Linear(hidden_dim, dim, bias=False)
+        for layer in (self.w1, self.w2, self.w3):
+            _init_linear(layer)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w3(F.silu(self.w1(x)) * self.w2(x))
+
+
+class LearnableCoordinateRoPE(nn.Module):
+    """Learnable per-axis coordinate-conditioned RoPE for 3D points.
+
+    Combines RoPE (Su et al., 2021) with learnable per-axis spectral
+    parameters (matching ``StringSeparableEncoding``). For each axis the
+    rotation angle is ``2*pi*coord_axis * exp(log_freq) + phase`` where
+    ``log_freq`` and ``phase`` are learnable. Pairs of head dims are
+    rotated by the resulting angle, with axes split round-robin so each
+    axis controls a contiguous slice of the head dim.
+
+    Multi-sigma init places the initial frequencies across an octave
+    spread (sigmas) so the model starts with broad spectral coverage.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        ndim: int = 3,
+        init_sigmas: list[float] | tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+    ):
+        super().__init__()
+        if head_dim < 2:
+            raise ValueError("LearnableCoordinateRoPE requires head_dim >= 2")
+        self.head_dim = head_dim
+        self.ndim = ndim
+        self.total_pairs = head_dim // 2
+        base, extra = divmod(self.total_pairs, ndim)
+        self.pairs_per_axis = [base + (a < extra) for a in range(ndim)]
+        max_pairs = max(self.pairs_per_axis) if self.pairs_per_axis else 0
+        log_freq_init = torch.zeros(ndim, max_pairs)
+        for axis in range(ndim):
+            for i in range(self.pairs_per_axis[axis]):
+                log_freq_init[axis, i] = math.log(init_sigmas[i % len(init_sigmas)])
+        self.log_freq = nn.Parameter(log_freq_init)
+        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
+        self.init_sigmas = tuple(init_sigmas)
+
+    def angles(self, coords: torch.Tensor) -> torch.Tensor:
+        parts = []
+        for axis, n_pairs in enumerate(self.pairs_per_axis):
+            if n_pairs == 0:
+                continue
+            freq = self.log_freq[axis, :n_pairs].exp().to(coords.dtype)
+            phase = self.phase[axis, :n_pairs].to(coords.dtype)
+            angle = 2.0 * math.pi * coords[..., axis : axis + 1] * freq + phase
+            parts.append(angle)
+        return torch.cat(parts, dim=-1) if parts else coords.new_zeros(*coords.shape[:-1], 0)
+
+    @staticmethod
+    def _rotate_pairs(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        total_pairs = theta.shape[-1]
+        rot_dim = total_pairs * 2
+        if rot_dim == 0:
+            return x
+        x_rot = x[..., :rot_dim].float().reshape(*x.shape[:-1], total_pairs, 2)
+        cos = theta.float().cos().unsqueeze(-1)
+        sin = theta.float().sin().unsqueeze(-1)
+        x0 = x_rot[..., 0:1]
+        x1 = x_rot[..., 1:2]
+        rot = torch.cat([x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1)
+        rot = rot.flatten(-2)
+        if rot_dim < x.shape[-1]:
+            return torch.cat([rot.to(x.dtype), x[..., rot_dim:]], dim=-1)
+        return rot.to(x.dtype)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        q_coords: torch.Tensor,
+        k_coords: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if k_coords is None:
+            k_coords = q_coords
+        theta_q = self.angles(q_coords).unsqueeze(1)
+        theta_k = self.angles(k_coords).unsqueeze(1)
+        return self._rotate_pairs(q, theta_q), self._rotate_pairs(k, theta_k)
+
+
+class SupernodePoolingDense(nn.Module):
+    """Dense, positions-only supernode pooling (AB-UPT-style).
+
+    Given a batched dense point cloud and a set of pre-selected anchor
+    indices (supernodes), build per-anchor features by:
+      1. anchor-centric kNN to gather the ``k`` nearest input points,
+      2. embed the relative position (with magnitude) via
+         ``ContinuousSincosEmbed``,
+      3. apply a small MLP and mean-aggregate per anchor,
+      4. concat with the absolute pos-embed of the anchor and project.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        ndim: int = 3,
+        k: int = 32,
+        knn_chunk_size: int = 128,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.ndim = ndim
+        self.k = k
+        self.knn_chunk_size = knn_chunk_size
+        self.rel_pos_embed = ContinuousSincosEmbed(hidden_dim=hidden_dim, input_dim=ndim + 1)
+        self.abs_pos_embed = ContinuousSincosEmbed(hidden_dim=hidden_dim, input_dim=ndim)
+        self.message = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, hidden_dim),
+        )
+        self.proj = nn.Linear(2 * hidden_dim, hidden_dim)
+        for layer in self.message:
+            if isinstance(layer, nn.Linear):
+                _init_linear(layer)
+        _init_linear(self.proj)
+
+    def _anchor_knn(
+        self,
+        pos: torch.Tensor,
+        anchor_pos: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        K = anchor_pos.shape[1]
+        knn_indices = torch.empty(
+            pos.shape[0], K, self.k, device=pos.device, dtype=torch.long
+        )
+        chunk = self.knn_chunk_size
+        with torch.no_grad():
+            pos_float = pos.detach().float()
+            anchor_float = anchor_pos.detach().float()
+            invalid = ~mask.bool() if mask is not None else None
+            for start in range(0, K, chunk):
+                end = min(start + chunk, K)
+                dist = torch.cdist(anchor_float[:, start:end], pos_float)
+                if invalid is not None:
+                    dist = dist.masked_fill(invalid.unsqueeze(1), float("inf"))
+                _, idx = dist.topk(k=self.k, largest=False, dim=-1)
+                knn_indices[:, start:end] = idx
+        return knn_indices
+
+    def forward(
+        self,
+        pos: torch.Tensor,
+        anchor_pos: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, _ = pos.shape
+        K = anchor_pos.shape[1]
+        knn_idx = self._anchor_knn(pos, anchor_pos, mask=mask)
+        gather_index = knn_idx.unsqueeze(-1).expand(-1, -1, -1, self.ndim)
+        nb_pos = torch.gather(
+            pos.unsqueeze(1).expand(-1, K, -1, -1),
+            dim=2,
+            index=gather_index,
+        )
+        rel_pos = anchor_pos.unsqueeze(2) - nb_pos
+        rel_mag = rel_pos.norm(dim=-1, keepdim=True)
+        rel_input = torch.cat([rel_pos, rel_mag], dim=-1)
+        rel_emb = self.rel_pos_embed(rel_input)
+        msg = self.message(rel_emb)
+        anchor_feat = msg.mean(dim=2)
+        abs_emb = self.abs_pos_embed(anchor_pos)
+        combined = torch.cat([anchor_feat, abs_emb], dim=-1)
+        return self.proj(combined)
+
+
+def _select_anchor_indices(
+    valid_counts: torch.Tensor,
+    K: int,
+    N: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Per-sample stride selection of ``K`` anchor indices from valid points."""
+    B = int(valid_counts.shape[0])
+    indices = torch.empty(B, K, device=device, dtype=torch.long)
+    for b in range(B):
+        v = max(1, int(valid_counts[b].item()))
+        if v >= K:
+            stride = max(1, v // K)
+            base = torch.arange(0, K * stride, stride, device=device)[:K]
+            base = base.clamp(max=v - 1)
+            indices[b] = base
+        else:
+            base = torch.arange(0, K, device=device).clamp(max=v - 1)
+            indices[b] = base
+    return indices
+
+
+class ABUPTAnchorBlock(nn.Module):
+    """AB-UPT-style anchor self-attention block with learnable coordinate RoPE."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        rope: LearnableCoordinateRoPE,
+        mlp_hidden_dim: int | None = None,
+        qk_norm: bool = True,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.rope = rope
+        self.qk_norm = qk_norm
+        self.dropout = dropout
+
+        self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.qkv = nn.Linear(hidden_dim, 3 * hidden_dim, bias=False)
+        self.proj = nn.Linear(hidden_dim, hidden_dim)
+        if qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+            self.k_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+        else:
+            self.q_norm = None
+            self.k_norm = None
+        if mlp_hidden_dim is None:
+            mlp_hidden_dim = int(round(hidden_dim * 8 / 3))
+        self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.mlp = SwiGLU(hidden_dim, mlp_hidden_dim)
+        _init_linear(self.qkv)
+        _init_linear(self.proj)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        coords: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, K, _ = x.shape
+        h = self.norm1(x)
+        qkv = self.qkv(h)
+        q, k, v = qkv.chunk(3, dim=-1)
+        q = q.reshape(B, K, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        k = k.reshape(B, K, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        v = v.reshape(B, K, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        if self.q_norm is not None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        q, k = self.rope(q, k, coords)
+        sdpa_kwargs = dict(dropout_p=self.dropout if self.training else 0.0)
+        if attn_mask is not None:
+            valid = attn_mask.bool()
+            am = torch.zeros(B, 1, 1, K, device=x.device, dtype=q.dtype)
+            am = am.masked_fill(~valid[:, None, None, :], float("-inf"))
+            sdpa_kwargs["attn_mask"] = am
+        out = F.scaled_dot_product_attention(q, k, v, **sdpa_kwargs)
+        out = out.transpose(1, 2).reshape(B, K, self.hidden_dim)
+        x = x + self.proj(out)
+        x = x + self.mlp(self.norm2(x))
+        if attn_mask is not None:
+            x = _apply_token_mask(x, attn_mask)
+        return x
+
+
+class ABUPTAnchorToPointBlock(nn.Module):
+    """Cross-attention from points (queries) to anchors (keys/values)."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        rope: LearnableCoordinateRoPE,
+        mlp_hidden_dim: int | None = None,
+        qk_norm: bool = True,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.rope = rope
+        self.qk_norm = qk_norm
+        self.dropout = dropout
+
+        self.q_norm_in = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.kv_norm_in = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.kv_proj = nn.Linear(hidden_dim, 2 * hidden_dim, bias=False)
+        self.proj = nn.Linear(hidden_dim, hidden_dim)
+        if qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+            self.k_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True)
+        else:
+            self.q_norm = None
+            self.k_norm = None
+        if mlp_hidden_dim is None:
+            mlp_hidden_dim = int(round(hidden_dim * 8 / 3))
+        self.mlp_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.mlp = SwiGLU(hidden_dim, mlp_hidden_dim)
+        _init_linear(self.q_proj)
+        _init_linear(self.kv_proj)
+        _init_linear(self.proj)
+
+    def forward(
+        self,
+        point_x: torch.Tensor,
+        point_coords: torch.Tensor,
+        anchor_x: torch.Tensor,
+        anchor_coords: torch.Tensor,
+        point_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, _ = point_x.shape
+        K = anchor_x.shape[1]
+        q_in = self.q_norm_in(point_x)
+        kv_in = self.kv_norm_in(anchor_x)
+        q = self.q_proj(q_in)
+        kv = self.kv_proj(kv_in)
+        k, v = kv.chunk(2, dim=-1)
+        q = q.reshape(B, N, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        k = k.reshape(B, K, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        v = v.reshape(B, K, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        if self.q_norm is not None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        q, k = self.rope(q, k, point_coords, anchor_coords)
+        out = F.scaled_dot_product_attention(
+            q, k, v, dropout_p=self.dropout if self.training else 0.0
+        )
+        out = out.transpose(1, 2).reshape(B, N, self.hidden_dim)
+        x = point_x + self.proj(out)
+        x = x + self.mlp(self.mlp_norm(x))
+        if point_mask is not None:
+            x = _apply_token_mask(x, point_mask)
+        return x
+
+
+class ABUPTGeomBranch(nn.Module):
+    """Parallel AB-UPT-style geometry branch producing an additive residual.
+
+    Given raw point coordinates and post-backbone point features, this branch:
+      1. Selects K anchor indices per sample (stride sampling within valid points).
+      2. Pools input points to anchor features via ``SupernodePoolingDense``.
+      3. Runs ``n_layers`` anchor self-attention blocks with shared
+         ``LearnableCoordinateRoPE``.
+      4. Anchor->point cross-attention broadcasts back to per-point features.
+      5. Final output projection (zero-init) so the branch starts as identity
+         residual at training step 0.
+
+    The branch contributes a learned correction on top of the existing
+    Transolver backbone via additive residual at the post-norm, pre-head stage.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        n_anchors: int = 1024,
+        n_layers: int = 3,
+        ndim: int = 3,
+        rope_init_sigmas: list[float] | tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        qk_norm: bool = True,
+        dropout: float = 0.0,
+        pool_k: int = 32,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.n_anchors = int(n_anchors)
+        self.n_layers = int(n_layers)
+        self.ndim = ndim
+
+        self.rope = LearnableCoordinateRoPE(
+            head_dim=self.head_dim, ndim=ndim, init_sigmas=rope_init_sigmas,
+        )
+        self.supernode_pool = SupernodePoolingDense(
+            hidden_dim=hidden_dim, ndim=ndim, k=pool_k,
+        )
+        self.anchor_blocks = nn.ModuleList(
+            [
+                ABUPTAnchorBlock(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    rope=self.rope,
+                    qk_norm=qk_norm,
+                    dropout=dropout,
+                )
+                for _ in range(self.n_layers)
+            ]
+        )
+        self.cross = ABUPTAnchorToPointBlock(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            rope=self.rope,
+            qk_norm=qk_norm,
+            dropout=dropout,
+        )
+        # Zero-init so the branch starts as the identity residual.
+        self.out_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        nn.init.zeros_(self.out_proj.weight)
+        if self.out_proj.bias is not None:
+            nn.init.zeros_(self.out_proj.bias)
+
+    def forward(
+        self,
+        coords: torch.Tensor,
+        point_features: torch.Tensor,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """
+        coords: ``[B, N, 3]`` raw point coordinates
+        point_features: ``[B, N, D]`` per-point features (post-backbone)
+        mask: ``[B, N]`` valid-point mask (True for valid)
+        Returns: ``[B, N, D]`` residual to add to point_features
+        """
+        B, N, _ = coords.shape
+        K = self.n_anchors
+        if mask is not None:
+            valid_counts = mask.sum(dim=-1).long()
+        else:
+            valid_counts = torch.full(
+                (B,), N, dtype=torch.long, device=coords.device
+            )
+        anchor_idx = _select_anchor_indices(valid_counts, K, N, coords.device)
+        gather_idx = anchor_idx.unsqueeze(-1).expand(-1, -1, self.ndim)
+        anchor_coords = torch.gather(coords, dim=1, index=gather_idx)
+        anchor_features = self.supernode_pool(coords, anchor_coords, mask=mask)
+        for block in self.anchor_blocks:
+            anchor_features = block(anchor_features, anchor_coords)
+        out = self.cross(
+            point_x=point_features,
+            point_coords=coords,
+            anchor_x=anchor_features,
+            anchor_coords=anchor_coords,
+            point_mask=mask,
+        )
+        out = self.out_norm(out)
+        residual = self.out_proj(out)
+        if mask is not None:
+            residual = _apply_token_mask(residual, mask)
+        return residual
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -342,6 +799,11 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_abupt_geom_branch: bool = False,
+        geom_branch_n_anchors: int = 1024,
+        geom_branch_n_layers: int = 3,
+        geom_branch_pool_k: int = 32,
+        geom_branch_rope_init_sigmas: list[float] | tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +816,11 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_abupt_geom_branch = bool(use_abupt_geom_branch)
+        self.geom_branch_n_anchors = int(geom_branch_n_anchors)
+        self.geom_branch_n_layers = int(geom_branch_n_layers)
+        self.geom_branch_pool_k = int(geom_branch_pool_k)
+        self.geom_branch_rope_init_sigmas = tuple(geom_branch_rope_init_sigmas)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -419,6 +886,32 @@ class SurfaceTransolver(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        if self.use_abupt_geom_branch:
+            self.geom_branch_surface = ABUPTGeomBranch(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                n_anchors=self.geom_branch_n_anchors,
+                n_layers=self.geom_branch_n_layers,
+                ndim=space_dim,
+                rope_init_sigmas=self.geom_branch_rope_init_sigmas,
+                qk_norm=use_qk_norm,
+                dropout=dropout,
+                pool_k=self.geom_branch_pool_k,
+            )
+            self.geom_branch_volume = ABUPTGeomBranch(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                n_anchors=self.geom_branch_n_anchors,
+                n_layers=self.geom_branch_n_layers,
+                ndim=space_dim,
+                rope_init_sigmas=self.geom_branch_rope_init_sigmas,
+                qk_norm=use_qk_norm,
+                dropout=dropout,
+                pool_k=self.geom_branch_pool_k,
+            )
+        else:
+            self.geom_branch_surface = None
+            self.geom_branch_volume = None
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
@@ -506,6 +999,20 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if self.use_abupt_geom_branch:
+            if surface_x is not None and surface_tokens > 0:
+                surf_coords = surface_x[..., : self.space_dim]
+                surf_residual = self.geom_branch_surface(
+                    surf_coords, surface_hidden, surface_mask,
+                )
+                surface_hidden = surface_hidden + surf_residual
+            if volume_x is not None and volume_tokens > 0:
+                vol_coords = volume_x[..., : self.space_dim]
+                vol_residual = self.geom_branch_volume(
+                    vol_coords, volume_hidden, volume_mask,
+                )
+                volume_hidden = volume_hidden + vol_residual
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -137,6 +137,13 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_abupt_geom_branch: bool = False
+    geom_branch_n_anchors: int = 1024
+    geom_branch_n_layers: int = 3
+    geom_branch_pool_k: int = 32
+    geom_branch_warmup_fraction: float = 0.0
+    geom_branch_lr_scale: float = 1.0
+    geom_branch_warmup_vol_weight: float = 1.0
     debug: bool = False
 
 
@@ -219,6 +226,51 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_abupt_geom_branch": (
+            "Add an AB-UPT-style geometry branch in parallel to the "
+            "Transolver backbone. Two independent branches (surface and "
+            "volume) each compute supernode pooling -> anchor self-attention "
+            "(with learnable coordinate RoPE) -> anchor->point cross-attention "
+            "and produce an additive residual fused into the per-point hidden "
+            "before the output heads. Output projection is zero-initialised so "
+            "the residual starts as identity. Used together with "
+            "--geom-branch-warmup-fraction / --geom-branch-lr-scale / "
+            "--geom-branch-warmup-vol-weight to give the branch a dedicated "
+            "training schedule on top of the warm Transolver path."
+        ),
+        "geom_branch_n_anchors": (
+            "Number of anchor tokens K per branch when "
+            "--use-abupt-geom-branch is enabled. Stride sampling within each "
+            "sample's valid points ensures anchors land on real positions."
+        ),
+        "geom_branch_n_layers": (
+            "Number of anchor self-attention blocks per geometry branch."
+        ),
+        "geom_branch_pool_k": (
+            "kNN neighbour count used by SupernodePoolingDense to form each "
+            "anchor's input feature."
+        ),
+        "geom_branch_warmup_fraction": (
+            "Fraction of total optimizer steps to run with the Transolver "
+            "backbone frozen (only the geometry branch params train). 0.0 "
+            "disables the warmup phase; 0.2 freezes the backbone for the "
+            "first 20%% of steps. After warmup, the backbone is unfrozen and "
+            "all params train jointly."
+        ),
+        "geom_branch_lr_scale": (
+            "Multiplier applied to the geometry-branch learning rate relative "
+            "to the global LR. The two parameter groups (backbone vs geometry "
+            "branch) share the cosine schedule so the ratio is preserved at "
+            "every step. Default 1.0 = same LR; 2.0 lets the geometry branch "
+            "catch up to the warm backbone."
+        ),
+        "geom_branch_warmup_vol_weight": (
+            "Volume-pressure loss weight applied during the warmup phase "
+            "(while backbone is frozen). After warmup, "
+            "--volume-loss-weight is restored. Used to orient the geometry "
+            "branch toward closing the volume_pressure val->test gap during "
+            "its dedicated training window."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -233,8 +285,62 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _is_geom_branch_param_name(name: str) -> bool:
+    """Identify parameters belonging to the parallel AB-UPT geometry branch.
+
+    Used to split the model into two optimizer parameter groups so the
+    geometry branch can use a different LR (--geom-branch-lr-scale) than
+    the Transolver backbone.
+    """
+    return "geom_branch" in name
+
+
+def _split_param_groups(
+    model: nn.Module, config: Config
+) -> tuple[list[nn.Parameter], list[nn.Parameter]]:
+    """Return (backbone_params, geom_branch_params).
+
+    The backbone group keeps frozen params registered in the optimizer so
+    that the warmup-end unfreeze does not need to re-register them.
+    """
+    geom_params: list[nn.Parameter] = []
+    backbone_params: list[nn.Parameter] = []
+    for name, p in model.named_parameters():
+        if _is_geom_branch_param_name(name):
+            geom_params.append(p)
+        else:
+            backbone_params.append(p)
+    return backbone_params, geom_params
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    use_geom_groups = bool(
+        config.use_abupt_geom_branch
+        and (config.geom_branch_lr_scale != 1.0 or config.geom_branch_warmup_fraction > 0.0)
+    )
+    if use_geom_groups:
+        backbone_params, geom_params = _split_param_groups(model, config)
+        param_groups: list[dict] = [
+            {"params": backbone_params, "lr": config.lr, "name": "backbone"},
+            {
+                "params": geom_params,
+                "lr": config.lr * config.geom_branch_lr_scale,
+                "name": "geom_branch",
+            },
+        ]
+        if optimizer_name == "adamw":
+            return torch.optim.AdamW(param_groups, weight_decay=config.weight_decay)
+        if optimizer_name == "lion":
+            from lion_pytorch import Lion
+
+            return Lion(
+                param_groups,
+                weight_decay=config.weight_decay,
+                betas=(config.lion_beta1, config.lion_beta2),
+                use_triton=False,
+            )
+        raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
             model.parameters(),
@@ -264,6 +370,70 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def collect_geom_branch_subset_grad_norms(model: nn.Module) -> dict[str, float]:
+    """Return grad-norm telemetry for the parallel AB-UPT geometry branch.
+
+    Walks ``named_parameters`` once and accumulates the L2 norm of three
+    disjoint subsets:
+      - geom_branch_surface (the surface-side branch)
+      - geom_branch_volume  (the volume-side branch)
+      - backbone (everything else; should be ~0 during the warmup freeze)
+    """
+    parts: dict[str, float] = {
+        "surface_sq": 0.0,
+        "volume_sq": 0.0,
+        "backbone_sq": 0.0,
+    }
+    for name, p in model.named_parameters():
+        if p.grad is None:
+            continue
+        grad = p.grad.detach()
+        sq = float(grad.float().square().sum().item())
+        if "geom_branch_surface" in name:
+            parts["surface_sq"] += sq
+        elif "geom_branch_volume" in name:
+            parts["volume_sq"] += sq
+        else:
+            parts["backbone_sq"] += sq
+    return {
+        "geom_branch/grad_norm_surface": math.sqrt(parts["surface_sq"]),
+        "geom_branch/grad_norm_volume": math.sqrt(parts["volume_sq"]),
+        "geom_branch/grad_norm_backbone": math.sqrt(parts["backbone_sq"]),
+    }
+
+
+def collect_geom_branch_static_metrics(model: nn.Module) -> dict[str, float]:
+    """Return per-validation static diagnostics about the geom branch state.
+
+    Tracks the supernode pooling output projection RMS to gauge whether
+    the pool is learning meaningful aggregation weights.
+    """
+    metrics: dict[str, float] = {}
+    for branch in ("geom_branch_surface", "geom_branch_volume"):
+        module = getattr(model, branch, None)
+        if module is None:
+            continue
+        pool_proj = getattr(module.supernode_pool, "proj", None)
+        if pool_proj is None:
+            continue
+        w = pool_proj.weight.detach().float()
+        metrics[f"geom_branch/{branch}/supernode_weight_rms"] = float(
+            w.pow(2).mean().sqrt().item()
+        )
+        out_proj = getattr(module, "out_proj", None)
+        if out_proj is not None:
+            w = out_proj.weight.detach().float()
+            metrics[f"geom_branch/{branch}/out_proj_weight_rms"] = float(
+                w.pow(2).mean().sqrt().item()
+            )
+        rope_log_freq = getattr(module.rope, "log_freq", None)
+        if rope_log_freq is not None:
+            lf = rope_log_freq.detach().float()
+            metrics[f"geom_branch/{branch}/rope_log_freq_mean"] = float(lf.mean().item())
+            metrics[f"geom_branch/{branch}/rope_log_freq_std"] = float(lf.std().item())
+    return metrics
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -297,6 +467,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_abupt_geom_branch=config.use_abupt_geom_branch,
+        geom_branch_n_anchors=config.geom_branch_n_anchors,
+        geom_branch_n_layers=config.geom_branch_n_layers,
+        geom_branch_pool_k=config.geom_branch_pool_k,
     )
 
 
@@ -753,6 +927,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            if config.use_abupt_geom_branch and config.geom_branch_warmup_fraction > 0.0:
+                # Backbone params have requires_grad=False during warmup; DDP needs
+                # find_unused_parameters=True so the autograd graph reduction
+                # tolerates the temporarily-unused params.
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
@@ -815,6 +994,34 @@ def main(argv: Iterable[str] | None = None) -> None:
             print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
         train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
         val_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
+
+        geom_warmup_steps = 0
+        backbone_currently_frozen = False
+        if config.use_abupt_geom_branch and config.geom_branch_warmup_fraction > 0.0:
+            geom_warmup_steps = int(
+                round(total_estimated_steps * config.geom_branch_warmup_fraction)
+            )
+            geom_warmup_steps = max(1, geom_warmup_steps)
+            for name, p in base_model.named_parameters():
+                if not _is_geom_branch_param_name(name):
+                    p.requires_grad_(False)
+            backbone_currently_frozen = True
+            if state.is_main:
+                trainable_now = sum(
+                    p.numel() for p in base_model.parameters() if p.requires_grad
+                )
+                frozen_now = sum(
+                    p.numel() for p in base_model.parameters() if not p.requires_grad
+                )
+                print(
+                    f"Geom-branch warmup: freezing backbone for first "
+                    f"{geom_warmup_steps}/{total_estimated_steps} steps "
+                    f"({config.geom_branch_warmup_fraction*100:.1f}%); "
+                    f"trainable={trainable_now/1e6:.2f}M frozen={frozen_now/1e6:.2f}M; "
+                    f"vol_weight {config.geom_branch_warmup_vol_weight} during warmup, "
+                    f"{config.volume_loss_weight} after; "
+                    f"geom_branch lr_scale={config.geom_branch_lr_scale}"
+                )
 
         # Log multi-sigma RFF init layout for verification.
         if state.is_main:
@@ -914,6 +1121,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                is_geom_warmup_phase = (
+                    config.use_abupt_geom_branch
+                    and geom_warmup_steps > 0
+                    and global_step < geom_warmup_steps
+                )
+                if backbone_currently_frozen and not is_geom_warmup_phase:
+                    for p in base_model.parameters():
+                        p.requires_grad_(True)
+                    backbone_currently_frozen = False
+                    if state.is_main:
+                        print(
+                            f"Geom-branch warmup ended at global_step={global_step}; "
+                            f"unfreezing backbone"
+                        )
+                current_vol_weight = (
+                    config.geom_branch_warmup_vol_weight
+                    if is_geom_warmup_phase
+                    else config.volume_loss_weight
+                )
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1006,7 +1232,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         config.amp_mode,
                         surface_loss_weight=config.surface_loss_weight,
-                        volume_loss_weight=config.volume_loss_weight,
+                        volume_loss_weight=current_vol_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
                     )
                 optimizer.zero_grad(set_to_none=True)
@@ -1035,6 +1261,33 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                 }
+                if config.use_abupt_geom_branch:
+                    geom_lr = next(
+                        (
+                            float(g["lr"])
+                            for g in optimizer.param_groups
+                            if g.get("name") == "geom_branch"
+                        ),
+                        float(current_lr),
+                    )
+                    backbone_lr = next(
+                        (
+                            float(g["lr"])
+                            for g in optimizer.param_groups
+                            if g.get("name") == "backbone"
+                        ),
+                        float(current_lr),
+                    )
+                    train_log.update(
+                        {
+                            "geom_branch/is_warmup_phase": 1.0 if is_geom_warmup_phase else 0.0,
+                            "geom_branch/backbone_frozen": 1.0 if backbone_currently_frozen else 0.0,
+                            "geom_branch/active_vol_weight": float(current_vol_weight),
+                            "geom_branch/lr": geom_lr,
+                            "geom_branch/backbone_lr": backbone_lr,
+                            "geom_branch/warmup_steps": float(geom_warmup_steps),
+                        }
+                    )
                 if not loss_is_nonfinite:
                     train_log.update(
                         {
@@ -1055,6 +1308,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
+                    if config.use_abupt_geom_branch:
+                        train_log.update(
+                            collect_geom_branch_subset_grad_norms(base_model)
+                        )
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
                             base_model.parameters(),
@@ -1240,6 +1497,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if config.use_abupt_geom_branch:
+                    log_metrics.update(collect_geom_branch_static_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**AB-UPT Geometry Branch v2: Backbone Freeze + Differential LR + Vol_pressure Aux Weight (Issue #618)**

This is the direct follow-up to PR #626 (frieren, AB-UPT geometry branch v1), based on the key positive signal in that run and the diagnostic analysis from Issue #618.

### What PR #626 showed (and why we are re-running)

PR #626 ran a full AB-UPT-style geometry branch with learnable STRING-RoPE and achieved val_abupt=9.1197% — a regression from the SOTA 6.5985%. But there was a **hidden generalization signal** that justifies this follow-up:

**The vol_pressure val→test gap compressed from 3.17× to 2.07× (a 35% improvement).**

- Without geometry branch: val_vol_p ≈ 4.0% → test_vol_p ≈ 12.7% (3.17× gap)
- With geometry branch (PR #626): gap compressed to 2.07× — the model was genuinely generalizing better to the 4 OOD test cases (run_133, run_226, run_203, run_158) that account for 92% of squared test_vol_p deviation (confirmed by PR #767 diagnostic)

This is exactly the signal we care about for Phase 1 geometry conditioning. The problem is **training efficiency** — the geometry branch parameters received the same LR as the pre-trained backbone, meaning they were under-trained relative to the warm backbone they competed with.

### The fix: three targeted training efficiency improvements

**Fix 1: Freeze main backbone for first 20% of training (geometry warmup phase)**

During the first `warmup_fraction=0.20` of total training steps (= first ~2.6 epochs on 13-epoch budget), freeze the shared Transolver backbone weights and train **only** the geometry branch parameters. This lets the geometry branch reach a useful representation before it has to compete with the already-warm backbone.

After the warmup phase, unfreeze all parameters and continue with normal joint training.

**Fix 2: 2× geometry branch LR (differential learning rate)**

After the warmup phase, apply a `2×` LR multiplier to the geometry branch parameters via parameter groups. If the global LR is 9e-5, geometry branch params use 1.8e-4.

This is orthogonal to Fix 1 — during the freeze phase, only geometry branch parameters are updated (at their 2× LR). After unfreezing, backbone continues at 9e-5 while geometry branch continues at 1.8e-4.

**Fix 3: vol_pressure auxiliary loss weight 2.0 during warmup**

During the geometry warmup phase (first 20% of steps), use `vol_pressure_loss_weight=2.0` to force the geometry branch to focus on the metric it most improved in PR #626. After the warmup phase, anneal back to the standard `volume_loss_weight=1.0`.

---

## Instructions

### Architecture reference

The full AB-UPT geometry branch architecture from PR #626 is the base. Frieren implemented this in PR #626 and should have the codebase knowledge to rebuild it efficiently.

Key architecture:
- Supernode pooling geometry branch (K=1024 anchors) with learnable STRING-RoPE on Q/K
- Two independent branches (surface and volume), each with their own supernode pooler + anchor stack
- Anchor→Point cross-attention to broadcast back to point-level representations
- Input STRING-sep encoding retained (per #333 lesson — never strip input features)

Reference code (read end-to-end before coding):
- Model: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/model.py
- RoPE frequency: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/modules/rope_frequency.py
- Supernode pooling: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/modules/supernode_pooling_posonly.py

### Code changes required in train.py / trainer_runtime.py

#### 1. Backbone freeze + geometry warmup phase

Add CLI flags:
```
--geom-branch-warmup-fraction 0.2   (float, default=0.0 = no freeze)
```

In `trainer_runtime.py` (or `main()` in `train.py`), before the training loop:
- Identify `backbone_params` (all params belonging to the Transolver backbone layers, NOT the geometry branch)
- Identify `geom_branch_params` (all params belonging to the supernode pooler, anchor blocks, cross-attention)

At each step, check if `global_step < warmup_steps`:
- If yes: zero-out or skip backbone gradients (or use `requires_grad=False` on backbone params for the warmup phase — either approach is fine, but setting `requires_grad=False` on the fly is cleaner)
- If no AND first time past warmup: unfreeze backbone params and log `geom_branch/warmup_phase_ended=True` to W&B

Log `geom_branch/is_warmup_phase` (bool 0/1) per step.

#### 2. Differential LR for geometry branch

Add CLI flags:
```
--geom-branch-lr-scale 2.0   (float, default=1.0 = same LR as backbone)
```

In `build_optimizer` (or before optimizer construction), create separate param groups:
```python
geom_branch_params = [p for name, p in base_model.named_parameters() 
                      if 'geom_branch' in name or 'supernode' in name or 'anchor_block' in name
                      and p.requires_grad]
geom_param_ids = {id(p) for p in geom_branch_params}
backbone_params = [p for p in base_model.parameters() 
                   if id(p) not in geom_param_ids and p.requires_grad]
param_groups = [
    {'params': backbone_params, 'lr': config.lr},
    {'params': geom_branch_params, 'lr': config.lr * config.geom_branch_lr_scale},
]
```

Log `geom_branch/lr` per epoch.

#### 3. Vol_pressure aux weight during warmup

Add CLI flags:
```
--geom-branch-warmup-vol-weight 2.0   (float, default=1.0)
```

During warmup steps, use `volume_loss_weight = config.geom_branch_warmup_vol_weight` instead of `config.volume_loss_weight`. After warmup, revert to `config.volume_loss_weight`. Log `geom_branch/active_vol_weight` per step.

### Run command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-abupt-geom-branch \
  --geom-branch-n-anchors 1024 \
  --geom-branch-warmup-fraction 0.2 \
  --geom-branch-lr-scale 2.0 \
  --geom-branch-warmup-vol-weight 2.0 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>35,21728:val_primary/abupt_axis_mean_rel_l2_pct>14,32592:val_primary/abupt_axis_mean_rel_l2_pct>10" \
  --wandb-group abupt-geom-branch-warmup-fix \
  --wandb-name frieren/geom-branch-v2-warmup
```

**Note on `--use-abupt-geom-branch` and `--geom-branch-n-anchors`:** These flags need to be added to `train.py`/`Config` as part of your implementation. They did not exist in PR #626 (which hard-coded the geometry branch parameters). Please implement them properly as CLI flags so the architecture is parameterizable.

### W&B logging requirements

Per validation epoch:
- `geom_branch/is_warmup_phase` (0 or 1)
- `geom_branch/lr` (current effective LR on geometry branch params)
- `geom_branch/active_vol_weight` (current vol_pressure loss weight)
- `geom_branch/grad_norm_surface` (L2 norm of surface geometry branch gradients)
- `geom_branch/grad_norm_volume` (L2 norm of volume geometry branch gradients)
- `geom_branch/grad_norm_backbone` (L2 norm of backbone gradients — should be zero during warmup)
- `geom_branch/supernode_weight_rms` (RMS of supernode pooling weights — are they learning?)

Per training step (every `gradient_log_every` steps):
- `geom_branch/backbone_frozen` (bool 0/1)
- `geom_branch/vol_weight` (active vol_pressure loss weight at this step)

---

## Kill Gates

The geometry branch v1 (PR #626) had EP1=18% which is within the kill gate. Use slightly more generous gates since we know the warmup phase will inflate EP1 and EP2:

| Gate | Step | Threshold | Notes |
|------|------|-----------|-------|
| EP1 | 10,864 | val_abupt > 40% | Generous — backbone is frozen, geometry branch learning from scratch |
| EP3 | 32,592 | val_abupt > 14% | Should be on track by EP3 after warmup ends at ~EP2.6 |
| EP5 | 54,320 | val_abupt > 10% | By EP5 both branches should be jointly optimized |

---

## Baseline to beat

**Single-model SOTA** (PR #592, alphonse, run `4k25s25e`):
- val_abupt = **6.5985%** (EP4)
- test_abupt = **7.9915%**

**Prior AB-UPT geometry branch v1** (PR #626, frieren, CLOSED NEGATIVE):
- val_abupt = 9.1197% (regression vs SOTA)
- **vol_pressure val→test gap: 2.07× (vs 3.17× without geometry branch = 35% compression)**
- Key lesson: geometry branch needs more training budget and priority relative to warm backbone

**Vol-pressure anchor target** (PR #681):
- test_vol_p = **11.374%** (vol-pressure best anchor — the target to beat on the OOD gap)

---

## Key question we are testing

Is the 3.17×→2.07× vol_pressure generalization improvement from PR #626 robust, and does it survive when:
1. The geometry branch gets a dedicated warmup phase before competing with the backbone
2. Geometry branch parameters receive 2× the effective LR
3. The vol_pressure loss is upweighted during warmup to orient the geometry branch toward the OOD gap

If yes: the geometry branch is the right architecture for closing the vol_pressure test gap. We then compose it with the best model configuration.
If no: the geometry branch's generalization benefit was unstable and we need a different approach.

**Most important diagnostic:** Does the test_vol_p gap compress below the anchor (11.374%)? Secondary: does val_abupt land within 0.5pp of the single-model SOTA (≤7.1%)?

---

## Final report fields

Please include in your results comment:
- Per-epoch table: display_ep, warmup_phase, val_abupt, val_vol_p, val_surface_p, val_wall_shear (ws_x/ws_y/ws_z)
- Geometry branch diagnostics per epoch: grad_norm_backbone vs grad_norm_{surface,volume}_geom, supernode_weight_rms, active_vol_weight
- Final test metrics (test_abupt, test_vol_p, test_surface_p, test_wall_shear) from best-val checkpoint
- vol_pressure val→test gap ratio: val_vol_p / test_vol_p for each epoch (did the warmup fix help the gap?)
- Comparison to PR #626 val_abupt and val→test gap ratio

**Reference:** Issue #618
