### PR TITLE
frieren: Curriculum y-flip augmentation (ramp p 0→0.5 over EP1–EP3)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+frieren/curriculum-yflip-vol-ood

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    yflip_prob: float = 0.0
+    yflip_warmup_epochs: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,25 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "yflip_prob": (
+            "Per-batch probability of Y-axis flip augmentation (PR #957). "
+            "DrivAerML cars share lateral mirror symmetry; reflecting "
+            "across the XZ plane (y -> -y) is an approximate symmetry of "
+            "the CFD solution. With probability p each training batch is "
+            "reflected: y coord and ny normal of surface_x negate, y coord "
+            "of volume_x negates, tau_y of surface_y negates; area, sdf, "
+            "cp, tau_x, tau_z, vol_p are invariant. Eval/test never "
+            "flipped. Default 0.0 disables. Recommended 0.5."
+        ),
+        "yflip_warmup_epochs": (
+            "Linear curriculum ramp for --yflip-prob (PR #962). When >0, "
+            "the effective probability at epoch e (0-indexed) is "
+            "yflip_prob * (e+1) / warmup_epochs, capped at yflip_prob. "
+            "Lets the model first learn the base aerodynamic distribution "
+            "(low p early) before progressively introducing y-symmetry "
+            "regularization. Default 0 disables the curriculum (constant "
+            "yflip_prob from epoch 0)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -309,6 +330,53 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
     )
+
+
+def apply_yflip_to_batch(batch, yflip_prob: float) -> tuple[object, bool]:
+    """Reflect a training batch across the XZ plane (y -> -y) with probability `yflip_prob`.
+
+    DrivAerML cars share a right-hand-drive lateral mirror symmetry; the CFD
+    physics is symmetric under this reflection so the augmented sample is
+    physically valid. Channels that flip:
+      surface_x[..., 1]  (y coord)
+      surface_x[..., 4]  (ny normal)
+      volume_x [..., 1]  (y coord)
+      surface_y[..., 2]  (tau_y)
+    Invariant: x, z, nx, nz, area, sdf, cp, tau_x, tau_z, vol_p.
+
+    Returns the (possibly flipped) batch and a bool indicating whether the
+    flip was applied to this batch. Each rank decides independently — DDP
+    averages gradients across ranks for whatever batch each rank actually saw.
+    """
+
+    if yflip_prob <= 0.0:
+        return batch, False
+    if torch.rand(1).item() >= yflip_prob:
+        return batch, False
+
+    batch.surface_x = batch.surface_x.clone()
+    batch.surface_x[..., 1] = -batch.surface_x[..., 1]
+    batch.surface_x[..., 4] = -batch.surface_x[..., 4]
+    batch.volume_x = batch.volume_x.clone()
+    batch.volume_x[..., 1] = -batch.volume_x[..., 1]
+    batch.surface_y = batch.surface_y.clone()
+    batch.surface_y[..., 2] = -batch.surface_y[..., 2]
+    return batch, True
+
+
+def compute_yflip_effective_prob(target_prob: float, warmup_epochs: int, epoch: int) -> float:
+    """Linear curriculum ramp from p=0 at epoch 0 to `target_prob` over `warmup_epochs` epochs.
+
+    p_effective(epoch) = min(target_prob, target_prob * (epoch + 1) / warmup_epochs)
+
+    For epoch+1 >= warmup_epochs, p_effective = target_prob.
+    If warmup_epochs <= 0 the curriculum is disabled and target_prob is returned unchanged.
+    """
+
+    if target_prob <= 0.0 or warmup_epochs <= 0:
+        return target_prob
+    progress = (epoch + 1) / warmup_epochs
+    return min(target_prob, target_prob * progress)
 
 
 def train_loss(
@@ -930,12 +998,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             train_loss_sum = 0.0
             n_batches = 0
 
+            yflip_prob_effective = compute_yflip_effective_prob(
+                config.yflip_prob, config.yflip_warmup_epochs, epoch
+            )
+            if state.is_main and config.yflip_prob > 0.0:
+                print(
+                    f"[yflip] epoch {epoch} (EP{epoch + 1}) "
+                    f"p_effective={yflip_prob_effective:.4f} "
+                    f"(target={config.yflip_prob}, warmup_epochs={config.yflip_warmup_epochs})"
+                )
+
             for batch in tqdm(
                 train_loader,
                 desc=f"Epoch {epoch + 1}/{max_epochs}",
                 leave=False,
                 disable=not state.is_main,
             ):
+                batch, yflip_applied = apply_yflip_to_batch(batch, yflip_prob_effective)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1056,6 +1135,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/yflip_prob_target": float(config.yflip_prob),
+                    "train/yflip_prob_effective": float(yflip_prob_effective),
+                    "train/yflip_applied": 1.0 if yflip_applied else 0.0,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis

PR #957 (fixed p=0.5 y-flip augmentation) was killed at EP3 with val_abupt=8.33% (gate ≤8.0% ❌) and val_vol_p=5.07% (gate ≤5.0% ❌). The EP2 trajectory was strong (vol_p dropped from 19.7% → 6.4% → 5.1%), but the flat-on augmentation added too much convergence cost within the 13-epoch budget.

**Hypothesis**: Ramping y-flip probability from p=0 to p=0.5 over EP1–EP3 allows the model to first learn the base aerodynamic distribution (p=0 in EP1), then progressively introduce y-symmetry regularization. This should preserve the vol_pressure benefit while recovering the convergence cost, enabling the model to hit the EP3 gate and continue to EP13.

The 4 OOD test cases (run_133/158/203/226) that dominate vol_pressure error are geometrically unusual — y-flip augmentation forces the model to exploit bilateral symmetry, which should improve generalization to these outlier geometries.

## Current Baseline

| Metric | Value |
|--------|-------|
| val_abupt (single best PR #823) | 6.4407% |
| test_abupt (single best PR #823) | 7.6992% |
| test_vol_p (single best PR #823) | 11.6704% |
| val_abupt (ensemble K=6, PR #880) | 6.0289% |
| test_abupt (ensemble K=6, PR #880) | 7.3693% |
| **test_vol_p (ensemble K=6, PR #880)** | **11.3478% ← primary target** |

Vol-pressure promotion ladder: Weak ≤11.0% | Solid ≤10.0% | Major ≤8.5% | Target ≤6.08%

## Prior Art

- PR #957 (`frieren/yflip-augmentation-vol-ood`) — fixed p=0.5 run (`biawznxp`):
  | EP | step  | val_abupt | val_vol_p |
  |----|-------|-----------|-----------|
  | 1  | 10864 | 33.46%    | 19.68%    |
  | 2  | 21729 | 9.71%     | 6.45%     |
  | 3  | 30496 | 8.33%     | 5.08%     |
  → Killed at EP3 gate (abupt ≥8.0% and vol_p ≥5.0%). Strong vol_p signal but convergence too slow with full-strength augmentation from EP1.

## Approach

Implement curriculum ramp via `--yflip-prob 0.5 --yflip-warmup-epochs 3`:
- EP1: p = 0.5 × (1/3) = 0.167
- EP2: p = 0.5 × (2/3) = 0.333
- EP3+: p = 0.5 (full strength)

This lets the model first learn base aerodynamic features, then gradually strengthens the bilateral-symmetry regularization.

If `--yflip-warmup-epochs` is not already implemented on your branch, implement it as a linear ramp of `--yflip-prob` over the specified number of epochs starting from p=0 at epoch 0.

## Training Command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --yflip-prob 0.5 --yflip-warmup-epochs 3 \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<30" \
  --wandb-group frieren-curriculum-yflip \
  --wandb-name frieren/curriculum-yflip-warmup3-p05
```

**Note on kill thresholds**: `500:train/loss<5` is intentionally omitted — y-flip augmentation does not cause the same loss spike pattern as SDF token masking (confirmed by PR #957 trajectory). Only the EP2 abupt divergence gate is retained.

## Gate Schedule

| Epoch | Steps   | Gate                                      | Action if miss |
|-------|---------|-------------------------------------------|----------------|
| EP1   | 10,864  | val_abupt ≤ 30%                           | Kill (diverged) |
| EP3   | 32,592  | val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0%    | Kill if both miss |
| EP5   | 54,320  | val_abupt ≤ 7.5%                          | Kill |
| EP8   | 86,912  | val_abupt ≤ 7.0%                          | Kill |
| EP13  | 141,232 | val_abupt ≤ 6.44% (beat baseline)         | Report terminal result |

## Success Criteria

- Primary: test_vol_p below ensemble SOTA (11.3478%) — target ≤10.5%
- Secondary: val_abupt improves over baseline (6.4407%)

## Result Format

Please report results using the standard SENPAI-RESULT format at EP13 (or at whichever gate you stop):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test/abupt_axis_mean_rel_l2_pct","value":<number>}}
```