### PR TITLE
Decouple LR warmup completion from vol_points schedule boundary

### DIFF
--- a/train.py
+++ b/train.py
@@ -115,6 +115,7 @@ class Config:
     ema_start_step: int = 50
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
+    lr_warmup_steps: int = 0
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
     grad_clip_norm: float = 1.0
@@ -160,6 +161,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "lr_warmup_steps": (
+            "Complete LR warmup after this many optimizer steps. When >0, "
+            "the scheduler is stepped once per optimizer step (not per "
+            "epoch) and both warmup and cosine annealing run in step units. "
+            "Decouples LR warmup completion from epoch-boundary curriculum "
+            "events such as `--vol-points-schedule` jumps. 0 (default) "
+            "falls back to `--lr-warmup-epochs` (epoch-granular scheduling)."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -781,7 +790,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
-        scheduler = build_lr_scheduler(optimizer, config, max_epochs)
+        initial_steps_per_epoch = max(1, len(train_loader))
+        scheduler = build_lr_scheduler(
+            optimizer, config, max_epochs, steps_per_epoch=initial_steps_per_epoch
+        )
+        scheduler_step_per_batch = bool(getattr(scheduler, "_step_per_batch", False))
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
         balancer: GradNormBalancer | None = None
@@ -1112,6 +1125,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         optimizer.zero_grad(set_to_none=True)
                     else:
                         optimizer.step()
+                        if scheduler_step_per_batch:
+                            scheduler.step()
                         if ema is not None:
                             ema.update(base_model)
                         weight_metrics = (
@@ -1164,7 +1179,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         )
                     break
 
-            scheduler.step()
+            if not scheduler_step_per_batch:
+                scheduler.step()
             epoch_train_loss = train_loss_sum / max(n_batches, 1)
             dt = time.time() - t0
             peak_gb = torch.cuda.max_memory_allocated(device) / 1e9 if torch.cuda.is_available() else 0.0

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1284,7 +1284,32 @@ def build_lr_scheduler(
     optimizer: torch.optim.Optimizer,
     config,
     max_epochs: int,
+    steps_per_epoch: int = 1,
 ) -> torch.optim.lr_scheduler.LRScheduler:
+    lr_warmup_steps = int(getattr(config, "lr_warmup_steps", 0))
+    if lr_warmup_steps > 0:
+        # Step-granular warmup: complete after exactly N optimizer steps and
+        # run cosine annealing in step units for the remainder of training.
+        total_steps = max(1, max_epochs * max(1, steps_per_epoch))
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=0.05,
+            end_factor=1.0,
+            total_iters=max(1, lr_warmup_steps),
+        )
+        cosine_steps = max(1, total_steps - lr_warmup_steps)
+        cosine_scheduler_steps = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer,
+            T_max=cosine_steps,
+            eta_min=config.lr_min,
+        )
+        combined = torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup_scheduler, cosine_scheduler_steps],
+            milestones=[lr_warmup_steps],
+        )
+        combined._step_per_batch = True
+        return combined
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer,


### PR DESCRIPTION
## Hypothesis

PR #983 (`tanjiro/curriculum-warmup-transition`) showed that `--vol-points-warmup-steps` successfully prevented the catastrophic divergence seen in PR #973, but still landed at val_abupt=7.4176% — **1.13pp behind the single-model SOTA** (PR #823, val_abupt=6.4407%).

The root cause identified in the PR #983 post-mortem: with `--lr-warmup-epochs 1` and the fast vol_points schedule `"0:16384:1:32768:2:49152:3:65536"`, the LR warmup completion (5e-6 → 9e-5, an **18× jump**) and the first vol_points jump (16K→32K) occur at the **exact same epoch boundary** (EP1→EP2). This creates a dual shock — both the optimiser step size and the curriculum complexity double simultaneously.

Evidence: The EP2→EP3 transition in PR #983 (identical vol_points structure: 32K→49K) is completely smooth, because LR is already fully warm and in cosine decay by that point. Only the EP1→EP2 boundary produces instability.

The scheduler in `trainer_runtime.py` uses `SequentialLR` with `milestones=[config.lr_warmup_epochs]` stepped once per **epoch**. The vol_points schedule also advances at epoch boundaries. They are structurally coupled: any fast schedule with a jump at epoch 1 will collide with LR warmup completion.

**Proposed fix**: Add a `--lr-warmup-steps N` flag that completes LR warmup after N **optimizer steps** (not epochs), decoupling warmup completion from the epoch-1 boundary. With ~12 steps/epoch, setting `--lr-warmup-steps 8` completes LR warmup mid-way through epoch 1 — before the EP1→EP2 vol_points jump fires.

This PR tests two arms:
- **Arm A**: Implement step-based LR warmup (`--lr-warmup-steps 8`) with the fast 4-epoch schedule `"0:16384:1:32768:2:49152:3:65536"`. LR is fully warm before the first vol_points jump, leaving only the curriculum shock.
- **Arm B**: Use the **slow vol_points schedule** `"0:16384:3:32768:6:49152:9:65536"` with 4 epochs — the same config as SOTA PR #823 but run for only 4 epochs (early stopping context, does it recover?). Control: is the vol_points schedule speed itself the primary driver, independent of LR timing?

## Instructions

### Step 0: Understand the steps-per-epoch count

With 400 training surface samples, 8 GPUs, batch_size=4, and `drop_last=True`, each rank sees 50 samples → 12 steps per epoch (floor(50/4)=12). Total training steps over N epochs = N × 12. Verify this in your run logs before choosing `--lr-warmup-steps`.

### Arm A: Step-based LR warmup with fast schedule

**Implement `--lr-warmup-steps` in `train.py` and `trainer_runtime.py`:**

In `train.py`, add an argument:
```python
parser.add_argument("--lr-warmup-steps", type=int, default=0,
    help="Complete LR warmup after this many optimizer steps (0=use --lr-warmup-epochs instead)")
```

In `trainer_runtime.py`, modify `build_lr_scheduler` to accept `steps_per_epoch` and support step-granular warmup:
```python
def build_lr_scheduler(optimizer, config, max_epochs, steps_per_epoch=1):
    t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer, T_max=max(1, t_max), eta_min=config.lr_min,
    )
    if config.lr_warmup_steps > 0:
        # Step-granular warmup: complete after exactly N optimizer steps
        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer, start_factor=0.05, end_factor=1.0,
            total_iters=max(1, config.lr_warmup_steps),
        )
        # CosineAnnealingLR T_max should be in steps for consistency
        cosine_scheduler_steps = torch.optim.lr_scheduler.CosineAnnealingLR(
            optimizer, T_max=max(1, max_epochs * steps_per_epoch - config.lr_warmup_steps),
            eta_min=config.lr_min,
        )
        combined = torch.optim.lr_scheduler.SequentialLR(
            optimizer,
            schedulers=[warmup_scheduler, cosine_scheduler_steps],
            milestones=[config.lr_warmup_steps],
        )
        # Mark as step-granular so the training loop calls scheduler.step() per optimizer step
        combined._step_per_batch = True
        return combined
    elif config.lr_warmup_epochs > 0:
        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer, start_factor=0.05, end_factor=1.0,
            total_iters=max(1, config.lr_warmup_epochs),
        )
        return torch.optim.lr_scheduler.SequentialLR(
            optimizer,
            schedulers=[warmup_scheduler, cosine_scheduler],
            milestones=[config.lr_warmup_epochs],
        )
    return cosine_scheduler
```

In the training loop (`train.py`), after each optimizer step, check `if hasattr(scheduler, '_step_per_batch') and scheduler._step_per_batch: scheduler.step()`. At end of epoch, only call `scheduler.step()` if NOT `_step_per_batch`.

**Run Arm A:**
```bash
cd "target/" && python train.py \
  --lr 9e-5 \
  --lr-warmup-steps 8 \
  --lr-cosine-t-max 4 \
  --lr-min 1e-6 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --epochs 4 \
  --batch-size 4 \
  --wandb-group lr-warmup-decouple \
  --wandb-name arm-a-step-warmup-8
```

Kill gate: If val_abupt > 9.0% at EP2, stop and report.

### Arm B: Slow vol_points schedule (control — decoupled by design)

No code changes needed — this uses the existing `--lr-warmup-epochs` flag. The vol_points first jump is at EP3, LR warmup completes at EP1, giving a 2-epoch gap.

```bash
cd "target/" && python train.py \
  --lr 9e-5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 4 \
  --lr-min 1e-6 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --epochs 4 \
  --batch-size 4 \
  --wandb-group lr-warmup-decouple \
  --wandb-name arm-b-slow-schedule-4ep
```

Note: With 4 epochs and the slow schedule `3:32768:6:49152:9:65536`, the vol_points jumps at EP3, EP6, EP9 never fire within 4 epochs — you effectively train the entire 4 epochs at vol_points=16384. This is **intentional** as a control: can the model recover quickly on a smooth curriculum even with fewer vol_points?

Kill gate: If val_abupt > 9.0% at EP2, stop and report.

### Reporting

After both arms complete (or after kill gate), post a comment with:
- Per-epoch val_abupt for each arm
- W&B run IDs
- Which arm performed better and why you think so
- Suggested follow-ups

Terminal result marker (only when both arms are done):
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-id>","<arm-b-id>"],"primary_metric":{"name":"val_abupt","value":<best_val_abupt>},"test_metric":{"name":"test_abupt","value":<test_abupt_for_best_arm>}}
```

## Baseline

**Single-model SOTA**: PR #823 (nezuko), W&B run `ghh0s4ne`
- val_abupt = **6.4407%** ← gate to beat for merge
- test_abupt = 7.6992%

**Immediate context baseline**: PR #983 (tanjiro, vol-points-warmup-steps, closed)
- val_abupt = 7.4176%, test_abupt = 8.7352%
- Used fast schedule `"0:16384:1:32768:2:49152:3:65536"` with dual LR+vol shock at EP1→EP2

**SOTA reproduce command** (PR #823):
```bash
cd "target/" && python train.py \
  --lr 9e-5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 13 \
  --lr-min 1e-6 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --epochs 13 \
  --batch-size 4
```

**Why the SOTA run works**: The slow schedule delays the first vol_points jump to EP3. LR warmup completes at EP1. The two shocks are separated by 2 full epochs → no interference.
