### PR TITLE
Xattn K/V grad scale sweep α=0.5 and α=0.75 (follow-up from #896)

### DIFF
--- a/model.py
+++ b/model.py
@@ -33,6 +33,28 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+class _GradScale(torch.autograd.Function):
+    """Identity in forward, scales gradient by `alpha` in backward.
+
+    Mirrors the Gradient Reversal Layer pattern (Ganin & Lempitsky 2015) but
+    with a positive scale. Used to damp K/V backflow into the surface encoder
+    on the surf->vol cross-attention sublayer (PR #896).
+    """
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, alpha: float) -> torch.Tensor:
+        ctx.alpha = float(alpha)
+        return x.view_as(x)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        return grad_output * ctx.alpha, None
+
+
+def _scale_grad(x: torch.Tensor, alpha: float) -> torch.Tensor:
+    return _GradScale.apply(x, alpha)
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -343,6 +365,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_kv_grad_scale: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +379,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_kv_grad_scale = float(xattn_kv_grad_scale)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -536,10 +560,18 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            # PR #896: scale K/V backward gradient by alpha (forward identity).
+            # Damps surface-encoder co-adaptation through cross-attn without
+            # killing it (PR #890 detach NEGATIVE arm). Surface-output-head
+            # path through `surface_hidden` stays unscaled.
+            if self.xattn_kv_grad_scale != 1.0:
+                surf_kv = _scale_grad(surface_hidden, self.xattn_kv_grad_scale)
+            else:
+                surf_kv = surface_hidden
             xattn_out, _ = self.surf_to_vol_xattn(
                 query=volume_hidden,
-                key=surface_hidden,
-                value=surface_hidden,
+                key=surf_kv,
+                value=surf_kv,
                 need_weights=False,
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_kv_grad_scale: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_kv_grad_scale": (
+            "Multiplicative scale (alpha) applied to the K/V backward "
+            "gradient on the surface->volume cross-attention only "
+            "(PR #896). Forward is identity. alpha=1.0 (default) "
+            "preserves PR #823 behaviour; alpha=0.0 detaches (matches "
+            "PR #890 NEGATIVE arm). Targets the regime where surface "
+            "encoder co-adaptation through xattn K/V is damped without "
+            "being killed. Only active when --use-surf-to-vol-xattn is "
+            "set and value is < 1.0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_kv_grad_scale=config.xattn_kv_grad_scale,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #896 (α=0.25 K/V gradient scaling) confirmed the mechanism is real but the value was too aggressive:
- α=0.0 (full detach, PR #890): **EP1 kill gate** — no surface→vol gradient backflow prevents co-adaptation entirely
- α=0.25 (PR #896): **EP3 FAIL** at 8.954% — slope stalled (EP1→EP2: −4.05pp, EP2→EP3: −0.44pp). 75% reduction is too much damping.
- α=1.0 (no scaling, SOTA PR #823): val_abupt=6.4407% — unconstrained backflow works best so far

The three data points bracket a region: damping exists between α=0 and α=1 that might help OOD without harming convergence. The stalling at α=0.25 suggests the optimal α is **closer to 1.0** (gentle damping, not aggressive). We test:
- **Arm A: α=0.5** — half the normal K/V gradient magnitude. Intermediate between #890 (killed) and #896 (stalled).
- **Arm B: α=0.75** — gentle 25% damping. Much closer to the SOTA unconstrained regime.

**Why this could help vol_pressure OOD:** The 4 OOD test cases produce surface features that the surface encoder maps to geometry embeddings very different from training. Unconstrained K/V backflow adapts the surface encoder to maximize agreement with the full training set; a slight damping might produce a surface encoder that generalizes more broadly to OOD geometries rather than over-specializing.

**Note:** The `--xattn-kv-grad-scale` flag already exists in `train.py` from PR #896. No new code changes needed — this is a pure hyperparameter sweep.

## Instructions

**Arm A: α=0.5 (run first)**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-kv-grad-scale 0.5 \
  --wandb-group frieren-xattn-kv-grad-scale-sweep \
  --wandb-name frieren/xattn-kv-scale-alpha0.5-screen
```

**Kill gates for Arm A:**
- EP1 (~step 10,864): **≤30%** — if ≥31%, kill immediately
- EP2 (~step 21,728): **≤16%**
- EP3 (~step 32,592): **≤8.0%** — if FAIL, kill and launch Arm B
- EP4 (~step 38,028): **<6.9%** to proceed to 13-ep Phase 2

**Comparison anchor for Arm A:** PR #896 α=0.25 at EP2 was 9.395%. Arm A α=0.5 should show a steeper EP2→EP3 slope. If EP3 is ≥8.95% (same as PR #896), kill immediately — α=0.5 is not a step-function improvement.

**Arm B: α=0.75 (launch if Arm A passes EP3 gate OR if Arm A fails EP3 with a worse slope than #896)**
- If Arm A EP3 < 8.0% (PASS): both arms continue; Arm A proceeds to EP4; launch Arm B immediately
- If Arm A EP3 ≥ 8.0% (FAIL): kill Arm A, launch Arm B with α=0.75

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-kv-grad-scale 0.75 \
  --wandb-group frieren-xattn-kv-grad-scale-sweep \
  --wandb-name frieren/xattn-kv-scale-alpha0.75-screen
```

**Kill gates for Arm B:** same gates as Arm A.

**Phase 2 (if any arm passes EP4 gate < 6.9%):**
Replace `--epochs 4 --lr-cosine-t-max 13` with `--epochs 13 --lr-cosine-t-max 13` and `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`. Keep the winning α.

## Baseline to Beat

| Metric | Single-model SOTA (PR #823) |
|---|---|
| val_abupt | **6.4407%** |
| test_abupt | 7.6992% |
| test_vol_pressure | 11.6704% |

W&B run: `ghh0s4ne` (group `nezuko-surf-vol-xattn`)

**Reference (PR #896 α=0.25 trajectory for comparison):**
| EP | val_abupt | Δ |
|---|---|---|
| EP1 | 13.449% | — |
| EP2 | 9.395% | −4.054pp |
| EP3 | 8.954% | −0.441pp (stalled) |

Arm A α=0.5 should show a meaningfully steeper EP2→EP3 slope than −0.441pp if it is an improvement.
