### PR TITLE
6L EMA decay=0.999 + eval-raw-vs-ema: retest UNTESTED EMA hypothesis

### DIFF
--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -50,6 +50,11 @@ class EMA:
         self.step_counter += 1
         if self.step_counter < self.start_step:
             return
+        if self.step_counter == self.start_step:
+            for name, param in model.named_parameters():
+                if param.requires_grad and name in self.shadow:
+                    self.shadow[name].copy_(param.detach())
+            return
         for name, param in model.named_parameters():
             if param.requires_grad and name in self.shadow:
                 self.shadow[name].mul_(self.decay).add_(param.detach(), alpha=1 - self.decay)


### PR DESCRIPTION
## Hypothesis

EMA (Exponential Moving Average) of model weights with corrected decay=0.999 + eval-raw-vs-ema flag will reduce the val→test vol_p generalization gap. The hypothesis is that EMA weight averaging smooths the loss landscape, producing flatter minima that generalize better to OOD test configurations.

**Why EMA is UNTESTED (not rejected):** PR #944 used `--ema-decay 0.9999` which gives an effective lookback window of 1/(1-0.9999) = 10,000 steps (~1.8 epochs). At EP5 (step ~27,469), EMA had only tracked for ~22,469 steps — the shadow weights were still 10.67% contaminated by the corrected-but-stale initialization. The run failed EP5 gate at 8.7923% vs ≤8.0%, but this reflects the lagged EMA weights being used in evaluation, not the hypothesis's fundamental merit.

**Corrected design:**
- `--ema-decay 0.999` → lookback window = 1/(1-0.999) = 1,000 steps (~0.18 epochs). EMA converges to current model state within <1 epoch, enabling fair gate evaluation from EP5 onward.
- `--ema-start-step 500` → EMA begins after 500 steps (during LR warmup). With the warm-start fix now in `trainer_runtime.py` (shadow copied from model weights at `start_step`), contamination is zero.
- `--eval-raw-vs-ema` → evaluates BOTH raw model weights and EMA weights at each checkpoint. Kill gates are based on raw model (fair baseline comparison); final test can compare both. This flag was unavailable in prior EMA runs.

**Supporting evidence:** EMA weight averaging is used in production SOTA models (timm ModelEmaV2, HuggingFace EMAModel, DDPM, many CLIP variants). The EMA warm-start bug fix in PR #944 is architecturally correct and already committed to the branch. Pre-wave run `wyz68o8r` (EMA-proxy GradNorm) achieved test_vol_p=12.213% — worse than SOTA — but that was a different mechanism (GradNorm-based proxy, not true EMA).

**Primary target:** Reduce test_vol_p from 10.758% (wave SOTA `5x8wofzm`) via flatter minima generalization. Secondary: maintain or improve surf_p and wall shear channels.

## Instructions

Use the **6L STRING baseline config** (same as PR #939/nezuko WD=0.005 baseline, only adding EMA flags):

```bash
torchrun --nproc-per-node=8 train.py \
  --model-pe string_multisigma \
  --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 6 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --gradnorm-lr 1e-2 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --weight-decay 0.005 \
  --use-ema \
  --ema-decay 0.999 \
  --ema-start-step 500 \
  --eval-raw-vs-ema \
  --optimizer lion \
  --lr 1e-4 \
  --lr-warmup-steps 500 \
  --batch-size 2 \
  --train-surface-points 40000 \
  --train-volume-points 65000 \
  --no-compile-model \
  --epochs 41 \
  --kill-thresholds "27380:val_primary/abupt_axis_mean_rel_l2_pct<7.5,54760:val_primary/abupt_axis_mean_rel_l2_pct<7.2,82140:val_primary/abupt_axis_mean_rel_l2_pct<6.80,109520:val_primary/abupt_axis_mean_rel_l2_pct<6.75,164280:val_primary/abupt_axis_mean_rel_l2_pct<6.60" \
  --wandb-group ema-corrected-decay-axis
```

**Kill gate schedule** (steps based on 5,476 steps/epoch at batch_size=2, 8 GPUs, ~30,580 samples):
- EP5 (step 27,380): `val_primary/abupt_axis_mean_rel_l2_pct < 7.5`
- EP10 (step 54,760): `val_primary/abupt_axis_mean_rel_l2_pct < 7.2`
- EP15 (step 82,140): `val_primary/abupt_axis_mean_rel_l2_pct < 6.80`
- EP20 (step 109,520): `val_primary/abupt_axis_mean_rel_l2_pct < 6.75`
- EP30 (step 164,280): `val_primary/abupt_axis_mean_rel_l2_pct < 6.60`

> Note: Kill thresholds use `<` (less than) operator — not `>`. Verify your `--kill-thresholds` implementation uses `<` before launching (PRs #945 and earlier had a `>` vs `<` bug).

**Important:** The EP5 gate uses ≤8.0% for EMA (due to warmup lag), but we're evaluating raw model weights via `--eval-raw-vs-ema`, so gates should be based on **raw** model metrics in W&B. Look for `val_primary/abupt_axis_mean_rel_l2_pct` (raw) vs `val_ema_primary/abupt_axis_mean_rel_l2_pct` (EMA) in W&B.

**After terminal epoch:** Run the standard eval-only script (as in prior PRs) with both raw and EMA model checkpoints and report both `test_primary/abupt_axis_mean_rel_l2_pct` values in your SENPAI-RESULT.

**W&B group:** `--wandb-group ema-corrected-decay-axis` — use this so related EMA runs are grouped.

## Baseline to beat

Current wave SOTA (PR #740, run `5x8wofzm`):
- `test_primary/abupt_axis_mean_rel_l2_pct`: **7.5195%**
- `test_primary/surface_pressure_rel_l2_pct`: 3.8810%
- `test_primary/volume_pressure_rel_l2_pct`: 10.7580%
- `test_primary/wall_shear_rel_l2_pct`: 7.0610%

Active val leader for gate comparison (PR #939, run `yfitnqia`, nezuko WD=0.005 6L):
- EP5 val_abupt: **6.9188%** (gate ≤7.5% cleared by 0.58pp)
- EP10 gate (≤7.2%) pending

**Central research problem:** Persistent val→test vol_p gap of ~+7pp across ALL completed long runs. val vol_p reaches ~3.7–4.2%, test vol_p stays ~10.7–11.8%. Weight decay axis fully explored and REJECTED (WD=0.005 and WD=0.01 both show identical gap). EMA weight averaging with correct decay=0.999 is the next best unexplored mechanism for flatter-minima generalization.

## Expected outcome

If EMA with decay=0.999 succeeds:
- Raw model val_abupt should track close to baseline (≤6.60% at EP30)
- EMA model val_abupt may show slightly different trajectory (logged via --eval-raw-vs-ema)
- test_vol_p target: < 10.758% (beat wave SOTA vol_p component)

## Terminal result format

Post a comment with:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Also include in the comment:
- Raw model test_abupt and EMA model test_abupt (from --eval-raw-vs-ema)
- test_vol_p breakdown (raw vs EMA if available)
- GradNorm final loss weights (w_surf_p, w_vol_p, w_wall)
