### PR TITLE
alphonse: STRING-sep frozen-freq ablation (phase-only adaptation)

### DIFF
--- a/model.py
+++ b/model.py
@@ -96,11 +96,15 @@ class StringSeparableEncoding(nn.Module):
         num_features: int = 32,
         sigma: float = 1.0,
         init_sigmas: list[float] | None = None,
+        freeze_freqs: bool = False,
     ):
         super().__init__()
         self.in_dim = in_dim
         self.num_features = num_features
-        # log_freq[d, f]: learnable log-frequency per axis per feature
+        self.freeze_freqs = freeze_freqs
+        # log_freq[d, f]: log-frequency per axis per feature. Trainable Parameter
+        # by default; non-trainable buffer when freeze_freqs=True (ablation:
+        # isolates octave-init contribution from learned frequency adaptation).
         if init_sigmas is not None and len(init_sigmas) > 1:
             # Multi-sigma init (PR #488): round-robin per-feature sigma so the
             # encoding starts with broad spectral coverage across frequency
@@ -111,11 +115,13 @@ class StringSeparableEncoding(nn.Module):
                 dtype=torch.float32,
             )
             log_freq_init = log_sigmas.unsqueeze(0).expand(in_dim, num_features).clone()
-            self.log_freq = nn.Parameter(log_freq_init)
         else:
-            self.log_freq = nn.Parameter(
-                torch.full((in_dim, num_features), math.log(sigma))
-            )
+            log_freq_init = torch.full((in_dim, num_features), math.log(sigma))
+
+        if freeze_freqs:
+            self.register_buffer("log_freq", log_freq_init)
+        else:
+            self.log_freq = nn.Parameter(log_freq_init)
         # phase[d, f]: learnable phase per axis per feature
         self.phase = nn.Parameter(torch.zeros(in_dim, num_features))
 
@@ -340,6 +346,7 @@ class SurfaceTransolver(nn.Module):
         rff_num_features: int = 0,
         rff_sigma: float = 1.0,
         rff_init_sigmas: list[float] | None = None,
+        rff_freeze_freqs: bool = False,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
@@ -353,6 +360,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_num_features = rff_num_features
         self.rff_sigma = rff_sigma
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
+        self.rff_freeze_freqs = rff_freeze_freqs
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
@@ -369,12 +377,14 @@ class SurfaceTransolver(nn.Module):
                 num_features=string_sep_features,
                 sigma=rff_sigma,
                 init_sigmas=self.rff_init_sigmas,
+                freeze_freqs=rff_freeze_freqs,
             )
             self.volume_string_sep = StringSeparableEncoding(
                 in_dim=space_dim,
                 num_features=string_sep_features,
                 sigma=rff_sigma,
                 init_sigmas=self.rff_init_sigmas,
+                freeze_freqs=rff_freeze_freqs,
             )
             string_sep_out_dim = self.surface_string_sep.output_dim  # 2 * space_dim * num_features
             self.pos_embed = ContinuousSincosEmbed(hidden_dim=n_hidden, input_dim=space_dim)

--- a/train.py
+++ b/train.py
@@ -100,6 +100,7 @@ class Config:
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     rff_init_sigmas: str = ""
+    rff_freeze_freqs: bool = False
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
@@ -305,6 +306,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_num_features=config.rff_num_features,
         rff_sigma=config.rff_sigma,
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
+        rff_freeze_freqs=config.rff_freeze_freqs,
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
@@ -852,6 +854,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+
+        if config.rff_freeze_freqs and state.is_main:
+            for attr in ("surface_string_sep", "volume_string_sep"):
+                ss = getattr(base_model, attr, None)
+                if ss is None:
+                    continue
+                assert not any(
+                    name == "log_freq" for name, _ in ss.named_parameters()
+                ), f"log_freq is still a parameter in {attr} — freeze failed!"
+                buf_names = {name for name, _ in ss.named_buffers()}
+                assert "log_freq" in buf_names, f"log_freq buffer missing in {attr}"
+                print(f"FREEZE CHECK: {attr}.log_freq is a buffer (non-trainable)")
 
         run = init_wandb_run(
             config=config,


### PR DESCRIPTION
## Hypothesis

**STRING-sep frozen-frequency ablation** — test whether gradient-based frequency adaptation in `StringSeparableEncoding` is actually helping, or whether the multi-sigma octave initialization alone is doing all the work.

Currently, `log_freq` in `StringSeparableEncoding` is an `nn.Parameter` (fully trainable). The SOTA octave initialization (`{0.25, 0.5, 1.0, 2.0, 4.0}` round-robin) was designed to span the relevant spatial frequency spectrum. If the learned frequency adaptation is critical, freezing it will hurt performance. If the init is the key contributor, freezing will have minimal effect — and could even help by reducing overfitting.

The ablation: register `log_freq` as a **non-trainable buffer** (frozen at init values), keep only `phase` as `nn.Parameter`. This isolates the contribution of frequency learning from phase learning.

## Current Baseline

| Metric | Value | PR | Run |
|--------|-------|-----|-----|
| **val_abupt (single-model gate)** | **6.4407%** | #823 | `ghh0s4ne` |
| surface_pressure | 4.3027% | #823 | `ghh0s4ne` |
| volume_pressure | 3.8296% | #823 | `ghh0s4ne` |
| wall_shear | 7.6637% | #823 | `ghh0s4ne` |
| **val_abupt (ensemble SOTA)** | **6.0289%** | #880 | `zst3y2mp` |

Single-model gate: val_abupt < **6.4407%**

## Implementation Instructions

### Step 1: Add `rff_freeze_freqs` flag to `train.py`

In the `Config` dataclass (around line 102, where `rff_init_sigmas` is defined), add:

```python
rff_freeze_freqs: bool = False
```

This adds a `--rff-freeze-freqs` / `--no-rff-freeze-freqs` CLI flag automatically via `simple_parsing`.

### Step 2: Add `freeze_freqs` parameter to `StringSeparableEncoding` in `model.py`

Modify `StringSeparableEncoding.__init__` to accept and use `freeze_freqs: bool = False`:

```python
class StringSeparableEncoding(nn.Module):
    def __init__(
        self,
        in_dim: int,
        num_features: int = 32,
        sigma: float = 1.0,
        init_sigmas: list[float] | None = None,
        freeze_freqs: bool = False,   # ← NEW
    ):
        super().__init__()
        self.in_dim = in_dim
        self.num_features = num_features
        # Build log_freq_init as before
        if init_sigmas is not None and len(init_sigmas) > 1:
            log_sigmas = torch.tensor(
                [math.log(init_sigmas[f % len(init_sigmas)]) for f in range(num_features)],
                dtype=torch.float32,
            )
            log_freq_init = log_sigmas.unsqueeze(0).expand(in_dim, num_features).clone()
        else:
            log_freq_init = torch.full((in_dim, num_features), math.log(sigma))

        if freeze_freqs:
            # Register as non-trainable buffer — frozen at octave init
            self.register_buffer("log_freq", log_freq_init)
        else:
            # Original behaviour — trainable
            self.log_freq = nn.Parameter(log_freq_init)

        self.phase = nn.Parameter(torch.zeros(in_dim, num_features))
```

The `forward` method is unchanged — `torch.exp(self.log_freq.to(dtype=x.dtype))` works on both buffers and Parameters.

Note: `collect_string_sep_metrics` in `train.py` calls `.detach().float()` on `log_freq`, which also works on both buffers and Parameters — no changes needed there.

### Step 3: Thread `freeze_freqs` through `SurfaceTransolver`

In `SurfaceTransolver.__init__` (around line 340 in `model.py`), add `freeze_freqs: bool = False` to the constructor signature and pass it when constructing the two `StringSeparableEncoding` instances:

```python
# In SurfaceTransolver.__init__ signature:
def __init__(self, ..., freeze_freqs: bool = False, ...):
    ...
    self.surface_string_sep = StringSeparableEncoding(
        in_dim=space_dim,
        num_features=string_sep_features,
        sigma=rff_sigma,
        init_sigmas=self.rff_init_sigmas,
        freeze_freqs=freeze_freqs,     # ← NEW
    )
    self.volume_string_sep = StringSeparableEncoding(
        in_dim=space_dim,
        num_features=string_sep_features,
        sigma=rff_sigma,
        init_sigmas=self.rff_init_sigmas,
        freeze_freqs=freeze_freqs,     # ← NEW
    )
```

### Step 4: Thread `freeze_freqs` from `train.py` to `SurfaceTransolver`

In `train.py`, wherever `SurfaceTransolver` is constructed (look for `rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas)`), add:

```python
freeze_freqs=config.rff_freeze_freqs,
```

### Step 5: Verification check

Before training, add a quick sanity check to confirm `log_freq` is not in the trainable param count when `freeze_freqs=True`:

```python
if config.rff_freeze_freqs:
    ss = getattr(base_model, "surface_string_sep", None)
    if ss is not None:
        # log_freq should be a buffer, not a parameter
        assert not any(name == "log_freq" for name, _ in ss.named_parameters()), \
            "log_freq is still a parameter — freeze failed!"
        print("FREEZE CHECK: surface log_freq is a buffer (non-trainable) ✓")
```

## Run Instructions

**4-epoch screen run** (gate: EP1 ≤30%, EP3 ≤8.0% AND vol_p ≤5.0%):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --rff-freeze-freqs \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group alphonse-string-frozen-freq-ablation \
  --wandb-name alphonse/frozen-freq-4ep
```

**If EP3 passes both gates (val_abupt ≤8.0% AND vol_p ≤5.0%), extend to 13 epochs:**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --rff-freeze-freqs \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group alphonse-string-frozen-freq-ablation \
  --wandb-name alphonse/frozen-freq-13ep
```

## EP Gates

| Gate | Metric | Threshold |
|------|--------|-----------|
| EP1 | val_abupt | ≤ 30% |
| EP3 | val_abupt | ≤ 8.0% |
| EP3 | vol_pressure | ≤ 5.0% |
| EP5 | val_abupt | ≤ 7.5% |
| EP8 | val_abupt | ≤ 7.0% |
| EP13 | val_abupt | < 6.4407% (SOTA) |

Kill the run and post results if any gate fails. If EP3 passes, stop the 4-ep run and start the 13-ep run from scratch (no checkpoint resume needed; just rerun with the 13-ep command above and the longer vol-points schedule).

## What to Report

Please report in a PR comment at each gate:
1. `val_abupt` and `vol_pressure` at the gate epoch
2. Whether the gate passed or failed
3. The W&B run ID

Terminal result format:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

## What This Tells Us

- **If frozen ≈ learned**: The multi-sigma octave initialization (`{0.25, 0.5, 1.0, 2.0, 4.0}`) is the key structural prior; gradient-based frequency adaptation is not providing meaningful additional benefit. We can simplify the architecture.
- **If frozen >> learned (worse)**: Frequency adaptation is genuinely important — the model is learning task-specific frequencies that differ from the octave prior. Worth investigating what frequencies it learns.
- **If frozen < learned (better)**: Overfitting in frequency space — frozen octave initialization acts as regularization. Suggests the frequency space is being over-parameterized.

This result will directly inform whether future STRING-sep development should focus on better initializations (frequencies-as-hyperparameter) or on architectures that allow richer frequency learning.
