### PR TITLE
[thorfinn] SDF-FiLM Conditioning on Vol Token Hidden States

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,35 @@ class Transformer(nn.Module):
         return x
 
 
+class SDFFilm(nn.Module):
+    """SDF-conditioned FiLM (Perez et al. 2018) for vol-token modulation.
+
+    Computes per-point ``(gamma, beta)`` from a normalised SDF scalar via a
+    2-layer MLP. Applied as a residual gate ``h <- (1 + gamma) * h + beta``,
+    so the layer is identity when ``gamma=0, beta=0``. The final linear is
+    zero-initialised (weight and bias) so the conditioning is identity at
+    step 0 and grows in only as gradient signal supports it (a safe init
+    that preserves the well-tuned baseline behaviour at epoch 0).
+    """
+
+    def __init__(self, hidden_dim: int, mlp_hidden: int = 64):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.linear1 = nn.Linear(1, mlp_hidden)
+        self.act = nn.SiLU()
+        self.linear2 = nn.Linear(mlp_hidden, 2 * hidden_dim)
+        nn.init.trunc_normal_(self.linear1.weight, std=0.02)
+        nn.init.zeros_(self.linear1.bias)
+        nn.init.zeros_(self.linear2.weight)
+        nn.init.zeros_(self.linear2.bias)
+
+    def forward(self, sdf_norm: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # sdf_norm: [B, N_vol] (broadcasted to [B, N_vol, 1] internally).
+        film = self.linear2(self.act(self.linear1(sdf_norm.unsqueeze(-1))))
+        gamma, beta = film.chunk(2, dim=-1)
+        return gamma, beta
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +372,10 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_film_vol_conditioning: bool = False,
+        sdf_film_mean: float = 0.228,
+        sdf_film_std: float = 1.634,
+        sdf_film_mlp_hidden: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +389,9 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_film_vol_conditioning = bool(use_sdf_film_vol_conditioning)
+        self.sdf_film_mean = float(sdf_film_mean)
+        self.sdf_film_std = float(sdf_film_std)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +480,16 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # SDF-FiLM vol-token conditioning (PR #967): a single shared MLP
+        # computes per-point (gamma, beta) from the normalised SDF and
+        # modulates vol-token hidden states after each backbone block via
+        # the residual form ``h <- (1 + gamma) * h + beta``. Zero-init last
+        # linear keeps the model identical to the baseline at step 0.
+        if self.use_sdf_film_vol_conditioning:
+            self.sdf_film = SDFFilm(hidden_dim=n_hidden, mlp_hidden=int(sdf_film_mlp_hidden))
+        else:
+            self.sdf_film = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -520,7 +566,56 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        film_active = (
+            self.use_sdf_film_vol_conditioning
+            and self.sdf_film is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        )
+        if film_active:
+            # Precompute the normalised SDF used for FiLM conditioning. SDF
+            # column lives at index 3 of volume_x (xyz, sdf). Normalise to
+            # zero-mean / unit-var using empirical train statistics so the
+            # conditioning input has a well-scaled distribution regardless
+            # of dataset-specific units.
+            vol_sdf = volume_x[:, :, 3].to(dtype=hidden.dtype)
+            sdf_norm = (vol_sdf - self.sdf_film_mean) / self.sdf_film_std
+            vol_start = surface_tokens
+            vol_end = surface_tokens + volume_tokens
+            vol_mask = attn_mask[:, vol_start:vol_end]
+            film_gamma_abs_means: list[torch.Tensor] = []
+            film_beta_abs_means: list[torch.Tensor] = []
+            for block in self.backbone.blocks:
+                hidden = block(hidden, attn_mask=attn_mask)
+                h_vol = hidden[:, vol_start:vol_end]
+                gamma, beta = self.sdf_film(sdf_norm)
+                h_vol_modulated = (1.0 + gamma) * h_vol + beta
+                h_vol_modulated = _apply_token_mask(h_vol_modulated, vol_mask)
+                if surface_tokens > 0:
+                    hidden = torch.cat([hidden[:, :vol_start], h_vol_modulated], dim=1)
+                else:
+                    hidden = h_vol_modulated
+                if self.training:
+                    with torch.no_grad():
+                        m = vol_mask.unsqueeze(-1).to(dtype=gamma.dtype)
+                        denom = m.sum().clamp_min(1.0) * gamma.shape[-1]
+                        film_gamma_abs_means.append((gamma.abs() * m).sum() / denom)
+                        film_beta_abs_means.append((beta.abs() * m).sum() / denom)
+            self._last_film_gamma_abs_mean = (
+                torch.stack(film_gamma_abs_means).mean()
+                if film_gamma_abs_means
+                else None
+            )
+            self._last_film_beta_abs_mean = (
+                torch.stack(film_beta_abs_means).mean()
+                if film_beta_abs_means
+                else None
+            )
+        else:
+            hidden = self.backbone(hidden, attn_mask=attn_mask)
+            self._last_film_gamma_abs_mean = None
+            self._last_film_beta_abs_mean = None
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,10 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_film_vol_conditioning: bool = False
+    sdf_film_mean: float = 0.228
+    sdf_film_std: float = 1.634
+    sdf_film_mlp_hidden: int = 64
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +233,32 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_film_vol_conditioning": (
+            "Enable SDF-FiLM vol-token conditioning (PR #967, Perez et al. "
+            "2018). A shared 2-layer MLP "
+            "(Linear(1, sdf_film_mlp_hidden) -> SiLU -> "
+            "Linear(sdf_film_mlp_hidden, 2 * model_hidden_dim)) maps the "
+            "normalised SDF scalar to per-point (gamma, beta) and "
+            "modulates volume token hidden states after each backbone "
+            "block via the residual form h_vol <- (1 + gamma) * h_vol + "
+            "beta. Surface tokens are unchanged. The MLP final linear is "
+            "zero-initialised (weight and bias) so the layer is identity "
+            "at step 0 (preserves the well-tuned baseline at epoch 0)."
+        ),
+        "sdf_film_mean": (
+            "Empirical SDF mean used to normalise the FiLM input "
+            "(sdf_norm = (sdf - mean) / std). Default 0.228 was "
+            "estimated from 30 random train cases (1.5M points)."
+        ),
+        "sdf_film_std": (
+            "Empirical SDF std used to normalise the FiLM input "
+            "(sdf_norm = (sdf - mean) / std). Default 1.634 was "
+            "estimated from 30 random train cases (1.5M points)."
+        ),
+        "sdf_film_mlp_hidden": (
+            "Hidden width of the FiLM MLP (Linear(1, H) -> SiLU -> "
+            "Linear(H, 2 * model_hidden_dim)). Default 64."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +338,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_film_vol_conditioning=config.use_sdf_film_vol_conditioning,
+        sdf_film_mean=config.sdf_film_mean,
+        sdf_film_std=config.sdf_film_std,
+        sdf_film_mlp_hidden=config.sdf_film_mlp_hidden,
     )
 
 
@@ -852,6 +886,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_sdf_film_vol_conditioning:
+                print(
+                    f"SDF-FiLM vol conditioning: ENABLED "
+                    f"mean={config.sdf_film_mean} std={config.sdf_film_std} "
+                    f"mlp_hidden={config.sdf_film_mlp_hidden} "
+                    f"shared MLP across all {config.model_layers} backbone layers, "
+                    f"residual form h <- (1+gamma)*h + beta, last linear zero-init"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +925,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["sdf_film/enabled"] = bool(config.use_sdf_film_vol_conditioning)
+            if config.use_sdf_film_vol_conditioning:
+                wandb.summary["sdf_film/mean"] = config.sdf_film_mean
+                wandb.summary["sdf_film/std"] = config.sdf_film_std
+                wandb.summary["sdf_film/mlp_hidden"] = config.sdf_film_mlp_hidden
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1070,6 +1117,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                if config.use_sdf_film_vol_conditioning:
+                    gamma_stat = getattr(base_model, "_last_film_gamma_abs_mean", None)
+                    beta_stat = getattr(base_model, "_last_film_beta_abs_mean", None)
+                    if gamma_stat is not None:
+                        train_log["train/sdf_film/gamma_abs_mean"] = float(
+                            gamma_stat.detach().cpu().item()
+                        )
+                    if beta_stat is not None:
+                        train_log["train/sdf_film/beta_abs_mean"] = float(
+                            beta_stat.detach().cpu().item()
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
# [thorfinn] SDF-FiLM Conditioning on Vol Token Hidden States

## Hypothesis

Using the signed-distance-field (SDF) value to compute FiLM (Feature-wise
Linear Modulation) scale (γ) and shift (β) applied to volume token hidden
states inside the Transolver backbone will give the model an adaptive,
geometry-conditioned inductive bias throughout all transformer layers.

The OOD test cases (run_133, run_158, run_203, run_226) dominate ~92% of the
squared test_vol_p error — geometry-conditioned hidden-state modulation should
help the model distinguish near-surface vs. far-field vol regions at every
layer, not just at input or output.

**Why FiLM conditioning is distinct from all closed SDF axes:**

| Closed axis | Where SDF acts | Mechanism |
|---|---|---|
| SDF-zone masking (#953, #963) | Training loop | Stochastic token dropout |
| SDF-modulated vol PE (#935) | Positional encoding only | Scales STRING-sep RFF features |
| CoordVolHead (#959) | Output head | Raw xyz appended after backbone |
| SDF-stratified vol loss (#930) | Loss | Re-weights voxels by zone |
| SDF vol input feature (#966) | Input features | SDF scalar prepended before backbone |

**This PR:** A lightweight learned 2-layer MLP (`sdf → Linear(1,64) → SiLU →
Linear(64, 2×hidden_dim)`) computes per-point (γ, β) at each transformer
layer. After each TransolverBlock processes the vol tokens, apply:
`h_vol ← γ * h_vol + β` (element-wise, shape `[B, N_vol, hidden_dim]`).
The MLP weights are shared across all L=5 layers (parameter-efficient), or
you can optionally use per-layer MLPs. Start with shared weights.

FiLM conditioning has strong precedent in conditional generation (Perez et al.
2018, FILM: Visual Reasoning with a General Conditioning Layer) and has been
used successfully in physics surrogate models where a scalar condition (e.g.
Reynolds number, geometry distance) must modulate internal representations.

## Implementation

Add a new flag `--use-sdf-film-vol-conditioning` (bool, default False).

When enabled:
1. Build a small MLP: `nn.Sequential(nn.Linear(1, 64), nn.SiLU(), nn.Linear(64, 2 * hidden_dim))`.
   Initialise the final linear's weight and bias to zero so that at init
   γ=0 and β=0 → h_vol is unchanged at step 0 (safe initialisation).
   Actually: init the bias of the last layer to `[1.0, ..., 0.0]` (first
   hidden_dim → γ initialised to 1, second hidden_dim → β initialised to 0).
   This ensures the FiLM starts as identity.
2. The SDF scalar is already loaded in the data pipeline (used by
   `--vol-sdf-zone-*` dropout). Re-use the same field.
3. Normalise the SDF scalar (zero-mean / unit-var using dataset statistics).
4. After each TransolverBlock (applied to the vol token sequence), compute:
   ```python
   film_out = self.sdf_film_mlp(sdf_norm.unsqueeze(-1))  # [B, N_vol, 2*H]
   gamma, beta = film_out.chunk(2, dim=-1)
   h_vol = (1 + gamma) * h_vol + beta  # additive residual style
   ```
   Using `(1 + gamma)` is the residual FiLM form — it ensures the identity
   path is always preserved when gamma≈0 at init.
5. Surface token processing is unchanged; only vol hidden states are
   modulated.

Keep it minimal: one MLP, shared across layers, applied post-block.
Do **not** bundle any other changes.

## Screening run (4 epochs)

Use the SOTA reproduce command below with `--epochs 4`, 4-ep vol schedule,
and `--use-sdf-film-vol-conditioning`. Kill thresholds as standard.

**Gate schedule (4-ep):**

| Epoch | val_abupt gate |
|---|---|
| EP1 end | ≤ 30% |
| EP2 end | ≤ 16% |
| EP3 end | ≤ 8% |
| EP4 end | ≤ 6.9% |

If EP4 passes, continue to 13-ep confirmation run.

**13-ep gate schedule (if screening passes):**

| Checkpoint | val_abupt gate |
|---|---|
| EP1 | ≤ 30% |
| EP5 | ≤ 7.5% |
| EP10 | ≤ 7.20% |
| EP13 | terminal |

## Current best baseline (single-model SOTA — beat this to merge)

| Metric | Value | W&B run |
|---|---|---|
| val_abupt | **6.4407%** | `ghh0s4ne` |
| test_abupt | 7.6992% | |
| test_vol_p | 11.6704% | |

PR: #823 (nezuko/surf-vol-xattn)

## Reproduce command (4-ep screening)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-film-vol-conditioning \
  --wandb-group thorfinn-sdf-film-vol-conditioning \
  --wandb-name thorfinn/sdf-film-vol-conditioning-4ep \
  --kill-thresholds "500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

## Kill thresholds

`"500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"`

## Reporting

Post a `SENPAI-RESULT` marker after the screening run and again after the
confirmation run (if applicable).

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

Report val_abupt, test_abupt, test_vol_p, and per-axis breakdown at each
gate epoch. Also report the FiLM γ and β statistics (mean absolute values)
to diagnose whether the conditioning is being used.
