### PR TITLE
fern: H2 SDF-modulated vol PE octave scaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -135,6 +135,54 @@ class StringSeparableEncoding(nn.Module):
         # flatten last two dims: [..., 2 * in_dim * num_features]
         return enc.flatten(start_dim=-2)
 
+    def forward_with_octave_weights(
+        self,
+        x: torch.Tensor,
+        octave_weights: torch.Tensor,
+        init_sigmas: list[float],
+    ) -> torch.Tensor:
+        """Forward pass that applies per-sigma-octave scalar weights.
+
+        Each feature index ``f`` belongs to sigma octave ``f % n_sigmas``,
+        following the round-robin assignment used at init.  ``octave_weights``
+        has shape ``[..., n_sigmas]`` and is broadcast over all features in
+        that octave and over sin/cos dims.
+
+        Args:
+            x: [..., in_dim] coordinate tensor.
+            octave_weights: [..., n_sigmas] — one scalar per sigma octave per
+                token, computed by the SDF MLP.
+            init_sigmas: list of sigma values used at init (determines octave
+                assignment, i.e. n_sigmas == len(init_sigmas)).
+
+        Returns:
+            [..., 2 * in_dim * num_features] — same shape as ``forward()``.
+        """
+        freq = torch.exp(self.log_freq.to(dtype=x.dtype))
+        phase = self.phase.to(dtype=x.dtype)
+        proj = 2.0 * math.pi * x.unsqueeze(-1) * freq + phase
+        enc = torch.cat([proj.sin(), proj.cos()], dim=-1)
+        # enc: [..., in_dim, 2 * num_features]
+        # Build per-feature weight vector from octave_weights.
+        n_sigmas = len(init_sigmas)
+        n_features = self.num_features
+        # feature_octave_idx[f] = f % n_sigmas  (for f in 0..num_features-1)
+        # We need to index octave_weights at dimension -1 for each feature,
+        # duplicated for sin and cos halves.
+        feature_idx = list(range(n_features))
+        # octave index for each of the 2*num_features entries in enc's last dim
+        # (sin half: features 0..n_features-1; cos half: same pattern)
+        octave_idx = [f % n_sigmas for f in feature_idx] * 2  # length: 2*num_features
+        octave_idx_tensor = torch.tensor(
+            octave_idx, dtype=torch.long, device=x.device
+        )  # [2*num_features]
+        # Gather per-feature weights: [..., 2*num_features]
+        per_feature_w = octave_weights[..., octave_idx_tensor]  # [..., 2*num_features]
+        # Expand to match enc: [..., in_dim, 2*num_features]
+        per_feature_w = per_feature_w.unsqueeze(-2)  # [..., 1, 2*num_features]
+        enc = enc * per_feature_w
+        return enc.flatten(start_dim=-2)
+
 
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
@@ -343,6 +391,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_pe_scaling: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +405,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_pe_scaling = use_sdf_pe_scaling
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -400,6 +450,31 @@ class SurfaceTransolver(nn.Module):
 
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
+
+        # SDF-modulated vol PE scaling (H2 hypothesis).
+        # A tiny MLP reads each vol token's signed-distance value (scalar) and
+        # outputs one positive weight per sigma octave.  The weights modulate
+        # the per-octave STRING-sep features before they enter the linear
+        # projection, so the model can learn that near-surface tokens (small
+        # |SDF|) should use higher-frequency octaves while far-field tokens
+        # can rely on smoother, lower-frequency bases.
+        #
+        # Identity init: Softplus(0.541) ≈ 1.0, so all octave weights start at
+        # 1.0 and the module is transparent at epoch 0.
+        if use_sdf_pe_scaling and pos_encoding_mode == "string_separable":
+            n_sigmas = len(self.rff_init_sigmas) if self.rff_init_sigmas else 1
+            self.sdf_pe_mlp: nn.Sequential | None = nn.Sequential(
+                nn.Linear(1, 16),
+                nn.SiLU(),
+                nn.Linear(16, n_sigmas),
+                nn.Softplus(),
+            )
+            # Identity init: set final Linear bias so Softplus output ≈ 1.0.
+            # Softplus(x) ≈ 1 when x = log(exp(1) - 1) ≈ 0.5413.
+            nn.init.zeros_(self.sdf_pe_mlp[2].weight)
+            nn.init.constant_(self.sdf_pe_mlp[2].bias, math.log(math.exp(1.0) - 1.0))
+        else:
+            self.sdf_pe_mlp = None
 
         surface_proj_in = surface_extra_dim + rff_out_dim
         volume_proj_in = volume_extra_dim + rff_out_dim
@@ -453,6 +528,7 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        sdf_col: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
@@ -460,7 +536,22 @@ class SurfaceTransolver(nn.Module):
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
         if string_sep is not None:
-            feature_parts.append(string_sep(pos))
+            if (
+                self.sdf_pe_mlp is not None
+                and sdf_col is not None
+                and self.rff_init_sigmas is not None
+            ):
+                # SDF-modulated octave scaling: tiny MLP maps each token's SDF
+                # value -> per-sigma-octave positive weight, then scale the
+                # STRING-sep features before projection.
+                octave_weights = self.sdf_pe_mlp(sdf_col)  # [..., n_sigmas]
+                feature_parts.append(
+                    string_sep.forward_with_octave_weights(
+                        pos, octave_weights, self.rff_init_sigmas
+                    )
+                )
+            else:
+                feature_parts.append(string_sep(pos))
         elif rff is not None:
             feature_parts.append(rff(pos))
         if project_features is not None and feature_parts:
@@ -506,6 +597,8 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
+            # SDF column is index 3 (0-based) in the volume input: [x, y, z, sdf, ...].
+            vol_sdf_col = volume_x[:, :, 3:4] if self.sdf_pe_mlp is not None else None
             tokens.append(
                 self._encode_group(
                     volume_x,
@@ -514,6 +607,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    sdf_col=vol_sdf_col,
                 )
             )
             masks.append(volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_pe_scaling: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -308,6 +309,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_pe_scaling=config.use_sdf_pe_scaling,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H2: SDF-modulated vol PE octave scaling** — a tiny (~112-param) MLP reads each vol token's SDF value (scalar) and outputs 5 per-octave scale weights that multiply the STRING separable RFF features before they enter the linear projection. Near-surface tokens (small |SDF|) benefit from high-frequency octaves; far-field tokens use smoother bases. Identity init (`Softplus(log(exp(1)−1)) ≈ 1.0`) ensures zero parameter change at epoch 0.

**Architecture:**
- `sdf_pe_mlp`: `Linear(1→16) → SiLU → Linear(16→n_sigmas) → Softplus`
- SDF column: `vol_x[:, :, 3:4]` (4th column, 0-indexed)
- Octave mapping: feature `f` → sigma octave `f % n_sigmas`
- Identity init: `nn.init.zeros_(weight)`, `nn.init.constant_(bias, log(exp(1)−1) ≈ 0.5413)`
- Only active when `pos_encoding_mode == "string_separable"` and `use_sdf_pe_scaling=True`

## Gate criteria (4-ep screen)

| Gate | Metric | Threshold |
|------|--------|-----------|
| EP1 kill | val_abupt | > 30% → abort |
| EP4 continue | val_abupt | ≤ 6.9% → continue to full 13ep |

## Current baseline

| Metric | Value | PR | W&B run |
|--------|-------|----|---------|
| val_abupt | 6.4407% | #823 | ghh0s4ne |
| test_abupt | 7.6992% | #823 | ghh0s4ne |

## Reproduce command (4-ep screen)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-pe-scaling \
  --wandb-group fern-sdf-pe-octave-scaling \
  --wandb-name fern/sdf-pe-octave-scaling-4ep
```

If EP4 gate passes (val_abupt ≤ 6.9%), run full 13ep:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-pe-scaling \
  --wandb-group fern-sdf-pe-octave-scaling \
  --wandb-name fern/sdf-pe-octave-scaling-13ep
```

## Implementation summary

- `model.py`: `StringSeparableEncoding.forward_with_octave_weights()` — new method computing per-feature octave weights from SDF MLP output; `sdf_pe_mlp` construction with identity init; `_encode_group()` extended with `sdf_col` kwarg; `forward()` extracts `vol_sdf_col = volume_x[:, :, 3:4]`.
- `train.py`: `use_sdf_pe_scaling: bool = False` in `Config`; wired into `build_model()`.
- Parameter overhead: ~112 params (negligible).