### PR TITLE
Constant xattn temperature scale=0.5 control

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_temp_scale: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_temp_scale = float(xattn_temp_scale)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -537,7 +539,7 @@ class SurfaceTransolver(nn.Module):
             and volume_tokens > 0
         ):
             xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
+                query=volume_hidden * self.xattn_temp_scale,
                 key=surface_hidden,
                 value=surface_hidden,
                 need_weights=False,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_temp_scale: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -308,6 +309,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_temp_scale=config.xattn_temp_scale,
     )
 
 


### PR DESCRIPTION
# Constant xattn temperature scale=0.5 control

## Hypothesis

PR #974 trained a 33-parameter MLP to predict per-token xattn temperature scales from SDF values. The MLP collapsed to a global constant: `scale_mean=0.515`, `tau_std=0.00177` — 3 orders of magnitude smaller than the global drift. It was not learning per-token boundary differentiation; it was discovering that globally sharpening the attention (scale ≈ 0.5 → temperature ≈ 0.5) is useful.

This experiment tests whether that global sharpening has intrinsic value by hardcoding `scale=0.5` with **zero learnable parameters**. This cleanly isolates the global sharpening signal from the per-token locality hypothesis.

Mechanism: multiply `volume_hidden` (Q vectors) by `0.5` before passing to `nn.MultiheadAttention`. Since PyTorch's `nn.MultiheadAttention` applies its own `1/sqrt(head_dim)` scaling internally, multiplying Q by 0.5 is equivalent to halving the effective attention temperature (sharpening the distribution).

## Implementation

Two minimal changes only:

**train.py** — add `xattn_temp_scale: float = 1.0` field to `Config` dataclass; pass `xattn_temp_scale=config.xattn_temp_scale` in `build_model`.

**model.py** — add `xattn_temp_scale: float = 1.0` param to `SurfaceTransolver.__init__`; store as `self.xattn_temp_scale`; change xattn forward call from `query=volume_hidden` to `query=volume_hidden * self.xattn_temp_scale`.

Zero new parameters. No gradient through the scale (plain float, not `nn.Parameter`). Identity at `scale=1.0` (default).

## Current best metrics (single-model gate)

| Metric | Value | Source |
|---|---|---|
| val_abupt (primary) | **6.4407%** | PR #823, run `ghh0s4ne` |
| val_vol_p | ~4.8% | PR #823 |

EP3 dual gate: val_abupt ≤ 8.0% AND vol_vol_p ≤ 5.0%

Full SOTA training stack: L=5, hidden_dim=512, heads=4, slices=128, Lion lr=9e-5, wd=5e-4, tau_y×1.5, tau_z×2.0, surface_w=2.0, EMA=0.999, grad-clip=0.5, lr-warmup=1, STRING-sep, QK-norm, rff16, rff-init-sigmas="0.25,0.5,1.0,2.0,4.0", no-compile, use-surf-to-vol-xattn.

## Run command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-temp-scale 0.5 \
  --wandb-group thorfinn-constant-attn-temp-scale \
  --wandb-name thorfinn/xattn-temp-scale-0.5-fast4ep
```

## EP gate protocol

Report val_abupt and vol_vol_p after each epoch. Kill if:
- EP1 > 30%
- EP2 > 16%
- EP3 fails dual gate: val_abupt > 8.0% OR vol_vol_p > 5.0%

EP3 gate is strict dual — both must pass to proceed to EP4.

## Expected outcome

If the hardcoded scale=0.5 beats or matches the MLP baseline (PR #974 EP3: val_abupt=8.148%), it confirms global attention sharpening has standalone value. If it passes the EP3 dual gate and completes EP4, we have a simpler zero-param improvement to merge.

If it fails EP3, it suggests the MLP in PR #974 was not purely learning global sharpening — there may have been some useful gradient signal from the SDF conditioning that we cannot replicate with a constant.

## Terminal result marker

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"val_abupt","value":<number>}}
```
