### PR TITLE
Vol k-NN graph attn post-xattn: locality-preserving vol token mixing

### DIFF
--- a/model.py
+++ b/model.py
@@ -288,6 +288,127 @@ class TransformerBlock(nn.Module):
         return x
 
 
+class VolumeKNNAttention(nn.Module):
+    """k-NN graph attention on volume tokens post-surf-xattn (PR #916).
+
+    Each vol token (Q) attends to its ``k`` spatial nearest neighbours (K/V)
+    in raw xyz space. ``out_proj`` is zero-initialised so the residual update
+    is identity at init, preserving the upstream xattn baseline at epoch 0.
+
+    Implementation notes:
+    - kNN distances are computed in float32 with ``no_grad`` and chunked along
+      the query axis, avoiding the ``(B, N, N)`` materialisation that
+      ``torch.cdist`` would create. Padded positions (``vol_mask=False``) are
+      pushed to a large distance so they never enter any token's k-nearest
+      set; padded queries are zeroed at the output.
+    - Attention is implemented manually because ``nn.MultiheadAttention`` /
+      SDPA fails with the very large batch dim (``B*N`` ~ 65k) we get when
+      flattening per-token kNN sets under bf16 autocast. Since each query
+      attends to only ``k`` keys, manual matmuls are both correct and cheap.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int = 4,
+        k: int = 8,
+        chunk_size: int = 2048,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.k = k
+        self.chunk_size = chunk_size
+        self.dropout_p = dropout
+        self.q_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.k_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.v_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.out_proj = LinearProjection(hidden_dim, hidden_dim)
+        self.attn_dropout = nn.Dropout(dropout)
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        # Identity-at-init: zero-init the output projection so the residual
+        # update is exactly zero at step 0.
+        nn.init.zeros_(self.out_proj.project.weight)
+        nn.init.zeros_(self.out_proj.project.bias)
+
+    def _knn_indices(
+        self,
+        vol_coords: torch.Tensor,
+        vol_mask: torch.Tensor,
+        k: int,
+    ) -> torch.Tensor:
+        B, N, _ = vol_coords.shape
+        device = vol_coords.device
+        # Force float32 distances regardless of any active autocast: bf16
+        # rounding can otherwise produce ties / wrong neighbour indices.
+        coords = vol_coords.detach().float()
+        # Push padded positions to "infinity" so they are never selected as
+        # neighbours of any valid query token. (B, 1, N) broadcast.
+        invalid = (~vol_mask).unsqueeze(1).to(coords.dtype) * 1.0e8
+        knn_idx = torch.zeros(B, N, k, dtype=torch.long, device=device)
+        chunk = max(1, self.chunk_size)
+        for start in range(0, N, chunk):
+            end = min(start + chunk, N)
+            diff = coords[:, start:end, :].unsqueeze(2) - coords.unsqueeze(1)
+            dist2 = (diff * diff).sum(-1)  # (B, C, N), float32
+            dist2 = dist2 + invalid  # broadcasts (B, 1, N) -> (B, C, N)
+            self_idx = torch.arange(start, end, device=device)
+            local_idx = torch.arange(end - start, device=device)
+            dist2[:, local_idx, self_idx] = 1.0e9
+            knn_idx[:, start:end, :] = dist2.topk(k, dim=-1, largest=False).indices
+        return knn_idx
+
+    def forward(
+        self,
+        vol_hidden: torch.Tensor,
+        vol_coords: torch.Tensor,
+        vol_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        B, N, D = vol_hidden.shape
+        H = self.num_heads
+        d = self.head_dim
+        k = min(self.k, N)
+        if N == 0 or k == 0:
+            return vol_hidden
+
+        with torch.no_grad():
+            knn_idx = self._knn_indices(vol_coords, vol_mask, k)  # (B, N, k)
+
+        # Project Q, K, V once for all tokens, then gather neighbours.
+        q = self.q_proj(vol_hidden).reshape(B, N, H, d)
+        k_proj = self.k_proj(vol_hidden).reshape(B, N, H, d)
+        v_proj = self.v_proj(vol_hidden).reshape(B, N, H, d)
+
+        # Flat indexing into the (B*N, H, d) buffer with batch offsets so we
+        # never materialise (B, N, N, *) anywhere.
+        b_offset = torch.arange(B, device=vol_hidden.device).view(B, 1, 1) * N
+        flat_idx = (knn_idx + b_offset).reshape(B * N * k)
+        k_flat = k_proj.reshape(B * N, H, d)
+        v_flat = v_proj.reshape(B * N, H, d)
+        # k_n / v_n: (B, N, k, H, d) -> (B, N, H, k, d)
+        k_n = k_flat[flat_idx].reshape(B, N, k, H, d).permute(0, 1, 3, 2, 4)
+        v_n = v_flat[flat_idx].reshape(B, N, k, H, d).permute(0, 1, 3, 2, 4)
+
+        # Manual scaled dot-product attention with seq_len_q=1, seq_len_k=k.
+        # q_h: (B, N, H, 1, d); attn_logits: (B, N, H, 1, k).
+        scale = 1.0 / math.sqrt(d)
+        q_h = q.unsqueeze(-2)
+        attn_logits = torch.matmul(q_h, k_n.transpose(-2, -1)) * scale
+        attn_weights = attn_logits.softmax(dim=-1)
+        attn_weights = self.attn_dropout(attn_weights)
+        attn_out = torch.matmul(attn_weights, v_n).squeeze(-2)  # (B, N, H, d)
+        attn_out = attn_out.reshape(B, N, D)
+
+        attn_out = self.out_proj(attn_out)
+        attn_out = _apply_token_mask(attn_out, vol_mask)
+        out = self.norm(vol_hidden + attn_out)
+        return _apply_token_mask(out, vol_mask)
+
+
 class Transformer(nn.Module):
     def __init__(
         self,
@@ -343,6 +464,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_knn_attn: bool = False,
+        use_vol_knn_attn_k: int = 8,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +479,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_knn_attn = use_vol_knn_attn
+        self.use_vol_knn_attn_k = use_vol_knn_attn_k
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +568,20 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # k-NN graph attention on volume tokens (PR #916). Inserted after the
+        # surf->vol xattn residual update so each vol token can mix with its
+        # spatial nearest neighbours. out_proj zero-initialised => identity at
+        # init, preserving the upstream baseline.
+        if use_vol_knn_attn:
+            self.vol_knn_attn = VolumeKNNAttention(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                k=use_vol_knn_attn_k,
+                dropout=dropout,
+            )
+        else:
+            self.vol_knn_attn = None
 
     def _encode_group(
         self,
@@ -545,6 +684,18 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.vol_knn_attn is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            vol_coords = volume_x[:, :, : self.space_dim]
+            volume_hidden = self.vol_knn_attn(
+                vol_hidden=volume_hidden,
+                vol_coords=vol_coords,
+                vol_mask=volume_mask,
+            )
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_knn_attn: bool = False
+    use_vol_knn_attn_k: int = 8
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_knn_attn": (
+            "Enable k-NN graph attention on vol tokens post-xattn "
+            "(PR #916). Each vol token attends to its k spatial nearest "
+            "neighbours (raw xyz). out_proj zero-initialised so the block "
+            "is identity at init. Recommended with --use-surf-to-vol-xattn."
+        ),
+        "use_vol_knn_attn_k": (
+            "Number of nearest neighbours for vol-kNN-attn (PR #916). "
+            "Default 8 (~wake-structure scale at N_vol=65536, ~1m^3 "
+            "domain). k=16 doubles compute but increases neighbourhood "
+            "reach."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_knn_attn=config.use_vol_knn_attn,
+        use_vol_knn_attn_k=config.use_vol_knn_attn_k,
     )
 
 
@@ -773,7 +789,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_knn_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

After surface→volume cross-attention (PR #823), each volume token has been enriched with surface context, but vol tokens still cannot communicate with each other. PR #906 (edward) tests full vol-self-attention for this role, which is O(N_vol²) and adds ~524K params.

This PR tests a more *locality-aware* approach: **k-nearest-neighbor graph attention on vol tokens, post-xattn**. Rather than every vol token attending to every other vol token globally, each token attends only to its k spatial nearest neighbors (k=8). This is:
- Cheap: O(N_vol · k) vs O(N_vol²) — at N_vol=65536, k=8 uses 8192× fewer attention pairs
- Physically motivated: in CFD, pressure and shear stress are governed by local spatial coupling (boundary layer gradients, wake interactions). The 4 OOD vol_p outlier cases (#767) have anomalous near-wake geometry — k-NN attention lets nearby vol tokens share this locality signal.
- Identity-at-init: zero-init out_proj preserves the xattn baseline exactly at epoch 0

Reference architecture: [PointNet++ (Qi et al. 2017)](https://arxiv.org/abs/1706.02413), [Graph Transformer Networks (Yun et al. 2019)](https://arxiv.org/abs/1911.06455), and [Point Transformer (Zhao et al. 2021)](https://arxiv.org/abs/2012.09164) all demonstrate that locality-preserving k-NN attention outperforms global self-attention for 3D point clouds at modest k values.

**Why k=8 specifically:** At N_vol=65536 with ~1m³ domain, k=8 gives ~1 neighbor per ~4cm³ — roughly wake-structure scale. k=16 is also reasonable but doubles compute; k=4 may be too sparse for pressure propagation.

## Instructions

You will add a `--use-vol-knn-attn` flag that, when enabled, inserts a k-NN graph attention block on `volume_hidden` immediately *after* the surf→vol xattn residual update (but before `volume_out`).

### Step 1: Add the flag to `train.py`

In the `TrainConfig` dataclass (around line 105), add:
```python
use_vol_knn_attn: bool = False
use_vol_knn_attn_k: int = 8
```

In `build_arg_parser` (around line 223), add argument descriptions:
```python
"use_vol_knn_attn": (
    "--use-vol-knn-attn",
    "Enable k-NN graph attention on vol tokens post-xattn (PR #916). "
    "Each vol token attends to its k spatial nearest neighbors. "
    "out_proj zero-initialised for identity-at-init. "
    "Requires --use-surf-to-vol-xattn.",
),
"use_vol_knn_attn_k": (
    "--use-vol-knn-attn-k",
    "Number of nearest neighbors for vol-kNN-attn (default 8).",
),
```

Pass both new fields through to `SurfaceTransolver(...)` at the model construction call (around line 310):
```python
use_vol_knn_attn=config.use_vol_knn_attn,
use_vol_knn_attn_k=config.use_vol_knn_attn_k,
```

Also gate `find_unused_parameters=True` for the new flag (around line 776):
```python
if config.use_surf_to_vol_xattn or config.use_vol_knn_attn:
    ddp_kwargs["find_unused_parameters"] = True
```

### Step 2: Implement in `model.py`

**Add `VolumeKNNAttention` class** (place after `TransformerBlock`, before `Transformer`):

```python
class VolumeKNNAttention(nn.Module):
    """
    k-NN graph attention on volume tokens post-surf-xattn.
    Each vol token (Q) attends to its k spatial nearest neighbours (K/V).
    out_proj zero-initialised → identity residual at init.
    """

    def __init__(self, hidden_dim: int, num_heads: int = 4, k: int = 8):
        super().__init__()
        self.k = k
        self.attn = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            batch_first=True,
        )
        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
        # Zero-init out_proj for identity-at-init
        nn.init.zeros_(self.attn.out_proj.weight)
        nn.init.zeros_(self.attn.out_proj.bias)

    def forward(
        self,
        vol_hidden: torch.Tensor,      # (B, N_vol, D)
        vol_coords: torch.Tensor,      # (B, N_vol, 3) — raw xyz for kNN
        vol_mask: torch.Tensor,        # (B, N_vol) bool, True = valid
    ) -> torch.Tensor:
        B, N, D = vol_hidden.shape
        k = min(self.k, N)

        # --- build k-NN indices (no gradients needed) ---
        with torch.no_grad():
            # pairwise squared distances: (B, N, N)
            diff = vol_coords.unsqueeze(2) - vol_coords.unsqueeze(1)  # (B, N, N, 3)
            dist2 = (diff * diff).sum(-1)  # (B, N, N)
            # exclude self by setting diagonal to large value
            dist2 = dist2 + torch.eye(N, device=dist2.device, dtype=dist2.dtype).unsqueeze(0) * 1e9
            # top-k nearest (smallest dist), shape (B, N, k)
            knn_idx = dist2.topk(k, dim=-1, largest=False).indices  # (B, N, k)

        # --- gather k-NN features as keys/values ---
        # knn_idx: (B, N, k) → expand to (B, N, k, D)
        idx_exp = knn_idx.unsqueeze(-1).expand(B, N, k, D)
        # vol_hidden expanded: (B, N, D) → (B, N, 1, D) → (B, N, k, D)
        knn_feats = torch.gather(
            vol_hidden.unsqueeze(2).expand(B, N, N, D),
            dim=2,
            index=idx_exp,
        )  # (B, N, k, D)

        # Reshape for batched attention: treat each point's k-NN as its own seq
        # Q: (B*N, 1, D),  K/V: (B*N, k, D)
        q = vol_hidden.reshape(B * N, 1, D)
        kv = knn_feats.reshape(B * N, k, D)

        attn_out, _ = self.attn(query=q, key=kv, value=kv, need_weights=False)
        attn_out = attn_out.reshape(B, N, D)  # (B, N, D)

        # Residual + norm
        out = self.norm(vol_hidden + attn_out)
        # Re-apply mask (zero out padding tokens)
        out = out * vol_mask.unsqueeze(-1)
        return out
```

**Note on memory:** The `knn_feats` gather above allocates an (B, N, N, D) intermediate tensor on the dist2 computation path. At B=4, N=65536, this is 4×65536×65536×4 bytes ≈ 68GB — **too large**. Use a chunked implementation instead. Replace the knn_idx computation with:

```python
        with torch.no_grad():
            # Chunked distance computation to avoid (B, N, N, 3) OOM
            # Process N tokens in chunks of chunk_size at a time
            chunk_size = 2048
            knn_idx = torch.zeros(B, N, k, dtype=torch.long, device=vol_hidden.device)
            for start in range(0, N, chunk_size):
                end = min(start + chunk_size, N)
                # chunk coords: (B, end-start, 3)
                chunk = vol_coords[:, start:end, :]  # (B, C, 3)
                # distances from chunk to all tokens: (B, C, N)
                diff = chunk.unsqueeze(2) - vol_coords.unsqueeze(1)  # (B, C, N, 3)
                dist2 = (diff * diff).sum(-1)  # (B, C, N)
                # mask self-distance
                self_mask = torch.zeros(B, end - start, N, device=dist2.device, dtype=dist2.dtype)
                row_idx = torch.arange(start, end, device=dist2.device)
                self_mask[:, torch.arange(end - start, device=dist2.device), row_idx] = 1e9
                dist2 = dist2 + self_mask
                knn_idx[:, start:end, :] = dist2.topk(k, dim=-1, largest=False).indices
```

Then for the gather, use a memory-efficient version without the (B, N, N, D) expansion:
```python
        # Memory-efficient gather: (B, N, k, D)
        idx_exp = knn_idx.unsqueeze(-1).expand(B, N, k, D)
        vol_exp = vol_hidden.unsqueeze(2).expand(B, N, k, D)  # safe: stride-only broadcast
        # gather along dim=1 (token dimension)
        knn_feats = torch.gather(
            vol_hidden[:, :, None, :].expand(B, N, k, D),
            dim=1,
            index=knn_idx.unsqueeze(-1).expand(B, N, k, D),
        )
```

Wait — the gather above is also O(B·N·k·D). At B=4, N=65536, k=8, D=512: 4×65536×8×512×4 bytes = 4GB — OK.

The problematic part is `vol_hidden.unsqueeze(2).expand(B, N, N, D)`. The correct gather is:

```python
        # Correct memory-efficient gather: no (B, N, N, D) materialisation
        # knn_idx: (B, N, k) — indices into the N dimension
        # vol_hidden: (B, N, D) → gather → (B, N, k, D)
        # Flatten B*N for the gather operation
        flat_hidden = vol_hidden.reshape(B * N, D)  # (B*N, D)
        # For each (b, i, j) in knn_idx, the global index is b*N + knn_idx[b,i,j]
        b_offset = torch.arange(B, device=vol_hidden.device).view(B, 1, 1) * N
        global_idx = (knn_idx + b_offset).reshape(B * N * k)  # (B*N*k,)
        knn_feats = flat_hidden[global_idx].reshape(B, N, k, D)  # (B, N, k, D)
```

This allocates only O(B·N·k·D) and avoids any O(B·N²) materialization.

**Wire into `SurfaceTransolver.__init__`** (around line 345):
```python
use_vol_knn_attn: bool = False,
use_vol_knn_attn_k: int = 8,
```
and in the body:
```python
self.use_vol_knn_attn = use_vol_knn_attn
if use_vol_knn_attn:
    self.vol_knn_attn = VolumeKNNAttention(
        hidden_dim=n_hidden,
        num_heads=num_heads,  # use same heads as backbone
        k=use_vol_knn_attn_k,
    )
else:
    self.vol_knn_attn = None
```

**Wire into `SurfaceTransolver.forward`** — insert immediately after the surf-xattn residual update (after line 547, before line 549 `if surface_x is not None:`):
```python
        if (
            self.vol_knn_attn is not None
            and volume_x is not None
            and volume_tokens > 0
        ):
            # volume_x[:, :, :3] is the xyz spatial coordinates
            vol_coords = volume_x[:, :, :3]
            volume_hidden = self.vol_knn_attn(
                vol_hidden=volume_hidden,
                vol_coords=vol_coords,
                vol_mask=volume_mask,
            )
```

### Step 3: Run the 4-epoch screen

Run this command:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-knn-attn \
  --use-vol-knn-attn-k 8 \
  --wandb-group askeladd-vol-knn-graph-attn \
  --wandb-name askeladd/vol-knn-attn-k8-4ep
```

**Kill gates (4-ep screen):**
- EP1 (≈step 10,864): `val_primary/abupt_axis_mean_rel_l2_pct` ≤ **30%**
- EP2 (≈step 21,728): ≤ **16%**
- EP3 (≈step 32,592): ≤ **8.0%**
- EP4 (≈step 38,030): ≤ **6.9%**

If EP3 or EP4 pass, continue to full 13-epoch run with identical flags but `--epochs 13 --lr-cosine-t-max 13`.

### Step 4: If 4-ep screen passes, run full 13-ep training

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-knn-attn \
  --use-vol-knn-attn-k 8 \
  --wandb-group askeladd-vol-knn-graph-attn \
  --wandb-name askeladd/vol-knn-attn-k8-13ep
```

## Baseline

**Single-model SOTA (PR #823, nezuko, run `ghh0s4ne`):**
- `val_primary/abupt_axis_mean_rel_l2_pct` = **6.4407%** (EP13)
- `test_primary/abupt_axis_mean_rel_l2_pct` = **7.6992%**
- `test_primary/volume_pressure_rel_l2_pct` = **11.6704%** ← primary OOD target
- `val_primary/surface_pressure_rel_l2_pct` = 4.1836%
- `val_primary/volume_pressure_rel_l2_pct` = 3.8557%
- `val_primary/wall_shear_rel_l2_pct` = 7.3448%

**Single-model training gate:** beat `val_abupt < 6.4407%`

**W&B baseline run:** [`ghh0s4ne`](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ghh0s4ne)

**EP1 baseline (from #823 training trajectory):** 28.63% — your EP1 should be ≤30%

## Implementation Notes

- The chunked kNN distance computation avoids OOM. At `chunk_size=2048`, `N_vol=65536`, this is 32 chunks × (B=4 × 2048 × 65536 × 3 × 4 bytes) ≈ 6.4GB per-chunk peak — acceptable.
- Do NOT use `torch.cdist` — it materializes the full (B, N, N) distance matrix.
- Verify `vol_coords = volume_x[:, :, :3]` gives actual xyz (check `DrivAerMLSurfaceDataset.__getitem__` if unsure; the first 3 dims of volume features are always xyz in this dataset).
- `VolumeKNNAttention` should be identity at init: after loading, run `model.vol_knn_attn.attn.out_proj.weight.abs().max()` — should be 0.0.
- After EP1, report `val_primary/abupt_axis_mean_rel_l2_pct` AND `val_primary/volume_pressure_rel_l2_pct` in your PR comment.

## Suggested follow-ups (if this PR wins)
- k=16 variant (double neighbor radius)
- k-NN radius threshold instead of fixed k (adaptive locality)
- Apply kNN attn at every backbone block boundary, not just post-xattn
