### PR TITLE
[frieren] Pre-xattn vol self-attention before surf→vol xattn

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_pre_xattn_vol_self_attn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,26 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Pre-xattn vol self-attention (PR #988): lets vol hidden states
+        # coordinate among themselves BEFORE feeding into surf->vol xattn as
+        # queries. Pre-norm residual `vol_h + MHA(LN(vol_h))` with zero-init
+        # out_proj (identity-at-init). key_padding_mask=~volume_mask is
+        # semantically required for self-attention (padding keys would
+        # otherwise contaminate non-padding queries through softmax).
+        if use_pre_xattn_vol_self_attn:
+            self.pre_xattn_vol_ln = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.pre_xattn_vol_mha = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.weight)
+            nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.bias)
+        else:
+            self.pre_xattn_vol_ln = None
+            self.pre_xattn_vol_mha = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -528,6 +550,23 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.pre_xattn_vol_mha is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            vol_h_norm = self.pre_xattn_vol_ln(volume_hidden)
+            vol_h_out, _ = self.pre_xattn_vol_mha(
+                vol_h_norm,
+                vol_h_norm,
+                vol_h_norm,
+                key_padding_mask=~volume_mask,
+                need_weights=False,
+            )
+            vol_h_out = _apply_token_mask(vol_h_out, volume_mask)
+            volume_hidden = volume_hidden + vol_h_out
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_pre_xattn_vol_self_attn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_pre_xattn_vol_self_attn": (
+            "Enable pre-xattn vol self-attention (PR #988). After the "
+            "post-backbone LayerNorm split and BEFORE the surf->vol "
+            "cross-attention, a single nn.MultiheadAttention block lets "
+            "volume hidden states attend to themselves (Q=K=V=vol_hidden) "
+            "with key_padding_mask=~volume_mask, so vol queries become "
+            "context-aware before extracting surface information. Pre-norm "
+            "residual `vol_h + MHA(LN(vol_h))` with zero-initialised "
+            "out_proj weight and bias (identity-at-init). embed_dim follows "
+            "--model-hidden-dim and num_heads follows --model-heads. "
+            "Requires DDP find_unused_parameters=True."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_pre_xattn_vol_self_attn=config.use_pre_xattn_vol_self_attn,
     )
 
 
@@ -773,7 +787,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_pre_xattn_vol_self_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The current surf→vol cross-attention module (`--use-surf-to-vol-xattn`) uses vol hidden states as Q and surf hidden states as K/V. The vol queries going into that cross-attention are raw backbone outputs — they carry no mutual context between vol points. Adding a self-attention pass over the vol hidden states **before** the surf→vol cross-attention could allow vol points to coordinate with each other first (building awareness of local flow structure), making them better queries for extracting surface information.

Prior wins in this architecture: post-backbone surf→vol xattn (+1.05M params, −0.158pp val) shipped in PR #823. Post-xattn capacity additions (deeper xattn stacks) were 0-for-3, suggesting adding capacity **after** the xattn boundary isn't the bottleneck. This tests whether adding capacity **before** the xattn boundary — letting vol points aggregate among themselves — is the missing ingredient.

Reference: Self-attention before cross-attention is a pattern from Perceiver IO and many encoder-decoder architectures where the query side benefits from contextualizing itself before attending to a conditioning signal.

## Implementation

This is a `model.py`-only change (~15–20 lines). Do **not** modify `train.py`'s existing logic; add a new flag and gate the module on it.

### New flag
```
--use-pre-xattn-vol-self-attn    (bool, default False)
```

### In `model.py` `__init__`:
```python
self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
if use_pre_xattn_vol_self_attn:
    self.pre_xattn_vol_ln = nn.LayerNorm(hidden_dim)
    self.pre_xattn_vol_mha = nn.MultiheadAttention(
        embed_dim=hidden_dim,  # 512
        num_heads=num_heads,   # 4
        batch_first=True,
        dropout=0.0,
    )
    # Zero-init out_proj → identity-at-init (same pattern as surf→vol xattn)
    nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.weight)
    nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.bias)
```

### In `model.py` `forward`, immediately **before** the existing `surf_to_vol_xattn` block:
```python
if self.use_pre_xattn_vol_self_attn:
    vol_h_res = vol_h
    vol_h_norm = self.pre_xattn_vol_ln(vol_h)
    vol_h_out, _ = self.pre_xattn_vol_mha(
        vol_h_norm, vol_h_norm, vol_h_norm,
        key_padding_mask=~volume_mask,
    )
    vol_h = vol_h_res + vol_h_out  # residual add
```

**Parameter count:** ~2.1M added (512×512×3 QKV + 512×512 out_proj = 1,048,576 + 262,144 = ~1.31M projection weights + biases; plus LayerNorm). Expected total ~18.3M.

### DDP requirement
When `--use-pre-xattn-vol-self-attn` is enabled, set `find_unused_parameters=True` in the DDP wrapper (same as existing `--use-surf-to-vol-xattn` pattern). Use `--no-compile-model` (required on this cluster regardless).

### Smoke test
Before launching the full run, do a 10-step smoke test to confirm:
1. No crash, no NaN loss at step 0.
2. `pre_xattn_vol_mha.out_proj.weight` is all-zeros at step 0.
3. Gradient flows to `pre_xattn_vol_mha.in_proj_weight` at step 1.
4. `--no-use-surf-to-vol-xattn` run confirms the module degrades to baseline (zero contribution at init).

## Training run

**4-epoch fast screen**, same schedule as SOTA (PR #823):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-q \
  --use-surf-to-vol-xattn \
  --use-pre-xattn-vol-self-attn \
  --no-compile-model \
  --epochs 4 --lr-cosine-t-max 4 \
  --vol-points-schedule 0:16384:1:32768:2:49152:3:65536 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<30,21729:val_primary/abupt_axis_mean_rel_l2_pct<16,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0,38030:val_primary/abupt_axis_mean_rel_l2_pct<6.9" \
  --wandb-group frieren-pre-xattn-vol-self-attn
```

## EP gate protocol

Report val metrics at each EP gate. The primary metric is `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better).

| Gate | Step | Kill threshold |
|------|------|----------------|
| EP1 | 10864 | val_abupt > 30% → kill |
| EP2 | 21729 | val_abupt > 16% → kill |
| EP3 | 32594 | val_abupt > 8.0% **AND** vol_p > 5.0% → kill |
| EP4 | 38030 | Report SENPAI-RESULT |

At EP4 (or earlier if killed), post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline (target to beat)

**Single-model SOTA:** PR #823, W&B run `ghh0s4ne`

| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | 11.6704% |
| wall_shear | 7.3448% | 7.0429% |

**EP-by-EP reference (PR #823 `ghh0s4ne`):**
| EP | step | val_abupt |
|----|------|-----------|
| EP1 | 10864 | 28.63% |
| EP2 | 21729 | 8.15% |
| EP3 | 32594 | 7.12% |
| EP4 | 38030 | 6.81% |

Your EP4 target: **≤ 6.44%** (beat single-model SOTA). A result ≤6.40% would be a meaningful step.
