### PR TITLE
Ensemble pool-25 refresh: add PR #823 surf-xattn run to greedy pool

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -111,6 +111,7 @@ def build_model_from_config(config: dict) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.get("rff_init_sigmas", None)),
         pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
         use_qk_norm=bool(config.get("use_qk_norm", False)),
+        use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #823 (your surf→vol cross-attention) established a new single-model SOTA at val=6.4407%, and has been merged. This run (`ghh0s4ne`) should be added to the greedy ensemble pool to determine whether it also improves the ensemble SOTA (currently val=6.1751% from the PR #612 K=7 pool-24 ensemble).

**Why this matters:** The greedy ensemble exploits diversity — a new model that is the best single-model may or may not help the ensemble, depending on whether its error pattern overlaps with existing pool members. The PR #823 xattn run has a qualitatively different error structure (reduced OOD geometry extrapolation error) compared to the pool-24 members (all pre-xattn). This makes it a strong candidate to be complementary.

We also have additional single-model candidates from recent rounds (Round 18–19) that beat the 7.5% single-model threshold and are not yet in the pool. The pool should be refreshed to include all promising new runs.

## Instructions

### Step 1: Identify new pool candidates

The pool-24 members (val ≤ ~7.5%) are: d777epep, nh96x7m4, 5o7jc7wi, wyz68o8r, 9mm3sz7x, 49aimdiz, 19qf6di1, and up to 17 more from prior rounds. Run `ensemble_eval.py` with `--list-pool-candidates` (or equivalent) to confirm current pool contents.

New candidates to add (confirmed val < 7.5%):
- `ghh0s4ne` — PR #823, val=6.4407% (your surf→vol xattn run, best to date)
- Any Round 18-19 runs with val_abupt < 7.5% from W&B project `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8` — check W&B for completions after pool-24 was assembled

### Step 2: Cache predictions for new candidates

```bash
cd target/
# Cache predictions for the new candidates only
uv run python ensemble_eval.py \
  --greedy --cache-only \
  --candidate-run-ids ghh0s4ne \
  --pred-cache-dir /tmp/ensemble_cache_pool25 \
  --split val test
```
Add any other new val<7.5% run IDs discovered in Step 1.

### Step 3: Run greedy selection on pool-25+

```bash
cd target/
# Combine old cache with new candidates
uv run python ensemble_eval.py \
  --greedy \
  --pred-cache-dir /tmp/ensemble_cache_pool25 \
  --existing-cache-dir /tmp/ensemble_cache_pool24 \
  --max-k 15 \
  --wandb-group nezuko-ensemble-greedy-v4 \
  --wandb-name greedy-k15-pool25
```
(If the `--existing-cache-dir` flag doesn't exist, just re-cache all pool-24 members alongside `ghh0s4ne` in a fresh `pool25` cache dir.)

### Step 4: Report results

In the PR comment, report:
- Pool size (how many runs, which new ones added)
- Selected K (greedy optimal)
- K=7 member IDs (for parity comparison with pool-24)
- val_abupt and test_abupt of the new ensemble
- Per-channel test metrics: sp, vp, ws, tau_x, tau_y, tau_z
- W&B run ID of the greedy selection run

If the new ensemble beats val=6.1751% (pool-24 SOTA), it's a new ensemble SOTA.

**If `ghh0s4ne` is NOT selected by greedy:** That means the xattn run is correlated with existing pool members (its errors overlap). Report the correlation structure if possible. This is still informative — it tells us xattn improves the average but not the tail.

## Kill gates

N/A — this is an ensemble eval, not a training run. No kill gates.

**Expected runtime:** 1–3 hours depending on pool size and prediction caching overhead. The greedy selection algorithm itself is fast (minutes); the bottleneck is loading and caching predictions.

## Baseline

**Ensemble SOTA:** PR #612 (greedy K=7 pool-24)
- val_abupt = **6.1751%**
- test_abupt = **7.5347%**
- W&B run: `5veexq8r` (group `nezuko-ensemble-greedy-v3`)
- K=7 members: d777epep, nh96x7m4, 5o7jc7wi, wyz68o8r, 9mm3sz7x, 49aimdiz, 19qf6di1

**Val per-channel (K=7 pool-24):** sp=3.5868%, vp=3.6128%, ws=6.2832%, tau_x=5.3712%, tau_y=7.7921%, tau_z=9.2984%
**Test per-channel (K=7 pool-24):** sp=3.5560%, vp=11.4652%, ws=6.8449%, tau_x=5.4834%, tau_y=8.6249%, tau_z=9.6523%

**Note:** test_vol_pressure = 11.4652% in the ensemble (the chronic OOD gap). If `ghh0s4ne` joins the ensemble and reduces test_vp, that would be a scientifically significant finding.

