### PR TITLE
fern: stochastic vol subsampling + coord noise for vol_p gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -31,6 +31,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from data import DrivAerMLCase, DrivAerMLSurfaceDataset
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -132,6 +133,9 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_stochastic_volume_sampling: bool = False
+    use_coord_noise: bool = False
+    coord_noise_sigma: float = 0.02
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -189,6 +193,78 @@ def parse_pe_init_sigmas(spec: str) -> list[float] | None:
         return None
     sigmas = [float(s) for s in spec.split(",") if s.strip()]
     return sigmas or None
+
+
+class StochasticVolumeTrainDataset(DrivAerMLSurfaceDataset):
+    """Train dataset that draws volume indices with a fresh OS-seeded RNG per call.
+
+    The parent's ``train_random`` mode uses ``torch.randint`` against the global
+    torch RNG; with DDP each rank starts the same global seed and DataLoader
+    workers seed as ``base_seed + worker_id``, so worker ``w`` on every rank
+    yields the same index sequence. The model can therefore see a small number
+    of correlated volume-point loci across ranks and epochs. Using
+    ``np.random.default_rng()`` with no seed pulls fresh OS entropy on every
+    call, fully decorrelating volume sampling across ranks, workers, and
+    successive ``__getitem__`` invocations. Surface sampling is unchanged.
+    """
+
+    def _stochastic_volume_indices(
+        self,
+        total: int,
+        count: int,
+        view,
+        *,
+        group_view_count: int,
+    ) -> torch.Tensor | None:
+        if view.view_index >= group_view_count:
+            return torch.empty(0, dtype=torch.long)
+        if count <= 0 or total <= count:
+            return None if view.view_index == 0 else torch.empty(0, dtype=torch.long)
+        rng = np.random.default_rng()
+        idx = rng.integers(0, total, size=count, dtype=np.int64)
+        idx.sort()
+        return torch.from_numpy(idx)
+
+    def __getitem__(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+        volume_idx = self._stochastic_volume_indices(
+            counts["n_volume"],
+            self.max_volume_points,
+            view,
+            group_view_count=view.volume_view_count,
+        )
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=None if volume_idx is None else volume_idx.numpy(),
+        )
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = "train_stochastic_random"
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
 
 
 class GradNormWeights(nn.Module):
@@ -299,6 +375,8 @@ def train_loss(
     volume_loss_weight: float = 1.0,
     use_y_symmetry_aug: bool = False,
     y_symmetry_aug_prob: float = 0.5,
+    use_coord_noise: bool = False,
+    coord_noise_sigma: float = 0.02,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
@@ -308,6 +386,17 @@ def train_loss(
         if aug_log is not None:
             aug_log["n_flipped"] = int(flip_mask.sum().item())
             aug_log["batch_size"] = int(flip_mask.shape[0])
+    if use_coord_noise and coord_noise_sigma > 0.0:
+        # Inject Gaussian noise into volume xyz channels (0:3) but NOT sdf (3).
+        # Mask out padded rows so loss/MSE computation against padding stays zero.
+        vol_xyz = batch.volume_x[..., :3]
+        noise = torch.randn_like(vol_xyz) * coord_noise_sigma
+        valid = batch.volume_mask.to(noise.dtype).unsqueeze(-1)
+        batch.volume_x = batch.volume_x.clone()
+        batch.volume_x[..., :3] = vol_xyz + noise * valid
+        if aug_log is not None:
+            aug_log["coord_noise_applied"] = 1
+            aug_log["coord_noise_sigma"] = float(coord_noise_sigma)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -438,7 +527,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             run_eval_only(config, state)
             return
         if config.seed >= 0:
-            seed_everything(config.seed)
+            # Per-rank seed offset decorrelates DataLoader-worker RNG sequences
+            # (each rank's worker_id otherwise inherits the same base seed and
+            # produces identical torch.randint streams). DDP broadcasts model
+            # weights at construction time, so divergent init seeds do not
+            # break parameter sync.
+            rank_offset = (
+                state.rank if config.use_stochastic_volume_sampling else 0
+            )
+            seed_everything(config.seed + rank_offset)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
@@ -451,6 +548,22 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_stochastic_volume_sampling:
+            # Promote the train dataset to the stochastic-volume variant. Mutating
+            # __class__ keeps all parent state (store, views, point limits) intact
+            # while routing volume index draws through np.random.default_rng().
+            base_train_ds = train_loader.dataset
+            if not isinstance(base_train_ds, DrivAerMLSurfaceDataset):
+                raise RuntimeError(
+                    "Stochastic volume sampling requires a DrivAerMLSurfaceDataset; "
+                    f"got {type(base_train_ds).__name__}"
+                )
+            base_train_ds.__class__ = StochasticVolumeTrainDataset
+            if state.is_main:
+                print(
+                    "Stochastic volume sampling enabled: each __getitem__ draws "
+                    "fresh OS-seeded volume indices (surface sampling unchanged)."
+                )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(
@@ -570,7 +683,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
-                aug_log: dict[str, int] = {}
+                aug_log: dict[str, float] = {}
                 loss, batch_loss_metrics, task_losses = train_loss(
                     model,
                     batch,
@@ -581,6 +694,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     volume_loss_weight=config.volume_loss_weight,
                     use_y_symmetry_aug=config.use_y_symmetry_aug,
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
+                    use_coord_noise=config.use_coord_noise,
+                    coord_noise_sigma=config.coord_noise_sigma,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
                 )
@@ -594,6 +709,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"[aug debug] EP0 step0 (rank0): "
                         f"{aug_log.get('n_flipped', 0)}/{aug_log.get('batch_size', 0)} "
                         f"samples y-flipped"
+                    )
+                if (
+                    config.use_coord_noise
+                    and state.is_main
+                    and epoch == 0
+                    and global_step == 0
+                ):
+                    print(
+                        f"[aug debug] EP0 step0 (rank0): coord noise "
+                        f"sigma={config.coord_noise_sigma} applied to volume xyz "
+                        f"(applied={aug_log.get('coord_noise_applied', 0)})"
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -645,6 +771,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     train_log["train/aug/y_symmetry_batch_size"] = aug_log.get(
                         "batch_size", 0
                     )
+                if config.use_coord_noise:
+                    train_log["train/aug/coord_noise_sigma"] = float(
+                        config.coord_noise_sigma
+                    )
+                    train_log["train/aug/coord_noise_applied"] = float(
+                        aug_log.get("coord_noise_applied", 0)
+                    )
+                if config.use_stochastic_volume_sampling:
+                    train_log["train/aug/stochastic_volume_sampling"] = 1.0
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

**Stochastic volume point subsampling + geometric coordinate noise to close the structural val→test vol_p gap**

Every completed long run on this wave shows a systematic ~7pp val→test gap in `volume_pressure_rel_l2_pct` (val≈4.0–4.5%, test≈10.7–12.2%), regardless of weight decay, EMA, GradNorm α, dropout, depth, extended cosine, or static loss weighting. The gap is structural, not weight-magnitude-driven.

**Root cause hypothesis:** The model is memorizing the specific spatial distribution of volume query point locations in the training set. During validation, it sees the same 65k point loci it was trained on (deterministic view-based sampling with `view_count=ceil(total/65k)` leaves the same points recurring every epoch for most cases). During inference/test, it encounters the full held-out test cases with potentially different spatial coverage. The model learns the geometry of the sample grid rather than the underlying pressure field.

**Proposed fix — two orthogonal augmentation mechanisms to implement together:**

### Arm A: Aggressive per-batch random volume point subsampling (randomized seeds)
Change the training dataloader to draw a completely fresh random subset of volume points for each batch rather than cycling through fixed views. Concretely: for every training batch, independently draw `train_volume_points=65k` points uniformly WITHOUT caching/recycling view indices between epochs. This forces the model to see different volume point neighborhoods every batch, preventing spatial memorization.

The key change is in how the dataloader samples volume points during training — each call to `__getitem__` should use a freshly seeded RNG rather than a deterministic sequence tied to epoch/view_index. Surface points should remain as-is (they are not implicated in the gap).

Also: pass `--seed` with different values across the 8 DDP ranks so each rank sees a different random draw per step (currently all 8 ranks likely draw the same view indices if seeded identically).

### Arm B: Coordinate noise injection on volume point positions
Add Gaussian noise to volume `xyz` coordinates during training (NOT during eval/test). Scale: σ=0.02 in normalized coordinate space (roughly 2cm physical scale given ~1m car). This makes the model robust to small perturbations in where query points land, preventing overfitting to exact grid locations.

The noise should be added to the input features `[x, y, z, sdf]` — specifically the `xyz` channels only. SDF values should NOT be noised (they are structural). Zero noise at eval time (standard train/test split of augmentations).

Both arms test the same core hypothesis via different mechanisms. **Run both arms simultaneously** on the 8 GPUs (4 GPUs each, batch_size=1 per rank = batch_size=4 total — or alternatively run sequentially if 8 GPUs needed per arm).

Actually, given the 8-GPU setup, **run as two sequential arms**: Arm A first (random subsampling), Arm B second (coordinate noise). If Arm A clears EP5 ≤7.5%, continue to EP15 gate. If Arm A fails, launch Arm B immediately.

---

## Why this direction hasn't been falsified yet

All previous approaches attacked the gap at the model or loss level (regularization, weight balancing, smoothing via EMA). None have attacked it at the **data augmentation / distribution coverage** level. The hypothesis that the model memorizes spatial query loci is distinct from weight magnitude or gradient scale explanations.

Reference: the proportional sampling experiment (PR #951, `wd5kgp2n`) explored point *count* ratios but not point *location randomization*. The EMA experiment (PR #954) smoothed weights but left the training distribution unchanged.

---

## Instructions to the Student

### Setup
Base your code on the current `drivaerml-long-20260504` branch. Use the 6L STRING (5-octave) + GradNorm α=0.5 + WD=0.005 + Y-sym p=0.5 baseline config — the same as PR #939 (`yfitnqia`) which is currently running.

### Arm A: Per-batch random volume point subsampling

**Code change:** In `data/loader.py` (or wherever the point view sampling is implemented), modify the training path so that volume point indices are drawn with a fresh `np.random.default_rng()` on **each call to `__getitem__`** rather than being fixed to a deterministic `(epoch, view_index)` pair. Specifically:

1. Find where `view_count` and view index cycling happen for volume points in training mode.
2. Replace the deterministic index selection with a call like:
   ```python
   rng = np.random.default_rng()  # fresh seed every call
   vol_idx = rng.choice(n_vol_total, size=self.train_volume_points, replace=True)
   ```
3. Keep surface point sampling deterministic (do NOT change surface sampling).
4. Use `--seed 42` as the base seed but ensure each DDP rank gets a different offset (e.g., `seed + rank`).

Launch command (Arm A):
```bash
python train.py \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --wandb-group vol-test-gap-domain-adaptation \
  --wandb-name fern-vol-rand-subsample \
  --kill-thresholds "5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

### Arm B: Coordinate noise injection (launch if Arm A fails EP5 gate)

**Code change:** In `train.py` or `trainer_runtime.py`, add a training-only augmentation that injects Gaussian noise into volume point `xyz` coordinates (channels 0, 1, 2 of the volume feature tensor) with σ=0.02 in normalized space. Do NOT noise SDF (channel 3). Do NOT apply noise during validation or test.

```python
# In training step, after loading volume_x batch:
if self.training:
    noise = torch.randn_like(volume_x[:, :, :3]) * 0.02
    volume_x = volume_x.clone()
    volume_x[:, :, :3] = volume_x[:, :, :3] + noise
```

Launch command (Arm B):
```bash
python train.py \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --wandb-group vol-test-gap-domain-adaptation \
  --wandb-name fern-vol-coord-noise \
  --kill-thresholds "5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

### Kill gates (STRICT — same as wave baseline)

| Epoch | Threshold | Notes |
|-------|-----------|-------|
| EP5   | ≤7.5%     | Hard kill if missed |
| EP10  | ≤7.2%     | Hard kill if missed |
| EP15  | ≤6.80%    | Hard kill if missed |
| EP20  | ≤6.70%    | Hard kill if missed |
| EP25  | ≤6.65%    | Hard kill if missed |
| EP30  | ≤6.60%    | Terminal |

### Key observables to track

1. **val_vol_p vs test_vol_p at terminal**: We expect the gap to shrink if the hypothesis is correct. Even a 1–2pp reduction in test_vol_p (from ~11% toward ~9%) would be scientifically significant.
2. **Convergence speed**: Random subsampling may slow early convergence (EP1–EP3 may be slightly higher). This is acceptable if EP5 still clears ≤7.5%.
3. **GradNorm weight trajectory for w_vol**: Watch whether vol_p task weight remains stable or drifts — stochastic sampling changes gradient variance.

### Reporting

When posting results, please include:
- val_vol_p at each epoch gate
- test_vol_p at terminal (from the standard test eval after best-val checkpoint reload)
- The val→test gap explicitly (test_vol_p − val_vol_p)
- Whether EP5 gate was cleared

---

## Baseline to beat

**Wave SOTA:** PR #740 (`5x8wofzm`)
- `test_primary/abupt_axis_mean_rel_l2_pct` = **7.5195%** ← must beat this to merge
- `test_primary/surface_pressure_rel_l2_pct` = 3.881%
- `test_primary/volume_pressure_rel_l2_pct` = 10.758%
- `test_primary/wall_shear_rel_l2_pct` = 7.061%

**Current wave val leader (mid-run, not merged):** PR #939 `yfitnqia` EP20=6.5829% (nezuko, WD=0.005 6L)

**Public reference targets (AB-UPT):**
- surf_p = 3.82%, wall = 7.29%, vol_p = 6.08%

**Structural gap summary (all completed runs):**

| Run | val_vol_p | test_vol_p | gap |
|-----|-----------|-----------|-----|
| #800 `hmhfnedy` | 4.28% | 12.04% | +7.76pp |
| #844 `7dqsxvbq` | 4.06% | 11.16% | +7.10pp |
| #874 `rm6u10ro` | 4.13% | 11.36% | +7.23pp |
| #900 `os6v64lq` | ~4.0% | 11.84% | +7.4pp |
| #914 `wdxtdmhy` | 4.17% | 11.90% | +7.72pp |
| #954 `gwiucb33` | 4.67% | 12.18% | +7.51pp |
| #740 `5x8wofzm` | — | 10.76% | — (SOTA) |

The vol_p gap is present in every single run. This experiment attempts to close it via spatial distribution coverage augmentation.

---

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
