### PR TITLE
feat: SDF-stratified volume importance sampling to close val→test vol_p gap

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -259,6 +261,84 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     raise ValueError(
         f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
     )
+
+
+def _install_sdf_stratified_vol_sampling(
+    train_dataset,
+    *,
+    alpha: float,
+    n_vol: int,
+    is_main: bool,
+) -> None:
+    """Monkey-patch ``train_dataset.__getitem__`` to draw volume points with
+    importance weights ``w[i] = 1 + alpha * |sdf[i]|`` via ``torch.multinomial``.
+
+    Per-case ``|sdf|`` is cached after the first read so subsequent draws only
+    pay an mmap row-indexed read for the resampled subset.
+    """
+    import types
+
+    from data.loader import DrivAerMLCase, _load_npy_rows
+
+    sdf_cache: dict[str, torch.Tensor] = {}
+
+    def _get_abs_sdf(self, case_id: str) -> torch.Tensor:
+        cached = sdf_cache.get(case_id)
+        if cached is not None:
+            return cached
+        case_dir = self.store.root / case_id
+        sdf_arr = _load_npy_rows(case_dir / "volume_sdf.npy", rows=None)
+        weights = torch.from_numpy(sdf_arr.reshape(-1).astype(np.float32, copy=False)).abs()
+        sdf_cache[case_id] = weights
+        return weights
+
+    def _sdf_stratified_getitem(self, idx: int):
+        view = self.views[idx]
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+        abs_sdf = _get_abs_sdf(self, view.case_id)
+        n_total = abs_sdf.shape[0]
+        n_sample = min(n_vol, n_total) if n_vol > 0 else n_total
+        weights = 1.0 + alpha * abs_sdf
+        vol_idx_t = torch.multinomial(weights, n_sample, replacement=True).sort().values
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=vol_idx_t.numpy(),
+        )
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(n_total)
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = "sdf_stratified"
+        metadata["sdf_stratified_alpha"] = float(alpha)
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+    train_dataset.__getitem__ = types.MethodType(_sdf_stratified_getitem, train_dataset)
+    if is_main:
+        print(
+            f"SDF-stratified volume sampling enabled: alpha={alpha}, "
+            f"n_vol={n_vol} (weights = 1 + alpha * |sdf|, with replacement)"
+        )
 
 
 def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
@@ -451,6 +531,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            _install_sdf_stratified_vol_sampling(
+                train_loader.dataset,
+                alpha=config.sdf_stratified_alpha,
+                n_vol=config.train_volume_points,
+                is_main=state.is_main,
+            )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(


### PR DESCRIPTION
## Hypothesis

**SDF-stratified volume importance sampling** — replace the uniform-random volume point selection in `train_random` mode with SDF-weighted sampling where far-field (high `|sdf|`) volume points are drawn with higher probability. 

### Motivation

The structural val→test `vol_p` gap (+7–8 pp, confirmed across every completed run) is a **data distribution problem**. The test set contains car geometries with a wider range of aerodynamic configurations than the 400-case training set. Far-field volume cells (high `|sdf|`) carry the global pressure field signature — they are the cells where the pressure gradient from the body propagates outward. If training systematically under-samples these cells (because uniform random sampling assigns equal weight to near-surface boundary-layer cells and far-field cells, but the near-surface region is geometrically denser), the model may not learn robust far-field pressure representations, causing it to generalise poorly to test geometries.

**SDF-stratified sampling biases training draws toward high-|sdf| (far-field) volume points.** The weight for point `i` is:

```
weight[i] = 1 + α * |sdf[i]|
```

where `α` controls the strength of the bias (start with `α=2.0`). The sampling is done **with replacement** using `torch.multinomial` to preserve the stochastic per-batch draw that makes this a form of domain adaptation.

This is **mechanistically distinct** from PR #968 (fern, stochastic uniform random subsampling) — #968 changes *when* the sample is drawn (fresh every batch vs fixed per-view), this PR changes *which distribution* the sample is drawn from.

### Implementation

Since `data/loader.py` is **read-only**, monkey-patch the dataset in `train.py`. The key is a two-stage approach:

1. Load ALL volume points for each training case (pass `volume_rows=None` to `load_case`)
2. In a wrapping `__getitem__`, subsample `N` points using SDF-based weights via `torch.multinomial`

Here is the exact monkey-patching logic to add to `train.py` after the dataset is created but before the DataLoader is built:

```python
# ── SDF-STRATIFIED VOLUME IMPORTANCE SAMPLING monkey-patch ──────────────────
# Inject into train.py after dataset construction (not in data/loader.py).
# The patch replaces __getitem__ so that:
#   - All volume points are loaded (volume_rows=None)
#   - N=train_volume_points points are resampled per call using SDF weights
# eval dataset is NOT patched — eval remains deterministic strided chunks.

if args.use_sdf_stratified_vol_sampling:
    import types
    _ALPHA = args.sdf_stratified_alpha   # default 2.0
    _N_VOL = args.train_volume_points    # target count

    _orig_train_getitem = train_dataset.__class__.__getitem__

    def _sdf_stratified_getitem(self, idx):
        # ── 1. Get the view metadata without capping volume rows ──────────
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)

        # Load surface normally (capped), volume fully uncapped
        surface_idx = self._indices(
            counts["n_surface"],
            self.max_surface_points,
            view,
            group_view_count=view.surface_view_count,
        )
        case = self.store.load_case(
            view.case_id,
            surface_rows=None if surface_idx is None else surface_idx.numpy(),
            volume_rows=None,  # load ALL volume points
        )

        # ── 2. SDF-stratified resample ────────────────────────────────────
        n_total = case.volume_x.shape[0]
        n_sample = min(_N_VOL, n_total)
        sdf_vals = case.volume_x[:, 3].abs()           # channel 3 = SDF
        weights = 1.0 + _ALPHA * sdf_vals              # [N_total]
        vol_idx = torch.multinomial(weights, n_sample, replacement=True)
        vol_idx = vol_idx.sort().values

        # ── 3. Rebuild case with resampled volume ─────────────────────────
        metadata = dict(case.metadata)
        metadata["n_volume_full"] = n_total
        metadata["n_volume_loaded"] = n_sample
        metadata["volume_view_index"] = int(view.view_index)
        metadata["volume_view_count"] = int(view.volume_view_count)
        metadata["volume_sampling_mode"] = "sdf_stratified"
        metadata["joint_view_count"] = int(view.view_count)
        metadata["n_surface_full"] = int(counts["n_surface"])
        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
        metadata["surface_view_index"] = int(view.view_index)
        metadata["surface_view_count"] = int(view.surface_view_count)
        metadata["surface_sampling_mode"] = view.sampling_mode

        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case.case_id,
            surface_x=case.surface_x,
            surface_y=case.surface_y,
            volume_x=case.volume_x[vol_idx],
            volume_y=case.volume_y[vol_idx],
            metadata=metadata,
        )

    train_dataset.__getitem__ = types.MethodType(_sdf_stratified_getitem, train_dataset)
# ── end monkey-patch ─────────────────────────────────────────────────────────
```

You also need to add `--use-sdf-stratified-vol-sampling` and `--sdf-stratified-alpha` CLI args:

```python
parser.add_argument("--use-sdf-stratified-vol-sampling", action="store_true", default=False)
parser.add_argument("--sdf-stratified-alpha", type=float, default=2.0,
                    help="Bias strength: weight[i] = 1 + alpha * |sdf[i]|. Default 2.0.")
```

**Important**: When `max_volume_points=0` (no cap, load all), the monkey-patch is a no-op since all points are already loaded — the SDF resample still runs but just samples `N_VOL` points from the full set, which is fine.

### Run spec

Single arm (Arm A: α=2.0, 30 epochs full).

```bash
python train.py \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 2.0 \
  --wandb-group vol-test-gap-sdf-stratified \
  --wandb-name frieren-sdf-stratified-alpha2 \
  --kill-thresholds "5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

**If Arm A (α=2.0) passes EP5 gate (≤7.5%):** Continue to completion.

**If Arm A fails EP5 gate:** Try Arm B with α=5.0 (stronger far-field bias). Use the same command but change `--sdf-stratified-alpha 5.0` and `--wandb-name frieren-sdf-stratified-alpha5`.

### Expected outcome

- **Primary signal**: `val_primary/volume_pressure_rel_l2_pct` should be competitive with or below the current wave best of **6.5290%** at EP30
- **Key diagnostic**: Monitor `val_primary/volume_pressure_rel_l2_pct` at EP5, EP10. If far-field sampling is helping, we should see earlier convergence on vol_p compared to the baseline (#740 trajectory)
- **Test gap signal**: We expect this hypothesis directly addresses the val→test distribution gap — the test metric should be closer to the val metric than in previous runs

### Current baselines

| Metric | Wave SOTA (PR #740, `5x8wofzm`) | AB-UPT Target |
|---|---|---|
| `abupt_axis_mean_rel_l2_pct` | **7.5195%** | < 6.49% |
| `surf_p` rel L2 | ~3.82% | 3.82% |
| `vol_p` rel L2 | ~10.758% | 6.08% |
| `wall` rel L2 | ~7.29% | 7.29% |

Kill gates: EP5≤7.5%, EP10≤7.2%, EP15≤6.80%, EP20≤6.70%, EP25≤6.65%, EP30≤6.60%

### Implementation checklist

- [ ] Add `--use-sdf-stratified-vol-sampling` and `--sdf-stratified-alpha` CLI args
- [ ] Monkey-patch `train_dataset.__getitem__` in `train.py` after dataset construction
- [ ] Confirm `volume_sampling_mode="sdf_stratified"` appears in W&B config (logged by metadata)
- [ ] Confirm `use_sdf_stratified_vol_sampling=True` in W&B config
- [ ] Run a 1-step smoke test with `--debug` before launching full DDP run
- [ ] Report EP1 metric as sanity check (should be ≤30% abupt_axis_mean)
- [ ] Report EP5 gate result (hard gate ≤7.5%)

### Reporting

Report results with the following terminal marker when the run concludes:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

If a second arm (α=5.0) is needed, add it to `wandb_run_ids` and set `pending_arms=false` only when the final arm is done.
