### PR TITLE
tanjiro: vol-specific positional encoding sigmas for volume branch

### DIFF
--- a/model.py
+++ b/model.py
@@ -340,6 +340,7 @@ class SurfaceTransolver(nn.Module):
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
         rff_init_sigmas: list[float] | None = None,
+        vol_rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
@@ -353,6 +354,9 @@ class SurfaceTransolver(nn.Module):
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
+        self.vol_rff_init_sigmas = (
+            list(vol_rff_init_sigmas) if vol_rff_init_sigmas else None
+        )
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
@@ -370,11 +374,19 @@ class SurfaceTransolver(nn.Module):
                 sigma=rff_sigma,
                 init_sigmas=self.rff_init_sigmas,
             )
+            # PR #918: volume branch can use its own (typically lower-frequency)
+            # init sigmas. When vol_rff_init_sigmas is None, fall back to the
+            # shared rff_init_sigmas for backwards compatibility.
+            _vol_init_sigmas = (
+                self.vol_rff_init_sigmas
+                if self.vol_rff_init_sigmas is not None
+                else self.rff_init_sigmas
+            )
             self.volume_string_sep = StringSeparableEncoding(
                 in_dim=space_dim,
                 num_features=string_sep_features,
                 sigma=rff_sigma,
-                init_sigmas=self.rff_init_sigmas,
+                init_sigmas=_vol_init_sigmas,
             )
             string_sep_out_dim = self.surface_string_sep.output_dim  # 2 * space_dim * num_features
             self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)

--- a/train.py
+++ b/train.py
@@ -100,6 +100,7 @@ class Config:
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     rff_init_sigmas: str = ""
+    vol_rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "vol_rff_init_sigmas": (
+            "Comma-separated initial sigma values for the VOLUME "
+            "StringSeparableEncoding (PR #918). When set, the volume "
+            "branch's per-axis log-frequencies are initialised from "
+            "these sigmas independently of the surface branch's "
+            "--rff-init-sigmas. Empty (default) falls back to "
+            "--rff-init-sigmas, preserving prior behavior. Volume "
+            "pressure is a smoother global field than surface "
+            "pressure, so lower-frequency sigmas (e.g. "
+            "'0.05,0.1,0.25,0.5,1.0') often suit it better. Only "
+            "used when --pos-encoding-mode=string_separable."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -305,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
+        vol_rff_init_sigmas=parse_rff_init_sigmas(config.vol_rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,


### PR DESCRIPTION
## Hypothesis

Volume and surface pressure fields inhabit fundamentally different spatial frequency regimes. Surface pressure has sharp boundary-layer gradients and fine-scale features (length scales ~0.01–0.1 m), while volume pressure is a smoother global field with longer-range correlations (length scales ~0.1–1.0 m). Yet today, **both `surface_string_sep` and `volume_string_sep` are initialized with the same sigmas** (`0.25,0.5,1.0,2.0,4.0`), meaning the volume branch is trying to learn volumetric position encodings starting from surface-tuned frequencies.

This shared initialization biases the volume positional encoding toward high-frequency surface features and likely explains why `vol_p` shows a severe test-vs-val gap (~3× worse at test than val). The volume branch never develops its own low-frequency spatial vocabulary because it starts in the wrong frequency regime.

**Proposed fix**: Add a `--vol-rff-init-sigmas` CLI flag that initializes `volume_string_sep` with independent, lower-frequency sigmas (`0.05,0.1,0.25,0.5,1.0`) suited to the smoother volumetric domain, while `surface_string_sep` retains the current surface-tuned sigmas (`0.25,0.5,1.0,2.0,4.0`).

This is a **zero-overhead change**: same parameter count, same architecture, same training budget — just a different starting point that lets the volume encoding specialize to volumetric spatial scales from the first gradient step.

**Expected outcome**: Improved `vol_p` (both val and test), with test-vs-val gap narrowing toward ~1.5–2× rather than ~3×. Primary metric target: `val_abupt < 6.4407%`.

## Implementation Instructions

You will need to make two coordinated changes: one to `target/train.py` and one to `target/model.py`.

### 1. `target/train.py` — add new CLI flag

Find the `--rff-init-sigmas` argument (near the other `--rff-*` flags) and add a new argument immediately after it:

```python
parser.add_argument(
    "--vol-rff-init-sigmas",
    type=str,
    default=None,
    help=(
        "Comma-separated initial sigma values for the VOLUME StringSeparableEncoding. "
        "If None, falls back to --rff-init-sigmas (current behavior). "
        "Example: '0.05,0.1,0.25,0.5,1.0'"
    ),
)
```

Then find where `SurfaceTransolver(...)` is constructed (search for `rff_init_sigmas=`) and add a `vol_rff_init_sigmas` kwarg:

```python
vol_rff_init_sigmas = (
    parse_rff_init_sigmas(config.vol_rff_init_sigmas)
    if config.vol_rff_init_sigmas is not None
    else None  # will fall back to rff_init_sigmas inside model
)
model = SurfaceTransolver(
    ...,
    rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
    vol_rff_init_sigmas=vol_rff_init_sigmas,
    ...
)
```

### 2. `target/model.py` — accept and use the new param

In `SurfaceTransolver.__init__`, find the signature and add `vol_rff_init_sigmas=None`:

```python
def __init__(self, ..., rff_init_sigmas=None, vol_rff_init_sigmas=None, ...):
```

Then find where `self.volume_string_sep` is initialized (it currently uses the same `init_sigmas=self.rff_init_sigmas` as the surface branch). Change it to use its own sigmas when provided:

```python
# Surface StringSeparableEncoding — unchanged
self.surface_string_sep = StringSeparableEncoding(
    in_dim=space_dim,
    num_features=string_sep_features,
    sigma=rff_sigma,
    init_sigmas=self.rff_init_sigmas,
)

# Volume StringSeparableEncoding — use vol-specific sigmas if provided
_vol_init_sigmas = vol_rff_init_sigmas if vol_rff_init_sigmas is not None else self.rff_init_sigmas
self.volume_string_sep = StringSeparableEncoding(
    in_dim=space_dim,
    num_features=string_sep_features,
    sigma=rff_sigma,
    init_sigmas=_vol_init_sigmas,
)
```

That's the complete change. No other files need to be modified.

### Run the 4-epoch screen first

Use these sigmas for the first run: `--vol-rff-init-sigmas "0.05,0.1,0.25,0.5,1.0"` (5 frequencies shifted ~2–4× lower than surface).

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --vol-rff-init-sigmas "0.05,0.1,0.25,0.5,1.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group vol-rff-positional-encoding
```

**Screen gates** (kill if not beaten by end of epoch):
- EP1: `val_abupt ≤ 30%`
- EP2: `val_abupt ≤ 16%`
- EP3: `val_abupt ≤ 8.0%`
- EP4: `val_abupt < 6.9%`

If the 4-epoch screen passes, run the full 13-epoch training:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --vol-rff-init-sigmas "0.05,0.1,0.25,0.5,1.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group vol-rff-positional-encoding
```

### Optional follow-up (if screen passes, run in parallel)

Try even lower-frequency sigmas to probe the sensitivity:
- Arm B: `--vol-rff-init-sigmas "0.02,0.05,0.1,0.25,0.5"` (ultra-low freq)
- Arm C: `--vol-rff-init-sigmas "0.1,0.25,0.5,1.0,2.0"` (moderate shift)

Use `--wandb-group vol-rff-positional-encoding` for all arms so they're grouped in W&B.

## Baseline

Current best metrics (PR #823, single-model SOTA):

| Metric | Val | Test |
|--------|-----|------|
| `abupt` (primary) | **6.4407%** | 7.6992% |
| `surface_pressure` | 4.1836% | 3.8451% |
| `volume_pressure` | 3.8557% | **11.6704%** ← primary target |
| `wall_shear` | 7.3448% | 7.0429% |

Gate: `val_abupt < 6.4407%` to beat baseline.

Note the severe `vol_p` test-vs-val gap (val≈3.86%, test≈11.67%, ~3× ratio) — this is the **primary systematic issue** this experiment targets.

Baseline W&B run: `ghh0s4ne` — [wandb link](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ghh0s4ne)

Baseline reproduce command:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn
```
