### PR TITLE
Y-flip augmentation + surf→vol xattn: ×2 training data for OOD vol_p

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    y_flip_prob: float = 0.0
     debug: bool = False
 
 
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "y_flip_prob": (
+            "Probability [0,1] of flipping each training sample about Y=0 "
+            "(X-Z symmetry plane). DrivAerML cars are symmetric about Y=0, "
+            "so this is a physically-exact data augmentation that doubles "
+            "effective training signal. Per-channel sign rules: flip y, "
+            "normal_y, and tau_y; cp / tau_x / tau_z / vol_p / sdf are "
+            "y-reflection invariant. Applied only on the training path; "
+            "validation/test never flips. 0.0 = disabled (default). "
+            "Recommended: 0.5."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +322,26 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_y_flip(batch, prob: float, device: torch.device) -> None:
+    """Apply per-sample Y=0 mirror augmentation in-place to the batch.
+
+    DrivAerML cars are symmetric about the Y=0 (X-Z) plane. Per-channel
+    sign rules under y-reflection:
+      surface_x[..., 1] (y), surface_x[..., 4] (normal_y) -> flipped
+      surface_y[..., 2] (wall_shear_y / tau_y) -> flipped (vector y-component)
+      volume_x[..., 1] (y) -> flipped
+      cp / tau_x / tau_z / vol_pressure / sdf -> invariant
+    """
+
+    if prob <= 0.0:
+        return
+    flip_mask = torch.rand(batch.surface_x.shape[0], device=device) < prob
+    batch.surface_x[flip_mask, :, 1] *= -1.0
+    batch.surface_x[flip_mask, :, 4] *= -1.0
+    batch.surface_y[flip_mask, :, 2] *= -1.0
+    batch.volume_x[flip_mask, :, 1] *= -1.0
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,8 +352,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    y_flip_prob: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    apply_y_flip(batch, y_flip_prob, device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -364,6 +397,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    y_flip_prob: float = 0.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -374,6 +409,7 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    apply_y_flip(batch, y_flip_prob, device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -939,7 +975,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model, batch, transform, device, config.amp_mode,
+                        y_flip_prob=config.y_flip_prob,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1067,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        y_flip_prob=config.y_flip_prob,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
# Y-Flip Augmentation + Surf→Vol Xattn: ×2 Training Data for OOD Vol_P

## Hypothesis

DrivAerML geometries are Y=0-symmetric (left-right symmetric around the centerplane). This means that for every training sample, a physically-exact mirrored copy exists: flip all Y-coordinates and negate the Y-components of vector fields (τ_y). This effectively **doubles the training data at zero label cost** and should improve generalization to the 4 OOD test cases that drive 92% of the squared vol_pressure test error.

**This experiment builds on the single-model SOTA** (PR #823, val_abupt=6.4407%) by adding Y-flip augmentation on top of the surf→vol xattn architecture. The two interventions are likely orthogonal: xattn adds geometry-conditioning capacity, while Y-flip adds data diversity targeting OOD robustness.

**Prior context:** PR #877 tested Y-flip in isolation (without xattn). It was closed due to a merge conflict in advisor-side notes. This PR tests Y-flip **composed with** the SOTA xattn model.

## Implementation

You need to implement Y-flip augmentation in the data loading pipeline with probability p=0.5.

### Physics of DrivAerML Y-flip

DrivAerML cars are Y=0-symmetric. For a valid augmented sample:
- Surface/volume **coordinates**: negate Y-component → `coords[:, 1] *= -1`
- Surface pressure, volume pressure: **scalar fields — unchanged**
- Wall shear stress τ_x: **scalar/x-component — unchanged**
- Wall shear τ_y: **negate** → this is a Y-component of a vector field
- Wall shear τ_z: **unchanged** (Z-component, symmetric)
- Volume velocity (if predicted): negate Y-component

### Suggested implementation

In `train.py` (or the dataset/dataloader), add a training-time augmentation that with probability `p=0.5`:
1. Flips Y-coordinates of all surface and volume points: `pts[:, 1] = -pts[:, 1]`
2. Negates the τ_y label channel

Add a CLI flag `--y-flip-prob` (default 0.0, set to 0.5 for this experiment) to enable augmentation cleanly.

**Important:** Apply augmentation only during training, never during validation/test evaluation.

## Training Setup

Use the SOTA 4-epoch screen config with surf→vol xattn enabled:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --y-flip-prob 0.5 \
  --wandb-group askeladd-y-flip-xattn \
  --wandb-name askeladd/y-flip-xattn-4ep-screen
```

**DDP note:** `--find-unused-parameters` (or `find_unused_parameters=True` in DDP init) is required when using `--use-surf-to-vol-xattn`.

## Kill Gates (4-ep screen)

| Epoch | Kill if val_abupt > |
|-------|-------------------|
| EP1   | 30%               |
| EP2   | 16%               |
| EP3   | 8%                |
| EP4   | 6.9% (target beat)|

## Target

Beat single-model SOTA: **val_abupt < 6.4407%** (PR #823)

Special focus on vol_pressure improvement — the primary OOD target per Issue #717.

## Current Baselines

| Metric | Single-model SOTA | Ensemble SOTA |
|--------|------------------|---------------|
| val_abupt | 6.4407% (PR #823) | 6.0289% (PR #880) |
| test_abupt | 7.6992% | 7.3693% |
| test_vol_pressure | 11.6704% | 11.3478% |

Per-channel val (SOTA, PR #823):
- surface_pressure: 4.1836%
- volume_pressure: 3.8557%
- wall_shear: 7.3448%
- tau_x: 5.7782%, tau_y: 7.5977%, tau_z: 9.0116%

## W&B

Project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
Group: `askeladd-y-flip-xattn`

## Expected Outcome

Y-flip doubles training diversity for Y=0-symmetric geometries. Combined with surf→vol xattn's geometry-conditioning capacity, this should improve both val_abupt and — critically — test_vol_pressure by reducing OOD sensitivity to the 4 outlier test cases (run_133, run_226, run_203, run_158).
