### PR TITLE
tanjiro: curriculum warm-up ramp at vol-points transitions

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,6 +130,7 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    vol_points_warmup_steps: int = 0
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -160,6 +161,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "vol_points_warmup_steps": (
+            "Linear ramp length (in optimizer steps) for vol_points at each "
+            "curriculum transition. When --vol-points-schedule increases the "
+            "view size at an epoch boundary, the batch's volume tensors are "
+            "truncated to a linearly interpolated value between the previous "
+            "and new view size over the first N steps of the new epoch. "
+            "Default 0 disables the ramp (original abrupt-transition behavior). "
+            "Tests the hypothesis that curriculum shock is the limiting factor "
+            "in fast-schedule approaches (see PR #973 for the shock mechanism)."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -891,6 +902,8 @@ def main(argv: Iterable[str] | None = None) -> None:
         early_stop_reason: str | None = None
         timeout_hit = False
         train_start = time.time()
+        prev_train_vol_points = current_train_vol_points
+        vol_transition_step = 0
 
         for epoch in range(max_epochs):
             if vol_points_schedule:
@@ -905,12 +918,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                             f"Volume-points curriculum: epoch {epoch} -> "
                             f"train_volume_points={desired_vol_points} "
                             f"(was {current_train_vol_points})"
+                            + (
+                                f" [ramp over {config.vol_points_warmup_steps} steps]"
+                                if config.vol_points_warmup_steps > 0
+                                and desired_vol_points > current_train_vol_points
+                                else ""
+                            )
                         )
+                    prev_train_vol_points = current_train_vol_points
                     config.train_volume_points = desired_vol_points
                     train_loader = rebuild_train_loader_with_vol_points(
                         config, train_loader, desired_vol_points, state
                     )
                     current_train_vol_points = desired_vol_points
+                    vol_transition_step = global_step
             if isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
             timeout_hit = distributed_any(
@@ -936,6 +957,26 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                effective_vol_points = current_train_vol_points
+                vol_warmup_alpha = 1.0
+                if (
+                    config.vol_points_warmup_steps > 0
+                    and prev_train_vol_points < current_train_vol_points
+                ):
+                    steps_since_transition = global_step - vol_transition_step
+                    if steps_since_transition < config.vol_points_warmup_steps:
+                        vol_warmup_alpha = (
+                            steps_since_transition / config.vol_points_warmup_steps
+                        )
+                        effective_vol_points = int(
+                            prev_train_vol_points
+                            + vol_warmup_alpha
+                            * (current_train_vol_points - prev_train_vol_points)
+                        )
+                        if effective_vol_points < batch.volume_x.shape[1]:
+                            batch.volume_x = batch.volume_x[:, :effective_vol_points, :]
+                            batch.volume_y = batch.volume_y[:, :effective_vol_points, :]
+                            batch.volume_mask = batch.volume_mask[:, :effective_vol_points]
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1054,6 +1095,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/lr": current_lr,
                     "lr": current_lr,
                     "train/vol_points": float(current_train_vol_points),
+                    "train/effective_vol_points": float(effective_vol_points),
+                    "train/vol_warmup_alpha": float(vol_warmup_alpha),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                 }


### PR DESCRIPTION
## Hypothesis

PR #973 provided definitive evidence that the EP1→EP2 curriculum jump (16K→32K volume points) causes **information-loss-driven curriculum shock**: both tanh (Arm A) and asinh (Arm B) SDF encodings died at the *identical* step 10868 — three steps after the curriculum transition — with exponentially growing loss (0.030 → 2.709 → 4.994 → 10.627) and gradients (16.5 → 59.7 → 130.8 → 277.3 gnorm).

The mechanism: bounded SDF encodings collapse per-cell uniqueness. Cells at different distances (e.g., 10m and 36km from surface) map to nearly identical tanh/asinh values near ±1. When vol_points doubles from 16K→32K at EP2, the model is flooded with "look-alike" tokens that have near-identical SDF encodings but different ground-truth pressures — causing gradient divergence within 3 steps.

The fix: **gradual curriculum transition**. Instead of jumping 16K→32K in a single step, ramp vol_points linearly from 16K to 32K over the first N=500 steps of EP2, giving the model time to adapt its internal representations before being flooded with new tokens.

This tests whether the curriculum shock is the limiting factor in the fast-schedule approach, independent of SDF encoding choice.

## Instructions

This experiment requires a **linear warm-up ramp of vol_points** at each curriculum transition boundary. The implementation strategy:

### Option A: Use an existing curriculum warm-up flag (check first)

Run `python train.py --help | grep -i "warmup\|ramp\|curriculum"` to check if a curriculum warm-up flag already exists. If `--vol-points-warmup-steps` or similar exists, use it.

### Option B: Implement a simple ramp in the training loop

If no flag exists, add a `--vol-points-warmup-steps N` argument (default 0 = no ramp, current behavior). When N > 0, at each curriculum step boundary, instead of jumping directly to the new vol_points value, linearly interpolate over the next N training steps:

```python
# In the per-step vol_points update logic:
if warmup_steps > 0 and steps_since_curriculum_change < warmup_steps:
    alpha = steps_since_curriculum_change / warmup_steps
    effective_vol_points = int(prev_vol_points + alpha * (target_vol_points - prev_vol_points))
else:
    effective_vol_points = target_vol_points
```

### Training command

Run **two arms** to test sensitivity to ramp length:

**Arm A — 500-step ramp:**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --vol-points-warmup-steps 500 \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group tanjiro-curriculum-warmup \
  --wandb-name tanjiro/curriculum-warmup-500steps
```

**Arm B — 200-step ramp (shorter, less disruption to LR schedule):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --vol-points-warmup-steps 200 \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --wandb-group tanjiro-curriculum-warmup \
  --wandb-name tanjiro/curriculum-warmup-200steps
```

**If `--vol-points-warmup-steps` does not exist:** implement it minimally in `train.py`, add the argument, and include the implementation diff in your PR update comment. Keep the implementation self-contained and no more than ~30 lines.

### Epoch gates

For each arm, report val metrics after each epoch. Kill that arm at first gate miss, continue the other arm.

| Epoch | val_abupt threshold | vol_p threshold | Action |
|-------|---------------------|-----------------|--------|
| EP1   | ≤30%                | —               | Kill arm if missed |
| EP2   | ≤16%                | —               | Kill arm if missed |
| EP3   | ≤8.0%               | ≤5.0% (dual)   | Kill arm if **either** missed |
| EP4   | ≤6.9%               | —               | Final result |

The critical gate to watch is EP2: the tanh/asinh arms died here (val_abupt ~26.5% vs threshold ≤16%). If the warm-up ramp survives EP2, that confirms the curriculum shock hypothesis.

Report all four metrics each epoch: `val_abupt`, `surf_p`, `vol_p`, `wall_shear`.

### What to watch for

- **Step-by-step loss and gnorm around step 10865 (EP2 boundary)** — the same window where PR #973 arms died. Post a table of loss/gnorm for steps 10860–10875 for each arm.
- **Scale of loss divergence**: if the ramp works, loss at step 10866 should stay near 0.030 (not jump to 2.7+).
- If Arm A (500 steps) survives but Arm B (200 steps) dies, the shock requires a longer ramp.

## Baseline

Current single-model SOTA: **val_abupt = 6.4407%** (PR #823, W&B run `ghh0s4ne`, surf→vol cross-attention)

EP-by-EP SOTA trajectory (PR #823):
- EP1: 28.6344%
- EP2: 8.1482%
- EP3: 7.1195%

PR #973 result for reference (tanh/asinh, no warmup — both killed at step 10868):
- EP1 (tanh): 28.6826% PASS | EP1 (asinh): 26.5567% PASS
- EP2: KILLED at step 10868 (3 steps past EP2 boundary)

## Result format

Post an update comment after EP2 with step-by-step loss/gnorm data around the EP2 boundary, then a terminal comment when complete:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-id>","<arm-b-id>"],"primary_metric":{"name":"val_abupt","value":<best_value>},"test_metric":{"name":"test_abupt","value":null}}
```

If only one arm survives to completion, report that arm's metric as the primary.
