### PR TITLE
frieren: SDF-stratified vol sampling to close vol_p OOD gap (4-ep screen)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -32,7 +33,8 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import DrivAerMLCase, DrivAerMLSurfaceDataset
+from data.loader import _resolve_artifact_path  # noqa: PLC2701 — internal helper reused for PVC fallback paths
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -65,6 +67,125 @@ from trainer_runtime import (
     timeout_budget_minutes,
     unwrap_model,
 )
+
+
+# ---------------------------------------------------------------------------
+# SDF-stratified volume sampling (per-worker cache + class-level patch)
+# ---------------------------------------------------------------------------
+
+# Per-process |SDF| cache keyed by case_id. Each DataLoader worker forks from
+# the rank process so this dict is independent per worker, populated lazily on
+# the first hit of a case_id. With persistent_workers=True the cache stays
+# warm across epochs. Memory budget: ~0.5-1M points/case * 4 bytes/float32
+# ~= 2-4 MB/case; ~400 cases => ~1-1.6 GB per worker worst case (sharded
+# across DDP ranks, so each worker only sees a subset in practice).
+_SDF_ABS_CACHE: dict[str, torch.Tensor] = {}
+
+
+def _load_case_sdf_abs(root, case_id: str, expected_n: int) -> torch.Tensor:
+    """Return the absolute SDF column for a case as a 1-D float32 tensor.
+
+    Lazy-loads from `volume_sdf.npy` on first access and caches in
+    `_SDF_ABS_CACHE` for subsequent draws.
+    """
+
+    cached = _SDF_ABS_CACHE.get(case_id)
+    if cached is not None:
+        if cached.shape[0] != expected_n:
+            raise RuntimeError(
+                f"SDF cache for {case_id} has size {cached.shape[0]} but "
+                f"case_point_counts reports {expected_n}; cache poisoning?"
+            )
+        return cached
+    from pathlib import Path
+
+    sdf_path = Path(root) / case_id / "volume_sdf.npy"
+    resolved = _resolve_artifact_path(sdf_path)
+    sdf_np = np.asarray(np.load(resolved), dtype=np.float32).reshape(-1)
+    if sdf_np.shape[0] != expected_n:
+        raise RuntimeError(
+            f"volume_sdf.npy for {case_id} has {sdf_np.shape[0]} rows but "
+            f"case_point_counts reports {expected_n}"
+        )
+    tensor = torch.from_numpy(np.abs(sdf_np)).contiguous()
+    _SDF_ABS_CACHE[case_id] = tensor
+    return tensor
+
+
+# Patched __getitem__ for SDF-stratified train sampling. Falls back to the
+# original implementation when sampling_mode != "train_random" so eval splits
+# remain full-fidelity strided. The alpha value is read from a class-level
+# attribute set by `enable_sdf_stratified_sampling`.
+_orig_drivaerml_getitem = None
+
+
+def enable_sdf_stratified_sampling(alpha: float) -> None:
+    """Patch DrivAerMLSurfaceDataset.__getitem__ for SDF-stratified train sampling.
+
+    Idempotent: safe to call multiple times; the original __getitem__ is
+    captured only once and re-used as the fallback for non-train samplers
+    and for the curriculum-rebuilt train datasets.
+    """
+
+    global _orig_drivaerml_getitem
+    if _orig_drivaerml_getitem is None:
+        _orig_drivaerml_getitem = DrivAerMLSurfaceDataset.__getitem__
+    DrivAerMLSurfaceDataset._sdf_stratified_alpha = float(alpha)
+
+    def _patched_getitem(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        if view.sampling_mode != "train_random":
+            return _orig_drivaerml_getitem(self, idx)
+
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+
+        n_total = int(counts["n_volume"])
+        N_vol = int(self.max_volume_points)
+        if view.view_index >= view.volume_view_count:
+            volume_idx_np = np.empty(0, dtype=np.int64)
+        elif N_vol <= 0 or n_total <= N_vol:
+            volume_idx_np = None
+        else:
+            sdf_abs = _load_case_sdf_abs(self.store.root, view.case_id, n_total)
+            alpha = getattr(self, "_sdf_stratified_alpha", 2.0)
+            weights = 1.0 + alpha * sdf_abs
+            sampled = torch.multinomial(weights, N_vol, replacement=True)
+            volume_idx_np = sampled.sort().values.numpy()
+
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=volume_idx_np,
+        )
+
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = "sdf_stratified"
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+    DrivAerMLSurfaceDataset.__getitem__ = _patched_getitem
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +259,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
     debug: bool = False
 
 
@@ -228,6 +351,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_sdf_stratified_vol_sampling": (
+            "Bias the train-time volume point sampling toward far-field "
+            "(large |SDF|) tokens. For each train view we sample "
+            "train_volume_points indices via torch.multinomial with weights "
+            "w[i] = 1 + alpha * |sdf[i]|. The per-case |SDF| array is "
+            "lazy-loaded once per worker process and cached in memory. "
+            "Eval (eval_chunk strided) views are unaffected so val/test "
+            "metrics remain full-fidelity. Targets the val_vol_p / "
+            "test_vol_p OOD generalisation gap."
+        ),
+        "sdf_stratified_alpha": (
+            "Bias strength for SDF-stratified volume sampling: "
+            "weight[i] = 1 + alpha * |sdf[i]|. alpha=0 reproduces uniform "
+            "sampling; alpha=2.0 (default) gives ~3.5x more weight to "
+            "points at |sdf|=1m vs the surface, and ~160x at |sdf|~80m. "
+            "Only used when --use-sdf-stratified-vol-sampling is set."
         ),
     }
     for field in fields(Config):
@@ -736,6 +876,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
         current_train_vol_points = config.train_volume_points
 
+        if config.use_sdf_stratified_vol_sampling:
+            enable_sdf_stratified_sampling(config.sdf_stratified_alpha)
+            if state.is_main:
+                print(
+                    "SDF-stratified vol sampling: enabled "
+                    f"alpha={config.sdf_stratified_alpha} "
+                    "(train __getitem__ uses w[i]=1+alpha*|sdf[i]|; "
+                    "eval splits unchanged)"
+                )
+
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
@@ -883,6 +1033,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["data/use_sdf_stratified_vol_sampling"] = bool(
+                config.use_sdf_stratified_vol_sampling
+            )
+            wandb.summary["data/sdf_stratified_alpha"] = float(
+                config.sdf_stratified_alpha
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
# Hypothesis: SDF-Stratified Volume Point Sampling

## Motivation

The primary systematic gap in our current SOTA is the **vol_p OOD generalization gap**:
- val_vol_p = 3.86% vs test_vol_p = **11.67%** (3.02× ratio)
- Overall: val_abupt = 6.44% vs test_abupt = 7.70%

The model sees far-field volume points rarely during training because uniform random sampling heavily favors the dense near-surface region (where SDF ≈ 0). Far-field points carry most of the global pressure signal, yet they are systematically under-represented. SDF-stratified importance sampling biases selection toward large-|SDF| tokens, forcing the model to learn the global pressure field.

**Approach:** Replace uniform vol-point selection with importance-weighted sampling:

```
weight[i] = 1 + α * |sdf[i]|
```

where `sdf[i]` = `volume_x[:, 3]` (the 4th feature channel, which is SDF distance). With α=2.0, the top 10% of far-field points receive ~33% of sampled draws vs 10% under uniform sampling.

SDF distribution stats from prior experiment (PR #972):
- |sdf| q50 = 0.004 m, q90 = 0.20 m, q99 = 3.6 m, max = 80.7 m
- α=2.0 → ~160× weight ratio between far-field and near-surface points

## Current Baseline (SOTA — tay, PR #823, run `ghh0s4ne`)

| Metric | Val | Test |
|---|---|---|
| abupt | **6.4407%** | 7.6992% |
| surf_p | 4.1836% | 3.8451% |
| vol_p | 3.8557% | **11.6704%** |
| wall | 7.3448% | 7.0429% |

- Gate: val_abupt < **6.4407%** to beat baseline
- Params: ~17M; Training: 833 min on 8×H100s; Peak mem: 75.9 GB/97 GB

## Your Task: 4-Epoch Screen

Run a 4-epoch screen on the tay SOTA config with SDF-stratified vol sampling enabled.

### Step 1: Implement the new CLI flags

Add to `train.py` argument parser:

```python
parser.add_argument("--use-sdf-stratified-vol-sampling", action="store_true", default=False,
                    help="Bias vol-point sampling toward far-field (large |SDF|) tokens.")
parser.add_argument("--sdf-stratified-alpha", type=float, default=2.0,
                    help="Bias strength: weight[i] = 1 + alpha * |sdf[i]|. Default 2.0.")
```

### Step 2: Monkey-patch the train dataset after construction

After `train_dataset` is built (but before the DataLoader), insert:

```python
if args.use_sdf_stratified_vol_sampling:
    import types
    _ALPHA = args.sdf_stratified_alpha    # 2.0
    _N_VOL = args.train_volume_points     # 65536

    _orig_train_getitem = train_dataset.__class__.__getitem__

    def _sdf_stratified_getitem(self, idx):
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)
        surface_idx = self._indices(
            counts["n_surface"], self.max_surface_points, view,
            group_view_count=view.surface_view_count,
        )
        # Load ALL volume points (volume_rows=None) so we can compute weights
        case = self.store.load_case(
            view.case_id,
            surface_rows=None if surface_idx is None else surface_idx.numpy(),
            volume_rows=None,
        )
        n_total = case.volume_x.shape[0]
        n_sample = min(_N_VOL, n_total)
        sdf_vals = case.volume_x[:, 3].abs()     # channel 3 = SDF distance
        weights = 1.0 + _ALPHA * sdf_vals        # [N_total]
        vol_idx = torch.multinomial(weights, n_sample, replacement=True)
        vol_idx = vol_idx.sort().values          # sort for spatial locality
        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case.case_id,
            surface_x=case.surface_x,
            surface_y=case.surface_y,
            volume_x=case.volume_x[vol_idx],
            volume_y=case.volume_y[vol_idx],
            metadata=case.metadata,
        )

    train_dataset.__class__.__getitem__ = _sdf_stratified_getitem
```

**I/O note:** Loading all volume points per call is expensive. If the dataloader stores volume data in memory or supports caching, use a per-process `volume_sdf.npy` cache keyed by `case_id` to avoid re-reading all volume data on every `__getitem__` call. See PR #972 for the caching pattern.

**SDPA note:** `--use-surf-to-vol-xattn` requires flash SDPA to avoid OOM. This should already be active in the SOTA config — confirm `torch.backends.cuda.enable_flash_sdp(True)` is set before the xattn forward pass.

### Step 3: Run the 4-epoch screen

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 2.0 \
  --wandb-group frieren-sdf-stratified-vol \
  --wandb-name frieren/sdf-stratified-vol-ep4-alpha2
```

## Epoch Gates

| After EP | val_abupt target | Action if missed |
|---|---|---|
| EP1 | ≤ 30% | Kill — diverged |
| EP4 | ≤ 6.80% | Report result; advisor decides on full run |

## What to Report

Post a PR comment with:
1. EP1–EP4 val_abupt per epoch (table)
2. EP4 breakdown: val_surf_p, val_vol_p, val_wall (to check if vol_p OOD gap narrows)
3. W&B run ID
4. Any implementation issues encountered

Terminal result marker (when complete):
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

## Why This Matters

This experiment directly targets the largest gap between our val and test performance. If SDF-stratified sampling reduces the vol_p test gap (currently 3.02×), it would represent a qualitative improvement in out-of-distribution generalization — exactly what we need to push test_abupt below 7%.
