### PR TITLE
fern: Manifold Mixup hidden-state regularization (backbone)

### DIFF
--- a/train.py
+++ b/train.py
@@ -17,6 +17,7 @@ import argparse
 import gc
 import math
 import os
+import random
 import time
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
@@ -54,6 +55,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    manifold_mixup_train_loss,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -138,6 +140,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_manifold_mixup: bool = False
+    manifold_mixup_alpha: float = 0.2
+    manifold_mixup_prob: float = 0.5
     debug: bool = False
 
 
@@ -228,6 +233,32 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_manifold_mixup": (
+            "Enable Manifold Mixup (Verma et al., ICML 2019, "
+            "https://arxiv.org/abs/1806.05236) on the Transolver backbone. "
+            "Per training step, with probability --manifold-mixup-prob, "
+            "register a forward hook on a uniformly random backbone block "
+            "k in [0, n_layers-1] that replaces the block's output with "
+            "lam * h + (1-lam) * h[perm], where lam ~ Beta(alpha, alpha) "
+            "(reflected so lam>=0.5) and perm is a random batch permutation. "
+            "The remaining blocks plus the surface->volume cross-attention "
+            "and output heads see the mixed hidden state; the loss is "
+            "lam * MSE(pred, y) + (1-lam) * MSE(pred, y[perm]) for both "
+            "surface and volume targets. The hook is removed before the "
+            "next batch. Eval and EMA copies always run unmixed."
+        ),
+        "manifold_mixup_alpha": (
+            "Beta-distribution alpha for Manifold Mixup mixing coefficient "
+            "lam ~ Beta(alpha, alpha). Lower values concentrate mass near "
+            "0 and 1 (mild mixing), higher values near 0.5 (strong mixing). "
+            "Reflected so the effective lam>=0.5. Default 0.2 (Verma et al. "
+            "best on small-dataset image classification)."
+        ),
+        "manifold_mixup_prob": (
+            "Probability per batch that Manifold Mixup is applied. With "
+            "(1 - prob) the batch is processed normally, giving the model "
+            "clean supervision. Default 0.5."
         ),
     }
     for field in fields(Config):
@@ -1021,16 +1052,38 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
-                    loss, batch_loss_metrics = train_loss(
-                        model,
-                        batch,
-                        transform,
-                        device,
-                        config.amp_mode,
-                        surface_loss_weight=config.surface_loss_weight,
-                        volume_loss_weight=config.volume_loss_weight,
-                        surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                    apply_mixup = (
+                        config.use_manifold_mixup
+                        and random.random() < config.manifold_mixup_prob
                     )
+                    if apply_mixup:
+                        loss, batch_loss_metrics = manifold_mixup_train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                            alpha=config.manifold_mixup_alpha,
+                        )
+                    else:
+                        loss, batch_loss_metrics = train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        )
+                        if config.use_manifold_mixup:
+                            batch_loss_metrics = {
+                                **batch_loss_metrics,
+                                "manifold_mixup/applied": 0.0,
+                            }
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1070,6 +1123,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for mixup_key in ("manifold_mixup/lam", "manifold_mixup/layer_k", "manifold_mixup/applied"):
+                        if mixup_key in batch_loss_metrics:
+                            train_log[f"train/{mixup_key}"] = batch_loss_metrics[mixup_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 import os
+import random
 import re
 import subprocess
 from contextlib import nullcontext
@@ -1514,3 +1515,128 @@ def run_final_evaluation(
         test_metrics=test_metrics,
         n_params=n_params,
     )
+
+
+def sample_manifold_mixup(
+    *,
+    alpha: float,
+    num_layers: int,
+    batch_size: int,
+    device: torch.device,
+) -> tuple[float, int, torch.Tensor]:
+    """Sample (lam, layer_index, perm) for one Manifold Mixup step.
+
+    lam is reflected to [0.5, 1.0] for stable mixing per the original paper.
+    Layer index is uniform over [0, num_layers - 1]. Perm is a random batch
+    permutation on the given device.
+    """
+    lam_raw = random.betavariate(alpha, alpha)
+    lam = max(lam_raw, 1.0 - lam_raw)
+    layer_index = random.randint(0, max(num_layers - 1, 0))
+    perm = torch.randperm(batch_size, device=device)
+    return lam, layer_index, perm
+
+
+def manifold_mixup_train_loss(
+    model: nn.Module,
+    batch,
+    transform,
+    device: torch.device,
+    amp_mode: str,
+    *,
+    surface_loss_weight: float,
+    volume_loss_weight: float,
+    surface_channel_weights: torch.Tensor | None,
+    alpha: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Forward+loss with Manifold Mixup applied at a random backbone block.
+
+    Registers a forward hook on ``base_model.backbone.blocks[k]`` that mixes
+    the block's output across a random batch permutation:
+    ``output_mixed = lam * output + (1 - lam) * output[perm]``.
+
+    The remaining backbone blocks, the optional surface->volume xattn, and
+    the output heads then process the mixed hidden state. Loss is the
+    standard manifold mixup form
+    ``lam * L(pred, y) + (1 - lam) * L(pred, y[perm])`` for both surface
+    and volume targets, with sample-i's mask used as the validity mask in
+    both terms.
+
+    Each rank samples ``lam``, ``perm``, and the layer index ``k`` independently;
+    DDP gradient sync remains correct because every rank still uses every
+    parameter on every step (the hook only modifies the value flowing
+    through layer k).
+    """
+    batch = batch.to(device)
+    surface_target = transform.apply_surface(batch.surface_y)
+    volume_target = transform.apply_volume(batch.volume_y)
+
+    base = unwrap_model(model)
+    blocks = base.backbone.blocks
+    num_layers = len(blocks)
+    batch_size = (
+        batch.surface_x.shape[0] if batch.surface_x is not None else batch.volume_x.shape[0]
+    )
+    lam, layer_index, perm = sample_manifold_mixup(
+        alpha=alpha,
+        num_layers=num_layers,
+        batch_size=batch_size,
+        device=device,
+    )
+
+    def hook_fn(module, inputs, output):
+        return lam * output + (1.0 - lam) * output[perm]
+
+    handle = blocks[layer_index].register_forward_hook(hook_fn)
+    try:
+        with autocast_context(device, amp_mode):
+            out = model(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+            surface_pred = out["surface_preds"]
+            volume_pred = out["volume_preds"]
+
+            surface_target_perm = surface_target[perm]
+            volume_target_perm = volume_target[perm]
+            if surface_channel_weights is not None:
+                sl_a = weighted_channel_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+                sl_b = weighted_channel_mse(
+                    surface_pred,
+                    surface_target_perm,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+            else:
+                sl_a = masked_mse(surface_pred, surface_target, batch.surface_mask)
+                sl_b = masked_mse(surface_pred, surface_target_perm, batch.surface_mask)
+            surface_loss = lam * sl_a + (1.0 - lam) * sl_b
+
+            vl_a = masked_mse(volume_pred, volume_target, batch.volume_mask)
+            vl_b = masked_mse(volume_pred, volume_target_perm, batch.volume_mask)
+            volume_loss = lam * vl_a + (1.0 - lam) * vl_b
+
+            weighted_surface_loss = surface_loss_weight * surface_loss
+            weighted_volume_loss = volume_loss_weight * volume_loss
+            loss = weighted_surface_loss + weighted_volume_loss
+            base_mse_loss = surface_loss + volume_loss
+    finally:
+        handle.remove()
+
+    return loss, {
+        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
+        "surface_loss": float(surface_loss.detach().cpu().item()),
+        "volume_loss": float(volume_loss.detach().cpu().item()),
+        "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
+        "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "manifold_mixup/lam": float(lam),
+        "manifold_mixup/layer_k": float(layer_index),
+        "manifold_mixup/applied": 1.0,
+    }


### PR DESCRIPTION
## Hypothesis

**Manifold Mixup** (Verma et al. 2019, NeurIPS) applies convex interpolation between two samples' *intermediate hidden states* at a randomly selected backbone Transolver layer, rather than in input space. The interpolated hidden states propagate forward through the remaining layers; the scalar loss weights are mixed with the same λ drawn from Beta(α, α).

The 400-car DrivAerML training set is small enough that hidden-space augmentation may meaningfully reduce the val→test generalization gap. The vol_p val→test gap (3.86% → 11.67%, a 3×+ spread) is our biggest performance delta and is consistent with the model over-fitting to geometry patterns in training. Manifold Mixup is a strong regularizer that creates smoother interpolations in hidden space than input Mixup — it has shown consistent gains on small-dataset regression settings.

This is architecturally orthogonal to all currently running experiments (SDF PE modulation, geometry Q-bias, surface-point curriculum, vol-pressure aux head, adaptive surface loss, SDF-vol loss weighting).

## Implementation Instructions

### 1. Add CLI flags in `train.py`

Add two new arguments to the argparse block:
```python
parser.add_argument("--use-manifold-mixup", action="store_true", default=False,
                    help="Apply Manifold Mixup regularization in backbone transformer layers")
parser.add_argument("--manifold-mixup-alpha", type=float, default=0.2,
                    help="Beta distribution alpha for Manifold Mixup (default: 0.2)")
parser.add_argument("--manifold-mixup-prob", type=float, default=0.5,
                    help="Probability of applying Manifold Mixup per batch (default: 0.5)")
```

### 2. Implement in `trainer_runtime.py`

The Transolver backbone is a stack of `L=5` transformer layers. You need to intercept the forward pass at a randomly chosen layer index `k ~ Uniform(0, L-1)`, interpolate the hidden states of two randomly paired samples in the batch, then let the remaining layers process the mixed states.

**Approach**: Use PyTorch forward hooks to capture the output of layer `k`, mix, then inject.

In the training step (inside the loss computation), when `--use-manifold-mixup` is active and `random.random() < manifold_mixup_prob`:

```python
import torch, random
import numpy as np

def apply_manifold_mixup(model, batch, alpha=0.2):
    """
    Applies Manifold Mixup at a random backbone transformer layer.
    
    Returns:
        loss_weights: tensor of shape [B] to scale per-sample losses
        lambda_val: the mixing coefficient
    """
    B = batch_size
    # Sample mixing coefficient
    lam = np.random.beta(alpha, alpha)
    lam = max(lam, 1 - lam)  # ensure lam >= 0.5 for stable mixing
    
    # Random permutation for pairing
    perm = torch.randperm(B, device=device)
    
    # Random layer index in [0, L-1]
    L = model.num_layers  # 5
    k = random.randint(0, L - 1)
    
    # Register a forward hook on layer k that mixes hidden states
    mixed = {}
    def hook_fn(module, input, output):
        # output shape: [B, N, D] (tokens × hidden_dim)
        mixed['lam'] = lam
        mixed['perm'] = perm
        # Mix: h_mixed = lam * h + (1-lam) * h[perm]
        return lam * output + (1 - lam) * output[perm]
    
    handle = model.backbone.layers[k].register_forward_hook(hook_fn)
    
    # Forward pass with hook active
    output = model(batch)
    handle.remove()
    
    return output, lam, perm
```

For the loss, apply per-sample mixing to the loss weights:
```python
# loss_per_sample: [B] 
# Mix: loss_mixed = lam * loss(pred, y) + (1-lam) * loss(pred, y[perm])
# In practice: run the full forward pass with mixed hidden states,
# then compute loss against both y and y[perm] with weights lam and (1-lam)
loss = lam * criterion(pred, targets) + (1 - lam) * criterion(pred, targets[perm])
```

**Concretely**: the simplest correct implementation is:
1. Register the hook on `model.backbone.layers[k]` (check the exact attribute name in the model code — it may be `model.layers`, `model.encoder.layers`, or `model.transolver_blocks`)
2. Run the normal forward pass — the hook fires automatically during `.forward()`
3. Compute loss against both `targets` and `targets[perm]` with weights `lam` and `1-lam`
4. Remove the hook

If the model does not expose `.layers` as a `nn.ModuleList`, you may need to register hooks on the individual sub-modules. Read the model source before implementing to find the correct layer attribute.

### 3. No-op guard

When `--use-manifold-mixup` is False (the default), code paths must be identical to baseline — no overhead, no changed behavior.

## Experiment Plan

### Screen run (4 epochs, kill-gate check)

Run with `α=0.2, p_mix=0.5` first:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-manifold-mixup --manifold-mixup-alpha 0.2 --manifold-mixup-prob 0.5 \
  --wandb-group fern-manifold-mixup \
  --wandb-name fern/manifold-mixup-alpha02-4ep
```

### Kill gates (abort if exceeded at any epoch)

| Epoch | val_abupt abort threshold |
|-------|--------------------------|
| EP1   | > 30%                    |
| EP2   | > 16%                    |
| EP3   | > 8.0%                   |
| EP4   | > 6.9%                   |

### If screen passes EP4 gate (val_abupt ≤ 6.9%), run full 13-epoch:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-manifold-mixup --manifold-mixup-alpha 0.2 --manifold-mixup-prob 0.5 \
  --wandb-group fern-manifold-mixup \
  --wandb-name fern/manifold-mixup-alpha02-13ep
```

### If EP4 screen fails, try α=0.5 (stronger regularization):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-manifold-mixup --manifold-mixup-alpha 0.5 --manifold-mixup-prob 0.5 \
  --wandb-group fern-manifold-mixup \
  --wandb-name fern/manifold-mixup-alpha05-4ep
```

## Current Baseline (target to beat)

**Single-model SOTA** — PR #823, W&B run `ghh0s4ne`:

| Metric        | val        | test       |
|---------------|------------|------------|
| abupt (primary) | **6.4407%** | **7.6992%** |
| surf_p        | 4.1836%    | 3.8451%    |
| vol_p         | 3.8557%    | 11.6704%   |
| wall_shear    | 7.3448%    | 7.0429%    |

**Win condition**: val_abupt < 6.4407% with terminal=true, pending_arms=false

**Ensemble SOTA** — PR #880, run `zst3y2mp`: val_abupt = 6.0289%

## Reporting

After each epoch gate check, post a comment with current metrics. When the run is terminal, post:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

If aborting on a kill gate:
```
SENPAI-RESULT: {"terminal":true,"status":"killed","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
