### PR TITLE
Train-time y-axis mirror aug: attack val/test volume gap with symmetry prior

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,6 +130,7 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    use_train_mirror_aug: bool = False
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_train_mirror_aug": (
+            "Enable training-time stochastic y-axis mirror augmentation "
+            "(PR #901). For each sample in a training batch, with "
+            "probability 0.5 reflect the geometry across y=0 by negating "
+            "surface_x[y@1, ny@4], surface_y[tau_y@2], and volume_x[y@1]. "
+            "Volume_y (scalar pressure) and *_mask are invariant; padded "
+            "rows are zero so the mask invariant is preserved. Strictly "
+            "training-only; never applied during val/test eval."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +321,33 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_y_mirror_aug(batch) -> None:
+    """Stochastic per-sample y-axis mirror, applied in place on a training batch.
+
+    DrivAerML cars are approximately symmetric about y=0; reflecting the
+    geometry across that plane yields a physically valid sample. Per-sample
+    flip decisions (p=0.5) negate:
+      - ``surface_x[..., 1]`` (y-coord) and ``surface_x[..., 4]`` (ny normal)
+      - ``surface_y[..., 2]`` (tau_y wall-shear-y component)
+      - ``volume_x[..., 1]`` (y-coord)
+    ``volume_y`` (scalar pressure), ``surface_mask``, and ``volume_mask`` are
+    invariant; padded rows are zero so the mask invariant is preserved
+    automatically. ``torch.rand`` is per-rank under DDP, which is the correct
+    behavior for stochastic augmentation on locally-scattered batch slices.
+    """
+    batch_size = batch.surface_x.shape[0]
+    device = batch.surface_x.device
+    flip_mask = torch.rand(batch_size, device=device) < 0.5  # [B] bool
+    sign = torch.where(flip_mask, -1.0, 1.0).view(batch_size, 1)
+    sx_sign = sign.to(batch.surface_x.dtype)
+    sy_sign = sign.to(batch.surface_y.dtype)
+    vx_sign = sign.to(batch.volume_x.dtype)
+    batch.surface_x[..., 1].mul_(sx_sign)
+    batch.surface_x[..., 4].mul_(sx_sign)
+    batch.surface_y[..., 2].mul_(sy_sign)
+    batch.volume_x[..., 1].mul_(vx_sign)
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,8 +358,11 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_mirror_aug: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    if use_mirror_aug:
+        apply_y_mirror_aug(batch)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -364,6 +404,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_mirror_aug: bool = False,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -374,6 +416,8 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    if use_mirror_aug:
+        apply_y_mirror_aug(batch)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -852,6 +896,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_train_mirror_aug:
+                print(
+                    "Train-time y-mirror aug: ENABLED (p=0.5 per sample). "
+                    "Negating surface_x[y@1, ny@4], surface_y[tau_y@2], "
+                    "volume_x[y@1]. Volume_y and *_mask invariant."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +933,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["aug/use_train_mirror_aug"] = config.use_train_mirror_aug
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -939,7 +990,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model, batch, transform, device, config.amp_mode,
+                        use_mirror_aug=config.use_train_mirror_aug,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1082,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_mirror_aug=config.use_train_mirror_aug,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
## Hypothesis

The single biggest open problem in this programme is the **3× val/test gap on volume pressure** (val ~3.6%, test ~11.3% — see Issue #717 and human directive: "test volume pressure L2 is the only thing that matters now"). This gap is geometric, not optimization-based: multiple runs with strong val volume completely fail to transfer.

Automotive aerodynamics has a **near-perfect left-right (y-axis) symmetry**: every car in DrivAerML is approximately symmetric about its longitudinal centerline plane (y=0), and the steady-state RANS flow field they're regressing inherits this symmetry. **The model is currently not given this prior at all** — every training pass sees only the as-given orientation. By training-time augmenting with a mirror reflection across y, we double the effective dataset size in the geometry direction the model is most likely to fail to generalize over.

This is fundamentally different from PR #735 (inference-time TTA mirror, which worsened test volume to 13.478%): inference-time TTA averages predictions from a non-mirror-trained model, exposing its lack of mirror robustness; **training-time mirror augmentation gives the model the inductive bias from step 0**. This is standard practice in 3D point-cloud and mesh-based learning (PointNet, Point Transformer, geometric DL libraries) and consistently improves OOD generalization on shape datasets.

## Instructions

In `target/train.py`, add a new TrainingConfig field:
```python
use_train_mirror_aug: bool = False
```

In the **training step only** (NOT validation/eval), after the batch is on GPU, apply a stochastic y-axis mirror to each sample in the batch with probability 0.5:

```python
if config.use_train_mirror_aug:
    # Draw per-sample flip decisions: shape [B]
    flip_mask = torch.rand(batch.surface_coords.shape[0], device=batch.surface_coords.device) < 0.5
    # Helper to negate a single coord/target channel selectively
    # batch.surface_coords: [B, N_surf, 3] — channels: [x, y, z]
    # batch.volume_coords:  [B, N_vol,  3] — channels: [x, y, z]
    # batch.surface_targets: [B, N_surf, 4] — channels: [cp, tau_x, tau_y, tau_z]
    
    fm = flip_mask[:, None, None]  # [B, 1, 1] for broadcasting
    
    # Negate y-coordinate (axis 1) on surface and volume coords
    sc = batch.surface_coords.clone()
    sc[..., 1] = torch.where(fm.expand_as(sc[..., 1:2]).squeeze(-1),
                              -sc[..., 1], sc[..., 1])
    batch = batch._replace(surface_coords=sc)
    
    vc = batch.volume_coords.clone()
    vc[..., 1] = torch.where(fm.expand_as(vc[..., 1:2]).squeeze(-1),
                              -vc[..., 1], vc[..., 1])
    batch = batch._replace(volume_coords=vc)
    
    # Negate tau_y (channel index 2) in surface_targets — tau_y flips sign under y-mirror
    st = batch.surface_targets.clone()
    st[..., 2] = torch.where(fm.expand_as(st[..., 2:3]).squeeze(-1),
                              -st[..., 2], st[..., 2])
    batch = batch._replace(surface_targets=st)
    
    # Volume targets (pressure scalar) — unchanged; masks — unchanged
```

**Channel ordering check FIRST:** Before running, confirm surface_targets channels are `[cp, tau_x, tau_y, tau_z]` as documented at train.py:751-754. If the channel ordering differs, adjust the index for tau_y accordingly. A wrong index silently corrupts training. Print channel shapes at EP1 step 0 and verify.

**Validation/eval guard:** Place the above block under a `if training:` or step-context guard — augmentation must be completely absent from val/eval passes.

**DDP correctness:** Run the aug on each rank's local batch slice after DDP scatter — `torch.rand` is called per-rank and that's fine; gradients are averaged across ranks so stochastic mirroring per-rank is correct.

### Reproduce commands

**Arm A (4-ep screen):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --use-train-mirror-aug \
  --wandb-group fern-train-mirror-aug \
  --wandb-name fern/train-mirror-aug-4ep
```

**Arm B (13-ep full) — only launch if Arm A EP4 ≤ 7.0%:**
Same as Arm A but with `--epochs 13 --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" --wandb-name fern/train-mirror-aug-13ep`.

**W&B group:** `fern-train-mirror-aug`

### Arm A gates

| Checkpoint | Step  | val_abupt gate | SOTA ref |
|---|---|---|---|
| EP1 | 10,864 | ≤35% | PR #823 EP1=28.63% (mirror aug may slow EP1) |
| EP2 | 21,728 | ≤16% | PR #823 EP2=8.15% |
| EP3 | ~32,594 | ≤8.5% | PR #823 EP3=7.12% |
| EP4 | ~38,030 | ≤7.0% → launch Arm B | PR #823 EP4=6.81% |

Kill if EP1 > 35% (sign-flip error on wrong channel), or EP3 > 8.5%.

### Win criterion (Arm B)

- Primary: **test volume pressure L2 < 11.3478%** (current pool best) — human directive says this is the only target.
- Secondary: **val_abupt < 6.4407%** (single-model SOTA).
- A sub-11% test volume result counts as a merge candidate even if val_abupt doesn't beat SOTA.

### Reporting

After Arm B (or after kill), report:
1. Per-epoch val_abupt + val volume_pressure trajectory (table).
2. **Best-checkpoint test metrics** — especially `test_primary/volume_pressure_rel_l2_pct`.
3. Code diff summary: which lines you touched in train.py, which fields you mirrored, and the exact channel index used for tau_y.

## Baseline

Single-model SOTA — PR #823 (nezuko, surf→vol xattn, run `ghh0s4ne`):

| Metric | Val | Test |
|---|---:|---:|
| **abupt** | **6.4407%** | **7.6992%** |
| surface_pressure | 4.1836 | 3.8451 |
| **volume_pressure** | 3.8557 | **11.6704** ← primary target |
| wall_shear | 7.3448 | 7.0429 |
| tau_x | 5.7782 | 6.2773 |
| tau_y | 7.5977 | 7.6657 |
| tau_z | 9.0116 | 9.0375 |

EP trajectory (PR #823 reference): EP1=28.63 → EP2=8.15 → EP3=7.12 → EP4=6.81 → EP6=6.59 → EP13=6.44%.

Test volume_pressure target to beat: **< 11.3478%** (current K=6 ensemble pool best from PR #880).

## Implementation Notes

- Zero throughput overhead: the mirror op is a trivial in-place tensor negation on GPU.
- **Do NOT apply mirror during val/eval.** The flag is train-only.
- When `--no-use-train-mirror-aug` or flag absent, training must be bit-identical to PR #823 reproduce command.
- The `_replace` pattern works if batch is a named tuple; adapt to your batch container's API.
- If normals (surface normals) are present as a batch field, also negate their y-component under the mirror.
