### PR TITLE
[edward] Per-case bbox geometry scalar conditioning for vol OOD gap

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_geo_scalar_conditioning: bool = False,
+        geo_scalar_dim: int = 4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +358,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_geo_scalar_conditioning = use_geo_scalar_conditioning
+        self.geo_scalar_dim = geo_scalar_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +448,25 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Per-case bbox geometry scalar conditioning (PR #980): inject a small
+        # FiLM-style bias derived from per-case [L, H, W, A_front] into the
+        # volume decoder hidden state. Zero-init weight AND bias so the layer
+        # is identity at init (preserves baseline behavior at epoch 0). The
+        # case_geo_norm lookup is populated externally after construction via
+        # ``set_case_geo_norm``; forward() looks up the per-batch geometry by
+        # ``case_ids``.
+        if use_geo_scalar_conditioning:
+            self.geo_proj = nn.Linear(geo_scalar_dim, n_hidden, bias=True)
+            nn.init.zeros_(self.geo_proj.weight)
+            nn.init.zeros_(self.geo_proj.bias)
+        else:
+            self.geo_proj = None
+        self._case_geo_norm: dict[str, torch.Tensor] = {}
+
+    def set_case_geo_norm(self, mapping: dict[str, torch.Tensor]) -> None:
+        """Register per-case normalized geometry scalars (shape [geo_scalar_dim])."""
+        self._case_geo_norm = {k: v.detach().clone() for k, v in mapping.items()}
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -477,6 +500,7 @@ class SurfaceTransolver(nn.Module):
         surface_mask: torch.Tensor | None = None,
         volume_x: torch.Tensor | None = None,
         volume_mask: torch.Tensor | None = None,
+        case_ids: list[str] | None = None,
     ) -> dict[str, torch.Tensor]:
         if surface_x is None and volume_x is None:
             raise ValueError("SurfaceTransolver requires surface_x or volume_x")
@@ -545,6 +569,24 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.geo_proj is not None
+            and volume_x is not None
+            and volume_tokens > 0
+            and case_ids is not None
+            and self._case_geo_norm
+        ):
+            device = volume_hidden.device
+            dtype = volume_hidden.dtype
+            geo_rows = [self._case_geo_norm.get(cid) for cid in case_ids]
+            if all(row is not None for row in geo_rows):
+                geo_batch = torch.stack(
+                    [row.to(device=device, dtype=dtype) for row in geo_rows], dim=0
+                )
+                geo_emb = self.geo_proj(geo_batch)  # [B, hidden_dim]
+                volume_hidden = volume_hidden + geo_emb.unsqueeze(1)
+                volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_geo_scalar_conditioning: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_geo_scalar_conditioning": (
+            "Enable per-case bbox geometry scalar conditioning (PR #980). "
+            "At startup, computes per-case [L, H, W, A_front] scalars from "
+            "the full-surface bounding box and normalises by train-split "
+            "mean/std. During forward, a zero-initialised "
+            "nn.Linear(4, hidden_dim) projects the per-case scalars into a "
+            "FiLM-style additive bias on the volume hidden state before the "
+            "volume output head. Targets the OOD val->test volume_pressure "
+            "gap by giving the vol decoder explicit handles on car geometry."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,7 +319,69 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_geo_scalar_conditioning=config.use_geo_scalar_conditioning,
     )
+
+
+GEO_SCALAR_NAMES = ("L", "H", "W", "A_front")
+
+
+def compute_case_bbox_scalars(store, case_ids: list[str]) -> dict[str, torch.Tensor]:
+    """Compute per-case [L, H, W, A_front] from full surface_xyz.npy via mmap.
+
+    For each case, loads surface_xyz.npy in mmap mode (no full read), computes
+    the per-axis min/max over all surface points, and packs the result as a
+    1-D tensor of length 4 in the order (X-length, Z-height, Y-width,
+    H*W frontal-area-proxy). The DrivAerML world frame is X=streamwise,
+    Y=lateral, Z=vertical, so:
+        L = X_max - X_min  (length)
+        H = Z_max - Z_min  (height)
+        W = Y_max - Y_min  (width)
+        A_front = H * W    (frontal area proxy)
+    """
+
+    import numpy as np
+
+    out: dict[str, torch.Tensor] = {}
+    for case_id in case_ids:
+        path = store.root / case_id / "surface_xyz.npy"
+        from data.loader import _resolve_artifact_path  # type: ignore
+
+        resolved = _resolve_artifact_path(path)
+        arr = np.load(resolved, mmap_mode="r")
+        # arr: [N, 3], float32
+        xyz_min = np.asarray(arr.min(axis=0), dtype=np.float32)
+        xyz_max = np.asarray(arr.max(axis=0), dtype=np.float32)
+        dims = xyz_max - xyz_min  # [dX, dY, dZ]
+        L = float(dims[0])
+        W = float(dims[1])
+        H = float(dims[2])
+        A_front = H * W
+        out[case_id] = torch.tensor([L, H, W, A_front], dtype=torch.float32)
+    return out
+
+
+def build_case_geo_norm(
+    store,
+    train_case_ids: list[str],
+    extra_case_ids: list[str],
+) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor]:
+    """Compute train-statistic-normalized per-case geometry scalars.
+
+    Returns (case_geo_norm, geo_mean, geo_std). The mean/std are computed
+    from the training split only so val/test geometry magnitudes reflect
+    distribution shift in the normalized space.
+    """
+
+    all_case_ids = list(dict.fromkeys(list(train_case_ids) + list(extra_case_ids)))
+    raw = compute_case_bbox_scalars(store, all_case_ids)
+    train_stack = torch.stack([raw[cid] for cid in train_case_ids], dim=0)  # [N_train, 4]
+    geo_mean = train_stack.mean(dim=0)
+    geo_std = train_stack.std(dim=0, unbiased=False).clamp(min=1e-6)
+    case_geo_norm: dict[str, torch.Tensor] = {
+        cid: (vec - geo_mean) / geo_std for cid, vec in raw.items()
+    }
+    return case_geo_norm, geo_mean, geo_std
 
 
 def train_loss(
@@ -331,6 +404,7 @@ def train_loss(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            case_ids=batch.case_ids,
         )
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
@@ -382,6 +456,7 @@ def per_task_train_losses(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            case_ids=batch.case_ids,
         )
         surface_pred = out["surface_preds"]
         sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
@@ -758,6 +833,32 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+
+        # Per-case bbox geometry scalar conditioning (PR #980): pre-compute
+        # per-case [L, H, W, A_front] from the full-surface bbox via mmap on
+        # surface_xyz.npy, normalise by train-split mean/std, and register on
+        # the model so forward() can build a [B, 4] geo tensor by case_id.
+        geo_mean_log: list[float] = []
+        geo_std_log: list[float] = []
+        if config.use_geo_scalar_conditioning:
+            store = train_loader.dataset.store
+            train_case_ids = list(train_loader.dataset.case_ids)
+            extra_case_ids: list[str] = []
+            for loader_dict in (val_loaders, test_loaders):
+                for loader in loader_dict.values():
+                    extra_case_ids.extend(loader.dataset.case_ids)
+            case_geo_norm, geo_mean, geo_std = build_case_geo_norm(
+                store, train_case_ids, extra_case_ids
+            )
+            model.set_case_geo_norm(case_geo_norm)
+            geo_mean_log = [float(x) for x in geo_mean.tolist()]
+            geo_std_log = [float(x) for x in geo_std.tolist()]
+            if state.is_main:
+                print(
+                    f"GeoScalarCond enabled: {len(case_geo_norm)} cases; "
+                    f"train mean={dict(zip(GEO_SCALAR_NAMES, geo_mean_log))}; "
+                    f"train std={dict(zip(GEO_SCALAR_NAMES, geo_std_log))}"
+                )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -883,6 +984,14 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.use_geo_scalar_conditioning:
+                for name, value in zip(GEO_SCALAR_NAMES, geo_mean_log):
+                    wandb.summary[f"geo/train_mean_{name}"] = value
+                for name, value in zip(GEO_SCALAR_NAMES, geo_std_log):
+                    wandb.summary[f"geo/train_std_{name}"] = value
+                wandb.summary["geo/num_cases"] = len(
+                    getattr(base_model, "_case_geo_norm", {})
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -966,6 +966,7 @@ def accumulate_eval_batch(
             surface_mask=batch.surface_mask,
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
+            case_ids=batch.case_ids,
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()


### PR DESCRIPTION
## Hypothesis

Per-case global geometry scalar descriptors — frontal area, height, width, car length derived from the surface bounding box — fed as explicit conditioning inputs into the volume decoder MLP can close the val→test volume pressure gap.

The 4 worst OOD test cases (run_133, run_226, run_203, run_158) account for 92% of the squared test_vol_p deviation, and they likely differ in gross geometry (wider/taller/shorter bodies) from the centre of the training distribution. The current Transolver encodes no explicit geometry: all cases are embedded with the same architecture and the same coordinate space. Giving the vol head a few normalised scalar handles on "what shape car this is" should reduce the OOD sensitivity of the vol decoder, at zero architectural cost and zero extra parameters in the backbone.

This is distinct from related concurrent experiments:
- **PR #978** (dl24-tanjiro) — normalises the 3D *coordinate frame* (bbox-relative [-1,1]³), not the shape scalars
- **PR #976** (alphonse) — learns a geometry embedding by mean-pooling *learned surface hidden states*, not raw geometric measurements
- **PR #972** (dl24-frieren) — redistributes volume *sampling density* by SDF proximity

**Why scalars work here:** Frontal area and aspect ratio are known aerodynamic similarity parameters (Reynolds-number similarity, drag scaling). At inference the model has never seen run_133's geometry; a 4-scalar side-channel makes that geometry explicit rather than forcing the backbone to infer it from noisy point-cloud statistics.

Reference: FiLM conditioning (Perez et al., 2018 https://arxiv.org/abs/1709.07871) and continuous conditioning signals in implicit neural networks (e.g. Neural Process / HyperNetwork literature).

## Instructions

Implement a 4-scalar per-case geometry conditioning module in `target/train.py` and wire it into the volume decoder MLP head. Steps:

### 1. Extract 4 geometry scalars from the surface bounding box

In the training loop, after loading each batch, compute per-case bbox geometry scalars from `surface_x[:, :3]` (the surface XYZ coordinates already available in each batch):

```python
# surface_x: [N_surf, D], first 3 cols are XYZ
surf_xyz = surface_x[:, :3]  # shape [N_surf, 3]
bbox_min = surf_xyz.min(dim=0).values   # [3]
bbox_max = surf_xyz.max(dim=0).values   # [3]
dims = bbox_max - bbox_min              # [L, H, W] in dataset axis order (X=length, Y=width, Z=height)
L, W, H = dims[0], dims[1], dims[2]
A_front = H * W                         # frontal area proxy
AR = H / (W + 1e-6)                     # height/width aspect ratio
geo_raw = torch.stack([L, H, W, A_front], dim=0)  # [4]
```

**Important:** Handle the volume-only view case (where `surface_x.shape[0] == 0`) by using a cached full-surface bbox from the data loader, similar to the approach in PR #978. If `surface_x` is empty, skip the scalar computation and use zeros (the geo_raw fallback). Check how the dataloader handles this edge case in PR #978 for reference.

### 2. Normalise using running statistics

Maintain a fixed normalisation using dataset-wide mean/std estimated from the training set (a reasonable prior is: L~4.5m σ=0.3, H~1.4m σ=0.15, W~1.9m σ=0.1, A_front~2.66m² σ=0.45 — but feel free to compute from the actual data if a helper function is easy to add):

```python
GEO_MEAN = torch.tensor([4.5, 1.4, 1.9, 2.66], device=device)
GEO_STD  = torch.tensor([0.30, 0.15, 0.10, 0.45], device=device)
geo_norm = (geo_raw - GEO_MEAN) / GEO_STD   # [4], ~N(0,1) at train time
```

### 3. Project to hidden dim and condition the vol head

Add a small linear projection layer in the model:

```python
self.geo_proj = nn.Linear(4, hidden_dim, bias=True)
# zero-init to identity-at-init: start neutral, let gradient discover utility
nn.init.zeros_(self.geo_proj.weight)
nn.init.zeros_(self.geo_proj.bias)
```

In the forward pass, just before the volume MLP output head, broadcast and add the geometry embedding as a bias:

```python
geo_emb = self.geo_proj(geo_norm)          # [hidden_dim]
vol_hidden = vol_hidden + geo_emb.unsqueeze(0)  # broadcast over N_vol tokens
vol_out = self.vol_head(vol_hidden)
```

The zero-init means the model starts from the exact same initialisation as the current SOTA — training can only improve from here, it cannot regress at step 0.

### 4. Per-batch vs per-case handling in DDP

Because each rank processes a different case per-GPU (batch_size=4 but cases are distributed across 8 ranks), compute `geo_norm` per-case inside the forward pass or the data loop. The simplest correct approach is to pass `geo_norm` as an extra tensor argument into the model's forward method, shape `[B, 4]` (one row per case in the batch), and broadcast to `[B, N_vol, hidden_dim]` in the vol conditioning step.

### 5. Training configuration

Run a 4-epoch screen with the standard vol-curriculum, then continue to EP10 if EP4 < 6.9%:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 10 --epochs 10 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-gradnorm --gradnorm-alpha 0.5 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<30,21729:val_primary/abupt_axis_mean_rel_l2_pct<16,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0,38030:val_primary/abupt_axis_mean_rel_l2_pct<6.9" \
  --wandb-group edward-bbox-geo-scalar-conditioning \
  --wandb-name edward/geo-scalar-cond-ep10
```

### 6. Key diagnostics to report at each EP gate

At every epoch validation, log:
- `val_abupt` (primary gate metric), `val_vol_p`, `val_surf_p`, `val_wall`
- The actual `geo_proj.weight` gradient norm (to confirm the conditioning is receiving signal)
- If possible: per-case vol_p breakdown for the 4 known OOD cases (run_133, run_226, run_203, run_158)

## Gate schedule

| Epoch | Step | Kill threshold (val_abupt) |
|-------|------|---------------------------|
| EP1   | ~10864 | ≤30% |
| EP2   | ~21729 | ≤16% |
| EP3   | ~32594 | ≤8.0% |
| EP4   | ~38030 | ≤6.9% |

If EP4 passes, continue to EP10. Report results at every epoch.

## Baseline

**Single-model SOTA — PR #823 (nezuko, surf→vol xattn, EP13 best checkpoint)**
- `val_abupt` = **6.4407%**
- `val_surf_p` = 4.1836%, `val_vol_p` = 3.8557%, `val_wall` = 7.3448%
- `test_abupt` = 7.6992%, `test_vol_p` = 11.6704% ← OOD gap target
- W&B run: `ghh0s4ne` (group `nezuko-surf-vol-xattn`)
- **Beat target: val_abupt < 6.4407%**

**Current new single-model SOTA — PR #958 (nezuko, dedicated aux vol decoder, EP13 best checkpoint)**
- `val_abupt` = **6.2869%** (run `29nohj67`, Arm A)
- `val_vol_p` = 3.3953%, `test_vol_p` = 10.6052%
- **Beat target: val_abupt < 6.2869%**

Reproduce baseline (to verify your implementation gives same EP1-EP4 trajectory before the geo conditioning is wired):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn
```
