### PR TITLE
Vol→vol self-attention block post surf→vol xattn (decoder pattern)

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -112,6 +112,7 @@ def build_model_from_config(config: dict) -> SurfaceTransolver:
         pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
         use_qk_norm=bool(config.get("use_qk_norm", False)),
         use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        use_vol_self_attn_block=bool(config.get("use_vol_self_attn_block", False)),
     )
 
 

--- a/model.py
+++ b/model.py
@@ -256,6 +256,53 @@ class TransolverAttention(nn.Module):
         return _apply_token_mask(out_x, attn_mask)
 
 
+class VolSelfAttnBlock(nn.Module):
+    """Pre-norm vol-only self-attention + FFN, inserted after surf->vol xattn (PR #906).
+
+    Standard Vaswani 2017 decoder pattern: cross-attention conditions vol tokens
+    on surface geometry (PR #823); this block lets the conditioned vol tokens
+    spatially communicate to form a coherent volume pressure field. Output
+    projections (self_attn.out_proj, ffn[-1]) are zero-initialised so the block
+    is identity at init and preserves the PR #823 baseline at epoch 0.
+
+    Matches the PR #906 spec exactly: no key_padding_mask (so the SDPA fast path
+    stays available on bf16). Padding pollution is bounded because the input is
+    pre-masked by ``_apply_token_mask`` upstream and the final ``volume_out``
+    output is masked again, leaving only constant-offset bias terms to be
+    absorbed by the model.
+    """
+
+    def __init__(self, hidden_dim: int, num_heads: int, mlp_ratio: float = 4.0, dropout: float = 0.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.self_attn = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            batch_first=True,
+            dropout=dropout,
+        )
+        self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
+        mlp_hidden = int(hidden_dim * mlp_ratio)
+        self.ffn = nn.Sequential(
+            nn.Linear(hidden_dim, mlp_hidden),
+            nn.GELU(),
+            nn.Linear(mlp_hidden, hidden_dim),
+        )
+        nn.init.zeros_(self.self_attn.out_proj.weight)
+        nn.init.zeros_(self.self_attn.out_proj.bias)
+        nn.init.zeros_(self.ffn[-1].weight)
+        nn.init.zeros_(self.ffn[-1].bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x_norm = self.norm1(x)
+        attn_out, _ = self.self_attn(x_norm, x_norm, x_norm, need_weights=False)
+        x = residual + attn_out
+        residual = x
+        x = residual + self.ffn(self.norm2(x))
+        return x
+
+
 class TransformerBlock(nn.Module):
     def __init__(
         self,
@@ -343,6 +390,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_self_attn_block: bool = False,
+        vol_self_attn_mlp_ratio: float | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +405,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_self_attn_block = use_vol_self_attn_block
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +493,26 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # Vol-only self-attention + FFN block (PR #906): standard Vaswani 2017
+        # decoder pattern applied to volume tokens after surf->vol xattn. Lets
+        # the surface-conditioned vol tokens spatially communicate before the
+        # volume regression head. Identity-at-init via zero-init out_proj on
+        # both the attention sublayer and the FFN's second linear.
+        if use_vol_self_attn_block:
+            mlp_ratio_effective = (
+                float(vol_self_attn_mlp_ratio)
+                if vol_self_attn_mlp_ratio is not None
+                else float(mlp_ratio)
+            )
+            self.vol_self_attn_block = VolSelfAttnBlock(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                mlp_ratio=mlp_ratio_effective,
+                dropout=dropout,
+            )
+        else:
+            self.vol_self_attn_block = None
 
     def _encode_group(
         self,
@@ -544,6 +614,14 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.vol_self_attn_block is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            volume_hidden = self.vol_self_attn_block(volume_hidden)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_self_attn_block: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_self_attn_block": (
+            "Enable vol-only self-attention + FFN block (PR #906) after the "
+            "surf->vol cross-attention residual update, before the volume "
+            "regression head. Standard Vaswani 2017 decoder pattern: cross-"
+            "attention conditions vol tokens on surface geometry, then this "
+            "block lets the conditioned vol tokens spatially communicate to "
+            "form a coherent volume pressure field. Pre-norm; "
+            "nn.MultiheadAttention(embed_dim=hidden, heads=--model-heads) + "
+            "MLP(--model-mlp-ratio expansion). Output projections are "
+            "zero-initialised so the block is identity at init. Requires "
+            "--use-surf-to-vol-xattn (the prior conditioning step)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_self_attn_block=config.use_vol_self_attn_block,
     )
 
 
@@ -773,7 +787,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_self_attn_block:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The surf→vol cross-attention (PR #823) lets volume tokens query surface geometry — a proven broad-spectrum win. But after xattn, each vol token has only received a surface-conditioning signal; the vol tokens cannot yet communicate with **each other**. Volumetric pressure in CFD has inherently non-local spatial structure (wake propagation, pressure gradients, stagnation zones) that requires vol-to-vol communication, not just surface conditioning.

This PR adds a **vol-only self-attention block** immediately after the surf→vol xattn residual update, before the volume regression head. The block lets vol tokens spatially integrate the surface-conditioning signal they just received. This is architecturally distinct from:
- PR #884 / #890 (two-layer xattn — K/V gradient backflow NEGATIVE): we are NOT adding another surf→vol xattn, only a vol→vol self-attention
- PR #891 (post-xattn FFN NEGATIVE): we are NOT just adding an FFN, but adding full spatial attention among vol tokens

**Why this matters for test_vol_pressure OOD:** The 4 OOD test cases likely produce unusual pressure fields in specific spatial regions. A vol-self-attention block after xattn allows vol tokens near the anomalous geometry (which just received surface conditioning signals via xattn) to spatially communicate and form a coherent volume pressure field. An FFN alone cannot do this — it processes each vol token independently.

**Implementation:** Add one `nn.MultiheadAttention(embed_dim=512, num_heads=4, batch_first=True)` + `nn.LayerNorm(512)` + `nn.Linear(512, 2048) + GELU + nn.Linear(2048, 512)` block that operates on vol_hidden **after** the surf→vol xattn output. Zero-init the out_proj of the attention and the second linear of the FFN. Residual connections; pre-norm (LayerNorm before attention, LayerNorm before FFN).

**References:** This is the standard "decoder block" pattern from the original Transformer (Vaswani 2017) — encoder cross-attention followed by self-attention + FFN on the decoder side. We are using it here as a "volume decoder refinement block" after xattn conditioning.

## Instructions

1. **Add a new flag** `--use-vol-self-attn-block` (bool, default False) to `train.py`

2. **Add a `VolSelfAttnBlock` module** in `train.py` (or the model file):
   ```python
   class VolSelfAttnBlock(nn.Module):
       def __init__(self, hidden_dim: int, num_heads: int, mlp_ratio: float = 4.0):
           super().__init__()
           self.norm1 = nn.LayerNorm(hidden_dim)
           self.self_attn = nn.MultiheadAttention(
               embed_dim=hidden_dim, num_heads=num_heads,
               batch_first=True, dropout=0.0
           )
           self.norm2 = nn.LayerNorm(hidden_dim)
           self.ffn = nn.Sequential(
               nn.Linear(hidden_dim, int(hidden_dim * mlp_ratio)),
               nn.GELU(),
               nn.Linear(int(hidden_dim * mlp_ratio), hidden_dim),
           )
           # zero-init output projections for identity-at-init
           nn.init.zeros_(self.self_attn.out_proj.weight)
           nn.init.zeros_(self.self_attn.out_proj.bias)
           nn.init.zeros_(self.ffn[-1].weight)
           nn.init.zeros_(self.ffn[-1].bias)

       def forward(self, x):  # x: (B, N_vol, hidden_dim)
           # Pre-norm self-attention
           residual = x
           x_norm = self.norm1(x)
           attn_out, _ = self.self_attn(x_norm, x_norm, x_norm, need_weights=False)
           x = residual + attn_out
           # Pre-norm FFN
           residual = x
           x = residual + self.ffn(self.norm2(x))
           return x
   ```

3. **Insert the block** after the surf→vol xattn residual update, before the vol regression head:
   ```python
   # Existing: vol_hidden = vol_hidden + xattn_out  (residual from surf→vol xattn)
   # ADD: if self.vol_self_attn_block is not None:
   #          vol_hidden = self.vol_self_attn_block(vol_hidden)
   # Then: vol_out = self.vol_head(vol_hidden)
   ```

4. **DDP constraint**: Add `find_unused_parameters=True` on the DDP wrapper (already required for `--use-surf-to-vol-xattn` — ensure it also covers this new module).

5. **Run the 4-epoch screen** with the standard SOTA config + `--use-surf-to-vol-xattn --use-vol-self-attn-block`:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-self-attn-block \
  --wandb-group edward-vol-self-attn-post-xattn \
  --wandb-name edward/vol-self-attn-screen
```

6. **Kill gates** (report val_abupt at each epoch boundary):
   - EP1 (step ~10,864): must be **≤30%**
   - EP2 (step ~21,728): must be **≤16%**
   - EP3 (step ~32,592): must be **≤8.0%**
   - EP4 (step ~38,028 or timeout): must be **<6.9%** to proceed to Phase 2

7. **If Phase 1 passes** (EP4 < 6.9%): run the full 13-epoch schedule with the same flags, replacing `--epochs 4 --lr-cosine-t-max 13` with `--epochs 13 --lr-cosine-t-max 13` and using the 13-epoch vol-curriculum `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`.

## Baseline to Beat

| Metric | Single-model SOTA (PR #823) | Target |
|---|---|---|
| val_abupt | **6.4407%** | < 6.4407% |
| test_abupt | 7.6992% | — |
| test_vol_pressure | 11.6704% | ≤ 11.0% (weak win) |
| val_vol_pressure | 3.8557% | — |

W&B run: `ghh0s4ne` (group `nezuko-surf-vol-xattn`)

**Note:** `--use-surf-to-vol-xattn` is required and must come before `--use-vol-self-attn-block`. The `find_unused_parameters=True` DDP flag must be active when either of these is used.
