### PR TITLE
Surface-head-only isolation: 2-layer MLP surface head, plain Linear vol head

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_surface_mlp_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_surface_mlp_head = use_surface_mlp_head
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -421,7 +423,19 @@ class SurfaceTransolver(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        # Surface output head: either a 2-layer MLP (--use-surface-mlp-head) or
+        # a plain Linear projection (baseline). The MLP variant matches the
+        # surface head from PR #958 Arm A, which improved test wall-shear
+        # metrics. The volume head is always a plain Linear (isolates the
+        # surface gain from the failed 3-layer vol MLP in PR #958 Arm B).
+        if use_surface_mlp_head:
+            self.surface_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, self.surface_output_dim),
+            )
+        else:
+            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_mlp_head: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surface_mlp_head": (
+            "Replace the plain Linear surface output head with a 2-layer MLP "
+            "(hidden_dim -> SiLU -> surface_output_dim). Matches the surface "
+            "head from PR #958 Arm A, which improved test wall-shear metrics. "
+            "The volume head is always a plain Linear when this flag is set, "
+            "isolating the surface gain from the vol decoder. Default: False."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +316,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_mlp_head=config.use_surface_mlp_head,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #958 Arm A showed that a **2-layer MLP surface output head** (hidden → SiLU → output) improved test wall-shear stress metrics by **−0.058pp** on all three τ channels (τ_x, τ_y, τ_z). However, Arm A also included a **3-layer vol MLP head** which failed to close the OOD vol_p gap (test_vol_p worsened by +0.336pp).

This PR isolates the surface head change: keep the 2-layer surface MLP that clearly helped, revert the volume head to plain Linear. The question: does the wall-shear improvement stand on its own, and does removing the failed vol decoder restore/improve val_abupt vs the new SOTA?

**Hypothesis**: The 2-layer surface MLP head captures surface-level non-linearities that the linear head cannot. The vol decoder depth was neutral-to-negative. Isolating just the surface head should yield comparable or better val_abupt than PR #958 Arm A (6.2869%) without the vol_p regression.

## Implementation

New flag: `--use-surface-mlp-head`

When set, `surface_out` becomes:
```python
nn.Sequential(
    nn.Linear(512, 512),  # hidden_dim = 512
    nn.SiLU(),
    nn.Linear(512, 4),    # [cp, tau_x, tau_y, tau_z]
)
```

`volume_out` remains a plain `LinearProjection(512, 1)` — unchanged from baseline.

This is a surgical 1-parameter change with ~263K extra parameters (+1.5% over baseline 16.99M). The vol decoder is untouched.

## Baseline to beat

| Metric | Current SOTA (PR #958 Arm A, W&B `29nohj67`) |
|--------|----------------------------------------------|
| val_primary/abupt_axis_mean_rel_l2_pct | **6.2869%** |
| val_surface/surf_p_rel_l2_pct | ~1.02% |
| val_surface/tau_x_rel_l2_pct | ~7.95% |
| val_surface/tau_y_rel_l2_pct | ~9.07% |
| val_surface/tau_z_rel_l2_pct | ~8.86% |
| val_volume/vol_p_rel_l2_pct | ~4.53% |
| test_volume/vol_p_rel_l2_pct | ~12.01% |
| test_surface/tau_x_rel_l2_pct | (wall-shear improved −0.058pp from baseline) |

Previous single-model ensemble SOTA from PR #880: **6.0289%**

## EP Gates (4-epoch screen first)

- EP1 ≤ 30%
- EP3 ≤ 8.0% AND vol_p ≤ 5.0%
- EP4 ≤ 6.9%

If all EP gates pass, run to EP13 (full training).

## Instructions to askeladd

**Step 1: 4-epoch screen**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 \
  --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-surface-mlp-head \
  --wandb-group askeladd-surface-head-only \
  --wandb-name askeladd/surface-head-only-ep4-screen
```

**EP gate check after screen:**
- EP1 val_abupt ≤ 30% → continue
- EP3 val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0% → continue
- EP4 val_abupt ≤ 6.9% → proceed to full run

**Step 2: Full run (if EP gates pass)**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 \
  --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-surface-mlp-head \
  --wandb-group askeladd-surface-head-only \
  --wandb-name askeladd/surface-head-only-ep13-full
```

## Key things to report

1. **EP1, EP3, EP4 val_abupt** (kill/continue decision)
2. Final val_abupt (beat 6.2869%?)
3. **val_surface/tau_x_rel_l2_pct**, **tau_y**, **tau_z** vs baseline (does wall-shear still improve?)
4. **val_volume/vol_p_rel_l2_pct** and **test_volume/vol_p_rel_l2_pct** (does removing the vol MLP restore vol_p?)
5. W&B run IDs for both screen and full run
6. Any observations on convergence speed vs baseline

## Suggested follow-ups (if positive)

- If surface MLP helps: try 3-layer surface MLP (more capacity) as next iteration
- If vol_p OOD gap improves vs PR #958 Arm B: confirms the vol decoder was hurting, not helping
- Combine with geometry embedding (per-case conditioning) if this succeeds

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<screen-run-id>","<full-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_volume/vol_p_rel_l2_pct","value":<number>}}
```