### PR TITLE
askeladd: AB-UPT geometry branch v3 — L5 SOTA backbone + supernode pooling 4-ep screen

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,210 @@ class Transformer(nn.Module):
         return x
 
 
+class GeometryBranch(nn.Module):
+    """AB-UPT-style geometry branch: supernode pooling + anchor-to-point cross-attention.
+
+    Implements the v3 design from PR #836 / based on PR #802 (v2): K=1024 supernode
+    anchors are sampled from the volume mesh; a cross-attention pools per-point
+    features into anchor latents (Step 1, "supernode pooling"); a second
+    cross-attention broadcasts anchor features back to all points (Step 2,
+    "anchor->point xattn"). Both attentions use STRING-separable additive
+    positional bias on Q/K with the same sigma init as the backbone, matching
+    the PR's "STRING-separable RoPE on Q/K (sigma={0.25,0.5,1.0,2.0,4.0},
+    rff_num_features=16)" instruction (additive PE form, consistent with how
+    StringSeparableEncoding is used in the input encoder).
+
+    Output is a per-point geometry-aware feature tensor [B, N_total, H] that is
+    added residually to the backbone hidden states before the surface/volume
+    output heads.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        space_dim: int = 3,
+        n_anchors: int = 1024,
+        rff_num_features: int = 16,
+        rff_init_sigmas: list[float] | None = None,
+        use_qk_norm: bool = True,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("GeometryBranch hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.dim_head = hidden_dim // num_heads
+        self.space_dim = space_dim
+        self.n_anchors = n_anchors
+        self.use_qk_norm = use_qk_norm
+
+        self.string_sep = StringSeparableEncoding(
+            in_dim=space_dim,
+            num_features=rff_num_features,
+            sigma=1.0,
+            init_sigmas=rff_init_sigmas,
+        )
+        string_dim = self.string_sep.output_dim
+        self.pool_pos_q = LinearProjection(string_dim, hidden_dim)
+        self.pool_pos_k = LinearProjection(string_dim, hidden_dim)
+        self.xattn_pos_q = LinearProjection(string_dim, hidden_dim)
+        self.xattn_pos_k = LinearProjection(string_dim, hidden_dim)
+
+        self.anchor_pos_embed = ContinuousSincosEmbed(hidden_dim=hidden_dim, input_dim=space_dim)
+        self.anchor_init_proj = LinearProjection(string_dim, hidden_dim)
+        self.anchor_placeholder = nn.Parameter(torch.rand(1, 1, hidden_dim) / hidden_dim)
+
+        self.pool_norm_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.pool_norm_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.pool_q = LinearProjection(hidden_dim, hidden_dim)
+        self.pool_k = LinearProjection(hidden_dim, hidden_dim)
+        self.pool_v = LinearProjection(hidden_dim, hidden_dim)
+        self.pool_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.pool_dropout = nn.Dropout(dropout)
+        if use_qk_norm:
+            self.pool_q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.pool_k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+        else:
+            self.pool_q_norm = None
+            self.pool_k_norm = None
+
+        self.xattn_norm_q = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.xattn_norm_kv = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.xattn_q = LinearProjection(hidden_dim, hidden_dim)
+        self.xattn_k = LinearProjection(hidden_dim, hidden_dim)
+        self.xattn_v = LinearProjection(hidden_dim, hidden_dim)
+        self.xattn_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.xattn_dropout = nn.Dropout(dropout)
+        if use_qk_norm:
+            self.xattn_q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.xattn_k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+        else:
+            self.xattn_q_norm = None
+            self.xattn_k_norm = None
+
+    def _split_heads(self, t: torch.Tensor) -> torch.Tensor:
+        b, n, _ = t.shape
+        return t.view(b, n, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+
+    def _merge_heads(self, t: torch.Tensor) -> torch.Tensor:
+        b, _, n, _ = t.shape
+        return t.permute(0, 2, 1, 3).contiguous().view(b, n, self.hidden_dim)
+
+    @staticmethod
+    def _sample_anchors(
+        coords: torch.Tensor,
+        mask: torch.Tensor,
+        n_anchors: int,
+    ) -> torch.Tensor:
+        """Random uniform sampling of K anchors from masked points (per-batch).
+
+        Returns coords [B, n_anchors, 3]. Falls back to repeating valid points
+        when a sample has fewer valid points than n_anchors (rare in practice).
+        """
+        b, n, dim = coords.shape
+        device = coords.device
+        anchors = coords.new_zeros(b, n_anchors, dim)
+        for i in range(b):
+            valid = mask[i] > 0
+            n_valid = int(valid.sum().item())
+            if n_valid <= 0:
+                continue
+            valid_coords = coords[i][valid]
+            if n_valid >= n_anchors:
+                idx = torch.randperm(n_valid, device=device)[:n_anchors]
+                anchors[i] = valid_coords[idx]
+            else:
+                idx = torch.randint(0, n_valid, (n_anchors,), device=device)
+                anchors[i] = valid_coords[idx]
+        return anchors
+
+    def forward(
+        self,
+        point_features: torch.Tensor,
+        point_coords: torch.Tensor,
+        point_mask: torch.Tensor,
+        anchor_source_coords: torch.Tensor,
+        anchor_source_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Run the geometry branch.
+
+        point_features: [B, N_total, H] backbone hidden states for all points
+        point_coords:   [B, N_total, 3] coords matching point_features
+        point_mask:     [B, N_total] padding mask for points (1=valid, 0=pad)
+        anchor_source_coords: [B, N_vol, 3] coords to sample anchors from (volume mesh)
+        anchor_source_mask:   [B, N_vol] padding mask for anchor source
+
+        Returns (point_geom_features, diagnostics).
+        """
+
+        b, n_total, _ = point_features.shape
+        device = point_features.device
+
+        with torch.no_grad():
+            anchor_coords = self._sample_anchors(
+                anchor_source_coords, anchor_source_mask, self.n_anchors
+            )
+
+        anchor_string = self.string_sep(anchor_coords)
+        anchor_pos_h = self.anchor_pos_embed(anchor_coords)
+        anchor_features = anchor_pos_h + self.anchor_init_proj(anchor_string) + self.anchor_placeholder
+
+        point_string = self.string_sep(point_coords)
+
+        point_mask_ftype = point_mask.to(dtype=point_features.dtype)
+
+        q_anchor_pos = self.pool_pos_q(anchor_string)
+        k_point_pos = self.pool_pos_k(point_string)
+
+        q_in = self.pool_norm_q(anchor_features) + q_anchor_pos
+        kv_in = (
+            self.pool_norm_kv(point_features) * point_mask_ftype.unsqueeze(-1)
+            + k_point_pos
+        )
+        q = self._split_heads(self.pool_q(q_in))
+        k = self._split_heads(self.pool_k(kv_in))
+        v = self._split_heads(self.pool_v(kv_in) * point_mask_ftype.unsqueeze(-1))
+        if self.pool_q_norm is not None:
+            q = self.pool_q_norm(q)
+            k = self.pool_k_norm(k)
+        kv_attn_mask = point_mask.to(device=device).unsqueeze(1).unsqueeze(1).bool()
+        pool_out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=kv_attn_mask.expand(-1, self.num_heads, self.n_anchors, -1),
+            dropout_p=0.0,
+        )
+        anchor_features = anchor_features + self.pool_dropout(self.pool_proj(self._merge_heads(pool_out)))
+
+        q_point_pos = self.xattn_pos_q(point_string)
+        k_anchor_pos = self.xattn_pos_k(anchor_string)
+
+        q_in2 = (
+            self.xattn_norm_q(point_features) * point_mask_ftype.unsqueeze(-1)
+            + q_point_pos
+        )
+        kv_in2 = self.xattn_norm_kv(anchor_features) + k_anchor_pos
+        q2 = self._split_heads(self.xattn_q(q_in2))
+        k2 = self._split_heads(self.xattn_k(kv_in2))
+        v2 = self._split_heads(self.xattn_v(kv_in2))
+        if self.xattn_q_norm is not None:
+            q2 = self.xattn_q_norm(q2)
+            k2 = self.xattn_k_norm(k2)
+        xattn_out = F.scaled_dot_product_attention(q2, k2, v2, dropout_p=0.0)
+        point_geom_features = self.xattn_proj(self._merge_heads(xattn_out))
+        point_geom_features = self.xattn_dropout(point_geom_features)
+        point_geom_features = point_geom_features * point_mask_ftype.unsqueeze(-1)
+
+        diagnostics = {
+            "anchor_features_rms": anchor_features.detach().float().pow(2).mean().sqrt(),
+            "point_geom_features_rms": point_geom_features.detach().float().pow(2).mean().sqrt(),
+        }
+        return point_geom_features, diagnostics
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -342,6 +546,9 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_geom_branch: bool = False,
+        geom_branch_n_anchors: int = 1024,
+        geom_branch_rff_num_features: int = 16,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -421,6 +628,40 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        self.use_geom_branch = use_geom_branch
+        self.geom_branch_n_anchors = geom_branch_n_anchors
+        if use_geom_branch:
+            geom_init_sigmas = (
+                list(rff_init_sigmas) if rff_init_sigmas else None
+            )
+            self.geom_branch = GeometryBranch(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                space_dim=space_dim,
+                n_anchors=geom_branch_n_anchors,
+                rff_num_features=geom_branch_rff_num_features,
+                rff_init_sigmas=geom_init_sigmas,
+                use_qk_norm=use_qk_norm,
+                dropout=dropout,
+            )
+            geom_hidden = n_hidden // 2
+            self.geom_branch_surface_head = nn.Sequential(
+                nn.LayerNorm(n_hidden, eps=1e-6),
+                LinearProjection(n_hidden, geom_hidden),
+                nn.GELU(),
+                LinearProjection(geom_hidden, self.surface_output_dim),
+            )
+            self.geom_branch_volume_head = nn.Sequential(
+                nn.LayerNorm(n_hidden, eps=1e-6),
+                LinearProjection(n_hidden, geom_hidden),
+                nn.GELU(),
+                LinearProjection(geom_hidden, self.volume_output_dim),
+            )
+        else:
+            self.geom_branch = None
+            self.geom_branch_surface_head = None
+            self.geom_branch_volume_head = None
 
     def _encode_group(
         self,
@@ -507,22 +748,64 @@ class SurfaceTransolver(nn.Module):
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
-        if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
-        else:
-            batch_size = volume_x.shape[0]
-            surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+        geom_diagnostics: dict[str, torch.Tensor] = {}
+        if self.use_geom_branch and self.geom_branch is not None:
+            point_coord_parts: list[torch.Tensor] = []
+            if surface_x is not None:
+                point_coord_parts.append(surface_x[:, :, : self.space_dim])
+            if volume_x is not None:
+                point_coord_parts.append(volume_x[:, :, : self.space_dim])
+            point_coords = torch.cat(point_coord_parts, dim=1)
 
-        if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
-        else:
-            batch_size = surface_x.shape[0]
-            volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+            if volume_x is not None:
+                anchor_source_coords = volume_x[:, :, : self.space_dim]
+                anchor_source_mask = volume_mask
+            else:
+                anchor_source_coords = surface_x[:, :, : self.space_dim]
+                anchor_source_mask = surface_mask
 
-        return {
+            geom_features, geom_diagnostics = self.geom_branch(
+                point_features=hidden_norm,
+                point_coords=point_coords,
+                point_mask=attn_mask,
+                anchor_source_coords=anchor_source_coords,
+                anchor_source_mask=anchor_source_mask,
+            )
+            combined = hidden_norm + geom_features
+            combined_surface = combined[:, :surface_tokens]
+            combined_volume = combined[:, surface_tokens : surface_tokens + volume_tokens]
+
+            if surface_x is not None:
+                surface_preds = self.geom_branch_surface_head(combined_surface) * surface_mask.unsqueeze(-1)
+            else:
+                batch_size = volume_x.shape[0]
+                surface_preds = combined.new_zeros(batch_size, 0, self.surface_output_dim)
+
+            if volume_x is not None:
+                volume_preds = self.geom_branch_volume_head(combined_volume) * volume_mask.unsqueeze(-1)
+            else:
+                batch_size = surface_x.shape[0]
+                volume_preds = combined.new_zeros(batch_size, 0, self.volume_output_dim)
+        else:
+            if surface_x is not None:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            else:
+                batch_size = volume_x.shape[0]
+                surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+
+            if volume_x is not None:
+                volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            else:
+                batch_size = surface_x.shape[0]
+                volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+
+        out = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        for name, tensor in geom_diagnostics.items():
+            out[f"geom_branch/{name}"] = tensor
+        return out

--- a/train.py
+++ b/train.py
@@ -797,7 +797,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
-            if config.use_abupt_geom_branch and config.geom_branch_warmup_fraction > 0.0:
+            if config.use_abupt_geom_branch:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)

--- a/train.py
+++ b/train.py
@@ -137,6 +137,12 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_abupt_geom_branch: bool = False
+    geom_branch_n_anchors: int = 1024
+    geom_branch_rff_num_features: int = 16
+    geom_branch_warmup_fraction: float = 0.0
+    geom_branch_lr_scale: float = 1.0
+    geom_branch_warmup_vol_weight: float = 0.0
     debug: bool = False
 
 
@@ -235,9 +241,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    if config.use_abupt_geom_branch and config.geom_branch_lr_scale != 1.0:
+        backbone_params, geom_branch_params, _, _ = split_param_groups(model)
+        param_groups = [
+            {"params": backbone_params, "lr": config.lr},
+            {
+                "params": geom_branch_params,
+                "lr": config.lr * config.geom_branch_lr_scale,
+            },
+        ]
+        opt_param_input = param_groups
+    else:
+        opt_param_input = list(model.parameters())
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
-            model.parameters(),
+            opt_param_input,
             lr=config.lr,
             weight_decay=config.weight_decay,
         )
@@ -245,7 +263,7 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
+            opt_param_input,
             lr=config.lr,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
@@ -297,7 +315,33 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_geom_branch=config.use_abupt_geom_branch,
+        geom_branch_n_anchors=config.geom_branch_n_anchors,
+        geom_branch_rff_num_features=config.geom_branch_rff_num_features,
     )
+
+
+GEOM_BRANCH_PARAM_NAME_TOKENS = ("geom_branch",)
+
+
+def is_geom_branch_param_name(name: str) -> bool:
+    return any(token in name for token in GEOM_BRANCH_PARAM_NAME_TOKENS)
+
+
+def split_param_groups(model: nn.Module) -> tuple[list[nn.Parameter], list[nn.Parameter], list[str], list[str]]:
+    """Split model parameters into (backbone, geom_branch) groups by name."""
+    backbone_params: list[nn.Parameter] = []
+    geom_branch_params: list[nn.Parameter] = []
+    backbone_names: list[str] = []
+    geom_branch_names: list[str] = []
+    for name, param in model.named_parameters():
+        if is_geom_branch_param_name(name):
+            geom_branch_params.append(param)
+            geom_branch_names.append(name)
+        else:
+            backbone_params.append(param)
+            backbone_names.append(name)
+    return backbone_params, geom_branch_params, backbone_names, geom_branch_names
 
 
 def train_loss(
@@ -753,6 +797,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_kwargs = {}
             if device.type == "cuda":
                 ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            if config.use_abupt_geom_branch and config.geom_branch_warmup_fraction > 0.0:
+                ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
@@ -815,6 +861,34 @@ def main(argv: Iterable[str] | None = None) -> None:
             print("Kill thresholds:", "; ".join(threshold.describe() for threshold in kill_thresholds))
         train_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
         val_slope_tracker = MetricSlopeTracker(total_estimated_steps, config.slope_log_fraction)
+
+        geom_branch_active = config.use_abupt_geom_branch
+        geom_warmup_steps = 0
+        backbone_param_list: list[nn.Parameter] = []
+        geom_branch_param_list: list[nn.Parameter] = []
+        backbone_currently_frozen = False
+        if geom_branch_active:
+            backbone_param_list, geom_branch_param_list, _, geom_branch_names = split_param_groups(base_model)
+            geom_warmup_steps = int(
+                round(total_estimated_steps * max(0.0, config.geom_branch_warmup_fraction))
+            )
+            geom_warmup_steps = min(geom_warmup_steps, total_estimated_steps)
+            if state.is_main:
+                geom_param_count = sum(p.numel() for p in geom_branch_param_list)
+                backbone_param_count = sum(p.numel() for p in backbone_param_list)
+                print(
+                    f"AB-UPT geom branch enabled: anchors={config.geom_branch_n_anchors} "
+                    f"rff_features={config.geom_branch_rff_num_features} "
+                    f"warmup_steps={geom_warmup_steps}/{total_estimated_steps} "
+                    f"(fraction={config.geom_branch_warmup_fraction}) "
+                    f"lr_scale={config.geom_branch_lr_scale} "
+                    f"warmup_vol_weight={config.geom_branch_warmup_vol_weight} "
+                    f"params={geom_param_count:,d} (geom) + {backbone_param_count:,d} (backbone)"
+                )
+            if geom_warmup_steps > 0:
+                for p in backbone_param_list:
+                    p.requires_grad_(False)
+                backbone_currently_frozen = True
 
         # Log multi-sigma RFF init layout for verification.
         if state.is_main:
@@ -999,6 +1073,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    geom_active_vol_weight = config.volume_loss_weight
+                    if geom_branch_active and global_step < geom_warmup_steps:
+                        geom_active_vol_weight = config.geom_branch_warmup_vol_weight
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1006,11 +1083,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         config.amp_mode,
                         surface_loss_weight=config.surface_loss_weight,
-                        volume_loss_weight=config.volume_loss_weight,
+                        volume_loss_weight=geom_active_vol_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
+                if geom_branch_active:
+                    geom_in_warmup = global_step <= geom_warmup_steps
+                    if backbone_currently_frozen and not geom_in_warmup:
+                        for p in backbone_param_list:
+                            p.requires_grad_(True)
+                        backbone_currently_frozen = False
+                        if state.is_main:
+                            print(
+                                f"[geom_branch] step {global_step}: backbone unfrozen "
+                                f"(warmup_steps={geom_warmup_steps})"
+                            )
                 current_lr = scheduler.get_last_lr()[0]
                 loss_is_nonfinite = not bool(torch.isfinite(loss.detach()).item())
                 skip_step = distributed_any(state, loss_is_nonfinite, device)
@@ -1050,6 +1138,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if geom_branch_active:
+                    is_warmup = global_step <= geom_warmup_steps
+                    train_log.update(
+                        {
+                            "geom_branch/is_warmup_phase": 1.0 if is_warmup else 0.0,
+                            "geom_branch/backbone_frozen": 1.0 if backbone_currently_frozen else 0.0,
+                            "geom_branch/lr": optimizer.param_groups[-1]["lr"]
+                            if config.geom_branch_lr_scale != 1.0
+                            else current_lr,
+                            "geom_branch/backbone_lr": optimizer.param_groups[0]["lr"],
+                            "geom_branch/active_vol_weight": geom_active_vol_weight,
+                            "geom_branch/warmup_steps": float(geom_warmup_steps),
+                        }
+                    )
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
@@ -1078,6 +1180,27 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/step_skipped": 1.0 if skip_step else 0.0,
                         }
                     )
+                    if (
+                        geom_branch_active
+                        and should_log_gradients
+                        and not skip_step
+                        and (backbone_param_list or geom_branch_param_list)
+                    ):
+                        with torch.no_grad():
+                            bb_norm_sq = torch.zeros((), device=device, dtype=torch.float32)
+                            gb_norm_sq = torch.zeros((), device=device, dtype=torch.float32)
+                            for p in backbone_param_list:
+                                if p.grad is not None:
+                                    bb_norm_sq = bb_norm_sq + p.grad.detach().float().pow(2).sum()
+                            for p in geom_branch_param_list:
+                                if p.grad is not None:
+                                    gb_norm_sq = gb_norm_sq + p.grad.detach().float().pow(2).sum()
+                            train_log["geom_branch/grad_norm_backbone"] = float(
+                                bb_norm_sq.sqrt().cpu().item()
+                            )
+                            train_log["geom_branch/grad_norm_geom"] = float(
+                                gb_norm_sq.sqrt().cpu().item()
+                            )
                     gradient_metrics = (
                         collect_gradient_metrics(
                             model,


### PR DESCRIPTION
## Hypothesis

AB-UPT geometry branch v3: compose the validated supernode-pooling geometry branch architecture from PR #802 (v2) with the current L5 SOTA backbone (PR #592). PR #802 demonstrated 30% compression of the OOD vol_pressure gap (3.17× → 2.225×) even at sub-SOTA training efficiency. The failure mode of v2 was not architecture but training priority: the geometry branch competed with an already-warm backbone at the same LR without a warmup phase. v3 fixes this by:

1. Using the current L5 SOTA backbone (hidden_dim=512, heads=4, slices=128) as the trunk — v2 used L4.
2. Starting with a 4-epoch screen to validate the signal quickly before committing to full 13-epoch training.
3. Retaining all three v2 training fixes: backbone freeze warmup, differential LR, and vol aux weight during warmup.

**Geometry branch architecture (from PR #802):**
- Supernode pooling: K=1024 anchor points sampled from volume mesh, STRING-separable RoPE on Q/K (same frequencies as backbone: σ={0.25,0.5,1.0,2.0,4.0}, rff_num_features=16)
- Two independent output branches: surface head and volume head, each a 2-layer MLP projecting from geometry-branch features + backbone features (via cross-attention from anchors to mesh points)
- Anchor→Point cross-attention (K=1024 anchors broadcast to all vol/surface points) — this is separate from and parallel to the backbone's slice attention

**Three training fixes (retain exactly from v2):**
1. **Backbone freeze warmup** (`--geom-branch-warmup-fraction 0.2`): First 20% of steps (~0.8 epochs on 4-ep), freeze backbone, train only geometry branch params. Log `geom_branch/is_warmup_phase`, `geom_branch/backbone_frozen`.
2. **Differential LR** (`--geom-branch-lr-scale 2.0`): After warmup, geometry branch params get 2× LR (= 1.8e-4 when backbone is at 9e-5). Construct separate optimizer param groups.
3. **Vol aux weight during warmup** (`--geom-branch-warmup-vol-weight 2.0`): During warmup steps, volume_loss_weight=2.0; after warmup reverts to standard config value.

**Reference implementation (PR #802 — NOT merged into tay, implement fresh):**
- Model architecture: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/model.py
- RoPE frequency: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/modules/rope_frequency.py
- Supernode pooling: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers/blob/main/src/modules/supernode_pooling_posonly.py

## Instructions

Implement the following new CLI flags in `target/train.py` and hook them into the model/training loop:

```
--use-abupt-geom-branch        # bool flag, default False
--geom-branch-n-anchors 1024   # int, number of supernode anchor points
--geom-branch-warmup-fraction 0.2  # float, fraction of total steps to freeze backbone
--geom-branch-lr-scale 2.0     # float, LR multiplier for geometry branch params
--geom-branch-warmup-vol-weight 2.0  # float, vol loss weight during warmup phase
```

**Step 1 — Supernode pooling (geometry branch input):**
- At each forward pass, sample K=`--geom-branch-n-anchors` anchor points from the volume mesh coords (x, y, z) using farthest-point sampling or random uniform sampling.
- Compute attention from volume points to anchors using STRING-separable RoPE (same σ values as backbone): `softmax(Q_vol @ K_anchor^T / sqrt(d)) @ V_anchor`. This pools geometric information into K=1024 anchor representations.
- The anchor representations form the "geometry branch latent".

**Step 2 — Anchor→Point cross-attention (geometry branch output):**
- Add a cross-attention layer: queries from backbone slice tokens, keys/values from anchor representations.
- This injects geometry context into the backbone's processing.
- OR alternatively: after backbone produces per-point features, add a residual: `features += CrossAttn(queries=point_features, keys=anchor_features, values=anchor_features)`.

**Step 3 — Optimizer param groups:**
```python
geometry_params = [p for name, p in model.named_parameters() if 'geom_branch' in name]
backbone_params = [p for name, p in model.named_parameters() if 'geom_branch' not in name]
optimizer = Lion([
    {'params': backbone_params, 'lr': args.lr},
    {'params': geometry_params, 'lr': args.lr * args.geom_branch_lr_scale},
], betas=(0.9, 0.99), weight_decay=args.weight_decay)
```

**Step 4 — Backbone freeze warmup:**
```python
warmup_steps = int(total_steps * args.geom_branch_warmup_fraction)
if current_step < warmup_steps:
    for p in backbone_params: p.requires_grad_(False)
    current_vol_weight = args.geom_branch_warmup_vol_weight
else:
    for p in backbone_params: p.requires_grad_(True)
    current_vol_weight = config.volume_loss_weight  # standard value
```

**Step 5 — W&B logging (add to your existing metrics dict):**
```python
'geom_branch/is_warmup_phase': int(current_step < warmup_steps),
'geom_branch/backbone_frozen': int(current_step < warmup_steps),
'geom_branch/lr': optimizer.param_groups[1]['lr'],
'geom_branch/active_vol_weight': current_vol_weight,
```

**Step 6 — Run command (4-epoch screen first):**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-abupt-geom-branch \
  --geom-branch-n-anchors 1024 \
  --geom-branch-warmup-fraction 0.2 \
  --geom-branch-lr-scale 2.0 \
  --geom-branch-warmup-vol-weight 2.0 \
  --wandb-group abupt-geom-branch-v3 --wandb-name askeladd/geom-branch-v3-ep4
```

**Kill gates (generous: EP1 backbone is frozen):**
- EP1 val_abupt > 40% → kill (backbone frozen, geometry branch only, should still make forward progress)
- EP2 val_abupt > 16% → kill
- EP4 val_abupt > 10% → kill (if EP4 val_abupt ≤ 10%, continue to full 13-epoch run)

**If EP4 passes (≤ 10%), run full 13-epoch:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-abupt-geom-branch \
  --geom-branch-n-anchors 1024 \
  --geom-branch-warmup-fraction 0.2 \
  --geom-branch-lr-scale 2.0 \
  --geom-branch-warmup-vol-weight 2.0 \
  --wandb-group abupt-geom-branch-v3 --wandb-name askeladd/geom-branch-v3-ep13
```

## Baseline

Current single-model SOTA (PR #592, alphonse depth-L5):

| Metric | Value |
|--------|-------|
| val_abupt | **6.5985%** ← gate to beat |
| val surface_pressure | 4.3322% |
| val volume_pressure | 3.9456% |
| val wall_shear_x | 6.5420% |
| val wall_shear_y | 8.3631% |
| val wall_shear_z | 9.8099% |
| test_abupt | 7.9915% |

Best vol_pressure anchor (PR #681, run `dc031qpt`): test_vol_p = **11.374%**

W&B run: `4k25s25e` (PR #592)

Reproduce command (baseline):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536
```

**V2 reference (PR #802, CLOSED / NOT MERGED — use as architecture guide only):**
- val_abupt=8.563%, test_vol_p=13.299%, OOD gap 3.17×→2.225× (30% compression)
- v2 used L4 backbone; v3 uses L5 backbone with the same geometry branch

## Vol-pressure promotion ladder

| Tier | Threshold |
|------|-----------|
| Weak | ≤ 11.0% |
| Solid | ≤ 10.0% |
| Major | ≤ 8.5% |
| Target | ≤ 6.08% (AB-UPT reference) |

## Expected result

EP4: val_abupt ~8–10% (geometry branch learning, backbone catching up after warmup)
EP13: val_abupt < 6.5985% (if geometry branch compresses OOD variance as in v2)
test_vol_p: targeting ≤ 11.0% (Weak tier), aim for ≤ 10.0% (Solid tier)

Please report: val_abupt, val_surface_pressure, val_volume_pressure, val_wall_shear_{x,y,z}, test_vol_p, W&B run ID, and whether EP4 kill gates were passed.
