### PR TITLE
STRING RoPE: slice-centroid local coords as RoPE anchor (2 sigma arms)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_slice_centroid_string: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,12 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_slice_centroid_string = use_slice_centroid_string
+        if use_slice_centroid_string and pos_encoding_mode != "string_separable":
+            raise ValueError(
+                "use_slice_centroid_string requires --pos-encoding-mode string_separable"
+            )
+        self.slice_num = slice_num
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -397,6 +404,26 @@ class SurfaceTransolver(nn.Module):
                 self.surface_rff = None
                 self.volume_rff = None
                 rff_out_dim = 0
+
+        # Slice-centroid local-coordinate STRING (PR #955). A small input-level
+        # slice router maps the absolute coord embedding to soft slice
+        # assignments; the per-slice centroid is the weighted mean of absolute
+        # coords; each point's centroid is the soft mixture of slice centroids
+        # weighted by the point's slice-assignment probability. STRING-sep is
+        # then evaluated on (coord - centroid_per_point) instead of the raw
+        # coord. The router weight is zero-initialised so at step 0 all
+        # softmax outputs are uniform, every point's centroid equals the
+        # per-batch global mean, and STRING sees a constant translation of
+        # the absolute coord (which is just a learnable phase shift in the
+        # STRING sin/cos basis -- effectively identity at init).
+        if use_slice_centroid_string:
+            self.surface_slice_router = nn.Linear(n_hidden, slice_num, bias=False)
+            self.volume_slice_router = nn.Linear(n_hidden, slice_num, bias=False)
+            nn.init.zeros_(self.surface_slice_router.weight)
+            nn.init.zeros_(self.volume_slice_router.weight)
+        else:
+            self.surface_slice_router = None
+            self.volume_slice_router = None
 
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
@@ -450,17 +477,41 @@ class SurfaceTransolver(nn.Module):
         *,
         rff: nn.Module | None,
         string_sep: nn.Module | None,
+        slice_router: nn.Module | None,
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
+        if string_sep is not None and slice_router is not None:
+            # Use the absolute coord embedding to predict soft slice
+            # assignments, derive a per-point centroid, and feed
+            # (coord - centroid) into STRING-sep instead of the raw coord.
+            slice_logits = slice_router(hidden)  # [B, N, S]
+            slice_weights = F.softmax(slice_logits, dim=-1)  # softmax over slices
+            if mask is not None:
+                slice_weights = slice_weights * mask.unsqueeze(-1).to(
+                    device=slice_weights.device, dtype=slice_weights.dtype
+                )
+            # Per-slice centroid = weighted mean of pos within each slice
+            # (only valid points contribute when masked).
+            slice_norm = slice_weights.sum(dim=1).unsqueeze(-1)  # [B, S, 1]
+            centroids = torch.einsum("bns,bnd->bsd", slice_weights, pos) / (
+                slice_norm + 1e-6
+            )  # [B, S, 3]
+            # Per-point centroid = soft mixture of slice centroids
+            # weighted by the point's slice-assignment probability.
+            centroid_per_point = torch.einsum("bns,bsd->bnd", slice_weights, centroids)  # [B, N, 3]
+            string_input = pos - centroid_per_point
+        else:
+            string_input = pos
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
         if string_sep is not None:
-            feature_parts.append(string_sep(pos))
+            feature_parts.append(string_sep(string_input))
         elif rff is not None:
             feature_parts.append(rff(pos))
         if project_features is not None and feature_parts:
@@ -497,9 +548,11 @@ class SurfaceTransolver(nn.Module):
                     surface_x,
                     rff=self.surface_rff,
                     string_sep=self.surface_string_sep,
+                    slice_router=self.surface_slice_router,
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    mask=surface_mask,
                 )
             )
             masks.append(surface_mask)
@@ -511,9 +564,11 @@ class SurfaceTransolver(nn.Module):
                     volume_x,
                     rff=self.volume_rff,
                     string_sep=self.volume_string_sep,
+                    slice_router=self.volume_slice_router,
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    mask=volume_mask,
                 )
             )
             masks.append(volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_slice_centroid_string: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_slice_centroid_string": (
+            "Enable slice-centroid local-coordinate STRING-sep encoding "
+            "(PR #955). An input-level slice router predicts soft slice "
+            "assignments from the absolute coord embedding; per-slice "
+            "centroids are weighted means of the absolute coords; per-point "
+            "centroids are soft mixtures of slice centroids. STRING-sep is "
+            "then evaluated on (coord - centroid_per_point) instead of the "
+            "raw coord. The router weight is zero-initialised so at step 0 "
+            "centroids equal the per-batch global mean and the encoding is "
+            "an identity-equivalent translation of the absolute coord. "
+            "Requires --pos-encoding-mode string_separable."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_slice_centroid_string=config.use_slice_centroid_string,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Transolver groups point-cloud tokens into slices and applies attention over slice representatives. The current STRING-sep positional encoding uses absolute world coordinates as the RoPE anchor for each point. We hypothesize that using the **per-slice centroid** as the local coordinate origin for RoPE will:

1. Make attention geometry-relative (each point's PE is expressed as displacement from its slice's centroid) rather than absolute — yielding translation-equivariance within a slice.
2. Reduce the dynamic range of the coordinate input to RoPE, concentrating spectral energy in the sub-0.25 m frequency band where inter-point variation within a slice actually lives (a typical slice spans ~0.05–0.2 m).
3. Improve OOD generalization for volume_pressure: OOD geometries differ in global pose/bounding-box, but their local centroid-relative geometry (fin shape, underbody geometry, wake topology) remains structurally similar to training geometries.

This builds on PR #783 (merged, Anchor-STRING RoPE v3) and the Issue #618 directive.

Reference: STRING positional encoding — Heo et al. 2024; Transolver slice-grouping — Wu et al. 2024.

## Implementation Instructions

**Student: implement slice-centroid RoPE in `model.py`.**

The core idea: instead of encoding raw `(x, y, z)` coordinates as RoPE frequencies, encode `(x - cx, y - cy, z - cz)` where `(cx, cy, cz)` is the centroid of the slice that the point belongs to.

### Step 1 — Compute slice assignments and centroids

Inside the forward pass of your Transolver layer, after the softmax slice-routing weights `A` are computed (shape `[B, N, S]` where S=128 slices):

```python
# A: [B, N, S] — soft slice assignment weights (after softmax)
# coords: [B, N, 3] — raw xyz coordinates

# Hard or soft centroid: use soft (differentiable)
# centroids: [B, S, 3]
A_norm = A / (A.sum(dim=1, keepdim=True) + 1e-8)  # normalize over N points
centroids = torch.einsum('bns,bnd->bsd', A_norm, coords)  # [B, S, 3]

# For each point, its centroid is a soft blend of all slice centroids
# weighted by its assignment probability:
# centroid_per_point: [B, N, 3]
centroid_per_point = torch.einsum('bns,bsd->bnd', A, centroids)
```

### Step 2 — Express coordinates relative to centroid

```python
# local_coords: [B, N, 3]
local_coords = coords - centroid_per_point
```

### Step 3 — Feed local_coords into RoPE/STRING encoding

Replace the current STRING-sep encoding call (which uses absolute `coords`) with `local_coords`. Keep all other positional encoding hyperparameters identical to SOTA:
- `--pos-encoding-mode string_separable`
- `--rff-num-features 16`
- `--rff-init-sigmas "0.25,0.5,1.0,2.0,4.0"` (5-octave ladder)

### Step 4 — Make sigma ladder match local scale

Since local coordinates typically span [-0.15, 0.15] m (sub-slice range), add a smaller-scale sigma at the bottom:

Use `--rff-init-sigmas "0.05,0.1,0.25,0.5,1.0"` (shift the ladder down 2 octaves for the local coordinate space).

**Run 2 arms to compare:**
- **Arm A**: `--rff-init-sigmas "0.25,0.5,1.0,2.0,4.0"` (same as SOTA baseline, global scale)
- **Arm B**: `--rff-init-sigmas "0.05,0.1,0.25,0.5,1.0"` (local scale, shifted 2 octaves down)

Use `--wandb-group alphonse-string-slice-centroid-rope` for both arms.

### Full reproduce command (Arm A — global sigma ladder):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group alphonse-string-slice-centroid-rope \
  --wandb-name alphonse/string-slice-centroid-rope-armA-global-sigma
```

### Full reproduce command (Arm B — local sigma ladder):

Same as above but with `--rff-init-sigmas "0.05,0.1,0.25,0.5,1.0"` and `--wandb-name alphonse/string-slice-centroid-rope-armB-local-sigma`.

### Notes

- Do NOT use `--compile-model` (torch.compile + DDP NCCL deadlock on this cluster).
- The centroid computation must be done **before** the STRING encoding and **within** the forward pass so gradients flow back through A (the slice routing weights).
- If the centroid computation causes instability (NaN), add a `detach()` on `centroids` only — not on `A_norm`.
- Report EP1 metrics for both arms so I can kill underperforming arms early.

## Baseline (Single-model SOTA — PR #823)

Beat: **val_abupt < 6.4407%**

| Metric | Val | Test |
|--------|-----|------|
| abupt_axis_mean_rel_l2_pct | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | **11.6704%** |
| wall_shear | 7.3448% | 7.0429% |
| tau_x | 5.7782% | 6.2773% |
| tau_y | 7.5977% | 7.6657% |
| tau_z | 9.0116% | 9.0375% |

W&B run: `ghh0s4ne` (group: `nezuko-surf-vol-xattn`)

**OOD gap priority**: The volume_pressure test error is 3.0× the val error (11.67% vs 3.86%). Any reduction in this gap is highly valuable. The 4 OOD test geometries (run_133, run_226, run_203, run_158) account for ~92% of squared vol_p test error.

Ensemble gate (to beat ensemble SOTA): **val_abupt < 6.0289%** (PR #880, W&B: `zst3y2mp`)
