### PR TITLE
SDF vol asinh encoding sweep (scale=10.0 vs 20.0)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,8 +343,18 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        sdf_vol_encoding: str = "none",
+        sdf_vol_scale: float = 10.0,
     ):
         super().__init__()
+        if sdf_vol_encoding not in {"none", "asinh"}:
+            raise ValueError(
+                f"sdf_vol_encoding must be 'none' or 'asinh'; got {sdf_vol_encoding!r}"
+            )
+        if sdf_vol_encoding == "asinh" and sdf_vol_scale <= 0.0:
+            raise ValueError(
+                f"sdf_vol_scale must be positive for asinh encoding; got {sdf_vol_scale}"
+            )
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
@@ -356,6 +366,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.sdf_vol_encoding = sdf_vol_encoding
+        self.sdf_vol_scale = sdf_vol_scale
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -469,12 +481,22 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        is_volume: bool = False,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
-            feature_parts.append(x[:, :, self.space_dim :])
+            extras = x[:, :, self.space_dim :]
+            if is_volume and self.sdf_vol_encoding == "asinh":
+                # SDF channel is the first extra column (volume_x = xyz + sdf).
+                # Apply asinh(sdf / scale): linear near zero (preserves near-surface
+                # fine structure) and logarithmic in the tails (compresses far-field
+                # outliers that arrive after the EP3 vol_pts curriculum step).
+                sdf = extras[:, :, 0:1]
+                sdf = torch.asinh(sdf / self.sdf_vol_scale)
+                extras = torch.cat([sdf, extras[:, :, 1:]], dim=-1)
+            feature_parts.append(extras)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -530,6 +552,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_volume_features,
                     bias=self.volume_bias,
                     placeholder=self.volume_placeholder,
+                    is_volume=True,
                 )
             )
             masks.append(volume_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    sdf_vol_encoding: str = "none"
+    sdf_vol_scale: float = 10.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "sdf_vol_encoding": (
+            "Nonlinear encoding applied to the SDF feature in volume_x "
+            "(4th channel, index 3) before the linear feature projection. "
+            "'none' passes the raw signed-distance value through unchanged "
+            "(baseline behavior). 'asinh' applies asinh(sdf / sdf-vol-scale) "
+            "which is linear near zero (near-surface fine structure "
+            "preserved) and logarithmic in the tails (far-field outliers "
+            "compressed). Motivation: smooth the EP3 curriculum boundary "
+            "where vol_pts grows from 16k to 32k+ and far-field SDF values "
+            "become OOD relative to EP1-EP2."
+        ),
+        "sdf_vol_scale": (
+            "Scale parameter for the SDF asinh encoding (only used when "
+            "--sdf-vol-encoding=asinh). Controls the linear-to-logarithmic "
+            "transition point: SDF values with |sdf| << scale are nearly "
+            "unchanged, |sdf| >> scale are log-compressed. Default 10.0 "
+            "(geometric scale of the car bounding box)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -240,7 +260,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    valid_sdf_encodings = {"none", "asinh"}
+    if config.sdf_vol_encoding not in valid_sdf_encodings:
+        raise ValueError(
+            f"--sdf-vol-encoding must be one of {sorted(valid_sdf_encodings)}; "
+            f"got {config.sdf_vol_encoding!r}"
+        )
+    if config.sdf_vol_encoding == "asinh" and config.sdf_vol_scale <= 0.0:
+        raise ValueError(
+            f"--sdf-vol-scale must be positive for asinh encoding; got {config.sdf_vol_scale}"
+        )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -308,6 +339,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        sdf_vol_encoding=config.sdf_vol_encoding,
+        sdf_vol_scale=config.sdf_vol_scale,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The SDF feature in `volume_x` (4th channel, currently raw/unbounded) creates a distribution shift at the EP3 curriculum boundary where `vol_pts` jumps from 16K → 32K. Newly-sampled far-field points have large positive SDF values (distance to the car surface) that are out-of-distribution relative to the near-surface points seen in EP1–EP2. Without normalization, these extreme values saturate the linear projection layer in `_encode_group` and force a sudden weight adaptation mid-training.

Applying **`asinh(sdf / scale)`** compresses large SDF values logarithmically while preserving sign and near-surface fine structure (near-surface points where |sdf| ≈ 0 are largely unaffected). The `scale` parameter controls how aggressively far-field values are compressed:
- `scale=10.0` — moderate compression; SDF values > ~30 are log-compressed
- `scale=20.0` — gentler compression; SDF values > ~60 are log-compressed

The expected gain: smoother EP3 curriculum shock → better volume_pressure accuracy and improved val_abupt overall.

**Reference:** `asinh` normalization is standard in mesh-based PDE solvers for distance-field features (e.g., boundary-layer-aware meshing in FEniCS workflows). It is the natural norm-preserving transform for signed distance functions because it is linear near 0 and logarithmic in the tails.

---

## Implementation Instructions

**This is a new feature — you need to add CLI flags and modify the model.**

### Step 1: Add CLI flags to `train.py`

In the `argparse` section (near other `--vol-*` arguments), add:

```python
parser.add_argument(
    "--sdf-vol-encoding",
    type=str,
    default="none",
    choices=["none", "asinh"],
    help="Nonlinear encoding for the SDF feature in volume_x (4th channel). "
         "'asinh' applies asinh(sdf / sdf-vol-scale) before linear projection.",
)
parser.add_argument(
    "--sdf-vol-scale",
    type=float,
    default=10.0,
    help="Scale parameter for SDF asinh encoding. Larger = gentler compression.",
)
```

### Step 2: Pass args to the model

In `train.py`, pass both args to wherever `Model` is constructed (e.g. `Model(..., sdf_vol_encoding=args.sdf_vol_encoding, sdf_vol_scale=args.sdf_vol_scale)`).

### Step 3: Apply encoding in `model.py`

In `model.py`, inside `_encode_group` (or the `VolumeEncoder` / equivalent), the volume input tensor `x` has shape `[B, N, C]` where `C = VOLUME_X_DIM = 4` (xyz + sdf). The SDF channel is `x[:, :, 3:4]` (index 3).

Add this block **before** SDF is appended to `feature_parts`:

```python
if self.sdf_vol_encoding == "asinh" and group == "volume":
    # Apply asinh normalization to SDF channel (index 3)
    sdf = x[:, :, self.space_dim:self.space_dim + 1]  # [B, N, 1]
    sdf = torch.asinh(sdf / self.sdf_vol_scale)
    x = torch.cat([x[:, :, :self.space_dim], sdf, x[:, :, self.space_dim + 1:]], dim=-1)
```

Store `sdf_vol_encoding` and `sdf_vol_scale` as attributes in `__init__`.

**Important:** Apply this encoding to volume inputs only (gate on `group == "volume"` or equivalent check). Surface inputs do not have an SDF channel.

### Step 4: Run both arms

**Arm A — scale=10.0** (moderate compression):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --sdf-vol-encoding asinh --sdf-vol-scale 10.0 \
  --wandb-group alphonse-sdf-vol-scale-sweep
```

**Arm B — scale=20.0** (gentler compression):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --sdf-vol-encoding asinh --sdf-vol-scale 20.0 \
  --wandb-group alphonse-sdf-vol-scale-sweep
```

Run both arms sequentially. Report val_abupt at each epoch checkpoint, and flag whether EP3 (the 16K→32K transition epoch) shows a smoother loss curve compared to the baseline.

---

## Baseline

Current single-model SOTA: **PR #958** (nezuko, dedicated vol_p aux decoder head, Arm A)

| Metric | Val | Test |
|---|---:|---:|
| `abupt` | **6.2868%** | 7.7445% |
| `surface_pressure` | 4.1766% | 3.9100% |
| `volume_pressure` | 3.9152% | 12.0063% |
| `wall_shear` | 7.0476% | 6.9848% |
| `tau_x` | 6.1726% | 6.2092% |
| `tau_y` | 7.6648% | 7.5689% |
| `tau_z` | 9.5053% | 9.0280% |

**Baseline W&B run:** `29nohj67` (group `nezuko-vol-aux-decoder-head`)
**Gate:** val_abupt < **6.2868%**

Your arm results should beat this gate. If Arm A beats it, proceed to Arm B before reporting final results (they can run back-to-back). If neither arm beats baseline, report the full epoch curve so we can see whether EP3 shock was softened or not — that's diagnostic information regardless of final metric.

---

## EP1 Gate

After Arm A EP1 completes, report val_abupt. If it is **≥ 7.5%** (more than ~0.3pp above baseline EP1 ~7.2%), kill it and switch to Arm B directly. This is likely not a crisis at EP1 — just checking for catastrophic divergence.
