### PR TITLE
nezuko: SDF-stratified vol loss to close 3× test_vp OOD gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -85,6 +85,7 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    vol_sdf_loss_weight_lambda: float = 0.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "vol_sdf_loss_weight_lambda": (
+            "If >0, weight each volume-point MSE by exp(-sdf/lambda) (PR "
+            "#930). sdf is taken from volume_x[..., 3] (raw, in metres). "
+            "SDF is clamped to [0, 5*lambda] before the exponential to "
+            "bound the weight ratio at exp(5) approx 148; the weight is "
+            "then renormalised so its mean over valid points is 1. "
+            "0 = disabled (baseline masked_mse)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +320,42 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def sdf_weighted_volume_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    volume_x: torch.Tensor,
+    lam: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """SDF-stratified per-point volume MSE (PR #930).
+
+    Weight per point by exp(-sdf/lam), with sdf = volume_x[..., 3] clamped to
+    [0, 5*lam] (so weight ratio is bounded by exp(5) ~ 148). Renormalises the
+    weight so its mean over valid points is 1, preserving overall loss scale.
+    """
+    sdf = volume_x[..., 3].detach().to(dtype=pred.dtype)
+    sdf = sdf.clamp(min=0.0, max=5.0 * lam)
+    raw_w = torch.exp(-sdf / lam)
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype)
+    valid_count = mask_f.sum().clamp_min(1.0)
+    mean_w = (raw_w * mask_f).sum() / valid_count
+    w = raw_w / mean_w.clamp_min(1e-12)
+    sq_err = (pred - target).square()
+    while w.ndim < sq_err.ndim:
+        w = w.unsqueeze(-1)
+    weighted_sq = sq_err * w
+    while mask_f.ndim < weighted_sq.ndim:
+        mask_f = mask_f.unsqueeze(-1)
+    denom = mask_f.expand_as(weighted_sq).sum().clamp_min(1.0)
+    loss = (weighted_sq * mask_f).sum() / denom
+    diag = {
+        "vol_sdf_w_min": float(raw_w[mask.bool()].min().detach().item()) if bool(mask.any()) else 0.0,
+        "vol_sdf_w_max": float(raw_w[mask.bool()].max().detach().item()) if bool(mask.any()) else 0.0,
+        "vol_sdf_w_mean_raw": float(mean_w.detach().item()),
+    }
+    return loss, diag
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,10 +366,12 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_sdf_loss_weight_lambda: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    sdf_diag: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -341,18 +388,29 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        if vol_sdf_loss_weight_lambda > 0.0:
+            volume_loss, sdf_diag = sdf_weighted_volume_mse(
+                out["volume_preds"],
+                volume_target,
+                batch.volume_mask,
+                batch.volume_x,
+                vol_sdf_loss_weight_lambda,
+            )
+        else:
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(sdf_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1030,6 +1088,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_sdf_loss_weight_lambda=config.vol_sdf_loss_weight_lambda,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1129,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "vol_sdf_w_min" in batch_loss_metrics:
+                        train_log["train/vol_sdf/w_min"] = batch_loss_metrics["vol_sdf_w_min"]
+                        train_log["train/vol_sdf/w_max"] = batch_loss_metrics["vol_sdf_w_max"]
+                        train_log["train/vol_sdf/w_mean_raw"] = batch_loss_metrics["vol_sdf_w_mean_raw"]
+                        train_log["train/vol_sdf/lambda"] = config.vol_sdf_loss_weight_lambda
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**SDF-stratified volume loss weighting to close the 3×  val→test volume-pressure OOD gap.**

The volume-pressure test error (≈11.3–11.7%) is roughly **3×** the validation error (≈3.6%), while surface errors generalise well (test ≈ val for sp and ws). This asymmetry suggests the model learns geometry-dependent volume representations that overfit to the 400-car training distribution's interior flow topology, and fails on the 50-test-car distribution shift.

**Key insight:** volume points closest to the car surface are the most physically constrained — at any SDF value near zero, the no-slip and pressure-continuity BCs must hold, independently of geometry. In contrast, far-field volume points (high SDF) depend strongly on the specific geometry and free-stream conditions, making them high-variance predictors across different car shapes.

**Proposal:** add an SDF-exponential weighting to the per-point volume MSE loss during training:

```
weight_i = exp(-sdf_i / λ)    (λ is a learnable or fixed length-scale)
```

where `sdf_i = volume_x[i, 3]` (already the 4th feature in volume inputs, normalised). Near-surface points (small SDF) receive weight ≈ 1; far-field points are down-weighted by `exp(-sdf/λ)`. This biases the model toward high-fidelity prediction in the boundary-adjacent region where physics is tightly constrained and OOD robustness should be higher.

The intuition: if the model is penalised strongly for near-surface errors and less for far-field errors, it is forced to learn representations tied to boundary conditions rather than global flow topology. That representation should generalise better to unseen geometries whose far-field topology differs but whose near-surface physics obeys the same conservation laws.

## Implementation

All changes go in `target/train.py` and/or `target/trainer_runtime.py`. **Do not touch `model.py` forward pass.**

### Step 1 — add a `--vol-sdf-loss-weight-lambda` flag

In `train.py` (near the other volume-related args):
```python
parser.add_argument("--vol-sdf-loss-weight-lambda", type=float, default=0.0,
    help="If >0, weight each volume point's MSE by exp(-sdf/λ). sdf taken from volume_x[...,3]. 0 = disabled.")
```

### Step 2 — compute per-point weights in the volume loss

In `trainer_runtime.py` (or wherever the volume MSE is computed), locate the code that computes volume loss and add:

```python
if args.vol_sdf_loss_weight_lambda > 0:
    # volume_x has shape [B, N, 4]: (x, y, z, sdf)
    sdf = volume_x[..., 3].detach()          # [B, N]
    sdf = sdf.clamp(min=0.0)                 # only outside-surface points
    w = torch.exp(-sdf / args.vol_sdf_loss_weight_lambda)  # [B, N]
    w = w / w.mean(dim=-1, keepdim=True)     # renormalise so mean weight = 1
    # vol_loss_per_point has shape [B, N, C] or [B, N]; broadcast accordingly
    vol_loss = (vol_loss_per_point * w.unsqueeze(-1)).mean()
else:
    vol_loss = vol_loss_per_point.mean()
```

Adjust variable names to match the actual local names in the codebase — the key operations are:
1. extract `sdf = volume_x[..., 3]`
2. `weight = exp(-sdf / λ)`
3. normalise weight so mean = 1 (prevents λ-dependent loss-scale shift)
4. multiply per-point loss by weight before averaging

### Step 3 — run a small λ-sweep (Arms A, B, C) and one control arm

Use `--wandb-group nezuko-sdf-vol-loss` for all runs.

**Arm A — λ = 0.10** (aggressive near-surface bias, fast decay)
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --vol-sdf-loss-weight-lambda 0.10 \
  --wandb-group nezuko-sdf-vol-loss \
  --wandb-name nezuko/sdf-vol-loss-lam010
```

**Arm B — λ = 0.30** (moderate near-surface bias)
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --vol-sdf-loss-weight-lambda 0.30 \
  --wandb-group nezuko-sdf-vol-loss \
  --wandb-name nezuko/sdf-vol-loss-lam030
```

**Arm C — λ = 1.00** (gentle near-surface bias, slow decay)
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --vol-sdf-loss-weight-lambda 1.00 \
  --wandb-group nezuko-sdf-vol-loss \
  --wandb-name nezuko/sdf-vol-loss-lam100
```

**Arm D — control (λ=0, no SDF weighting, identical to SOTA)** — run this only if you want a clean same-machine baseline; it's optional since the SOTA wandb run is `ghh0s4ne`.

### Step 4 — EP3 gate

After 3 epochs of each arm, check `val_volume_pressure_rel_l2_pct` in W&B. Kill any arm where this metric is already ≥ 3.8% (above the SOTA val_vp = 3.5678%). Focus GPU time on the surviving arm(s) for the full 13 epochs.

### Step 5 — report results

In the PR comment, report for each arm:
- `val_abupt_axis_mean_rel_l2_pct`
- `val_volume_pressure_rel_l2_pct`
- `test_abupt_axis_mean_rel_l2_pct` (if val_abupt < 6.44%)
- `test_volume_pressure_rel_l2_pct` (if val_abupt < 6.44%)
- W&B run IDs

The most important metric is `test_volume_pressure_rel_l2_pct` — we need this to drop from 11.3% toward 6%. A result is terminal when all arms are done or killed and you have final epoch metrics.

## Suggested follow-ups (for your notes)

If the SDF-weighted loss helps, a natural extension is **SDF-stratified sampling**: over-sample volume points near the surface (SDF < threshold) and under-sample far-field points, so the model sees more boundary-adjacent examples per gradient step.

## Current Baselines

| Metric | Single-model SOTA (PR #823, run `ghh0s4ne`) | Ensemble SOTA (PR #880, K=6) |
|---|---|---|
| val_abupt_axis_mean_rel_l2_pct | 6.4407% | 6.0289% |
| test_abupt_axis_mean_rel_l2_pct | 7.6992% | 7.3693% |
| val_surface_pressure_rel_l2_pct | 4.1299% | 3.8550% |
| test_surface_pressure_rel_l2_pct | 3.8451% | 3.6007% |
| val_volume_pressure_rel_l2_pct | 3.9437% | 3.5678% |
| test_volume_pressure_rel_l2_pct | 11.6704% | 11.3478% |

**Single-model gate to beat:** val_abupt < **6.4407%**
**Ensemble gate to beat:** val_abupt < **6.0289%**

The critical target: reduce `test_volume_pressure_rel_l2_pct` from ≈11.3% toward the AB-UPT reference of **6.08%**. The val↔test gap (3.027×) is the primary research problem this session.

## AB-UPT Reference Targets

| Metric | AB-UPT target |
|---|---|
| surface_pressure | 3.82% |
| wall_shear | 7.29% |
| volume_pressure | **6.08%** |
