### PR TITLE
vol-decoder-separation: independent vol_p transformer tower (decoder separation)

### DIFF
--- a/model.py
+++ b/model.py
@@ -295,8 +295,109 @@ class Transformer(nn.Module):
         return x
 
 
+class VolPressureTower(nn.Module):
+    """Independent Transolver tower for volume pressure prediction.
+
+    Bypasses the shared surface/volume backbone entirely: receives raw
+    volume features (``volume_x``) directly, projects them through an
+    independent positional embedding + feature projection, runs them
+    through its own Transolver stack, and emits a single-channel volume
+    pressure prediction. The tower shares no parameters with the surface
+    backbone, so its gradient signal is fully decoupled from the surface
+    tasks (no gradient coupling through shared weights or final norm).
+
+    Hypothesis: the shared backbone's gradient coupling between surface
+    and volume tasks causes the volume head to learn surface-biased
+    representations that overfit to val-set volume geometry (val→test
+    vol_p gap +7–8pp across 20+ closed PRs). An independent tower trains
+    vol_p without surface-gradient contamination, freeing it to develop
+    orthogonal inductive biases.
+    """
+
+    def __init__(
+        self,
+        *,
+        space_dim: int = 3,
+        volume_input_dim: int = VOLUME_X_DIM,
+        volume_output_dim: int = VOLUME_Y_DIM,
+        n_layers: int = 3,
+        hidden_dim: int = 256,
+        n_heads: int = 8,
+        mlp_ratio: int | float = 2,
+        slice_num: int = 96,
+        dropout: float = 0.0,
+        pe_kind: str = "sincos",
+        pe_num_features: int = 16,
+        pe_init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        if hidden_dim % n_heads != 0:
+            raise ValueError("VolPressureTower hidden_dim must be divisible by n_heads")
+        self.space_dim = space_dim
+        self.volume_input_dim = volume_input_dim
+        self.volume_output_dim = volume_output_dim
+        self.hidden_dim = hidden_dim
+        self.pe_kind = pe_kind
+        self.pe_num_features = pe_num_features
+        self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+
+        if pe_kind == "sincos":
+            self.pos_embed: nn.Module = ContinuousSincosEmbed(
+                hidden_dim=hidden_dim, input_dim=space_dim,
+            )
+        elif pe_kind == "string_multisigma":
+            self.pos_embed = MultiSigmaStringPosEmbed(
+                hidden_dim=hidden_dim,
+                input_dim=space_dim,
+                num_features=pe_num_features,
+                init_sigmas=self.pe_init_sigmas,
+            )
+        else:
+            raise ValueError(
+                f"Unknown pe_kind '{pe_kind}'. Supported: sincos, string_multisigma."
+            )
+        self.volume_bias = MLP(
+            input_dim=hidden_dim, hidden_dim=hidden_dim, output_dim=hidden_dim
+        )
+        self.project_volume_features = (
+            LinearProjection(volume_extra_dim, hidden_dim) if volume_extra_dim > 0 else None
+        )
+        self.volume_placeholder = nn.Parameter(torch.rand(1, 1, hidden_dim) / hidden_dim)
+        self.backbone = Transformer(
+            depth=n_layers,
+            hidden_dim=hidden_dim,
+            num_heads=n_heads,
+            mlp_expansion_factor=mlp_ratio,
+            num_slices=slice_num,
+            dropout=dropout,
+        )
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.volume_out = LinearProjection(hidden_dim, volume_output_dim)
+
+    def forward(
+        self, volume_x: torch.Tensor, volume_mask: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pos = volume_x[:, :, : self.space_dim]
+        hidden = self.pos_embed(pos)
+        if self.project_volume_features is not None and volume_x.shape[-1] > self.space_dim:
+            hidden = hidden + self.project_volume_features(volume_x[:, :, self.space_dim :])
+        hidden = self.volume_bias(hidden) + self.volume_placeholder
+        hidden = _apply_token_mask(hidden, volume_mask)
+        hidden = self.backbone(hidden, attn_mask=volume_mask)
+        hidden = _apply_token_mask(hidden, volume_mask)
+        hidden_norm = _apply_token_mask(self.norm(hidden), volume_mask)
+        preds = self.volume_out(hidden_norm) * volume_mask.unsqueeze(-1)
+        return preds, hidden_norm
+
+
 class SurfaceTransolver(nn.Module):
-    """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
+    """Grouped Transolver for surface pressure, wall shear, and volume pressure.
+
+    With ``use_vol_tower=True`` the volume pathway is delegated to an
+    independent :class:`VolPressureTower` and the shared backbone only
+    processes surface tokens; volume_x bypasses the shared backbone entirely.
+    """
 
     def __init__(
         self,
@@ -315,6 +416,13 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        use_vol_tower: bool = False,
+        vol_tower_layers: int = 3,
+        vol_tower_hidden_dim: int = 256,
+        vol_tower_heads: int = 8,
+        vol_tower_mlp_ratio: int | float = 2,
+        vol_tower_slices: int = 96,
+        vol_tower_pe_kind: str | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -325,6 +433,7 @@ class SurfaceTransolver(nn.Module):
         self.pe_kind = pe_kind
         self.pe_num_features = pe_num_features
         self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        self.use_vol_tower = use_vol_tower
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -344,15 +453,20 @@ class SurfaceTransolver(nn.Module):
                 f"Unknown pe_kind '{pe_kind}'. Supported: sincos, string_multisigma."
             )
         self.surface_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
-        self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
         self.project_surface_features = (
             LinearProjection(surface_extra_dim, n_hidden) if surface_extra_dim > 0 else None
         )
-        self.project_volume_features = (
-            LinearProjection(volume_extra_dim, n_hidden) if volume_extra_dim > 0 else None
-        )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
-        self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        if use_vol_tower:
+            self.volume_bias = None
+            self.project_volume_features = None
+            self.volume_placeholder = None
+        else:
+            self.volume_bias = MLP(input_dim=n_hidden, hidden_dim=n_hidden, output_dim=n_hidden)
+            self.project_volume_features = (
+                LinearProjection(volume_extra_dim, n_hidden) if volume_extra_dim > 0 else None
+            )
+            self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -363,7 +477,25 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
-        self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        if use_vol_tower:
+            self.volume_out = None
+            self.vol_tower = VolPressureTower(
+                space_dim=space_dim,
+                volume_input_dim=volume_input_dim,
+                volume_output_dim=volume_output_dim,
+                n_layers=vol_tower_layers,
+                hidden_dim=vol_tower_hidden_dim,
+                n_heads=vol_tower_heads,
+                mlp_ratio=vol_tower_mlp_ratio,
+                slice_num=vol_tower_slices,
+                dropout=dropout,
+                pe_kind=vol_tower_pe_kind if vol_tower_pe_kind is not None else pe_kind,
+                pe_num_features=pe_num_features,
+                pe_init_sigmas=self.pe_init_sigmas,
+            )
+        else:
+            self.vol_tower = None
+            self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
         self,
@@ -393,6 +525,14 @@ class SurfaceTransolver(nn.Module):
             raise ValueError("SurfaceTransolver requires surface_mask when surface_x is provided")
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
+
+        if self.use_vol_tower:
+            return self._forward_with_tower(
+                surface_x=surface_x,
+                surface_mask=surface_mask,
+                volume_x=volume_x,
+                volume_mask=volume_mask,
+            )
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
@@ -452,4 +592,46 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+        }
+
+    def _forward_with_tower(
+        self,
+        *,
+        surface_x: torch.Tensor | None,
+        surface_mask: torch.Tensor | None,
+        volume_x: torch.Tensor | None,
+        volume_mask: torch.Tensor | None,
+    ) -> dict[str, torch.Tensor]:
+        if surface_x is not None:
+            surface_in = self._encode_group(
+                surface_x,
+                project_features=self.project_surface_features,
+                bias=self.surface_bias,
+                placeholder=self.surface_placeholder,
+            )
+            surface_in = _apply_token_mask(surface_in, surface_mask)
+            surface_hidden = self.backbone(surface_in, attn_mask=surface_mask)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
+            surface_hidden_norm = _apply_token_mask(self.norm(surface_hidden), surface_mask)
+            surface_preds = self.surface_out(surface_hidden_norm) * surface_mask.unsqueeze(-1)
+        else:
+            batch_size = volume_x.shape[0]
+            hidden_dim = self.norm.normalized_shape[0]
+            surface_hidden_norm = volume_x.new_zeros(batch_size, 0, hidden_dim)
+            surface_preds = volume_x.new_zeros(batch_size, 0, self.surface_output_dim)
+
+        if volume_x is not None:
+            volume_preds, volume_hidden_norm = self.vol_tower(volume_x, volume_mask)
+        else:
+            batch_size = surface_x.shape[0]
+            tower_hidden_dim = self.vol_tower.hidden_dim
+            volume_preds = surface_x.new_zeros(batch_size, 0, self.volume_output_dim)
+            volume_hidden_norm = surface_x.new_zeros(batch_size, 0, tower_hidden_dim)
+
+        return {
+            "surface_preds": surface_preds,
+            "volume_preds": volume_preds,
+            "hidden": surface_hidden_norm,
+            "surface_hidden": surface_hidden_norm,
+            "volume_hidden": volume_hidden_norm,
         }

--- a/train.py
+++ b/train.py
@@ -132,6 +132,13 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_vol_tower: bool = False
+    vol_tower_layers: int = 3
+    vol_tower_hidden_dim: int = 256
+    vol_tower_heads: int = 8
+    vol_tower_mlp_ratio: float = 2.0
+    vol_tower_slices: int = 96
+    vol_tower_pe: str = ""
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -235,6 +242,13 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_vol_tower=config.use_vol_tower,
+        vol_tower_layers=config.vol_tower_layers,
+        vol_tower_hidden_dim=config.vol_tower_hidden_dim,
+        vol_tower_heads=config.vol_tower_heads,
+        vol_tower_mlp_ratio=config.vol_tower_mlp_ratio,
+        vol_tower_slices=config.vol_tower_slices,
+        vol_tower_pe_kind=(config.vol_tower_pe or None),
     )
 
 
@@ -301,6 +315,7 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    gradnorm_surface_only: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
@@ -326,11 +341,21 @@ def train_loss(
             volume_per_ch = per_channel_masked_mse(
                 out["volume_preds"], volume_target, batch.volume_mask
             )  # [1]: vol_p
-            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
             w_detached = gradnorm_weights.weights.detach()
-            loss = (w_detached * task_losses).sum()
-            weighted_surface_loss = (w_detached[:4] * surface_per_ch).sum()
-            weighted_volume_loss = w_detached[4] * volume_per_ch[0]
+            if gradnorm_surface_only:
+                # Tower mode: GradNorm balances only the 4 surface tasks
+                # (they share the backbone). vol_p trains independently
+                # through the tower with a fixed weight, since the tower
+                # is fully decoupled from the shared backbone gradient.
+                task_losses = surface_per_ch  # [4]
+                weighted_surface_loss = (w_detached * surface_per_ch).sum()
+                weighted_volume_loss = volume_loss_weight * volume_loss
+                loss = weighted_surface_loss + weighted_volume_loss
+            else:
+                task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
+                loss = (w_detached * task_losses).sum()
+                weighted_surface_loss = (w_detached[:4] * surface_per_ch).sum()
+                weighted_volume_loss = w_detached[4] * volume_per_ch[0]
         else:
             task_losses = None
             weighted_surface_loss = surface_loss_weight * surface_loss
@@ -480,8 +505,16 @@ def main(argv: Iterable[str] | None = None) -> None:
         gradnorm_weights: GradNormWeights | None = None
         gradnorm_opt: torch.optim.Optimizer | None = None
         gradnorm_L0: torch.Tensor | None = None
-        gradnorm_n_tasks = 5  # cp, tau_x, tau_y, tau_z, vol_p
-        gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z", "vol_p")
+        gradnorm_surface_only = bool(config.use_vol_tower)
+        if gradnorm_surface_only:
+            # vol_p flows through the independent tower and therefore
+            # does NOT share gradient with the backbone — exclude it
+            # from the GradNorm balancing set.
+            gradnorm_n_tasks = 4
+            gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z")
+        else:
+            gradnorm_n_tasks = 5  # cp, tau_x, tau_y, tau_z, vol_p
+            gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z", "vol_p")
         if config.use_gradnorm:
             gradnorm_weights = GradNormWeights(n_tasks=gradnorm_n_tasks).to(device)
             gradnorm_opt = torch.optim.Adam(
@@ -490,7 +523,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             if state.is_main:
                 print(
                     f"GradNorm enabled: alpha={config.gradnorm_alpha}, "
-                    f"n_tasks={gradnorm_n_tasks}, lr={config.gradnorm_lr}"
+                    f"n_tasks={gradnorm_n_tasks}, lr={config.gradnorm_lr}, "
+                    f"surface_only={gradnorm_surface_only}"
                 )
         total_estimated_steps = max(1, max_epochs * max(len(train_loader), 1))
         if kill_thresholds and state.is_main:
@@ -583,6 +617,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    gradnorm_surface_only=gradnorm_surface_only,
                 )
                 if (
                     config.use_y_symmetry_aug


### PR DESCRIPTION
## Hypothesis: Independent Vol-Pressure Transformer Tower (Architectural Decoder Separation)

The val→test `vol_p` gap (+7–8pp: val ~3.8% vs test ~10.8%) has been confirmed as a **structural data distribution problem** across 20+ closed PRs. Every model-side intervention on the *shared* backbone pathway has failed: loss weighting, regularization, optimizer variants, EMA, data augmentation, and coordinate normalization all failed to close the gap. The shared backbone's gradient coupling between surface and volume tasks causes the volume head to learn surface-biased representations that overfit to val-set volume geometry.

**New direction:** Add a second, fully independent transformer tower in `model.py` dedicated solely to `vol_p` decoding. This tower receives raw volume point features `volume_x` directly, bypassing the shared backbone entirely. By decoupling the volume pathway from the surface pathway's gradient signal, the vol_p tower can develop orthogonal inductive biases and potentially generalize differently to the test-set's OOD volume point distributions.

**Research question:** Does architectural separation of the volume decoder from the surface backbone improve test-set `vol_p` generalization, reducing the structural val→test gap?

---

## Instructions to the Student

### What to implement

In `model.py`, add a `VolPressureTower` module that processes volume features independently of the shared surface backbone:

1. **Add `VolPressureTower` class** — a standalone transformer module with 2–3 Transolver-style layers (hidden_dim=256, heads=8) that takes raw volume point features directly as input. This tower should have its own cross-attention/self-attention stack, not shared with the surface decoder.

2. **Route `volume_preds` through `VolPressureTower`** — in the main model's `forward()`, pass `volume_x` and `volume_mask` directly to `VolPressureTower`, bypassing the shared backbone's volume head. The tower outputs `[B, N_volume, 1]` (volume pressure only).

3. **Keep surface predictions unchanged** — `surface_preds [B, N_surface, 4]` continue to flow through the existing shared backbone pathway. Do not modify the surface decoder.

4. **GradNorm adjustment** — With the vol_p pathway now fully separate, GradNorm `α=0.5` should operate only over the surface task gradients (the backbone). The vol_p tower trains on its own loss gradient independently. Keep `--use-gradnorm --gradnorm-alpha 0.5`.

5. **Volume loss weight** — Keep `--volume-loss-weight 1.0` (default). The tower is fully independent so there is no risk of it dominating the shared backbone's gradients.

**Tower architecture suggestion:**
```python
class VolPressureTower(nn.Module):
    def __init__(self, in_dim, hidden_dim=256, n_heads=8, n_layers=3, mlp_ratio=2):
        # in_dim: raw volume feature dimension (match model's input projection)
        # n_layers=3 Transolver-style blocks
        # Output projection: hidden_dim -> 1 (vol pressure)
```

The key invariant: `volume_x` must be projected to `hidden_dim` inside the tower (do **not** reuse the shared backbone's input projection), so the tower is truly independent from end to end.

### Files you may edit
- `model.py` — add `VolPressureTower`, wire into main model `forward()`
- `train.py` — no changes needed unless you need to expose new CLI flags
- `trainer_runtime.py` — no changes needed

**Read-only (do NOT modify):** `data/loader.py`, `data/generate_manifest.py`, `data/preload.py`, `data/split_manifest.json`

### Kill gates (apply at validation steps)
Steps per epoch DDP8 bs=1: ~10,975 steps/epoch (87,794 train samples / 8 ranks)

| Validation step | Epoch | `val_abupt` threshold |
|---|---|---|
| 27,469 | EP2.5 | ≤ 7.50% |
| 54,938 | EP5.0 | ≤ 7.20% |
| 82,407 | EP7.5 | ≤ 6.80% |
| 109,876 | EP10.0 | ≤ 6.70% |
| 137,345 | EP12.5 | ≤ 6.65% |
| 164,814 | EP15.0 | ≤ 6.60% |

Kill and report if any gate is missed. Report `val_vol_p` at each gate — this is the key diagnostic metric for whether the tower is helping.

### Reproduce command

```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --batch-size 1 \
  --train-volume-points 65000 \
  --train-surface-points 65000 \
  --epochs 30 \
  --lr-cosine-t-max 30 \
  --weight-decay 0.005 \
  --seed 42 \
  --amp-mode bf16 \
  --no-use-ema \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --wandb-group vol-decoder-separation
```

### What to report

At each kill gate, report in a PR comment:
- `val_abupt` (primary metric)
- `val_vol_p` (key diagnostic — are we closing the val→test gap?)
- `val_surf_p`, `val_wall` for completeness
- W&B run ID

Terminal result must include:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"test_primary/abupt_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/volume_pressure_rel_l2_pct","value":<number>}}
```

---

## Baseline to beat

**Wave SOTA — PR #740, W&B run `5x8wofzm`:**

| Metric | Value |
|---|---|
| `test_primary/abupt_rel_l2_pct` | **7.5195%** |
| `test_primary/surface_pressure_rel_l2_pct` | 3.881% |
| `test_primary/volume_pressure_rel_l2_pct` | **10.758%** ← primary target |
| `test_primary/wallshearstress_rel_l2_pct` | 7.061% |

**AB-UPT reference (public):**

| Metric | Value |
|---|---|
| `abupt_rel_l2_pct` | 7.29% (our wave currently 7.52% — 0.23pp gap) |
| `surface_pressure_rel_l2_pct` | 3.82% |
| `volume_pressure_rel_l2_pct` | **6.08%** ← ultimate target (gap of 4.68pp vs our wave) |
| `wallshearstress_rel_l2_pct` | 7.29% |

The `vol_p` gap between our wave best (10.758%) and AB-UPT (6.08%) is 4.68pp. This is the single largest source of error in our wave. Architectural decoder separation is the next escalation tier after all model-side interventions on the shared pathway were falsified.

---

## Context: Why model-side fixes failed

The following interventions have been **falsified** (≥20 closed PRs) — do NOT retry these:
- Weight decay variants (0.005, 0.01)
- Dropout (0.1)
- GradNorm α variants (0.25, 0.75)
- Fixed vol_p loss weight (2×, 3×)
- Extended cosine / LR schedule variants
- EMA (decay=0.999, 0.9999)
- BBox canonical coordinate normalization
- TTA Y-symmetry
- DropPath stochastic depth
- Vol coord noise (σ=0.005)
- Stochastic vol subsampling
- SDF-stratified sampling
- PCGrad (wrong config — separate relaunch)
- SWA (separate relaunch)

The common failure mode: any intervention that amplifies vol_p gradient improves val_vol_p but **widens** the test gap (val overfitting). An independent tower that trains vol_p from scratch, without surface gradient contamination, is the key architectural change that hasn't been tried.
