### PR TITLE
[askeladd] H4: Manifold Mixup on backbone hidden states

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_manifold_mixup: bool = False
+    mixup_alpha: float = 0.2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_manifold_mixup": (
+            "Enable Manifold Mixup (Verma et al., ICML 2019, "
+            "https://arxiv.org/abs/1806.05236) on post-backbone hidden "
+            "states. On 50%% of training steps (gated by a cross-rank-"
+            "synced Bernoulli flip), two forward passes are run with the "
+            "second pass on a within-rank-shuffled batch. The "
+            "post-norm surface_hidden and volume_hidden tensors are mixed "
+            "with lam~Beta(alpha,alpha) and decoded through the existing "
+            "output heads. Targets are mixed in normalized space with the "
+            "same lam. Surface and volume masks are intersected so only "
+            "positions valid in both samples contribute. PR #1006."
+        ),
+        "mixup_alpha": (
+            "Beta(alpha, alpha) parameter for Manifold Mixup. Lower "
+            "values (~0.2) concentrate lam near 0 and 1 (mostly near-clean "
+            "samples with rare strong interpolations). Higher values "
+            "(~1.0) give uniform lam in [0,1]. RegMixup / C-Mixup "
+            "literature recommends 0.1-0.5 for regression tasks. Default "
+            "0.2."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -309,6 +331,85 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
     )
+
+
+def manifold_mixup_train_loss(
+    model: nn.Module,
+    batch,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    *,
+    lam: float,
+    idx_b: torch.Tensor,
+    surface_loss_weight: float = 1.0,
+    volume_loss_weight: float = 1.0,
+    surface_channel_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Manifold Mixup (PR #1006): two forward passes, mix post-norm hidden
+    states with lam, decode via output heads, supervise against lam-mixed
+    normalized targets. ``idx_b`` is the within-rank permutation for
+    sample B; ``lam`` is the Beta-sampled mixing weight. Caller must
+    ensure ``lam`` and the gate decision are synchronized across DDP
+    ranks; ``idx_b`` is per-rank (within-rank shuffle).
+    """
+
+    batch = batch.to(device)
+    base_model = unwrap_model(model)
+
+    surface_target_a = transform.apply_surface(batch.surface_y)
+    volume_target_a = transform.apply_volume(batch.volume_y)
+    surface_target_b = surface_target_a[idx_b]
+    volume_target_b = volume_target_a[idx_b]
+    surface_target_mix = lam * surface_target_a + (1.0 - lam) * surface_target_b
+    volume_target_mix = lam * volume_target_a + (1.0 - lam) * volume_target_b
+
+    surface_mask_mix = batch.surface_mask & batch.surface_mask[idx_b]
+    volume_mask_mix = batch.volume_mask & batch.volume_mask[idx_b]
+
+    with autocast_context(device, amp_mode):
+        out_a = model(
+            surface_x=batch.surface_x,
+            surface_mask=batch.surface_mask,
+            volume_x=batch.volume_x,
+            volume_mask=batch.volume_mask,
+        )
+        out_b = model(
+            surface_x=batch.surface_x[idx_b],
+            surface_mask=batch.surface_mask[idx_b],
+            volume_x=batch.volume_x[idx_b],
+            volume_mask=batch.volume_mask[idx_b],
+        )
+        surf_h_mix = lam * out_a["surface_hidden"] + (1.0 - lam) * out_b["surface_hidden"]
+        vol_h_mix = lam * out_a["volume_hidden"] + (1.0 - lam) * out_b["volume_hidden"]
+
+        surface_mask_mix_f = surface_mask_mix.to(dtype=surf_h_mix.dtype).unsqueeze(-1)
+        volume_mask_mix_f = volume_mask_mix.to(dtype=vol_h_mix.dtype).unsqueeze(-1)
+        surface_preds_mix = base_model.surface_out(surf_h_mix) * surface_mask_mix_f
+        volume_preds_mix = base_model.volume_out(vol_h_mix) * volume_mask_mix_f
+
+        if surface_channel_weights is not None:
+            surface_loss = weighted_channel_mse(
+                surface_preds_mix,
+                surface_target_mix,
+                surface_mask_mix,
+                surface_channel_weights,
+            )
+        else:
+            surface_loss = masked_mse(surface_preds_mix, surface_target_mix, surface_mask_mix)
+        volume_loss = masked_mse(volume_preds_mix, volume_target_mix, volume_mask_mix)
+        weighted_surface_loss = surface_loss_weight * surface_loss
+        weighted_volume_loss = volume_loss_weight * volume_loss
+        loss = weighted_surface_loss + weighted_volume_loss
+        base_mse_loss = surface_loss + volume_loss
+    return loss, {
+        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
+        "surface_loss": float(surface_loss.detach().cpu().item()),
+        "volume_loss": float(volume_loss.detach().cpu().item()),
+        "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
+        "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "mixup_lam": float(lam),
+    }
 
 
 def train_loss(
@@ -773,7 +874,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_manifold_mixup:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1021,16 +1122,53 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
-                    loss, batch_loss_metrics = train_loss(
-                        model,
-                        batch,
-                        transform,
-                        device,
-                        config.amp_mode,
-                        surface_loss_weight=config.surface_loss_weight,
-                        volume_loss_weight=config.volume_loss_weight,
-                        surface_channel_weights=surface_channel_weights if use_channel_weights else None,
-                    )
+                    mixup_active = False
+                    mixup_lam = 0.0
+                    if config.use_manifold_mixup:
+                        # Sample the 50% gate and lam on rank 0, broadcast so
+                        # every rank takes the same forward path (else DDP
+                        # graph mismatch deadlocks the gradient bucket).
+                        sync = torch.zeros(2, device=device, dtype=torch.float32)
+                        if state.is_main:
+                            sync[0] = float(torch.rand(1).item())
+                            sync[1] = float(
+                                torch.distributions.Beta(
+                                    config.mixup_alpha, config.mixup_alpha
+                                ).sample().item()
+                            )
+                        if state.enabled:
+                            dist.broadcast(sync, src=0)
+                        mixup_active = bool(sync[0].item() < 0.5)
+                        mixup_lam = float(sync[1].item())
+                    if mixup_active:
+                        B = batch.surface_x.shape[0]
+                        idx_b = torch.randperm(B, device=device)
+                        loss, batch_loss_metrics = manifold_mixup_train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            lam=mixup_lam,
+                            idx_b=idx_b,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        )
+                    else:
+                        loss, batch_loss_metrics = train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        )
+                    if config.use_manifold_mixup:
+                        batch_loss_metrics["mixup_active"] = 1.0 if mixup_active else 0.0
+                        batch_loss_metrics["mixup_lam"] = mixup_lam if mixup_active else 0.0
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1070,6 +1208,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "mixup_active" in batch_loss_metrics:
+                        train_log["train/mixup_active"] = batch_loss_metrics["mixup_active"]
+                        train_log["train/mixup_lam"] = batch_loss_metrics["mixup_lam"]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Manifold Mixup on backbone hidden states** as a regularizer to improve generalization on OOD volume-pressure predictions.

Standard input-space Mixup interpolates raw inputs. Manifold Mixup (Verma et al. 2019) instead interpolates *hidden representations* at a mid-network layer, producing smoother decision boundaries and better generalization. Given that our primary gap is OOD `test_vol_p` (val≈3.5%, test≈11.3%, ~3.2× multiplier), we hypothesize that smoothing the latent space between training samples will reduce overfitting to in-distribution volume-pressure patterns.

**Key idea:** On 50% of training steps, run two forward passes (batch A and shuffled-within-rank batch B), mix the resulting `surface_hidden` and `volume_hidden` tensors with `lam ~ Beta(0.2, 0.2)`, decode with the output heads, and supervise against the correspondingly mixed targets.

---

## Baseline to beat

| Metric | Value |
|--------|-------|
| **val_abupt** | **6.2868%** (single-model SOTA, PR #958) |
| val_surface_pressure | 3.9764% |
| val_vol_pressure | 3.5854% |
| val_wall_shear | 7.2116% |
| test_abupt | 7.7445% |
| test_vol_p | 12.0063% |

**Ensemble SOTA:** val_abupt=6.0289% (PR #880, K=6 greedy)

---

## Implementation spec

### 1. Config additions (`train.py`, `Config` dataclass)

```python
use_manifold_mixup: bool = False
mixup_alpha: float = 0.2
```

Add corresponding CLI flags:
```python
parser.add_argument("--use-manifold-mixup", action="store_true", default=False)
parser.add_argument("--mixup-alpha", type=float, default=0.2)
```

### 2. DDP find_unused_parameters (`main()`, near the DDP wrapping block)

```python
if config.use_surf_to_vol_xattn or config.use_manifold_mixup:
    ddp_kwargs["find_unused_parameters"] = True
```

Manifold Mixup runs two forward passes per step (when active), but on the 50% of steps where it is NOT active the normal forward is used — so `find_unused_parameters=True` may not be strictly needed if both paths always touch all parameters. However add it defensively to prevent DDP hang.

### 3. Training loop injection (`main()`, in the per-step training block)

Find the standard `train_loss()` call block (used when `not config.use_gradnorm`). Replace/wrap it as follows:

```python
if config.use_manifold_mixup and torch.rand(1).item() < 0.5:
    # ── Manifold Mixup step ──────────────────────────────────────────
    lam = torch.distributions.Beta(
        config.mixup_alpha, config.mixup_alpha
    ).sample().item()
    B = batch.surface_x.shape[0]
    idx_b = torch.randperm(B, device=device)

    # Forward pass A (original batch order)
    out_a = model(
        surface_x=batch.surface_x,
        surface_mask=batch.surface_mask,
        volume_x=batch.volume_x,
        volume_mask=batch.volume_mask,
    )
    # Forward pass B (shuffled within rank — no cross-rank communication needed)
    out_b = model(
        surface_x=batch.surface_x[idx_b],
        surface_mask=batch.surface_mask[idx_b],
        volume_x=batch.volume_x[idx_b],
        volume_mask=batch.volume_mask[idx_b],
    )
    # Mix latent representations
    surf_h_mix = lam * out_a["surface_hidden"] + (1 - lam) * out_b["surface_hidden"]
    vol_h_mix  = lam * out_a["volume_hidden"]  + (1 - lam) * out_b["volume_hidden"]
    # Intersection masks (only supervise positions present in BOTH examples)
    surf_mask_mix = batch.surface_mask & batch.surface_mask[idx_b]
    vol_mask_mix  = batch.volume_mask  & batch.volume_mask[idx_b]
    # Decode from mixed hidden states (bypass backbone, call output heads directly)
    base_model = unwrap_model(model)   # already available in main() scope
    surf_preds = base_model.surface_out(surf_h_mix) * surf_mask_mix.unsqueeze(-1)
    vol_preds  = base_model.volume_out(vol_h_mix)   * vol_mask_mix.unsqueeze(-1)
    # Mix targets (apply normalization transform first, then mix)
    surf_tgt_a = transform.inverse_surface(batch.surface_y)  # normalized
    surf_tgt_b = transform.inverse_surface(batch.surface_y[idx_b])
    vol_tgt_a  = transform.inverse_volume(batch.volume_y)
    vol_tgt_b  = transform.inverse_volume(batch.volume_y[idx_b])
    surf_target_mix = lam * surf_tgt_a + (1 - lam) * surf_tgt_b
    vol_target_mix  = lam * vol_tgt_a  + (1 - lam) * vol_tgt_b
    # MSE loss on mixed predictions vs mixed targets
    surface_loss = masked_mse(surf_preds, surf_target_mix, surf_mask_mix)
    volume_loss  = masked_mse(vol_preds,  vol_target_mix,  vol_mask_mix)
    loss = (config.surface_loss_weight * surface_loss
            + config.volume_loss_weight * volume_loss)
    batch_loss_metrics = {"surface_loss": surface_loss.item(), "volume_loss": volume_loss.item()}
    # ── End Manifold Mixup step ──────────────────────────────────────
else:
    loss, batch_loss_metrics = train_loss(
        model, batch, transform, device, config.amp_mode,
        surface_loss_weight=config.surface_loss_weight,
        volume_loss_weight=config.volume_loss_weight,
        surface_channel_weights=surface_channel_weights if use_channel_weights else None,
    )
```

**Important implementation note on targets:** You need to check how `train_loss()` uses the transform. If it calls `transform.apply_surface(batch.surface_y)` (i.e., applies forward normalization), use that same call. If targets are already normalized in the batch, skip the transform call. Match what `train_loss()` does exactly to avoid loss-scale mismatches.

### 4. Model `forward_from_hidden()` (optional but recommended)

Add a helper to `SurfaceTransolver` in `model.py` to make this pattern reusable and explicit:

```python
def forward_from_hidden(self, surface_hidden, volume_hidden, surface_mask, volume_mask):
    """Decode from pre-computed (possibly mixed) hidden states, bypassing backbone."""
    surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
    volume_preds  = self.volume_out(volume_hidden)   * volume_mask.unsqueeze(-1)
    return {"surface_preds": surface_preds, "volume_preds": volume_preds}
```

This is optional — calling `base_model.surface_out(...)` directly in the training loop also works.

---

## Run specification

**Single arm.**

```bash
python train.py \
  --use-manifold-mixup \
  --mixup-alpha 0.2 \
  --epochs 4 \
  --lr-cosine-t-max 13 \
  --vol-curriculum "0:16384:1:32768:2:49152:3:65536" \
  --wandb-group "askeladd-manifold-mixup-backbone"
```

Stack on top of the current SOTA config (PR #958 = PR #823 surf→vol cross-attention + dedicated vol_p aux head). Ensure `--use-surf-to-vol-xattn` and `--use-vol-aux-head` (or equivalent flags) are also set as in PR #958.

**Do NOT use GradNorm for this experiment** (`--use-gradnorm` must NOT be set) — Manifold Mixup does not currently have a per-task loss decomposition compatible with GradNorm.

---

## EP gates

Step alignment for 4-ep screens (`"0:16384:1:32768:2:49152:3:65536"`):
- EP1 ≈ step 10,864 — kill if val_abupt > **13.5%** (slightly relaxed vs standard 35% to account for mixup regularization initially hurting metrics)
- EP2 ≈ step 16,300 — kill if val_abupt > 10.0%
- EP3 ≈ step 19,926 — kill if val_abupt > 8.0% AND vol_p > 5.5% (both must fail to kill)
- EP4 ≈ step 22,644 — terminal

**Log val metrics at each EP checkpoint** and post a SENPAI-RESULT marker at EP4.

---

## Terminal result format

Post as a **PR comment** (not in the PR body) once EP4 is complete:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<value>},"test_metric":{"name":"test_abupt","value":<value>}}
```

---

## References

- Verma et al. (2019) "Manifold Mixup: Better Representations by Interpolating Hidden States" — ICML 2019
- Zhang et al. (2018) "mixup: Beyond Empirical Risk Minimization" — ICLR 2018 (input-space baseline)