### PR TITLE
thorfinn: per-sample OOD loss weighting for 4 outlier vol_p geometries

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    ood_neighbor_ids: str = ""
+    ood_loss_multiplier: float = 1.0
     debug: bool = False
 
 
@@ -229,6 +231,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "ood_neighbor_ids": (
+            "Comma-separated train-set geometry IDs whose per-sample "
+            "loss contribution is multiplied by --ood-loss-multiplier "
+            "during training. Intended for upweighting train cases "
+            "geometrically nearest to OOD test cases (PR #888). When "
+            "empty (default) the loss is unchanged."
+        ),
+        "ood_loss_multiplier": (
+            "Multiplicative upweight applied to the squared-error "
+            "contribution of each --ood-neighbor-ids sample, applied to "
+            "both the surface and volume MSE before reduction. Default "
+            "1.0 is identical to baseline."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +326,61 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def per_sample_weighted_masked_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    sample_weights: torch.Tensor,
+) -> torch.Tensor:
+    """``masked_mse`` with each sample's squared error scaled by ``sample_weights[b]``.
+
+    Identical to ``masked_mse`` when ``sample_weights`` is all ones: the denominator
+    is the unweighted valid-point count, so ``w == 1`` everywhere reproduces the
+    baseline reduction exactly.
+    """
+    expanded_mask = mask
+    while expanded_mask.ndim < pred.ndim:
+        expanded_mask = expanded_mask.unsqueeze(-1)
+    expanded_mask = expanded_mask.to(device=pred.device, dtype=pred.dtype)
+    w = sample_weights.to(device=pred.device, dtype=pred.dtype)
+    while w.ndim < pred.ndim:
+        w = w.unsqueeze(-1)
+    sq_err = (pred - target).square()
+    weighted = sq_err * expanded_mask * w
+    denominator = expanded_mask.expand_as(sq_err).sum()
+    if bool(denominator.detach().cpu().item() > 0):
+        return weighted.sum() / denominator.clamp_min(1.0)
+    return sq_err.sum() * 0.0
+
+
+def per_sample_weighted_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    channel_weights: torch.Tensor,
+    sample_weights: torch.Tensor,
+) -> torch.Tensor:
+    """``weighted_channel_mse`` with per-sample upweighting; identity at ``w == 1``."""
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    chan_w = channel_weights.to(device=pred.device, dtype=pred.dtype)
+    if chan_w.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"channel_weights last-dim {chan_w.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    samp_w = sample_weights.to(device=pred.device, dtype=pred.dtype)
+    while samp_w.ndim < pred.ndim:
+        samp_w = samp_w.unsqueeze(-1)
+    sq_err = (pred - target).square()
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighted = sq_err * chan_w * mask_dev * samp_w
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,6 +391,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    sample_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -333,15 +404,40 @@ def train_loss(
             volume_mask=batch.volume_mask,
         )
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
+            if sample_weights is not None:
+                surface_loss = per_sample_weighted_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                    sample_weights,
+                )
+            else:
+                surface_loss = weighted_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+        else:
+            if sample_weights is not None:
+                surface_loss = per_sample_weighted_masked_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    sample_weights,
+                )
+            else:
+                surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        if sample_weights is not None:
+            volume_loss = per_sample_weighted_masked_mse(
+                out["volume_preds"],
+                volume_target,
+                batch.volume_mask,
+                sample_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -353,6 +449,34 @@ def train_loss(
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+
+
+def parse_ood_neighbor_ids(spec: str) -> set[str]:
+    spec = (spec or "").strip()
+    if not spec:
+        return set()
+    return {token.strip() for token in spec.split(",") if token.strip()}
+
+
+def compute_sample_weights(
+    case_ids: list[str],
+    ood_set: set[str],
+    multiplier: float,
+    device: torch.device,
+) -> tuple[torch.Tensor, int]:
+    """Return ``([B] float32 weights, n_ood_in_batch)``.
+
+    Returns ``ones`` when no OOD neighbors are flagged in the batch so the
+    downstream computation matches the unweighted reduction exactly.
+    """
+    n_ood = sum(1 for cid in case_ids if cid in ood_set)
+    weights = torch.ones(len(case_ids), device=device, dtype=torch.float32)
+    if n_ood == 0 or multiplier == 1.0:
+        return weights, n_ood
+    for i, cid in enumerate(case_ids):
+        if cid in ood_set:
+            weights[i] = multiplier
+    return weights, n_ood
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -758,6 +882,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        ood_neighbor_set = parse_ood_neighbor_ids(config.ood_neighbor_ids)
+        use_ood_weighting = bool(ood_neighbor_set) and config.ood_loss_multiplier != 1.0
+        if state.is_main and use_ood_weighting:
+            print(
+                f"OOD per-sample loss weighting: multiplier={config.ood_loss_multiplier} "
+                f"on {len(ood_neighbor_set)} train cases: {sorted(ood_neighbor_set)}"
+            )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -883,6 +1014,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/ood_neighbor_ids"] = sorted(ood_neighbor_set)
+            wandb.summary["loss/ood_neighbor_count"] = len(ood_neighbor_set)
+            wandb.summary["loss/ood_loss_multiplier"] = config.ood_loss_multiplier
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -937,6 +1071,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                ood_batch_metrics: dict[str, float] = {}
+                if use_ood_weighting:
+                    sample_weights, n_ood_in_batch = compute_sample_weights(
+                        batch.case_ids,
+                        ood_neighbor_set,
+                        config.ood_loss_multiplier,
+                        device,
+                    )
+                    ood_batch_metrics = {
+                        "train/ood/samples_in_batch": float(n_ood_in_batch),
+                        "train/ood/multiplier": float(config.ood_loss_multiplier),
+                    }
+                else:
+                    sample_weights = None
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1030,6 +1178,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        sample_weights=sample_weights,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1072,6 +1221,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if ood_batch_metrics:
+                    train_log.update(ood_batch_metrics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

The 4 OOD test geometries (run_133, run_226, run_203, run_158) account for 92% of squared test_vol_p deviation. The SOTA surf→vol cross-attention (PR #823) confirmed that OOD test/val ratio is UNCHANGED at 3.027× — xattn is a general capacity boost, not a targeted OOD fix. The hypothesis is that **per-sample loss upweighting of OOD geometries during training** will directly reduce vol_p error on those 4 cases without degrading in-distribution performance.

The key insight: MSE loss treats all geometries equally. For a model that already generalises well on the in-distribution test cases (test_vol_p ≈ 3.9–4.2% excluding OOD), the limiting factor is that the 4 outlier geometries contribute too little gradient signal relative to their outsized test impact. Boosting their per-sample loss weight by a factor of 3× should meaningfully bias the optimisation toward those cases.

This experiment requires **new implementation** in `train.py`. Two hyperparameter arms:
- **Arm A**: OOD multiplier = 3.0
- **Arm B**: OOD multiplier = 5.0

Both arms use the full SOTA xattn config (PR #823) as the base.

## Instructions

**Step 1: Implement per-sample OOD loss weighting**

Add two new CLI flags to `train.py`:
- `--ood-geo-ids`: comma-separated list of geometry IDs (folder names) that are OOD samples, e.g. `"run_133,run_226,run_203,run_158"`
- `--ood-loss-multiplier`: float, multiplicative upweight for those geometries' loss contribution (default=1.0, i.e. no change)

In the training loop, when computing the per-batch loss:
1. For each sample in the batch, look up its geometry ID (should already be in the batch dict or dataloader metadata — check how the dataset emits sample IDs).
2. If the geometry ID is in `ood_geo_ids`, multiply the loss for that sample by `ood_loss_multiplier` before summing/averaging across the batch.

The weighting must apply to the **total loss per sample** (not per-task). Implement at the batch level, before the `.backward()` call. The simplest approach:
```python
# In train step, after computing per-sample losses:
if args.ood_geo_ids:
    weights = torch.ones(batch_size, device=device)
    for i, geo_id in enumerate(batch_geo_ids):
        if geo_id in ood_geo_id_set:
            weights[i] = args.ood_loss_multiplier
    loss = (per_sample_losses * weights).mean()
```

**Step 2: Run two arms**

Use `--wandb-group thorfinn-ood-weighting` to group both arms.

**Arm A — multiplier=3.0** (run first):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --ood-geo-ids "run_133,run_226,run_203,run_158" \
  --ood-loss-multiplier 3.0 \
  --wandb-group thorfinn-ood-weighting \
  --wandb-name thorfinn/ood-weight-3x
```

**Arm B — multiplier=5.0** (run after Arm A):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --ood-geo-ids "run_133,run_226,run_203,run_158" \
  --ood-loss-multiplier 5.0 \
  --wandb-group thorfinn-ood-weighting \
  --wandb-name thorfinn/ood-weight-5x
```

**Step 3: Kill gates (per arm)**

Kill each arm early if not meeting the threshold:
- EP1: val_abupt < 30%
- EP2: val_abupt < 16%
- EP3: val_abupt < 8%
- EP4: val_abupt ≤ 6.5985%

If the model regresses significantly vs baseline on in-distribution val_abupt, discontinue that arm (upweighting can hurt generalisation if the multiplier is too aggressive).

**Step 4: Report**

In your PR results comment, include:
- For each arm: final val_abupt, test_abupt, test_vol_p
- **Also report test_vol_p specifically for the 4 OOD geometries** (run_133, run_226, run_203, run_158) if your eval code can extract per-geometry errors — this is the primary diagnostic
- The W&B run IDs for both arms

## Baseline

Current single-model SOTA (PR #823, run `ghh0s4ne`):
- val_abupt: **6.4407%**
- test_abupt: **7.6992%**
- test_vol_p: **11.6704%**

Kill gate: EP4 val_abupt ≤ 6.4407% (must beat this to be a winner)

| Metric | SOTA |
|--------|------|
| val_abupt | 6.4407% |
| test_abupt | 7.6992% |
| test_vol_p | 11.6704% |
| test_vol_p (excl. 4 OOD) | ~3.9–4.2% |

OOD context: run_133, run_226, run_203, run_158 account for 92% of squared test_vol_p deviation. Excluding them, test_vol_p ≈ 3.9–4.2% — well below AB-UPT reference of 6.08%.
