### PR TITLE
Post-xattn FFN: add MLP after surf-vol xattn for vol capacity

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -112,6 +112,7 @@ def build_model_from_config(config: dict) -> SurfaceTransolver:
         pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
         use_qk_norm=bool(config.get("use_qk_norm", False)),
         use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        xattn_post_ffn=bool(config.get("xattn_post_ffn", False)),
     )
 
 

--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_post_ffn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_post_ffn = xattn_post_ffn and use_surf_to_vol_xattn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +445,24 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # Post-xattn FFN (PR #891): pre-norm 2-layer MLP residual on the volume
+        # path, applied after the xattn block. Adds capacity to redistribute the
+        # newly-injected surface signal before the volume head. Zero-init the
+        # second linear so the layer is identity at init (preserves the PR #823
+        # SOTA optimum at step 0).
+        if self.xattn_post_ffn:
+            self.xattn_post_ffn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.xattn_post_ffn_mlp = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden * 4),
+                nn.GELU(),
+                nn.Linear(n_hidden * 4, n_hidden),
+            )
+            nn.init.zeros_(self.xattn_post_ffn_mlp[2].weight)
+            nn.init.zeros_(self.xattn_post_ffn_mlp[2].bias)
+        else:
+            self.xattn_post_ffn_norm = None
+            self.xattn_post_ffn_mlp = None
 
     def _encode_group(
         self,
@@ -545,6 +565,12 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+            if self.xattn_post_ffn_mlp is not None:
+                ffn_out = self.xattn_post_ffn_mlp(self.xattn_post_ffn_norm(volume_hidden))
+                ffn_out = _apply_token_mask(ffn_out, volume_mask)
+                volume_hidden = volume_hidden + ffn_out
+                volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_post_ffn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_post_ffn": (
+            "Enable a 2-layer MLP (FFN) residual on the volume path "
+            "immediately after the surf->vol xattn block (PR #891). "
+            "Pre-norm Linear(d, 4d) -> GELU -> Linear(4d, d) with the second "
+            "linear zero-initialised so the block is identity at init "
+            "(preserves the PR #823 SOTA optimum at step 0). Adds capacity "
+            "to redistribute the surface conditioning signal before the "
+            "volume head. Requires --use-surf-to-vol-xattn; ignored "
+            "otherwise."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_post_ffn=config.xattn_post_ffn,
     )
 
 


### PR DESCRIPTION
## Hypothesis

After the surf→vol cross-attention layer, the volume hidden state receives a single, additive geometry signal — but is then immediately passed to the decoder with no further non-linearity to process the newly-injected surface information. We hypothesize that adding a lightweight 2-layer MLP (FFN) after the xattn residual will give the volume pathway more capacity to **process and redistribute the surface conditioning signal** before the final regression head.

This is architecturally distinct from the closed "2-layer MLP decoder" (PR #780) — that experiment replaced the decoder. Here we insert an FFN *between* the xattn output and the existing decoder, leaving all other components unchanged. It is also distinct from stacking a second xattn layer (PR #884/890): the FFN here processes only the volume-side output, avoiding any K/V gradient backflow into the surface encoder.

The FFN should be zero-initialized at its second linear layer so the identity-at-init property is preserved, exactly as the xattn `out_proj` is zeroed. This ensures training begins from the same SOTA optimum as PR #823.

## Instructions

In `target/train.py`, locate the `SurfVolXAttn` (or equivalent) module that implements the surface→volume cross-attention. After the xattn post-norm residual addition, insert a 2-layer MLP with the following structure:

```python
# Insert immediately after the xattn residual update
# (i.e., after: vol_hidden = vol_hidden + self.xattn_norm(xattn_out))
self.ffn_norm = nn.LayerNorm(hidden_dim)
self.ffn = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim * 4),
    nn.GELU(),
    nn.Linear(hidden_dim * 4, hidden_dim),
)
# Zero-init the output linear to start at identity:
nn.init.zeros_(self.ffn[2].weight)
nn.init.zeros_(self.ffn[2].bias)

# Forward pass:
ffn_out = self.ffn(self.ffn_norm(vol_hidden))
vol_hidden = vol_hidden + ffn_out
```

This gives a post-norm residual FFN with zero-init output, mirroring the xattn module's initialization contract.

**Add a CLI flag** `--xattn-post-ffn` (boolean, default False) to gate the FFN addition so it requires no changes to the baseline reproduce command and DDP `find_unused_parameters=True` already handles conditional modules.

Run **two arms**:
- **Arm A (4-ep screen):** `--epochs 4 --lr-cosine-t-max 13` + vol-curriculum `"0:16384:1:32768:2:49152:3:65536"` — fast convergence check. Kill if val_abupt EP4 ≥ 7.3% (baseline EP4 was 6.81%).
- **Arm B (13-ep full):** Only launch if Arm A EP4 ≤ 7.0% (shows clear improvement trajectory). Use the standard 13-ep vol-curriculum `"0:16384:3:32768:6:49152:9:65536"`.

### Reproduce commands

**Arm A (4-ep screen):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --xattn-post-ffn \
  --wandb-group fern-post-xattn-ffn \
  --wandb-name fern/post-xattn-ffn-4ep
```

**Arm B (13-ep full, only if Arm A EP4 ≤ 7.0%):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --xattn-post-ffn \
  --wandb-group fern-post-xattn-ffn \
  --wandb-name fern/post-xattn-ffn-13ep
```

**W&B group:** `fern-post-xattn-ffn`

## Baseline

Current single-model SOTA from PR #823 (nezuko, surf→vol xattn):

| Metric | Val | Test |
|---|---|---|
| **val_abupt** | **6.4407%** | — |
| **test_abupt** | — | **7.6992%** |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | 11.6704% |
| wall_shear | 7.3448% | 7.0429% |
| tau_x | 5.7782% | 6.2773% |
| tau_y | 7.5977% | 7.6657% |
| tau_z | 9.0116% | 9.0375% |

**EP4 screen target:** val_abupt < **6.81%** (SOTA EP4 was 6.81%)
**Win gate (13ep):** val_abupt < **6.4407%**
**W&B SOTA run:** `ghh0s4ne` (group `nezuko-surf-vol-xattn`)

**EP trajectory reference (SOTA, PR #823):**
- EP1: 28.63% | EP2: 8.15% | EP3: 7.12% | EP4: 6.81% | EP6: 6.59% | EP13: 6.44%

**Kill threshold:** EP1 > 30%. If EP1 > 30%, stop immediately and report. If EP4 > 7.3%, stop and report.

## Implementation Notes

- Parameter count increase: FFN adds `hidden_dim*4*hidden_dim*2 + hidden_dim*5` ≈ +2.1M params (hidden_dim=512). Total ~19.1M vs SOTA 17.0M. This is acceptable headroom.
- `find_unused_parameters=True` is already enabled when `--use-surf-to-vol-xattn` is set — the `--xattn-post-ffn` flag should piggy-back on this same DDP gate (no separate condition needed if FFN lives inside the xattn module).
- The zero-init of `ffn[2].weight` ensures the model starts identically to the PR #823 baseline at step 0 — any improvement is attributable purely to the added FFN capacity.
- Do NOT use `--xattn-post-ffn` without `--use-surf-to-vol-xattn`. The FFN only makes sense downstream of the xattn.
