### PR TITLE
Coordinate-conditioned volume output MLP head (xyz→pressure spatial prior)

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,44 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+class CoordVolHead(nn.Module):
+    """Volume output MLP conditioned on backbone hidden state and raw xyz coords.
+
+    Volume pressure has strong spatial structure (stagnation at the nose, suction
+    at the roof, wake behind the car). The reference linear head forces the
+    backbone to encode that spatial structure implicitly. This head receives
+    ``[hidden(n_hidden) || coords(coord_dim)]`` and lets the MLP learn an
+    explicit spatial prior. Final layer is zero-init so the model emits zero
+    on the first step (preserves the baseline output at init when used after a
+    zeroed xattn block; otherwise yields a stable warm-start identical to a
+    randomly initialised volume head with weight 0).
+    """
+
+    def __init__(self, n_hidden: int = 512, coord_dim: int = 3):
+        super().__init__()
+        self.n_hidden = n_hidden
+        self.coord_dim = coord_dim
+        self.mlp = nn.Sequential(
+            nn.Linear(n_hidden + coord_dim, 256),
+            nn.SiLU(),
+            nn.Linear(256, 64),
+            nn.SiLU(),
+            nn.Linear(64, 1),
+        )
+        # Initialise the two interior layers with the standard truncated normal
+        # used elsewhere in the model so gradient flow is well-conditioned.
+        _init_linear(self.mlp[0])
+        _init_linear(self.mlp[2])
+        # Zero-init the final layer so the head outputs 0 at init - matches
+        # baseline output for stable training from step 0.
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+
+    def forward(self, hidden: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        x = torch.cat([hidden, coords.to(dtype=hidden.dtype)], dim=-1)
+        return self.mlp(x)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -343,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_coord_vol_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +395,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_coord_vol_head = use_coord_vol_head
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +483,19 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # Coordinate-conditioned volume head (PR #959). When enabled, the volume
+        # MLP receives ``[hidden || xyz]`` instead of just ``hidden``, giving the
+        # decoder explicit access to spatial position. ``self.volume_out`` is
+        # always built so its parameters remain visible to W&B telemetry; only
+        # the forward pass routing differs.
+        if use_coord_vol_head:
+            self.coord_vol_head = CoordVolHead(
+                n_hidden=n_hidden,
+                coord_dim=space_dim,
+            )
+        else:
+            self.coord_vol_head = None
 
     def _encode_group(
         self,
@@ -553,7 +606,12 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            if self.coord_vol_head is not None:
+                vol_coords = volume_x[:, :, : self.space_dim]
+                volume_preds = self.coord_vol_head(volume_hidden, vol_coords)
+                volume_preds = volume_preds * volume_mask.unsqueeze(-1)
+            else:
+                volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_coord_vol_head: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_coord_vol_head": (
+            "Enable coord-conditioned volume output MLP (PR #959). Replaces "
+            "the linear volume head with a 3-layer MLP whose input is "
+            "[volume_hidden || xyz] (n_hidden+space_dim -> 256 -> 64 -> 1, "
+            "SiLU activations). Final layer weight and bias are zero-init "
+            "so the model emits 0 at step 0; the explicit coordinate input "
+            "lets the decoder learn a spatial prior for volume pressure "
+            "(stagnation, suction, wake) without burning backbone capacity."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_coord_vol_head=config.use_coord_vol_head,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current volume output head is a single linear projection: `self.volume_out = LinearProjection(n_hidden=512, 1)`. This forces the model to encode ALL spatial structure needed for pressure prediction into the 512-dim backbone hidden state. Volume pressure is strongly correlated with spatial position — stagnation zones at the front, suction peaks, wake regions — but the decoder has no direct access to where a point lives in space.

We hypothesize that giving the volume output MLP direct access to the raw 3D coordinates `(x, y, z)` as an additional input allows it to learn a physics-informed spatial prior over pressure distributions. This is architecturally distinct from the "2-layer MLP decoder" axis (closed — that just added depth); here we are adding **coordinates as INPUT features** to an MLP decoder, not merely making the projection deeper.

Concretely: replace `LinearProjection(512 → 1)` with a 3-layer MLP that receives `[hidden(512) || coords(3)] → Linear(515, 256) → SiLU → Linear(256, 64) → SiLU → Linear(64, 1)`. Zero-init the final `Linear(64, 1)` layer (both weight and bias) so the model starts at the exact same output as the current linear head and training is stable from the first step.

The coordinates are already available in `volume_x[:, :, :3]` inside the forward pass — no new data pipeline work required. This adds ~133K parameters on top of the 15.9M baseline.

**Physically motivated**: pressure = f(position, flow features). The backbone captures flow features. Coordinates give the decoder the position component explicitly.

## Instructions

**New flag**: `--use-coord-vol-head` / `--no-use-coord-vol-head` (default: `False`)

**Step 1: Add the CoordVolHead module** in `target/model.py`, after the existing `LinearProjection` class:

```python
class CoordVolHead(nn.Module):
    """Volume output MLP conditioned on both backbone hidden state and raw XYZ coords."""

    def __init__(self, n_hidden: int = 512, coord_dim: int = 3):
        super().__init__()
        self.mlp = nn.Sequential(
            nn.Linear(n_hidden + coord_dim, 256),
            nn.SiLU(),
            nn.Linear(256, 64),
            nn.SiLU(),
            nn.Linear(64, 1),
        )
        # Zero-init final layer → exact baseline output at init, stable training
        nn.init.zeros_(self.mlp[-1].weight)
        nn.init.zeros_(self.mlp[-1].bias)

    def forward(self, hidden: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
        """
        hidden: [B, N_vol, n_hidden]
        coords: [B, N_vol, 3]   — raw (x, y, z) from volume_x[:, :, :3]
        returns: [B, N_vol, 1]
        """
        x = torch.cat([hidden, coords], dim=-1)
        return self.mlp(x)
```

**Step 2: In `SurfaceTransolver.__init__`**, add the flag and conditionally build the head:

```python
# After existing self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
if use_coord_vol_head:
    self.coord_vol_head = CoordVolHead(n_hidden=n_hidden, coord_dim=self.space_dim)
    # Remove or bypass self.volume_out for volume pressure channel
```

Alternatively (simpler implementation): keep `self.volume_out` but override the volume channel:

```python
self.use_coord_vol_head = use_coord_vol_head
if use_coord_vol_head:
    self.coord_vol_head = CoordVolHead(n_hidden=n_hidden, coord_dim=self.space_dim)
```

**Step 3: In `SurfaceTransolver.forward`**, after `volume_hidden` is extracted from the backbone output, replace the linear projection for the volume output:

```python
if self.use_coord_vol_head:
    # volume_x shape: [B, N_vol, 4] — first 3 dims are (x, y, z)
    vol_coords = volume_x[:, :, :self.space_dim]  # [B, N_vol, 3]
    volume_out = self.coord_vol_head(volume_hidden, vol_coords)  # [B, N_vol, 1]
else:
    volume_out = self.volume_out(volume_hidden)  # [B, N_vol, 1]
```

Make sure `volume_x` is accessible in the forward method at the point where `volume_hidden` is used. If it is not currently passed through, you will need to thread it through from the point where it enters the forward pass (it is available as the raw input to `_encode_group`).

**Step 4: Add the CLI flag** in `target/train.py`:

```python
parser.add_argument("--use-coord-vol-head", action="store_true", default=False,
                    help="Replace linear volume output head with coord-conditioned 3-layer MLP")
parser.add_argument("--no-use-coord-vol-head", dest="use_coord_vol_head", action="store_false")
```

Pass `use_coord_vol_head=args.use_coord_vol_head` when constructing the model.

## Screening run (4-epoch gate)

Run with `--use-coord-vol-head` added to the baseline command. Kill gates apply as usual:
- EP1: val_vol_p ≤ 30% AND val_abupt ≤ 30%
- EP2: val_vol_p ≤ 16% AND val_abupt ≤ 16%
- EP3: val_vol_p ≤ 8.0% AND val_abupt ≤ 8.0%
- EP4: val_vol_p ≤ 6.9% AND val_abupt ≤ 6.9%

If EP4 passes, proceed to a full 13-epoch confirmaton run.

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-coord-vol-head \
  --wandb-group tanjiro-coord-vol-head \
  --wandb-name tanjiro/coord-vol-head-4ep
```

If all EP gates pass, run the 13-epoch confirmation:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-coord-vol-head \
  --wandb-group tanjiro-coord-vol-head \
  --wandb-name tanjiro/coord-vol-head-13ep
```

## Baseline (single-model SOTA — PR #823, nezuko surf→vol xattn)

| Metric | Value |
|---|---|
| val_abupt | **6.4407%** |
| test_abupt | 7.6992% |
| val_surface_pressure | 4.1836% |
| val_volume_pressure | **3.8557%** |
| val_wall_shear | 7.3448% |
| test_volume_pressure | 11.6704% |

**W&B run:** `ghh0s4ne` · **Gate:** val_abupt < 6.4407%

## Reporting

Report val_abupt, val_vol_p, val_surface_p, val_wall_shear at each EP gate checkpoint. Report test metrics from the best-val checkpoint after the full 13-epoch run.

Terminal result marker (update with actual values):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
