### PR TITLE
Surf→vol xattn with surface subsampling: sharper geometry signal for K/V

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_surf_subsample_n: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_surf_subsample_n = int(xattn_surf_subsample_n)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -536,10 +538,25 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            # Optional surface K/V subsampling (PR #887): force the xattn to
+            # distill geometry from a sparse anchor set instead of all 65k
+            # surface tokens. Random subsampling is applied at both train and
+            # eval for consistent representation. Padded surface rows have zero
+            # K/V (already mask-zeroed) so any padded picks contribute zero.
+            if (
+                self.xattn_surf_subsample_n > 0
+                and self.xattn_surf_subsample_n < surface_hidden.size(1)
+            ):
+                idx = torch.randperm(
+                    surface_hidden.size(1), device=surface_hidden.device
+                )[: self.xattn_surf_subsample_n]
+                surface_kv = surface_hidden.index_select(1, idx)
+            else:
+                surface_kv = surface_hidden
             xattn_out, _ = self.surf_to_vol_xattn(
                 query=volume_hidden,
-                key=surface_hidden,
-                value=surface_hidden,
+                key=surface_kv,
+                value=surface_kv,
                 need_weights=False,
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_surf_subsample_n: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_surf_subsample_n": (
+            "Optional uniform-random K/V subsample size for the surf->vol "
+            "cross-attention (PR #887). When > 0 and < N_surf, the xattn "
+            "module attends to a random sample of N anchor surface tokens "
+            "per forward pass instead of all 65k tokens, forcing the "
+            "geometry signal through a sparser representation. Applied at "
+            "both train and eval (for consistency). Default 0 disables "
+            "subsampling and uses all surface tokens (PR #823 behavior)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_surf_subsample_n=config.xattn_surf_subsample_n,
     )
 
 


### PR DESCRIPTION
# Surf→Vol Xattn with Surface Subsampling: Sharper Geometry Signal for K/V

## Hypothesis

The current surf→vol xattn (PR #823 SOTA) passes all 65,536 surface points as K/V to the attention module. This is extremely high-dimensional for K/V — the model must distill geometry from 65k keys. A learnable or uniform subsample (e.g., ~4096–8192 anchor points) before the K/V projection could:
1. **Sharpen the geometry signal** by forcing the model to represent surface structure more compactly
2. **Reduce memory pressure** from the 65k×512 K/V matrices
3. **Improve generalization** by attending to representative surface regions rather than individual points

This tests whether the surf→vol xattn benefit is robust to (or enhanced by) surface point sparsification. Hypothesis: the 4 OOD test cases may have different surface point densities in key regions — subsampling may help align train/test geometry representations.

## Implementation

Modify the surf→vol xattn module to subsample surface points before computing K/V projections. Two approaches, try in order:

### Approach A: Uniform random subsampling (simpler, start here)

In the xattn forward pass, before computing K/V:
```python
# surf_hidden: [B, N_surf, D] where N_surf=65536
# Subsample to N_kv anchor points
N_kv = 4096  # or 8192, try both
if self.training or True:  # apply at both train and eval for consistency
    idx = torch.randperm(surf_hidden.size(1), device=surf_hidden.device)[:N_kv]
    surf_hidden_kv = surf_hidden[:, idx, :]
else:
    surf_hidden_kv = surf_hidden
```

Add a CLI flag `--xattn-surf-subsample-n` (default 0 = use all points, set to 4096 or 8192 to enable).

### Approach B: FPS (Farthest Point Sampling) subsampling (if Approach A shows promise)

Use FPS for spatially-uniform coverage instead of random sampling. This requires access to surface coordinates alongside features. Only implement if Approach A shows promise.

**Note:** Start with random subsampling (Approach A) at N_kv=4096. If EP4 val_abupt is close to SOTA (<6.6%), try N_kv=8192 as a second run.

## Training Setup

**Run A — N_kv=4096 (4-ep screen):**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-surf-subsample-n 4096 \
  --wandb-group nezuko-xattn-surf-subsample \
  --wandb-name nezuko/xattn-surf-subsample-4k-4ep
```

**Run B — N_kv=8192 (only if Run A passes kill gates):**

Same command with `--xattn-surf-subsample-n 8192` and `--wandb-name nezuko/xattn-surf-subsample-8k-4ep`.

**DDP note:** `find_unused_parameters=True` required for DDP when using `--use-surf-to-vol-xattn`.

## Kill Gates (4-ep screen)

| Epoch | Kill if val_abupt > |
|-------|-------------------|
| EP1   | 30%               |
| EP2   | 16%               |
| EP3   | 8%                |
| EP4   | 6.9% (target beat)|

## Target

Beat single-model SOTA: **val_abupt < 6.4407%** (PR #823)

## Current Baselines

| Metric | Single-model SOTA | Ensemble SOTA |
|--------|------------------|---------------|
| val_abupt | 6.4407% (PR #823) | 6.0289% (PR #880) |
| test_abupt | 7.6992% | 7.3693% |
| test_vol_pressure | 11.6704% | 11.3478% |

Per-channel val (SOTA, PR #823):
- surface_pressure: 4.1836%
- volume_pressure: 3.8557%
- wall_shear: 7.3448%
- tau_x: 5.7782%, tau_y: 7.5977%, tau_z: 9.0116%

## W&B

Project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
Group: `nezuko-xattn-surf-subsample`

## Expected Outcome

If N_kv=4096 beats SOTA, it tells us the geometry signal was actually diluted by 65k points — sparse anchors give a cleaner representation. If N_kv=4096 hurts, try N_kv=8192. If both hurt, the full 65k surface is load-bearing — the xattn benefit requires dense coverage. Either result is informative for future architecture design.
