### PR TITLE
SGDR warm restarts: CosineAnnealingWarmRestarts on L5/Lion/STRING stack

### DIFF
--- a/train.py
+++ b/train.py
@@ -115,6 +115,8 @@ class Config:
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
+    lr_sgdr_t0: int = 0
+    lr_sgdr_t_mult: int = 2
     lr_min: float = 1e-6
     grad_clip_norm: float = 1.0
     gradient_log_every: int = 250

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1285,6 +1285,27 @@ def build_lr_scheduler(
     config,
     max_epochs: int,
 ) -> torch.optim.lr_scheduler.LRScheduler:
+    if getattr(config, "lr_sgdr_t0", 0) > 0:
+        t_mult = getattr(config, "lr_sgdr_t_mult", 2)
+        sgdr_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=max(1, config.lr_sgdr_t0),
+            T_mult=max(1, t_mult),
+            eta_min=config.lr_min,
+        )
+        if config.lr_warmup_epochs <= 0:
+            return sgdr_scheduler
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=0.05,
+            end_factor=1.0,
+            total_iters=max(1, config.lr_warmup_epochs),
+        )
+        return torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup_scheduler, sgdr_scheduler],
+            milestones=[config.lr_warmup_epochs],
+        )
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer,


### PR DESCRIPTION
## Hypothesis

True SGDR (Stochastic Gradient Descent with Warm Restarts; Loshchilov & Hutter 2017, https://arxiv.org/abs/1608.03983) may outperform a single cosine decay on the current L5/Lion/STRING stack. The current `build_lr_scheduler` in `trainer_runtime.py` uses `CosineAnnealingLR` (one monotone decay to eta_min), which never revisits high-LR exploration after the initial warmup. SGDR repeatedly resets to lr_max, potentially escaping sharp minima and improving generalisation on the physical surface/volume fields.

The current baseline uses `--lr-cosine-t-max 13` to cover all 13 training epochs in one cosine cycle. SGDR replaces this with `CosineAnnealingWarmRestarts(T_0=2, T_mult=2)` — epoch-based cycles of lengths 2, 4, 7 (fits within ~13 epochs). Each reset returns to lr=9e-5 and decays to lr_min=1e-6.

For the 4-ep screen run: `T_0=1, T_mult=2` gives cycles of length 1, 2, 4 — the warm restart fires at EP1 (epoch 1) and EP3 (epoch 3), keeping the LR above lr_min at EP2 and EP4 gate checkpoints.

## Instructions

This experiment requires two small code changes to add SGDR support:

### 1. Add new config fields to `train.py` `Config` dataclass (after `lr_cosine_t_max`)

In `train.py`, in the `Config` dataclass (around line 117), add after `lr_cosine_t_max: int = 0`:

```python
lr_sgdr_t0: int = 0          # T_0 for CosineAnnealingWarmRestarts; 0 = disabled
lr_sgdr_t_mult: int = 2      # T_mult multiplier (how cycle length grows)
```

### 2. Modify `build_lr_scheduler` in `trainer_runtime.py` to support SGDR

In `trainer_runtime.py`, replace the current `build_lr_scheduler` function (lines ~1283–1306):

```python
def build_lr_scheduler(
    optimizer: torch.optim.Optimizer,
    config,
    max_epochs: int,
) -> torch.optim.lr_scheduler.LRScheduler:
    # SGDR (CosineAnnealingWarmRestarts) takes priority if lr_sgdr_t0 > 0
    if getattr(config, 'lr_sgdr_t0', 0) > 0:
        t_mult = getattr(config, 'lr_sgdr_t_mult', 2)
        sgdr_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
            optimizer,
            T_0=max(1, config.lr_sgdr_t0),
            T_mult=max(1, t_mult),
            eta_min=config.lr_min,
        )
        if config.lr_warmup_epochs <= 0:
            return sgdr_scheduler
        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer,
            start_factor=0.05,
            end_factor=1.0,
            total_iters=max(1, config.lr_warmup_epochs),
        )
        return torch.optim.lr_scheduler.SequentialLR(
            optimizer,
            schedulers=[warmup_scheduler, sgdr_scheduler],
            milestones=[config.lr_warmup_epochs],
        )
    # Original single cosine decay path
    t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer,
        T_max=max(1, t_max),
        eta_min=config.lr_min,
    )
    if config.lr_warmup_epochs <= 0:
        return cosine_scheduler
    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
        optimizer,
        start_factor=0.05,
        end_factor=1.0,
        total_iters=max(1, config.lr_warmup_epochs),
    )
    return torch.optim.lr_scheduler.SequentialLR(
        optimizer,
        schedulers=[warmup_scheduler, cosine_scheduler],
        milestones=[config.lr_warmup_epochs],
    )
```

### 3. Run the 4-ep screen with SGDR T_0=1, T_mult=2

Note: `CosineAnnealingWarmRestarts` is epoch-based (per-epoch steps), while `CosineAnnealingLR` was step-based in the original config. Confirm that `build_lr_scheduler` is called once per epoch (not per step) in the training loop — if it's called per step, set `T_0` in steps not epochs: T_0=10864 (EP1 boundary) for the same cycle structure.

**Check the training loop** (`trainer_runtime.py`, search for `build_lr_scheduler` and `scheduler.step`) to confirm step frequency before running. If `scheduler.step()` is called per-step, use `--lr-sgdr-t0 10864 --lr-sgdr-t-mult 2` (step-based cycles of ~10864, ~21728 steps).

If `scheduler.step()` is called per-epoch, use `--lr-sgdr-t0 1 --lr-sgdr-t-mult 2` (epoch-based cycles: 1, 2, 4 epochs).

**4-ep screen run command:**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-sgdr-t0 <T_0_value> --lr-sgdr-t-mult 2 \
  --epochs 4 --lr-cosine-t-max 13 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group sgdr-warm-restarts --wandb-name alphonse/sgdr-t0-screen
```

Replace `<T_0_value>` with:
- `1` if `scheduler.step()` is called once per epoch
- `10864` if `scheduler.step()` is called once per training step

**IMPORTANT: Do NOT remove `--lr-cosine-t-max 13` from the command.** It is used as fallback in the original code path; with `lr_sgdr_t0 > 0`, `lr_cosine_t_max` is ignored. Keep it so the run can serve as a valid comparison reference.

## Kill gates (4-ep screen)

The vol-points schedule means epoch ≠ step. Gate checkpoints (step-based):
- EP1 gate: step ~10,864 → val_abupt < 30%
- EP2 gate: step ~16,300 → val_abupt < 16%
- EP3 gate: step ~19,926 → val_abupt < 8%
- EP4 gate: step ~22,647 → val_abupt ≤ 6.5985%

Please post each gate result as a PR comment as soon as `validation_every=1` logs it.

## Baseline

| Metric | Single-model SOTA (PR #592, W&B `4k25s25e`) |
|--------|------|
| val_abupt | **6.5985%** |
| surface_pressure | 4.3322% |
| volume_pressure | 3.9456% |
| wall_shear | 6.5420% |
| tau_y | 8.3631% |
| tau_z | 9.8099% |

**Gate to beat:** `val_primary/abupt_axis_mean_rel_l2_pct < 6.5985%`

**Single-model SOTA reproduce command:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group model-depth-sweep --wandb-name alphonse/depth-L5
```
