### PR TITLE
Mild yaw-only rotation aug (yaw±3°, p=0.3) — follow-up to #925

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,10 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_random_rotation_aug: bool = False
+    rotation_aug_yaw_deg: float = 5.0
+    rotation_aug_pitch_deg: float = 3.0
+    rotation_aug_p: float = 0.5
     debug: bool = False
 
 
@@ -229,6 +233,35 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_random_rotation_aug": (
+            "Enable train-time random small-angle rotation augmentation "
+            "(PR #925): each sample gets, with probability "
+            "--rotation-aug-p, an independent yaw (about z) sampled "
+            "uniformly in [-yaw_deg, yaw_deg] composed with a pitch "
+            "(about y) sampled uniformly in [-pitch_deg, pitch_deg]. The "
+            "rotation R is applied jointly to surface xyz and normals "
+            "(channels 0:3 and 3:6 of surface_x; normals re-normalised), "
+            "volume xyz (channels 0:3 of volume_x), and the wall-shear "
+            "vector targets (channels 1:4 of surface_y). Scalar fields "
+            "(cp, panel area, SDF, volume pressure) are untouched. Padded "
+            "rows (zeros) remain zero. Applied in train_loss / "
+            "per_task_train_losses only; eval/test paths are unaffected."
+        ),
+        "rotation_aug_yaw_deg": (
+            "Half-range (degrees) for the uniform yaw distribution about "
+            "the z-axis. Angles drawn in [-yaw_deg, yaw_deg]. Default 5.0. "
+            "Used only when --use-random-rotation-aug is set."
+        ),
+        "rotation_aug_pitch_deg": (
+            "Half-range (degrees) for the uniform pitch distribution "
+            "about the y-axis. Angles drawn in [-pitch_deg, pitch_deg]. "
+            "Default 3.0. Used only when --use-random-rotation-aug is set."
+        ),
+        "rotation_aug_p": (
+            "Per-sample probability of applying a non-trivial rotation. "
+            "Samples that fail the Bernoulli draw use angle=0 (identity). "
+            "Default 0.5."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +344,97 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_random_rotation_aug(
+    batch,
+    *,
+    yaw_deg: float,
+    pitch_deg: float,
+    p_aug: float,
+) -> dict[str, float]:
+    """Apply per-sample random small-angle rotation to surface + volume tensors.
+
+    Rotation is composed from a yaw (about z) and a pitch (about y) drawn
+    uniformly in [-yaw_deg, yaw_deg] and [-pitch_deg, pitch_deg] respectively.
+    Each sample is rotated with probability ``p_aug``; samples that miss the
+    Bernoulli draw get angle=0 (identity, no-op).
+
+    Modifies ``batch`` in-place. Padded points (mask=False) are zero rows in
+    surface_x / volume_x / surface_y, so rotating them produces zeros — the
+    invariant is preserved without explicit masking.
+
+    Returns a small telemetry dict with the realised rotation distribution.
+    """
+    device = batch.surface_x.device
+    B = batch.surface_x.shape[0]
+
+    yaw_rad_max = math.radians(yaw_deg)
+    pitch_rad_max = math.radians(pitch_deg)
+
+    do_aug = torch.rand(B, device=device) < p_aug
+    yaw = (torch.rand(B, device=device) * 2 - 1) * yaw_rad_max
+    pitch = (torch.rand(B, device=device) * 2 - 1) * pitch_rad_max
+    do_aug_f = do_aug.to(yaw.dtype)
+    yaw = yaw * do_aug_f
+    pitch = pitch * do_aug_f
+
+    cy, sy = yaw.cos(), yaw.sin()
+    cp_, sp_ = pitch.cos(), pitch.sin()
+    zero = torch.zeros_like(yaw)
+    one = torch.ones_like(yaw)
+
+    Rz = torch.stack([
+        torch.stack([cy, -sy, zero], dim=-1),
+        torch.stack([sy, cy, zero], dim=-1),
+        torch.stack([zero, zero, one], dim=-1),
+    ], dim=1)
+    Ry = torch.stack([
+        torch.stack([cp_, zero, sp_], dim=-1),
+        torch.stack([zero, one, zero], dim=-1),
+        torch.stack([-sp_, zero, cp_], dim=-1),
+    ], dim=1)
+    R = torch.bmm(Ry, Rz)
+
+    surf_dtype = batch.surface_x.dtype
+    vol_dtype = batch.volume_x.dtype
+    surf_y_dtype = batch.surface_y.dtype
+
+    R_surf = R.to(surf_dtype)
+    R_vol = R.to(vol_dtype)
+    R_surf_y = R.to(surf_y_dtype)
+
+    surf_xyz = batch.surface_x[..., 0:3]
+    surf_nrm = batch.surface_x[..., 3:6]
+    rotated_xyz = torch.bmm(surf_xyz, R_surf.transpose(1, 2))
+    rotated_nrm = torch.bmm(surf_nrm, R_surf.transpose(1, 2))
+    nrm_norm = rotated_nrm.float().norm(dim=-1, keepdim=True).clamp(min=1e-8)
+    rotated_nrm = (rotated_nrm.float() / nrm_norm).to(surf_dtype)
+    batch.surface_x = torch.cat(
+        [rotated_xyz, rotated_nrm, batch.surface_x[..., 6:]], dim=-1
+    )
+
+    vol_xyz = batch.volume_x[..., 0:3]
+    rotated_vol_xyz = torch.bmm(vol_xyz, R_vol.transpose(1, 2))
+    batch.volume_x = torch.cat(
+        [rotated_vol_xyz, batch.volume_x[..., 3:]], dim=-1
+    )
+
+    tau = batch.surface_y[..., 1:4]
+    rotated_tau = torch.bmm(tau, R_surf_y.transpose(1, 2))
+    batch.surface_y = torch.cat(
+        [batch.surface_y[..., 0:1], rotated_tau], dim=-1
+    )
+
+    yaw_deg_realised = (yaw * 180.0 / math.pi).abs()
+    pitch_deg_realised = (pitch * 180.0 / math.pi).abs()
+    return {
+        "rotation_aug/fraction_rotated": float(do_aug_f.mean().item()),
+        "rotation_aug/mean_abs_yaw_deg": float(yaw_deg_realised.mean().item()),
+        "rotation_aug/mean_abs_pitch_deg": float(pitch_deg_realised.mean().item()),
+        "rotation_aug/max_abs_yaw_deg": float(yaw_deg_realised.max().item()),
+        "rotation_aug/max_abs_pitch_deg": float(pitch_deg_realised.max().item()),
+    }
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,8 +445,17 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    rotation_aug: dict | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    rotation_aug_metrics: dict[str, float] = {}
+    if rotation_aug is not None:
+        rotation_aug_metrics = apply_random_rotation_aug(
+            batch,
+            yaw_deg=rotation_aug["yaw_deg"],
+            pitch_deg=rotation_aug["pitch_deg"],
+            p_aug=rotation_aug["p_aug"],
+        )
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -346,13 +479,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(rotation_aug_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -364,16 +499,28 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
-) -> list[torch.Tensor]:
+    *,
+    rotation_aug: dict | None = None,
+) -> tuple[list[torch.Tensor], dict[str, float]]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
-    Returns scalar tensors in order: [sp, tau_x, tau_y, tau_z, vp].
-    All five share the same forward graph so the GradNorm balancer can
-    extract per-task gradient norms via ``torch.autograd.grad`` with
+    Returns ``(losses, aug_metrics)`` where ``losses`` is a list of scalar
+    tensors in order ``[sp, tau_x, tau_y, tau_z, vp]`` and ``aug_metrics``
+    is the (possibly empty) rotation-augmentation telemetry from this batch.
+    All five losses share the same forward graph so the GradNorm balancer
+    can extract per-task gradient norms via ``torch.autograd.grad`` with
     ``retain_graph=True``.
     """
 
     batch = batch.to(device)
+    aug_metrics: dict[str, float] = {}
+    if rotation_aug is not None:
+        aug_metrics = apply_random_rotation_aug(
+            batch,
+            yaw_deg=rotation_aug["yaw_deg"],
+            pitch_deg=rotation_aug["pitch_deg"],
+            p_aug=rotation_aug["p_aug"],
+        )
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -389,7 +536,7 @@ def per_task_train_losses(
         tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
         tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
+    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss], aug_metrics
 
 
 GRADNORM_MODES = ("full", "ema_proxy")
@@ -852,6 +999,27 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_random_rotation_aug:
+                print(
+                    "Random rotation aug ON: yaw=±"
+                    f"{config.rotation_aug_yaw_deg}° (z-axis), pitch=±"
+                    f"{config.rotation_aug_pitch_deg}° (y-axis), p_aug="
+                    f"{config.rotation_aug_p}; applied to surface_xyz, "
+                    "surface_normals (re-normalised), volume_xyz, and "
+                    "wall-shear vector targets."
+                )
+            else:
+                print("Random rotation aug OFF.")
+
+        rotation_aug_kwargs: dict | None = (
+            {
+                "yaw_deg": config.rotation_aug_yaw_deg,
+                "pitch_deg": config.rotation_aug_pitch_deg,
+                "p_aug": config.rotation_aug_p,
+            }
+            if config.use_random_rotation_aug
+            else None
+        )
 
         run = init_wandb_run(
             config=config,
@@ -937,9 +1105,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                rotation_aug_metrics: dict[str, float] = {}
                 if balancer is not None:
-                    per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                    per_task_losses, rotation_aug_metrics = per_task_train_losses(
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        rotation_aug=rotation_aug_kwargs,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,7 +1204,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        rotation_aug=rotation_aug_kwargs,
                     )
+                    rotation_aug_metrics = {
+                        k: v
+                        for k, v in batch_loss_metrics.items()
+                        if k.startswith("rotation_aug/")
+                    }
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1072,6 +1252,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if rotation_aug_metrics:
+                    train_log.update(rotation_aug_metrics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

**Mild yaw-only rotation augmentation** as a targeted follow-up to PR #925 (yaw±5°/pitch±3°/p=0.5 — NEGATIVE, EP3=9.11%).

PR #925 failed the EP3 gate (9.11% vs ≤8.0% target) primarily because wall-shear error was 10.14% — far above the 7.1% EP3 baseline. The joint yaw+pitch rotation requires rotating all three wall-shear vector components (τ_x, τ_y, τ_z) through a compound R_pitch @ R_yaw matrix, introducing high entropy in the τ_y and τ_z channels that the model had insufficient 4-epoch budget to adapt to.

This PR tests a **strictly simpler** variant:
- **Yaw-only** (pitch=0°): Only τ_x and τ_z are mixed; τ_y (lift-direction) is unchanged. No compound rotation matrix.
- **Yaw ± 3°** (down from ±5°): Smaller augmentation range → lower entropy cost per sample.
- **p=0.3** (down from 0.5): 30% chance of augmentation per sample → model sees un-augmented data 70% of the time.

**Physical motivation:** DrivAerML's OOD test geometries (run_133, run_226, run_203, run_158) account for 92% of the squared test_vol_p deviation. These cases represent atypical body geometries and proportions. Automotive wind-tunnel tests almost always vary primarily in yaw angle (crosswind simulation) — pitch variation is rare. A yaw-only augmentation targets the most physically relevant distribution shift while keeping wall-shear vector rotation tractable.

**Hypothesis to test:** A mild yaw-only augmentation (yaw±3°, p=0.3) passes the 4-epoch EP3 gate (≤8.0%) and improves OOD generalization at long-run EP13, without the wall-shear degradation seen in PR #925.

---

## Current Baseline to Beat

**Single-model SOTA:** PR #823 (nezuko, surf→vol xattn), W&B run `ghh0s4ne`

| Metric | Val | Test |
|--------|----:|-----:|
| **val_abupt** | **6.4407%** | — |
| **test_abupt** | — | **7.6992%** |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | 11.6704% |
| wall_shear | 7.3448% | 7.0429% |
| tau_x | 5.7782% | 6.2773% |
| tau_y | 7.5977% | 7.6657% |
| tau_z | 9.0116% | 9.0375% |

**Single-model training gate:** val_abupt < **6.4407%**

**4-epoch screen kill-gates:**
| Epoch | Gate |
|-------|------|
| EP1 | ≤30.0% |
| EP2 | ≤16.0% |
| EP3 | ≤ 8.0% |
| EP4 | < 6.9% |

**Reference EP3 trajectory for baseline run `ghh0s4ne`:** EP1=28.63%, EP2=8.15%, EP3=7.12%

---

## Instructions to Student

### Overview

Implement a **yaw-only** rotation augmentation variant with smaller magnitude and lower probability than PR #925. The key change is `pitch_deg=0.0` — this eliminates the compound rotation matrix and removes τ_y from the mixing.

### Step 1: Locate the rotation aug implementation

Find the rotation augmentation code from PR #925. It likely lives in `train.py` or a utility module called by the training loop. Look for a function like `random_rotation_aug`, `apply_rotation_aug`, or similar — or for the flags `--use-random-rotation-aug`, `--rotation-aug-yaw-deg`, `--rotation-aug-pitch-deg`, `--rotation-aug-p`.

### Step 2: Modify the augmentation parameters

Change the following from the PR #925 values:

| Parameter | PR #925 (NEGATIVE) | This PR (target) |
|-----------|-------------------:|----------------:|
| `yaw_deg` | 5.0° | **3.0°** |
| `pitch_deg` | 3.0° | **0.0°** |
| `p_aug` | 0.5 | **0.3** |

With `pitch_deg=0.0`, the rotation matrix simplifies to a pure yaw rotation around the vertical axis:
```python
R = R_yaw_only = [[cos(θ), 0, sin(θ)],
                   [0,     1, 0     ],
                   [-sin(θ), 0, cos(θ)]]
```
This mixes only the X and Z components of `surface_xyz`, `vol_xyz`, `surface_normals`, and wall-shear vectors (`tau_x`, `tau_z`). `tau_y` is unchanged — avoiding the primary failure mode of PR #925.

### Step 3: Run the 4-epoch screen

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-random-rotation-aug \
  --rotation-aug-yaw-deg 3.0 \
  --rotation-aug-pitch-deg 0.0 \
  --rotation-aug-p 0.3 \
  --wandb-group alphonse-mild-yaw-only-rotation-aug \
  --wandb-name alphonse/mild-yaw-only-4ep-screen
```

**Adapt flag names to match whatever PR #925 actually implemented.** If the flags differ, use the correct ones. The key numerical values are `yaw_deg=3.0`, `pitch_deg=0.0`, `p_aug=0.3`.

### Step 4: Kill-gate evaluation

After each epoch, report val_abupt and all per-channel metrics. Kill the run immediately if any gate is violated:

- **EP1:** val_abupt > 30.0% → KILL
- **EP2:** val_abupt > 16.0% → KILL
- **EP3:** val_abupt > 8.0% → KILL
- **EP4:** val_abupt ≥ 6.9% → KILL (do not promote)

**If EP3 passes and you have bandwidth**, pay particular attention to per-channel wsh breakdown at EP3 — report `wall_shear`, `tau_x`, `tau_y`, `tau_z` separately. This is how we distinguish yaw-only from joint-rotation benefit.

### Step 5: Long run (if EP4 < 6.9%)

If EP4 passes the gate, promote to the full 13-epoch run:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-random-rotation-aug \
  --rotation-aug-yaw-deg 3.0 \
  --rotation-aug-pitch-deg 0.0 \
  --rotation-aug-p 0.3 \
  --wandb-group alphonse-mild-yaw-only-rotation-aug \
  --wandb-name alphonse/mild-yaw-only-13ep
```

Note the vol-points schedule changes: for 13 epochs use `"0:16384:3:32768:6:49152:9:65536"` (ramp starts at EP3, not EP1).

### Step 6: Report results

Post a PR comment with:
1. Per-epoch val_abupt through EP4 (or to kill point)
2. EP3 per-channel breakdown: `surf_p`, `vol_p`, `wsh`, `tau_x`, `tau_y`, `tau_z`
3. W&B run ID(s)
4. Comparison table vs PR #925 EP3 per-channel metrics (especially wsh: 10.14% → target <8.0%)
5. If long run completes: full EP13 metrics vs baseline table above

Terminal result marker (once final):
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

---

## Context from Prior Experiment

**PR #925 EP3 per-channel breakdown:**
| Channel | EP3 | Gate |
|---------|----:|------|
| surface_pressure | 5.96% | — |
| volume_pressure | 6.14% | — |
| wall_shear | **10.14%** | PRIMARY DRAG |
| val_abupt | 9.11% | ≤8.0% FAIL |

The wall-shear degradation (10.14% vs ~7.1% EP3 baseline) was the entire failure. This PR's yaw-only + p=0.3 design directly targets that failure mode. If wsh at EP3 is ≤8.5%, the 4-epoch screen should pass.

**Suggested diagnostics:** If EP3 still struggles, check whether τ_y is degrading — it should NOT change under yaw-only rotation, so τ_y degradation would indicate a bug in the pitch=0 path (e.g., compound matrix still being applied).
