### PR TITLE
Mid-backbone surf→vol xattn injection at L=3 + final-layer xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -488,18 +488,30 @@ class SurfaceTransolver(nn.Module):
         key: torch.Tensor,
         value: torch.Tensor,
         need_weights: bool,
+        entropy_query_budget: int = 1024,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if need_weights:
-            out, weights = mha(
-                query=query,
-                key=key,
-                value=value,
-                need_weights=True,
-                average_attn_weights=False,
-            )
-            return out, weights
         out, _ = mha(query=query, key=key, value=value, need_weights=False)
-        return out, None
+        if not need_weights:
+            return out, None
+        # Diagnostic-only: a need_weights=True call materializes the full
+        # [B, H, n_q, n_kv] attention tensor and OOMs at val resolution
+        # (65536x65536 ~127 GiB). Each query has an independent softmax over
+        # keys, so we subsample queries to a small budget to get an unbiased
+        # per-head entropy estimate.
+        n_q = query.shape[1]
+        if n_q > entropy_query_budget:
+            idx = torch.randperm(n_q, device=query.device)[:entropy_query_budget]
+            sub_q = query.index_select(1, idx)
+        else:
+            sub_q = query
+        _, weights = mha(
+            query=sub_q,
+            key=key,
+            value=value,
+            need_weights=True,
+            average_attn_weights=False,
+        )
+        return out, weights
 
     def _record_attn_entropy(self, slot: str, weights: torch.Tensor) -> None:
         # weights: [B, num_heads, L_q, L_kv] -> per-head mean entropy this batch

--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_mid_layer: int = -1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -444,6 +445,91 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Mid-backbone surf->vol xattn (PR #892): inject a second xattn AFTER
+        # backbone block index `xattn_mid_layer` so the geometry-conditioned
+        # volume features are then refined by the remaining backbone blocks.
+        # Updates only the volume slice of the shared sequence; surface tokens
+        # pass through unchanged (avoids the gradient-backflow failure mode of
+        # PR #884's stacked-at-final variant). Zero-init out_proj => identity
+        # at init, preserves baseline behavior at epoch 0.
+        if use_surf_to_vol_xattn and xattn_mid_layer >= 0:
+            if xattn_mid_layer >= n_layers - 1:
+                raise ValueError(
+                    f"xattn_mid_layer={xattn_mid_layer} must be < n_layers-1={n_layers - 1} "
+                    f"so that at least one backbone block follows the mid-injection."
+                )
+            self.surf_to_vol_xattn_mid = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            self.surf_to_vol_xattn_mid_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            nn.init.zeros_(self.surf_to_vol_xattn_mid.out_proj.weight)
+            nn.init.zeros_(self.surf_to_vol_xattn_mid.out_proj.bias)
+            self.xattn_mid_layer = xattn_mid_layer
+        else:
+            self.surf_to_vol_xattn_mid = None
+            self.surf_to_vol_xattn_mid_norm = None
+            self.xattn_mid_layer = -1
+
+        # Diagnostic flag: when True, the surf->vol xattn forwards run with
+        # need_weights=True and accumulate per-head attention entropy into
+        # `_xattn_entropy_buf`. Off by default to keep the train forward fast;
+        # the val loop turns it on around evaluate_split (see train.py).
+        self.compute_xattn_entropy = False
+        self._xattn_entropy_buf: dict[str, list[float]] = {"mid": [], "final": []}
+
+    @staticmethod
+    def _run_xattn(
+        mha: nn.MultiheadAttention,
+        *,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        need_weights: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if need_weights:
+            out, weights = mha(
+                query=query,
+                key=key,
+                value=value,
+                need_weights=True,
+                average_attn_weights=False,
+            )
+            return out, weights
+        out, _ = mha(query=query, key=key, value=value, need_weights=False)
+        return out, None
+
+    def _record_attn_entropy(self, slot: str, weights: torch.Tensor) -> None:
+        # weights: [B, num_heads, L_q, L_kv] -> per-head mean entropy this batch
+        # ([H]). The val loop averages across batches and reports both the
+        # mean across heads and the std across heads (per-head spread is a
+        # stronger collapse/diversification signal than the mean alone).
+        eps = 1e-12
+        w = weights.detach().float().clamp_min(eps)
+        entropy = -(w * w.log()).sum(dim=-1)
+        per_head = entropy.mean(dim=(0, 2))
+        self._xattn_entropy_buf.setdefault(slot, []).append(per_head.cpu())
+
+    def reset_xattn_entropy_log(self) -> None:
+        self._xattn_entropy_buf = {"mid": [], "final": []}
+
+    def consume_xattn_entropy_metrics(self, prefix: str = "xattn") -> dict[str, float]:
+        metrics: dict[str, float] = {}
+        for slot, batch_values in self._xattn_entropy_buf.items():
+            if not batch_values:
+                continue
+            stacked = torch.stack(batch_values, dim=0)
+            per_head_avg = stacked.mean(dim=0)
+            metrics[f"{prefix}/{slot}_attn_entropy"] = float(per_head_avg.mean().item())
+            if per_head_avg.numel() > 1:
+                metrics[f"{prefix}/{slot}_attn_entropy_head_std"] = float(
+                    per_head_avg.std(unbiased=False).item()
+                )
+        self.reset_xattn_entropy_log()
+        return metrics
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -520,8 +606,38 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
-        hidden = _apply_token_mask(hidden, attn_mask)
+
+        run_mid_xattn = (
+            self.surf_to_vol_xattn_mid is not None
+            and self.xattn_mid_layer >= 0
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        )
+        if run_mid_xattn:
+            for i, block in enumerate(self.backbone.blocks):
+                hidden = block(hidden, attn_mask=attn_mask)
+                if i == self.xattn_mid_layer:
+                    surf_h = hidden[:, :surface_tokens]
+                    vol_h = hidden[:, surface_tokens : surface_tokens + volume_tokens]
+                    mid_out, mid_w = self._run_xattn(
+                        self.surf_to_vol_xattn_mid,
+                        query=vol_h,
+                        key=surf_h,
+                        value=surf_h,
+                        need_weights=self.compute_xattn_entropy,
+                    )
+                    if mid_w is not None:
+                        self._record_attn_entropy("mid", mid_w)
+                    mid_out = _apply_token_mask(mid_out, volume_mask)
+                    vol_h = self.surf_to_vol_xattn_mid_norm(vol_h + mid_out)
+                    vol_h = _apply_token_mask(vol_h, volume_mask)
+                    hidden = torch.cat([surf_h, vol_h], dim=1)
+            hidden = _apply_token_mask(hidden, attn_mask)
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
+            hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
         cursor = 0
@@ -536,12 +652,15 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
-            xattn_out, _ = self.surf_to_vol_xattn(
+            xattn_out, final_w = self._run_xattn(
+                self.surf_to_vol_xattn,
                 query=volume_hidden,
                 key=surface_hidden,
                 value=surface_hidden,
-                need_weights=False,
+                need_weights=self.compute_xattn_entropy,
             )
+            if final_w is not None:
+                self._record_attn_entropy("final", final_w)
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_mid_layer: int = -1
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_mid_layer": (
+            "Mid-backbone surf->vol cross-attention injection (PR #892). When "
+            ">=0 (and --use-surf-to-vol-xattn is set), insert an additional "
+            "MHA module after backbone block index `xattn_mid_layer` (0-indexed) "
+            "so the volume slice is enriched with surface K/V mid-backbone, "
+            "then refined by the remaining blocks. Surface tokens are not "
+            "modified. Zero-init out_proj => identity at init. -1 disables "
+            "(default; PR #823 single-final-xattn behavior)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_mid_layer=config.xattn_mid_layer,
     )
 
 
@@ -1239,6 +1250,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
+            xattn_diag_enabled = config.use_surf_to_vol_xattn and (
+                base_model.surf_to_vol_xattn is not None
+                or base_model.surf_to_vol_xattn_mid is not None
+            )
+            if xattn_diag_enabled:
+                base_model.compute_xattn_entropy = True
+                base_model.reset_xattn_entropy_log()
             val_metrics = {
                 name: evaluate_split(
                     model,
@@ -1250,6 +1268,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
                 for name, loader in val_loaders.items()
             }
+            xattn_entropy_metrics: dict[str, float] = {}
+            if xattn_diag_enabled:
+                xattn_entropy_metrics = base_model.consume_xattn_entropy_metrics(prefix="xattn")
+                base_model.compute_xattn_entropy = False
 
             if state.is_main:
                 if raw_val_metrics is not None:
@@ -1262,6 +1284,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                if xattn_entropy_metrics:
+                    log_metrics.update(xattn_entropy_metrics)
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The current surf→vol cross-attention (PR #823 SOTA) fires **after** the full Transolver backbone and post-backbone LayerNorm: it lets volume queries attend to surface keys/values at the very end of the forward pass. This placement means the geometry-conditioned volume representation gets **no further processing** — the enriched hidden state goes directly to the output head.

This experiment tests **mid-backbone xattn injection at L=3** (0-indexed: after `backbone.blocks[2]`, the third of five blocks): a surf→vol cross-attention module is inserted mid-backbone so the geometry-conditioned volume features are then processed by backbone blocks L4 and L5. The final-layer xattn (PR #823) is retained unchanged — so the total architecture is:

```
[Encode surf + vol] → [L1] → [L2] → [L3] → [mid-xattn: vol_Q, surf_K/V] → [L4] → [L5] → [final-xattn: vol_Q, surf_K/V] → output heads
```

Both xattn modules are zero-init (identity at init). The mid-backbone injection uses a **separate** `nn.MultiheadAttention(embed_dim=512, num_heads=4)` module with its own LayerNorm. This is NOT a two-layer stacked xattn at the end (which failed in PR #884 due to gradient backflow). It is a spatially-distributed injection that allows the backbone itself to refine the geometry-conditioned representation over L4 and L5.

**Motivation:** If surface geometry information is beneficial for vol_p (confirmed by PR #823), injecting it earlier in the backbone allows 2 more Transolver blocks to mix and refine that signal across both surface and volume tokens — potentially closing more of the OOD gap than a single late injection can.

**Expected failure mode to monitor:** If the mid-backbone xattn destabilizes the shared backbone (surface tokens also pass through L4/L5 after the mid-xattn was applied to volume tokens in the shared sequence), we may see surface metrics regress like in PR #884. To mitigate: the mid-xattn updates **only the volume slice** of the concatenated hidden sequence (apply the residual only to volume token positions), leaving surface token positions untouched in the shared sequence.

## Instructions

Modify `model.py` (and the `--use-surf-to-vol-xattn` flag path in `train.py` if needed) to implement mid-backbone + final-layer dual xattn:

**Step 1: Add a new `--xattn-mid-layer` flag to `train.py`** (default=`None` / disabled; when set to `-1` or omitted, the existing behavior is preserved):
```
--xattn-mid-layer INT   Insert an additional surf→vol xattn after this 0-indexed backbone block (default: -1 disabled)
```

**Step 2: Modify `SurfaceTransolver.__init__`** to add a second xattn module when `xattn_mid_layer >= 0` AND `use_surf_to_vol_xattn`:
```python
# Mid-backbone xattn (this PR)
if use_surf_to_vol_xattn and xattn_mid_layer >= 0:
    self.surf_to_vol_xattn_mid = nn.MultiheadAttention(
        embed_dim=n_hidden, num_heads=n_head, batch_first=True, dropout=dropout
    )
    self.surf_to_vol_xattn_mid_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.surf_to_vol_xattn_mid.out_proj.weight)
    nn.init.zeros_(self.surf_to_vol_xattn_mid.out_proj.bias)
    self.xattn_mid_layer = xattn_mid_layer
else:
    self.surf_to_vol_xattn_mid = None
    self.surf_to_vol_xattn_mid_norm = None
    self.xattn_mid_layer = -1
```

**Step 3: Modify `SurfaceTransolver.forward`** to split the backbone loop and inject mid-backbone xattn. Replace:
```python
hidden = self.backbone(hidden, attn_mask=attn_mask)
```
With:
```python
if self.surf_to_vol_xattn_mid is not None and self.xattn_mid_layer >= 0:
    # Run backbone blocks up to and including xattn_mid_layer
    for i, block in enumerate(self.backbone.blocks):
        hidden = block(hidden, attn_mask=attn_mask)
        if i == self.xattn_mid_layer:
            # Extract volume slice, apply xattn, write back
            _surf_h = hidden[:, :surface_tokens]    # [B, N_surf, D]
            _vol_h  = hidden[:, surface_tokens : surface_tokens + volume_tokens]  # [B, N_vol, D]
            _xattn_out, _ = self.surf_to_vol_xattn_mid(
                query=_vol_h, key=_surf_h, value=_surf_h, need_weights=False
            )
            _xattn_out = _apply_token_mask(_xattn_out, volume_mask)
            _vol_h = self.surf_to_vol_xattn_mid_norm(_vol_h + _xattn_out)
            _vol_h = _apply_token_mask(_vol_h, volume_mask)
            # Write enriched volume hidden back into shared sequence
            hidden = torch.cat([_surf_h, _vol_h, hidden[:, surface_tokens + volume_tokens:]], dim=1)
else:
    hidden = self.backbone(hidden, attn_mask=attn_mask)
```

**Important:** The shared backbone sequence contains ONLY surface + volume tokens (no extra tokens). So `hidden[:, :surface_tokens]` = surface portion and `hidden[:, surface_tokens:surface_tokens+volume_tokens]` = volume portion. The mid-xattn updates only the volume portion; the surface portion is NOT modified (unlike PR #884's stacking which could let gradients flow backward through K/V into the surface encoder from the FINAL layer, the mid-backbone module is bounded by L4/L5 blocks above it).

**Step 4: Run the 4-ep screen** with `--xattn-mid-layer 2` (inject after block[2], the third block out of 5):

```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --use-surf-to-vol-xattn \
  --xattn-mid-layer 2 \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --epochs 4 \
  --lr-cosine-t-max 13 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --wandb-group nezuko-xattn-mid-backbone \
  --wandb-name nezuko/xattn-mid-backbone-l3 \
  --optimizer lion \
  --ema-decay 0.999 \
  --use-ema \
  --use-qk-norm \
  --pos-encoding-mode string_separable \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --kill-thresholds "1:0.30,2:0.16,3:0.08,4:0.069"
```

**Kill gates (4-ep screen):**
- EP1: val_abupt < 30%
- EP2: val_abupt < 16%
- EP3: val_abupt < 8% (advisory — if missed by <0.5pp, continue to EP4)
- EP4: val_abupt < 6.9% to beat single-model SOTA; < 6.4407% to achieve new SOTA

**If EP4 passes (val_abupt < 6.4407%):** Post full per-target breakdown and mark PR ready for review. We will launch the 13-ep full training run.

**If EP4 misses (6.4407% ≤ val_abupt < 6.9%):** Report EP4 per-target metrics including vol_p. If vol_p < 3.7% (below ensemble SOTA) the direction is worth continuing even if overall abupt doesn't beat single-model SOTA.

**If EP4 fails hard (val_abupt ≥ 6.9%):** Report full breakdown and close.

**Diagnostic to add:** Log `xattn_mid_attn_entropy` (mean entropy of attention weights across heads and batch) at each validation step for BOTH the mid-backbone and final xattn modules, so we can tell if the mid-backbone module is attending diffusely or sharply.

## Baseline

**Single-model SOTA (target to beat):**
- val_abupt = **6.4407%** — PR #823 (nezuko `ghh0s4ne`)
- val: surface_pressure=4.1836%, volume_pressure=3.8557%, wall_shear=7.3448%, tau_x=5.7782%, tau_y=7.5977%, tau_z=9.0116%
- test_abupt = 7.6992%, test_vol_p = 11.6704%

**Ensemble SOTA (for reference):**
- val_abupt = **6.0289%** — PR #880 (nezuko `zst3y2mp` K=6 pool-32)

**4-ep screen trajectory of PR #823 baseline (same hyperparams):**
| EP | val_abupt |
|----|-----------|
| EP1 | 28.6344% |
| EP2 | 8.1482% |
| EP3 | 7.1195% |
| EP4 | 6.8087% |

Your kill gates:
- EP1 < 30% (target ~28%) — note: mid-backbone xattn adds 2.1M params, expect similar EP1 vs PR #823
- EP2 < 16% (target ~8%)
- EP3 < 8% (advisory)
- EP4 < 6.9% (hard gate) / < 6.4407% (new SOTA)

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
