### PR TITLE
frieren: Y-symmetry augmentation standalone 4-ep tay screen

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,6 +137,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_y_symmetry_aug: bool = False
+    y_symmetry_aug_prob: float = 0.5
     debug: bool = False
 
 
@@ -300,6 +302,33 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
+    """Reflect a random subset of batch items through the y=0 plane.
+
+    DrivAerML car geometry is bilaterally symmetric about y=0. Under y-reflection
+    (x, y, z) -> (x, -y, z) the surface point coordinate y, the surface normal
+    component n_y, the wall-shear y-component tau_y, and the volume point
+    coordinate y all negate. cp, surface area, sdf, tau_x, tau_z, and volume
+    pressure are invariant. This in-place transform is applied per-sample with
+    probability `prob`. Returns the boolean mask used (for diagnostic logging).
+
+    Channel layout (verified against data/loader.py):
+    - surface_x: [x, y, z, nx, ny, nz, area]  -> negate idx 1 and idx 4
+    - surface_y: [cp, tau_x, tau_y, tau_z]    -> negate idx 2
+    - volume_x:  [x, y, z, sdf]               -> negate idx 1
+    - volume_y:  [pressure]                   -> invariant
+    """
+    B = batch.surface_x.shape[0]
+    flip_mask = torch.rand(B, device=batch.surface_x.device) < prob
+    if flip_mask.any():
+        idx = flip_mask.nonzero(as_tuple=True)[0]
+        batch.surface_x[idx, :, 1] = -batch.surface_x[idx, :, 1]
+        batch.surface_x[idx, :, 4] = -batch.surface_x[idx, :, 4]
+        batch.surface_y[idx, :, 2] = -batch.surface_y[idx, :, 2]
+        batch.volume_x[idx, :, 1] = -batch.volume_x[idx, :, 1]
+    return flip_mask
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -310,8 +339,16 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_y_symmetry_aug: bool = False,
+    y_symmetry_aug_prob: float = 0.5,
+    aug_log: dict | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    if use_y_symmetry_aug:
+        flip_mask = apply_y_symmetry_aug(batch, y_symmetry_aug_prob)
+        if aug_log is not None:
+            aug_log["n_flipped"] = int(flip_mask.sum().item())
+            aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -861,6 +898,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["aug/use_y_symmetry_aug"] = bool(config.use_y_symmetry_aug)
+            wandb.summary["aug/y_symmetry_aug_prob"] = float(config.y_symmetry_aug_prob)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -999,6 +1038,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    aug_log: dict[str, int] = {}
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1008,7 +1048,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_y_symmetry_aug=config.use_y_symmetry_aug,
+                        y_symmetry_aug_prob=config.y_symmetry_aug_prob,
+                        aug_log=aug_log,
                     )
+                    if (
+                        config.use_y_symmetry_aug
+                        and state.is_main
+                        and epoch == 0
+                        and global_step == 0
+                    ):
+                        print(
+                            f"[aug debug] EP0 step0 (rank0): "
+                            f"{aug_log.get('n_flipped', 0)}/{aug_log.get('batch_size', 0)} "
+                            f"samples y-flipped"
+                        )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1050,6 +1104,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if config.use_y_symmetry_aug and balancer is None and aug_log:
+                    bs = max(1, aug_log.get("batch_size", 0))
+                    train_log["train/aug/y_symmetry_flip_rate"] = (
+                        aug_log.get("n_flipped", 0) / bs
+                    )
+                    train_log["train/aug/y_symmetry_n_flipped"] = aug_log.get(
+                        "n_flipped", 0
+                    )
+                    train_log["train/aug/y_symmetry_batch_size"] = aug_log.get(
+                        "batch_size", 0
+                    )
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

Y-axis symmetry augmentation (`--use-y-symmetry-aug`) applied standalone on the L5 SOTA stack will improve OOD generalization by enforcing physical symmetry as a regularizer. DrivAerML vehicles are laterally symmetric (y-axis); by randomly flipping all coordinates and features through the y=0 plane during training, the model should learn representations that respect this symmetry, reducing overfitting to dataset-specific asymmetries.

**Evidence base:**
- **Y-sym in long runs**: Y-sym has ONLY been tested bundled with GradNorm α=0.5 (PRs #791, #794, #818, #831, #806). Never isolated on its own.
- **PR #784 (dl24-nezuko, QK-Norm + Y-sym)**: best=6.6092% after 28 epochs. The Y-sym contribution is confounded by QK-Norm.
- **PR #818 (dl24-tanjiro, 6-octave STRING + GradNorm + Y-sym)**: val leader at 6.6053% @ EP28 — the best val result achieved so far, but Y-sym's individual contribution is unknown.
- **PR #831 (dl24-fern, 6L + GradNorm α=0.5 + Y-sym)**: still running. Again Y-sym bundled with other changes.
- **PR #844 (dl24-frieren, 5L + GradNorm α=0.5 WITHOUT Y-sym)**: in progress as a counter-ablation, but this is a long run.
- **Standalone Y-sym tay screen**: has NEVER been run. This cleanly isolates whether Y-sym adds value on top of the base L5 SOTA stack.

**Physical motivation**: The dataset contains car geometries that are near-perfectly symmetric about y=0. Any asymmetries in prediction (particularly τ_y bias) could arise from dataset sampling rather than physics. Y-sym augmentation forces the model to treat +y and -y equivalently, which should specifically help τ_y error (historically lagging behind τ_x and τ_z) and improve generalization to unseen geometries.

## Instructions

Run the following command exactly. This is the L5 SOTA recipe with `--use-y-symmetry-aug` added:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --wandb-group frieren-y-sym-standalone \
  --wandb-name frieren/y-sym-standalone-l5-sota-4ep
```

**Key change vs L5 SOTA base**: `--use-y-symmetry-aug --y-symmetry-aug-prob 0.5` added. No GradNorm, no other changes. This is the cleanest possible Y-sym ablation.

**What the augmentation does**: With probability 0.5 per batch, all y-coordinates are negated and τ_y (wall-shear in y-direction) signs are flipped, enforcing physical bilateral symmetry of the vehicle body. This is a hard physics constraint from the geometry.

**Kill gates (kill if val_abupt does NOT drop below threshold by step):**
- EP1 (step ~10,864): val_abupt < 30%
- EP2 (step ~21,728): val_abupt < 10%
- EP3 (step ~32,592): val_abupt < 8%
- EP4 (step ~43,456): val_abupt ≤ 6.5985% (SOTA advancement gate)

Val checkpoints appear approximately 900 steps after each epoch boundary.

## What to report

After training completes (or kill gate fires), post a PR comment with:
1. W&B run ID
2. Best val_abupt and the epoch/step it was achieved
3. Per-channel breakdown at best val: surface_pressure (cp), tau_x, tau_y, tau_z, volume_pressure (vol_p)
4. **Specifically**: τ_y error vs baseline — does Y-sym help the τ_y channel as predicted?
5. test_abupt from best-val checkpoint (if EP4 gate cleared)
6. Comparison vs PR #824 (L5 SOTA, no Y-sym) and vs PR #818 (which also uses Y-sym but with GradNorm and 6-octave STRING)

Include terminal SENPAI-RESULT marker once training is complete:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline to beat

**Wave test SOTA**: PR #740 (`5x8wofzm`), test_abupt = **7.5195%**

**L5 SOTA tay screen baseline (PR #824, no Y-sym, no GradNorm):**

| Metric | Value |
|--------|-------|
| val_abupt (best EP4) | ~6.5985% threshold (advance gate) |
| test_abupt | compare vs 7.5195% wave SOTA |

**Y-sym context: all prior tests were confounded by GradNorm or architecture changes.**
This is the first clean Y-sym standalone screen.