### PR TITLE
[fern] SDF-modulated vol PE octave scaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_pe_scaling: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_pe_scaling = use_sdf_pe_scaling
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,24 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # SDF-modulated volume PE: tiny gating MLP that reads the per-point SDF
+        # scalar (vol_x[:, :, 3]) and outputs K=space_dim per-axis scale factors
+        # applied to the pre-flatten STRING-sep stack before flattening.
+        # Zero-init weights + bias=0.5413 on last linear so Softplus(0.5413)≈1.0
+        # (identity at step 0, full gradient flow thereafter).
+        if use_sdf_pe_scaling:
+            num_rff_octaves = space_dim  # K = in_dim axes in StringSeparableEncoding
+            self.sdf_pe_mlp = nn.Sequential(
+                nn.Linear(1, 16),
+                nn.SiLU(),
+                nn.Linear(16, num_rff_octaves),
+                nn.Softplus(),
+            )
+            nn.init.zeros_(self.sdf_pe_mlp[2].weight)
+            nn.init.constant_(self.sdf_pe_mlp[2].bias, 0.5413)
+        else:
+            self.sdf_pe_mlp = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -506,16 +526,49 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    volume_x,
-                    rff=self.volume_rff,
-                    string_sep=self.volume_string_sep,
-                    project_features=self.project_volume_features,
-                    bias=self.volume_bias,
-                    placeholder=self.volume_placeholder,
+            if (
+                self.use_sdf_pe_scaling
+                and self.volume_string_sep is not None
+                and self.sdf_pe_mlp is not None
+            ):
+                # SDF-modulated volume PE: reshape STRING-sep output to
+                # [B, N, K, 2*num_features], apply per-axis scales, re-flatten.
+                pos = volume_x[:, :, : self.space_dim]
+                vol_pe_flat = self.volume_string_sep(pos)  # [B, N, K*2*num_features]
+                K = self.space_dim
+                d2 = vol_pe_flat.shape[-1] // K
+                vol_pe_stack = vol_pe_flat.view(*vol_pe_flat.shape[:-1], K, d2)  # [B, N, K, 2*num_features]
+                sdf_vals = volume_x[:, :, 3:4]  # [B, N, 1]
+                axis_scales = self.sdf_pe_mlp(sdf_vals)  # [B, N, K]
+                vol_pe_stack = vol_pe_stack * axis_scales.unsqueeze(-1)  # [B, N, K, 2*num_features]
+                vol_pe_modulated = vol_pe_stack.flatten(start_dim=-2)  # [B, N, K*2*num_features]
+
+                # Build volume hidden state manually (mirrors _encode_group logic)
+                vol_hidden = self.pos_embed(pos)
+                feature_parts: list[torch.Tensor] = []
+                if volume_x.shape[-1] > self.space_dim:
+                    feature_parts.append(volume_x[:, :, self.space_dim :])
+                feature_parts.append(vol_pe_modulated)
+                if self.project_volume_features is not None and feature_parts:
+                    features = (
+                        feature_parts[0]
+                        if len(feature_parts) == 1
+                        else torch.cat(feature_parts, dim=-1)
+                    )
+                    vol_hidden = vol_hidden + self.project_volume_features(features)
+                vol_token = self.volume_bias(vol_hidden) + self.volume_placeholder
+                tokens.append(vol_token)
+            else:
+                tokens.append(
+                    self._encode_group(
+                        volume_x,
+                        rff=self.volume_rff,
+                        string_sep=self.volume_string_sep,
+                        project_features=self.project_volume_features,
+                        bias=self.volume_bias,
+                        placeholder=self.volume_placeholder,
+                    )
                 )
-            )
             masks.append(volume_mask)
 
         attn_mask = torch.cat(masks, dim=1)

--- a/model.py
+++ b/model.py
@@ -123,7 +123,11 @@ class StringSeparableEncoding(nn.Module):
     def output_dim(self) -> int:
         return 2 * self.in_dim * self.num_features
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        per_feature_scales: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         # x: [..., in_dim]
         # freq: [in_dim, num_features]
         freq = torch.exp(self.log_freq.to(dtype=x.dtype))
@@ -132,6 +136,18 @@ class StringSeparableEncoding(nn.Module):
         proj = 2.0 * math.pi * x.unsqueeze(-1) * freq + phase
         # sin and cos each: [..., in_dim, num_features]
         enc = torch.cat([proj.sin(), proj.cos()], dim=-1)
+        if per_feature_scales is not None:
+            # per_feature_scales: [..., num_features] — one scalar per octave
+            # (feature index). Apply identically to sin and cos and broadcast
+            # over the in_dim axes. Reshape exposes the (sin, cos) and
+            # num_features dims explicitly so the multiplication is unambiguous.
+            enc_shape = enc.shape
+            enc = enc.view(*enc_shape[:-1], 2, self.num_features)
+            scales = per_feature_scales.to(dtype=enc.dtype)
+            # scales: [..., num_features] -> [..., 1, 1, num_features] for broadcast
+            # over (in_dim, 2) axes of enc.
+            enc = enc * scales[..., None, None, :]
+            enc = enc.reshape(enc_shape)
         # flatten last two dims: [..., 2 * in_dim * num_features]
         return enc.flatten(start_dim=-2)
 
@@ -446,13 +462,17 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
-        # SDF-modulated volume PE: tiny gating MLP that reads the per-point SDF
-        # scalar (vol_x[:, :, 3]) and outputs K=space_dim per-axis scale factors
-        # applied to the pre-flatten STRING-sep stack before flattening.
-        # Zero-init weights + bias=0.5413 on last linear so Softplus(0.5413)≈1.0
-        # (identity at step 0, full gradient flow thereafter).
-        if use_sdf_pe_scaling:
-            num_rff_octaves = space_dim  # K = in_dim axes in StringSeparableEncoding
+        # SDF-modulated volume PE (PR #989): a tiny gating MLP reads the
+        # per-point SDF scalar (vol_x[:, :, 3]) and outputs K = num_features
+        # per-octave amplitude scale factors that multiply each octave band of
+        # the STRING-separable volume PE (broadcast over the 3 axes and the
+        # sin/cos pair). Hypothesis: near-surface points (small |SDF|) benefit
+        # from boosting higher-frequency octaves; far-field points (large |SDF|)
+        # benefit from low-frequency / smooth amplitudes.
+        # Zero-init last Linear weight + bias = ln(e-1) ≈ 0.5413 so the Softplus
+        # output is exactly 1.0 at step 0 — identity transform, baseline preserved.
+        if use_sdf_pe_scaling and pos_encoding_mode == "string_separable":
+            num_rff_octaves = self.volume_string_sep.num_features
             self.sdf_pe_mlp = nn.Sequential(
                 nn.Linear(1, 16),
                 nn.SiLU(),
@@ -473,6 +493,7 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        string_sep_scales: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
@@ -480,7 +501,7 @@ class SurfaceTransolver(nn.Module):
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
         if string_sep is not None:
-            feature_parts.append(string_sep(pos))
+            feature_parts.append(string_sep(pos, per_feature_scales=string_sep_scales))
         elif rff is not None:
             feature_parts.append(rff(pos))
         if project_features is not None and feature_parts:
@@ -526,49 +547,27 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
+            string_sep_scales: torch.Tensor | None = None
             if (
                 self.use_sdf_pe_scaling
                 and self.volume_string_sep is not None
                 and self.sdf_pe_mlp is not None
             ):
-                # SDF-modulated volume PE: reshape STRING-sep output to
-                # [B, N, K, 2*num_features], apply per-axis scales, re-flatten.
-                pos = volume_x[:, :, : self.space_dim]
-                vol_pe_flat = self.volume_string_sep(pos)  # [B, N, K*2*num_features]
-                K = self.space_dim
-                d2 = vol_pe_flat.shape[-1] // K
-                vol_pe_stack = vol_pe_flat.view(*vol_pe_flat.shape[:-1], K, d2)  # [B, N, K, 2*num_features]
-                sdf_vals = volume_x[:, :, 3:4]  # [B, N, 1]
-                axis_scales = self.sdf_pe_mlp(sdf_vals)  # [B, N, K]
-                vol_pe_stack = vol_pe_stack * axis_scales.unsqueeze(-1)  # [B, N, K, 2*num_features]
-                vol_pe_modulated = vol_pe_stack.flatten(start_dim=-2)  # [B, N, K*2*num_features]
-
-                # Build volume hidden state manually (mirrors _encode_group logic)
-                vol_hidden = self.pos_embed(pos)
-                feature_parts: list[torch.Tensor] = []
-                if volume_x.shape[-1] > self.space_dim:
-                    feature_parts.append(volume_x[:, :, self.space_dim :])
-                feature_parts.append(vol_pe_modulated)
-                if self.project_volume_features is not None and feature_parts:
-                    features = (
-                        feature_parts[0]
-                        if len(feature_parts) == 1
-                        else torch.cat(feature_parts, dim=-1)
-                    )
-                    vol_hidden = vol_hidden + self.project_volume_features(features)
-                vol_token = self.volume_bias(vol_hidden) + self.volume_placeholder
-                tokens.append(vol_token)
-            else:
-                tokens.append(
-                    self._encode_group(
-                        volume_x,
-                        rff=self.volume_rff,
-                        string_sep=self.volume_string_sep,
-                        project_features=self.project_volume_features,
-                        bias=self.volume_bias,
-                        placeholder=self.volume_placeholder,
-                    )
+                # SDF channel is concatenated as the 4th channel of volume_x
+                # (loader emits [x, y, z, sdf]; see data/loader.py:290-293).
+                sdf_vals = volume_x[:, :, 3:4]
+                string_sep_scales = self.sdf_pe_mlp(sdf_vals)
+            tokens.append(
+                self._encode_group(
+                    volume_x,
+                    rff=self.volume_rff,
+                    string_sep=self.volume_string_sep,
+                    project_features=self.project_volume_features,
+                    bias=self.volume_bias,
+                    placeholder=self.volume_placeholder,
+                    string_sep_scales=string_sep_scales,
                 )
+            )
             masks.append(volume_mask)
 
         attn_mask = torch.cat(masks, dim=1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_pe_scaling: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -308,6 +309,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_pe_scaling=config.use_sdf_pe_scaling,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The volume positional encoding uses Random Fourier Features (RFF/STRING) with fixed octave frequency scales. Points near the car surface (small |SDF|) experience much steeper spatial gradients in flow quantities (boundary layer, pressure stagnation) than far-field points (large |SDF|). A single fixed-frequency RFF basis treats all vol points identically, but near-surface points need higher-frequency detail while far-field points need lower-frequency smoothness.

**Proposal:** Learn a tiny MLP (~112 params) that reads the point's signed-distance-function value (`vol_x[:, :, 3]`) and outputs per-octave frequency scale factors. This SDF-aware re-weighting of RFF octaves is learned end-to-end and adds negligible parameter overhead. Zero-init to identity (all octave weights → 1.0) so baseline behavior is preserved at step 0.

This is fundamentally different from SDF-stratified sampling (tried and NEGATIVE, PR #981) — we are not changing which points are sampled, but how their positions are encoded given prior knowledge that SDF magnitude correlates with the characteristic length scale of local flow features.

## Implementation

`model.py`-only change (~20–25 lines). New flag:
```
--use-sdf-pe-scaling    (bool, default False)
```

### Architecture

The volume RFF positional encoding produces a stacked multi-octave embedding. With `string_separable` mode, the PE for each vol point is a concatenation of K octave bands. Add a tiny gating MLP:

```python
# In model.py __init__ (when use_sdf_pe_scaling=True):
self.sdf_pe_mlp = nn.Sequential(
    nn.Linear(1, 16),
    nn.SiLU(),
    nn.Linear(16, num_rff_octaves),  # K octaves — check actual value in code
    nn.Softplus(),                    # ensures positive scales
)
# Init final linear bias so Softplus output ≈ 1.0 at step 0:
# Softplus(x) ≈ 1.0 when x ≈ log(exp(1)-1) ≈ 0.5413
nn.init.zeros_(self.sdf_pe_mlp[-2].weight)  # last Linear before Softplus
nn.init.constant_(self.sdf_pe_mlp[-2].bias, 0.5413)
```

### In `model.py` `forward`, after computing the RFF vol PE but before concatenating with other vol features:
```python
if self.use_sdf_pe_scaling:
    sdf_vals = vol_x[:, :, 3:4]           # [B, N_vol, 1] — SDF channel
    octave_scales = self.sdf_pe_mlp(sdf_vals)  # [B, N_vol, K]
    # vol_pe_stack: [B, N_vol, K, 2*d_rff_per_octave] (pre-flatten RFF stack)
    vol_pe_stack = vol_pe_stack * octave_scales.unsqueeze(-1)
    vol_pe = vol_pe_stack.flatten(-2)       # [B, N_vol, K * 2*d_rff_per_octave]
```

**Important:** You need to check how `string_separable` RFF is structured in `model.py` to find where to insert the scaling. The SDF channel index in `vol_x` must also be verified — confirm it matches the `volume_sdf.npy` channel.

**Parameter count:** ~112 (1×16 + 16×K + biases). K is the number of RFF octaves in the STRING mode — check the existing code. Total model params will increase by ~112.

### Smoke test
Before the full run, verify:
1. `sdf_pe_mlp[-2].bias` starts at 0.5413; `Softplus(0.5413) ≈ 1.0`.
2. At step 0, `vol_pe` is bit-identical (within float32 precision) to baseline (all scales = 1.0 → identity transform).
3. Gradients flow through `sdf_pe_mlp` at step 1.

## Training run

**4-epoch fast screen**, same schedule as SOTA (PR #823):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-q \
  --use-surf-to-vol-xattn \
  --use-sdf-pe-scaling \
  --no-compile-model \
  --epochs 4 --lr-cosine-t-max 4 \
  --vol-points-schedule 0:16384:1:32768:2:49152:3:65536 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<30,21729:val_primary/abupt_axis_mean_rel_l2_pct<16,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0,38030:val_primary/abupt_axis_mean_rel_l2_pct<6.9" \
  --wandb-group fern-sdf-modulated-vol-pe
```

## EP gate protocol

Report val metrics at each EP gate. Primary metric: `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better).

| Gate | Step | Kill threshold |
|------|------|----------------|
| EP1 | 10864 | val_abupt > 30% → kill |
| EP2 | 21729 | val_abupt > 16% → kill |
| EP3 | 32594 | val_abupt > 8.0% AND vol_p > 5.0% → kill |
| EP4 | 38030 | Report SENPAI-RESULT |

At EP4 (or if killed), post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline (target to beat)

**Single-model SOTA:** PR #823, W&B run `ghh0s4ne`

| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | 11.6704% |
| wall_shear | 7.3448% | 7.0429% |

**EP-by-EP reference (PR #823 `ghh0s4ne`):**
| EP | step | val_abupt |
|----|------|-----------|
| EP1 | 10864 | 28.63% |
| EP2 | 21729 | 8.15% |
| EP3 | 32594 | 7.12% |
| EP4 | 38030 | 6.81% |

Target: EP4 val_abupt **≤ 6.44%** (beat single-model SOTA). A result ≤6.40% would be a clear win.
