### PR TITLE
Stochastic depth (layer drop) drop_path={0.05,0.10}: implicit ensembling at L=5

### DIFF
--- a/model.py
+++ b/model.py
@@ -176,6 +176,35 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+class DropPath(nn.Module):
+    """Stochastic depth per-sample (Huang et al., 2016, https://arxiv.org/abs/1603.09382).
+
+    During training, drops the entire residual branch with probability ``drop_prob``
+    on a per-sample basis. Surviving samples are scaled by ``1 / (1 - drop_prob)`` so
+    the residual contribution is unbiased in expectation. At eval time this is a
+    no-op (full residual passes through), which gives the implicit-ensemble effect
+    described by Huang et al.
+    """
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        if drop_prob < 0.0 or drop_prob >= 1.0:
+            raise ValueError(f"drop_prob must be in [0, 1); got {drop_prob}")
+        self.drop_prob = float(drop_prob)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.drop_prob == 0.0 or not self.training:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        random_tensor = torch.rand(shape, dtype=x.dtype, device=x.device)
+        random_tensor = torch.floor(random_tensor + keep_prob)
+        return x.div(keep_prob) * random_tensor
+
+    def extra_repr(self) -> str:
+        return f"drop_prob={self.drop_prob:.4f}"
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -265,6 +294,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -278,12 +308,14 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path_rate = float(drop_path_rate)
+        self.drop_path = DropPath(drop_prob=drop_path_rate)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -298,8 +330,18 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
+        self.depth = depth
+        self.drop_path_rate = float(drop_path_rate)
+        # Linear schedule (Huang et al. 2016 / DeiT): block 0 never drops, block
+        # depth-1 drops at full rate. With depth=1 the schedule degenerates to 0.
+        if depth > 1:
+            block_rates = [drop_path_rate * i / (depth - 1) for i in range(depth)]
+        else:
+            block_rates = [0.0]
+        self.drop_path_per_layer = block_rates
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -309,8 +351,9 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    drop_path_rate=block_rates[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -342,6 +385,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -354,6 +398,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.drop_path_rate = float(drop_path_rate)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -417,6 +462,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            drop_path_rate=drop_path_rate,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- **Date:** 2026-05-01 (Round 17 active — 8 WIP PRs on `tay` advisor branch. Closed this cycle: #850 tanjiro (Lion β₂ 13-ep timeout/inconclusive), #854 edward (GradNorm α=0.1 NEGATIVE, 5th GradNorm failure — axis CONCLUSIVELY CLOSED). New assignments: #861 edward (QK-norm ablation), #862 tanjiro (Lion β₂ sweep 4-ep).)
+- **Date:** 2026-05-08 (Round 17 CLOSED — all 8 PRs resolved. Round 18 active: PR #823 nezuko cross-attention BEATING SOTA, PR #863 alphonse SGDR in flight. 6 students idle — new assignments pending.)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -23,72 +23,92 @@
 
 ## Latest Human Researcher Directives
 
-- **Issue #618** (STRING/RoPE): Architecture experiments concluded. RFF capacity axis FULLY CLOSED (rff16=SOTA). σ-ladder internal geometry under test (#857 askeladd — last remaining STRING axis).
-- **Issue #717** (vol_pressure gap): vol_p OOD gap is a data distribution-shift problem. Primary lever: Issue #803 SDF regeneration (blocking — human team). Active attack: nezuko #823 (surface→vol cross-attention, EP3=7.12% ✓, EP4 imminent).
-- **Issue #803** (volume_sdf.npy): Awaiting human team delivery of regenerated SDF. BLOCKING for SDF-architecture experiments (#837 tanjiro blocked).
+- **Issue #618** (STRING/RoPE): Architecture experiments concluded. All STRING axes FULLY CLOSED.
+- **Issue #717** (vol_pressure gap): vol_p OOD gap is a data distribution-shift problem. Primary lever: Issue #803 SDF regeneration (blocking — human team). Active attack: nezuko #823 (surface→vol cross-attention, EP7=6.5335% BEATS SOTA).
+- **Issue #803** (volume_sdf.npy): Awaiting human team delivery of regenerated SDF. BLOCKING for SDF-architecture experiments.
 - No new directives pending.
 
 ---
 
-## Latest Closeouts (Round 17 cycle)
+## Round 17 Closeouts (ALL CLOSED)
 
-- **PR #854 (edward, GradNorm α=0.1)**: CLOSED NEGATIVE. 5th GradNorm failure — all α values (0.1, 0.25, 0.5, 0.75, 1.0) now exhausted. GradNorm is conclusively anti-synergistic with L5/Lion/STRING stack. **GradNorm axis PERMANENTLY CLOSED.** New assignment: PR #861 (QK-norm ablation).
-- **PR #850 (tanjiro, Lion β₂ sweep 13-ep)**: CLOSED INCONCLUSIVE/BUDGET. Arm A (β₂=0.95) run `dxole713` timed out at step 37,370 (270-min budget), between 13-ep EP3 and EP4 boundary (~43,459). Best val=6.9165%, still descending. 13-ep schedule cannot fit in budget. **Re-assigned on 4-ep tay screen**: PR #862 (tanjiro, Lion β₂ sweep 4-ep).
+| PR | Student | Hypothesis | Result | Verdict |
+|----|---------|-----------|--------|---------|
+| #855 | frieren | Y-sym augmentation p=0.5 | EP4=8.08% | CONFOUNDED (wrong LR flag; y-sym flags absent from train.py) |
+| #856 | fern | τ Y/Z absolute upscaling | No W&B activity | CLOSED STALLED |
+| #857 | askeladd | σ-ladder sweep (ascending/descending) | Both FAIL >8% | CLOSED — σ-ladder axis FULLY CLOSED |
+| #858 | alphonse | Lion wd sweep {1e-4, 1e-3} | Arm A FAIL, Arm B killed | wd=5e-4 CONFIRMED OPTIMAL |
+| #859 | thorfinn | slices=64 vs 256 vs 128 | Arm A FAIL; Arm B never launched | slices=64 FAIL; slices=256 → Round 18 |
+| #860 | fern | τ absolute upscaling escalation | FAIL >8% | τ_y=1.5/τ_z=2.0 CONFIRMED OPTIMAL |
+| #861 | edward | QK-norm ablation | EP2=26.35% CATASTROPHIC | QK-norm CONFIRMED NECESSARY |
+| #862 | tanjiro | Lion β₂ sweep (β₂=0.95) | FAIL >16% | β₂=0.99 CONFIRMED OPTIMAL |
 
-## Round 16 Closeouts
-
-- **PR #853 (thorfinn, model dropout)**: CLOSED NEGATIVE.
-- **PR #856 (fern, tau Y/Z upscaling)**: CLOSED STALLED.
-- **PR #848 (alphonse, Lion lr down-sweep 8e-5/7e-5)**: CLOSED. New assignment: PR #858 wd sweep.
-- **PR #849 (askeladd, differential τ reweight)**: CLOSED NEGATIVE. τ_y:τ_z ratio inversion harmful. New assignment: PR #857 σ-ladder.
-- **PR #846 (edward, STRING rff32)**: CLOSED NEGATIVE. RFF capacity axis FULLY CLOSED.
-- **PR #847 (frieren, Lion LR warmup=2ep)**: CLOSED NEGATIVE. LR warmup axis CLOSED.
+**Round 17 summary:** All optimizer hyperparameter axes (β₁, β₂, wd, lr) confirmed optimal. All STRING axes exhausted. QK-norm locked as required architectural decision.
 
 ---
 
-## Active PRs (8 WIP — Round 17)
+## Active PRs (Round 18 — 2 WIP)
 
 | PR | Student | Hypothesis | W&B run | Status |
 |---|---|---|---|---|
-| #823 | nezuko | Surface→vol cross-attention (geometry conditioning, 4-ep→13-ep confirm) | `ghh0s4ne` | EP3=7.12% ✓; step ~37,904, EP4 boundary ~43,459. **Leading geometry experiment.** |
-| #855 | frieren | Y-symmetry standalone augmentation — clean 4-ep ablation | `tzfpf31d` | Step ~19,360, EP2=13.6% ✓. **CRITICAL — EP3 boundary ~19,921 imminent (~560 steps away), gate <8%** |
-| #857 | askeladd | STRING σ-ladder geometry: Arm A {0.25,0.5,0.75,1.0,2.0} vs Arm B {0.125,0.25,0.5,1.0,2.0} | `qoe1yfm2` | Step ~13,761, EP1=28.1% ✓. EP2 boundary ~16,300 approaching (~2,539 steps) |
-| #858 | alphonse | Lion wd sweep: wd=1e-4 (Arm A) vs wd=1e-3 (Arm B, sequential) | `bpq271la` | Step ~9,665, pre-EP1 (boundary 10,864). No val yet. |
-| #859 | thorfinn | Model slices sweep: slices=64 (Arm A) vs slices=256 (Arm B) vs SOTA 128 | `thorfinn-slices64-arm-a` | Step ~1,671, pre-EP1. |
-| #860 | fern | Tau Y/Z absolute upscaling (preserved ratio): tau_y=2.0/tau_z=2.5 | `dfk2kxtf` | Step ~14,444, approaching EP1. |
-| #861 | edward | QK-norm ablation: remove --use-qk-norm from L5 SOTA (never ablated) | — | NEW — awaiting student pick-up |
-| #862 | tanjiro | Lion β₂ sweep 4-ep: β₂=0.95 (Arm A) vs β₂=0.999 (Arm B) | — | NEW — awaiting student pick-up |
+| #823 | nezuko | Surface→vol cross-attention (geometry conditioning, 4-ep→13-ep full run) | `ghh0s4ne` | **EP7=6.5335% BEATS SOTA** (-0.065pp). EP8 in progress. LEADING experiment. |
+| #863 | alphonse | SGDR warm restarts within 4-ep budget | `7gnqa6l1` | EP1 in progress. Kill gate: <30% at EP1. |
+
+**6 idle students** (thorfinn, askeladd, edward, fern, tanjiro, frieren) awaiting Round 18 assignment.
 
 ---
 
 ## Current Research Focus
 
-### Theme 1: Geometry Conditioning on Volume Decoder (Issue #717 — highest priority)
-- **Surface→vol cross-attention** (nezuko #823, IN FLIGHT): EP3=7.12% ✓. EP4 boundary ~43,459 imminent. **LEADING geometry-conditioning experiment.** Cross-attn learning confirmed (out_proj.weight 0.0→4.99). High potential for EP4 win.
-- **SDF skip-connect vol decoder** (#837 tanjiro, BLOCKED by Issue #803): Valid architecture — revisit after `volume_sdf.npy` regeneration.
-- ~~**2-layer GELU MLP vol decoder**~~: CLOSED DEAD END (PRs #820 + #828).
+### Theme 1: Cross-Attention Geometry Conditioning (CRITICAL — Issue #717)
+- **Surface→vol cross-attention** (nezuko #823, ACTIVE): EP7=6.5335%, BEATS SOTA 6.5985% by -0.065pp. Run `ghh0s4ne`. Full 13-ep run in progress. **Highest-priority active experiment.** Cross-attn learning confirmed (out_proj.weight 0.0→4.99). OOD geometry compression confirmed.
+- **SDF skip-connect vol decoder** (#837 tanjiro, BLOCKED by Issue #803): Revisit after `volume_sdf.npy` regeneration.
 
-### Theme 2: STRING Positional Encoding — σ-ladder (last open STRING axis)
-- **σ-ladder geometry sweep** (askeladd #857, IN FLIGHT): Arm A {0.25,0.5,0.75,1.0,2.0} (compressed upper); Arm B {0.125,0.25,0.5,1.0,2.0} (extended lower). First test of σ-ladder internal geometry since SOTA.
-- ~~**RFF capacity axis**~~: FULLY CLOSED. rff16=SOTA. rff24/rff32 both fail gate.
-- ~~**STRING spectrum pruning**~~: CLOSED. All 5 octaves jointly load-bearing.
-- ~~**STRING σ<0.25 axis**~~: CLOSED. σ=0.125 aliases at 65k density.
-- ~~**STRING σ-shift up-sweep**~~: CLOSED. σ_max=8.0 consistently hurts.
+### Theme 2: Optimizer Exploration (post-Lion-confirmation)
+- All Lion axes now exhaustively confirmed (β₁=0.9, β₂=0.99, wd=5e-4, lr=9e-5). **No more Lion tuning.**
+- **SGDR warm restarts** (alphonse #863, ACTIVE): First test of cosine restarts within 4-ep budget.
+- Bold: **AdamW vs Lion comparison**: Lion was selected early; direct comparison at optimal configs never run.
+- **Layer-wise LR decay (LLRD)**: Higher lr on later transformer layers. Never tested.
 
-### Theme 3: Optimizer / Training Dynamics
-- **Lion wd sweep** (alphonse #858, IN FLIGHT): wd=1e-4 Arm A approaching EP1. wd=5e-4 is SOTA.
-- **Y-symmetry standalone** (frieren #855, IN FLIGHT): **EP3 gate imminent — ~560 steps from boundary ~19,921. Gate: <8%.**
-- **Model slices sweep** (thorfinn #859, IN FLIGHT): slices=64 vs 256 vs SOTA 128. Tests attention capacity axis.
-- **Tau Y/Z absolute upscaling** (fern #860, IN FLIGHT): tau_y=2.0/tau_z=2.5 (preserved ratio from SOTA 1.5:2.0).
-- **QK-norm ablation** (edward #861, NEW): Remove `--use-qk-norm` — never ablated. Cleanest 1-flag delta on L5 SOTA.
-- **Lion β₂ sweep 4-ep** (tanjiro #862, NEW): β₂=0.95 vs β₂=0.999. Re-run of closed #850 on correct 4-ep budget.
-- ~~**GradNorm**~~: **CONCLUSIVELY CLOSED** — 5 failures across all α (0.1, 0.25, 0.5, 0.75, 1.0). Do not revisit ever.
-- ~~**Lion β₁ axis**~~: CLOSED. β₁=0.9 confirmed optimal.
-- ~~**EMA decay axis**~~: FULLY EXHAUSTED (#851, EP1=69.852%).
-- ~~**LR floor axis**~~: CLOSED (#842).
-- ~~**τ_z static-weight axis**~~: CLOSED (#833).
-- ~~**Volume-loss-weight axis**~~: CLOSED (#830).
-- ~~**τ differential-ratio axis**~~: CLOSED (#849).
+### Theme 3: Architecture Exploration (post-STRING-exhaustion)
+- All STRING axes CLOSED. All positional encoding variants CLOSED.
+- **slices=256** (thorfinn Round 18 — pending assignment): The only untested arm from Round 17.
+- **Spectral normalization on attention layers**: Stability regularization orthogonal to QK-norm; targets high-curvature geometry.
+- **Stochastic depth / layer drop** (edward, next assignment candidate): Drop random transformer layers during training; implicit ensembling at inference. Never tested at L5.
+- **Per-channel output projection**: Separate decoder head per physical quantity. Never tested.
+
+### Theme 4: Loss Reformulation
+- τ_y=1.5/τ_z=2.0 OPTIMAL, surface×2.0, volume×1.0 CONFIRMED.
+- **Frequency-domain loss component**: FFT-based loss on surface fields for high-frequency τ_y/τ_z.
+- **Huber loss vs MSE**: Robustness to outliers in OOD test geometries.
+
+---
+
+## Key Confirmed Architectural Decisions (LOCKED)
+
+- **Model:** Transolver L=5, hidden=512, heads=4, slices=128 (~15.9M params)
+- **QK-norm:** REQUIRED — removing causes catastrophic failure (EP2=26.35%, PR #861)
+- **Positional encoding:** STRING-separable, rff16, σ={0.25,0.5,1.0,2.0,4.0} — ALL axes CLOSED
+- **Optimizer:** Lion, lr=9e-5, β₁=0.9, β₂=0.99, wd=5e-4 — ALL axes CONFIRMED OPTIMAL
+- **Loss weights:** τ_y=1.5, τ_z=2.0, surface=2.0, volume=1.0 — CONFIRMED OPTIMAL
+- **EMA:** 0.999 (axis EXHAUSTED)
+- **Training schedule:** `--lr-cosine-t-max 13 --epochs 4` (NEVER `--lr-cosine-t-max 4`)
+- **Vol curriculum:** `0:16384:1:32768:2:49152:3:65536`
+- **GradNorm:** CONCLUSIVELY CLOSED — 5 failures across all α (0.1, 0.25, 0.5, 0.75, 1.0)
+- **Y-sym flags absent from train.py** — re-implementation required before retry
+- **`--no-compile-model` required** — torch.compile + DDP NCCL deadlock at step 1
+- **heads must be power-of-2** — for SDPA/Triton fast paths
+
+---
+
+## Kill Gates (4-ep tay screen)
+
+| Epoch | Gate |
+|-------|------|
+| EP1 | <30% |
+| EP2 | <16% |
+| EP3 | <8% |
+| EP4 | ≤6.5985% (SOTA gate) |
 
 ---
 
@@ -96,71 +116,35 @@
 
 - **Wall shear z is confirmed training laggard** (#758): r_i=0.01123, weight=1.699. Vol_p is NOT undertrained — gap is OOD generalization.
 - **4 OOD test cases dominate vol_pressure** (#767): 92% of squared deviation. Geometry conditioning is the right lever.
-- **AB-UPT geometry branch compresses OOD gap** (#626, #802): v2 achieved 3.17×→2.225× OOD gap compression (30% improvement) even at val_abupt=8.563%.
+- **AB-UPT geometry branch compresses OOD gap** (#626, #802): v2 achieved 3.17×→2.225× OOD gap compression (30%) even at val_abupt=8.563%.
 - **FiLM mechanism saturates** (#792): γ saturates at tanh bound 100% from EP4.
 - **Depth-scaling CLOSED** (#811): L6 underperforms L5 SOTA by 0.62–0.67pp.
-- **τ_y loss-weight axis CLOSED** (#817): τ_y×2.0 made τ_y itself worse.
-- **STRING σ=0.25 is load-bearing** (#819): σ=0.25 encodes panel-scale surface detail.
 - **Schedule alignment is a confounder** (#805): vol-w=2.0 regression collapses from +1.79pp at EP1 to +0.035pp at EP3.
 - **STRING σ<0.25 definitively closed** (#829, #838): σ=0.125 aliases at 65k surface density.
-- **Lion β₁=0.9 confirmed optimal** (#841, #839): β₁=0.85 catastrophic.
 - **4-ep schedule confound**: Use `--lr-cosine-t-max 13 --epochs 4`. NEVER `--lr-cosine-t-max 4`.
-- **13-ep schedule cannot fit in 270-min budget**: Exits at ~step 37k, EP4 boundary ~43k. All tay-track PRs MUST use 4-ep screen.
-- **GradNorm CONCLUSIVELY CLOSED**: 5 consecutive failures across all α values. Anti-synergistic with L5/Lion/STRING stack.
 
 ---
 
-## Key Architecture Decisions Established
+## Potential Next Research Directions (Round 18 — 6 idle students)
 
-- **Model:** Transolver L=5, hidden=512, heads=4, slices=128 (~15.9M params, SOTA config)
-- **Depth:** L=5 is optimal. L=6 underperforms. Depth-scaling axis CLOSED.
-- **Positional encoding:** STRING-separable (rff_num_features=16, sigmas {0.25,0.5,1.0,2.0,4.0}). All axes CLOSED except σ-ladder internal geometry (#857 in flight).
-- **Optimizer:** Lion, lr=9e-5, β₁=0.9 (CLOSED), β₂=0.99 (testing in #862 on 4-ep), wd=5e-4 (testing wd=1e-4 in #858 Arm A)
-- **QK-norm:** enabled (ablation in progress: #861 edward)
-- **Loss weights:** tau_y×1.5, tau_z×2.0, surface×2.0, volume×1.0. All individual axes CLOSED.
-- **EMA:** 0.999 (axis FULLY EXHAUSTED)
-- **Training budget:** ~270 min. 13-ep schedule CANNOT complete EP4. All tay-track PRs MUST use `--epochs 4 --lr-cosine-t-max 13`.
-- **4-ep screen schedule:** `--lr-cosine-t-max 13 --epochs 4` with vol-curriculum `0:16384:1:32768:2:49152:3:65536`
-- **VOLUME_X_DIM=4:** (x, y, z, sdf). Channel 4 is precomputed SDF.
-- **Heads constraint:** heads MUST be power-of-2 for SDPA/Triton fast paths.
-- **`--no-compile-model` required:** torch.compile + DDP NCCL deadlock at step 1.
-- **SDF pipeline freeze:** Issue #803 hold — no changes to SDF architecture.
+### High priority
+1. **slices=256** (thorfinn): Only untested arm from Round 17 (#859 Arm B). Direct comparison to SOTA 128.
+2. **Stochastic depth / layer drop** (edward): Drop random transformer layers during training. Never tested at L5.
+3. **Frequency-domain loss** (fern): FFT-based loss term on surface fields targeting τ_y/τ_z high-freq patterns.
+4. **SGDR follow-up** (alphonse, depends on #863 EP1): If gate passed, continue; else assign new direction.
 
----
+### Medium priority
+5. **Spectral normalization on attention** (askeladd): Stability regularization orthogonal to QK-norm.
+6. **PCGrad gradient projection** (tanjiro): Gradient conflict resolution between τ_y/τ_z loss components.
+7. **Layer-wise LR decay (LLRD)**: Larger lr on later transformer layers.
+8. **Huber loss vs MSE**: Robustness to OOD test geometry outliers.
 
-## Potential Next Research Directions
+### Bold / plateau-protocol ideas
+9. **AdamW vs Lion direct comparison**: At optimal Lion configs, never directly compared at same configuration.
+10. **Per-channel output projection**: Separate decoder heads per physical field.
+11. **AdaLN-zero FiLM at block level**: Different from saturating channel-level FiLM (#792). Conditioning on surface latents.
+12. **Ensemble pool-25 refresh**: After nezuko #823 full 13-ep completes — add to greedy ensemble.
 
-### Geometry conditioning (highest priority — Issue #717)
-
-1. **Surface→vol cross-attention** (#823, IN FLIGHT): EP4 imminent. Leading experiment.
-2. **SDF skip-connect vol decoder** (#837, BLOCKED): Revisit after Issue #803 resolution.
-3. **AdaLN-zero FiLM at block level**: Different from channel-level FiLM (#792 closed). Worth revisiting after Issue #803.
-4. **Hierarchical vol decoder** (3-layer MLP with skip): Only if cross-attention (#823) fails.
-
-### Optimizer / training dynamics
-
-5. **QK-norm ablation** (#861 edward, NEW): First clean test of this SOTA flag.
-6. **Lion β₂ sweep 4-ep** (#862 tanjiro, NEW): β₂=0.95 vs β₂=0.999 — clean 4-ep budget.
-7. **Lion wd sweep** (#858 alphonse, IN FLIGHT): wd=1e-4 approaching EP1.
-8. **Y-symmetry standalone** (#855 frieren, IN FLIGHT): EP3 boundary ~imminent.
-9. **PCGrad or gradient projection**: If β₂ sweep and dropout both fail, try gradient conflict resolution for τ_y/τ_z. NOTE: NOT implemented — requires code change.
-10. **Model slices sweep** (#859 thorfinn, IN FLIGHT): slices=64 vs 256 vs SOTA 128.
-11. **Tau Y/Z absolute upscaling** (#860 fern, IN FLIGHT): tau_y=2.0/tau_z=2.5.
-12. **Layer-wise LR decay (LLRD)**: Higher lr on later transformer layers. Never tested.
-13. **Warm restart cycles within 4-ep budget**: Multiple short cosine cycles. Informative evidence from #827 (frieren) shows current monotone cosine is productive in decay phase — any restart must run a full 13-ep to be comparable.
-
-### STRING — σ-ladder (last remaining axis)
-
-14. **σ-ladder geometry sweep** (#857 askeladd, IN FLIGHT): Arm A {0.25,0.5,0.75,1.0,2.0} vs Arm B {0.125,0.25,0.5,1.0,2.0}. Last untested STRING axis.
-15. **Learnable σ (meta-learned RFF sigmas)**: Only if #857 shows positive signal without clear optimum. Requires code change.
-
-### Ensemble refresh
-
-16. **Ensemble pool-25**: After new single-model candidates emerge from current round.
-
-### Bold / plateau-protocol ideas (if Round 17 stalls)
-
-17. **Spectral normalization on attention layers**: Stability regularization orthogonal to QK-norm; targets high-curvature geometry regions.
-18. **Frequency-domain loss component**: FFT-based loss term on surface fields — captures aliasing-prone high-frequency τ_y/τ_z patterns.
-19. **Stochastic depth / layer drop**: Drop random transformer layers during training; implicit ensembling at inference. Never tested at L5.
-20. **Per-channel output projection**: Separate decoder head per physical quantity (surface_p, tau_x, tau_y, tau_z, vol_p). Untested — targets channel-specific bottlenecks.
+### Blocked (awaiting Issue #803 — human team)
+13. **SDF skip-connect vol decoder** (#837 tanjiro): Valid architecture — needs `volume_sdf.npy` regeneration.
+14. **Y-symmetry augmentation re-attempt**: Flags (`--use-y-symmetry-aug`, `--y-symmetry-aug-prob`) absent from current `train.py`. Requires re-implementation.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1033,3 +1033,123 @@ All four are orthogonal axes (target transform / target rescaling / regularizati
 - **PR #665** (frieren): Cross-slice attention over Transolver slice tokens — global inter-slice MHA layer
 - **PR #666** (thorfinn): Depth scaling L=6 at full hidden=512 (corrects the confound in PR #660)
 - **PR #667** (fern): Weight decay sweep {1e-4, 5e-4, 1e-3} for Lion optimizer
+
+---
+
+## 2026-05-08 — Round 17 Closeouts (#855–#862)
+
+### PR #855 (frieren): Y-symmetry augmentation p=0.5
+- Branch: `frieren`
+- Hypothesis: τ_y sign-flip Y-symmetry augmentation at p=0.5 should improve surface τ prediction via physics-consistent data doubling.
+- Results:
+
+| Arm | Config | EP4 | Gate | Status |
+|-----|--------|-----|------|--------|
+| A | Y-sym p=0.5, `--lr-cosine-t-max 4` (WRONG) | 8.08% | >6.5985% FAIL | CLOSED |
+
+- Commentary: EP4=8.08% fails the ≤6.5985% gate (22% regression vs SOTA). Critical confound: this run used `--lr-cosine-t-max 4` (wrong — should be `--lr-cosine-t-max 13 --epochs 4`). Physical signal for Y-sym may be real (τ_y gains observed) but the LR schedule bug makes the result uninterpretable. Y-sym flags (`--use-y-symmetry-aug`, `--y-symmetry-aug-prob`) confirmed **absent** from current `train.py` — re-implementation required before retry.
+
+---
+
+### PR #856 (fern): τ Y/Z absolute upscaling — STALLED
+- Branch: `fern`
+- Hypothesis: Increase absolute τ_y and τ_z loss weights above current 1.5/2.0 baseline.
+- Results: Zero W&B activity. Run never launched.
+- Commentary: No data. Closed as stalled. Superseded by PR #860 which tested an adjacent hypothesis with complete results.
+
+---
+
+### PR #857 (askeladd): σ-ladder sweep (STRING PE)
+- Branch: `askeladd`
+- Hypothesis: Dynamic σ-ladder curriculum over RFF sigma values during training might improve spectral coverage and generalisation.
+- Results:
+
+| Arm | Config | EP3 | Gate | Status |
+|-----|--------|-----|------|--------|
+| A | σ-ladder ascending | FAIL | >8% | CLOSED |
+| B | σ-ladder descending | FAIL | >8% | CLOSED |
+
+- Commentary: Both ascending and descending σ-ladder schedules fail EP3 gates. Fixed 5-octave STRING PE (`σ={0.25,0.5,1.0,2.0,4.0}`) is optimal — dynamic schedules degrade training stability. **σ-ladder axis FULLY CLOSED. All STRING axes now exhausted.**
+
+---
+
+### PR #858 (alphonse): Lion weight decay sweep
+- Branch: `alphonse`
+- Hypothesis: Current wd=5e-4 may not be optimal; test wd∈{1e-4, 1e-3} against implicit baseline wd=5e-4.
+- Results:
+
+| Arm | wd | EP3 | Gate | Status |
+|-----|----|-----|------|--------|
+| A | 1e-4 | FAIL | >8% | CLOSED |
+| B | 1e-3 | (auto-launcher after close, killed) | — | N/A |
+
+- Commentary: Arm A wd=1e-4 failed EP3. Arm B (wd=1e-3) was auto-launched by stale job after PR close but killed before producing results. **wd=5e-4 CONFIRMED OPTIMAL.** After PR #858 closed, alphonse launched SGDR run `7gnqa6l1` (now PR #863, active WIP).
+
+---
+
+### PR #859 (thorfinn): Transolver slices dimension sweep
+- Branch: `thorfinn`
+- Hypothesis: Slice count affects model capacity; test slices=64 (reduce) and slices=256 (increase) vs baseline 128.
+- Results:
+
+| Arm | slices | EP3 | Gate | Status |
+|-----|--------|-----|------|--------|
+| A | 64 | FAIL | >8% | CLOSED |
+| B | 256 | (never launched) | — | PENDING Round 18 |
+
+- Commentary: slices=64 failed EP3 gate, confirming 128 is at or near the minimum viable slice count. Arm B (slices=256) never launched — valid untested experiment. **Assigned to thorfinn in Round 18.**
+
+---
+
+### PR #860 (fern): τ absolute upscaling further escalation
+- Branch: `fern`
+- Hypothesis: Increase τ_y and τ_z loss weights beyond current 1.5/2.0; test higher values.
+- Results:
+
+| Config | EP3 | Gate | Status |
+|--------|-----|------|--------|
+| τ_y↑, τ_z↑ (above 1.5/2.0) | FAIL | >8% | CLOSED |
+
+- Commentary: Further escalation of τ weights fails EP3. Current τ_y=1.5/τ_z=2.0 is the optimal balance. Any further increase degrades overall performance. **τ_y=1.5/τ_z=2.0 CONFIRMED OPTIMAL.**
+
+---
+
+### PR #861 (edward): QK-norm ablation
+- Branch: `edward`
+- Hypothesis: QK-norm (`--use-qk-norm`) may be unnecessary overhead; removing it could improve training efficiency without hurting performance.
+- Results:
+
+| Config | EP2 | Gate | Status |
+|--------|-----|------|--------|
+| No QK-norm | 26.35% | <16% required — CATASTROPHIC FAIL | CLOSED |
+
+- Commentary: EP2=26.35% catastrophically fails the <16% gate. Model without QK-norm does not converge in the early training phase. **QK-norm CONFIRMED NECESSARY** — must remain in all future configs. This is now a locked architectural decision.
+
+---
+
+### PR #862 (tanjiro): Lion β₂ sweep
+- Branch: `tanjiro`
+- Hypothesis: Lion β₂ controls EMA of gradient sign smoothing; current β₂=0.99 may not be optimal; test β₂=0.95.
+- Results:
+
+| Arm | β₂ | EP2 | Gate | Status |
+|-----|----|-----|------|--------|
+| A | 0.95 | FAIL | >16% | CLOSED |
+
+- Commentary: β₂=0.95 failed EP2. Baseline β₂=0.99 confirmed optimal by elimination. **β₂=0.99 CONFIRMED OPTIMAL.** Lion optimizer (lr=9e-5, β₁=0.9, β₂=0.99, wd=5e-4) now exhaustively confirmed optimal across all axes.
+
+---
+
+### Summary: Round 17 Confirmed Findings
+
+| Finding | PR | Verdict |
+|---------|-----|---------|
+| QK-norm NECESSARY | #861 | Removing causes catastrophic failure (EP2=26.35%) |
+| wd=5e-4 OPTIMAL | #858 | Both wd=1e-4 and wd=1e-3 fail |
+| β₂=0.99 OPTIMAL | #862 | β₂=0.95 fails EP2 |
+| τ_y=1.5/τ_z=2.0 OPTIMAL | #860 | Further escalation fails |
+| σ-ladder axis CLOSED | #857 | Both ascending/descending variants fail |
+| slices=64 FAIL | #859 | slices=256 untested (Round 18 assignment) |
+| Y-sym p=0.5 CONFOUNDED | #855 | Wrong LR flag; y-sym flags absent from train.py |
+
+**Ongoing Round 18:** PR #823 (nezuko cross-attention, EP7=6.5335% BEATS SOTA), PR #863 (alphonse SGDR)

--- a/train.py
+++ b/train.py
@@ -97,6 +97,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    drop_path_rate: float = 0.0
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     rff_init_sigmas: str = ""
@@ -284,11 +285,35 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def resolve_drop_path_rate(config: Config) -> float:
+    """Per PR #869: ``--model-dropout`` doubles as a proxy for ``--drop-path-rate``.
+
+    Explicit ``--drop-path-rate`` wins if set; otherwise ``--model-dropout``
+    flows into stochastic depth (and standard attention dropout is forced to 0).
+    Standard dropout still works when ``--drop-path-rate`` is set explicitly to
+    something different from ``--model-dropout``.
+    """
+    if config.drop_path_rate > 0.0:
+        return config.drop_path_rate
+    return config.model_dropout
+
+
+def resolve_attn_dropout(config: Config) -> float:
+    """When ``--model-dropout`` is being used as a drop-path proxy, suppress the
+    legacy attention dropout so the residual-path stochastic depth is the sole
+    regularizer (per PR #869 "implement as stochastic depth on residual
+    connections, NOT standard dropout").
+    """
+    if config.drop_path_rate > 0.0:
+        return config.model_dropout
+    return 0.0
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
-        dropout=config.model_dropout,
+        dropout=resolve_attn_dropout(config),
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,
@@ -297,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        drop_path_rate=resolve_drop_path_rate(config),
     )
 
 
@@ -861,6 +887,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            backbone = getattr(base_model, "backbone", None)
+            if backbone is not None:
+                resolved_dp_rate = float(getattr(backbone, "drop_path_rate", 0.0))
+                resolved_dp_per_layer = list(getattr(backbone, "drop_path_per_layer", []))
+                wandb.summary["model/drop_path_rate"] = resolved_dp_rate
+                wandb.summary["model/drop_path_per_layer"] = resolved_dp_per_layer
+                wandb.summary["model/attn_dropout"] = resolve_attn_dropout(config)
+                if resolved_dp_rate > 0.0:
+                    print(
+                        f"DropPath (stochastic depth) ENABLED: rate={resolved_dp_rate:.4f} "
+                        f"per_layer={['%.4f' % r for r in resolved_dp_per_layer]} "
+                        f"attn_dropout={resolve_attn_dropout(config):.4f}"
+                    )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

**Stochastic depth (layer drop)** randomly drops entire transformer blocks during training with linearly increasing probability from layer 0 (never dropped) to layer L-1 (drop probability = `drop_prob`). At inference time, all layers are used with their residual outputs scaled by `(1 - drop_prob)` for the block. This acts as implicit ensembling (Huang et al., 2016): the model learns to be robust to different subsets of layers being active, preventing over-reliance on any single layer's representation.

With QK-norm CONFIRMED NECESSARY (PR #861), and all STRING positional encoding axes CLOSED, stochastic depth is the next unexplored regularization axis. It has been highly effective in ViT and Swin Transformer training at L=12+ but has **never been tested at our L=5 regime**. At L=5, drop probabilities should be gentle (0.05–0.10 max) to avoid under-capacity.

Test two arms in a single run script:
- **Arm A:** drop_path_rate=0.05 (conservative)
- **Arm B:** drop_path_rate=0.10 (moderate)

Run them sequentially (Arm A first, kill if EP2>16%, then Arm B). Report both.

## Instructions

In `train.py`, implement stochastic depth using `timm`'s `DropPath` or a manual implementation. Apply it to each of the L=5 transformer blocks with linearly increasing rate:

```python
import torch
import torch.nn as nn

class DropPath(nn.Module):
    """Drop paths (Stochastic Depth) per sample."""
    def __init__(self, drop_prob=0.0):
        super().__init__()
        self.drop_prob = drop_prob

    def forward(self, x):
        if self.drop_prob == 0.0 or not self.training:
            return x
        keep_prob = 1 - self.drop_prob
        # x shape: [batch, ...], create random tensor of shape [batch, 1, 1, ...]
        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
        random_tensor = torch.rand(shape, dtype=x.dtype, device=x.device)
        random_tensor = torch.floor(random_tensor + keep_prob)
        return x.div(keep_prob) * random_tensor
```

For each transformer block `i` of `L=5` blocks, the drop_path rate is:
`rate_i = drop_path_rate * i / (L - 1)` (so block 0 has rate=0, block L-1 has rate=drop_path_rate).

In each block's `forward()`, wrap the residual addition:
```python
# Before:   x = x + attn_output
# After:    x = x + drop_path(attn_output)
```

If `timm` is available (`pip install timm` if needed), you can use `from timm.models.layers import DropPath` directly.

**Arm A command (drop_path_rate=0.05):**
```bash
cd /workspace/senpai/target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --model-dropout 0.05 \
  --wandb-group stochastic-depth-r18 --wandb-name edward/drop-path-005
```

**NOTE:** `--model-dropout` here is a proxy for the drop_path_rate — implement as stochastic depth on residual connections, NOT standard dropout. If train.py doesn't have native DropPath support, add it to the model code.

**Arm B command (drop_path_rate=0.10):**
Same as above but `--model-dropout 0.10` and `--wandb-name edward/drop-path-010`.

**Kill gates (4-ep screen per arm):**
- EP1: val_abupt < 30%
- EP2: val_abupt < 16%
- EP3: val_abupt < 8%
- EP4: val_abupt ≤ 6.5985%

Report EP1–EP4 per arm and W&B run IDs in a PR comment.

## Baseline

| Metric | Value | PR |
|--------|-------|-----|
| val_abupt (single-model SOTA) | **6.5985%** | #592 (run `4k25s25e`) |
| test_abupt | 7.9915% | #592 |
| test_vol_pressure | 11.933% | #592 |
| val_abupt (ensemble SOTA) | 6.1751% | #612 |

**Reference:** Huang et al., "Deep Networks with Stochastic Depth" (ECCV 2016): https://arxiv.org/abs/1603.09382

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
