### PR TITLE
tanjiro: SDF-modulated volume PE (per-octave scaler, ~61 params)

### DIFF
--- a/model.py
+++ b/model.py
@@ -146,15 +146,18 @@ class SdfVolPEScaler(nn.Module):
     Consecutive features round-robin across octaves: octave index for output
     dim ``d`` is ``((d % (2 * num_features)) % num_features) % num_octaves``.
 
-    The scaler produces ``num_octaves`` multiplicative weights in (0, 1] from
-    the per-token SDF value.  At init, Linear(8→5) bias=0 and weight~0 so all
-    sigmoid outputs start near 0.5, giving mild suppression that the optimiser
-    can quickly lift.  The sigmoid ceiling of 1.0 prevents amplification;
-    interior tokens (positive SDF) and exterior tokens (negative SDF) learn
-    different scaling profiles automatically.
+    Identity-init (PR #935 retry): Linear(8→num_octaves) weight=0 and
+    bias=+4.0, so all sigmoid outputs start at sigmoid(4) ≈ 0.982 — near
+    full-PE passthrough at step 0.  This eliminates the EP1-EP2 burn-in seen
+    in the prior run (run jlnk973q), where bias=0 caused outputs to start at
+    sigmoid(0)=0.5 and waste 1-2 epochs learning to lift the gates back up.
+    The scaler now learns to *attenuate* PE in the regimes where it helps
+    (e.g., interior tokens far from surface) rather than starting at half
+    strength.  Sigmoid derivative at z=4 is ~0.018, sufficient for gradient
+    flow.
     """
 
-    def __init__(self, num_octaves: int = 5):
+    def __init__(self, num_octaves: int = 5, init_bias: float = 4.0):
         super().__init__()
         self.num_octaves = num_octaves
         self.net = nn.Sequential(
@@ -163,11 +166,11 @@ class SdfVolPEScaler(nn.Module):
             nn.Linear(8, num_octaves),
             nn.Sigmoid(),
         )
-        # Initialise so all outputs start near 0.5 (mild attenuation at init)
+        # Identity-init: outputs start at sigmoid(init_bias) ≈ 1.0 → full PE
         nn.init.trunc_normal_(self.net[0].weight, std=0.02)
         nn.init.zeros_(self.net[0].bias)
         nn.init.zeros_(self.net[2].weight)
-        nn.init.zeros_(self.net[2].bias)
+        nn.init.constant_(self.net[2].bias, init_bias)
 
     def forward(self, sdf: torch.Tensor) -> torch.Tensor:
         # sdf: [B, N, 1]

--- a/model.py
+++ b/model.py
@@ -136,6 +136,44 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class SdfVolPEScaler(nn.Module):
+    """Tiny MLP that maps per-token SDF scalars to per-octave PE scale weights.
+
+    Architecture: Linear(1→8) → GELU → Linear(8→num_octaves) → Sigmoid
+
+    For a StringSeparableEncoding with ``num_features`` features and ``in_dim``
+    spatial axes the output has shape ``[..., 2 * in_dim * num_features]``.
+    Consecutive features round-robin across octaves: octave index for output
+    dim ``d`` is ``((d % (2 * num_features)) % num_features) % num_octaves``.
+
+    The scaler produces ``num_octaves`` multiplicative weights in (0, 1] from
+    the per-token SDF value.  At init, Linear(8→5) bias=0 and weight~0 so all
+    sigmoid outputs start near 0.5, giving mild suppression that the optimiser
+    can quickly lift.  The sigmoid ceiling of 1.0 prevents amplification;
+    interior tokens (positive SDF) and exterior tokens (negative SDF) learn
+    different scaling profiles automatically.
+    """
+
+    def __init__(self, num_octaves: int = 5):
+        super().__init__()
+        self.num_octaves = num_octaves
+        self.net = nn.Sequential(
+            nn.Linear(1, 8),
+            nn.GELU(),
+            nn.Linear(8, num_octaves),
+            nn.Sigmoid(),
+        )
+        # Initialise so all outputs start near 0.5 (mild attenuation at init)
+        nn.init.trunc_normal_(self.net[0].weight, std=0.02)
+        nn.init.zeros_(self.net[0].bias)
+        nn.init.zeros_(self.net[2].weight)
+        nn.init.zeros_(self.net[2].bias)
+
+    def forward(self, sdf: torch.Tensor) -> torch.Tensor:
+        # sdf: [B, N, 1]
+        return self.net(sdf)  # [B, N, num_octaves]
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -343,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_vol_pe: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +395,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_vol_pe = use_sdf_vol_pe
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -397,6 +437,26 @@ class SurfaceTransolver(nn.Module):
                 self.surface_rff = None
                 self.volume_rff = None
                 rff_out_dim = 0
+
+        # SDF-modulated volume PE (PR #935): tiny MLP that reads per-token SDF
+        # and outputs per-octave multiplicative scale weights applied to the
+        # StringSeparable PE output before feature projection.
+        # Only active when use_sdf_vol_pe=True AND pos_encoding_mode="string_separable".
+        if use_sdf_vol_pe and pos_encoding_mode == "string_separable":
+            _num_octaves = 5
+            self.sdf_vol_pe_scaler = SdfVolPEScaler(num_octaves=_num_octaves)
+            # Pre-compute octave assignment for each of the string_sep output dims.
+            # For output dim d: octave = ((d % (2 * num_features)) % num_features) % num_octaves
+            _nf = string_sep_features
+            _out_dim = 2 * space_dim * _nf  # = surface_string_sep.output_dim
+            _octave_idx = torch.tensor(
+                [((d % (2 * _nf)) % _nf) % _num_octaves for d in range(_out_dim)],
+                dtype=torch.long,
+            )
+            self.register_buffer("_octave_idx", _octave_idx)
+        else:
+            self.sdf_vol_pe_scaler = None
+            self.register_buffer("_octave_idx", None)
 
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -453,6 +513,7 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        is_volume: bool = False,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
@@ -460,7 +521,17 @@ class SurfaceTransolver(nn.Module):
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
         if string_sep is not None:
-            feature_parts.append(string_sep(pos))
+            pe = string_sep(pos)  # [B, N, 2 * space_dim * num_features]
+            # Apply SDF-modulated per-octave scaling for the volume group only
+            if is_volume and self.sdf_vol_pe_scaler is not None and x.shape[-1] > self.space_dim:
+                # SDF is the first (and only) extra feature for the volume group
+                sdf = x[:, :, self.space_dim : self.space_dim + 1]  # [B, N, 1]
+                octave_weights = self.sdf_vol_pe_scaler(sdf)  # [B, N, num_octaves]
+                # Gather per-dim weights via octave assignment buffer
+                # _octave_idx: [out_dim] — maps each PE dim to an octave index
+                per_dim_weights = octave_weights[:, :, self._octave_idx]  # [B, N, out_dim]
+                pe = pe * per_dim_weights
+            feature_parts.append(pe)
         elif rff is not None:
             feature_parts.append(rff(pos))
         if project_features is not None and feature_parts:
@@ -514,6 +585,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    is_volume=True,
                 )
             )
             masks.append(volume_mask)

--- a/test_eval.py
+++ b/test_eval.py
@@ -1,0 +1,208 @@
+"""Standalone test-eval-only script for PR #935.
+
+Loads a saved checkpoint (best-val-by-abupt EMA snapshot) and runs
+evaluate_split on the test loader, mirroring run_final_evaluation's
+test_primary/* metric layout.
+
+Single-GPU eval is used (test split is ~50 cases, ~few minutes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import torch
+import wandb
+
+from train import Config, build_model
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    full_eval_loaders_from,
+    make_loaders,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PR #935 test-eval-only")
+    parser.add_argument(
+        "--checkpoint",
+        default="outputs/drivaerml/run-ixrg3mg1/checkpoint.pt",
+        help="Path to checkpoint.pt to evaluate.",
+    )
+    parser.add_argument(
+        "--source-run-id",
+        default="ixrg3mg1",
+        help="W&B run id of the training run that produced the checkpoint.",
+    )
+    parser.add_argument("--wandb-name", default="tanjiro/sdf-vol-pe-test-eval-ixrg3mg1")
+    parser.add_argument("--wandb-group", default="tanjiro-sdf-vol-pe-identity-init")
+    parser.add_argument("--no-wandb", action="store_true")
+    parser.add_argument("--num-workers", type=int, default=4)
+    return parser.parse_args()
+
+
+def _print_split(label: str, m: dict[str, float]) -> None:
+    print(f"\n=== {label} ===")
+    for k in [
+        "abupt_axis_mean_rel_l2_pct",
+        "surface_pressure_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+    ]:
+        if k in m:
+            print(f"  {k}: {m[k]:.4f}")
+    cases_keys = [k for k in ("cases", "surface_cases", "volume_cases") if k in m]
+    if cases_keys:
+        print("  " + ", ".join(f"{k}={int(m[k])}" for k in cases_keys))
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    ckpt_path = Path(args.checkpoint).resolve()
+    print(f"Loading checkpoint: {ckpt_path}")
+    ckpt = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)
+    cfg_dict = dict(ckpt["config"])
+
+    cfg_dict["num_workers"] = args.num_workers
+    cfg_dict["compile_model"] = False
+    cfg = Config(**cfg_dict)
+    print(f"  source_epoch={ckpt.get('epoch')} checkpoint_source={ckpt.get('checkpoint_source')}")
+    print(f"  selection_metric={ckpt.get('selection_metric')}")
+    print(f"  use_sdf_vol_pe={cfg.use_sdf_vol_pe} use_surf_to_vol_xattn={cfg.use_surf_to_vol_xattn}")
+
+    print("\nBuilding loaders…")
+    _train_loader, val_loaders, test_loaders, stats = make_loaders(cfg, distributed_state=None)
+    final_val_loaders = full_eval_loaders_from(val_loaders, cfg)
+    final_test_loaders = full_eval_loaders_from(test_loaders, cfg)
+    print(f"  val_loaders: {list(final_val_loaders.keys())} (val sizes: "
+          + ", ".join(f"{k}={len(v.dataset)}" for k, v in final_val_loaders.items()) + ")")
+    print(f"  test_loaders: {list(final_test_loaders.keys())} (test sizes: "
+          + ", ".join(f"{k}={len(v.dataset)}" for k, v in final_test_loaders.items()) + ")")
+
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(cfg).to(device)
+    state_dict = ckpt["model"]
+    state_dict = {k.removeprefix("_orig_mod."): v for k, v in state_dict.items()}
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    print(f"  load_state_dict: {len(missing)} missing, {len(unexpected)} unexpected")
+    for k in missing:
+        print(f"    missing: {k}")
+    for k in unexpected:
+        print(f"    unexpected: {k}")
+    model.eval()
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"  Model: SurfaceTransolver ({n_params / 1e6:.2f}M params)")
+
+    run = None
+    if not args.no_wandb:
+        run = wandb.init(
+            project="senpai-v1-drivaerml-ddp8",
+            entity="wandb-applied-ai-team",
+            name=args.wandb_name,
+            group=args.wandb_group,
+            tags=["test-eval-only", "pr-935", "ixrg3mg1"],
+            config={
+                **cfg_dict,
+                "_eval_only": True,
+                "_source_checkpoint": str(ckpt_path),
+                "_source_run_id": args.source_run_id,
+                "_source_epoch": int(ckpt.get("epoch", -1)),
+                "_source_checkpoint_source": ckpt.get("checkpoint_source"),
+            },
+            reinit=True,
+        )
+
+    with torch.no_grad():
+        print("\nRunning full_val evaluation (sanity check vs recorded best val)…")
+        full_val_metrics = {
+            name: evaluate_split(model, loader, transform, device, amp_mode=cfg.amp_mode)
+            for name, loader in final_val_loaders.items()
+        }
+        for split_name, m in full_val_metrics.items():
+            _print_split(f"full_val/{split_name}", m)
+
+        print("\nRunning test evaluation…")
+        test_metrics = {
+            name: evaluate_split(model, loader, transform, device, amp_mode=cfg.amp_mode)
+            for name, loader in final_test_loaders.items()
+        }
+        for split_name, m in test_metrics.items():
+            _print_split(f"test/{split_name}", m)
+
+    if run is not None:
+        log_payload: dict[str, float] = {}
+
+        def _emit(prefix: str, mdict: dict[str, dict[str, float]]) -> None:
+            for split_name, metrics in mdict.items():
+                for k, v in metrics.items():
+                    log_payload[f"{prefix}/{split_name}/{k}"] = float(v)
+
+        _emit("full_val", full_val_metrics)
+        _emit("test", test_metrics)
+
+        primary_keys = [
+            "abupt_axis_mean_rel_l2_pct",
+            "surface_pressure_rel_l2_pct",
+            "volume_pressure_rel_l2_pct",
+            "wall_shear_rel_l2_pct",
+            "wall_shear_x_rel_l2_pct",
+            "wall_shear_y_rel_l2_pct",
+            "wall_shear_z_rel_l2_pct",
+        ]
+        for primary_prefix, mdict_split_key in [
+            ("full_val_primary", ("val_surface", full_val_metrics)),
+            ("test_primary", ("test_surface", test_metrics)),
+        ]:
+            split_key, mdict = mdict_split_key
+            if split_key in mdict:
+                source = mdict[split_key]
+                for k in primary_keys:
+                    if k in source:
+                        log_payload[f"{primary_prefix}/{k}"] = float(source[k])
+
+        wandb.log(log_payload)
+        wandb.summary.update(log_payload)
+        wandb.summary.update({
+            "best_epoch": int(ckpt.get("epoch", -1)),
+            "best_checkpoint/source": ckpt.get("checkpoint_source"),
+        })
+        wandb.finish()
+
+    val_surf = full_val_metrics["val_surface"]
+    tsurf = test_metrics["test_surface"]
+
+    print("\nSENPAI-RESULT")
+    print(f"source_run_id={args.source_run_id}")
+    print(f"source_epoch={int(ckpt.get('epoch', -1))}")
+    print(f"source_checkpoint_source={ckpt.get('checkpoint_source')}")
+    print(f"full_val_abupt={val_surf['abupt_axis_mean_rel_l2_pct']:.4f}")
+    print(f"full_val_surface_pressure={val_surf['surface_pressure_rel_l2_pct']:.4f}")
+    print(f"full_val_volume_pressure={val_surf['volume_pressure_rel_l2_pct']:.4f}")
+    print(f"full_val_wall_shear={val_surf['wall_shear_rel_l2_pct']:.4f}")
+    print(f"test_abupt={tsurf['abupt_axis_mean_rel_l2_pct']:.4f}")
+    print(f"test_surface_pressure={tsurf['surface_pressure_rel_l2_pct']:.4f}")
+    print(f"test_volume_pressure={tsurf['volume_pressure_rel_l2_pct']:.4f}")
+    print(f"test_wall_shear={tsurf['wall_shear_rel_l2_pct']:.4f}")
+    print(f"test_wall_shear_x={tsurf.get('wall_shear_x_rel_l2_pct', float('nan')):.4f}")
+    print(f"test_wall_shear_y={tsurf.get('wall_shear_y_rel_l2_pct', float('nan')):.4f}")
+    print(f"test_wall_shear_z={tsurf.get('wall_shear_z_rel_l2_pct', float('nan')):.4f}")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    os.environ.setdefault("WANDB_ENTITY", "wandb-applied-ai-team")
+    main()

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_vol_pe: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_vol_pe": (
+            "Enable SDF-modulated volume positional encoding (PR #935). "
+            "A tiny MLP (SdfVolPEScaler, ~61 params) maps the per-token SDF "
+            "scalar from the volume input [x,y,z,sdf] to per-octave "
+            "multiplicative weights applied to the StringSeparableEncoding "
+            "output for volume tokens only. Only active when "
+            "--pos-encoding-mode string_separable is also set. "
+            "Output-layer weights are zero-initialised (identity at init)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +304,46 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_sdf_vol_pe_metrics(model: nn.Module) -> dict[str, float]:
+    """Log SdfVolPEScaler param stats and probe its octave outputs at sample SDFs.
+
+    Probe is detached and runs on CPU at fixed SDF anchors covering interior
+    (sdf>0), boundary (sdf~0), and exterior (sdf<0) regions so we can detect
+    mode collapse / dead-gate failure modes without hooking into forward pass.
+    """
+    scaler = getattr(model, "sdf_vol_pe_scaler", None)
+    if scaler is None:
+        return {}
+    metrics: dict[str, float] = {}
+    prefix = "sdf_vol_pe"
+    # Final-layer parameter stats (detect saturation / collapse)
+    final_w = scaler.net[2].weight.detach().float()
+    final_b = scaler.net[2].bias.detach().float()
+    metrics[f"{prefix}/final_w_norm"] = float(final_w.norm().item())
+    metrics[f"{prefix}/final_w_max_abs"] = float(final_w.abs().max().item())
+    metrics[f"{prefix}/final_b_max_abs"] = float(final_b.abs().max().item())
+    # Probe at canonical SDF values to see how octave scales drift over training.
+    with torch.no_grad():
+        device = final_w.device
+        anchors = torch.tensor(
+            [[-0.5], [-0.1], [0.0], [0.1], [0.5]],
+            dtype=torch.float32,
+            device=device,
+        ).unsqueeze(0)  # [1, 5, 1]
+        scales = scaler(anchors).squeeze(0).cpu()  # [5, num_octaves]
+        labels = ["sdf_neg_0p5", "sdf_neg_0p1", "sdf_0", "sdf_pos_0p1", "sdf_pos_0p5"]
+        for r, label in enumerate(labels):
+            for o in range(scales.shape[1]):
+                metrics[f"{prefix}/scale_{label}/oct{o}"] = float(scales[r, o].item())
+        # Cross-anchor std per octave -> detects mode collapse (std~0 means
+        # the scaler ignores SDF and outputs a constant per-octave scale).
+        across_anchor_std = scales.std(dim=0)  # [num_octaves]
+        for o in range(across_anchor_std.shape[0]):
+            metrics[f"{prefix}/scale_anchor_std/oct{o}"] = float(across_anchor_std[o].item())
+        metrics[f"{prefix}/scale_anchor_std/mean"] = float(across_anchor_std.mean().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +358,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_vol_pe=config.use_sdf_vol_pe,
     )
 
 
@@ -1262,6 +1313,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_sdf_vol_pe_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**H2: SDF-Modulated Volume Positional Encoding (per-octave scaler, ~61 params)**

The current SOTA model (PR #823) uses `StringSeparableEncoding` with 5 sigma octaves (0.25, 0.5, 1.0, 2.0, 4.0) for volume tokens. The raw SDF scalar is currently concatenated as a flat feature and projected together with the 96-dim string-sep output via `LinearProjection(97→512)`.

**Problem**: The val→test volume_pressure gap is ~3.2× (val≈3.86%, test≈11.67%). Analysis of the SDF distribution reveals that 4 OOD test cases (run_133, run_226, run_203, run_158) have `sdf_min ≈ 0` — their sampling pipeline omitted inside-body points. This creates a bimodal distribution (6 "restored" train cases share this pattern, 394 "normal" train cases have negative SDF values). The current flat SDF concatenation provides insufficient discrimination signal to the model about which SDF regime it is in.

**Hypothesis**: A lightweight `SdfVolPEScaler` MLP (~61 params) that reads the per-token SDF scalar and outputs 5 per-octave multiplicative scaling weights can teach the model to adapt its positional encoding based on the SDF regime. This gives the model an explicit physics-informed pathway to distinguish interior/exterior tokens and across-pipeline-mode variation — directly targeting the vol_p OOD gap.

**Architecture change** (`model.py` only):

```python
class SdfVolPEScaler(nn.Module):
    """~61-param MLP: SDF scalar -> 5 per-octave PE scale weights."""
    def __init__(self):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(1, 8),
            nn.GELU(),
            nn.Linear(8, 5),
            nn.Sigmoid(),
        )
    
    def forward(self, sdf):
        # sdf: [B, N, 1]
        return self.net(sdf)  # [B, N, 5]
```

In `_encode_group`, after computing `string_sep(pos)` (96-dim), extract per-token octave weights and apply multiplicative modulation:

```python
# Inside _encode_group, in the string_sep branch:
if string_sep is not None and self.use_sdf_vol_pe and x.shape[-1] > self.space_dim:
    sdf = x[:, :, self.space_dim:self.space_dim + 1]  # [B, N, 1]
    pe_raw = string_sep(pos)                           # [B, N, 96]
    # 96 = 2 * 3 * 16 features; octave for feature f = f % 5 (round-robin)
    # Reshape to [B, N, 32, 3] — but easier: build a [96] mask per octave
    # pe_raw grouped by octave via round-robin: feature index f -> octave f % 5
    # weights: [B, N, 5] -> expand to [B, N, 96] by repeating round-robin
    weights = self.sdf_vol_pe_scaler(sdf)  # [B, N, 5]
    # Each of the 96 output dims maps to sigma index: dim d -> (d // (2*3)) % 5
    # StringSeparableEncoding output layout: flatten over [in_dim=3, 2*num_features=32]
    # So dim d: feature index = (d % 32) // 2, octave = feature_idx % 5
    num_features = 16  # rff_num_features
    # Build octave assignment for each of 96 output dims
    # output: [sin(f0,x), sin(f1,x), ..., sin(f15,x), cos(f0,x), ..., cos(f15,x),
    #          sin(f0,y), ..., cos(f15,y), sin(f0,z), ..., cos(f15,z)]
    # layout: [in_dim=3, 2*num_features=32] flattened -> 96
    # feature_idx for dim d: (d % (2*num_features)) % num_features = (d%32) % 16
    # octave for dim d: feature_idx % 5 = ((d%32)%16) % 5
    octave_idx = torch.tensor(
        [((d % (2 * num_features)) % num_features) % 5 for d in range(2 * 3 * num_features)],
        device=pe_raw.device, dtype=torch.long
    )  # [96]
    scale = weights[:, :, octave_idx]  # [B, N, 96]
    feature_parts.append(pe_raw * scale)
else:
    if string_sep is not None:
        feature_parts.append(string_sep(pos))
```

**Parameter count**: `(1×8 + 8) + (8×5 + 5) = 16 + 45 = 61 params` — negligible model size impact.

---

## Instructions to the Student

### Step 1: Add `SdfVolPEScaler` to `model.py`

Add the class near `StringSeparableEncoding`:

```python
class SdfVolPEScaler(nn.Module):
    """Lightweight MLP: per-token SDF scalar -> 5 per-octave PE scale weights (~61 params)."""
    def __init__(self):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(1, 8),
            nn.GELU(),
            nn.Linear(8, 5),
            nn.Sigmoid(),
        )
    
    def forward(self, sdf: torch.Tensor) -> torch.Tensor:
        """sdf: [B, N, 1] -> weights: [B, N, 5]"""
        return self.net(sdf)
```

### Step 2: Add `use_sdf_vol_pe` flag to `SurfaceTransolver.__init__`

In `SurfaceTransolver.__init__`, add the parameter and conditionally instantiate:

```python
def __init__(self, ..., use_sdf_vol_pe: bool = False):
    ...
    self.use_sdf_vol_pe = use_sdf_vol_pe
    if use_sdf_vol_pe:
        self.sdf_vol_pe_scaler = SdfVolPEScaler()
```

### Step 3: Modify `_encode_group` to apply SDF-modulated PE for volume tokens

In `_encode_group`, replace the `string_sep` feature computation with octave-gated modulation when `use_sdf_vol_pe=True` and the group has SDF as an extra feature (i.e., volume group with `VOLUME_X_DIM=4`). The logic should:
1. Compute `pe_raw = string_sep(pos)` — shape `[B, N, 96]`
2. Extract `sdf = x[:, :, self.space_dim:self.space_dim+1]` — shape `[B, N, 1]`
3. Compute `weights = self.sdf_vol_pe_scaler(sdf)` — shape `[B, N, 5]`
4. Build `octave_idx` tensor (shape `[96]`) mapping each output dim to its octave index (0-4) via the round-robin assignment: `octave_idx[d] = ((d % 32) % 16) % 5`
5. Expand weights: `scale = weights[:, :, octave_idx]` — shape `[B, N, 96]`
6. Append `pe_raw * scale` to `feature_parts` instead of raw `pe_raw`

Only apply modulation when `self.use_sdf_vol_pe is True` AND the group is the volume group (has `x.shape[-1] > self.space_dim`). Surface group calls to `_encode_group` have `SURFACE_X_DIM == space_dim` so the fallback branch fires automatically.

**Important**: cache `octave_idx` as a buffer (`self.register_buffer('_octave_idx', ...)`) in `__init__` to avoid recomputation every forward pass.

### Step 4: Add CLI flag to `train.py`

Add `--use-sdf-vol-pe` / `--no-use-sdf-vol-pe` boolean flag (default `False`) in `train.py`'s argument parser. Pass it through to `SurfaceTransolver` construction.

### Step 5: Run a 4-epoch screening run

Use the following command (4 epochs, otherwise identical to SOTA baseline):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-vol-pe \
  --wandb-group tanjiro-sdf-vol-pe \
  --wandb-name tanjiro/sdf-vol-pe-4ep-screen
```

**Kill gates** (based on SOTA EP-by-EP trajectory from run `ghh0s4ne`):
- EP1: kill if val_abupt > 30%
- EP2: kill if val_abupt > 16%
- EP3: kill if val_abupt > 8.0%
- EP4: kill if val_abupt > 6.9%

If the 4-epoch screen passes all gates, extend to 13 epochs (full run):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-vol-pe \
  --wandb-group tanjiro-sdf-vol-pe \
  --wandb-name tanjiro/sdf-vol-pe-13ep-full
```

---

## Current Baseline (to beat)

**PR #823** — run `ghh0s4ne` (nezuko, surf-vol-xattn, StringSeparable PE, Lion optimizer, 13 epochs)

| Split | val_abupt | test_abupt |
|-------|-----------|------------|
| **Overall** | **6.4407%** | **7.6992%** |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | **11.6704%** |
| wall_shear | 7.3448% | 7.0429% |

**Gate**: val_abupt < **6.4407%** to be considered a winner.

**Primary target**: Close the val→test volume_pressure gap (currently 3.86% → 11.67%, a ~3.2× ratio). The SDF-modulated PE is specifically designed to address the OOD SDF distribution causing this gap.

**EP-by-EP val_abupt reference** (run `ghh0s4ne`):
| EP | val_abupt | Kill gate |
|----|-----------|-----------|
| 1  | 28.63%    | > 30% → kill |
| 2  | 8.15%     | > 16% → kill |
| 3  | 7.12%     | > 8.0% → kill |
| 4  | 6.81%     | > 6.9% → kill |
| 13 | 6.44%     | (SOTA) |

---

## Expected outcome

If the hypothesis is correct, the model should show:
1. Similar or better val_abupt (≤ 6.44%) at EP13
2. Reduced val→test volume_pressure gap (ideally test_vol_p < 9% vs current 11.67%)
3. No regression on surface metrics

Please report EP1–4 validation metrics immediately after each epoch, then proceed to full 13-epoch run if gates pass. Include W&B run IDs and the terminal `SENPAI-RESULT` marker when complete.
