### PR TITLE
Per-head learnable xattn temperature (4 scalars, init=1.0)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,85 @@ class Transformer(nn.Module):
         return x
 
 
+class SurfToVolCrossAttnPerHeadTemp(nn.Module):
+    """Surface->volume cross-attention with per-head learnable Q temperature.
+
+    Manual MHA implementation (separate Q/K/V projections + SDPA) so that the
+    per-head temperature multiplies Q *after* W_q projection — i.e. on the
+    (B, H, N_q, head_dim) tensor where each head is independent. Scaling Q
+    before W_q (the naive route) would fold the scalar into the projection and
+    couple the heads.
+
+    The temperature is stored as ``log_temp = nn.Parameter(zeros(num_heads))``
+    so the exponentiated value starts at 1.0 (neutral, identical to baseline
+    attention) and is symmetric around 1 under gradient updates. Larger temp
+    sharpens the per-head distribution; smaller temp smooths it.
+
+    Out-projection weight and bias are zero-initialised so the whole module is
+    identity at epoch 0 (matches the existing nn.MultiheadAttention setup in
+    SurfaceTransolver).
+    """
+
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.0):
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})"
+            )
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.dropout = dropout
+
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+
+        # Xavier uniform on the Q/K/V weights to match nn.MultiheadAttention's
+        # default initialisation, zero on the biases.
+        for proj in (self.q_proj, self.k_proj, self.v_proj):
+            nn.init.xavier_uniform_(proj.weight)
+            nn.init.zeros_(proj.bias)
+
+        # Zero-init out_proj for identity at init.
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+        # Per-head log-temperature; exp() -> 1.0 at init -> neutral.
+        self.log_temp = nn.Parameter(torch.zeros(num_heads))
+
+    def forward(
+        self,
+        *,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        need_weights: bool = False,
+    ) -> tuple[torch.Tensor, None]:
+        # query: (B, N_q, D); key/value: (B, N_k, D); batch_first.
+        B, N_q, D = query.shape
+        N_k = key.shape[1]
+        H = self.num_heads
+        dh = self.head_dim
+
+        q = self.q_proj(query).view(B, N_q, H, dh).transpose(1, 2)  # (B, H, N_q, dh)
+        k = self.k_proj(key).view(B, N_k, H, dh).transpose(1, 2)
+        v = self.v_proj(value).view(B, N_k, H, dh).transpose(1, 2)
+
+        # Per-head temperature on Q (post-projection, truly per-head).
+        # exp() keeps temp > 0 with a symmetric loss landscape around 1.
+        temp = self.log_temp.exp().to(q.dtype).view(1, H, 1, 1)
+        q = q * temp
+
+        dropout_p = self.dropout if self.training else 0.0
+        out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
+        out = out.transpose(1, 2).contiguous().view(B, N_q, D)
+        out = self.out_proj(out)
+        # Match nn.MultiheadAttention signature so the calling forward stays unchanged.
+        return out, None
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +422,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_xattn_per_head_temp: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +436,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_xattn_per_head_temp = use_xattn_per_head_temp
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -447,15 +528,29 @@ class SurfaceTransolver(nn.Module):
         # AND bias so the sublayer is identity at init (preserves baseline
         # behavior at epoch 0). See PR #823 hypothesis.
         if use_surf_to_vol_xattn:
-            self.surf_to_vol_xattn = nn.MultiheadAttention(
-                embed_dim=n_hidden,
-                num_heads=n_head,
-                batch_first=True,
-                dropout=dropout,
-            )
+            if use_xattn_per_head_temp:
+                # PR #1002: replace nn.MultiheadAttention with a manual
+                # implementation that applies a learnable per-head temperature
+                # to Q *after* W_q projection. Applying the scale before
+                # MultiheadAttention (the advisor's literal instructions) folds
+                # into W_q's linear projection and so does not actually realise
+                # per-head behaviour — different heads can only see different
+                # scales when scaled in the per-head reshape (B, H, T, dh).
+                self.surf_to_vol_xattn = SurfToVolCrossAttnPerHeadTemp(
+                    embed_dim=n_hidden,
+                    num_heads=n_head,
+                    dropout=dropout,
+                )
+            else:
+                self.surf_to_vol_xattn = nn.MultiheadAttention(
+                    embed_dim=n_hidden,
+                    num_heads=n_head,
+                    batch_first=True,
+                    dropout=dropout,
+                )
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
+                nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
             self.surf_to_vol_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.weight)
-            nn.init.zeros_(self.surf_to_vol_xattn.out_proj.bias)
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_xattn_per_head_temp: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_xattn_per_head_temp": (
+            "Enable per-head learnable Q temperature in the surf->vol "
+            "cross-attention (PR #1002). Replaces nn.MultiheadAttention with "
+            "a manual implementation that applies a per-head scalar to Q "
+            "*after* the W_q projection. Parameterised as log_temp = "
+            "nn.Parameter(zeros(num_heads)) so the exponentiated temperature "
+            "starts at 1.0 (neutral). Requires --use-surf-to-vol-xattn."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,7 +303,39 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_xattn_per_head_temp_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-head xattn temperature diagnostics (PR #1002).
+
+    Returns ``xattn_head_temp/head_{i}`` for each head's temperature
+    (= exp(log_temp)), plus the corresponding log_temp values and summary
+    statistics (mean/std/min/max) so that we can see whether the heads diverge
+    or collapse to a common value.
+    """
+    metrics: dict[str, float] = {}
+    xattn = getattr(model, "surf_to_vol_xattn", None)
+    if xattn is None:
+        return metrics
+    log_temp_param = getattr(xattn, "log_temp", None)
+    if log_temp_param is None:
+        return metrics
+    log_temp = log_temp_param.detach().float().cpu()
+    temp = log_temp.exp()
+    for h in range(log_temp.shape[0]):
+        metrics[f"xattn_head_temp/head_{h}"] = float(temp[h].item())
+        metrics[f"xattn_head_log_temp/head_{h}"] = float(log_temp[h].item())
+    metrics["xattn_head_temp/mean"] = float(temp.mean().item())
+    metrics["xattn_head_temp/std"] = float(temp.std().item()) if temp.numel() > 1 else 0.0
+    metrics["xattn_head_temp/min"] = float(temp.min().item())
+    metrics["xattn_head_temp/max"] = float(temp.max().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
+    if config.use_xattn_per_head_temp and not config.use_surf_to_vol_xattn:
+        raise ValueError(
+            "--use-xattn-per-head-temp requires --use-surf-to-vol-xattn; the "
+            "per-head temperature lives inside the surf->vol cross-attention."
+        )
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -308,6 +349,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_xattn_per_head_temp=config.use_xattn_per_head_temp,
     )
 
 
@@ -1262,6 +1304,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_xattn_per_head_temp_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Per-head learnable xattn temperature — replace the global constant Q-scaling from PR #984 with 4 independent `nn.Parameter` scalars (one per attention head), each initialized to 1.0. The motivation is that PR #984 showed a global Q×0.5 sharpening signal exists but failed to beat SOTA (val_abupt=7.490% vs 6.2868%). Allowing each head to learn its own temperature lets the model discover that some heads benefit from sharper attention distributions while others do not. PR #974 (SDF-conditioned MLP temperature) collapsed all heads to ~0.515 and was also NEGATIVE — the key difference here is that parameters are per-head and learned jointly with the rest of the model, initialized neutrally at 1.0.

## Implementation Instructions

All changes go in `target/train.py`. The surf-to-vol cross-attention module is `SurfToVolCrossAttn` (or equivalent — check for the class that wraps `nn.MultiheadAttention` with Q=vol_hidden, K=V=surf_hidden).

### Step 1 — Add `nn.Parameter` to the xattn module

In `__init__`, after `self.attn = nn.MultiheadAttention(embed_dim, num_heads, ...)`:

```python
self.use_per_head_temp = False  # toggled by flag
self.xattn_head_temp = nn.Parameter(torch.ones(num_heads))  # shape: (num_heads,)
```

### Step 2 — Apply per-head temperature in `forward`

Inside the forward pass, before calling `self.attn(query=..., key=..., value=...)`:

```python
if self.use_per_head_temp:
    # q shape entering MultiheadAttention is (B, N_vol, D) with batch_first=True
    B, N_vol, D = q.shape
    head_dim = D // self.num_heads
    # reshape to (B, N_vol, num_heads, head_dim)
    q = q.view(B, N_vol, self.num_heads, head_dim)
    # apply per-head scalar: temperature > 1.0 sharpens attention, < 1.0 smooths it
    q = q * self.xattn_head_temp[None, None, :, None]  # broadcast
    # reshape back to (B, N_vol, D)
    q = q.view(B, N_vol, D)
```

If the module uses `batch_first=False` (shape `(N_vol, B, D)`), adjust the reshape accordingly:
```python
N_vol, B, D = q.shape
q = q.view(N_vol, B, self.num_heads, head_dim)
q = q * self.xattn_head_temp[None, None, :, None]
q = q.view(N_vol, B, D)
```

### Step 3 — Add CLI flag

```python
parser.add_argument('--use-xattn-per-head-temp', action='store_true', default=False,
                    help='Enable per-head learnable temperature scaling in surf-to-vol cross-attention')
parser.add_argument('--no-use-xattn-per-head-temp', dest='use_xattn_per_head_temp', action='store_false')
```

Wire it: when `args.use_xattn_per_head_temp` is True and `args.use_surf_to_vol_xattn` is True, set `xattn_module.use_per_head_temp = True`.

### Step 4 — Log temperature values

Add a W&B log at the end of each epoch (inside the training loop):

```python
if args.use_xattn_per_head_temp and model has xattn:
    temps = xattn_module.xattn_head_temp.detach().cpu()
    for h, t in enumerate(temps):
        wandb.log({f"xattn_head_temp/head_{h}": t.item()}, step=global_step)
```

This lets us see whether individual heads converge to different temperatures or collapse to a common value.

## Run Command

Full SOTA stack + per-head temperature:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-xattn-per-head-temp \
  --wandb_group per-head-xattn-temp
```

## EP Gates

- **EP1** (end of epoch 1): val_abupt ≤ 30% — if above, kill immediately
- **EP2** (end of epoch 2): val_abupt ≤ 16% — if above, kill
- **EP3** (end of epoch 3): val_abupt ≤ 8.0% AND vol_p ≤ 5.0% — if either condition fails, kill

## Current Baseline (target to beat)

| Metric | Single-model SOTA (PR #958) |
|--------|---------------------------|
| val_abupt | **6.2868%** |
| test_abupt | 7.7445% |
| val surface_pressure | 4.1766% |
| val volume_pressure | 3.9152% |
| val wall_shear | 7.0476% |

W&B run: `29nohj67` (nezuko, vol aux decoder Arm A)

## Temperature History

| PR | Approach | Outcome |
|----|---------|---------|
| #974 | SDF-conditioned MLP temp (all heads) | Collapsed to scale_mean≈0.515 → NEGATIVE |
| #984 | Global constant Q×0.5 | val_abupt=7.490% → NEGATIVE |
| **#991** | **Per-head learned temp (init=1.0)** | **← this PR** |

## What to Report

In your terminal `SENPAI-RESULT` comment, include:
- The learned temperature values for each head at the end of training (`xattn_head_temp/head_0` through `head_3`)
- Whether heads converged to similar or diverse temperatures
- val_abupt and per-channel breakdown

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
