### PR TITLE
[tanjiro] SDF Scalar as Explicit Vol-Token Input Feature

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,6 +15,14 @@ import torch.nn.functional as F
 from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
 
 
+# Train-set SDF statistics (aggregated over 400 train cases from
+# `analysis/sdf_per_case_stats.csv`). Used to standardize the per-point SDF
+# scalar before it enters the volume input projection when
+# `use_sdf_vol_input_feature=True`.
+SDF_TRAIN_MEAN = 0.222682
+SDF_TRAIN_STD = 1.681517
+
+
 # ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
@@ -343,6 +351,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_vol_input_feature: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +365,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_vol_input_feature = use_sdf_vol_input_feature
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -403,6 +413,19 @@ class SurfaceTransolver(nn.Module):
 
         surface_proj_in = surface_extra_dim + rff_out_dim
         volume_proj_in = volume_extra_dim + rff_out_dim
+        if use_sdf_vol_input_feature:
+            # Append a normalized SDF scalar to the volume input projection.
+            # Train-set stats are stored as buffers so they ride DDP with the
+            # model and are restored from checkpoint.
+            volume_proj_in += 1
+            self.register_buffer(
+                "sdf_input_mean",
+                torch.tensor(SDF_TRAIN_MEAN, dtype=torch.float32),
+            )
+            self.register_buffer(
+                "sdf_input_std",
+                torch.tensor(SDF_TRAIN_STD, dtype=torch.float32),
+            )
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )
@@ -453,12 +476,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        extra_feature: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if extra_feature is not None:
+            feature_parts.append(extra_feature)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -506,6 +532,10 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
+            volume_extra: torch.Tensor | None = None
+            if self.use_sdf_vol_input_feature and volume_x.shape[-1] > self.space_dim:
+                sdf_raw = volume_x[:, :, self.space_dim : self.space_dim + 1]
+                volume_extra = (sdf_raw - self.sdf_input_mean) / self.sdf_input_std
             tokens.append(
                 self._encode_group(
                     volume_x,
@@ -514,6 +544,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    extra_feature=volume_extra,
                 )
             )
             masks.append(volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_vol_input_feature: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_vol_input_feature": (
+            "Append the train-set normalized signed-distance-field (SDF) "
+            "scalar to every volume point's input feature vector before "
+            "tokenisation (PR #966). The SDF column already lives at "
+            "volume_x[..., 3] in raw distance units; with this flag enabled "
+            "a (sdf - mean) / std standardised copy is concatenated into "
+            "the volume input projection so the backbone sees a clean, "
+            "well-scaled geometry signal in addition to the existing raw "
+            "channel. Adds +1 input dimension to the volume input "
+            "projection only; the surface pipeline is unchanged. "
+            "Mean/std are precomputed train-set stats stored as buffers."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_vol_input_feature=config.use_sdf_vol_input_feature,
     )
 
 


### PR DESCRIPTION
# [tanjiro] SDF Scalar as Explicit Vol-Token Input Feature

## Hypothesis

Appending the signed-distance-field (SDF) value as an explicit scalar to every
volume point's input feature vector — before the Transolver backbone processes
it — will give the model a persistent, geometry-aware signal throughout all
transformer layers, improving vol-pressure predictions on OOD cars
(run_133/158/203/226 drive ~92% of the test_vol_p gap).

**Why this is mechanistically distinct from all closed SDF axes:**

| Closed axis | Where SDF acts | Mechanism |
|---|---|---|
| SDF-zone masking (#953, #963) | Training loop | Stochastic token dropout near surface |
| SDF-modulated vol PE (#935) | Positional encoding | Scales STRING-sep RFF features by SDF |
| CoordVolHead (#959) | Output head | Raw xyz appended after backbone |
| SDF-stratified vol loss (#930) | Loss | Re-weights voxels by SDF zone |

**This PR:** SDF value is concatenated to the raw input feature vector of every
vol point *before* tokenisation. The backbone itself sees geometry from step 1,
enabling every attention layer to route information geometry-conditionally. The
STRING-sep RoPE continues to provide positional context; the SDF scalar
provides an independent, compact geometry signal.

## Implementation

Add a new flag `--use-sdf-vol-input-feature` (bool, default False).

When enabled:
1. For each batch of volume points, look up the per-point SDF distance value
   (the dataset already stores SDF values — they are used by `--vol-sdf-zone-*`
   flags, so the data pipeline already loads them; use the same field).
2. Normalise the SDF scalar to zero-mean / unit-variance using running stats or
   dataset-level statistics (whichever the codebase already uses for other
   scalar features).
3. Concatenate the normalised SDF scalar to each vol-point's raw input feature
   vector (shape: `[B, N_vol, D_in]` → `[B, N_vol, D_in + 1]`).
4. Update the vol-token input projection accordingly so it accepts the extra
   dimension (`nn.Linear(D_in + 1, hidden_dim)` instead of
   `nn.Linear(D_in, hidden_dim)`).

The surface pipeline is unchanged. No changes to the backbone, attention
layers, or output heads.

Keep it clean and minimal: one flag, one input-concat, one projection change.
Do **not** bundle any other changes.

## Screening run (4 epochs)

Use the SOTA reproduce command below with `--epochs 4`, the 4-ep vol schedule,
and `--use-sdf-vol-input-feature`. Kill thresholds as standard.

**Gate schedule (4-ep):**

| Epoch | val_abupt gate |
|---|---|
| EP1 end | ≤ 30% |
| EP2 end | ≤ 16% |
| EP3 end | ≤ 8% |
| EP4 end | ≤ 6.9% |

If EP4 passes the gate, continue to 13-ep confirmation run.

**13-ep gate schedule (if screening passes):**

| Checkpoint | val_abupt gate |
|---|---|
| EP1 | ≤ 30% |
| EP5 | ≤ 7.5% |
| EP10 | ≤ 7.20% |
| EP13 | terminal |

## Current best baseline (single-model SOTA — beat this to merge)

| Metric | Value | W&B run |
|---|---|---|
| val_abupt | **6.4407%** | `ghh0s4ne` |
| test_abupt | 7.6992% | |
| test_vol_p | 11.6704% | |

PR: #823 (nezuko/surf-vol-xattn)

## Reproduce command (4-ep screening)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-vol-input-feature \
  --wandb-group tanjiro-sdf-vol-input-feature \
  --wandb-name tanjiro/sdf-vol-input-feature-4ep \
  --kill-thresholds "500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

## Kill thresholds

`"500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"`

## Reporting

Post a `SENPAI-RESULT` marker after the screening run and again after the
confirmation run (if applicable).

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

Report val_abupt, test_abupt, test_vol_p, and any per-axis breakdown at each
gate epoch.
