### PR TITLE
askeladd: STRING-RoPE Exp1 — Learnable slice-centroid coordinate RoPE (Issue #618)

### DIFF
--- a/model.py
+++ b/model.py
@@ -136,6 +136,84 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class LearnableCoordinateRoPE(nn.Module):
+    """Learnable per-axis rotary positional encoding for coordinate-bearing tokens.
+
+    Applies coordinate-dependent Q/K rotation inside attention, using the same
+    multi-sigma ``log_freq + phase`` parameterisation as ``StringSeparableEncoding``.
+    Distributes ``head_dim // 2`` rotation pairs across ``ndim`` spatial axes; for
+    ``head_dim=128, ndim=3`` this gives ``pairs_per_axis=[22, 21, 21]`` and rotates
+    all 128 dims of each head. The remaining tail dims (when ``head_dim``/``2`` is
+    not a multiple of ``ndim``) pass through unmodified.
+
+    All cos/sin and rotation arithmetic runs in float32 to avoid bf16 mantissa
+    quantisation when ``theta`` is large (e.g. ``2pi*coord*sigma`` with sigma=4
+    can produce ``theta>20`` rad). Output dtype matches the input Q/K dtype.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        ndim: int = 3,
+        init_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+    ):
+        super().__init__()
+        self.head_dim = head_dim
+        self.ndim = ndim
+        self.init_sigmas = tuple(init_sigmas)
+        total_pairs = head_dim // 2
+        base = total_pairs // ndim
+        extra = total_pairs % ndim
+        self.pairs_per_axis = [base + (1 if axis < extra else 0) for axis in range(ndim)]
+        self.rot_dim = 2 * sum(self.pairs_per_axis)
+        max_pairs = max(self.pairs_per_axis) if self.pairs_per_axis else 0
+        self.log_freq = nn.Parameter(torch.zeros(ndim, max_pairs))
+        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
+        for axis, pairs in enumerate(self.pairs_per_axis):
+            vals = [
+                math.log(self.init_sigmas[i % len(self.init_sigmas)])
+                for i in range(pairs)
+            ]
+            if pairs > 0:
+                self.log_freq.data[axis, :pairs] = torch.tensor(vals, dtype=torch.float32)
+
+    def _angles(self, coords: torch.Tensor) -> torch.Tensor:
+        coords_f = coords.float()
+        parts: list[torch.Tensor] = []
+        for axis, pairs in enumerate(self.pairs_per_axis):
+            if pairs == 0:
+                continue
+            freq = self.log_freq[axis, :pairs].float().exp()
+            phase = self.phase[axis, :pairs].float()
+            theta = 2.0 * math.pi * coords_f[..., axis : axis + 1] * freq + phase
+            parts.append(theta)
+        return torch.cat(parts, dim=-1)
+
+    def _rotate(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        rot_dim = theta.shape[-1] * 2
+        x_dtype = x.dtype
+        x_float = x.float()
+        x_rot = x_float[..., :rot_dim].reshape(*x_float.shape[:-1], theta.shape[-1], 2)
+        cos = theta.cos().unsqueeze(-1)
+        sin = theta.sin().unsqueeze(-1)
+        x0 = x_rot[..., 0:1]
+        x1 = x_rot[..., 1:2]
+        rotated = torch.cat([x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1)
+        rotated = rotated.flatten(start_dim=-2).to(dtype=x_dtype)
+        if rot_dim < x.shape[-1]:
+            return torch.cat([rotated, x[..., rot_dim:]], dim=-1)
+        return rotated
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        coords: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        theta = self._angles(coords)
+        return self._rotate(q, theta), self._rotate(k, theta)
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -196,6 +274,9 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -221,7 +302,30 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        if slice_string_rope:
+            self.slice_string_rope = LearnableCoordinateRoPE(
+                head_dim=self.dim_head,
+                ndim=3,
+                init_sigmas=slice_string_rope_init_sigmas,
+            )
+            self.slice_string_rope_after_qk_norm = slice_string_rope_after_qk_norm
+        else:
+            self.slice_string_rope = None
+            self.slice_string_rope_after_qk_norm = True
+        # Diagnostic state captured each forward (non-persistent).
+        self.register_buffer(
+            "_last_centroid_spread", torch.zeros(()), persistent=False
+        )
+        self.register_buffer(
+            "_last_centroid_collapse", torch.zeros(()), persistent=False
+        )
+
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
@@ -234,15 +338,58 @@ class TransolverAttention(nn.Module):
             )
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
-        return slice_tokens, slice_weights
+        centroids: torch.Tensor | None = None
+        if self.slice_string_rope is not None and point_coords is not None:
+            sw_f = slice_weights.float()  # [B, H, N, S]
+            sw_sum = sw_f.sum(dim=2).clamp_min(1e-8)  # [B, H, S]
+            centroids = torch.einsum(
+                "bhns,bnd->bhsd", sw_f, point_coords.float()
+            ) / sw_sum.unsqueeze(-1)
+        return slice_tokens, slice_weights, centroids
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights, centroids = self.create_slices(
+            x, attn_mask=attn_mask, point_coords=point_coords
+        )
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
+        if (
+            self.slice_string_rope is not None
+            and centroids is not None
+            and not self.slice_string_rope_after_qk_norm
+        ):
+            q, k = self.slice_string_rope(q, k, centroids)
         if self.q_norm is not None:
             q = self.q_norm(q)
             k = self.k_norm(k)
+        if (
+            self.slice_string_rope is not None
+            and centroids is not None
+            and self.slice_string_rope_after_qk_norm
+        ):
+            q, k = self.slice_string_rope(q, k, centroids)
+        if centroids is not None:
+            with torch.no_grad():
+                cs = centroids.float()
+                # Mean per-axis std across slice dim → average over heads/batch.
+                self._last_centroid_spread = cs.std(dim=2).mean().detach()
+                # centroid_collapse_ratio: fraction of slice pairs with L2 dist < 0.05.
+                # Using a single-batch slice-vs-slice distance for diagnostic only.
+                centroids_b0 = cs[0]  # [H, S, 3]
+                pairwise = torch.cdist(centroids_b0, centroids_b0)  # [H, S, S]
+                S = pairwise.shape[-1]
+                offdiag = pairwise.masked_fill(
+                    torch.eye(S, dtype=torch.bool, device=pairwise.device)[None, :, :],
+                    float("inf"),
+                )
+                self._last_centroid_collapse = (
+                    (offdiag < 0.05).float().mean().detach()
+                )
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -265,6 +412,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -275,13 +425,23 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            slice_string_rope=slice_string_rope,
+            slice_string_rope_init_sigmas=slice_string_rope_init_sigmas,
+            slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(
+            self.norm1(x), attn_mask=attn_mask, point_coords=point_coords
+        )
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -298,6 +458,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -309,14 +472,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    slice_string_rope=slice_string_rope,
+                    slice_string_rope_init_sigmas=slice_string_rope_init_sigmas,
+                    slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        point_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, point_coords=point_coords)
         return x
 
 
@@ -343,6 +514,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        slice_string_rope: bool = False,
+        slice_string_rope_init_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        slice_string_rope_after_qk_norm: bool = True,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +530,9 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.slice_string_rope = slice_string_rope
+        self.slice_string_rope_init_sigmas = tuple(slice_string_rope_init_sigmas)
+        self.slice_string_rope_after_qk_norm = slice_string_rope_after_qk_norm
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -419,6 +596,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            slice_string_rope=slice_string_rope,
+            slice_string_rope_init_sigmas=tuple(slice_string_rope_init_sigmas),
+            slice_string_rope_after_qk_norm=slice_string_rope_after_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
@@ -487,6 +667,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -503,6 +684,7 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -517,10 +699,12 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
+        point_coords = torch.cat(coords_list, dim=1) if self.slice_string_rope else None
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, point_coords=point_coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    slice_string_rope: bool = False
+    slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    slice_string_rope_after_qk_norm: bool = True
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "slice_string_rope": (
+            "Enable learnable per-axis rotary positional encoding "
+            "(LearnableCoordinateRoPE) on slice-token Q/K inside "
+            "TransolverAttention (PR #932). Slice centroids are computed "
+            "as `slice_weights @ point_coords` (differentiable) and used "
+            "to rotate Q/K before scaled_dot_product_attention. The "
+            "input-level STRING-separable encoding is preserved unchanged."
+        ),
+        "slice_string_rope_init_sigmas": (
+            "Comma-separated multi-sigma init for the rotary log_freq "
+            "parameters (round-robin per axis, matching "
+            "StringSeparableEncoding). Default '0.25,0.5,1.0,2.0,4.0'."
+        ),
+        "slice_string_rope_after_qk_norm": (
+            "If True (default, Arm B), apply slice-string-RoPE after "
+            "QK-norm — matches modern LLM ordering (Llama-3, Qwen-3). "
+            "If False (Arm C), apply before QK-norm."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,7 +315,77 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_slice_string_rope_metrics(model: nn.Module) -> dict[str, float]:
+    """Aggregate slice-string-rope diagnostics across backbone blocks.
+
+    Reads the latest centroid_spread / centroid_collapse buffers captured by
+    each ``TransolverAttention.forward()``, and the per-axis ``log_freq``
+    statistics from each ``LearnableCoordinateRoPE``. Per-block detail is
+    logged alongside an across-block aggregate for triage.
+    """
+    backbone = getattr(model, "backbone", None)
+    if backbone is None or not hasattr(backbone, "blocks"):
+        return {}
+    metrics: dict[str, float] = {}
+    spreads: list[float] = []
+    collapses: list[float] = []
+    log_freq_axis_means: list[list[float]] = [[] for _ in range(3)]
+    log_freq_axis_stds: list[list[float]] = [[] for _ in range(3)]
+    any_active = False
+    for i, block in enumerate(backbone.blocks):
+        attn = getattr(block, "attention", None)
+        if attn is None:
+            continue
+        rope = getattr(attn, "slice_string_rope", None)
+        if rope is None:
+            continue
+        any_active = True
+        spread = getattr(attn, "_last_centroid_spread", None)
+        collapse = getattr(attn, "_last_centroid_collapse", None)
+        if spread is not None:
+            spread_val = float(spread.detach().cpu().item())
+            spreads.append(spread_val)
+            metrics[f"slice_string_rope/block_{i}/centroid_spread"] = spread_val
+        if collapse is not None:
+            collapse_val = float(collapse.detach().cpu().item())
+            collapses.append(collapse_val)
+            metrics[f"slice_string_rope/block_{i}/centroid_collapse_ratio"] = collapse_val
+        log_freq = rope.log_freq.detach().float()
+        prefix = f"slice_string_rope/block_{i}"
+        metrics[f"{prefix}/log_freq_mean"] = float(log_freq.mean().item())
+        metrics[f"{prefix}/log_freq_std"] = float(log_freq.std().item())
+        for axis in range(min(log_freq.shape[0], 3)):
+            ax_vals = log_freq[axis]
+            mean_val = float(ax_vals.mean().item())
+            std_val = float(ax_vals.std().item())
+            metrics[f"{prefix}/log_freq_axis_{axis}_mean"] = mean_val
+            metrics[f"{prefix}/log_freq_axis_{axis}_std"] = std_val
+            log_freq_axis_means[axis].append(mean_val)
+            log_freq_axis_stds[axis].append(std_val)
+    if not any_active:
+        return {}
+    if spreads:
+        metrics["slice_string_rope/centroid_spread_mean"] = sum(spreads) / len(spreads)
+    if collapses:
+        metrics["slice_string_rope/centroid_collapse_ratio_mean"] = sum(collapses) / len(
+            collapses
+        )
+    for axis in range(3):
+        if log_freq_axis_means[axis]:
+            metrics[f"slice_string_rope/log_freq_axis_{axis}_mean"] = sum(
+                log_freq_axis_means[axis]
+            ) / len(log_freq_axis_means[axis])
+        if log_freq_axis_stds[axis]:
+            metrics[f"slice_string_rope/log_freq_axis_{axis}_std"] = sum(
+                log_freq_axis_stds[axis]
+            ) / len(log_freq_axis_stds[axis])
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
+    slice_string_rope_init_sigmas = parse_rff_init_sigmas(
+        config.slice_string_rope_init_sigmas
+    ) or (0.25, 0.5, 1.0, 2.0, 4.0)
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -308,6 +399,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        slice_string_rope=config.slice_string_rope,
+        slice_string_rope_init_sigmas=tuple(slice_string_rope_init_sigmas),
+        slice_string_rope_after_qk_norm=config.slice_string_rope_after_qk_norm,
     )
 
 
@@ -1262,6 +1356,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_slice_string_rope_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The current tay `StringSeparableEncoding` applies coordinate features at the **input level** — it is additive spectral geometry encoding, not true attention-level coordinate rotation. The original STRING/RoPE idea is that Q/K attention itself should be rotated by coordinate-dependent group actions, enabling the model to learn relative spatial relationships directly in attention.

This experiment adds a **learnable per-axis rotary Q/K encoding applied to slice-token attention centroids** — the smallest possible step toward true attention-level STRING, compatible with the existing tay SOTA stack without changing the backbone or slicing mechanism.

**Core idea:** After Transolver creates slice tokens `[B, H, S, head_dim]`, compute differentiable slice centroids `[B, H, S, 3]` from `slice_weights @ point_coords`, then rotate Q and K via learnable STRING-RoPE before scaled_dot_product_attention. The input-level multi-sigma STRING features are **kept unchanged** — this is an additive enhancement, not a replacement.

This is **Experiment 1** from Issue #618. Only run experiment 1. Assign to student askeladd.

**Expected effect:** If slice centroids carry enough spatial signal, learnable rotary Q/K will allow the model to learn "which slices are spatially near each other" in the attention mechanism — complementing the input-level STRING features that encode per-point absolute coordinates.

## Implementation

You must add the following to `target/model.py` and add CLI flags in `target/train.py`.

### Step 1: Add `LearnableCoordinateRoPE` module to `model.py`

```python
import math
import torch
import torch.nn as nn

class LearnableCoordinateRoPE(nn.Module):
    """Learnable per-axis rotary positional encoding for coordinate-bearing tokens.
    
    Applies coordinate-dependent Q/K rotation inside attention, using the same
    multi-sigma log_freq + phase parameterisation as StringSeparableEncoding.
    """
    def __init__(self, head_dim: int, ndim: int = 3, init_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0)):
        super().__init__()
        self.head_dim = head_dim
        self.ndim = ndim
        total_pairs = head_dim // 2
        base = total_pairs // ndim
        extra = total_pairs % ndim
        self.pairs_per_axis = [base + (axis < extra) for axis in range(ndim)]
        self.rot_dim = 2 * sum(self.pairs_per_axis)

        max_pairs = max(self.pairs_per_axis)
        self.log_freq = nn.Parameter(torch.zeros(ndim, max_pairs))
        self.phase = nn.Parameter(torch.zeros(ndim, max_pairs))
        for axis, pairs in enumerate(self.pairs_per_axis):
            vals = [math.log(init_sigmas[i % len(init_sigmas)]) for i in range(pairs)]
            self.log_freq.data[axis, :pairs] = torch.tensor(vals)

    def _angles(self, coords: torch.Tensor) -> torch.Tensor:
        # coords: [..., 3]
        parts = []
        for axis, pairs in enumerate(self.pairs_per_axis):
            freq = self.log_freq[axis, :pairs].exp().to(dtype=coords.dtype)
            phase = self.phase[axis, :pairs].to(dtype=coords.dtype)
            theta = 2.0 * math.pi * coords[..., axis:axis+1] * freq + phase
            parts.append(theta)
        return torch.cat(parts, dim=-1)  # [..., num_pairs]

    def _rotate(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
        rot_dim = theta.shape[-1] * 2
        x_float = x.float()
        x_rot = x_float[..., :rot_dim].reshape(*x.shape[:-1], theta.shape[-1], 2)
        cos = theta.float().cos().unsqueeze(-1)
        sin = theta.float().sin().unsqueeze(-1)
        x0, x1 = x_rot[..., 0:1], x_rot[..., 1:2]
        y = torch.cat([x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1)
        y = y.flatten(start_dim=-2).to(dtype=x.dtype)
        if rot_dim < x.shape[-1]:
            return torch.cat([y, x[..., rot_dim:]], dim=-1)
        return y

    def forward(self, q: torch.Tensor, k: torch.Tensor, coords: torch.Tensor):
        # q, k: [B, H, S, head_dim]; coords: [B, H, S, 3]
        theta = self._angles(coords)  # [B, H, S, num_pairs]
        return self._rotate(q, theta), self._rotate(k, theta)
```

### Step 2: Add CLI flags in `target/train.py`

Add to the config dataclass (near other model flags):
```python
slice_string_rope: bool = False
slice_string_rope_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
slice_string_rope_after_qk_norm: bool = True  # True = apply after QK-norm (Arm B); False = before (Arm C)
```

Add argparse args:
```python
parser.add_argument("--slice-string-rope", action="store_true", default=False)
parser.add_argument("--no-slice-string-rope", action="store_false", dest="slice_string_rope")
parser.add_argument("--slice-string-rope-init-sigmas", type=str, default="0.25,0.5,1.0,2.0,4.0")
parser.add_argument("--slice-string-rope-after-qk-norm", action="store_true", default=True)
parser.add_argument("--no-slice-string-rope-after-qk-norm", action="store_false", dest="slice_string_rope_after_qk_norm")
```

### Step 3: Thread point coordinates through the backbone

In `SurfaceTransolver.forward()`, collect point coordinates alongside hidden states:

```python
# After assembling surface_tokens and volume_tokens, before backbone call:
coords_list = []
if self.use_surface:
    coords_list.append(surface_x[:, :, :self.space_dim])  # [B, N_surf, 3]
if self.use_volume:
    coords_list.append(volume_x[:, :, :self.space_dim])   # [B, N_vol, 3]
point_coords = torch.cat(coords_list, dim=1)  # [B, N_total, 3]

# Pass point_coords to backbone (add as optional kwarg):
hidden = self.backbone(hidden, attn_mask=attn_mask, point_coords=point_coords)
```

Modify `TransolverBlock.forward()` and `TransolverAttention.forward()` to accept and pass through `point_coords`.

### Step 4: Compute slice centroids and apply STRING-RoPE in `TransolverAttention.forward()`

After computing `slice_weights` and before `scaled_dot_product_attention`:

```python
# slice_weights: [B, H, N, S], point_coords: [B, N, 3]
if self.slice_string_rope is not None and point_coords is not None:
    # Compute differentiable slice centroids
    # slice_weights: [B, H, N, S] -> need sum over N
    sw_norm = slice_weights.float()  # [B, H, N, S]
    sw_sum = sw_norm.sum(dim=2).clamp_min(1e-8)  # [B, H, S]
    # centroids: [B, H, S, 3]
    centroids = torch.einsum(
        "bhns,bnd->bhsd",
        sw_norm,
        point_coords.float()
    ) / sw_sum.unsqueeze(-1)
    
    # Apply RoPE: rotate q and k by centroid coordinates
    if self.slice_string_rope_after_qk_norm:
        # Apply after QK-norm (Arm B): q and k have already been normalised
        q, k = self.slice_string_rope(q, k, centroids)
    # else: Arm C applies before QK-norm — move this block above the norm call
```

**Log these diagnostics to W&B:**
```python
if self.training:
    with torch.no_grad():
        # centroid spread: std of centroids across slice dim
        centroid_spread = centroids.std(dim=2).mean()  # scalar
        wandb.log({"slice_string_rope/centroid_spread_mean": centroid_spread})
        
        # log_freq stats per axis
        for ax in range(3):
            wandb.log({
                f"slice_string_rope/log_freq_axis_{ax}_mean": self.slice_string_rope.log_freq[ax].mean(),
                f"slice_string_rope/log_freq_axis_{ax}_std": self.slice_string_rope.log_freq[ax].std(),
            })
```

### Step 5: Instantiate in model constructor

```python
# In TransolverAttention.__init__:
self.slice_string_rope = None
self.slice_string_rope_after_qk_norm = True
if cfg.slice_string_rope:
    init_sigmas = tuple(float(s) for s in cfg.slice_string_rope_init_sigmas.split(","))
    self.slice_string_rope = LearnableCoordinateRoPE(
        head_dim=self.head_dim,
        ndim=3,
        init_sigmas=init_sigmas
    )
    self.slice_string_rope_after_qk_norm = cfg.slice_string_rope_after_qk_norm
```

## Run Plan

**Arm B (primary):** Slice-centroid STRING-RoPE applied *after* QK-norm  
**Arm C (secondary):** Slice-centroid STRING-RoPE applied *before* QK-norm  

Use W&B group `askeladd-string-rope-exp1` for both arms.

### Arm B command (4-epoch screen):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --slice-string-rope \
  --slice-string-rope-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --slice-string-rope-after-qk-norm \
  --wandb-group askeladd-string-rope-exp1 \
  --wandb-name askeladd/string-rope-exp1-arm-b-after-qknorm \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>=30"
```

### Arm C command (4-epoch screen):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --slice-string-rope \
  --slice-string-rope-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --no-slice-string-rope-after-qk-norm \
  --wandb-group askeladd-string-rope-exp1 \
  --wandb-name askeladd/string-rope-exp1-arm-c-before-qknorm \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>=30"
```

**Kill gate:** EP1 val_abupt ≥ 30% → terminate both arms.

**If either Arm B or C passes EP1 gate (<30%):**
- Continue to full 13-epoch run if EP4 val_abupt < 6.8%
- Full 13-ep command: replace `--lr-cosine-t-max 4 --epochs 4` with `--lr-cosine-t-max 13 --epochs 13` and update `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`

## W&B Diagnostics to Log

Log these every N steps (or per-epoch) to understand what the model learned:

- `slice_string_rope/centroid_spread_mean` — std of centroids over the slice dim. If this is near zero, slices are not spatially separated and RoPE cannot help. 
- `slice_string_rope/log_freq_axis_{0,1,2}_{mean,std}` — track if frequencies are evolving or collapsing
- `slice_string_rope/q_cos_sim_pre_post` (optional but informative) — cosine similarity of Q before vs after rotation; should be < 1.0 if RoPE is actually rotating

## Report Instructions

In your PR comment, report:

1. **EP1 val_abupt for Arm B and Arm C vs SOTA EP1 (28.6344%)**
2. If alive at EP4: val_abupt trajectory EP1–EP4 for each arm vs SOTA (28.63%, 8.15%, 7.12%, 6.81%)
3. **W&B diagnostics:**
   - `centroid_spread_mean` at EP1 end — if < 0.05, slice centroids are nearly identical, which means RoPE had no positional information to use
   - `log_freq_axis_{0,1,2}` evolution — are frequencies learning different scales per axis?
4. Table of final val metrics (all 5 channels + abupt) vs single-model SOTA
5. Any per-task improvement patterns (especially `volume_pressure_rel_l2_pct` — our primary target)

## Baseline (current SOTA)

**Single-model SOTA — PR #823 (nezuko, surf→vol cross-attn):**
| Metric | Val (EP13 best ckpt) | Test |
|---|---|---|
| `abupt_axis_mean_rel_l2_pct` | **6.4407%** | **7.6992%** |
| `surface_pressure_rel_l2_pct` | 4.1836% | 3.8451% |
| `volume_pressure_rel_l2_pct` | 3.8557% | **11.6704%** |
| `wall_shear_rel_l2_pct` | 7.3448% | 7.0429% |
| W&B run | `ghh0s4ne` | — |

**4-ep screen trajectory:** EP1=28.63%, EP2=8.15%, EP3=7.12%, EP4=6.81%  
**Single-model gate:** val_abupt < **6.4407%**  
**AB-UPT targets:** surface_pressure=3.82%, wall_shear=7.29%, **volume_pressure=6.08%**

**Decision rule:**
- Arm B or C passes EP1 (<30%) → continue to EP4 screen
- EP4 < 6.8% → continue to full 13-ep run
- Final val_abupt < 6.4407% → PR is a winner, report with SENPAI-RESULT marker
- If both arms fail EP1 → report NEGATIVE and both W&B run IDs
