### PR TITLE
Per-head learnable xattn temp scale (4 params)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        xattn_per_head_temp_scale: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.xattn_per_head_temp_scale = xattn_per_head_temp_scale
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -440,9 +442,21 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
             nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
+            # Per-head learnable temperature scaling (PR #991): each head gets
+            # its own scalar multiplying Q before xattn. Init=0.5 matches the
+            # constant-scale baseline from PR #984. With nn.MultiheadAttention's
+            # internal 1/sqrt(head_dim), multiplying Q by scale<1 sharpens the
+            # attention distribution per head.
+            if xattn_per_head_temp_scale:
+                self.xattn_head_temp_scale = nn.Parameter(torch.ones(n_head) * 0.5)
+            else:
+                self.xattn_head_temp_scale = None
+            self._xattn_n_head = n_head
+            self._xattn_head_dim = n_hidden // n_head
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+            self.xattn_head_temp_scale = None
 
     def _encode_group(
         self,
@@ -536,8 +550,16 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            if self.xattn_head_temp_scale is not None:
+                B, T, H = volume_hidden.shape
+                q = volume_hidden.reshape(B, T, self._xattn_n_head, self._xattn_head_dim)
+                q = q.permute(0, 2, 1, 3)
+                q = q * self.xattn_head_temp_scale[None, :, None, None]
+                volume_hidden_scaled = q.permute(0, 2, 1, 3).reshape(B, T, H)
+            else:
+                volume_hidden_scaled = volume_hidden
             xattn_out, _ = self.surf_to_vol_xattn(
-                query=volume_hidden,
+                query=volume_hidden_scaled,
                 key=surface_hidden,
                 value=surface_hidden,
                 need_weights=False,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    xattn_per_head_temp_scale: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "xattn_per_head_temp_scale": (
+            "Enable per-head learnable temperature scaling in surf->vol "
+            "xattn (PR #991). Adds n_head learnable scalars (init=0.5) that "
+            "multiply Q per-head before the MHA call. Sharpens attention "
+            "and lets each head discover its own optimal temperature. "
+            "Requires --use-surf-to-vol-xattn."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +284,30 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_xattn_head_temp_scale_metrics(model: nn.Module) -> dict[str, float]:
+    """Log per-head xattn temperature scales (PR #991).
+
+    Tracks per-head values, summary stats, and collapse detection
+    (range = max - min): a small range signals heads collapsed to a
+    single constant, which would indicate the global approximation
+    was sufficient and the extra params are not buying head-specific
+    sharpness.
+    """
+    metrics: dict[str, float] = {}
+    scale = getattr(model, "xattn_head_temp_scale", None)
+    if scale is None:
+        return metrics
+    scale = scale.detach().float()
+    for h in range(scale.shape[0]):
+        metrics[f"xattn_head_temp_scale/h{h}"] = float(scale[h].item())
+    metrics["xattn_head_temp_scale/mean"] = float(scale.mean().item())
+    metrics["xattn_head_temp_scale/std"] = float(scale.std().item())
+    metrics["xattn_head_temp_scale/min"] = float(scale.min().item())
+    metrics["xattn_head_temp_scale/max"] = float(scale.max().item())
+    metrics["xattn_head_temp_scale/range"] = float((scale.max() - scale.min()).item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +340,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        xattn_per_head_temp_scale=config.xattn_per_head_temp_scale,
     )
 
 
@@ -1262,6 +1295,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_xattn_head_temp_scale_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

PR #984 confirmed that a constant global xattn temperature scale=0.5 (0 learnable params) sharpens the surf→vol cross-attention and produces a real but insufficient improvement (EP4 val_abupt=7.49% vs SOTA 6.29%). The advisor's close note on PR #984 identified **per-head learnable temperature scaling** as the most promising follow-up: rather than a single scalar approximating what may be a per-head phenomenon, each of the 4 attention heads gets its own independent learned scale.

**Hypothesis**: With 4 learnable per-head temperature scalars (init=0.5, matching the PR #984 constant), each head can discover its optimal sharpness independently. If the global approximation was the limiting factor in PR #984, this should improve over the 7.49% EP4 result and potentially approach or beat single-model SOTA (6.29%).

Cost: 4 new parameters (from 0 in PR #984, from 33 in PR #974).

## Implementation Instructions

**Student: implement per-head learnable xattn temperature scaling in `model.py` and `train.py`.**

### 1. Add CLI flag to `train.py`

In the `Config` dataclass, add:
```python
xattn_per_head_temp_scale: bool = False
```

In `parse_args`, add an argparse entry (alongside the existing `--use-surf-to-vol-xattn` entry):
```python
parser.add_argument("--xattn-per-head-temp-scale", action="store_true", default=False,
                    help="Use 4 learnable per-head temperature scalars in surf→vol xattn (init=0.5).")
```

In `build_model`, pass the new field:
```python
return SurfaceTransolver(
    ...
    use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
    xattn_per_head_temp_scale=config.xattn_per_head_temp_scale,
)
```

### 2. Modify `model.py` — `SurfaceTransolver.__init__`

Add `xattn_per_head_temp_scale: bool = False` parameter to `__init__`. Inside the `if use_surf_to_vol_xattn:` block, after the zero-init lines:

```python
if use_surf_to_vol_xattn:
    self.surf_to_vol_xattn = nn.MultiheadAttention(
        embed_dim=n_hidden,
        num_heads=n_head,
        batch_first=True,
        dropout=dropout,
    )
    self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
    nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
    # Per-head temperature scaling
    if xattn_per_head_temp_scale:
        self.xattn_head_temp_scale = nn.Parameter(torch.ones(n_head) * 0.5)
    else:
        self.xattn_head_temp_scale = None
    self._xattn_n_head = n_head
    self._xattn_head_dim = n_hidden // n_head
else:
    self.surf_to_vol_xattn = None
    self.surf_to_vol_xattn_norm = None
    self.xattn_head_temp_scale = None
```

### 3. Modify `model.py` — `SurfaceTransolver.forward`

Replace the existing xattn query pass with a per-head scaled version:

```python
# BEFORE (current code):
xattn_out, _ = self.surf_to_vol_xattn(
    query=volume_hidden,
    key=surface_hidden,
    value=surface_hidden,
    need_weights=False,
)

# AFTER (new code):
if self.xattn_head_temp_scale is not None:
    # volume_hidden: (B, T, H) -> (B, n_head, T, head_dim)
    B, T, H = volume_hidden.shape
    q = volume_hidden.reshape(B, T, self._xattn_n_head, self._xattn_head_dim)
    q = q.permute(0, 2, 1, 3)  # (B, n_head, T, head_dim)
    q = q * self.xattn_head_temp_scale[None, :, None, None]
    volume_hidden_scaled = q.permute(0, 2, 1, 3).reshape(B, T, H)
else:
    volume_hidden_scaled = volume_hidden

xattn_out, _ = self.surf_to_vol_xattn(
    query=volume_hidden_scaled,
    key=surface_hidden,
    value=surface_hidden,
    need_weights=False,
)
```

### 4. Run command (4-epoch fast screen)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --xattn-per-head-temp-scale \
  --wandb-group thorfinn-per-head-xattn-temp-scale \
  --wandb-name thorfinn/per-head-xattn-temp-scale-4ep
```

### Notes
- Do NOT use `--compile-model`.
- The 4-epoch schedule uses a compressed vol-points curriculum; EP3 is the dual gate (val_abupt ≤8.0% AND vol_p ≤5.0%).
- Log `xattn_head_temp_scale` values to W&B at each epoch (e.g. `wandb.log({"xattn_head_temp_scale_h0": ..., "xattn_head_temp_scale_h1": ..., ...})`).
- Report the learned per-head scale values at EP1 to check for collapse (all heads converging to the same value would indicate global approximation is sufficient).

## Baseline

| Metric | Val | Source |
|--------|-----|--------|
| abupt_axis_mean_rel_l2_pct | **6.2869%** | PR #958 Arm A, run `29nohj67` (single-model SOTA) |
| surface_pressure | 4.1766% | PR #958 Arm A |
| volume_pressure | 3.9150% | PR #958 Arm A |
| wall_shear | 7.0476% | PR #958 Arm A |

**Gate: val_abupt < 6.4407%** (PR #823, W&B run `ghh0s4ne`)

**Prior xattn temp scale results (context):**
- PR #974: SDF-conditioned MLP (33 params), collapsed to ~0.515 constant → NEGATIVE
- PR #984: Constant scale=0.5 (0 params), EP4=7.4900% → NEGATIVE (global approximation insufficient)

Ensemble gate: **val_abupt < 6.0289%** (PR #880, W&B: `zst3y2mp`)

## EP Gate Protocol

- **EP1 ≤ 30%** — if above, kill immediately
- **EP2 ≤ 16%** — if above, kill immediately
- **EP3 dual gate**: val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0% (both required)
- **EP4 ≤ 6.9%** — hard kill threshold for full run
