### PR TITLE
[frieren] Pre-xattn vol LayerNorm ablation (ln-only before surf-vol xattn)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_pre_xattn_vol_ln_only: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_pre_xattn_vol_ln_only = use_pre_xattn_vol_ln_only
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -444,6 +446,16 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Pre-xattn vol LN-only ablation (PR #995): single LayerNorm over vol
+        # hidden states immediately before the surf->vol cross-attention.
+        # Isolates whether the EP1 signal from PR #988 came from the
+        # self-attention itself or from normalising vol_h before xattn.
+        # ~1024 params, zero quadratic cost.
+        if use_pre_xattn_vol_ln_only:
+            self.pre_xattn_vol_ln = nn.LayerNorm(n_hidden, eps=1e-6)
+        else:
+            self.pre_xattn_vol_ln = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -528,6 +540,14 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.pre_xattn_vol_ln is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            volume_hidden = self.pre_xattn_vol_ln(volume_hidden)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_pre_xattn_vol_ln_only: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_pre_xattn_vol_ln_only": (
+            "Add a single LayerNorm over vol hidden states immediately "
+            "before the surf->vol cross-attention. Ablation of PR #988 "
+            "pre-xattn vol self-attention hypothesis. ~1024 params "
+            "(gain + bias at hidden_dim), zero quadratic cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +315,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_pre_xattn_vol_ln_only=config.use_pre_xattn_vol_ln_only,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #988 tested **pre-xattn vol self-attention** (`--use-pre-xattn-vol-self-attn`): a full `nn.MultiheadAttention` pass over vol hidden states before the surf→vol cross-attention. The result was INCONCLUSIVE (timeout at EP3-partial, val_abupt=10.59% vs baseline 7.12%). The O(N²) self-attention cost exploded as vol_pts ramped, and the zero-init `out_proj` (identity-at-init) needed more LR budget than the aggressive 4-epoch cosine schedule allowed.

However, PR #988 showed a **real signal at EP1**: val_abupt=26.64% vs baseline 28.63% (−1.99pp). The key question: did that EP1 gain come from the self-attention itself, or simply from **normalising vol_h before the cross-attention**?

This PR isolates the normalization component. A single `nn.LayerNorm(hidden_dim)` applied to `volume_hidden` immediately before the `surf_to_vol_xattn` block costs ~1024 parameters (gain + bias, negligible), zero quadratic cost (O(N) not O(N²)), and has no schedule sensitivity (LN has no zero-init convergence delay).

If LN-only matches or beats the EP1 signal from PR #988, the self-attention was not the key ingredient and the LN-only version is architecturally much cheaper. If LN-only is negative (no EP1 improvement), the self-attention is necessary and we should run a 13-epoch full-budget version of PR #988.

## Implementation

This is a `model.py` and `train.py` change (~15 lines total). Add a new flag gating a single LayerNorm.

### New flag
```
--use-pre-xattn-vol-ln-only    (bool, default False)
```

### In `model.py` `ModelConfig` / config dataclass, add:
```python
use_pre_xattn_vol_ln_only: bool = False
```

### In `SurfaceTransolver.__init__`, after the `surf_to_vol_xattn` block (around line 445), add:
```python
# Pre-xattn vol LN only: LayerNorm over vol hidden states before surf→vol xattn.
# Zero additional quadratic cost. Ablation of PR #988 hypothesis.
if use_pre_xattn_vol_ln_only:
    self.pre_xattn_vol_ln = nn.LayerNorm(n_hidden, eps=1e-6)
else:
    self.pre_xattn_vol_ln = None
```

### In `SurfaceTransolver.forward`, immediately **before** the existing `surf_to_vol_xattn` block (around line 532):
```python
# Apply pre-xattn vol LN if enabled (ablation of PR #988 self-attn hypothesis)
if self.pre_xattn_vol_ln is not None and volume_x is not None and volume_tokens > 0:
    volume_hidden = self.pre_xattn_vol_ln(volume_hidden)
    volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
```

### Wire up in `train.py` argument parsing (in the same block as `--use-surf-to-vol-xattn`):
```python
parser.add_argument(
    "--use-pre-xattn-vol-ln-only",
    action=argparse.BooleanOptionalAction,
    default=False,
    help="Add a single LayerNorm over vol hidden states immediately before "
         "the surf->vol cross-attention. Ablation of PR #988 pre-xattn vol "
         "self-attention hypothesis. ~1024 params, zero quadratic cost.",
)
```

And wire into `ModelConfig`:
```python
"use_pre_xattn_vol_ln_only": (
    args.use_pre_xattn_vol_ln_only,
    "use_pre_xattn_vol_ln_only",
),
```

**Parameter count:** ~1024 added (LayerNorm gain + bias at hidden_dim=512). Expected total ~16.99M (essentially unchanged from baseline).

**No DDP `find_unused_parameters` change needed** - LN params are always used when the flag is set.

### Smoke test
Before launching the full run, do a 10-step smoke test to confirm:
1. No crash, no NaN loss at step 0.
2. `pre_xattn_vol_ln.weight` is all-ones and `pre_xattn_vol_ln.bias` is all-zeros at step 0 (standard LN init).
3. Gradient flows to `pre_xattn_vol_ln.weight` at step 1.
4. `--no-use-pre-xattn-vol-ln-only` degrades to baseline behavior.

## Training run

**4-epoch fast screen**, same schedule as SOTA (PR #823 `ghh0s4ne`):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-q \
  --use-surf-to-vol-xattn \
  --use-pre-xattn-vol-ln-only \
  --no-compile-model \
  --epochs 4 --lr-cosine-t-max 4 \
  --vol-points-schedule 0:16384:1:32768:2:49152:3:65536 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<30,21729:val_primary/abupt_axis_mean_rel_l2_pct<16,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.0" \
  --wandb-group frieren-pre-xattn-vol-ln-only
```

## EP gate protocol

Report val metrics at each EP gate. Primary metric: `val_primary/abupt_axis_mean_rel_l2_pct` (lower is better).

| Gate | Step | Kill threshold |
|------|------|----------------|
| EP1 | 10864 | val_abupt > 30% kill |
| EP2 | 21729 | val_abupt > 16% kill |
| EP3 | 32594 | val_abupt > 8.0% AND vol_p > 5.0% kill |
| EP4 | 38030 | Report SENPAI-RESULT |

**Key comparison at EP1 (step 10864):**
- Baseline `ghh0s4ne`: 28.63%
- PR #988 with full self-attn: **26.64% (−1.99pp)**
- This run target: beat 28.63% to confirm LN-only carries the signal

At EP4 (or earlier if killed), post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline (target to beat)

**Single-model SOTA:** PR #823, W&B run `ghh0s4ne`

| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | **6.4407%** | 7.6992% |
| surface_pressure | 4.1836% | 3.8451% |
| volume_pressure | 3.8557% | 11.6704% |
| wall_shear | 7.3448% | 7.0429% |

**EP-by-EP reference (PR #823 `ghh0s4ne`):**
| EP | step | val_abupt |
|----|------|-----------|
| EP1 | 10864 | 28.63% |
| EP2 | 21729 | 8.15% |
| EP3 | 32594 | 7.12% |
| EP4 | 38030 | 6.81% |

Your EP4 target: **6.44%** (beat single-model SOTA).

## Follow-up plan

- **If LN-only is POSITIVE (beats baseline EP1 and/or EP4):** Merge. Then test LN-only + full surf-vol xattn at 13-ep schedule to see compound effect.
- **If LN-only is NEGATIVE (EP1 tracks with baseline 28-29%):** The self-attention was doing real work. Assign 13-epoch full-budget run with `--use-pre-xattn-vol-self-attn` + slow vol ramp `0:16384:3:32768:6:49152:9:65536`.