### PR TITLE
askeladd: 2-layer GELU MLP vol decoder (512→256→1)

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_vol_decoder_mlp: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +355,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_vol_decoder_mlp = use_vol_decoder_mlp
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -420,7 +422,18 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
-        self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        if use_vol_decoder_mlp:
+            vol_hidden_dim = n_hidden // 2
+            self.volume_out = nn.Sequential(
+                nn.Linear(n_hidden, vol_hidden_dim, bias=True),
+                nn.GELU(),
+                nn.Linear(vol_hidden_dim, self.volume_output_dim, bias=True),
+            )
+            _init_linear(self.volume_out[0])
+            nn.init.zeros_(self.volume_out[-1].weight)
+            nn.init.zeros_(self.volume_out[-1].bias)
+        else:
+            self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
         self,

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    vol_decoder_mlp: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -297,6 +298,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_vol_decoder_mlp=config.vol_decoder_mlp,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current volume pressure decoder is a single linear projection (`LinearProjection(512→1)`). Given the chronic val→test gap on `volume_pressure` (val≈3.95%, test≈11.5%), we hypothesize that the backbone representation is good but the final mapping lacks the non-linearity needed to disentangle vol_p from the shared surface+volume hidden state. A 2-layer MLP decoder (512→256→ReLU→1) with skip-connection residual adds capacity exactly where it is needed — at the decoding boundary — without touching the backbone or adding regularization risk.

This is a low-complexity targeted intervention: ~256*513 ≈ 131k extra params on top of a 15.9M parameter model, directly on the bottleneck layer.

**Reference:** Replacing a linear decoder with a 1-hidden-layer MLP decoder is a standard technique when the latent space needs to be "unrolled" non-linearly into a target manifold (e.g., NeRF volumetric decoder, flow-field reconstruction heads).

## Implementation

Modify `target/model.py`:

1. Replace `self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)` with a 2-layer MLP:

```python
# In SurfaceTransolver.__init__, replace:
self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)

# With:
vol_hidden_dim = n_hidden // 2  # 256 for default 512d
self.volume_out = nn.Sequential(
    nn.Linear(n_hidden, vol_hidden_dim, bias=True),
    nn.GELU(),
    nn.Linear(vol_hidden_dim, self.volume_output_dim, bias=True),
)
# Zero-init the final layer so at init the decoder is a near-zero function
# (stable training start; gradient flows through the GELU immediately):
nn.init.zeros_(self.volume_out[-1].weight)
nn.init.zeros_(self.volume_out[-1].bias)
```

2. In `SurfaceTransolver.forward`, the prediction line `volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)` does NOT need to change — `nn.Sequential` is callable the same way.

3. Add a CLI flag `--vol-decoder-mlp` (bool, default False) to `train.py` so the run can be toggled without code changes. Pass it through `Config` → `build_model`. In `build_model`, pass `use_vol_decoder_mlp=config.vol_decoder_mlp` to `SurfaceTransolver.__init__` and wire it through the `__init__` logic above with an `if use_vol_decoder_mlp:` branch.

**Run ONE arm only** (keep it simple, one hypothesis):
- Run with `--vol-decoder-mlp` enabled on the full SOTA stack.

## Baseline metrics to beat

**Single-model SOTA (alphonse PR #592, run `4k25s25e`):**
- val_abupt = **6.5985%** ← gate to beat
- val_vol_p = 3.9456%, val_surface_p = 4.3322%, val_wall_shear = 6.5420%
- test_abupt = 7.9915%, test_vol_p = 11.4652% (ensemble)

Gate: val_abupt < **6.5985%** to beat single-model SOTA.

## Reproduce command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --no-compile-model \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --epochs 13 --lr-cosine-t-max 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-decoder-mlp \
  --wandb-group askeladd-vol-mlp-decoder \
  --wandb-name askeladd/vol-mlp-decoder-2layer-gelu
```

## Kill gate

- EP2: if val_abupt > 13% or val_vol_p > 8%, kill — the GELU decoder is causing instability.
- EP3: if val_abupt > 9.5%, kill — no pathway to beat 6.5985%.
- EP4: if val_abupt > 7.8%, the direction is not converging fast enough; close and report.

## Suggested diagnostics

After EP4, report:
1. val_abupt, val_vol_p, val_surface_p, val_wall_shear (all channels)
2. test_abupt, test_vol_p (from best-val checkpoint)
3. `||volume_out[-1].weight||_F` — check if the MLP last layer has stayed near-zero or grown
4. If possible: report grad norms on `volume_out[0].weight` vs `volume_out[-1].weight` at EP2

## Context

PR #812 (askeladd vol-head LoRA r=4/r=8) was just closed as a clean negative dead-end. The LoRA was architecturally neutralized because VOLUME_Y_DIM=1 forces rank(ΔW) ≤ 1 regardless of LoRA rank. This 2-layer MLP decoder addresses the same bottleneck problem but through a different mechanism: it adds non-linearity and depth to the decoding step rather than adding a rank-constrained linear correction.

The vol_p val→test gap (≈3× ratio) is the chronic open problem in this research programme. This experiment targets the decoding capacity as a potential contributor.
