### PR TITLE
fern: geometry-conditioned Q-bias for surf→vol xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_geom_q_bias: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_geom_q_bias = use_geom_q_bias
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +445,27 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # Geometry-conditioned Q-bias for the surf->vol cross-attention (PR #961):
+        # global geometry descriptor = masked mean over surface_hidden -> tiny MLP
+        # -> additive bias on the query-side input of surf->vol xattn ONLY (K/V
+        # and the residual stream are unchanged). Zero-init the final Linear so
+        # the bias starts at 0 and the module is identity at init.
+        if use_geom_q_bias:
+            if not use_surf_to_vol_xattn:
+                raise ValueError(
+                    "--use-geom-q-bias requires --use-surf-to-vol-xattn (the "
+                    "Q-bias attaches to the Q-projection of surf->vol xattn)."
+                )
+            self.geom_q_mlp = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.GELU(),
+                nn.Linear(n_hidden // 2, n_hidden),
+            )
+            nn.init.zeros_(self.geom_q_mlp[-1].weight)
+            nn.init.zeros_(self.geom_q_mlp[-1].bias)
+        else:
+            self.geom_q_mlp = None
 
     def _encode_group(
         self,
@@ -536,8 +559,19 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            if self.geom_q_mlp is not None:
+                # Masked mean over surface tokens (padded positions are already
+                # zeroed by _apply_token_mask above, so we just divide by the
+                # number of valid tokens per sample).
+                surf_mask_f = surface_mask.to(surface_hidden.dtype)
+                n_valid = surf_mask_f.sum(dim=1).clamp(min=1.0).unsqueeze(-1)
+                geom_desc = surface_hidden.sum(dim=1) / n_valid  # [B, D]
+                q_bias = self.geom_q_mlp(geom_desc).unsqueeze(1)  # [B, 1, D]
+                vol_h_for_q = volume_hidden + q_bias
+            else:
+                vol_h_for_q = volume_hidden
             xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
+                query=vol_h_for_q,
                 key=surface_hidden,
                 value=surface_hidden,
                 need_weights=False,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_geom_q_bias: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_geom_q_bias": (
+            "Enable geometry-conditioned Q-bias for the surf->vol "
+            "cross-attention (PR #961). Computes a global geometry "
+            "descriptor as the masked mean over surface_hidden, passes it "
+            "through a tiny MLP (D -> D/2 -> D, GELU), and adds the result "
+            "as a per-sample bias to the volume input of the Q-projection "
+            "ONLY. K/V and the residual stream are left untouched. Final "
+            "Linear is zero-initialised so the layer is identity at init. "
+            "Requires --use-surf-to-vol-xattn."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_geom_q_bias=config.use_geom_q_bias,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H3 — Geometry-Conditioned Q-Bias for surf→vol cross-attention.**

Volume queries currently attend to surface keys with a fixed Q-projection that has no awareness of *which* car this is. Two cars with very different rear geometries (e.g. notchback vs. estate) generate the same Q distribution from a given vol point, and the model has to disentangle "where am I in this car" purely from the keys/values. We hypothesize this is a major contributor to the OOD volume_pressure failure modes (run_133, run_226, run_203, run_158 contribute ~92% of squared test_vol_p deviation).

We add a global geometry descriptor — the mean over surface hidden states — passed through a tiny MLP, producing an additive bias that conditions the volume-side Q-projection on global geometry. The bias is **zero-initialized** so the model starts at exactly the current SOTA and only deviates if the bias helps.

This is orthogonal to:
- STRING centroid-RoPE (PR #955) and STRING sigma sweep (PR #960)
- Y-flip aug (PR #957)
- Vol-pressure aux head (PR #958)
- SDF-zone masking (PR #953)
- Coord-vol head (PR #959)
- Closed: post-xattn capacity (#891/#893/#906), pre-xattn vol self-attn (#929), Manifold Mixup (#952), GradNorm full-mode (#942)

Inspired by Equivariant Neural Fields literature where global shape codes condition local feature lookups.

## Implementation

**File: `model.py`** — find the surf→vol cross-attention block (gated by `--use-surf-to-vol-xattn`) and add a new gated module immediately *before* the Q-projection of that xattn:

```python
# In __init__ of the parent module:
self.use_geom_q_bias = use_geom_q_bias  # plumb through CLI
if self.use_geom_q_bias:
    self.geom_q_mlp = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim // 2),
        nn.GELU(),
        nn.Linear(hidden_dim // 2, hidden_dim),
    )
    # Zero-init the FINAL linear so the bias starts at zero
    nn.init.zeros_(self.geom_q_mlp[-1].weight)
    nn.init.zeros_(self.geom_q_mlp[-1].bias)

# In forward, immediately before the surf->vol xattn:
# surf_h: [B, N_surf, D], vol_h: [B, N_vol, D]
if self.use_geom_q_bias:
    geom_desc = surf_h.mean(dim=1)            # [B, D]
    q_bias = self.geom_q_mlp(geom_desc)       # [B, D]
    vol_h_for_q = vol_h + q_bias.unsqueeze(1) # [B, N_vol, D]
else:
    vol_h_for_q = vol_h

# Use vol_h_for_q ONLY for the Q-projection of surf->vol xattn.
# Keep vol_h unchanged for residual / V-projection / downstream.
```

Notes:
- Apply only to the **Q-projection** of surf→vol xattn. Do not touch K/V (those come from surf_h) and do not touch the residual stream.
- ~394K params (with hidden_dim=512): 512*256 + 256*512 + biases.
- Add CLI flag `--use-geom-q-bias` (store_true, default False) and plumb through to the model constructor.
- Do **not** modify any other architectural piece. Single-knob hypothesis.

## Phase 1 — 4-epoch screen (kill-gated)

Run a single 4-ep screen first to decide whether to commit a full 13-ep confirm.

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-geom-q-bias \
  --wandb_group fern-geom-q-bias
```

**Kill gates (val_abupt):**
- EP1 ≤ 30%
- EP2 ≤ 16%
- EP3 ≤ 8.0%
- EP4 ≤ 6.9%

Post a `SENPAI-RESULT` after the 4-ep screen. If EP4 val_abupt < 6.9% AND val_vol_p shows a meaningful trend (↓ vs SOTA's EP4 trajectory), advisor will direct you to launch the 13-ep confirm. If gates fail, post the result and stand down.

## Phase 2 — 13-epoch confirm (only on advisor go-ahead)

Same command as above but `--lr-cosine-t-max 13 --epochs 13 --vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`.

**Single-model training gate:** val_abupt < 6.4407% AND val_vol_p ≤ 3.8557% (no regression on the volume metric — this is the whole point of the experiment).

## Baseline (PR #823, W&B `ghh0s4ne`)

| Split | abupt | surf_p | vol_p | wall_shear | tau_x | tau_y | tau_z |
|---|---|---|---|---|---|---|---|
| **val** | **6.4407%** | 4.1836% | **3.8557%** | 7.3448% | 5.7782% | 7.5977% | 9.0116% |
| **test** | 7.6992% | 3.8451% | **11.6704%** | 7.0429% | 6.2773% | 7.6657% | 9.0375% |

AB-UPT reference targets: surface_pressure=3.82%, wall_shear=7.29%, **volume_pressure=6.08%**.

## Reporting

Post a single terminal `SENPAI-RESULT` per phase:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<float>},"test_metric":{"name":"test_abupt","value":<float>}}
```

Also include the per-component table (val + test) for surface_p, vol_p, wall_shear, tau_x, tau_y, tau_z, and call out vol_p movement explicitly. If you killed early on an EP gate, mark `status:"killed"` and report up to the latest epoch.
