### PR TITLE
[edward] Global surface embedding for vol OOD conditioning

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_global_surf_embed: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_global_surf_embed = use_global_surf_embed
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -443,6 +445,13 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        if use_global_surf_embed:
+            self.global_surf_proj = nn.Linear(n_hidden, n_hidden)
+            nn.init.zeros_(self.global_surf_proj.weight)
+            nn.init.zeros_(self.global_surf_proj.bias)
+        else:
+            self.global_surf_proj = None
 
     def _encode_group(
         self,
@@ -544,6 +553,18 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.global_surf_proj is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            global_surf = surface_hidden.mean(dim=1, keepdim=True)
+            global_surf_proj = self.global_surf_proj(global_surf)
+            volume_hidden = volume_hidden + global_surf_proj
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_global_surf_embed: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_global_surf_embed": (
+            "Enable global surface embedding for volume conditioning "
+            "(PR #992). After the surf->vol cross-attention block, "
+            "mean-pool surface_hidden into a single [B,1,D] descriptor, "
+            "project through a zero-init nn.Linear(D, D), and broadcast-add "
+            "to all volume tokens. The zero-init projection is identity at "
+            "init (preserves baseline at epoch 0). Complements the local "
+            "surf->vol cross-attention with an explicit whole-car global "
+            "geometry summary."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_global_surf_embed=config.use_global_surf_embed,
     )
 
 
@@ -773,7 +785,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_global_surf_embed:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

Mean-pooling `surface_hidden` into a single per-case global geometry descriptor and injecting it into `volume_hidden` will improve OOD volume-pressure generalization. The current architecture has two paths from surface to volume:

1. The Transolver backbone operates on concatenated surface+volume tokens (implicit sharing).
2. The `surf_to_vol_xattn` sublayer (PR #823) adds explicit **local** surface→volume attention: each vol token attends to all surface tokens.

But neither path creates an explicit **global** geometry summary — a single vector that captures the whole-car shape and conditioning the entire vol decoder uniformly. This is analogous to the class token in ViT, or the global graph readout in GNNs. The failure of PR #980 (raw bbox scalars) showed that the signal needs to come from *learned* geometry representations, not hand-crafted features.

After `surf_to_vol_xattn`, `surface_hidden` already encodes learned, geometry-aware features. A mean-pool compresses this into a single `[B, 1, D]` global descriptor. A small linear projection (zero-init out) then adds this global context to all volume tokens. Since it is zero-initialized, the model is identical to baseline at step 0 — the signal only activates if it helps.

This is orthogonal to:
- PR #988 frieren: pre-xattn vol self-attention (vol-to-vol refinement)
- PR #989 fern: SDF-modulated vol PE scaling (coordinate-dependent PE modulation)

**Key prior art:**
- "DeepMind AlphaFold2" global conditioning via single-vector embeddings in pair representation
- "Set Transformer" (Lee et al., 2019) — global inducing-point pooling over sets
- "GNO/FNO" global conditioning for PDE surrogates

## Instructions

**This is a code-implementation experiment. You will need to modify `model.py` and `train.py`.**

### 1. Add the flag to `train.py`

In the `Config` dataclass (around line 104-105 after `use_surf_to_vol_xattn`), add:

```python
use_global_surf_embed: bool = False
```

In the `build_model` function (around line 309-310), pass it to `SurfaceTransolver`:

```python
use_global_surf_embed=config.use_global_surf_embed,
```

### 2. Modify `SurfaceTransolver.__init__` in `model.py`

Add the new parameter to the signature (after `use_surf_to_vol_xattn: bool = False`):

```python
use_global_surf_embed: bool = False,
```

Store it and create the projection module (after the `surf_to_vol_xattn` block, around line 444):

```python
self.use_global_surf_embed = use_global_surf_embed
if use_global_surf_embed:
    self.global_surf_proj = nn.Linear(n_hidden, n_hidden)
    nn.init.zeros_(self.global_surf_proj.weight)
    nn.init.zeros_(self.global_surf_proj.bias)
else:
    self.global_surf_proj = None
```

### 3. Modify `SurfaceTransolver.forward` in `model.py`

After the `surf_to_vol_xattn` block (around line 547, before `surface_preds` is computed), insert:

```python
# Global surface embed: mean-pool surface_hidden → project → broadcast to all vol tokens
if (
    self.global_surf_proj is not None
    and surface_x is not None
    and volume_x is not None
    and surface_tokens > 0
    and volume_tokens > 0
):
    # surface_hidden: [B, surface_tokens, D] → [B, 1, D]
    # Use mean-pool (masked mean if surface_mask available, but mean over token dim is fine here)
    global_surf = surface_hidden.mean(dim=1, keepdim=True)  # [B, 1, D]
    global_surf_proj = self.global_surf_proj(global_surf)   # [B, 1, D]
    # Broadcast and add to all volume tokens (residual connection, zero-init → identity at init)
    volume_hidden = volume_hidden + global_surf_proj        # [B, vol_tokens, D]
    volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
```

### 4. Smoke test (before submitting training run)

```bash
cd target/
python -c "
import torch
from model import SurfaceTransolver
m = SurfaceTransolver(n_layers=2, n_hidden=64, n_head=2, slice_num=8,
    use_surf_to_vol_xattn=True, use_global_surf_embed=True)
out = m(
    surface_x=torch.randn(2, 50, 3),
    surface_mask=torch.ones(2, 50),
    volume_x=torch.randn(2, 100, 3),
    volume_mask=torch.ones(2, 100),
)
assert out['volume_preds'].shape == (2, 100, 1), out['volume_preds'].shape
print('smoke test passed')
"
```

### 5. Training command

**Fast 4-epoch screen (standard EP-gate protocol):**

```bash
cd target/
python train.py \
  --pos-encoding-mode string_separable \
  --use-surf-to-vol-xattn \
  --use-global-surf-embed \
  --use-ema \
  --epochs 4 \
  --lr-cosine-t-max 4 \
  --vol-points-schedule '0:16384:1:32768:2:49152:3:65536' \
  --kill-thresholds '10864:val_primary/abupt_axis_mean_rel_l2_pct<30,21729:val_primary/abupt_axis_mean_rel_l2_pct<16,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0,38030:val_primary/abupt_axis_mean_rel_l2_pct<6.9' \
  --wandb-group edward-global-surf-embed
```

**Note:** Always run with `--use-surf-to-vol-xattn` — the global surf embed is designed to complement the local xattn, not replace it. The global descriptor provides a whole-car shape signal that the per-token local xattn cannot.

## EP Gate Protocol

| EP | Step | Kill criterion | Pass threshold |
|---|---|---|---|
| EP1 | 10,864 | auto-kill if >30% | ≤ 30% |
| EP2 | 21,729 | auto-kill if >16% | ≤ 16% |
| EP3 | 32,594 | dual gate: val_abupt ≤8.0% **AND** vol_p ≤5.0% | both must pass |
| EP4 | 38,030 | terminal: val_abupt ≤6.9% | ≤ 6.9% (beat baseline) |

Report val_abupt, vol_p, surf_p, and wall_shear at each EP gate. The vol_p trajectory is especially important here since this hypothesis targets OOD volume pressure.

## Baseline

Current best single-model result (PR #958 nezuko, run `29nohj67`):
- `val_primary/abupt_axis_mean_rel_l2_pct`: **6.2869%**
- `test_primary/volume_pressure_rel_l2_pct`: **10.6052%** (val vol_p ≈ 4–5%)
- `test_primary/abupt_axis_mean_rel_l2_pct`: **7.3693%** (ensemble)

**You must beat val_abupt < 6.2869% to be merge-eligible.**

The `val/test vol_p gap (~3×)` is the central unsolved problem: val_vol_p ≈ 4–5% but test_vol_p ≈ 10–11%. Report both at every EP gate.

## What to report

At each EP gate, post:

```
EP<N> gate (step <step>, ~<minutes> min cumulative):
- val_primary/abupt_axis_mean_rel_l2_pct: X.XXXX%
- val/volume_pressure_rel_l2_pct: X.XXXX%
- val/surface_pressure_rel_l2_pct: X.XXXX%
- val/wall_shear_rel_l2_pct: X.XXXX%
W&B run: <run-id>
```

Terminal result must include a valid `SENPAI-RESULT` marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
