### PR TITLE
[edward] Pre-xattn vol self-attn: query refinement before surf→vol xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_pre_xattn_vol_self_attn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,25 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Pre-xattn vol self-attention (PR #929): single MHA sublayer where
+        # volume hidden states attend to themselves (Q=K=V=vol_hidden) BEFORE
+        # the surf->vol cross-attention. T5-decoder ordering: refine the query
+        # stream internally before reaching across to surface keys/values.
+        # Zero-init out_proj so the layer is identity at init.
+        if use_pre_xattn_vol_self_attn:
+            self.pre_xattn_vol_self_attn = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            self.pre_xattn_vol_self_attn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.weight)
+            nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.bias)
+        else:
+            self.pre_xattn_vol_self_attn = None
+            self.pre_xattn_vol_self_attn_norm = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -528,6 +549,25 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.pre_xattn_vol_self_attn is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            pre_xattn_out, _ = self.pre_xattn_vol_self_attn(
+                query=volume_hidden,
+                key=volume_hidden,
+                value=volume_hidden,
+                key_padding_mask=~volume_mask,
+                need_weights=False,
+            )
+            # Guard against NaN from fully-masked rows (a sample with zero valid
+            # volume tokens has key_padding_mask all True -> softmax NaN).
+            pre_xattn_out = pre_xattn_out.nan_to_num(nan=0.0)
+            pre_xattn_out = _apply_token_mask(pre_xattn_out, volume_mask)
+            volume_hidden = self.pre_xattn_vol_self_attn_norm(volume_hidden + pre_xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_pre_xattn_vol_self_attn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_pre_xattn_vol_self_attn": (
+            "Enable pre-xattn vol self-attention (PR #929). Before the "
+            "surf->vol cross-attention, a single nn.MultiheadAttention block "
+            "lets volume hidden states attend to each other (vol Q=K=V). "
+            "Zero-init out_proj for identity-at-init. embed_dim follows "
+            "--model-hidden-dim and num_heads follows --model-heads."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +316,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_pre_xattn_vol_self_attn=config.use_pre_xattn_vol_self_attn,
     )
 
 
@@ -773,7 +782,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_pre_xattn_vol_self_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**Pre-xattn vol self-attention**: insert a single `nn.MultiheadAttention` (zero-init `out_proj`) on the volume hidden states immediately BEFORE the surf→vol cross-attention from PR #823. Each vol token first attends to its vol-token spatial neighbors, then forms its xattn query against the surface K/V from a richer, neighborhood-aware representation.

**Why this lever, and why now:**
The post-xattn capacity axis is **0-for-3** on this benchmark (PR #884 two-layer xattn, PR #891 post-xattn FFN, PR #906 post-xattn vol self-attn — all NEGATIVE). The PR #906 closure conclusion explicitly identified pre-xattn capacity as one of three remaining viable directions. Pre-xattn vol self-attn is the **direct symmetric counter** to PR #906 (post-xattn) — same capacity, same parameter budget, opposite side of the cross-attention boundary.

The mechanism is precise: the surf→vol xattn forms its volume query Q from each vol token in isolation. After backbone L=5, vol tokens have communication via the shared slice tokens (Transolver physics-attention), but no direct point-to-point spatial communication. A vol-vol MHA pass before xattn lets each vol token aggregate evidence from its spatial neighbors before forming its cross-attention query — this is the Perceiver-IO pattern of alternating self-attn / cross-attn within the latent stream (Jaegle et al. 2022 NeurIPS).

**Hypothesis test outcome value (informative either way):**
- **Win (EP3<8.0%, EP13 beats 6.4407% val):** pre-xattn refinement is the right placement → unlocks follow-up PE + composition experiments
- **Loss (EP3≥8.0%):** capacity axis fully closed regardless of placement → redirect cleanly to OOD aug and PE levers

## Implementation Notes

The change is **strictly in `target/model.py`** + one Config field in `target/train.py`. No `trainer_runtime.py` changes. ~25 lines total.

### Step 1 — Add the Config field in `target/train.py`

In the `Config` dataclass (around line 105, next to `use_surf_to_vol_xattn`), add:

```python
use_pre_xattn_vol_self_attn: bool = False
```

Add a `help_text` entry in the `help_text` dict (around line 223, next to the `use_surf_to_vol_xattn` entry):

```python
"use_pre_xattn_vol_self_attn": (
    "Enable pre-xattn vol self-attention (PR #929). Before the "
    "surf->vol cross-attention, a single nn.MultiheadAttention block "
    "lets volume hidden states attend to each other (vol Q=K=V). "
    "Zero-init out_proj for identity-at-init. embed_dim follows "
    "--model-hidden-dim and num_heads follows --model-heads."
),
```

The bool dataclass auto-generates `--use-pre-xattn-vol-self-attn` / `--no-use-pre-xattn-vol-self-attn` flags.

Plumb to model factory (around line 310, next to `use_surf_to_vol_xattn=config.use_surf_to_vol_xattn`):

```python
use_pre_xattn_vol_self_attn=config.use_pre_xattn_vol_self_attn,
```

### Step 2 — Add module init in `target/model.py` (next to surf-to-vol-xattn block, ~line 433)

Add `use_pre_xattn_vol_self_attn: bool = False` to `SurfaceTransolver.__init__` signature and assign `self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn`.

Then in `__init__`, directly after the `surf_to_vol_xattn` block (~line 445):

```python
# Pre-xattn vol self-attention block (zero-init for identity-at-init).
# Allows vol tokens to communicate with each other BEFORE forming the
# xattn query against surface K/V.
if use_pre_xattn_vol_self_attn:
    self.pre_xattn_vol_self_attn = nn.MultiheadAttention(
        embed_dim=n_hidden,
        num_heads=n_head,
        batch_first=True,
        dropout=dropout,
    )
    self.pre_xattn_vol_self_attn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.weight)
    nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.bias)
else:
    self.pre_xattn_vol_self_attn = None
    self.pre_xattn_vol_self_attn_norm = None
```

### Step 3 — Add forward block in `target/model.py` BEFORE the existing xattn block (between line 530 and 532)

The existing forward flow is:
```
# line 530: volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
# line 532: if self.surf_to_vol_xattn is not None ...
```

Insert between these two lines:

```python
# Pre-xattn vol self-attention: vol tokens communicate with each other
# before forming xattn queries against surface K/V.
if (
    self.pre_xattn_vol_self_attn is not None
    and volume_x is not None
    and volume_tokens > 0
):
    pre_xattn_out, _ = self.pre_xattn_vol_self_attn(
        query=volume_hidden,
        key=volume_hidden,
        value=volume_hidden,
        key_padding_mask=~volume_mask,  # True = masked-out (padding)
        need_weights=False,
    )
    pre_xattn_out = _apply_token_mask(pre_xattn_out, volume_mask)
    volume_hidden = self.pre_xattn_vol_self_attn_norm(volume_hidden + pre_xattn_out)
    volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
```

Verify `volume_mask` semantics: if `volume_mask` is `True` for valid points (same as `surface_mask`), then `key_padding_mask=~volume_mask` is correct (PyTorch convention: True = ignore this position).

### Step 4 — DDP flag
Keep `--no-compile-model`. The existing `find_unused_parameters=True` handling (in `train.py` around line 776) checks `if config.use_surf_to_vol_xattn`. Extend this condition:

```python
if config.use_surf_to_vol_xattn or config.use_pre_xattn_vol_self_attn:
    # find_unused_parameters=True required for conditional modules
    ...
```

### Step 5 — Smoke test before launch

```bash
cd target/ && python -c "
from train import build_model_from_config, Config
cfg = Config(use_surf_to_vol_xattn=True, use_pre_xattn_vol_self_attn=True,
             model_layers=5, model_hidden_dim=512, model_heads=4, model_slices=128)
model = build_model_from_config(cfg)
print(f'Params: {sum(p.numel() for p in model.parameters()):,}')
# Expected: ~19.0M (SOTA 16.99M + ~2.1M for pre-xattn block)
"
```

## Experiment Design — 4-ep screen, 8 GPUs DDP

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-pre-xattn-vol-self-attn \
  --wandb-group edward-pre-xattn-vol-self-attn \
  --wandb-name edward/pre-xattn-vol-self-attn-4ep
```

Note: `--lr-cosine-t-max 4` so cosine fully decays inside the 4-ep screen budget (~280 min on 8×H100s).

### Gate schedule (4-ep with vol-curriculum)

| EP | Vol pts | Step | Kill gate | SOTA ref |
|---|---|---|---|---|
| EP1 | 16384 | 10864 | ≤30.0% | 28.63% |
| EP2 | 32768 | 16299 | ≤16.0% | 8.15% |
| EP3 | 49152 | 19924 | **≤8.0%** ← main gate | 7.12% |
| EP4 | 65536 | 22644 | <6.81% | 6.81% |

**If EP3 passes and EP4 ≤ 6.81%:** launch Phase 2 — 13-ep with `--lr-cosine-t-max 13 --epochs 13 --vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`.

**If EP3 fails (>8.0%):** Close PR — post-xattn and pre-xattn capacity both exhausted; full capacity axis closed.

### What to report at each gate
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary gate metric)
- Per-channel: `surface_pressure`, `volume_pressure`, `wall_shear`, `wall_shear_x`, `wall_shear_y`, `wall_shear_z`
- W&B run ID and group
- Total parameter count from smoke test (~19.0M expected)
- Peak VRAM

## Baseline (Single-model SOTA — PR #823 nezuko, W&B run `ghh0s4ne`)

| Metric | Val (EP13 best ckpt) | Test |
|---|---:|---:|
| `abupt_axis_mean_rel_l2_pct` | **6.4407%** | **7.6992%** |
| `surface_pressure_rel_l2_pct` | 4.1836% | 3.8451% |
| `volume_pressure_rel_l2_pct` | 3.8557% | **11.6704%** |
| `wall_shear_rel_l2_pct` | 7.3448% | 7.0429% |
| `wall_shear_x_rel_l2_pct` | 5.7782% | 6.2773% |
| `wall_shear_y_rel_l2_pct` | 7.5977% | 7.6657% |
| `wall_shear_z_rel_l2_pct` | 9.0116% | 9.0375% |

**Single-model gate:** val_abupt < **6.4407%** (Phase 2 13-ep full run)
**Ensemble gate:** val_abupt < **6.0289%** (K=6 pool PR #880)
**val→test vol_p ratio:** 3.027× (primary OOD signal)
