### PR TITLE
[nezuko] Surface→volume cross-attention for geometry-aware vol_p decoding (4-ep screen)

### DIFF
--- a/model.py
+++ b/model.py
@@ -342,6 +342,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_surf_to_vol_xattn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +355,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -421,6 +423,26 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # Surface->volume cross-attention (PR #823): single MHA sublayer where
+        # volume hidden states (Q) attend to surface hidden states (K/V).
+        # Bridges geometry-aware surface features into the volume decoder
+        # to address the OOD volume_pressure gap. Zero-init out_proj weight
+        # AND bias so the sublayer is identity at init (preserves baseline
+        # behavior at epoch 0). See PR #823 hypothesis.
+        if use_surf_to_vol_xattn:
+            self.surf_to_vol_xattn = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
+            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+        else:
+            self.surf_to_vol_xattn = None
+            self.surf_to_vol_xattn_norm = None
 
     def _encode_group(
         self,
@@ -506,6 +528,33 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.surf_to_vol_xattn is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            # surface_hidden has padded rows zeroed via _apply_token_mask above;
+            # without key_padding_mask, padded keys would contribute zero V but
+            # still dilute the softmax denominator over valid keys. The
+            # bool mask sets the score for those positions to -inf so they
+            # carry zero attention weight. PyTorch falls back to the math
+            # SDPA kernel when a mask is supplied (Flash-Attn 2 cannot
+            # represent arbitrary key-padding masks); set need_weights=False
+            # so MHA does not also materialise the (B, N_q, N_k) weight tensor.
+            surf_pad_mask = ~surface_mask.bool()
+            xattn_out, _ = self.surf_to_vol_xattn(
+                query=volume_hidden,
+                key=surface_hidden,
+                value=surface_hidden,
+                key_padding_mask=surf_pad_mask,
+                need_weights=False,
+            )
+            xattn_out = _apply_token_mask(xattn_out, volume_mask)
+            volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/model.py
+++ b/model.py
@@ -536,20 +536,19 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
-            # surface_hidden has padded rows zeroed via _apply_token_mask above;
-            # without key_padding_mask, padded keys would contribute zero V but
-            # still dilute the softmax denominator over valid keys. The
-            # bool mask sets the score for those positions to -inf so they
-            # carry zero attention weight. PyTorch falls back to the math
-            # SDPA kernel when a mask is supplied (Flash-Attn 2 cannot
-            # represent arbitrary key-padding masks); set need_weights=False
-            # so MHA does not also materialise the (B, N_q, N_k) weight tensor.
-            surf_pad_mask = ~surface_mask.bool()
+            # No key_padding_mask: surface_hidden padded rows are already zeroed
+            # by _apply_token_mask, so padded keys contribute V=0 to attention.
+            # Their softmax weights slightly dilute valid keys, but in this
+            # training regime surface_mask is all-True (cases have >>65536
+            # surface points so train_random sampling fills the buffer), so
+            # there is no padding to mask in practice. Dropping the mask lets
+            # SDPA dispatch to Flash-Attention 2 instead of the math kernel,
+            # which would materialise a (B, H, N_q, N_k) tensor (>30 GB at the
+            # production sequence sizes) and stall ranks under memory pressure.
             xattn_out, _ = self.surf_to_vol_xattn(
                 query=volume_hidden,
                 key=surface_hidden,
                 value=surface_hidden,
-                key_padding_mask=surf_pad_mask,
                 need_weights=False,
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)

--- a/model.py
+++ b/model.py
@@ -536,15 +536,6 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
-            # No key_padding_mask: surface_hidden padded rows are already zeroed
-            # by _apply_token_mask, so padded keys contribute V=0 to attention.
-            # Their softmax weights slightly dilute valid keys, but in this
-            # training regime surface_mask is all-True (cases have >>65536
-            # surface points so train_random sampling fills the buffer), so
-            # there is no padding to mask in practice. Dropping the mask lets
-            # SDPA dispatch to Flash-Attention 2 instead of the math kernel,
-            # which would materialise a (B, H, N_q, N_k) tensor (>30 GB at the
-            # production sequence sizes) and stall ranks under memory pressure.
             xattn_out, _ = self.surf_to_vol_xattn(
                 query=volume_hidden,
                 key=surface_hidden,

--- a/train.py
+++ b/train.py
@@ -764,6 +764,17 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            # The surface->volume cross-attention sublayer (PR #823) gates on
+            # `surface_tokens > 0`, but DrivAerML's loader returns
+            # max(surface_views, volume_views) views per case, so views with
+            # view_index >= surface_views have N_S=0 (and the gate skips the
+            # layer). Different ranks hit different sub-graphs in a single
+            # batch, so DDP's default find_unused_parameters=False deadlocks
+            # at the gradient bucket allreduce. Enabling find_unused_parameters
+            # whenever the cross-attention is on lets DDP synchronize unused
+            # params across ranks, at a small per-step overhead.
+            if config.use_surf_to_vol_xattn:
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -219,6 +220,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_surf_to_vol_xattn": (
+            "Enable surface->volume cross-attention (PR #823). After the "
+            "shared Transolver backbone, a single nn.MultiheadAttention "
+            "block lets volume hidden states (Q) attend to surface hidden "
+            "states (K/V) before the volume output head. The out_proj "
+            "weight and bias are zero-initialised so the layer is identity "
+            "at init (preserves baseline at epoch 0). embed_dim follows "
+            "--model-hidden-dim and num_heads follows --model-heads."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -297,6 +307,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current Transolver backbone processes surface and volume points **independently** — after the L=5 forward pass, the volume decoder has no direct access to surface geometry features. This is the leading explanation for the OOD vol_p gap: 4 OOD test cases (run_133, run_226, run_203, run_158) account for **92% of squared test_vol_p deviation** (val≈3.6% vs test≈11.5%, ~3× gap). These cases are geometric outliers whose surface feature patterns differ from the training distribution.

**Proposed fix:** After the backbone forward pass, add a single cross-attention sublayer where volume point hidden states (Q) attend to surface point hidden states (K/V). This bridges surface geometry into the volume decoder path in a geometry-aware, point-cloud-native way:

- Zero-init the output projection so the sublayer is an identity at init → preserves baseline behavior at epoch 0
- No positional encoding needed in the cross-attention layer (positions are already encoded in the hidden states from the backbone's RFF/STRING-separable PE)
- This is **SDF-freeze compliant**: uses existing surface hidden states only, no SDF-related architecture changes
- Adds ~2M params (512×512 Q/K/V projections ×4 heads), modest vs. ~15.9M backbone

Expected effect: surface geometry features (geometry class, curvature, boundary layer shape) are pooled into vol query tokens → geometry-aware volume pressure decoding → reduced OOD vol_p gap.

Reference: Cross-attention bridges between point-cloud modalities have improved OOD generalization in works like PointBERT, PCT, and FlowFormer by enabling explicit geometry conditioning across spatial scales.

## Instructions

**This is a 4-epoch screening run.** Implement the following in `target/model.py`:

### Architecture change

After the Transolver backbone's forward pass (the final slice-attention step), add one `nn.MultiheadAttention` cross-attention block in the volume decoder path:

```python
# In __init__: add after existing layers
self.surf_to_vol_xattn = nn.MultiheadAttention(
    embed_dim=512,    # must match model-hidden-dim
    num_heads=4,      # must match model-heads
    batch_first=True,
    dropout=0.0,
)
self.surf_to_vol_xattn_norm = nn.LayerNorm(512)
# Zero-init output projection for identity at init
nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)

# In forward: after backbone, before volume decoder head
# vol_hidden: [B, N_vol, 512]   (volume point hidden states)
# surf_hidden: [B, N_surf, 512] (surface point hidden states)
xattn_out, _ = self.surf_to_vol_xattn(
    query=vol_hidden,
    key=surf_hidden,
    value=surf_hidden,
)
vol_hidden = self.surf_to_vol_xattn_norm(vol_hidden + xattn_out)
```

Key constraints:
- `embed_dim` must equal `hidden_dim` (512 in the baseline config)
- `num_heads` must equal `model-heads` (4 in the baseline config)
- Apply **only** to the volume decoder path (not surface)
- The cross-attention should run after all L=5 Transolver layers but **before** the volume output MLP/head
- If memory pressure arises at `eval-volume-points=65536`, try reducing `--train-volume-points` to 49152 for the screening run

### Training command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group nezuko-surf-vol-xattn \
  --wandb-name nezuko/surf-vol-xattn-4ep
```

### What to report in the PR comment

Report the following metrics from the best val_abupt checkpoint:
- `val_abupt` (primary gate: must be < **6.5985%** to beat single-model SOTA)
- `val_vol_p` (target: < 3.6% would indicate OOD gap closing)
- `test_abupt`, `test_vol_p` (check whether the OOD gap narrows vs. baseline ~11.5%)
- W&B run ID and link
- Note whether training was stable (loss decreasing, no NaN)

If the 4-epoch screen shows val_abupt trend heading toward or below 6.5985%, please request a full 13-epoch run.

## Baseline

Current single-model SOTA — alphonse PR #592 (W&B run `4k25s25e`):

| Metric | Value |
|--------|-------|
| val_abupt (primary gate) | **6.5985%** |
| test_abupt | 7.9915% |
| val_vol_p | ~3.6% |
| test_vol_p | ~11.5% |

Current ensemble SOTA — nezuko PR #612 (K=7, pool-24):

| Metric | Value |
|--------|-------|
| val_abupt | **6.1751%** |
| test_abupt | 7.5347% |
| test_vol_p | **11.4652%** |

**To beat single-model gate: val_abupt < 6.5985%**

Reproduce SOTA single-model baseline:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32778:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group model-depth-sweep --wandb-name alphonse/depth-L5
```
