### PR TITLE
fern: learnable scalar/channel gate on surf→vol xattn residual

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -112,6 +112,7 @@ def build_model_from_config(config: dict) -> SurfaceTransolver:
         pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
         use_qk_norm=bool(config.get("use_qk_norm", False)),
         use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        xattn_gate_type=str(config.get("xattn_gate_type", "none")),
     )
 
 

--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_gate_type: str = "none",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,11 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        if xattn_gate_type not in ("none", "scalar", "channel"):
+            raise ValueError(
+                f"xattn_gate_type must be one of 'none', 'scalar', 'channel'; got {xattn_gate_type!r}"
+            )
+        self.xattn_gate_type = xattn_gate_type
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -427,9 +433,13 @@ class SurfaceTransolver(nn.Module):
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
         # Bridges geometry-aware surface features into the volume decoder
-        # to address the OOD volume_pressure gap. Zero-init out_proj weight
-        # AND bias so the sublayer is identity at init (preserves baseline
-        # behavior at epoch 0). See PR #823 hypothesis.
+        # to address the OOD volume_pressure gap.
+        #
+        # Identity-at-init is provided either by zero-initialising the MHA
+        # out_proj (gate_type='none', PR #823) or by a learnable gate
+        # (gate_type='scalar' or 'channel', PR #889). When the gate is
+        # active we MUST use standard init for out_proj — otherwise both
+        # the gate and out_proj are zero, killing the gradient signal.
         if use_surf_to_vol_xattn:
             self.surf_to_vol_xattn = nn.MultiheadAttention(
                 embed_dim=n_hidden,
@@ -437,12 +447,21 @@ class SurfaceTransolver(nn.Module):
                 batch_first=True,
                 dropout=dropout,
             )
-            self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+            if self.xattn_gate_type == "none":
+                self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+                self.xattn_gate = None
+            elif self.xattn_gate_type == "scalar":
+                self.surf_to_vol_xattn_norm = None
+                self.xattn_gate = nn.Parameter(torch.zeros(1))
+            else:  # 'channel'
+                self.surf_to_vol_xattn_norm = None
+                self.xattn_gate = nn.Parameter(torch.zeros(n_hidden))
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+            self.xattn_gate = None
 
     def _encode_group(
         self,
@@ -543,7 +562,10 @@ class SurfaceTransolver(nn.Module):
                 need_weights=False,
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
-            volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            if self.xattn_gate_type == "none":
+                volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            else:
+                volume_hidden = volume_hidden + self.xattn_gate * xattn_out
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_gate_type: str = "none"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_gate_type": (
+            "Residual injection style for the surf->vol cross-attention "
+            "(PR #889). 'none' (default) keeps the post-add LayerNorm wrap "
+            "and zero-init out_proj from PR #823. 'scalar' replaces it with "
+            "a single learnable gate alpha (init 0): "
+            "vol_hidden = vol_hidden + alpha * xattn_out. 'channel' uses a "
+            "per-channel diagonal gate alpha of size --model-hidden-dim "
+            "(LayerScale-style, init 0). When the gate is active, out_proj "
+            "uses standard init so dL/dalpha != 0 from step 1."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +287,25 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_xattn_gate_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-epoch summary of the surf->vol xattn gate (PR #889)."""
+    metrics: dict[str, float] = {}
+    gate = getattr(model, "xattn_gate", None)
+    gate_type = getattr(model, "xattn_gate_type", "none")
+    if gate is None or gate_type == "none":
+        return metrics
+    g = gate.detach().float()
+    metrics["xattn_gate/type"] = 1.0 if gate_type == "scalar" else 2.0
+    metrics["xattn_gate/numel"] = float(g.numel())
+    metrics["xattn_gate_mean"] = float(g.mean().item())
+    metrics["xattn_gate/abs_mean"] = float(g.abs().mean().item())
+    metrics["xattn_gate/abs_max"] = float(g.abs().max().item())
+    metrics["xattn_gate/std"] = float(g.std().item()) if g.numel() > 1 else 0.0
+    metrics["xattn_gate/min"] = float(g.min().item())
+    metrics["xattn_gate/max"] = float(g.max().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +338,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_gate_type=config.xattn_gate_type,
     )
 
 
@@ -1262,6 +1293,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_xattn_gate_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The surf→vol cross-attention module (PR #823) injects surface geometry information into the volume decoder by adding the xattn output directly to the volume hidden state as a residual. However, this **fixed additive injection** has no mechanism to modulate *how much* the surface geometry signal is incorporated — it's always added at full strength from the first training step.

The hypothesis is that a **learnable scalar gate on the xattn residual** will improve results by:
1. Initialising at zero (so training starts identically to the non-xattn baseline — the model inherits the pre-xattn optimum and learns to use geometry conditioning incrementally)
2. Allowing the model to learn the optimal mixing ratio between the backbone's own volume representations and the cross-attention geometry signal

This is analogous to the zero-init gating used in ControlNet and ResNet-style residual gating. The gate avoids destabilising early training and gives the optimiser a smooth path to the optimal xattn contribution.

Two arms test the gating mechanism design:
- **Arm A**: Scalar gate `α` (single learnable scalar, initialized to 0): `output = volume_hidden + α * xattn_out`
- **Arm B**: Per-head gate `α` (learnable vector of size `num_heads=4`, initialized to zeros): `output = volume_hidden + (α.unsqueeze(-1) * xattn_out_per_head).sum(dim=head)`

Both arms use the full SOTA xattn config (PR #823) as the base — same architecture, same hyperparameters, only the residual injection changes.

## Instructions

**Step 1: Implement the learnable gate in the surf→vol xattn module**

Find the `SurfToVolCrossAttention` module (or equivalent) in `target/model.py` (or wherever `--use-surf-to-vol-xattn` is implemented). It currently does something like:
```python
xattn_out, _ = self.cross_attn(query=vol_hidden, key=surf_hidden, value=surf_hidden)
vol_hidden = vol_hidden + xattn_out  # fixed residual
```

**Arm A — scalar gate:**
Add `self.xattn_gate = nn.Parameter(torch.zeros(1))` to the module's `__init__`. Change the residual to:
```python
xattn_out, _ = self.cross_attn(query=vol_hidden, key=surf_hidden, value=surf_hidden)
vol_hidden = vol_hidden + self.xattn_gate * xattn_out
```

**Arm B — per-head gate:**
Add `self.xattn_gate = nn.Parameter(torch.zeros(num_heads))` to `__init__`. Reshape the xattn output before gating so each head's contribution is scaled independently, then sum. (The `nn.MultiheadAttention` in PyTorch already combines heads in the forward pass — you'll need to use `batch_first=True` and split the output by head, or alternatively override `out_proj` to apply the gate before the output projection.) A simpler approach that approximates per-head gating: apply the gate as a learned linear re-weighting of the output channels: `self.xattn_gate = nn.Parameter(torch.zeros(embed_dim))` and `vol_hidden = vol_hidden + self.xattn_gate * xattn_out` (element-wise per-channel scalar).

Add a CLI flag `--xattn-gate-type` with choices `['none', 'scalar', 'channel']` (default `'none'` preserves the original behaviour). Set `'scalar'` for Arm A and `'channel'` for Arm B.

Log `self.xattn_gate.mean().item()` to W&B as `xattn_gate_mean` each epoch to track how the gate evolves during training.

**Step 2: Run two arms**

Use `--wandb-group fern-xattn-gate` to group both arms.

**Arm A — scalar gate:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-gate-type scalar \
  --wandb-group fern-xattn-gate \
  --wandb-name fern/xattn-gate-scalar
```

**Arm B — channel gate:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-gate-type channel \
  --wandb-group fern-xattn-gate \
  --wandb-name fern/xattn-gate-channel
```

**Step 3: Kill gates (per arm)**
- EP1: val_abupt < 30%
- EP2: val_abupt < 16%
- EP3: val_abupt < 8%
- EP4: val_abupt ≤ 6.4407% (must beat single-model SOTA)

**Step 4: Report**

In your PR results comment, include:
- For each arm: final val_abupt, test_abupt, test_vol_p, best epoch
- The final learned value of `xattn_gate_mean` at the best epoch for each arm (this tells us whether the gate converged to a meaningful non-zero value)
- The W&B run IDs for both arms

## Baseline

Current single-model SOTA (PR #823, run `ghh0s4ne`):
- val_abupt: **6.4407%**
- test_abupt: **7.6992%**
- test_vol_p: **11.6704%**

Kill gate: EP4 val_abupt ≤ 6.4407%

| Metric | SOTA |
|--------|------|
| val_abupt | 6.4407% |
| test_abupt | 7.6992% |
| test_vol_p | 11.6704% |

Reproduce SOTA (PR #823):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group nezuko-surf-vol-xattn \
  --wandb-name nezuko/surf-vol-xattn-13ep
```
