### PR TITLE
[askeladd] Vol geo features: centroid+bbox dist to reduce OOD vol_p gap

### DIFF
--- a/model.py
+++ b/model.py
@@ -33,6 +33,79 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+VOL_GEO_FEATURE_DIM = 4
+
+
+def compute_vol_geo_features(
+    surface_x: torch.Tensor,
+    volume_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    volume_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Cheap geometry-derived features for each volume point.
+
+    Returns ``[B, N_v, 4]`` of ``[d_centroid, d_bbox_x_norm, d_bbox_y_norm,
+    d_bbox_z_norm]``: distance from the surface centroid (normalised by the
+    surface bbox diagonal), and per-axis position inside the surface bounding
+    box (signed, ~[-1, 1] inside the box). Computed per-sample from valid
+    surface points. Samples with N_s == 0 or no valid surface points (e.g.
+    empty surface views emitted by the loader when surface/volume view counts
+    differ) yield all-zero geo features so the projection input dim stays
+    consistent.
+    """
+
+    B = volume_x.shape[0]
+    N_v = volume_x.shape[1]
+    N_s = surface_x.shape[1]
+
+    if N_s == 0:
+        return volume_x.new_zeros(B, N_v, VOL_GEO_FEATURE_DIM)
+
+    surf_xyz = surface_x[:, :, :3]
+    vol_xyz = volume_x[:, :, :3]
+
+    surf_dtype = surf_xyz.dtype
+    mask_s_b = surface_mask.unsqueeze(-1).bool()
+    mask_s_f = mask_s_b.to(dtype=surf_dtype)
+
+    valid_count = mask_s_f.sum(dim=1)
+    has_valid_surface = (valid_count > 0).squeeze(-1)
+
+    surf_count = valid_count.clamp(min=1.0)
+    centroid = (surf_xyz * mask_s_f).sum(dim=1) / surf_count
+
+    pos_inf = torch.full_like(surf_xyz, float("inf"))
+    neg_inf = torch.full_like(surf_xyz, float("-inf"))
+    surf_for_min = torch.where(mask_s_b, surf_xyz, pos_inf)
+    surf_for_max = torch.where(mask_s_b, surf_xyz, neg_inf)
+    bbox_min = surf_for_min.min(dim=1).values
+    bbox_max = surf_for_max.max(dim=1).values
+
+    # For samples whose surface mask is entirely False, bbox_min=+inf,
+    # bbox_max=-inf -> nan downstream. Replace those with a unit bbox; the
+    # final geo features for those samples are zeroed below anyway.
+    valid_b3 = has_valid_surface.unsqueeze(-1).expand_as(bbox_min)
+    bbox_min = torch.where(valid_b3, bbox_min, torch.zeros_like(bbox_min))
+    bbox_max = torch.where(valid_b3, bbox_max, torch.ones_like(bbox_max))
+
+    bbox_center = (bbox_min + bbox_max) * 0.5
+    bbox_half = (bbox_max - bbox_min) * 0.5 + 1e-6
+    d_bbox = (vol_xyz - bbox_center.unsqueeze(1)) / bbox_half.unsqueeze(1)
+
+    # Normalise d_centroid by the surface bbox diagonal so it sits on the
+    # same O(1) scale as d_bbox. Without this, raw metres (~5m for DrivAerML)
+    # produces a ~5x scale mismatch vs the bbox features fed into the same
+    # LinearProjection (no preceding nonlinearity to rescale). Loh et al.
+    # ICML 2024 motivates global geometry features alongside SDF.
+    diff = vol_xyz - centroid.unsqueeze(1)
+    bbox_diag = (2.0 * bbox_half).norm(dim=-1, keepdim=True).clamp(min=1e-6)
+    d_centroid = diff.norm(dim=-1, keepdim=True) / bbox_diag.unsqueeze(1)
+
+    vol_geo = torch.cat([d_centroid, d_bbox], dim=-1)
+    vol_geo = vol_geo * has_valid_surface.view(B, 1, 1).to(dtype=vol_geo.dtype)
+    return vol_geo * volume_mask.unsqueeze(-1).to(dtype=vol_geo.dtype)
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -343,6 +416,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_geo_features: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,8 +430,10 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_geo_features = use_vol_geo_features
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
-        volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+        vol_geo_extra = VOL_GEO_FEATURE_DIM if use_vol_geo_features else 0
+        volume_extra_dim = max(0, self.volume_input_dim - space_dim) + vol_geo_extra
 
         if pos_encoding_mode == "string_separable":
             # STRING-separable: learnable per-axis log_freq + phase,
@@ -484,6 +560,17 @@ class SurfaceTransolver(nn.Module):
             raise ValueError("SurfaceTransolver requires surface_mask when surface_x is provided")
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
+
+        if self.use_vol_geo_features and volume_x is not None and volume_mask is not None:
+            if surface_x is not None and surface_mask is not None:
+                vol_geo = compute_vol_geo_features(
+                    surface_x, volume_x, surface_mask, volume_mask
+                )
+            else:
+                vol_geo = volume_x.new_zeros(
+                    volume_x.shape[0], volume_x.shape[1], VOL_GEO_FEATURE_DIM
+                )
+            volume_x = torch.cat([volume_x, vol_geo.to(dtype=volume_x.dtype)], dim=-1)
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_geo_features: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_geo_features": (
+            "Augment each volume token with 4 cheap geometry-derived "
+            "scalar features (PR #926): d_centroid (Euclidean distance "
+            "from each vol point to the per-sample surface-point "
+            "centroid) and d_bbox_x/y/z (per-axis position inside the "
+            "surface bounding box, normalised to [-1, 1]). Computed "
+            "on-the-fly inside the model from surface_x and volume_x; "
+            "no preprocessing or loader changes required. Adds 0 "
+            "parameters and increases the volume input projection from "
+            "1 -> 5 extra channels (sdf + 4 geo)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +320,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_geo_features=config.use_vol_geo_features,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Adding **cheap geometry-derived scalar features** to the volume input tokens will provide the vol branch with direct geometric context about where each volume point sits relative to the car body. This targets the primary failure mode: 4 OOD test cases (run_133, run_226, run_203, run_158) that account for 92% of squared `test_vol_p` deviation. These cases have unusual near-body flow structures that the model cannot resolve from volumetric coordinates alone.

**The intervention:** Augment each volume token's input from `[x, y, z, sdf]` (4 features) to `[x, y, z, sdf, d_centroid, d_bbox_x, d_bbox_y, d_bbox_z]` (8 features), adding:
- `d_centroid`: Euclidean distance from each vol point to the surface-point centroid (mean of surface_xyz). Encodes "how far from the car body is this volume point" in a rotation-invariant way.
- `d_bbox_x`, `d_bbox_y`, `d_bbox_z`: Per-axis signed distance from each vol point to the nearest surface bounding-box face. Encodes spatial position within the aerodynamic domain.

**Why this might work vs SDF (PR #734, CLOSED NEGATIVE):**
- PR #734 used `volume_sdf.npy` (pre-computed SDF on volume grid) as a direct feature — but that's already in the vol input as the 4th channel. The current hypothesis adds *relative geometry* features (centroid distance, bbox distances) that are orthogonal to the SDF channel and encode global spatial context rather than local surface proximity.
- The centroid distance is particularly powerful for OOD cases: if the OOD car has an unusual size or position, `d_centroid` directly signals that the downstream vol regions are geometrically atypical.
- This is computed **on-the-fly per batch** from `surface_xyz` and `volume_xyz`, so no preprocessing or PVC changes are needed.

**Why this is cheaper than surf→vol xattn for geometry conditioning:**
- Surf→vol xattn (PR #823 SOTA) uses a full `nn.MultiheadAttention(512, 4)` = +1.05M params, applied after the backbone.
- Centroid/bbox distance features: 0 extra parameters (just 4 additional scalar inputs to the existing RFF/STRING encoder). The RFF encoding already maps `volume_x` through a learned frequency basis — 4 extra input channels are cheap.
- These features can **stack on top of xattn** (PR #823 stack) without conflict.

**Related literature:** Geometry-aware conditioning via distance-to-boundary features is standard in level-set and signed-distance-function methods for flow prediction. See: NeuralSDF (Zheng et al. 2021), GINO (Li et al. 2023) which uses SDF as a geometry conditioning channel for Fourier Neural Operators. The current approach is a simpler, cheaper variant of the same idea.

## Instructions

### Step 1: Compute centroid and bbox distance features in `target/train.py`

In the training loop (or in a preprocessing step before the forward call), after `batch = batch.to(device)`, compute the geometry features from `batch.surface_x` and `batch.volume_x`:

```python
def compute_vol_geo_features(surface_x, volume_x, surface_mask, volume_mask):
    """
    Compute centroid-distance and bbox-distance features for volume tokens.
    
    Args:
        surface_x:   [B, N_s, 7]  surface features [x,y,z, nx,ny,nz, area]
        volume_x:    [B, N_v, 4]  volume features  [x,y,z, sdf]
        surface_mask: [B, N_s]    True = valid surface point
        volume_mask:  [B, N_v]    True = valid volume point
    
    Returns:
        vol_geo: [B, N_v, 4]  extra geometry features to concat onto volume_x
                              [d_centroid, d_bbox_x, d_bbox_y, d_bbox_z]
    """
    B, N_s, _ = surface_x.shape
    _, N_v, _ = volume_x.shape
    
    surf_xyz = surface_x[:, :, :3]   # [B, N_s, 3]
    vol_xyz  = volume_x[:, :, :3]    # [B, N_v, 3]
    
    # Compute per-sample centroid of valid surface points
    mask_s_f = surface_mask.unsqueeze(-1).float()  # [B, N_s, 1]
    surf_count = mask_s_f.sum(dim=1).clamp(min=1)  # [B, 1]
    centroid = (surf_xyz * mask_s_f).sum(dim=1) / surf_count  # [B, 3]
    
    # d_centroid: distance from each vol point to surface centroid
    diff = vol_xyz - centroid.unsqueeze(1)  # [B, N_v, 3]
    d_centroid = diff.norm(dim=-1, keepdim=True)  # [B, N_v, 1]
    
    # Bounding box of valid surface points
    INF = 1e9
    surf_xyz_masked = surf_xyz.clone()
    surf_xyz_masked[~surface_mask] = float('nan')
    
    # Use nanmin/nanmax per axis
    bbox_min = torch.stack([
        surf_xyz_masked[:, :, ax].nan_to_num(nan=INF).min(dim=1).values
        for ax in range(3)
    ], dim=1)  # [B, 3]
    bbox_max = torch.stack([
        surf_xyz_masked[:, :, ax].nan_to_num(nan=-INF).max(dim=1).values
        for ax in range(3)
    ], dim=1)  # [B, 3]
    
    # Signed distance from each vol point to nearest bbox face per axis
    # (positive = inside bbox, negative = outside)
    bbox_min_b = bbox_min.unsqueeze(1)  # [B, 1, 3]
    bbox_max_b = bbox_max.unsqueeze(1)  # [B, 1, 3]
    
    # Distance to bbox center normalized by bbox half-extent
    bbox_center = (bbox_min_b + bbox_max_b) / 2.0
    bbox_half   = (bbox_max_b - bbox_min_b) / 2.0 + 1e-6
    
    d_bbox = (vol_xyz - bbox_center) / bbox_half  # [B, N_v, 3] normalized position in bbox
    
    # Concatenate: [d_centroid, d_bbox_x, d_bbox_y, d_bbox_z]
    vol_geo = torch.cat([d_centroid, d_bbox], dim=-1)  # [B, N_v, 4]
    
    # Zero out padding
    vol_geo = vol_geo * volume_mask.unsqueeze(-1).float()
    
    return vol_geo
```

### Step 2: Augment volume_x with the geometry features

After computing `vol_geo`, concatenate it onto `batch.volume_x` before passing to the model:

```python
if cfg.use_vol_geo_features:
    vol_geo = compute_vol_geo_features(
        batch.surface_x, batch.volume_x, batch.surface_mask, batch.volume_mask
    )
    # Concatenate: volume_x goes from [B, N_v, 4] -> [B, N_v, 8]
    batch = dataclasses.replace(batch, volume_x=torch.cat([batch.volume_x, vol_geo], dim=-1))
```

Add to `TrainConfig` dataclass:

```python
use_vol_geo_features: bool = False
```

### Step 3: Update model.py to accept 8-channel volume input

In `target/model.py`, the volume input projection layer expects `volume_in_dim` channels. Change the model initialization to accept the augmented input when `use_vol_geo_features=True`:

Find the volume input embedding (something like `self.vol_input_proj = nn.Linear(vol_in_dim, n_hidden)` or the RFF encoder that encodes `volume_x`). The input dimension needs to go from 4 → 8 when the extra features are active.

The simplest approach: pass `vol_in_dim=8` when constructing the model if `cfg.use_vol_geo_features` is True. In `train.py` model construction:

```python
vol_in_dim = 8 if cfg.use_vol_geo_features else 4
model = SurfaceTransolver(
    ...,
    vol_in_dim=vol_in_dim,  # or however the model takes this
)
```

**Note:** Check `target/model.py` to find the exact parameter name for the volume input dimension. The model's `__init__` likely has something like `n_vol_features` or `vol_input_dim`. If the architecture hardcodes `4` for vol input, you'll need to make it configurable. This is a small change.

### Step 4: Run the 4-epoch screen

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-geo-features \
  --wandb-group askeladd-vol-centroid-dist \
  --wandb-name askeladd/vol-geo-feat-centroid-bbox
```

### Gate schedule

| Epoch | Vol pts | ~iters/ep | Cumulative end-step |
|---|---|---|---|
| EP1 | 16384 | 10,864 | 10,864 |
| EP2 | 32768 | 5,435 | 16,299 |
| EP3 | 49152 | 3,625 | 19,924 |
| EP4 | 65536 | 2,720 | 22,644 |

Gates:
- **EP1 ≤30.0%** — kill if missed
- **EP2 ≤16.0%** — kill if missed
- **EP3 ≤8.0%** — kill if missed
- **EP4 <6.9%** — Phase 2 trigger

### What to watch for
- Val `volume_pressure_rel_l2_pct` is the primary signal. If it drops below 3.5% (vs baseline 3.86% val), that is a very strong signal.
- Track the val/test vol_p ratio — **if it drops below 2.5×, this is the OOD fix we've been looking for.**
- Report per-channel val metrics at each gate: `surface_pressure_rel_l2_pct`, `wall_shear_rel_l2_pct`, `volume_pressure_rel_l2_pct`

## Baseline (Single-model SOTA — PR #823)

| Metric | Val (EP13 best ckpt) | Test |
|---|---|---|
| `abupt_axis_mean_rel_l2_pct` | **6.4407%** | **7.6992%** |
| `surface_pressure_rel_l2_pct` | 4.1836% | 3.8451% |
| `volume_pressure_rel_l2_pct` | 3.8557% | **11.6704%** |
| `wall_shear_rel_l2_pct` | 7.3448% | 7.0429% |
| `wall_shear_x_rel_l2_pct` | 5.7782% | 6.2773% |
| `wall_shear_y_rel_l2_pct` | 7.5977% | 7.6657% |
| `wall_shear_z_rel_l2_pct` | 9.0116% | 9.0375% |

Val→Test vol_p ratio: 11.6704 / 3.8557 = **3.027×** (primary OOD gap target)

**W&B run:** `ghh0s4ne` (group `nezuko-surf-vol-xattn`)
**Single-model gate:** val_abupt < **6.4407%** at best EP

**4-ep SOTA EP-by-EP trajectory:**
EP1=28.63%, EP2=8.15%, EP3=7.12%, EP4=6.81%
