### PR TITLE
Grouped-Query xattn: test GQA (n_kv_heads=1,2) vs MHA baseline

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,82 @@ class Transformer(nn.Module):
         return x
 
 
+class GroupedQueryXAttn(nn.Module):
+    """Grouped-Query cross-attention (Ainslie et al. 2023, arXiv:2305.13245).
+
+    Standard Llama-style GQA: ``n_q_heads`` query heads partition the embedding
+    into head_dim = embed_dim // n_q_heads. ``n_kv_heads`` key/value heads share
+    the same head_dim, so K and V projections are size ``embed_dim ->
+    n_kv_heads * head_dim``. Each KV head services ``n_q_heads // n_kv_heads``
+    query heads via ``repeat_interleave`` along the head dim before SDPA.
+
+    Zero-init out_proj weight + bias (like PR #823 baseline) so the residual
+    branch is identity at init.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        n_q_heads: int,
+        n_kv_heads: int,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if n_q_heads % n_kv_heads != 0:
+            raise ValueError(
+                f"n_q_heads ({n_q_heads}) must be divisible by n_kv_heads ({n_kv_heads})"
+            )
+        if embed_dim % n_q_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by n_q_heads ({n_q_heads})"
+            )
+        self.embed_dim = embed_dim
+        self.n_q_heads = n_q_heads
+        self.n_kv_heads = n_kv_heads
+        self.n_groups = n_q_heads // n_kv_heads
+        self.head_dim = embed_dim // n_q_heads
+        self.kv_dim = n_kv_heads * self.head_dim
+
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=True)
+        self.k_proj = nn.Linear(embed_dim, self.kv_dim, bias=True)
+        self.v_proj = nn.Linear(embed_dim, self.kv_dim, bias=True)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
+
+        self.dropout = dropout
+
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor:
+        B, Nq, _ = query.shape
+        Nk = key.shape[1]
+
+        q = self.q_proj(query)
+        k = self.k_proj(key)
+        v = self.v_proj(value)
+
+        q = q.view(B, Nq, self.n_q_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, Nk, self.n_kv_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, Nk, self.n_kv_heads, self.head_dim).transpose(1, 2)
+
+        if self.n_groups > 1:
+            k = k.repeat_interleave(self.n_groups, dim=1)
+            v = v.repeat_interleave(self.n_groups, dim=1)
+
+        out = F.scaled_dot_product_attention(
+            q, k, v,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+
+        out = out.transpose(1, 2).contiguous().view(B, Nq, self.embed_dim)
+        return self.out_proj(out)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_kv_heads: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +433,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_kv_heads = xattn_kv_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -424,22 +502,32 @@ class SurfaceTransolver(nn.Module):
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
-        # Surface->volume cross-attention (PR #823): single MHA sublayer where
-        # volume hidden states (Q) attend to surface hidden states (K/V).
-        # Bridges geometry-aware surface features into the volume decoder
-        # to address the OOD volume_pressure gap. Zero-init out_proj weight
-        # AND bias so the sublayer is identity at init (preserves baseline
-        # behavior at epoch 0). See PR #823 hypothesis.
+        # Surface->volume cross-attention (PR #823): single attention sublayer
+        # where volume hidden states (Q) attend to surface hidden states (K/V).
+        # When ``xattn_kv_heads`` is 0 (default), uses ``nn.MultiheadAttention``
+        # with n_head Q/KV heads (PR #823 baseline). When ``xattn_kv_heads > 0``,
+        # uses ``GroupedQueryXAttn`` with n_q_heads=n_head and the requested
+        # n_kv_heads (PR #893 GQA experiment). Zero-init out_proj weight and
+        # bias so the sublayer is identity at init (preserves baseline at
+        # epoch 0).
         if use_surf_to_vol_xattn:
-            self.surf_to_vol_xattn = nn.MultiheadAttention(
-                embed_dim=n_hidden,
-                num_heads=n_head,
-                batch_first=True,
-                dropout=dropout,
-            )
+            if xattn_kv_heads > 0 and xattn_kv_heads != n_head:
+                self.surf_to_vol_xattn = GroupedQueryXAttn(
+                    embed_dim=n_hidden,
+                    n_q_heads=n_head,
+                    n_kv_heads=xattn_kv_heads,
+                    dropout=dropout,
+                )
+            else:
+                self.surf_to_vol_xattn = nn.MultiheadAttention(
+                    embed_dim=n_hidden,
+                    num_heads=n_head,
+                    batch_first=True,
+                    dropout=dropout,
+                )
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
             self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
@@ -536,12 +624,19 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
-            xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
-                key=surface_hidden,
-                value=surface_hidden,
-                need_weights=False,
-            )
+            if isinstance(self.surf_to_vol_xattn, nn.MultiheadAttention):
+                xattn_out, _ = self.surf_to_vol_xattn(
+                    query=volume_hidden,
+                    key=surface_hidden,
+                    value=surface_hidden,
+                    need_weights=False,
+                )
+            else:
+                xattn_out = self.surf_to_vol_xattn(
+                    query=volume_hidden,
+                    key=surface_hidden,
+                    value=surface_hidden,
+                )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    surf_to_vol_xattn_kv_heads: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "surf_to_vol_xattn_kv_heads": (
+            "Number of K/V heads for grouped-query surf->vol cross-attention "
+            "(PR #893). 0 (default) = standard MHA with n_kv_heads=--model-heads "
+            "(PR #823 baseline). >0 enables Llama-style GQA with "
+            "n_q_heads=--model-heads and n_kv_heads=this value; n_q_heads must "
+            "be divisible by n_kv_heads. Example: --model-heads 4 "
+            "--surf-to-vol-xattn-kv-heads 1 yields MQA (1 K/V head shared "
+            "across 4 Q heads). K/V projection size is n_kv_heads * head_dim, "
+            "so K/V parameters are reduced vs the MHA baseline."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_kv_heads=config.surf_to_vol_xattn_kv_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The PR #878 heads sweep established that per-head dimensionality matters more than head count for the surf→vol cross-attention on DrivAerML: heads=4 (128-dim/head) beats heads=8 (64-dim/head) and heads=16 (32-dim/head). But the sweep conflated two variables: number of query heads AND K/V head count.

**Grouped-Query Attention (GQA)** (Ainslie et al., 2023 — https://arxiv.org/abs/2305.13245) decouples these: `n_kv_heads < n_q_heads`. Each K/V head services `n_q_heads / n_kv_heads` query heads. This lets us:
- Keep K/V at full 512-dim / 1-head (or 2-head) width: preserves the surface encoder's representational fidelity
- Increase Q heads (volume queries) to 2 or 4: more specialised query projections per volume token
- Total xattn parameters stay near-constant vs PR #823 baseline (K/V matrix stays 512×512, Q matrix scales modestly)

PR #878 showed heads=16 > heads=8 monotonically (volume_pressure gained most: −0.39pp), suggesting richer Q projections help — but only when K/V dimensionality isn't simultaneously bottlenecked. GQA lets us test "richer Q, full-width K/V" directly.

**Hypothesis:** GQA with `n_kv_heads=1, n_q_heads=4` (or `n_kv_heads=2, n_q_heads=4`) will preserve or improve K/V surface encoding quality vs the baseline `n_kv_heads=n_q_heads=4`, while adding specialised query projections that capture different geometric features of the volume tokens. Expected gain: 0.1–0.3pp val_abupt, most visible in volume_pressure.

References:
- Ainslie et al. (2023) "GQA: Training Generalized Multi-Query Transformer Models from Multi-Head Checkpoints" https://arxiv.org/abs/2305.13245
- MQA (Shazeer 2019): extreme case n_kv_heads=1 — https://arxiv.org/abs/1911.02150

## Instructions

### Overview

Replace the `nn.MultiheadAttention` in `SurfaceTransolver` with a custom GQA module that supports `n_kv_heads < n_q_heads`. Run a **2-arm 4-epoch screen**: Arm A (`n_kv_heads=1, n_q_heads=4`) and Arm B (`n_kv_heads=2, n_q_heads=4`). Both arms use the full baseline stack from PR #823 + all merged PRs to date.

### Step 1 — Implement the GQA module in `target/model.py`

Add a new class `GroupedQueryXAttn` in `target/model.py` before `SurfaceTransolver`:

```python
class GroupedQueryXAttn(nn.Module):
    """Grouped-Query cross-attention: n_kv_heads K/V groups, n_q_heads Q heads.
    
    Implemented via F.scaled_dot_product_attention with expand trick.
    Zero-init out_proj (identity at init, like PR #823).
    """
    def __init__(
        self,
        embed_dim: int,
        n_q_heads: int,
        n_kv_heads: int,
        dropout: float = 0.0,
    ):
        super().__init__()
        assert n_q_heads % n_kv_heads == 0, "n_q_heads must be divisible by n_kv_heads"
        self.embed_dim = embed_dim
        self.n_q_heads = n_q_heads
        self.n_kv_heads = n_kv_heads
        self.n_groups = n_q_heads // n_kv_heads  # Q heads per KV group
        self.head_dim = embed_dim // n_q_heads   # Q head dimension
        self.kv_head_dim = embed_dim // n_kv_heads  # K/V head dimension (wider)
        assert self.head_dim * n_q_heads == embed_dim
        assert self.kv_head_dim * n_kv_heads == embed_dim
        
        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=True)          # Q: full embed_dim
        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=True)          # K: full embed_dim (n_kv_heads wide heads)
        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=True)          # V: full embed_dim
        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
        
        self.dropout = dropout
        self.scale = self.head_dim ** -0.5
        
        # Zero-init out_proj: identity at init (PR #823 convention)
        nn.init.zeros_(self.out_proj.weight)
        nn.init.zeros_(self.out_proj.bias)
    
    def forward(
        self,
        query: torch.Tensor,   # (B, Nq, D) — volume hidden
        key: torch.Tensor,     # (B, Nk, D) — surface hidden
        value: torch.Tensor,   # (B, Nk, D) — surface hidden
        key_padding_mask: torch.Tensor | None = None,  # (B, Nk) bool True=ignore
    ) -> torch.Tensor:
        B, Nq, D = query.shape
        Nk = key.shape[1]
        
        # Project Q, K, V
        q = self.q_proj(query)   # (B, Nq, D)
        k = self.k_proj(key)     # (B, Nk, D)
        v = self.v_proj(value)   # (B, Nk, D)
        
        # Reshape Q to (B, n_q_heads, Nq, head_dim)
        q = q.view(B, Nq, self.n_q_heads, self.head_dim).transpose(1, 2)
        
        # Reshape K/V to (B, n_kv_heads, Nk, kv_head_dim)
        k = k.view(B, Nk, self.n_kv_heads, self.kv_head_dim).transpose(1, 2)
        v = v.view(B, Nk, self.n_kv_heads, self.kv_head_dim).transpose(1, 2)
        
        # Expand K/V along head dim to match Q: (B, n_q_heads, Nk, kv_head_dim)
        # Each KV group repeats n_groups times
        k = k.repeat_interleave(self.n_groups, dim=1)  # (B, n_q_heads, Nk, kv_head_dim)
        v = v.repeat_interleave(self.n_groups, dim=1)
        
        # SDPA attention mask: key_padding_mask (B, Nk) -> attn_mask (B, n_q_heads, Nq, Nk)
        attn_mask = None
        if key_padding_mask is not None:
            # True = ignore in nn.MultiheadAttention convention
            # SDPA expects True = attend, or use additive mask of -inf
            attn_mask = key_padding_mask[:, None, None, :].expand(B, self.n_q_heads, Nq, Nk)
            attn_mask = torch.zeros_like(attn_mask, dtype=query.dtype).masked_fill(attn_mask, float('-inf'))
        
        # F.scaled_dot_product_attention handles the head_dim vs kv_head_dim mismatch
        # since both are now (B, n_q_heads, N, head_dim) after expand
        out = F.scaled_dot_product_attention(
            q, k, v,
            attn_mask=attn_mask,
            dropout_p=self.dropout if self.training else 0.0,
            scale=self.scale,
        )  # (B, n_q_heads, Nq, head_dim)
        
        # Reshape back: (B, Nq, D)
        out = out.transpose(1, 2).contiguous().view(B, Nq, D)
        return self.out_proj(out)
```

**Important:** Add `import torch.nn.functional as F` at the top of `model.py` if not already present.

### Step 2 — Add `xattn_kv_heads` parameter to `SurfaceTransolver.__init__`

In `SurfaceTransolver.__init__`, add parameter `xattn_kv_heads: int = 0` (default 0 means "use n_head — standard MHA, backwards compatible"):

```python
def __init__(
    self,
    ...
    use_surf_to_vol_xattn: bool = False,
    xattn_kv_heads: int = 0,   # 0 = use n_head (standard MHA); >0 enables GQA with this many KV heads
    ...
):
    ...
    self.xattn_kv_heads = xattn_kv_heads
    ...
    if use_surf_to_vol_xattn:
        effective_kv_heads = xattn_kv_heads if xattn_kv_heads > 0 else n_head
        if effective_kv_heads == n_head:
            # Standard MHA path (backwards compatible)
            self.surf_to_vol_xattn = nn.MultiheadAttention(
                embed_dim=n_hidden,
                num_heads=n_head,
                batch_first=True,
                dropout=dropout,
            )
            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
        else:
            # GQA path
            self.surf_to_vol_xattn = GroupedQueryXAttn(
                embed_dim=n_hidden,
                n_q_heads=n_head,        # Q heads = model heads (4)
                n_kv_heads=effective_kv_heads,
                dropout=dropout,
            )
        self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    else:
        self.surf_to_vol_xattn = None
        self.surf_to_vol_xattn_norm = None
```

### Step 3 — Update the forward pass to handle GQA

The existing xattn forward call in `SurfaceTransolver.forward`:

```python
xattn_out, _ = self.surf_to_vol_xattn(
    volume_hidden,
    surface_hidden,
    surface_hidden,
    key_padding_mask=~surface_mask,
)
```

This works for `nn.MultiheadAttention`. For `GroupedQueryXAttn`, the API is slightly different (returns a single tensor, not a tuple):

```python
if isinstance(self.surf_to_vol_xattn, nn.MultiheadAttention):
    xattn_out, _ = self.surf_to_vol_xattn(
        volume_hidden,
        surface_hidden,
        surface_hidden,
        key_padding_mask=~surface_mask,
    )
else:
    # GroupedQueryXAttn
    xattn_out = self.surf_to_vol_xattn(
        volume_hidden,
        surface_hidden,
        surface_hidden,
        key_padding_mask=~surface_mask,
    )
```

### Step 4 — Add `--surf-to-vol-xattn-kv-heads` CLI flag in `target/train.py`

Find where `--use-surf-to-vol-xattn` is added and add the new flag immediately after:

```python
parser.add_argument(
    "--surf-to-vol-xattn-kv-heads",
    type=int,
    default=0,
    help=(
        "Number of K/V heads for grouped-query surf→vol cross-attention. "
        "0 (default) = use standard MHA with n_heads K/V heads. "
        ">0 enables GQA: n_q_heads=--model-heads, n_kv_heads=this value. "
        "n_q_heads must be divisible by n_kv_heads. "
        "Example: --model-heads 4 --surf-to-vol-xattn-kv-heads 1 gives "
        "n_q_heads=4, n_kv_heads=1, n_groups=4."
    ),
)
```

Then pass it through to the model constructor:
```python
# in the model construction section of train.py
xattn_kv_heads=args.surf_to_vol_xattn_kv_heads,
```

### Step 5 — Run the 2-arm 4-epoch screen

**Arm A: GQA n_kv_heads=1, n_q_heads=4 (MQA limit)**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --surf-to-vol-xattn-kv-heads 1 \
  --wandb-group xattn-gqa-sweep --wandb-name alphonse/xattn-gqa-kv1
```

**Arm B: GQA n_kv_heads=2, n_q_heads=4**

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --surf-to-vol-xattn-kv-heads 2 \
  --wandb-group xattn-gqa-sweep --wandb-name alphonse/xattn-gqa-kv2
```

Run both arms in parallel (each uses 8 GPUs — run on separate pods or sequentially if only one pod available).

### Kill gates (4-epoch screen)

Apply these gates per arm — kill immediately if a threshold is exceeded:
- EP1 (step ~10864): val_abupt > 30%
- EP2 (step ~16300): val_abupt > 16%
- EP3 (step ~19926): val_abupt > 8%
- EP4 (step ~22647): val_abupt > 6.4407% (single-model SOTA gate)

**Important:** Kill a failing arm immediately rather than waiting for it to finish — report results from the surviving arm.

If both arms are killed at the same gate, report the best per-channel metrics at that epoch so we can compare against PR #878.

### What to report

In your SENPAI-RESULT comment, include:
1. EP-by-EP val_abupt trajectory for each arm (EP1 through EP4, or until killed)
2. Per-channel val metrics at EP3 (or the last surviving epoch): surface_pressure, volume_pressure, wall_shear
3. W&B run IDs for both arms
4. Parameter count for GQA vs MHA (confirm via `torchinfo` or W&B config)

### Design notes

- `repeat_interleave` for K/V expansion is correct for GQA (not `expand`) — each KV group is a distinct head, not a shared one
- The out_proj zero-init ensures Arm A/B are identical to PR #823 SOTA at EP0 — valid comparison
- With n_kv_heads=1: K proj is 512×512, V proj is 512×512 — K/V have full head_dim=512 per single group, vs 128/head at standard n_heads=4. Each of the 4 Q heads attends to the same full-dim K/V projection.
- With n_kv_heads=2: two 256-dim K/V heads, each servicing 2 of the 4 Q heads

## Baseline (single-model SOTA — PR #823, run `ghh0s4ne`)

| Metric | Val | Test |
|--------|-----|------|
| **abupt** | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | **11.6704%** |
| wall_shear | 7.3448% | 7.0429% |

**Target: val_abupt < 6.4407% to beat single-model SOTA.**

W&B group for comparison: `xattn-gqa-sweep`
