### PR TITLE
askeladd: additive LoRA on vol output head r=4/r=8 (retry)

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        vol_out_lora_rank: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +422,19 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        # Additive rank-r LoRA correction on the volume output head
+        # (Hu et al., 2021). y = volume_out(h) + B(A(h)). B is zero-initialised
+        # so the initial perturbation is exactly 0; training starts from the
+        # base model and learns a residual geometry-sensitive correction.
+        self.vol_out_lora_rank = int(vol_out_lora_rank)
+        if self.vol_out_lora_rank > 0:
+            self.vol_lora_A = nn.Linear(n_hidden, self.vol_out_lora_rank, bias=False)
+            self.vol_lora_B = nn.Linear(self.vol_out_lora_rank, self.volume_output_dim, bias=False)
+            nn.init.kaiming_uniform_(self.vol_lora_A.weight, a=math.sqrt(5))
+            nn.init.zeros_(self.vol_lora_B.weight)
+        else:
+            self.vol_lora_A = None
+            self.vol_lora_B = None
 
     def _encode_group(
         self,
@@ -515,6 +529,10 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            if self.vol_out_lora_rank > 0:
+                volume_preds = volume_preds + self.vol_lora_B(
+                    self.vol_lora_A(volume_hidden)
+                ) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/train.py
+++ b/train.py
@@ -137,6 +137,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_out_lora_rank: int = 0
     debug: bool = False
 
 
@@ -219,6 +220,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_out_lora_rank": (
+            "Rank r of an additive LoRA correction applied to the volume "
+            "output head: volume_preds = volume_out(h) + B(A(h)), with "
+            "A in R^(n_hidden x r), B in R^(r x volume_output_dim), B "
+            "zero-initialised so the initial perturbation is exactly 0. "
+            "Adds r*(n_hidden + volume_output_dim) parameters and is "
+            "trained jointly in the default optimizer param group. "
+            "Default 0 disables LoRA."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -297,6 +307,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        vol_out_lora_rank=config.vol_out_lora_rank,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Volume pressure has a chronic ~3× test-vs-val gap (val ≈ 3.6%, test ≈ 11.5% in the best ensemble, PR #612). The shared volume transformer features lack geometry-specific spatial capacity. Previous multiplicative SDF-gate approaches (PR #789 v2/v3/v4) collapsed via tanh-cap saturation. The fix: replace the multiplicative gate with an **additive rank-r LoRA on the volume output projection** — bounded, saturation-free, zero-init B so the initial correction is exactly 0 and training starts from the base model.

`volume_out_corrected(h) = volume_out(h) + B(A(h))`
where `A ∈ R^{n_hidden × r}`, `B ∈ R^{r × volume_output_dim}`, zero-init B, standard Kaiming A.

This directly addresses the vol_pressure test gap without touching the backbone or surface head. SDF is already in volume_x as channel 4 (VOLUME_X_DIM=4), so the model already has the geometry signal — the LoRA just adds output-head capacity to use it.

**NOTE:** This PR was previously assigned as PR #809. The student was idle 90+ min (zero torchrun activity) despite having 8 available GPUs. The branch was closed and the experiment reassigned. This is a fresh start — implement the changes and launch immediately.

## Instructions

### 1. model.py changes

In `SurfaceTransolver.__init__`, after the `self.volume_out = LinearProjection(...)` line, add:

```python
self.vol_lora_rank = getattr(config, 'vol_out_lora_rank', 0)
if self.vol_lora_rank > 0:
    r = self.vol_lora_rank
    self.vol_lora_A = nn.Linear(n_hidden, r, bias=False)
    self.vol_lora_B = nn.Linear(r, self.volume_output_dim, bias=False)
    nn.init.zeros_(self.vol_lora_B.weight)   # zero-init B → no perturbation at step 0
    # vol_lora_A uses default Kaiming init
```

In `SurfaceTransolver.forward`, after `volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)`, add:

```python
if self.vol_lora_rank > 0 and volume_x is not None:
    volume_preds = volume_preds + self.vol_lora_B(self.vol_lora_A(volume_hidden)) * volume_mask.unsqueeze(-1)
```

### 2. train.py changes

Add argparse flag:
```python
parser.add_argument('--vol-out-lora-rank', type=int, default=0,
    help='Rank of additive LoRA on volume output head (0=disabled).')
```

Thread into model config: `config.vol_out_lora_rank = args.vol_out_lora_rank`

The LoRA parameters go into the default optimizer param group (same Lion lr=9e-5, wd=5e-4 as the rest of the model).

### 3. Run protocol — 2 arms, wandb_group vol-head-lora

**Arm A — r=4 (primary, run first):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-out-lora-rank 4 \
  --wandb-group vol-head-lora --wandb-name askeladd/vol-lora-r4
```

**Arm B — r=8 (capacity scaling, run after Arm A passes EP2 gate):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-out-lora-rank 8 \
  --wandb-group vol-head-lora --wandb-name askeladd/vol-lora-r8
```

### 4. Kill gates

- EP1 (step 10,864): kill if val_abupt > 35%
- EP2 (step 21,728): kill if val_abupt > 12%

### 5. What to report

For each arm:
- W&B run ID (rank0) immediately on launch
- EP1 val_abupt (gate check)
- Per-epoch val_abupt + val_vol_p table
- Best val_abupt, epoch, and all per-channel metrics
- Whether val_vol_p test gap narrowed vs baseline (test_vol_p≈11.5%)

## Baseline

**Single-model SOTA: PR #592** (alphonse depth-L5)
- val_abupt = **6.5985%** (gate to beat)
- test_abupt = 7.9915%
- val: surface_p=4.3322%, vol_p=3.9456%, ws_x=6.5420%, ws_y=8.3631%, ws_z=9.8099%
- test: vol_p ≈ **11.5% (THE GAP TO CLOSE)**
- W&B: `4k25s25e` (group `model-depth-sweep`)

**Ensemble SOTA: PR #612** (nezuko K=7 pool-24)
- val_abupt = 6.1751% / test_abupt = 7.5347%
- test vol_p = 11.4652% (3× val gap — primary target)

**Vol-pressure promotion ladder:** Weak ≤11.0% | Solid ≤10.0% | Major ≤8.5% | Target ≤6.08%
