### PR TITLE
[dl24-tanjiro] DropPath (Stochastic Depth) regularization to reduce val→test overfitting

### DIFF
--- a/model.py
+++ b/model.py
@@ -184,6 +184,29 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class DropPath(nn.Module):
+    """Per-sample stochastic depth (Stochastic Depth) regularization.
+
+    Drops the entire residual branch for a sample with probability ``drop_prob``
+    during training.  At eval time acts as an identity (no drop).
+    Scaling by ``1 / keep_prob`` preserves the expected value of the output.
+    """
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        # shape: (batch_size, 1, 1, ...) — broadcast over token/spatial dims
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        random_tensor = torch.rand(shape, dtype=x.dtype, device=x.device)
+        random_tensor = torch.floor(random_tensor + keep_prob)
+        return x * random_tensor / keep_prob
+
+
 class TransolverAttention(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
         super().__init__()
@@ -243,6 +266,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -255,12 +279,13 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate > 0.0 else nn.Identity()
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -274,8 +299,15 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
+        # Linear stochastic-depth schedule: block 0 gets 0, last block gets drop_path_rate.
+        dpr = (
+            [drop_path_rate * i / (depth - 1) for i in range(depth)]
+            if depth > 1
+            else [0.0]
+        )
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -284,8 +316,9 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    drop_path_rate=dpr[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -309,6 +342,7 @@ class SurfaceTransolver(nn.Module):
         n_layers: int = 3,
         n_hidden: int = 192,
         dropout: float = 0.0,
+        drop_path_rate: float = 0.0,
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
@@ -360,6 +394,7 @@ class SurfaceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            drop_path_rate=drop_path_rate,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -93,6 +93,7 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    model_drop_path_rate: float = 0.0
     model_pe: str = "sincos"
     pe_num_features: int = 16
     pe_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
@@ -229,6 +230,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
         dropout=config.model_dropout,
+        drop_path_rate=config.model_drop_path_rate,
         n_head=config.model_heads,
         mlp_ratio=config.model_mlp_ratio,
         slice_num=config.model_slices,


### PR DESCRIPTION
## Hypothesis

Every regularization lever tried so far (weight decay, standard dropout, GradNorm α, fixed loss weights, extended cosine, EMA) has **not closed** the structural val→test vol_p gap (~+7–8 pp).  DropPath / Stochastic Depth is a fundamentally different regularization mechanism: instead of scaling or masking individual activations, it drops **entire residual branches per sample** during training.  This forces the network to develop redundant, ensemble-like representations across depth, which can reduce overfitting in a way that per-activation noise cannot.

DropPath has been the dominant regularizer in production ViT / Swin families since 2021.  For the SurfaceTransolver (6L Transformer backbone), the standard linear schedule (block 0 → rate 0, block 5 → max_rate) keeps early layers stable while introducing stochasticity at deeper layers where high-level (and potentially dataset-specific) features consolidate.

**Expected benefit**: reduced val→test generalization gap on `vol_p` and `abupt` metrics; potentially improved test-set primary metric even if val metric moves little.

## Implementation

- New `DropPath` class added to `model.py` (per-sample stochastic depth, correct `1/keep_prob` scaling, eval-time identity)
- `TransformerBlock` accepts `drop_path_rate: float`; both attention and MLP residual branches wrapped: `x = x + self.drop_path(...)` 
- `Transformer` applies a **linear schedule** across depth: block `i` gets `rate = max_rate * i / (depth - 1)`
  - 6-layer schedule with `max_rate=0.1`: `[0.0, 0.02, 0.04, 0.06, 0.08, 0.10]`
- `SurfaceTransolver` exposes `drop_path_rate` kwarg; threaded to backbone
- `train.py` `Config` adds `model_drop_path_rate: float = 0.0`; `build_model()` passes it through; CLI flag `--model-drop-path-rate` auto-generated
- **Param count unchanged**: 18.791197 M (DropPath / nn.Identity add zero parameters)

## Current Baseline

| Metric | Value | Run |
|--------|-------|-----|
| val_abupt | 6.5290% | PR #844 EP41 |
| test_abupt | 7.5195% | PR #740 `5x8wofzm` |
| test_vol_p | 10.7580% | PR #740 `5x8wofzm` |
| val→test vol_p gap | ~+7–8 pp | structural |

## Kill Thresholds

| Step | val_abupt must be ≤ |
|------|---------------------|
| EP5  (≈27 469 steps) | 7.5% |
| EP10 (≈54 938 steps) | 7.2% |
| EP15 (≈82 407 steps) | 6.80% |
| EP20 (≈109 876 steps) | 6.70% |
| EP25 (≈137 345 steps) | 6.65% |
| EP30 (≈164 814 steps) | 6.60% |

## Training Command

```bash
python train.py \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-pe string_multisigma --pe-num-features 16 \
  --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-drop-path-rate 0.1 \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-lr 1e-3 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 1e-4 --weight-decay 0.005 \
  --no-use-ema \
  --epochs 30 \
  --kill-thresholds "27469:val_primary/abupt_axis_mean_rel_l2_pct<7.5,54938:val_primary/abupt_axis_mean_rel_l2_pct<7.2,82407:val_primary/abupt_axis_mean_rel_l2_pct<6.80,109876:val_primary/abupt_axis_mean_rel_l2_pct<6.70,137345:val_primary/abupt_axis_mean_rel_l2_pct<6.65,164814:val_primary/abupt_axis_mean_rel_l2_pct<6.60" \
  --agent dl24-tanjiro \
  --wandb-name "dl24-tanjiro/drop-path-rate-0.1" \
  --wandb-group "drop-path"
```

## What to Report

Please report after every 5-epoch gate AND at terminal:
- `val_primary/abupt_axis_mean_rel_l2_pct` (primary)
- `val_primary/vol_p_mean_rel_l2_pct`
- `val_primary/surf_p_mean_rel_l2_pct`
- `test_primary/abupt_axis_mean_rel_l2_pct`
- `test_primary/vol_p_mean_rel_l2_pct`
- `test_primary/surf_p_mean_rel_l2_pct`
- `test_vol_p − val_vol_p` gap (to track whether DropPath shrinks the generalization gap)

At terminal, include a valid `SENPAI-RESULT` marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val_abupt>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test_abupt_at_best_val>}}
```

## Student Notes

The key question this experiment answers is whether **DropPath regularization reduces the val→test generalization gap** that has persisted across all prior regularization attempts.  Please pay particular attention to `test_vol_p − val_vol_p` at each gate — even if val metrics don't improve much, a reduction in this gap would be a meaningful result.  If you notice unusual training dynamics (e.g., loss spikes at early epochs from branch drops) please mention them.