### PR TITLE
[thorfinn] Geometric mixup augmentation to reduce OOD vol_p gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    geometric_mixup_alpha: float = 0.0
+    geometric_mixup_p: float = 0.5
     debug: bool = False
 
 
@@ -229,6 +231,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "geometric_mixup_alpha": (
+            "Geometric mixup augmentation strength (PR #921). When > 0, "
+            "for each training batch element with probability "
+            "--geometric-mixup-p, a second batch element is sampled and "
+            "lambda ~ Beta(alpha, alpha) is drawn (with lambda = "
+            "max(lambda, 1-lambda) so the primary geometry dominates). "
+            "Surface coords/normals/area, volume coords/sdf, and ALL "
+            "targets (cp, wall_shear xyz, volume_pressure) are linearly "
+            "interpolated index-wise. Surface normals are renormalised "
+            "post-mix. Mixing applies only at training; eval/test "
+            "untouched. 0.0 disables (default)."
+        ),
+        "geometric_mixup_p": (
+            "Per-element Bernoulli probability of applying geometric "
+            "mixup (PR #921). Only used when --geometric-mixup-alpha > 0. "
+            "Default 0.5 = each batch element has 50% chance of being "
+            "mixed with a partner."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -241,6 +261,104 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+def apply_geometric_mixup(batch, alpha: float, p: float = 0.5) -> tuple[object, dict[str, float]]:
+    """Geometric mixup augmentation for SurfaceBatch (PR #921).
+
+    For each batch element, with probability ``p``, a partner element is
+    chosen from the same batch (always different from self when B>=2) and
+    ``lambda ~ Beta(alpha, alpha)`` is drawn (then ``lambda = max(lambda,
+    1 - lambda)`` so the primary geometry dominates). Surface coords +
+    normals + area, volume coords + sdf, and ALL targets are linearly
+    interpolated index-wise; surface normals are renormalised post-mix.
+    The output mask is the primary's mask, with effective lambda = 1
+    at positions where the partner has padding (so the primary is
+    preserved unmodified there).
+    """
+    from data.loader import SurfaceBatch
+
+    metrics = {
+        "train/geometric_mixup/alpha": float(alpha),
+        "train/geometric_mixup/fraction_mixed": 0.0,
+        "train/geometric_mixup/lambda_mean": 1.0,
+    }
+    if alpha <= 0.0:
+        return batch, metrics
+    B = batch.surface_x.shape[0]
+    if B < 2:
+        return batch, metrics
+
+    device = batch.surface_x.device
+    dtype = batch.surface_x.dtype
+
+    do_mix = torch.rand(B, device=device) < float(p)
+
+    perm = torch.randperm(B, device=device)
+    self_idx = torch.arange(B, device=device)
+    same = perm == self_idx
+    if bool(same.any().item()):
+        perm = torch.where(same, (perm + 1) % B, perm)
+
+    lam = torch.distributions.Beta(float(alpha), float(alpha)).sample((B,)).to(device=device)
+    lam = torch.maximum(lam, 1.0 - lam)
+    lam = torch.where(do_mix, lam, torch.ones_like(lam))
+
+    pa_surface_x = batch.surface_x[perm]
+    pa_surface_y = batch.surface_y[perm]
+    pa_volume_x = batch.volume_x[perm]
+    pa_volume_y = batch.volume_y[perm]
+    pa_surface_mask = batch.surface_mask[perm]
+    pa_volume_mask = batch.volume_mask[perm]
+
+    surface_pos_mix = batch.surface_mask & pa_surface_mask  # only mix where both valid
+    volume_pos_mix = batch.volume_mask & pa_volume_mask
+
+    surface_eff_lam = torch.where(
+        surface_pos_mix,
+        lam.view(B, 1).expand_as(surface_pos_mix).to(dtype),
+        torch.ones_like(surface_pos_mix, dtype=dtype),
+    ).unsqueeze(-1)
+    volume_eff_lam = torch.where(
+        volume_pos_mix,
+        lam.view(B, 1).expand_as(volume_pos_mix).to(dtype),
+        torch.ones_like(volume_pos_mix, dtype=dtype),
+    ).unsqueeze(-1)
+
+    surface_x_mix = surface_eff_lam * batch.surface_x + (1.0 - surface_eff_lam) * pa_surface_x
+    surface_y_mix = surface_eff_lam * batch.surface_y + (1.0 - surface_eff_lam) * pa_surface_y
+    volume_x_mix = volume_eff_lam * batch.volume_x + (1.0 - volume_eff_lam) * pa_volume_x
+    volume_y_mix = volume_eff_lam * batch.volume_y + (1.0 - volume_eff_lam) * pa_volume_y
+
+    # Renormalise surface normals (channels 3:6) — lerp of unit vectors is non-unit.
+    normals_mix = surface_x_mix[..., 3:6]
+    normal_norm = torch.linalg.norm(normals_mix, dim=-1, keepdim=True).clamp(min=1e-6)
+    surface_x_mix = torch.cat(
+        [
+            surface_x_mix[..., 0:3],
+            normals_mix / normal_norm,
+            surface_x_mix[..., 6:7],
+        ],
+        dim=-1,
+    )
+
+    n_mixed = float(do_mix.sum().item())
+    metrics["train/geometric_mixup/fraction_mixed"] = n_mixed / float(B)
+    metrics["train/geometric_mixup/lambda_mean"] = (
+        float(lam[do_mix].mean().item()) if n_mixed > 0 else 1.0
+    )
+
+    mixed = SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x_mix,
+        surface_y=surface_y_mix,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x_mix,
+        volume_y=volume_y_mix,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+    return mixed, metrics
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -936,6 +1054,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mixup_metrics: dict[str, float] = {}
+                if config.geometric_mixup_alpha > 0.0:
+                    batch = batch.to(device)
+                    batch, mixup_metrics = apply_geometric_mixup(
+                        batch,
+                        alpha=config.geometric_mixup_alpha,
+                        p=config.geometric_mixup_p,
+                    )
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1072,6 +1198,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if mixup_metrics:
+                    train_log.update(mixup_metrics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

Geometric mixup augmentation to reduce the OOD vol_p gap. At train time, for each sample with probability p=0.5, randomly select a second training geometry and linearly interpolate both spatial coordinates (surface + vol point clouds) and all targets with a mixing weight α sampled from Beta(α_param, α_param). This generates virtual training examples that interpolate between real car geometries, potentially covering the gap between the training distribution and the 4 OOD test cases (run_133, run_226, run_203, run_158) that account for ~92% of squared test_vol_p deviation.

The vol_p OOD gap is extreme: test_vol_p ≈ 11.7% vs val_vol_p ≈ 3.9% (ratio ~3×), while val/test are well-matched for surface and wall-shear. Geometric mixup adds virtual interpolated geometries between training samples, which can act as implicit regularisation toward unseen geometry variants. This is orthogonal to all other changes currently in flight.

**Two-arm sweep (use all 8 GPUs, 4 per arm):**
- **Arm A** — α_param=0.5 (symmetric Beta, mean mix weight=0.5; strong interpolation)
- **Arm B** — α_param=0.3 (skewed toward one parent; gentler interpolation)

Both arms use mixup probability p=0.5 (applied per batch element independently).

## Implementation

Add a `--geometric-mixup-alpha` flag to `train.py` (default 0.0 = disabled). When enabled:
1. For each element in the batch with probability 0.5, sample a second random training element.
2. Sample λ ~ Beta(α, α). Set λ = max(λ, 1-λ) to keep the primary geometry dominant.
3. Linearly interpolate the surface point coordinates, volume point coordinates, and all targets (surface_pressure, volume_pressure, wall_shear components) with weight λ on the first sample and (1−λ) on the second.
4. Use the interpolated sample as the training input/target.

**Important**: Mixup applies only during training, not validation/test. Keep the existing loss weighting (`--tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0`) unchanged.

## Baseline to Beat

Single-model SOTA (PR #823, nezuko, W&B: `ghh0s4ne`):
| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | **11.6704%** ← target |
| wall_shear | 7.3448% | 7.0429% |

EP4 reference: val_abupt = 6.8087%

**AB-UPT targets**: surface_pressure ≤ 3.82%, wall_shear ≤ 7.29%, volume_pressure ≤ 6.08%

## Screen Protocol (4-ep, 8 GPUs total)

Run **two arms in parallel**, 4 GPUs each, using `torchrun --nproc_per_node=4`:

**Arm A** (`--geometric-mixup-alpha 0.5`):
```bash
cd target/ && torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --geometric-mixup-alpha 0.5 \
  --wandb_group geometric-mixup-ood
```

**Arm B** (`--geometric-mixup-alpha 0.3`):
```bash
cd target/ && torchrun --standalone --nproc_per_node=4 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --geometric-mixup-alpha 0.3 \
  --wandb_group geometric-mixup-ood
```

## Gate Criteria

**Proceed to full 13-ep run if either arm passes:**
- EP4 val_abupt ≤ 6.81% (matches PR #823 EP4 reference)

**Decisive positive signal:**
- test_vol_p < 11.0% (any reduction in OOD vol_p gap is informative)

**Full run command** (for the winning arm, using all 8 GPUs):
Replace `--epochs 4 --lr-cosine-t-max 13` with `--epochs 13 --lr-cosine-t-max 13` and `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`, use `--nproc_per_node=8`.

## Reporting

Report EP4 val_abupt for both arms, plus test_vol_p if full run completes. Include W&B run IDs for both arms. If neither arm passes the screen gate, report which α value performed better — the direction (mixup helping vs hurting) is itself informative.

---
tay
student:thorfinn
