### PR TITLE
Case-level hard-case oversampling for OOD vol_p generalization

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import csv
 import gc
 import math
 import os
@@ -22,13 +23,14 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Sampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
@@ -138,6 +140,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_hard_case_oversampling: bool = False
+    hard_case_alpha: float = 1.0
+    hard_case_sampler_seed: int = 42
     debug: bool = False
 
 
@@ -228,6 +233,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_hard_case_oversampling": (
+            "Enable case-level WeightedRandomSampler that oversamples "
+            "training cases geometrically similar to the OOD test cluster "
+            "(run_133, run_226, run_203, run_158). Per-case weight = "
+            "exp(-hard_case_alpha * d_i) where d_i is the z-score distance "
+            "in (CD, Vehicle_Height) space to the test-cluster centroid. "
+            "View weights inherit the case weight so cases with more "
+            "point-views keep their proportional contribution. DDP draws "
+            "a globally-consistent index list per epoch with a shared "
+            "seed and shards by rank to avoid gradient mismatch."
+        ),
+        "hard_case_alpha": (
+            "Sharpness of the exp(-alpha * d) reweighting. alpha=1.0 gives "
+            "~2-3x max/mean weight ratio (moderate); alpha=2.0 gives "
+            "~4-8x (aggressive). At 400 train cases, alpha>=2 reduces ESS "
+            "to ~30-40 effective cases; the run logs ESS and max/mean to "
+            "let you spot variance collapse."
+        ),
+        "hard_case_sampler_seed": (
+            "Base seed for the DistributedWeightedRandomSampler shared "
+            "across DDP ranks. Combined with the epoch index to produce "
+            "reproducible globally-consistent draws."
         ),
     }
     for field in fields(Config):
@@ -659,6 +687,234 @@ def vol_points_for_epoch(
     return current
 
 
+HARD_TEST_CASE_IDS: tuple[str, ...] = ("run_133", "run_226", "run_203", "run_158")
+
+_FORCE_CSV_CANDIDATES: tuple[str, ...] = (
+    "/mnt/new-pvc/Datasets/2_Drivearml/force_mom_all.csv",
+    "/mnt/pvc/Datasets/2_Drivearml/force_mom_all.csv",
+)
+_GEO_CSV_CANDIDATES: tuple[str, ...] = (
+    "/mnt/new-pvc/Datasets/2_Drivearml/geo_parameters_all.csv",
+    "/mnt/pvc/Datasets/2_Drivearml/geo_parameters_all.csv",
+)
+
+
+def _resolve_first_existing(paths: tuple[str, ...]) -> str:
+    for p in paths:
+        if Path(p).exists():
+            return p
+    raise FileNotFoundError(f"None of these geometry CSVs exist: {paths}")
+
+
+def _case_to_run_number(case_id: str) -> int:
+    return int(case_id.removeprefix("run_"))
+
+
+def _load_cd_table() -> dict[int, float]:
+    path = _resolve_first_existing(_FORCE_CSV_CANDIDATES)
+    out: dict[int, float] = {}
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            out[int(row["run"])] = float(row["cd"])
+    return out
+
+
+def _load_vehicle_height_table() -> dict[int, float]:
+    path = _resolve_first_existing(_GEO_CSV_CANDIDATES)
+    out: dict[int, float] = {}
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            clean = {k.strip(): v.strip() for k, v in row.items()}
+            out[int(clean["Run"])] = float(clean["Vehicle_Height"])
+    return out
+
+
+def build_hard_case_weights(
+    case_ids: list[str],
+    alpha: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Per-case oversampling weights toward the hard OOD test cluster.
+
+    Computes a z-score Euclidean distance from each training case to the
+    test-cluster centroid in (CD, Vehicle_Height) space (these two
+    covariates cover both the drag-coefficient and the dominant frontal-area
+    proxy in the DrivAerML design-of-experiments). The weight per case is
+    ``exp(-alpha * d_i)`` so cases similar to the test cluster are
+    oversampled.
+
+    Returns (weights, info) where ``info`` is a JSON-serialisable dict of
+    diagnostics (test-cluster means, train standardiser stats, ESS,
+    max/mean ratio) suitable for W&B logging.
+    """
+
+    cd_table = _load_cd_table()
+    height_table = _load_vehicle_height_table()
+
+    train_runs = [_case_to_run_number(c) for c in case_ids]
+    train_cd = np.array([cd_table[r] for r in train_runs], dtype=np.float64)
+    train_height = np.array([height_table[r] for r in train_runs], dtype=np.float64)
+
+    cd_std = float(train_cd.std()) + 1e-9
+    height_std = float(train_height.std()) + 1e-9
+
+    hard_runs = [_case_to_run_number(c) for c in HARD_TEST_CASE_IDS]
+    hard_cd = np.array([cd_table[r] for r in hard_runs], dtype=np.float64)
+    hard_height = np.array([height_table[r] for r in hard_runs], dtype=np.float64)
+    hard_cd_mean = float(hard_cd.mean())
+    hard_height_mean = float(hard_height.mean())
+
+    z_cd = np.abs(train_cd - hard_cd_mean) / cd_std
+    z_height = np.abs(train_height - hard_height_mean) / height_std
+    d = z_cd + z_height
+
+    weights = np.exp(-alpha * d)
+    weight_sum = float(weights.sum())
+    # ESS via Kish's formula: (sum w)^2 / sum w^2
+    ess = float(weight_sum * weight_sum / float((weights * weights).sum()))
+    mean_w = float(weights.mean())
+    max_w = float(weights.max())
+    min_w = float(weights.min())
+
+    info = {
+        "alpha": float(alpha),
+        "n_train_cases": int(len(case_ids)),
+        "train_cd_mean": float(train_cd.mean()),
+        "train_cd_std": cd_std,
+        "train_height_mean": float(train_height.mean()),
+        "train_height_std": height_std,
+        "hard_test_cd_mean": hard_cd_mean,
+        "hard_test_height_mean": hard_height_mean,
+        "d_mean": float(d.mean()),
+        "d_min": float(d.min()),
+        "d_max": float(d.max()),
+        "weight_min": min_w,
+        "weight_max": max_w,
+        "weight_mean": mean_w,
+        "weight_max_over_mean": max_w / mean_w,
+        "weight_min_over_mean": min_w / mean_w,
+        "effective_sample_size": ess,
+        "ess_fraction": ess / float(len(case_ids)),
+    }
+    return torch.from_numpy(weights).double(), info
+
+
+class DistributedWeightedRandomSampler(Sampler[int]):
+    """DDP-aware WeightedRandomSampler with synchronized global draws.
+
+    Each rank seeds an identical ``torch.Generator`` from
+    ``base_seed + epoch`` and draws the same ``num_samples`` global indices
+    via ``torch.multinomial``; rank ``r`` then takes the ``[r::world_size]``
+    slice. Because every rank sees the same draw, gradient bucket
+    synchronization stays consistent — independent per-rank seeds would
+    break DDP determinism (Byrd & Lipton, ICML 2019).
+    """
+
+    def __init__(
+        self,
+        weights: torch.Tensor,
+        *,
+        num_replicas: int,
+        rank: int,
+        num_samples: int | None = None,
+        base_seed: int = 42,
+    ):
+        if num_replicas <= 0:
+            raise ValueError(f"num_replicas must be positive, got {num_replicas}")
+        if not (0 <= rank < num_replicas):
+            raise ValueError(f"rank {rank} not in [0, {num_replicas})")
+        self.weights = torch.as_tensor(weights, dtype=torch.double).cpu()
+        if self.weights.ndim != 1 or self.weights.numel() == 0:
+            raise ValueError("weights must be a non-empty 1D tensor")
+        self.num_replicas = int(num_replicas)
+        self.rank = int(rank)
+        self.base_seed = int(base_seed)
+        self.epoch = 0
+        total = int(num_samples) if num_samples is not None else int(self.weights.numel())
+        # Match DistributedSampler(drop_last=True): keep total a multiple of world size.
+        self.num_samples_per_rank = total // self.num_replicas
+        self.total_samples = self.num_samples_per_rank * self.num_replicas
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = int(epoch)
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.base_seed + self.epoch)
+        global_indices = torch.multinomial(
+            self.weights,
+            self.total_samples,
+            replacement=True,
+            generator=generator,
+        )
+        rank_indices = global_indices[self.rank :: self.num_replicas]
+        return iter(rank_indices.tolist())
+
+    def __len__(self) -> int:
+        return self.num_samples_per_rank
+
+
+def _build_view_weights(
+    case_ids: list[str],
+    views,
+    alpha: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Expand per-case sampling weights to per-view weights for the dataset."""
+
+    case_weights, info = build_hard_case_weights(case_ids, alpha=alpha)
+    case_idx = {cid: i for i, cid in enumerate(case_ids)}
+    view_weights = torch.tensor(
+        [case_weights[case_idx[v.case_id]].item() for v in views],
+        dtype=torch.double,
+    )
+    info["n_views"] = int(view_weights.numel())
+    info["view_weight_min"] = float(view_weights.min().item())
+    info["view_weight_max"] = float(view_weights.max().item())
+    return view_weights, info
+
+
+def _wrap_loader_with_hard_case_sampler(
+    loader: DataLoader,
+    config: Config,
+    distributed_state,
+) -> tuple[DataLoader, dict[str, float] | None]:
+    """Rebuild ``loader`` with a hard-case WeightedRandomSampler if enabled."""
+
+    if not config.use_hard_case_oversampling:
+        return loader, None
+
+    train_ds = loader.dataset
+    view_weights, info = _build_view_weights(
+        train_ds.case_ids, train_ds.views, alpha=config.hard_case_alpha
+    )
+
+    if distributed_state is not None and distributed_state.enabled:
+        sampler = DistributedWeightedRandomSampler(
+            view_weights,
+            num_replicas=distributed_state.world_size,
+            rank=distributed_state.rank,
+            base_seed=config.hard_case_sampler_seed,
+        )
+    else:
+        from torch.utils.data import WeightedRandomSampler
+
+        sampler = WeightedRandomSampler(
+            weights=view_weights.tolist(),
+            num_samples=int(view_weights.numel()),
+            replacement=True,
+        )
+    new_loader = DataLoader(
+        train_ds,
+        batch_size=config.batch_size,
+        shuffle=False,
+        sampler=sampler,
+        drop_last=True,
+        **loader_kwargs(config),
+    )
+    return new_loader, info
+
+
 def rebuild_train_loader_with_vol_points(
     config: Config,
     old_train_loader: DataLoader,
@@ -684,6 +940,33 @@ def rebuild_train_loader_with_vol_points(
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
     )
+    if config.use_hard_case_oversampling:
+        view_weights, _ = _build_view_weights(
+            train_ds.case_ids, train_ds.views, alpha=config.hard_case_alpha
+        )
+        if distributed_state is not None and distributed_state.enabled:
+            train_sampler = DistributedWeightedRandomSampler(
+                view_weights,
+                num_replicas=distributed_state.world_size,
+                rank=distributed_state.rank,
+                base_seed=config.hard_case_sampler_seed,
+            )
+        else:
+            from torch.utils.data import WeightedRandomSampler
+
+            train_sampler = WeightedRandomSampler(
+                weights=view_weights.tolist(),
+                num_samples=int(view_weights.numel()),
+                replacement=True,
+            )
+        return DataLoader(
+            train_ds,
+            batch_size=config.batch_size,
+            shuffle=False,
+            sampler=train_sampler,
+            drop_last=True,
+            **loader_kwargs(config),
+        )
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:
@@ -737,6 +1020,21 @@ def main(argv: Iterable[str] | None = None) -> None:
         current_train_vol_points = config.train_volume_points
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        hard_case_info: dict[str, float] | None = None
+        if config.use_hard_case_oversampling:
+            train_loader, hard_case_info = _wrap_loader_with_hard_case_sampler(
+                train_loader, config, state
+            )
+            if state.is_main and hard_case_info is not None:
+                print(
+                    "Hard-case oversampling enabled: "
+                    f"alpha={hard_case_info['alpha']:.3f} "
+                    f"weight_max/mean={hard_case_info['weight_max_over_mean']:.2f} "
+                    f"weight_min/mean={hard_case_info['weight_min_over_mean']:.3f} "
+                    f"ESS={hard_case_info['effective_sample_size']:.1f}/"
+                    f"{hard_case_info['n_train_cases']} cases "
+                    f"({100.0 * hard_case_info['ess_fraction']:.1f}%)"
+                )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(
@@ -883,6 +1181,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if hard_case_info is not None:
+                for key, value in hard_case_info.items():
+                    wandb.summary[f"hard_case_oversampling/{key}"] = value
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -911,7 +1212,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         config, train_loader, desired_vol_points, state
                     )
                     current_train_vol_points = desired_vol_points
-            if isinstance(train_loader.sampler, DistributedSampler):
+            if isinstance(
+                train_loader.sampler,
+                (DistributedSampler, DistributedWeightedRandomSampler),
+            ):
                 train_loader.sampler.set_epoch(epoch)
             timeout_hit = distributed_any(
                 state,


### PR DESCRIPTION
## Hypothesis

The primary driver of the OOD vol_p test gap (val≈3.9%, test≈12.0%, ~3× multiplier) is that the 4 official test cases (run_133, run_226, run_203, run_158) have geometry characteristics that are underrepresented in the training distribution. Prior experiments with SDF-based near-surface and far-field volume point resampling (PR #996, #981) confirmed this is a data-distribution problem, not a model-capacity problem.

We hypothesize that **case-level weighted oversampling** — using `WeightedRandomSampler` to increase the sample rate of training cases geometrically similar to the test cases — will improve generalization to the OOD test set. If the model sees the boundary cases more often per epoch, it can calibrate pressure gradients for their geometry before the gradient signal decays.

The mechanism: each training case gets a sampling weight proportional to its geometric similarity to the test cluster (e.g., based on drag coefficient CD or frontal area A_front, since these are the principal geometry covariates available in the manifest). Cases with CD/A_front similar to the test cases get 2–4× higher sampling weight.

**This is a dataloader/trainer change only — no model changes.** The model.py and SOTA config are unchanged.

## Instructions

### Step 1: Identify test case geometry statistics

Load the manifest file and extract CD and A_front for the 4 test cases:
- run_133, run_226, run_203, run_158

Compute the mean CD and A_front of this test cluster. For each training case, compute a geometric distance metric `d_i = |CD_i - CD_test_mean| / std(CD_train) + |A_front_i - A_front_test_mean| / std(A_front_train)`.

### Step 2: Implement case-level WeightedRandomSampler

In `train.py` (or a dataset utility), compute per-case sampling weights:

```python
import torch
from torch.utils.data import WeightedRandomSampler

# distance d_i computed above; smaller = more similar to test cluster
# weight = exp(-alpha * d_i) where alpha controls oversampling strength
alpha = 1.0  # Arm A
weights_per_case = torch.exp(-alpha * torch.tensor(d_train))
# Map each training point index → its case weight
sample_weights = weights_per_case[case_idx_per_sample]
sampler = WeightedRandomSampler(
    weights=sample_weights,
    num_samples=len(sample_weights),
    replacement=True,
)
```

Add CLI flags:
- `--use-hard-case-oversampling` (bool, default False)
- `--hard-case-alpha ALPHA` (float, default 1.0) — controls sharpness of oversampling

### Step 3: Run two arms

**Arm A** — alpha=1.0 (moderate oversampling, ~2–3× for most-similar cases):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-hard-case-oversampling --hard-case-alpha 1.0 \
  --wandb-group fern-hard-case-oversampling --wandb-name fern_arm_a_alpha1
```

**Arm B** — alpha=2.0 (aggressive oversampling, ~4–8× for most-similar cases):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-hard-case-oversampling --hard-case-alpha 2.0 \
  --wandb-group fern-hard-case-oversampling --wandb-name fern_arm_b_alpha2
```

Run Arm A and Arm B in parallel. If Arm A passes EP3 but Arm B doesn't, report Arm A as terminal. If neither passes EP3, report both as NEGATIVE.

### EP gates (4-ep screen)

Steps align at: EP1=10,864 · EP2=16,300 · EP3=19,926 · EP4=22,644

- **EP1** (step ≈ 10,864): kill arm if val_abupt > 35%
- **EP2** (step ≈ 16,300): kill arm if val_abupt > 11.5%
- **EP3** (step ≈ 19,926): kill arm if val_abupt > 8.0% AND vol_p > 5.5% (both must fail; either passing means continue)
- **EP4** terminal: report val_abupt, vol_p, surface_pressure, wall_shear for all surviving arms

**Primary success signal:** val_abupt < 6.2868% for merge. Secondary signal: test_vol_p reduced toward val_vol_p (gap < 3×).

**If Arm A or B reaches EP4 with val_abupt < 6.2868%, promote to 13-epoch full run before reporting terminal.**

## Baseline

**Single-model SOTA (target to beat):** val_abupt=6.2868%, test_abupt=7.7445%
- volume_pressure: val=3.9152%, test=12.0063%
- surface_pressure: val=4.1766%, test=3.9100%
- wall_shear: val=7.0476%, test=6.9848%
- **W&B run:** `29nohj67` (group `nezuko-vol-aux-decoder-head`)
- **PR:** #958

**Note:** Even if val_abupt doesn't improve, a meaningful reduction in the vol_p test/val ratio (currently ~3×) would be valuable evidence for data distribution analysis. Report the ratio explicitly.

## Terminal result format

Post exactly one line (outside any code block) when done:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm_a_run_id>","<arm_b_run_id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_ep4_value>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test_value_or_null>}}
```
