### PR TITLE
[dl24-tanjiro] Per-case bbox normalization into canonical coordinate frame

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -328,6 +328,7 @@ class DrivAerMLCaseStore:
         self.root = _resolve_case_root(self.manifest, override_root=root)
         self.normalizers_path = self.root / "normalizers.json"
         self._point_count_cache: dict[str, dict[str, int]] = {}
+        self._surface_bbox_cache: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def case_ids(self, split: str) -> list[str]:
         return list(self.manifest["surface_splits"][split])
@@ -348,6 +349,17 @@ class DrivAerMLCaseStore:
             self._point_count_cache[case_id] = cached
         return dict(cached)
 
+    def case_surface_bbox(self, case_id: str) -> tuple[torch.Tensor, torch.Tensor]:
+        cached = self._surface_bbox_cache.get(case_id)
+        if cached is None:
+            xyz_path = _resolve_artifact_path(_case_dir(self.root, case_id) / "surface_xyz.npy")
+            arr = np.load(xyz_path, mmap_mode="r")
+            arr_min = np.asarray(arr.min(axis=0), dtype=np.float32)
+            arr_max = np.asarray(arr.max(axis=0), dtype=np.float32)
+            cached = (torch.from_numpy(arr_min), torch.from_numpy(arr_max))
+            self._surface_bbox_cache[case_id] = cached
+        return cached[0].clone(), cached[1].clone()
+
     def load_normalizers(self) -> dict:
         with self.normalizers_path.open() as f:
             return json.load(f)
@@ -367,6 +379,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_bbox_norm: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +389,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_bbox_norm = use_bbox_norm
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -445,6 +459,24 @@ class DrivAerMLSurfaceDataset(Dataset):
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
         )
+        if self.use_bbox_norm:
+            bbox_min, bbox_max = self.store.case_surface_bbox(view.case_id)
+            bbox_center = (bbox_min + bbox_max) / 2.0
+            bbox_half_extent = ((bbox_max - bbox_min) / 2.0).clamp(min=1e-6)
+            surface_x = case.surface_x.clone()
+            if surface_x.shape[0] > 0:
+                surface_x[:, :3] = (surface_x[:, :3] - bbox_center) / bbox_half_extent
+            volume_x = case.volume_x.clone()
+            if volume_x.shape[0] > 0:
+                volume_x[:, :3] = (volume_x[:, :3] - bbox_center) / bbox_half_extent
+            case = DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=surface_x,
+                surface_y=case.surface_y,
+                volume_x=volume_x,
+                volume_y=case.volume_y,
+                metadata=case.metadata,
+            )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
         metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
@@ -544,6 +576,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_bbox_norm: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +601,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_bbox_norm=use_bbox_norm,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +610,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_bbox_norm=use_bbox_norm,
         )
     }
     test_splits = {
@@ -585,6 +620,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_bbox_norm=use_bbox_norm,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/train.py
+++ b/train.py
@@ -132,6 +132,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_vol_coord_bbox_norm: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -281,6 +281,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_bbox_norm=getattr(config, "use_vol_coord_bbox_norm", False),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

The persistent ~+7–8pp val→test gap in `vol_p_rel_l2_pct` (val ~4.0–4.2% → test ~11–12%) is a distributional shift in **coordinate space**. Train and test DrivAerML cars differ in absolute geometric extent and position. The model's positional encoding sees different coordinate ranges at test time, causing the STRING multisigma PE features to land in poorly-covered regions, degrading volume pressure prediction.

**Fix**: normalize both `surface_x[:, :3]` and `volume_x[:, :3]` into a per-case car-relative canonical frame using the per-case surface point cloud bounding box. This is a zero-parameter, inference-time-compatible change: the same normalization applied during training is applied during evaluation, so train/val/test all see coordinates in `[-1, +1]^3` (roughly).

This specifically targets `vol_p_rel_l2_pct` (the test metric that matters per directive #882).

## Current Baseline (wave SOTA)
- PR #740: `test_abupt=7.5195%`, **`test_vol_p=10.7580%`**
- Val wave best (EP40): ~6.53% `val_abupt`

## Implementation

The student must make the following changes:

### 1. Add CLI flag to `train.py`
Add a boolean flag `--use-vol-coord-bbox-norm` / `--no-use-vol-coord-bbox-norm` (default: False).

### 2. Pass flag into dataset construction
Pass `use_bbox_norm=args.use_vol_coord_bbox_norm` into all `DrivAerMLSurfaceDataset(...)` constructor calls (train, val, and test splits).

### 3. Add `use_bbox_norm` parameter to `DrivAerMLSurfaceDataset`
In `target/data/loader.py`:
- Add `use_bbox_norm: bool = False` to `DrivAerMLSurfaceDataset.__init__`
- Store as `self.use_bbox_norm = use_bbox_norm`

### 4. Apply normalization in `__getitem__`
After `case = self.store.load_case(...)` (around line 443 in `loader.py`), before `metadata = dict(case.metadata)`, insert:

```python
if self.use_bbox_norm:
    surf_xyz = case.surface_x[:, :3]
    bbox_min = surf_xyz.min(dim=0).values
    bbox_max = surf_xyz.max(dim=0).values
    bbox_center = (bbox_min + bbox_max) / 2.0
    bbox_half_extent = ((bbox_max - bbox_min) / 2.0).clamp(min=1e-6)
    # Clone because DrivAerMLCase is frozen (dataclass)
    surface_x = case.surface_x.clone()
    surface_x[:, :3] = (surf_xyz - bbox_center) / bbox_half_extent
    volume_x = case.volume_x.clone()
    volume_x[:, :3] = (case.volume_x[:, :3] - bbox_center) / bbox_half_extent
    # Reconstruct frozen dataclass with normalized tensors
    case = DrivAerMLCase(
        case_id=case.case_id,
        surface_x=surface_x,
        surface_y=case.surface_y,
        volume_x=volume_x,
        volume_y=case.volume_y,
        metadata=case.metadata,
    )
```

**Key implementation notes**:
- Only normalize xyz columns (`[:, :3]`). Do NOT normalize normals (`[:, 3:6]`), panel area (`[:, 6]`), or SDF (`volume_x[:, 3]`).
- Use surface bbox (not volume bbox) as the canonical reference for both surface and volume normalization — ensures a consistent frame.
- Apply to ALL splits: train, val, and test. The same normalization must be applied consistently at inference time.
- `DrivAerMLCase` is `@dataclass(frozen=True)`, so you must construct a new instance — do not try to reassign fields in-place.

## Training Command

Standard 6L SurfaceTransolver + STRING + GradNorm + WD + Y-sym config, plus the new bbox norm flag:

```bash
torchrun --nproc_per_node=8 train.py \
  --wandb-group dl24-tanjiro-vol-coord-canonical-frame \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --model-layers 6 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --model-mlp-ratio 4 \
  --model-pe string \
  --pe-num-features 5 \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-ema \
  --ema-decay 0.999 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --train-surface-points 40000 \
  --train-volume-points 65000 \
  --eval-surface-points 40000 \
  --eval-volume-points 65000 \
  --lr-cosine-t-max 50 \
  --batch-size 4 \
  --use-vol-coord-bbox-norm
```

## Kill Thresholds (val `abupt_rel_l2_pct`, lower is better)

| Epoch | Maximum allowed `val_abupt` |
|-------|----------------------------|
| EP5   | ≤ 7.5%                     |
| EP10  | ≤ 7.2%                     |
| EP15  | ≤ 6.80%                    |
| EP20  | ≤ 6.70%                    |
| EP25  | ≤ 6.65%                    |
| EP30  | ≤ 6.60%                    |
| EP35  | ≤ 6.58%                    |
| EP40  | ≤ 6.55%                    |

If any epoch gate is missed, stop training immediately and report results. Do NOT continue past a failed gate.

## Success Criteria

Primary metric: `test_vol_p_rel_l2_pct` (lower is better).
- Beat baseline: `test_vol_p < 10.758%`
- Stretch goal: `test_vol_p < 10.0%`

If val performance looks strong (EP30+ val_abupt < 6.60%), request test eval before EP40 terminal.

## Reporting

At each gate epoch, post a comment with:
- W&B run ID
- `val_abupt_rel_l2_pct` at that epoch
- `val_vol_p_rel_l2_pct` at that epoch (track this closely — this is the key diagnostic metric for the hypothesis)
- Gate pass/fail

At terminal, post a comment with this single-line marker:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_rel_l2_pct","value":<number>},"test_metric":{"name":"test_vol_p_rel_l2_pct","value":<number>}}
```