### PR TITLE
Per-case geometry embedding: mean-pool surface hidden → volume conditioning

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_geo_embed: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_geo_embed = use_geo_embed
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,24 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Per-case geometry embedding (PR #976): after the backbone, mean-pool
+        # the masked surface hidden states into a single geometry code vector
+        # per sample in the batch. Project and add it to the volume hidden
+        # states before the surf->vol cross-attention (or directly before the
+        # volume output head when xattn is disabled).
+        #
+        # This gives the volume decoder a global shape-context signal that is
+        # independent of local point positions. At init the projection is
+        # zero-initialised, so the layer is identity (no change to baseline
+        # behavior at epoch 0). Unlike a learned ID lookup table, mean-pooling
+        # generalises to OOD test geometries at inference time.
+        if use_geo_embed:
+            self.geo_embed_proj = nn.Linear(n_hidden, n_hidden)
+            nn.init.zeros_(self.geo_embed_proj.weight)
+            nn.init.zeros_(self.geo_embed_proj.bias)
+        else:
+            self.geo_embed_proj = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -528,6 +548,21 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.geo_embed_proj is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            # Mean-pool masked surface hidden states → global geometry code [B, n_hidden]
+            surf_mask_float = surface_mask.unsqueeze(-1).float()  # [B, S, 1]
+            geo_code = (surface_hidden * surf_mask_float).sum(dim=1) / surf_mask_float.sum(dim=1).clamp(min=1.0)
+            # Project (zero-init → identity at epoch 0) and broadcast to volume sequence
+            geo_bias = self.geo_embed_proj(geo_code).unsqueeze(1)  # [B, 1, n_hidden]
+            volume_hidden = volume_hidden + geo_bias
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_geo_embed: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_geo_embed": (
+            "Enable per-case geometry embedding (PR #976). After the shared "
+            "Transolver backbone, mean-pool the masked surface hidden states "
+            "into a global geometry code vector [B, n_hidden] per sample. "
+            "Project via a zero-init nn.Linear(n_hidden, n_hidden) and add "
+            "the result to all volume hidden states before the surf->vol "
+            "cross-attention (or before the volume head when xattn is off). "
+            "Zero-init preserves baseline behaviour at epoch 0. Because the "
+            "code is computed from surface activations rather than a lookup "
+            "table, it generalises to OOD test geometries at inference time."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +320,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_geo_embed=config.use_geo_embed,
     )
 
 
@@ -773,7 +786,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_geo_embed:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

After the shared Transolver backbone, each car geometry has a unique shape signature that is not explicitly captured in the current architecture. The surface tokens encode per-point features, but the volume tokens receive no global geometry context before the surf→vol cross-attention step.

**Idea:** Mean-pool the masked surface hidden states (post-backbone, post-norm) into a per-sample global geometry code vector `[B, n_hidden]`. Project via a zero-initialized `nn.Linear(n_hidden, n_hidden)` and add the result (broadcast) to all volume hidden states **before** the surf→vol cross-attention. This gives the volume head a geometry-aware bias term that is computed on-the-fly from surface activations and therefore generalizes to OOD test geometries (no lookup table required).

Zero-init on both weight and bias ensures the module is a no-op at epoch 0, preserving baseline behavior. The grad signal will sculpt the projection as training progresses.

**Enabled by:** `--use-geo-embed` flag (new). Combines with `--use-surf-to-vol-xattn`.

## Current Baseline

| Metric | Value | PR / W&B run |
|---|---|---|
| val_primary/abupt_axis_mean_rel_l2_pct | **6.4407%** | PR #823 / `ghh0s4ne` |
| Ensemble val_primary (K=6) | 6.0289% | PR #880 / `zst3y2mp` |

**Training gate (4-ep screen):** EP1 ≤ 30%, EP3 ≤ 8.0% AND vol_p ≤ 5.0%, EP4 ≤ 6.9%

## Implementation

- `model.py` — `SurfaceTransolver.__init__`: new `use_geo_embed: bool = False` param; `geo_embed_proj = nn.Linear(n_hidden, n_hidden)` with both weight and bias zero-initialized; stored as `self.geo_embed_proj`.
- `model.py` — `forward`: after surface/volume hidden states are sliced from `hidden_norm`, mean-pool `surface_hidden` under `surface_mask` → `geo_code [B, n_hidden]` → project → add to `volume_hidden` → re-apply token mask → then proceed to surf→vol xattn.
- `train.py` — config dataclass: `use_geo_embed: bool = False`; help text; `build_model` kwarg; `find_unused_parameters` gate updated to `if config.use_surf_to_vol_xattn or config.use_geo_embed:`.

## 4-EP Screen Training Command

Run on 8 GPUs with vol-curriculum:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --use-geo-embed \
  --wandb-group alphonse-geo-embed \
  --wandb-name alphonse/geo-embed-4ep
```

## EP Gates

| Epoch | Gate |
|---|---|
| EP1 | val_abupt ≤ 30% (sanity / no divergence) |
| EP3 | val_abupt ≤ 8.0% **AND** vol_p ≤ 5.0% |
| EP4 | val_abupt ≤ 6.9% |

If EP3 passes, proceed to a full-length run:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 20 --epochs 20 \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn --use-geo-embed \
  --wandb-group alphonse-geo-embed \
  --wandb-name alphonse/geo-embed-20ep
```

## Expected Outcome

The geometry code provides a global shape prior that can help the model differentiate between different car configurations early in the forward pass, before the cross-attention mechanism. We expect this to improve surface-to-volume consistency, particularly for aerodynamic features that vary strongly with geometry (rear wake, underbody flow).

Target: val_abupt < 6.44% at EP4 screen → proceed to 20-epoch full run → beat baseline 6.4407%.

## Result

<!-- Student fills in below -->

SENPAI-RESULT: pending