### PR TITLE
Bbox norm + corrected STRING PE sigmas (÷5 rescale for [-1,+1] coords)

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -328,6 +328,7 @@ class DrivAerMLCaseStore:
         self.root = _resolve_case_root(self.manifest, override_root=root)
         self.normalizers_path = self.root / "normalizers.json"
         self._point_count_cache: dict[str, dict[str, int]] = {}
+        self._surface_bbox_cache: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def case_ids(self, split: str) -> list[str]:
         return list(self.manifest["surface_splits"][split])
@@ -348,6 +349,17 @@ class DrivAerMLCaseStore:
             self._point_count_cache[case_id] = cached
         return dict(cached)
 
+    def case_surface_bbox(self, case_id: str) -> tuple[torch.Tensor, torch.Tensor]:
+        cached = self._surface_bbox_cache.get(case_id)
+        if cached is None:
+            xyz_path = _resolve_artifact_path(_case_dir(self.root, case_id) / "surface_xyz.npy")
+            arr = np.load(xyz_path, mmap_mode="r")
+            arr_min = np.asarray(arr.min(axis=0), dtype=np.float32)
+            arr_max = np.asarray(arr.max(axis=0), dtype=np.float32)
+            cached = (torch.from_numpy(arr_min), torch.from_numpy(arr_max))
+            self._surface_bbox_cache[case_id] = cached
+        return cached[0].clone(), cached[1].clone()
+
     def load_normalizers(self) -> dict:
         with self.normalizers_path.open() as f:
             return json.load(f)
@@ -367,6 +379,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_bbox_norm: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +389,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_bbox_norm = use_bbox_norm
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -445,6 +459,24 @@ class DrivAerMLSurfaceDataset(Dataset):
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
         )
+        if self.use_bbox_norm:
+            bbox_min, bbox_max = self.store.case_surface_bbox(view.case_id)
+            bbox_center = (bbox_min + bbox_max) / 2.0
+            bbox_half_extent = ((bbox_max - bbox_min) / 2.0).clamp(min=1e-6)
+            surface_x = case.surface_x.clone()
+            if surface_x.shape[0] > 0:
+                surface_x[:, :3] = (surface_x[:, :3] - bbox_center) / bbox_half_extent
+            volume_x = case.volume_x.clone()
+            if volume_x.shape[0] > 0:
+                volume_x[:, :3] = (volume_x[:, :3] - bbox_center) / bbox_half_extent
+            case = DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=surface_x,
+                surface_y=case.surface_y,
+                volume_x=volume_x,
+                volume_y=case.volume_y,
+                metadata=case.metadata,
+            )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
         metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
@@ -544,6 +576,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_bbox_norm: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +601,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_bbox_norm=use_bbox_norm,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +610,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_bbox_norm=use_bbox_norm,
         )
     }
     test_splits = {
@@ -585,6 +620,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_bbox_norm=use_bbox_norm,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/train.py
+++ b/train.py
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_vol_coord_bbox_norm: bool = False
     debug: bool = False
 
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -281,6 +281,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_bbox_norm=getattr(config, "use_vol_coord_bbox_norm", False),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

Bbox normalization of volume coordinates to [-1,+1] failed in PR #978 because the STRING positional encoding sigmas (`0.25,0.5,1.0,2.0,4.0`) were tuned for raw ~5m coordinate ranges. When coords are normalised to [-1,+1] the effective scale shrinks by ~5×, creating a frequency mismatch that degrades representation quality. This PR tests whether **correcting the PE sigmas by ÷5** (`0.05,0.1,0.2,0.4,0.8`) restores and potentially improves performance by giving the model a canonical coordinate frame with properly matched positional encoding.

The bbox normalization loader fix (handling empty surface views in OOD cases) from PR #978 is already in the codebase on branch `dl24-tanjiro/vol-coord-canonical-frame` and will be cherry-picked or incorporated.

## Implementation

This experiment uses the full SOTA stack (PR #823) with two targeted changes:
1. `--use-vol-coord-bbox-norm` — normalise volume coordinates to [-1,+1] per-case surface bbox
2. `--rff-init-sigmas "0.05,0.1,0.2,0.4,0.8"` — ÷5 rescaling of STRING PE sigmas to match normalised coordinate range

**All other hyperparameters are identical to the SOTA reproduce command (PR #823).**

## Baseline to beat

| Metric | Single-model SOTA (PR #823) | Ensemble SOTA (PR #880) |
|---|---|---|
| val_abupt (primary) | **6.4407%** | **6.0289%** |
| test_abupt | 7.6992% | 7.3693% |
| test surface_pressure | 3.8451% | — |
| test volume_pressure | 11.6704% | — |
| test wall_shear | 7.0429% | — |

**EP gate thresholds:**
- EP1: val_abupt ≤ 30%
- EP2: val_abupt ≤ 16%
- EP3: val_abupt ≤ 8.0% AND val vol_p ≤ 5.0%
- EP4: val_abupt ≤ 6.9% (target: beat 6.4407%)
- EP5: val_abupt ≤ 7.5%

## Training command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.05,0.1,0.2,0.4,0.8" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-coord-bbox-norm \
  --wandb-group alphonse-bbox-norm-corrected-pe
```

## Implementation notes

- The `--use-vol-coord-bbox-norm` flag normalises each case's volume XYZ coordinates to [-1,+1] using the surface bounding box. The loader fix for empty surface views (OOD cases where `view_index >= surface_view_count`) is required and was implemented in PR #978 (`DrivAerMLCaseStore.case_surface_bbox(case_id)` using mmap'd `surface_xyz.npy`). You MUST incorporate this fix.
- The bbox normalization implementation is on branch `dl24-tanjiro/vol-coord-canonical-frame` — cherry-pick or reference that work.
- The key change vs SOTA: `--rff-init-sigmas "0.05,0.1,0.2,0.4,0.8"` (exactly ÷5 from default `"0.25,0.5,1.0,2.0,4.0"`). This ensures the STRING PE frequencies match the [-1,+1] coordinate range.
- Use `--find-unused-parameters` (DDP) if bbox norm introduces any conditionally-used modules.

## EP gate protocol

Report val_abupt at every epoch. Kill and report NEGATIVE if:
- EP1 (epoch 1): val_abupt > 30%
- EP2 (epoch 3): val_abupt > 16%
- EP3 (epoch 6): val_abupt > 8.0% OR vol_p > 5.0%
- EP5 (epoch 8): val_abupt > 7.5%

Target is EP4 (epoch 13): val_abupt < 6.4407% (beat SOTA PR #823).

## Expected result

With properly matched PE sigmas the canonical frame should either match or slightly improve on SOTA. The primary question: does coordinate normalisation + matched PE help or is it neutral? If val_abupt < 6.4407% at EP4, merge. If it hits EP5 gate (7.5%) but not EP4, close.
