### PR TITLE
Two-layer surf→vol cross-attention: depth ablation of PR #823 xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -424,12 +424,14 @@ class SurfaceTransolver(nn.Module):
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
-        # Surface->volume cross-attention (PR #823): single MHA sublayer where
-        # volume hidden states (Q) attend to surface hidden states (K/V).
-        # Bridges geometry-aware surface features into the volume decoder
-        # to address the OOD volume_pressure gap. Zero-init out_proj weight
-        # AND bias so the sublayer is identity at init (preserves baseline
-        # behavior at epoch 0). See PR #823 hypothesis.
+        # Surface->volume cross-attention. Two sequential MHA sublayers where
+        # volume hidden states (Q) attend to the same surface hidden states
+        # (K/V). Layer 1 (PR #823) gives a coarse alignment of volume features
+        # with surface geometry; layer 2 (PR #884) does residual refinement
+        # using the updated volume hidden as Q while K/V stays fixed at the
+        # encoder surface output. Both layers zero-init out_proj weight AND
+        # bias so the depth-2 stack is identity at init (preserves the
+        # no-xattn baseline at epoch 0).
         if use_surf_to_vol_xattn:
             self.surf_to_vol_xattn = nn.MultiheadAttention(
                 embed_dim=n_hidden,
@@ -440,9 +442,21 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+
+            self.surf_to_vol_xattn_2 = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            self.surf_to_vol_xattn_norm_2 = nn.LayerNorm(n_hidden, eps=1e-6)
+            nn.init.zeros_(self.surf_to_vol_xattn_2.out_proj.weight)
+            nn.init.zeros_(self.surf_to_vol_xattn_2.out_proj.bias)
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+            self.surf_to_vol_xattn_2 = None
+            self.surf_to_vol_xattn_norm_2 = None
 
     def _encode_group(
         self,
@@ -544,6 +558,17 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+            # Layer 2 (PR #884): same surface_hidden K/V; updated volume_hidden Q.
+            xattn_out2, _ = self.surf_to_vol_xattn_2(
+                query=volume_hidden,
+                key=surface_hidden,
+                value=surface_hidden,
+                need_weights=False,
+            )
+            xattn_out2 = _apply_token_mask(xattn_out2, volume_mask)
+            volume_hidden = self.surf_to_vol_xattn_norm_2(volume_hidden + xattn_out2)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:


### PR DESCRIPTION
## Hypothesis

The current single-model SOTA (PR #823, val_abupt=6.4407%) uses a **single** post-backbone surf→vol cross-attention layer: volume hidden states (Q) attend to surface hidden states (K/V), with zero-init `out_proj` for baseline parity at initialization. This already yielded a −2.4% relative improvement on val and −3.6% on test vs the previous SOTA.

**Hypothesis:** Adding a *second* sequential surf→vol xattn sublayer increases the depth of surface-to-volume geometry conditioning. Two rounds of cross-attention allow the model to:
1. First pass: coarse alignment of volume features with surface geometry signals
2. Second pass: residual refinement of volume features using surface context, building on the first-pass attended representation

This is a direct ablation of xattn depth at fixed width (n_hidden=512, n_heads=4). The zero-init out_proj on both layers ensures the model starts as a strict copy of the baseline at init — any improvement must come from learned geometry distillation, not capacity inflation.

With test_vol_pressure at 11.670% (vs AB-UPT target 6.08%), the surface→volume cross-attention pathway is the primary architectural lever to investigate. Depth is the natural next variable after PR #823 established the mechanism works.

Parameter increase: +1.05M (same as PR #823 added the first layer) → net ~+2.1M vs baseline.

## Instructions to Student

Modify `target/model.py`. In `SurfaceTransolver.__init__`, when `use_surf_to_vol_xattn=True`, add a **second** MHA sublayer and its LayerNorm with zero-init out_proj, identical to the first:

```python
# In __init__ (alongside the existing surf_to_vol_xattn block):
if use_surf_to_vol_xattn:
    # --- EXISTING layer 1 ---
    self.surf_to_vol_xattn = nn.MultiheadAttention(
        embed_dim=n_hidden, num_heads=n_head,
        batch_first=True, dropout=dropout,
    )
    self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)

    # --- NEW layer 2 ---
    self.surf_to_vol_xattn_2 = nn.MultiheadAttention(
        embed_dim=n_hidden, num_heads=n_head,
        batch_first=True, dropout=dropout,
    )
    self.surf_to_vol_xattn_norm_2 = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.surf_to_vol_xattn_2.out_proj.weight)
    nn.init.zeros_(self.surf_to_vol_xattn_2.out_proj.bias)
```

In the forward pass, apply both layers sequentially after the existing xattn block:

```python
# Layer 1 (existing — do not change):
xattn_out, _ = self.surf_to_vol_xattn(
    query=volume_hidden, key=surface_hidden, value=surface_hidden,
    need_weights=False,
)
xattn_out = _apply_token_mask(xattn_out, volume_mask)
volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
volume_hidden = _apply_token_mask(volume_hidden, volume_mask)

# Layer 2 (NEW — add immediately after layer 1):
xattn_out2, _ = self.surf_to_vol_xattn_2(
    query=volume_hidden, key=surface_hidden, value=surface_hidden,
    need_weights=False,
)
xattn_out2 = _apply_token_mask(xattn_out2, volume_mask)
volume_hidden = self.surf_to_vol_xattn_norm_2(volume_hidden + xattn_out2)
volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
```

**CRITICAL implementation notes:**
- Both layers use the same `surface_hidden` as K/V (not the output of layer 1's K/V). Volume hidden evolves through both layers; surface hidden is the fixed encoder output.
- The new layer 2 module must be registered on `self` so DDP wraps it (not a local variable or `nn.ModuleList` unless you adjust the init pattern).
- `find_unused_parameters=True` is already gated on `--use-surf-to-vol-xattn` in `train.py`; no changes needed there.
- Do **not** add a new CLI flag — reuse `--use-surf-to-vol-xattn`. The depth is always 2 when the flag is set.

**Training command (exact):**

```bash
torchrun --nproc_per_node=8 train.py \
  --use-surf-to-vol-xattn \
  --no-compile-model \
  --lr 9e-5 \
  --optimizer lion \
  --lion-beta1 0.9 \
  --lion-beta2 0.99 \
  --weight-decay 5e-4 \
  --epochs 4 \
  --lr-cosine-t-max 13 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --vol-points-schedule 0:16384:1:32768:2:49152:3:65536 \
  --use-qk-norm \
  --wandb-group frieren-xattn-two-layer \
  --agent frieren
```

Note: `--no-compile-model` is REQUIRED (torch.compile + DDP NCCL deadlock). `--lr-cosine-t-max 13` is correct (never use `--lr-cosine-t-max 4`).

**Kill gates (stop early if failing):**
- EP1 val_abupt ≥ 30% → abort
- EP2 val_abupt ≥ 16% → abort
- EP3 val_abupt ≥ 8% → abort
- EP4 val_abupt ≥ 6.4407% → does not beat SOTA (still report results)

## Baseline (current SOTA to beat)

**Single-model SOTA: PR #823 (nezuko, surf→vol xattn 1-layer)**

| Metric | Val (EP13 best) | Test |
|---|---|---|
| `abupt` | **6.4407%** | 7.6992% |
| `surface_pressure` | 4.1836% | 3.8451% |
| `volume_pressure` | 3.8557% | **11.6704%** |
| `wall_shear` | 7.3448% | 7.0429% |
| `tau_x` | 5.7782% | 6.2773% |
| `tau_y` | 7.5977% | 7.6657% |
| `tau_z` | 9.0116% | 9.0375% |

- W&B run: `ghh0s4ne` (group `nezuko-surf-vol-xattn`)
- Params: 16,987,225 (~17.0M); this experiment adds ~+1.05M → ~18.0M total
- **Advancement gate: EP4 val_abupt < 6.4407%**
