### PR TITLE
Mid-backbone surf→vol xattn injection: geometry conditioning at L=3

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_mid_backbone_xattn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_mid_backbone_xattn = use_mid_backbone_xattn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,25 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        if use_mid_backbone_xattn:
+            # Option B (PR #917 advisor approval, 2026-05-09): no post-LN on
+            # the mid-injection. LN(vol + 0) != vol because vol_mid is the
+            # raw post-block-2 residual (no prior LN), so a post-LN would
+            # break identity-at-init and replicate PR #892's EP1 failure.
+            # Strict identity holds with vol_mid = vol_mid + xattn_out and
+            # zero-init out_proj; the next backbone block's pre-norm handles
+            # the LN naturally.
+            self.mid_backbone_xattn = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            nn.init.zeros_(self.mid_backbone_xattn.out_proj.weight)
+            nn.init.zeros_(self.mid_backbone_xattn.out_proj.bias)
+        else:
+            self.mid_backbone_xattn = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -520,7 +541,44 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        if self.mid_backbone_xattn is not None:
+            split_idx = 3
+            for block in self.backbone.blocks[:split_idx]:
+                hidden = block(hidden, attn_mask=attn_mask)
+            hidden = _apply_token_mask(hidden, attn_mask)
+            if (
+                surface_x is not None
+                and volume_x is not None
+                and surface_tokens > 0
+                and volume_tokens > 0
+            ):
+                surf_mid = hidden[:, :surface_tokens]
+                vol_mid = hidden[:, surface_tokens : surface_tokens + volume_tokens]
+                xattn_mid_out, _ = self.mid_backbone_xattn(
+                    query=vol_mid,
+                    key=surf_mid,
+                    value=surf_mid,
+                    need_weights=False,
+                )
+                xattn_mid_out = _apply_token_mask(xattn_mid_out, volume_mask)
+                # Option B: residual-only (no post-LN). Strict identity at
+                # init with zero-init out_proj; pre-norm in backbone.blocks[3]
+                # handles normalization downstream.
+                vol_mid = vol_mid + xattn_mid_out
+                vol_mid = _apply_token_mask(vol_mid, volume_mask)
+                hidden = torch.cat(
+                    [
+                        surf_mid,
+                        vol_mid,
+                        hidden[:, surface_tokens + volume_tokens :],
+                    ],
+                    dim=1,
+                )
+            for block in self.backbone.blocks[split_idx:]:
+                hidden = block(hidden, attn_mask=attn_mask)
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_mid_backbone_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_mid_backbone_xattn": (
+            "Enable mid-backbone surf->vol cross-attention injection "
+            "after backbone block index 2 (i.e. after the 3rd of 5 layers; "
+            "PR #917). A separate nn.MultiheadAttention with its own "
+            "LayerNorm lets volume hidden states (Q) attend to surface "
+            "hidden states (K/V) mid-backbone, so subsequent blocks 3 and "
+            "4 can compound the geometry-conditioned volume tokens. "
+            "out_proj weight/bias zero-initialised. Composes with "
+            "--use-surf-to-vol-xattn (Arm B) or runs standalone (Arm A)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_mid_backbone_xattn=config.use_mid_backbone_xattn,
     )
 
 
@@ -773,7 +785,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_mid_backbone_xattn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The current surf→vol cross-attention (PR #823 SOTA) applies surface geometry conditioning **after the full L=5 backbone** (post-backbone LayerNorm). This means geometry information only reaches the volume tokens at the output head — layers L4 and L5 still evolve volume representations without any surface geometry context.

**Hypothesis:** Injecting a second surf→vol cross-attention at the **mid-backbone point (after layer L=3, index 2 of 0–4)** allows surface geometry to modulate the vol token representations **during** the deep backbone processing, not just after. L4 and L5 can then compound this geometry signal through additional Transolver attention and MLP passes. This mid-backbone injection should particularly help the 4 OOD test cases (run_133, run_226, run_203, run_158) which account for 92% of squared test_vol_p deviation — their near-wake anomalies require richer geometry-aware volume representations.

This approach is inspired by multi-scale feature fusion in FPN/U-Net architectures: conditioning early enough that the later layers can amplify and spatially integrate the geometry signal.

**Why L=3 (mid-point)?** L=5 backbone: indices 0, 1, 2, 3, 4. After layer-2 (the 3rd layer), the tokens have undergone half the attention+MLP computation. L3 and L4 then process geometry-conditioned volume tokens. The final-layer xattn (existing PR #823) still applies post-backbone for the output head.

## Instructions

Add a new CLI flag `--use-mid-backbone-xattn` to `train.py` and implement it in `model.py`. The change requires:

### 1. In `model.py` — `SurfaceTransolver.__init__`

Add parameter `use_mid_backbone_xattn: bool = False` and when `True`, create a second xattn sublayer registered as `self.mid_backbone_xattn` and `self.mid_backbone_xattn_norm`. Same architecture as the existing post-backbone xattn:

```python
# Mid-backbone surf→vol cross-attention (new hypothesis PR):
# Injects surface geometry into volume tokens after backbone layer L=3
# (index 2), allowing L4 and L5 to compound the geometry signal.
# Zero-init out_proj for identity-at-init.
if use_mid_backbone_xattn:
    self.mid_backbone_xattn = nn.MultiheadAttention(
        embed_dim=n_hidden,
        num_heads=n_head,
        batch_first=True,
        dropout=dropout,
    )
    self.mid_backbone_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.mid_backbone_xattn.out_proj.weight)
    nn.init.zeros_(self.mid_backbone_xattn.out_proj.bias)
else:
    self.mid_backbone_xattn = None
    self.mid_backbone_xattn_norm = None
```

Store `self.use_mid_backbone_xattn = use_mid_backbone_xattn`.

### 2. In `model.py` — `SurfaceTransolver.forward`

Replace the single `self.backbone(hidden, attn_mask=attn_mask)` call with a split execution that applies the mid-backbone xattn after layer-2:

```python
# Run backbone in two halves with mid-backbone xattn injection
if self.mid_backbone_xattn is not None:
    # First half: layers 0, 1, 2 (indices 0..2)
    for block in self.backbone.blocks[:3]:
        hidden = block(hidden, attn_mask=attn_mask)
    hidden = _apply_token_mask(hidden, attn_mask)
    # Extract current surface/volume token slices (pre-norm, raw hidden)
    cursor = 0
    if surface_x is not None:
        surf_mid = hidden[:, cursor : cursor + surface_tokens]
        cursor += surface_tokens
    if volume_x is not None:
        vol_mid = hidden[:, cursor : cursor + volume_tokens]
    # Mid-backbone surf→vol cross-attention (identity-at-init, zero out_proj)
    if (surface_x is not None and volume_x is not None
            and surface_tokens > 0 and volume_tokens > 0):
        xattn_mid_out, _ = self.mid_backbone_xattn(
            query=vol_mid,
            key=surf_mid,
            value=surf_mid,
            need_weights=False,
        )
        xattn_mid_out = _apply_token_mask(xattn_mid_out, volume_mask)
        vol_mid = self.mid_backbone_xattn_norm(vol_mid + xattn_mid_out)
        vol_mid = _apply_token_mask(vol_mid, volume_mask)
        # Write updated vol tokens back into hidden
        vol_start = 0
        if surface_x is not None:
            vol_start = surface_tokens
        hidden[:, vol_start : vol_start + volume_tokens] = vol_mid
    # Second half: layers 3, 4
    for block in self.backbone.blocks[3:]:
        hidden = block(hidden, attn_mask=attn_mask)
else:
    hidden = self.backbone(hidden, attn_mask=attn_mask)
```

### 3. In `train.py` — argument parsing and model instantiation

Add the flag (near the `--use-surf-to-vol-xattn` section):
```python
parser.add_argument("--use-mid-backbone-xattn", action=argparse.BooleanOptionalAction,
                    default=False,
                    help="Enable mid-backbone surf→vol cross-attention injection after layer L=3.")
```

Pass it through to `SurfaceTransolver` instantiation:
```python
use_mid_backbone_xattn=args.use_mid_backbone_xattn,
```

### 4. DDP `find_unused_parameters`

The existing `--use-surf-to-vol-xattn` already requires `find_unused_parameters=True` in the DDP wrapper (PR #823). Ensure that the condition for enabling this also covers `--use-mid-backbone-xattn`:
```python
find_unused_parameters = args.use_surf_to_vol_xattn or args.use_mid_backbone_xattn
```

### 5. Param count sanity check

The mid-backbone xattn adds one `nn.MultiheadAttention(512, 4)` + `nn.LayerNorm(512)` ≈ +1.05M params (same as the post-backbone xattn). Total model params should be ~18.04M (16.99M base + 1.05M post-backbone xattn from PR #823 + 1.05M mid-backbone xattn). Print and log the param count at the start of training.

### 6. Run Arm A (4-epoch screen, mid-backbone xattn only)

Use `--use-mid-backbone-xattn` **without** `--use-surf-to-vol-xattn` first (so we isolate the new mechanism's standalone contribution vs. the PR #823 post-backbone xattn):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-mid-backbone-xattn \
  --wandb-group nezuko-mid-backbone-xattn \
  --wandb-name nezuko/mid-backbone-xattn-standalone-screen
```

### 7. If Arm A passes EP3 (≤8.0%), run Arm B (4-epoch screen, both xattn injections)

Compose mid-backbone + post-backbone xattn (both `--use-mid-backbone-xattn --use-surf-to-vol-xattn`):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-mid-backbone-xattn \
  --use-surf-to-vol-xattn \
  --wandb-group nezuko-mid-backbone-xattn \
  --wandb-name nezuko/mid-backbone-xattn-composed-screen
```

### 8. If either arm passes EP4 (<6.9%), proceed to 13-epoch Phase 2

Change `--epochs 4` → `--epochs 13`, `--lr-cosine-t-max 13` (unchanged), `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`. Use the passing arm's config.

## Gates

- EP1 ≤30%, EP2 ≤16%, EP3 ≤8.0%, EP4 <6.9% (Phase 2 threshold)
- Kill on first missed gate. Post component breakdown (surf_p, vol_p, wall_shear).

## Baseline (current single-model SOTA — must beat to merge)

| Metric | Single-model SOTA (PR #823, run `ghh0s4ne`) |
|---|---|
| val_abupt | **6.4407%** |
| test_abupt | 7.6992% |
| test_vol_pressure | 11.6704% |
| val_surface_pressure | 4.1836% |
| val_volume_pressure | 3.8557% |
| val_wall_shear | 7.3448% |

**Training gate: val_abupt < 6.4407% (EP13 best checkpoint)**

The SOTA run `ghh0s4ne` EP-by-EP trajectory (for comparison):
- EP1: 28.63%, EP2: 8.15%, EP3: 7.12%, EP4: 6.81%, EP5: 6.67%, ..., EP13: 6.4407%

## Key implementation notes

- **`--no-compile-model` is required** — torch.compile + DDP NCCL deadlock at step 1
- **`find_unused_parameters=True` required for DDP** with conditional modules (`--use-mid-backbone-xattn`)
- **Zero-init out_proj** for identity-at-init is critical — without it the mid-backbone xattn will disrupt the backbone representations at epoch 0 before the surface encoder has learned geometry features
- **In-place hidden tensor update** in the forward pass: after the mid-backbone xattn, write the updated vol_mid tokens back into the `hidden` tensor so the second half of the backbone processes the geometry-conditioned tokens
- **Arm B is only worth running if Arm A passes EP3** — the standalone mid-backbone xattn must itself add value. If it fails, composing with post-backbone xattn won't save it.

## Suggested follow-ups (do not run in this PR)

- If Arm B (composed) beats Arm A (standalone), it suggests the two xattn injections are complementary — mid-backbone enriches the backbone processing, post-backbone enriches the output head
- If Arm A beats the baseline but Arm B doesn't, mid-backbone is sufficient and double-xattn overhead isn't justified
- If mid-backbone xattn wins, investigate which layer split (after L=2 vs L=3) is optimal — the current hypothesis uses after L=2 (0-indexed), which is exactly the mid-point of L=5
