### PR TITLE
Y-flip augmentation (p=0.5): physically-exact x2 training data for OOD vol_p

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    y_flip_prob: float = 0.0
     debug: bool = False
 
 
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "y_flip_prob": (
+            "Probability [0,1] of flipping each training sample about Y=0 "
+            "(X-Z symmetry plane). DrivAerML cars are symmetric about Y=0, "
+            "so this is a physically-exact data augmentation that doubles "
+            "effective training signal. Per-channel sign rules: flip y, "
+            "normal_y, and tau_y; cp / tau_x / tau_z / vol_p / sdf are "
+            "y-reflection invariant. Applied only on the training path; "
+            "validation/test never flips. 0.0 = disabled (default). "
+            "Recommended: 0.5."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +322,26 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_y_flip(batch, prob: float, device: torch.device) -> None:
+    """Apply per-sample Y=0 mirror augmentation in-place to the batch.
+
+    DrivAerML cars are symmetric about the Y=0 (X-Z) plane. Per-channel
+    sign rules under y-reflection:
+      surface_x[..., 1] (y), surface_x[..., 4] (normal_y) -> flipped
+      surface_y[..., 2] (wall_shear_y / tau_y) -> flipped (vector y-component)
+      volume_x[..., 1] (y) -> flipped
+      cp / tau_x / tau_z / vol_pressure / sdf -> invariant
+    """
+
+    if prob <= 0.0:
+        return
+    flip_mask = torch.rand(batch.surface_x.shape[0], device=device) < prob
+    batch.surface_x[flip_mask, :, 1] *= -1.0
+    batch.surface_x[flip_mask, :, 4] *= -1.0
+    batch.surface_y[flip_mask, :, 2] *= -1.0
+    batch.volume_x[flip_mask, :, 1] *= -1.0
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,8 +352,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    y_flip_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    apply_y_flip(batch, y_flip_prob, device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -364,6 +397,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    y_flip_prob: float = 0.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -374,6 +409,7 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    apply_y_flip(batch, y_flip_prob, device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -939,7 +975,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model, batch, transform, device, config.amp_mode,
+                        y_flip_prob=config.y_flip_prob,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1067,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        y_flip_prob=config.y_flip_prob,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
## Hypothesis

DrivAerML car geometries are symmetric about the Y=0 (X-Z) plane — the left side is a mirror image of the right side. A Y-axis flip is therefore a physically exact data augmentation that costs zero labelling effort and effectively doubles the training dataset.

The 4 OOD test cases (run_133, run_226, run_203, run_158) that drive 92% of test_vol_pressure squared error are likely OOD because they sit in a region of geometry space with low training density. Y-flip augmentation narrows this gap by covering more of the joint point-cloud × physics distribution without generating synthetic labels.

Prior attempt PR #855 (frieren) was confounded: the Y-sym feature flags were absent from train.py entirely, so the implementation never executed. This is a clean first test of the axis.

**Physical justification (per-channel sign rules):**
- `surface_x[:, 1]` (y-coord): flip → `−y`
- `surface_x[:, 4]` (normal_y): flip → `−normal_y`
- `surface_y[:, 2]` (wall_shear_y / τ_y): flip → `−τ_y` (wall shear y-component reverses under y-reflection)
- `volume_x[:, 1]` (y-coord): flip → `−y`
- `surface_pressure`, `wall_shear_x/z` (τ_x, τ_z), `volume_pressure`: unchanged (scalars or x/z components, invariant under y-reflection)

With p_augment=0.5 every sample has a 50% chance of being replaced by its Y-flipped twin each epoch. Total signal doubles with zero extra training examples required on disk.

## Instructions

Add a Y-flip augmentation to the **existing** `train.py` collate/batch path. No new flags for the dataset class required — implement as a per-batch augmentation applied on GPU just before the forward pass.

### 1. Add a new CLI flag

In the argument parser section of `train.py`, add:

```python
parser.add_argument("--y-flip-prob", type=float, default=0.0,
                    help="Probability [0,1] of flipping each sample about Y=0 (X-Z symmetry plane). "
                         "0.0 = disabled (default). Recommended: 0.5")
```

### 2. Apply the flip in the training loop

After `batch = batch.to(device)` (but **before** the forward pass), add:

```python
# Y-axis symmetry augmentation (only during training, not validation)
if args.y_flip_prob > 0.0:
    flip_mask = torch.rand(batch.surface_x.shape[0], device=device) < args.y_flip_prob  # (B,)
    if flip_mask.any():
        # surface_x: (B, N_surf, 7) = xyz(0:3) + normals(3:6) + area(6:7)
        # flip y-coord (dim 1) and normal_y (dim 4)
        batch.surface_x[flip_mask, :, 1] *= -1.0   # y coord
        batch.surface_x[flip_mask, :, 4] *= -1.0   # normal_y
        # surface_y: (B, N_surf, 4) = [cp, tau_x, tau_y, tau_z]
        # tau_y reverses under y-reflection
        batch.surface_y[flip_mask, :, 2] *= -1.0   # wall_shear_y
        # volume_x: (B, N_vol, 4) = [x, y, z, sdf]
        batch.volume_x[flip_mask, :, 1] *= -1.0    # y coord
        # volume_y (vol pressure) and cp, tau_x, tau_z are y-reflection invariant — unchanged
```

**Critical note:** `batch.surface_x`, `batch.surface_y`, `batch.volume_x`, `batch.volume_y` are all regular `torch.Tensor` fields (see `loader.py` `BatchedSample` dataclass). The in-place `*= -1.0` is safe because each batch creates a fresh tensor copy. Only flip during training (not the validation forward pass).

### 3. Run a 4-ep screen with p=0.5

Use the standard 4-ep screen config on the SOTA stack with the new flag:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --y-flip-prob 0.5 \
  --wandb-group y-sym-aug-r19 --wandb-name askeladd/y-flip-p05
```

### 4. 4-ep screen kill gates

| Epoch | val_abupt gate |
|---|---|
| EP1 | < 30% (kill if ≥ 30%) |
| EP2 | < 16% (kill if ≥ 16%) |
| EP3 | < 8% (kill if ≥ 8%) |
| EP4 | ≤ 6.5985% to beat SOTA |

If EP4 beats SOTA (< 6.5985%), run full 13-epoch training:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --y-flip-prob 0.5 \
  --wandb-group y-sym-aug-r19 --wandb-name askeladd/y-flip-p05-full
```

### 5. Report results

Add a comment on this PR with:
- EP1/EP2/EP3/EP4 val_abupt from W&B
- val_vol_pressure and test_vol_pressure at EP4 best checkpoint (key OOD diagnostic)
- W&B run ID and group
- Whether the y-flip produced any NaN in tau_y (check W&B logs for sign-flip anomalies)

## Baseline

**Single-model SOTA:** PR #592 (alphonse), W&B run `4k25s25e`
- val_abupt = **6.5985%** ← beat this
- test_abupt = 7.9915%
- val_vol_pressure = 3.9456%, test_vol_pressure = 11.933%
- val_wall_shear_y (τ_y) = 8.3631%

**Ensemble SOTA:** PR #612 (nezuko), K=7 greedy
- val_abupt = 6.1751%, test_abupt = 7.5347%

**Target:** val_abupt < 6.5985% at EP4 screen, then 13-ep full run for test metrics.
