### PR TITLE
Geometry-aware positional bias on surf→vol cross-attention queries

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_query_pos: str = "none",
+        xattn_rff_features: int = 16,
+        xattn_rff_sigma_ladder: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +359,13 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_query_pos = xattn_query_pos
+        self.xattn_rff_features = xattn_rff_features
+        self.xattn_rff_sigma_ladder = (
+            list(xattn_rff_sigma_ladder)
+            if xattn_rff_sigma_ladder
+            else [0.25, 0.5, 1.0, 2.0, 4.0]
+        )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -440,9 +450,37 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+
+            # Optional STRING-style RFF positional bias on the xattn Q/K/V
+            # inputs (PR #883). Frequencies are sampled once at construction
+            # time from a fixed sigma ladder (panel-scale .. body-scale) and
+            # registered as a buffer so DDP broadcasts rank-0 values to all
+            # ranks. The projection is zero-initialised so the xattn block
+            # is exactly identity at init (preserves SOTA parity at EP0).
+            if xattn_query_pos == "rff":
+                if xattn_rff_features <= 0:
+                    raise ValueError(
+                        "xattn_rff_features must be positive when xattn_query_pos='rff'"
+                    )
+                ladder = torch.tensor(self.xattn_rff_sigma_ladder, dtype=torch.float32)
+                idx = torch.randint(len(ladder), (xattn_rff_features,))
+                sigmas = ladder[idx].unsqueeze(-1)  # (xattn_rff_features, 1)
+                B = torch.randn(xattn_rff_features, space_dim) * sigmas
+                self.register_buffer("xattn_rff_B", B)
+                self.xattn_pos_proj = nn.Linear(
+                    2 * xattn_rff_features, n_hidden, bias=False
+                )
+                nn.init.zeros_(self.xattn_pos_proj.weight)
+            elif xattn_query_pos == "none":
+                self.xattn_pos_proj = None
+            else:
+                raise ValueError(
+                    f"Unknown xattn_query_pos '{xattn_query_pos}'. Supported: 'none', 'rff'."
+                )
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+            self.xattn_pos_proj = None
 
     def _encode_group(
         self,
@@ -536,10 +574,31 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            if self.xattn_pos_proj is not None:
+                # STRING-style RFF positional bias on Q (vol) and K/V (surf)
+                # before the xattn. Zero-init projection => identity at EP0.
+                B_proj = self.xattn_rff_B.to(dtype=volume_x.dtype)
+                vol_pos = volume_x[..., : self.space_dim]
+                surf_pos = surface_x[..., : self.space_dim]
+                vol_phi = 2.0 * math.pi * (vol_pos @ B_proj.T)
+                surf_phi = 2.0 * math.pi * (surf_pos @ B_proj.T)
+                vol_pe = self.xattn_pos_proj(
+                    torch.cat([vol_phi.sin(), vol_phi.cos()], dim=-1)
+                )
+                surf_pe = self.xattn_pos_proj(
+                    torch.cat([surf_phi.sin(), surf_phi.cos()], dim=-1)
+                )
+                vol_pe = _apply_token_mask(vol_pe, volume_mask)
+                surf_pe = _apply_token_mask(surf_pe, surface_mask)
+                q_in = volume_hidden + vol_pe
+                kv_in = surface_hidden + surf_pe
+            else:
+                q_in = volume_hidden
+                kv_in = surface_hidden
             xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
-                key=surface_hidden,
-                value=surface_hidden,
+                query=q_in,
+                key=kv_in,
+                value=kv_in,
                 need_weights=False,
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_query_pos: str = "none"
+    xattn_rff_features: int = 16
+    xattn_rff_sigma_ladder: str = "0.25,0.5,1.0,2.0,4.0"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_query_pos": (
+            "Geometry-aware positional bias on the surf->vol cross-attention "
+            "Q/K/V inputs (PR #883). 'none' (default) preserves the PR #823 "
+            "behavior. 'rff' adds STRING-style random Fourier features of the "
+            "raw 3D coordinates, projected to --model-hidden-dim by a "
+            "zero-initialised linear layer (so the xattn block is exactly "
+            "identity at init and any deviation is the new geometric channel "
+            "speaking). Frequencies are sampled once at construction from the "
+            "ladder set by --xattn-rff-sigma-ladder."
+        ),
+        "xattn_rff_features": (
+            "Number of RFF features for --xattn-query-pos rff. Default 16 "
+            "matches the existing STRING backbone encoding."
+        ),
+        "xattn_rff_sigma_ladder": (
+            "Comma-separated sigma ladder for the xattn RFF positional bias "
+            "(PR #883). Each feature samples one sigma uniformly; the buffer "
+            "B = randn(features, 3) * sigmas. Default '0.25,0.5,1.0,2.0,4.0' "
+            "matches the STRING ladder used elsewhere in this codebase."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +299,18 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def parse_xattn_rff_sigma_ladder(spec: str) -> list[float] | None:
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    sigmas = [float(token.strip()) for token in spec.split(",") if token.strip()]
+    if not sigmas:
+        return None
+    if any(s <= 0.0 for s in sigmas):
+        raise ValueError(f"--xattn-rff-sigma-ladder must be positive: {spec!r}")
+    return sigmas
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +343,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_query_pos=config.xattn_query_pos,
+        xattn_rff_features=config.xattn_rff_features,
+        xattn_rff_sigma_ladder=parse_xattn_rff_sigma_ladder(config.xattn_rff_sigma_ladder),
     )
 
 


### PR DESCRIPTION
# Geometry-aware positional bias on surf→vol cross-attention queries

**Hypothesis:** PR #823's surf→vol cross-attention adds raw `nn.MultiheadAttention(Q=volume, K=V=surface)` after the backbone — but the volume queries arrive with no explicit geometry signal at the xattn layer. Adding a **STRING-derived positional bias on the volume queries (and surface key/values)** lets the xattn condition more sharply on *which surface region* each volume point should attend to. This is a low-cost extension of the SOTA-establishing xattn module on Theme 1 (the highest-priority research axis post-PR #823).

The Transolver backbone already consumes STRING-positional-encoded surface and volume coordinates through its first encoder layer. By the time the xattn block runs (post-backbone, post-LayerNorm), the volume hidden states have been transformed many times and may have lost direct geometric specificity. Re-injecting a STRING-style positional encoding *at the xattn input* gives the cross-attention a clean geometric channel — like rotary positional encoding does for query-key dot products in language transformers.

**Why this is orthogonal to the other in-flight xattn experiments:**
- PR #878 (alphonse): more heads (8/16) — capacity ablation
- PR #879 (frieren, just closed): two-layer xattn — depth ablation
- This PR (tanjiro): geometry-aware queries — input-conditioning ablation

If any of these win independently, they likely compose (orthogonal axes).

---

## Baselines (must beat)

| Metric | Value | Source |
|---|---|---|
| **Single-model SOTA val_abupt** | **6.4407%** | PR #823 (run `ghh0s4ne`) |
| Test val_abupt | 7.6992% | PR #823 |
| Test vol_pressure | 11.6704% | PR #823 |

The new run **MUST** beat 6.4407% on `val_primary/abupt_axis_mean_rel_l2_pct` at EP4 (or EP3 best ckpt) to merge.

---

## Implementation

### Add STRING positional bias on the volume queries inside the xattn block

In `model.py`, the existing block (around line 433–546) is:

```python
if use_surf_to_vol_xattn:
    self.surf_to_vol_xattn = nn.MultiheadAttention(
        embed_dim=n_hidden, num_heads=n_head, batch_first=True
    )
    self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
...
xattn_out, _ = self.surf_to_vol_xattn(
    query=volume_hidden,
    key=surface_hidden,
    value=surface_hidden,
    ...
)
volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
```

**Add a query/key positional injection.** Use the volume coordinates and surface coordinates with a learnable RFF projection to produce a positional embedding the same dim as `n_hidden`, then add it to volume_hidden / surface_hidden right before the xattn. Sample frequencies from the STRING sigma ladder {0.25, 0.5, 1.0, 2.0, 4.0}:

```python
# In __init__ when use_surf_to_vol_xattn=True:
if xattn_query_pos == "rff":
    rff_features = xattn_rff_features  # default 16
    sigma_ladder = torch.tensor([0.25, 0.5, 1.0, 2.0, 4.0])
    idx = torch.randint(len(sigma_ladder), (rff_features,))
    sigmas = sigma_ladder[idx].unsqueeze(-1)             # (rff_features, 1)
    B = torch.randn(rff_features, 3) * sigmas            # (rff_features, 3)
    self.register_buffer("xattn_rff_B", B)
    self.xattn_pos_proj = nn.Linear(2 * rff_features, n_hidden, bias=False)
    nn.init.zeros_(self.xattn_pos_proj.weight)           # zero-init: starts as baseline
elif xattn_query_pos == "none":
    self.xattn_pos_proj = None

# In forward, just before the xattn call:
if self.xattn_pos_proj is not None:
    # vol_pos: (B, N_vol, 3); surf_pos: (B, N_surf, 3)
    vol_phi = volume_x[..., :3] @ self.xattn_rff_B.T  # (B, N_vol, rff_features)
    vol_pe = torch.cat([torch.sin(2*math.pi*vol_phi), torch.cos(2*math.pi*vol_phi)], dim=-1)
    vol_pe = self.xattn_pos_proj(vol_pe)
    surf_phi = surface_x[..., :3] @ self.xattn_rff_B.T
    surf_pe = torch.cat([torch.sin(2*math.pi*surf_phi), torch.cos(2*math.pi*surf_phi)], dim=-1)
    surf_pe = self.xattn_pos_proj(surf_pe)
    q_in = volume_hidden + vol_pe
    kv_in = surface_hidden + surf_pe
else:
    q_in = volume_hidden
    kv_in = surface_hidden

xattn_out, _ = self.surf_to_vol_xattn(
    query=q_in, key=kv_in, value=kv_in, ...
)
volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
```

**Critical zero-init detail:** `nn.init.zeros_(self.xattn_pos_proj.weight)` ensures the model starts EXACTLY as the SOTA baseline (xattn block input is unmodified at init). The positional bias is learned from zero — only kicks in if useful.

### CLI flags

Plumb args through `argparse` and `Config`:
- `--xattn-query-pos {none, rff}` (default `none` to preserve baseline behavior)
- `--xattn-rff-features INT` (default `16`, matching backbone STRING)

---

## Reproduce command

8 H100s, single arm — beat 6.4407% with `--xattn-query-pos rff`:

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-query-pos rff --xattn-rff-features 16 \
  --wandb-group xattn-pos-encoding-r20 --wandb-name tanjiro/xattn-rff-pos-4ep
```

---

## Kill gates (4-ep screen)

- EP0: `val_abupt ~= 6.4407%` at init (zero-init means baseline parity — confirm in your first val log line before training proceeds)
- EP1: `val_abupt < 30%`
- EP2: `val_abupt < 16%`
- EP3: `val_abupt < 8%`
- **EP4: `val_abupt <= 6.4407%` (beat single-model SOTA)** — required for merge

If EP3 misses 8% gate, kill and report. If EP4 doesn't beat SOTA but trajectory is monotonically improving, keep checkpoint and report — we may extend lr-cosine-t-max in a follow-up.

---

## Critical gotchas

- **Use `--lr-cosine-t-max 13 --epochs 4`** — never `--lr-cosine-t-max 4` (4-ep schedule confound).
- **`--no-compile-model`** required (torch.compile + DDP NCCL deadlock at step 1).
- **`find_unused_parameters=True`** is auto-set when `--use-surf-to-vol-xattn` is on (already handled in train.py).
- **Zero-init the new `xattn_pos_proj`** — non-negotiable; ensures EP0 parity with SOTA so any deviation is the new mechanism speaking.
- **Sample sigmas from the STRING ladder** — σ=0.25 is known load-bearing for panel-scale detail (PR #819 finding).
- **Match the existing STRING RFF feature count (`rff_features=16`)** for consistency unless you have reason to deviate.
- **`xattn_rff_B` must be a registered buffer** (not parameter) — frequencies are fixed, only the projection learns.

---

## Suggested follow-ups (record in your results, do NOT run yet)

1. If `xattn-query-pos rff` wins: try larger `rff_features` (32, 64) — capacity ablation on the geometric channel.
2. If wins: try **rotary** positional bias (rotate Q/K instead of additive) — closer to language-model RoPE.
3. If wins and PR #878 also wins: compose 8-head + xattn-pos-rff (orthogonal axes likely stack).

---

## Why this is the right experiment now

- **Theme 1 alignment**: surf→vol xattn (PR #823) is the biggest recent win. Round 20 ablates its capacity (#878 heads), depth (#879 two-layer, just closed), and now its **input conditioning** (this PR). Together they map the design surface around the new SOTA architecture.
- **Cheap, principled**: one new flag, ~25 lines of model.py, ~5 lines of train.py. Zero-init guarantees we don't regress.
- **Orthogonal to OOD work**: doesn't conflict with #877 (Y-flip), #876 (Huber), #870 (KNN smooth) which target the 4 OOD test cases.
- **Strong theoretical motivation**: Cross-attention without positional bias treats surface and volume points as bags of features. Real geometry is *spatial*, and STRING-style RFF encoding is the established mechanism for injecting that into this codebase.

Good luck — looking forward to seeing whether the geometric channel sharpens xattn or if the backbone has already encoded enough position signal by post-LN.
