### PR TITLE
Surf→vol xattn heads sweep: 8 vs 16 heads (baseline uses 4)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_num_heads: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -431,9 +432,15 @@ class SurfaceTransolver(nn.Module):
         # AND bias so the sublayer is identity at init (preserves baseline
         # behavior at epoch 0). See PR #823 hypothesis.
         if use_surf_to_vol_xattn:
+            effective_xattn_heads = xattn_num_heads if xattn_num_heads > 0 else n_head
+            if n_hidden % effective_xattn_heads != 0:
+                raise ValueError(
+                    f"xattn_num_heads={effective_xattn_heads} must divide n_hidden={n_hidden}"
+                )
+            self.xattn_num_heads = effective_xattn_heads
             self.surf_to_vol_xattn = nn.MultiheadAttention(
                 embed_dim=n_hidden,
-                num_heads=n_head,
+                num_heads=effective_xattn_heads,
                 batch_first=True,
                 dropout=dropout,
             )
@@ -441,6 +448,7 @@ class SurfaceTransolver(nn.Module):
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
         else:
+            self.xattn_num_heads = 0
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    surf_to_vol_xattn_num_heads: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "surf_to_vol_xattn_num_heads": (
+            "Cross-attention head count override for surf->vol xattn "
+            "(0 = use --model-heads). Must be a divisor of "
+            "--model-hidden-dim. PR #878 sweeps 8 vs 16 against the 4-head "
+            "default."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +315,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_num_heads=config.surf_to_vol_xattn_num_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The merged surface→volume cross-attention module (PR #823, new single-model SOTA val=6.4407%) uses `num_heads=4` — matching the backbone heads. The xattn bottleneck with 4 heads gives each head a 128-dim key space. Increasing xattn heads to 8 or 16 gives finer-grained cross-modal attention: more heads can specialize in different surface feature types (pressure vs wall shear, front vs rear body), potentially extracting richer geometry signals for the volume decoder.

**Key insight from PR #823:** The xattn improvement is broad-based (all channels), and the OOD test/val ratio is preserved (3.027×). This tells us the xattn is a general capacity boost — meaning more attention capacity (more heads) could unlock further improvement without changing the architecture topology.

**Mechanism:** `nn.MultiheadAttention(embed_dim=512, num_heads=H)` with H=8 or H=16 gives 64-dim or 32-dim head projections respectively, vs 128-dim for H=4. More heads → more specialization axes in cross-modal attention. Both H=8 and H=16 remain powers-of-2 (required for SDPA/Triton fast paths). We test both in parallel as a 2-arm sweep.

**Reference:** Multi-head attention scaling is well-studied: Vaswani et al. (2017) uses heads=8 for d=512. Liu et al. (2021) Swin Transformer uses heads=4 for 96d windows but scales up at wider dimensions. The xattn is bottlenecked by the head count, not parameter count (the MHA matrices are O(3 × d_model²) regardless of heads).

## Instructions

Add a `--surf-to-vol-xattn-num-heads` CLI flag to `target/train.py` and `target/model.py`. This flag overrides the xattn head count independently of the backbone `--model-heads`.

**Changes required:**

1. **`target/model.py` — `SurfaceTransolver.__init__`:**
   - Add `xattn_num_heads: int = 0` parameter (0 = default: use `n_head`)
   - In the xattn block construction, use `effective_xattn_heads = xattn_num_heads if xattn_num_heads > 0 else n_head`
   - Replace `num_heads=n_head` with `num_heads=effective_xattn_heads` in the `nn.MultiheadAttention(...)` call

2. **`target/train.py` — `Config` dataclass:**
   - Add `surf_to_vol_xattn_num_heads: int = 0`
   - Add help text: `"Cross-attention head count override for surf→vol xattn (0 = use model heads). Must be a divisor of model_hidden_dim=512."`

3. **`target/train.py` — `build_model`:**
   - Pass `xattn_num_heads=config.surf_to_vol_xattn_num_heads` to `SurfaceTransolver(...)`

Run **two arms** in sequence (Arm A first; kill Arm B if Arm A fails EP2 gate ≥16%):

**Arm A: xattn heads=8**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --surf-to-vol-xattn-num-heads 8 \
  --wandb-group xattn-heads-sweep-r19 --wandb-name alphonse/xattn-heads-8-4ep
```

**Arm B: xattn heads=16**
```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --surf-to-vol-xattn-num-heads 16 \
  --wandb-group xattn-heads-sweep-r19 --wandb-name alphonse/xattn-heads-16-4ep
```

**Report required in PR comment:**
- Both runs: EP1–EP4 val_abupt (one row per epoch per arm)
- Both W&B run IDs
- For the better arm at EP4: val per-channel (sp, vp, ws, tau_x, tau_y, tau_z)
- Note whether xattn heads=4 (SOTA) vs heads=8 vs heads=16 changes wall-clock per epoch

## Kill gates (4-ep tay screen)

| Epoch | Gate |
|-------|------|
| EP1 | <30% |
| EP2 | <16% |
| EP3 | <8% |
| EP4 | <6.4407% (must beat single-model SOTA) |

Kill any arm that misses its epoch gate. If both arms fail EP4, the 4-head default is optimal.

## Baseline

**Single-model SOTA:** PR #823 (nezuko surf→vol cross-attention)
- val_abupt = **6.4407%** (EP13, run `ghh0s4ne`)
- test_abupt = 7.6992%
- val per-channel: sp=4.1836%, vp=3.8557%, ws=7.3448%, tau_x=5.7782%, tau_y=7.5977%, tau_z=9.0116%
- Params: 16,987,225 (+1.05M vs prior L5 SOTA)

**New single-model training gate:** val_abupt < **6.4407%** at EP4 to advance to 13-ep full run.

