### PR TITLE
Dedicated vol_p aux decoder head: 2-arm loss-weight sweep

### DIFF
--- a/model.py
+++ b/model.py
@@ -421,8 +421,24 @@ class SurfaceTransolver(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
-        self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        # PR #958: dedicated vol_p auxiliary decoder head.
+        # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
+        # Volume head is a deeper 3-layer MLP for the harder vol_p task —
+        # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
+        self.surface_out = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, self.surface_output_dim),
+        )
+        self.surface_out.apply(_init_linear)
+        self.volume_out = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden // 2),
+            nn.SiLU(),
+            nn.Linear(n_hidden // 2, n_hidden // 4),
+            nn.SiLU(),
+            nn.Linear(n_hidden // 4, self.volume_output_dim),
+        )
+        self.volume_out.apply(_init_linear)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).


### PR DESCRIPTION
## Hypothesis

The current SOTA model uses a single shared decoder head for all output channels: surface_pressure (cp), wall_shear (tau_x, tau_y, tau_z), and volume_pressure — 5 channels total from one MLP. This sharing creates a tension: surface physics (cp distribution determined by boundary layer attachment) and volume physics (pressure field driven by far-field Bernoulli) have fundamentally different spatial structure and predictability.

We hypothesize that adding a **dedicated auxiliary decoder head for volume_pressure** — an independent MLP branch that takes the volume-point latent tokens and outputs a refined vol_p estimate — will improve volume_pressure prediction quality and reduce the OOD test gap. The auxiliary head allows the model to specialize capacity for the harder prediction task (vol_p test error 11.67% vs surface_pressure 3.85%) without degrading surface predictions.

This is motivated by:
1. The 3.0× OOD gap on vol_p (val 3.86% vs test 11.67%) vs ~1.0× gap on surface_pressure — the tasks have very different difficulty profiles
2. Multi-task learning theory: when loss magnitudes and gradient scales differ between tasks, separate output heads with independent gradient paths reduce interference
3. The vol→vol cross-attention skip in PR #823 already provides dedicated volume features — an aux head doubles down on this architecture principle

Addresses Issue #717 (vol_p OOD gap). No SDF data needed.

## Implementation Instructions

**Student: implement a dedicated vol_p auxiliary decoder head in `model.py`.**

### Architecture change

After the final Transolver layer, instead of a single output MLP for all channels, split into two branches:

```python
# In your model's __init__:
# Shared output head (surface + volume combined, as before)
self.output_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.SiLU(),
    nn.Linear(hidden_dim, 4)   # [cp, tau_x, tau_y, tau_z]
)

# Dedicated vol_p head (takes volume tokens only)
self.vol_pressure_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim // 2),
    nn.SiLU(),
    nn.Linear(hidden_dim // 2, hidden_dim // 4),
    nn.SiLU(),
    nn.Linear(hidden_dim // 4, 1)   # [vol_p]
)
```

### Forward pass change

```python
# surface_tokens: [B, N_s, hidden_dim]
# volume_tokens:  [B, N_v, hidden_dim]

# Surface predictions (unchanged)
surface_preds = self.output_head(surface_tokens)  # [B, N_s, 4]

# Volume predictions: use dedicated deeper head
vol_preds = self.vol_pressure_head(volume_tokens)  # [B, N_v, 1]

return {"surface_preds": surface_preds, "volume_preds": vol_preds}
```

### Loss weighting

The aux head requires rebalancing the volume loss weight since the dedicated head now has an independent gradient path. Test two loss weights:

**Arm A** — `--volume-loss-weight 1.0` (default, let the dedicated head find its own scale)

**Arm B** — `--volume-loss-weight 2.0` (upweight vol_p loss since we now have dedicated capacity to absorb it)

Use `--wandb-group nezuko-vol-aux-decoder-head` for both arms.

### Full reproduce command (Arm A — dedicated head, vol_loss=1.0):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group nezuko-vol-aux-decoder-head \
  --wandb-name nezuko/vol-aux-head-armA-volloss1
```

### Arm B command:
Same but add `--volume-loss-weight 2.0` and `--wandb-name nezuko/vol-aux-head-armB-volloss2`.

### Architecture details

- The `vol_pressure_head` is a 3-layer MLP (deeper than the shared head) to give it more capacity for the harder vol_p task.
- The shared `output_head` now only predicts 4 surface channels (cp, tau_x, tau_y, tau_z) — do NOT include vol_p in the shared head.
- If `--use-surf-to-vol-xattn` is enabled, the cross-attention output is fed into `volume_tokens` before the vol_pressure_head — this is correct and desirable.
- Parameter count increase is modest: hidden_dim=512, so the aux head adds 512×256 + 256×128 + 128×1 ≈ 165K params (~1.6% increase on ~10M param model).

### Notes

- Do NOT use `--compile-model`.
- Report `volume_pressure` val and test at each epoch separately — this is the primary metric of interest.
- Also report `surface_pressure` val — we want to confirm the aux head doesn't hurt surface quality.
- Kill Arm B at EP3 if vol_p val is worse than Arm A.
- If you see NaN in vol_p predictions, add gradient clipping specifically on `vol_pressure_head` parameters or reduce the vol loss weight.

## Baseline (Single-model SOTA — PR #823)

Beat: **val_abupt < 6.4407%**

| Metric | Val | Test |
|--------|-----|------|
| abupt_axis_mean_rel_l2_pct | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | **11.6704%** |
| wall_shear | 7.3448% | 7.0429% |
| tau_x | 5.7782% | 6.2773% |
| tau_y | 7.5977% | 7.6657% |
| tau_z | 9.0116% | 9.0375% |

W&B run: `ghh0s4ne` (group: `nezuko-surf-vol-xattn`)

**OOD gap priority**: vol_p test 11.67% vs val 3.86% (3×). The dedicated aux decoder head should help the model devote more capacity to this harder prediction.

Ensemble gate: **val_abupt < 6.0289%** (PR #880, W&B: `zst3y2mp`)
