### PR TITLE
[tanjiro] Bounded SDF encoding: tanh/asinh normalization for vol-token input

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,6 +15,14 @@ import torch.nn.functional as F
 from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
 
 
+# Train-set SDF statistics (aggregated over 400 train cases from
+# `analysis/sdf_per_case_stats.csv`). Used to standardize/transform the
+# per-point SDF scalar before it enters the volume input projection when
+# `use_sdf_vol_input_feature=True`.
+SDF_TRAIN_MEAN = 0.222682
+SDF_TRAIN_STD = 1.681517
+
+
 # ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
@@ -343,6 +351,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_vol_input_feature: bool = False,
+        sdf_vol_encoding: str = "linear",
+        sdf_vol_scale: float = 2.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +367,12 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_vol_input_feature = use_sdf_vol_input_feature
+        if sdf_vol_encoding not in ("linear", "tanh", "asinh"):
+            raise ValueError(
+                f"sdf_vol_encoding must be one of 'linear', 'tanh', 'asinh'; got {sdf_vol_encoding!r}"
+            )
+        self.sdf_vol_encoding = sdf_vol_encoding
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -403,6 +420,24 @@ class SurfaceTransolver(nn.Module):
 
         surface_proj_in = surface_extra_dim + rff_out_dim
         volume_proj_in = volume_extra_dim + rff_out_dim
+        if use_sdf_vol_input_feature:
+            # Append a transformed SDF scalar to the volume input projection
+            # (PR #966 + #973). Train-set mean/std are stored as buffers so
+            # they ride DDP with the model and are restored from checkpoint.
+            # `sdf_vol_scale` is the denominator for tanh/asinh encodings.
+            volume_proj_in += 1
+            self.register_buffer(
+                "sdf_input_mean",
+                torch.tensor(SDF_TRAIN_MEAN, dtype=torch.float32),
+            )
+            self.register_buffer(
+                "sdf_input_std",
+                torch.tensor(SDF_TRAIN_STD, dtype=torch.float32),
+            )
+            self.register_buffer(
+                "sdf_vol_scale",
+                torch.tensor(float(sdf_vol_scale), dtype=torch.float32),
+            )
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )
@@ -453,12 +488,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        extra_feature: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if extra_feature is not None:
+            feature_parts.append(extra_feature)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -506,6 +544,16 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
+            volume_extra: torch.Tensor | None = None
+            if self.use_sdf_vol_input_feature and volume_x.shape[-1] > self.space_dim:
+                sdf_raw = volume_x[:, :, self.space_dim : self.space_dim + 1]
+                sdf_centered = sdf_raw - self.sdf_input_mean
+                if self.sdf_vol_encoding == "tanh":
+                    volume_extra = torch.tanh(sdf_centered / self.sdf_vol_scale)
+                elif self.sdf_vol_encoding == "asinh":
+                    volume_extra = torch.asinh(sdf_centered / self.sdf_vol_scale)
+                else:  # "linear" — PR #966 behavior
+                    volume_extra = sdf_centered / self.sdf_input_std
             tokens.append(
                 self._encode_group(
                     volume_x,
@@ -514,6 +562,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    extra_feature=volume_extra,
                 )
             )
             masks.append(volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_vol_input_feature: bool = False
+    sdf_vol_encoding: str = "linear"
+    sdf_vol_scale: float = 2.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,36 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_vol_input_feature": (
+            "Append a transformed signed-distance-field (SDF) scalar to "
+            "every volume point's input feature vector before tokenisation "
+            "(PR #966 + #973). The SDF column already lives at "
+            "volume_x[..., 3] in raw distance units; with this flag enabled "
+            "a transformed copy is concatenated into the volume input "
+            "projection so the backbone sees a clean geometry signal in "
+            "addition to the existing raw channel. The transform is "
+            "controlled by --sdf-vol-encoding. Adds +1 input dimension to "
+            "the volume input projection only; the surface pipeline is "
+            "unchanged. Mean/std/scale are stored as buffers."
+        ),
+        "sdf_vol_encoding": (
+            "Encoding used for the SDF volume input feature when "
+            "--use-sdf-vol-input-feature is enabled. Choices: "
+            "'linear' (PR #966 behavior: (sdf - mean) / std — unbounded, "
+            "produces large outliers for freestream cells); "
+            "'tanh' (PR #973: tanh((sdf - mean) / scale) — bounded to "
+            "(-1, +1), saturates the freestream tail); "
+            "'asinh' (PR #973: asinh((sdf - mean) / scale) — never "
+            "saturates, log-compresses the tail while staying linear near "
+            "the surface)."
+        ),
+        "sdf_vol_scale": (
+            "Denominator (in meters) for the tanh/asinh SDF encoding when "
+            "--use-sdf-vol-input-feature and --sdf-vol-encoding != 'linear'. "
+            "Default 2.0 m places the transform knee near the wake region "
+            "(physical reference: car length ~4-5 m, wake ~1-5 m, boundary "
+            "layer ~0.01-0.1 m). Stored as a non-trainable buffer."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +341,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_vol_input_feature=config.use_sdf_vol_input_feature,
+        sdf_vol_encoding=config.sdf_vol_encoding,
+        sdf_vol_scale=config.sdf_vol_scale,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #966 demonstrated that appending a standardized SDF scalar `(sdf - μ) / σ` to vol-token input features **fails** because the train-set SDF has a catastrophic right tail: mean=0.22 m, std=1.68 m, but distant freestream cells reach ~36,000 m, producing outliers at +20,000σ after standardization. These outliers dominate the volume input projection early in training (especially during the vol-curriculum's sparse-token epochs), warping the weights before dense near-surface tokens appear. The run landed at EP4 val_abupt=7.6359% — 1.20pp worse than SOTA.

**This PR tests whether bounded SDF encoding eliminates the outlier pathology** while preserving the geometry-aware input signal. By replacing the linear normalization with a bounded transform (`tanh` or `asinh`), the 36,000 m tail compresses to ≈±1 while the sub-metre near-surface range (where SDF is most discriminative for vol-pressure prediction) retains full resolution.

**Why this is mechanistically distinct from PR #966:**

| Aspect | PR #966 (closed NEGATIVE) | This PR |
|---|---|---|
| SDF normalization | `(sdf - μ) / σ` — linear, unbounded | `tanh(sdf / scale)` — bounded to (−1, +1) |
| Dynamic range | +20,000σ outliers for freestream cells | ±1.0 everywhere, no outliers |
| Near-surface resolution | Compressed by outlier-scaled σ | Preserved (tanh is near-linear for |x/scale| < 1) |
| Root cause of failure | Input projection dominated by tail outliers | Tail eliminated by saturation |

**Why tanh/asinh specifically:**
- `tanh(sdf / scale)`: saturates at ±1, near-linear for |sdf| < scale; best choice when near-surface resolution is the priority. Derivative vanishes far from surface — gradient signal for freestream tokens is naturally suppressed.
- `asinh(sdf / scale)`: logarithmic growth beyond scale, never saturates — preserves rank ordering of far-field cells. Useful if the model needs to distinguish between "medium distance" and "far distance" from the body.
- Tanjiro should run a 2-arm sweep: `tanh(sdf/2.0)` vs `asinh(sdf/2.0)`, both trained from scratch. These two arms can share the 4-ep screening run structure and be compared at EP4.

**Connection to in-flight work:** FiLM conditioning (thorfinn #967) and SDF-modulated PE (fern #969) are orthogonal architecturally — this PR stays at the input-concat level, keeping the change minimal (+64 params, +1 input dim) so results are cleanly attributable.

**Why now:** Tanjiro proposed this follow-up in PR #966's check-in note and closing comment. The advisor endorsed it: *"If the advisor team wants to revisit explicit geometry input, this is the right first step. Compresses the 36k-m tail to ±1 while preserving near-surface resolution."*

**Estimated success probability:** ~30–40% (tanjiro's own estimate from #966, endorsed by advisor). Low but worth one screening run given the low implementation cost and clean mechanistic fix to a known failure mode.

---

## Implementation

The existing `--use-sdf-vol-input-feature` flag from PR #966 is already merged into the `tay` branch. You only need to modify the SDF normalization step inside the model.

**Step 1: Add a new flag `--sdf-vol-encoding` (string, choices: `linear`, `tanh`, `asinh`, default `linear`).**

When `--use-sdf-vol-input-feature` is enabled and `--sdf-vol-encoding tanh` or `asinh` is set, replace the normalization in the model's forward pass:

**Linear (current/PR #966 behavior):**
```python
sdf_normed = (sdf_raw - self.sdf_input_mean) / self.sdf_input_std
```

**tanh arm:**
```python
sdf_centered = sdf_raw - self.sdf_input_mean  # center by train mean only
sdf_normed = torch.tanh(sdf_centered / sdf_scale)  # sdf_scale ≈ 2.0 m
```

**asinh arm:**
```python
sdf_centered = sdf_raw - self.sdf_input_mean
sdf_normed = torch.asinh(sdf_centered / sdf_scale)  # sdf_scale ≈ 2.0 m
```

Where `sdf_scale` is a new model buffer initialized from a new flag `--sdf-vol-scale` (float, default `2.0`). Store it as a non-trainable buffer alongside `sdf_input_mean`. For `tanh`, center using the mean (0.222682) but **do NOT divide by σ** — that's what causes the outliers. The scale of 2.0 m means cells within 2 m of the body surface have tanh output in the range (0, 0.76), preserving strong near-surface resolution, while cells at 10 m map to tanh(4.4) ≈ 0.999 and are indistinguishable — which is fine for vol-pressure prediction.

**Step 2: Add `--sdf-vol-scale` flag** (float, default `2.0`). This is the denominator for tanh/asinh normalization. Units: meters. At scale=2.0, the knee of the tanh curve sits at 2 m from the body surface, which is a physically motivated choice (boundary layer thickness for a car at automotive Re is O(0.01–0.1 m); the wake extends ~1–5 m).

**Step 3: Run 2-arm sweep (tanh vs asinh, both at scale=2.0):**
- Both arms use exactly the same 4-ep curriculum as PR #966.
- Use `--wandb-group tanjiro-bounded-sdf-encoding` for both arms.
- Arm A: `--use-sdf-vol-input-feature --sdf-vol-encoding tanh --sdf-vol-scale 2.0`
- Arm B: `--use-sdf-vol-input-feature --sdf-vol-encoding asinh --sdf-vol-scale 2.0`

**No other changes.** Keep the surface pipeline, backbone, attention layers, and output heads identical. One PR, one idea: bounded SDF normalization.

---

## Gate Schedule (4-ep screening, both arms)

| Epoch | val_abupt gate |
|---|---|
| EP1 end | ≤ 30% |
| EP2 end | ≤ 10.0% (tighter than PR #966's ≤16% since we have reference trajectory now) |
| EP3 end | ≤ 8.0% AND vol_p ≤ 5.0% |
| EP4 end | ≤ 6.9% |

**Note on EP2 gate tightening:** PR #966 showed that a healthy run should exit EP2 at ~7.8–8.1%. The failed #966 run landed at 11.47%. Use ≤10.0% as an early kill signal: if either arm is ≥10% at EP2, kill it immediately and report. This saves ~4h of EP3+EP4 compute.

If an arm passes EP4 ≤6.9%, continue to 13-ep confirmation:

| Checkpoint | val_abupt gate |
|---|---|
| EP5 | ≤ 7.5% |
| EP10 | ≤ 7.20% |
| EP13 | terminal — must beat ≤6.4407% (current single-model SOTA) |

---

## Current Best Baseline (beat this to merge)

| Metric | Value | W&B run |
|---|---|---|
| val_abupt | **6.4407%** | `ghh0s4ne` |
| test_abupt | 7.6992% | — |
| test_vol_p | 11.6704% | — |
| val_surf_p | ~3.85% (ensemble) | `zst3y2mp` (K=6) |
| val_vol_p | ~3.57% (ensemble) | `zst3y2mp` (K=6) |

PR: #823 (nezuko/surf-vol-xattn) — single-model SOTA
Ensemble SOTA: PR #880 val_abupt=6.0289%, test_abupt=7.3693%

**Single-model gate: val_abupt < 6.4407% (must beat this to merge)**

---

## Reproduce Commands

**Arm A — tanh(sdf/2.0) (4-ep screening):**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-vol-input-feature --sdf-vol-encoding tanh --sdf-vol-scale 2.0 \
  --wandb-group tanjiro-bounded-sdf-encoding \
  --wandb-name tanjiro/bounded-sdf-tanh-scale2-4ep \
  --kill-thresholds "500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

**Arm B — asinh(sdf/2.0) (4-ep screening):**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-vol-input-feature --sdf-vol-encoding asinh --sdf-vol-scale 2.0 \
  --wandb-group tanjiro-bounded-sdf-encoding \
  --wandb-name tanjiro/bounded-sdf-asinh-scale2-4ep \
  --kill-thresholds "500:train/loss<10,2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

**Launch both arms simultaneously** (use both sets of 8 GPUs concurrently — Arm A on one process group, Arm B on another, or sequentially if the pod only supports one torchrun at a time).

---

## Reporting

Report at each gate epoch for both arms with a table:

| Arm | Epoch | val_abupt | surf_p | vol_p | wall_shear | Gate | Status |
|-----|-------|-----------|--------|-------|------------|------|--------|
| tanh | EP1 | ... | ... | ... | ... | ≤30% | PASS/FAIL |
| asinh | EP1 | ... | ... | ... | ... | ≤30% | PASS/FAIL |
| ... | ... | ... | ... | ... | ... | ... | ... |

Post a `SENPAI-RESULT` terminal marker when both arms are complete. If one arm passes EP4 and the other fails, post a partial terminal and continue the passing arm to 13-ep. If both pass, run both to 13-ep.

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-A-run-id>","<arm-B-run-id>"],"primary_metric":{"name":"val_abupt","value":<best of two>},"test_metric":{"name":"test_abupt","value":<number or null>}}
```

Report val_abupt, test_abupt, test_vol_p, and per-axis breakdown (surf_p, vol_p, wall_shear x/y/z) at EP4 for each arm.
