### PR TITLE
[thorfinn] SDF-Conditioned Attention Temperature on surf→vol xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_xattn_temperature: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_xattn_temperature = use_sdf_xattn_temperature
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,24 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # SDF-conditioned per-token attention temperature on surf->vol xattn
+        # (PR #974). A tiny MLP reads each volume token's normalised SDF
+        # scalar and emits tau in (0,1); attention logits are multiplied
+        # by (0.5 + tau) before the standard 1/sqrt(d) scaling. Final
+        # Linear is zero-initialised so tau starts at 0.5 and the
+        # effective scale starts at 1.0 (identity at init).
+        if use_surf_to_vol_xattn and use_sdf_xattn_temperature:
+            self.sdf_temp_mlp = nn.Sequential(
+                nn.Linear(1, 16),
+                nn.SiLU(),
+                nn.Linear(16, 1),
+                nn.Sigmoid(),
+            )
+            nn.init.zeros_(self.sdf_temp_mlp[2].weight)
+            nn.init.zeros_(self.sdf_temp_mlp[2].bias)
+        else:
+            self.sdf_temp_mlp = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -469,6 +489,84 @@ class SurfaceTransolver(nn.Module):
             )
             hidden = hidden + project_features(features)
         return bias(hidden) + placeholder
+
+    def _sdf_temp_xattn(
+        self,
+        *,
+        volume_hidden: torch.Tensor,
+        surface_hidden: torch.Tensor,
+        volume_x: torch.Tensor,
+    ) -> torch.Tensor:
+        # Per-token SDF-conditioned temperature: tau in (0,1) -> scale in (0.5, 1.5).
+        # Identity-approximate at init (tau=0.5 -> scale=1.0 matches uniform 1/sqrt(d)).
+        # SDF channel is volume_x[:, :, 3]; clip+rescale to roughly [0, 1].
+        sdf_raw = volume_x[:, :, 3:4].to(dtype=volume_hidden.dtype)
+        sdf_norm = sdf_raw.clamp(min=0.0, max=5.0) / 5.0
+        tau = self.sdf_temp_mlp(sdf_norm)
+        scale = 0.5 + tau
+
+        mha = self.surf_to_vol_xattn
+        d_model = mha.embed_dim
+        n_heads = mha.num_heads
+        d_head = d_model // n_heads
+        batch_size, n_vol, _ = volume_hidden.shape
+        n_surf = surface_hidden.shape[1]
+
+        W_q = mha.in_proj_weight[:d_model]
+        W_k = mha.in_proj_weight[d_model : 2 * d_model]
+        W_v = mha.in_proj_weight[2 * d_model :]
+        in_bias = mha.in_proj_bias
+        if in_bias is not None:
+            b_q = in_bias[:d_model]
+            b_k = in_bias[d_model : 2 * d_model]
+            b_v = in_bias[2 * d_model :]
+        else:
+            b_q = b_k = b_v = None
+
+        q = F.linear(volume_hidden, W_q, b_q)
+        k = F.linear(surface_hidden, W_k, b_k)
+        v = F.linear(surface_hidden, W_v, b_v)
+
+        q = q.view(batch_size, n_vol, n_heads, d_head).transpose(1, 2)
+        k = k.view(batch_size, n_surf, n_heads, d_head).transpose(1, 2)
+        v = v.view(batch_size, n_surf, n_heads, d_head).transpose(1, 2)
+
+        # Apply per-token scale by multiplying queries before SDPA. Math:
+        #   logits[i, j] = scale_i * (Q_i . K_j) / sqrt(d)
+        #               = ((scale_i * Q_i) . K_j) / sqrt(d)
+        # so baking scale_i into Q row i is exactly equivalent to scaling
+        # the logits row i, but lets us use the memory-efficient SDPA kernel
+        # (Flash / mem_efficient) instead of materialising a
+        # [B, H, N_vol, N_surf] logits tensor (which OOMs at production sizes).
+        scale_per_head = scale.unsqueeze(1)  # [B, 1, N_vol, 1] broadcast over H
+        q = q * scale_per_head
+
+        attn_out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            dropout_p=mha.dropout if self.training else 0.0,
+        )
+
+        attn_out = attn_out.transpose(1, 2).contiguous().view(batch_size, n_vol, d_model)
+        xattn_out = F.linear(attn_out, mha.out_proj.weight, mha.out_proj.bias)
+
+        # Stash latest tau / scale stats so train.py can harvest them for
+        # W&B logging at its normal logging cadence. Cheap (constant-size
+        # tensor reductions; .item() forces a sync only when consumed).
+        if self.training:
+            tau_f = tau.detach().float()
+            scale_f = scale.detach().float()
+            self._sdf_temp_last_stats = {
+                "model/sdf_temp_tau_mean": tau_f.mean(),
+                "model/sdf_temp_tau_std": tau_f.std(),
+                "model/sdf_temp_tau_min": tau_f.min(),
+                "model/sdf_temp_tau_max": tau_f.max(),
+                "model/sdf_temp_scale_mean": scale_f.mean(),
+                "model/sdf_temp_scale_std": scale_f.std(),
+            }
+
+        return xattn_out
 
     def forward(
         self,
@@ -536,12 +634,19 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
-            xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
-                key=surface_hidden,
-                value=surface_hidden,
-                need_weights=False,
-            )
+            if self.sdf_temp_mlp is not None:
+                xattn_out = self._sdf_temp_xattn(
+                    volume_hidden=volume_hidden,
+                    surface_hidden=surface_hidden,
+                    volume_x=volume_x,
+                )
+            else:
+                xattn_out, _ = self.surf_to_vol_xattn(
+                    query=volume_hidden,
+                    key=surface_hidden,
+                    value=surface_hidden,
+                    need_weights=False,
+                )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_xattn_temperature: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_xattn_temperature": (
+            "Per-vol-token SDF-conditioned attention temperature on "
+            "surf->vol xattn (PR #974). A tiny MLP "
+            "(Linear(1->16)->SiLU->Linear(16->1)->Sigmoid) reads the "
+            "normalised SDF scalar for each volume token and emits "
+            "tau in (0,1); attention logits are multiplied by "
+            "(0.5 + tau) before the standard 1/sqrt(d) scaling. "
+            "Final Linear is zero-initialised so tau=0.5 and the "
+            "effective scale starts at 1.0 (identity at init). "
+            "Requires --use-surf-to-vol-xattn."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +320,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_xattn_temperature=config.use_sdf_xattn_temperature,
     )
 
 
@@ -1126,6 +1139,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        if should_log_gradients and state.is_main:
+                            sdf_temp_stats = getattr(
+                                base_model, "_sdf_temp_last_stats", None
+                            )
+                            if sdf_temp_stats:
+                                train_log.update(
+                                    {k: float(v.item()) for k, v in sdf_temp_stats.items()}
+                                )
 
                 train_log.update(
                     train_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis

The surf→vol cross-attention sublayer (PR #823) lets every volume token attend uniformly to all surface tokens using a fixed `1/sqrt(d)` scaling of attention logits. But the physically correct attention pattern is **distance-dependent**: a volume point near the car surface (small SDF) should attend **sharply** to a few nearby surface points (boundary layer physics), while a far-field volume point (large SDF, freestream) should attend **broadly** over the entire surface (integrated pressure forcing).

The current uniform temperature cannot express this locality structure. We propose **SDF-conditioned per-token attention temperature**: a tiny MLP reads the normalised SDF value for each volume token and outputs a per-token multiplicative scale τ ∈ (0, 1) that is applied to the attention logits before softmax:

```
logits[i] = (Q_i @ K.T) * (0.5 + τ_i) / sqrt(d_head)
```

where τ_i ∈ (0,1) is predicted from `volume_x[:, :, 3]` (the SDF channel, already in the model inputs). At init, τ≈0.5 → scale≈1.0, so the layer is identity-approximate and the baseline is preserved. The MLP learns whether and how much to sharpen/broaden each token's attention based on its distance from the surface.

**Key properties:**
- ~33 learnable parameters (minimal overhead)
- Identity-approximate at init (safe to train from baseline checkpoint)
- Physically motivated: encodes boundary-layer locality into the attention mechanism
- Mechanistically distinct from all closed experiments (SDF-FiLM #967, geom Q-bias #950/#961, zone masking #953/#963)
- Works on top of the existing `--use-surf-to-vol-xattn` (PR #823) sublayer

## Instructions

### Step 1: Add the `--use-sdf-xattn-temperature` flag

In `target/train.py`, add a boolean CLI argument:
```python
parser.add_argument("--use-sdf-xattn-temperature", action="store_true", default=False,
    help="Per-vol-token SDF-conditioned attention temperature on surf->vol xattn. "
         "A tiny MLP (Linear(1->16)->SiLU->Linear(16->1)->Sigmoid) reads the normalised "
         "SDF scalar for each volume token and scales the attention logits.")
```

Pass it through to the model constructor.

### Step 2: Add the temperature MLP to `SurfaceTransolver.__init__` in `target/model.py`

Immediately after the `if use_surf_to_vol_xattn:` block (around line 433), add:

```python
        self.use_sdf_xattn_temperature = use_sdf_xattn_temperature
        if use_surf_to_vol_xattn and use_sdf_xattn_temperature:
            # Tiny MLP: normalised SDF (1-dim) -> per-token scale tau in (0,1)
            # Init: final bias=-0.0 -> sigmoid(0.0)=0.5 -> effective scale=0.5+0.5=1.0 (identity)
            self.sdf_temp_mlp = nn.Sequential(
                nn.Linear(1, 16),
                nn.SiLU(),
                nn.Linear(16, 1),
                nn.Sigmoid(),
            )
            # Identity-approximate init: final Linear output ≈ 0 → sigmoid ≈ 0.5
            nn.init.zeros_(self.sdf_temp_mlp[2].weight)
            nn.init.zeros_(self.sdf_temp_mlp[2].bias)
        else:
            self.sdf_temp_mlp = None
```

Also add `use_sdf_xattn_temperature: bool = False` to the `__init__` signature.

### Step 3: Implement custom attention in `SurfaceTransolver.forward`

Replace the existing `xattn_out, _ = self.surf_to_vol_xattn(...)` block with:

```python
        if (
            self.surf_to_vol_xattn is not None
            and surface_x is not None
            and volume_x is not None
            and surface_tokens > 0
            and volume_tokens > 0
        ):
            if self.sdf_temp_mlp is not None:
                # --- SDF-conditioned per-token attention temperature ---
                # volume_x shape: [B, N_vol, 4] — last channel is SDF
                sdf_raw = volume_x[:, :, 3:4]  # [B, N_vol, 1]
                # Normalise SDF to roughly [0,1] using soft clamp: SDF values
                # are typically in [-0.1, 5.0] for car geometries; clip to [0, 5]
                sdf_norm = (sdf_raw.clamp(min=0.0, max=5.0) / 5.0)  # [B, N_vol, 1]
                tau = self.sdf_temp_mlp(sdf_norm)  # [B, N_vol, 1], values in (0,1)
                scale = 0.5 + tau  # [B, N_vol, 1], values in (0.5, 1.5)

                # Manual attention: extract Q, K, V from the MHA module internals.
                # nn.MultiheadAttention stores in_proj_weight [3*d, d] and in_proj_bias [3*d].
                mha = self.surf_to_vol_xattn
                d_model = mha.embed_dim
                n_heads = mha.num_heads
                d_head = d_model // n_heads
                B = volume_hidden.shape[0]

                # in_proj_weight rows: [0:d]=Q, [d:2d]=K, [2d:3d]=V
                W_q = mha.in_proj_weight[:d_model]         # [d, d]
                W_k = mha.in_proj_weight[d_model:2*d_model] # [d, d]
                W_v = mha.in_proj_weight[2*d_model:]        # [d, d]
                b_q = mha.in_proj_bias[:d_model] if mha.in_proj_bias is not None else None
                b_k = mha.in_proj_bias[d_model:2*d_model] if mha.in_proj_bias is not None else None
                b_v = mha.in_proj_bias[2*d_model:] if mha.in_proj_bias is not None else None

                Q = F.linear(volume_hidden, W_q, b_q)   # [B, N_vol, d]
                K = F.linear(surface_hidden, W_k, b_k)  # [B, N_surf, d]
                V = F.linear(surface_hidden, W_v, b_v)  # [B, N_surf, d]

                # Reshape to multi-head format
                Q = Q.view(B, volume_tokens, n_heads, d_head).transpose(1, 2)   # [B, H, N_vol, d_h]
                K = K.view(B, surface_tokens, n_heads, d_head).transpose(1, 2)  # [B, H, N_surf, d_h]
                V = V.view(B, surface_tokens, n_heads, d_head).transpose(1, 2)  # [B, H, N_surf, d_h]

                # Scaled dot-product attention with per-token temperature
                scale_per_token = scale.transpose(1, 2).unsqueeze(-1)  # [B, 1, N_vol, 1] broadcast over heads
                # Logits: [B, H, N_vol, N_surf]
                logits = torch.matmul(Q, K.transpose(-2, -1)) * scale_per_token / (d_head ** 0.5)
                attn_weights = F.softmax(logits, dim=-1)
                if mha.dropout > 0.0 and self.training:
                    attn_weights = F.dropout(attn_weights, p=mha.dropout)
                attn_out = torch.matmul(attn_weights, V)  # [B, H, N_vol, d_h]

                # Merge heads and apply out_proj
                attn_out = attn_out.transpose(1, 2).contiguous().view(B, volume_tokens, d_model)
                xattn_out = F.linear(attn_out, mha.out_proj.weight, mha.out_proj.bias)

                # Log temperature statistics every 100 steps
                if self.training and hasattr(self, '_step_count'):
                    if self._step_count % 100 == 0:
                        import wandb
                        if wandb.run is not None:
                            wandb.log({
                                "model/sdf_temp_tau_mean": tau.mean().item(),
                                "model/sdf_temp_tau_std": tau.std().item(),
                                "model/sdf_temp_scale_mean": scale.mean().item(),
                            }, commit=False)
            else:
                # Original uniform-temperature attention
                xattn_out, _ = self.surf_to_vol_xattn(
                    query=volume_hidden,
                    key=surface_hidden,
                    value=surface_hidden,
                    need_weights=False,
                )
            xattn_out = _apply_token_mask(xattn_out, volume_mask)
            volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
```

**Note on `_step_count`:** If the model doesn't already have a step counter, the logging is skipped gracefully via `hasattr`. You can omit the W&B logging block if it causes issues — the temperature statistics are nice-to-have but not required.

### Step 4: Run a 4-epoch screening run

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-xattn-temperature \
  --wandb-group thorfinn-sdf-xattn-temperature \
  --wandb-name thorfinn/sdf-xattn-temp-ep4-screen \
  --kill-thresholds "2000:val_primary/abupt_axis_mean_rel_l2_pct<30"
```

**Note on kill thresholds:** Use `<30` at step 2000 (val-only, NO `train/loss` clause). The `train/loss<10` pattern misfires at curriculum boundary vol-pts transitions — avoid it entirely.

### Step 5: EP gates and reporting

| Epoch | Gate (val_abupt) |
|-------|-----------------|
| EP1   | ≤ 30%           |
| EP2   | ≤ 16%           |
| EP3   | ≤ 8%            |
| EP4   | ≤ 6.9%          |

**EP4 ≤ 6.9%** is the threshold to beat. The single-model SOTA is **6.4407%** (PR #823, run `ghh0s4ne`). If you pass EP4, continue to EP13 with `--lr-cosine-t-max 13 --epochs 13`.

Post a PR comment at each epoch gate with:
- W&B run ID
- val_abupt at that epoch
- Pass/Fail against the gate
- `model/sdf_temp_tau_mean` and `model/sdf_temp_scale_mean` if logged (tells us if the temperature is learning)

### Debugging tips

1. **If you get an error about `in_proj_weight` not existing:** PyTorch `nn.MultiheadAttention` uses `in_proj_weight` by default. Verify with `print(list(model.surf_to_vol_xattn.named_parameters()))`.

2. **If the manual attention implementation diverges:** Verify at EP0 that the loss matches the `--no-use-sdf-xattn-temperature` baseline (the zero-init ensures this). If it doesn't, check the scale broadcast — `scale_per_token` shape should be `[B, 1, N_vol, 1]`.

3. **If W&B logging causes a `commit=False` error:** Just remove the wandb.log block — it's diagnostic only.

4. **If `torch.compile` complains about the custom attention:** Keep `--no-compile-model` as specified (already in the command above).

## Baseline (current SOTA)

**Single-model SOTA — PR #823 (nezuko, surf→vol cross-attn):**
- val_abupt = **6.4407%**
- test_abupt = **7.6992%**
- val vol_p = 3.8557% | test vol_p = **11.6704%**
- W&B run: `ghh0s4ne`

**Ensemble SOTA — PR #880 (nezuko, K=6 greedy pool-32):**
- val_abupt = **6.0289%**
- test_abupt = **7.3693%**
- W&B run: `zst3y2mp`

**AB-UPT paper targets:** surface_pressure=3.82%, wall_shear=7.29%, **volume_pressure=6.08%**

**Target to beat:** val_abupt < 6.4407% (EP4 screen: val_abupt ≤ 6.9%)
