### PR TITLE
edward/sdf-film-vol-conditioning: SDF scalar FiLM conditioning of volume hidden states

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,78 @@ class Transformer(nn.Module):
         return x
 
 
+class GeomFiLMBlock(nn.Module):
+    """FiLM conditioning from per-case SDF scalar statistics (PR #1008).
+
+    Extracts per-sample summary statistics from the SDF field channel of
+    ``volume_x`` (e.g. ``sdf_min``, ``sdf_negative_frac``), encodes them via a
+    small 2-layer MLP, and applies scale+shift modulation to volume hidden
+    states. The output layer is zero-initialised so the block is identity at
+    init, preserving baseline behavior at epoch 0. Padded tokens are excluded
+    from the statistics using the provided ``volume_mask``.
+
+    Arm A (n_scalars=2): sdf_min, sdf_negative_frac.
+    Arm B (n_scalars=4): adds sdf_q05, sdf_near_surface_frac.
+    """
+
+    _SUPPORTED_N_SCALARS = (2, 4)
+
+    def __init__(self, n_scalars: int, n_hidden: int):
+        super().__init__()
+        if n_scalars not in self._SUPPORTED_N_SCALARS:
+            raise ValueError(
+                f"GeomFiLMBlock: n_scalars must be in {self._SUPPORTED_N_SCALARS}, got {n_scalars}"
+            )
+        self.n_scalars = n_scalars
+        self.n_hidden = n_hidden
+        self.mlp = nn.Sequential(
+            nn.Linear(n_scalars, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, n_hidden * 2),
+        )
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+
+    def compute_scalars(
+        self,
+        volume_x: torch.Tensor,
+        volume_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        # Use float32 for the statistics so torch.quantile (Arm B) and the
+        # subtraction in sdf_min stay numerically stable under bf16 autocast.
+        sdf = volume_x[:, :, 3].float()
+        if volume_mask is None:
+            valid = torch.ones_like(sdf, dtype=torch.bool)
+        else:
+            valid = volume_mask.bool()
+        n_valid = valid.to(dtype=sdf.dtype).sum(dim=1).clamp(min=1.0)
+        sdf_for_min = torch.where(valid, sdf, torch.full_like(sdf, float("inf")))
+        sdf_min = sdf_for_min.min(dim=1).values
+        sdf_neg = ((sdf < 0.0) & valid).to(dtype=sdf.dtype).sum(dim=1)
+        sdf_neg_frac = sdf_neg / n_valid
+        if self.n_scalars == 2:
+            return torch.stack([sdf_min, sdf_neg_frac], dim=1)
+        # For sdf_q05 we need to ignore padded points. Replace them with +inf
+        # then clamp to a large finite value so quantile interpolation is well
+        # defined; with full-batch valid points q05 lies well below the clamp.
+        sdf_q05 = torch.quantile(sdf_for_min.clamp(max=1e6), 0.05, dim=1)
+        near_surf = (
+            ((sdf > -0.05) & (sdf < 0.05) & valid).to(dtype=sdf.dtype).sum(dim=1) / n_valid
+        )
+        return torch.stack([sdf_min, sdf_neg_frac, sdf_q05, near_surf], dim=1)
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        volume_x: torch.Tensor,
+        volume_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        scalars = self.compute_scalars(volume_x, volume_mask)
+        params = self.mlp(scalars).to(dtype=hidden.dtype)
+        scale, shift = params.chunk(2, dim=-1)
+        return hidden * (1.0 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +415,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_sdf_geom_film: bool = False,
+        sdf_film_n_scalars: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +430,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_sdf_geom_film = use_sdf_geom_film
+        self.sdf_film_n_scalars = sdf_film_n_scalars
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -460,6 +536,13 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        if use_sdf_geom_film:
+            self.geom_film = GeomFiLMBlock(
+                n_scalars=sdf_film_n_scalars, n_hidden=n_hidden
+            )
+        else:
+            self.geom_film = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -544,6 +627,14 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.geom_film is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            volume_hidden = self.geom_film(volume_hidden, volume_x, volume_mask)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_sdf_geom_film: bool = False
+    sdf_film_n_scalars: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_geom_film": (
+            "Enable SDF-scalar FiLM conditioning of volume hidden states "
+            "(PR #1008). Extracts per-case scalar statistics from the SDF "
+            "field (channel 3 of volume_x), encodes them via a 2-layer MLP, "
+            "and applies feature-wise linear modulation (scale + shift) to "
+            "the volume hidden states before the surf->vol cross-attention. "
+            "Output layer is zero-initialised so the block is identity at "
+            "init and preserves baseline behavior at epoch 0. Padded tokens "
+            "are excluded from the scalar statistics via volume_mask."
+        ),
+        "sdf_film_n_scalars": (
+            "Number of SDF scalar statistics used by --use-sdf-geom-film. "
+            "Arm A (default): 2 = [sdf_min, sdf_negative_frac]. Arm B: 4 = "
+            "previous two + [sdf_q05, sdf_near_surface_frac]."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +311,25 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_geom_film_metrics(model: nn.Module) -> dict[str, float]:
+    """Log FiLM output-layer weight stats so we can see if the conditioning
+    has moved away from identity (the zero-init starting point)."""
+    metrics: dict[str, float] = {}
+    film = getattr(model, "geom_film", None)
+    if film is None:
+        return metrics
+    last_linear = film.mlp[-1]
+    w = last_linear.weight.detach().float()
+    b = last_linear.bias.detach().float()
+    metrics["geom_film/out_weight_l2"] = float(w.norm().item())
+    metrics["geom_film/out_weight_absmean"] = float(w.abs().mean().item())
+    metrics["geom_film/out_weight_absmax"] = float(w.abs().max().item())
+    metrics["geom_film/out_bias_l2"] = float(b.norm().item())
+    metrics["geom_film/out_bias_absmean"] = float(b.abs().mean().item())
+    metrics["geom_film/out_bias_absmax"] = float(b.abs().max().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +344,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_sdf_geom_film=config.use_sdf_geom_film,
+        sdf_film_n_scalars=config.sdf_film_n_scalars,
     )
 
 
@@ -773,7 +811,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_sdf_geom_film:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -883,6 +921,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/use_sdf_geom_film"] = config.use_sdf_geom_film
+            if config.use_sdf_geom_film:
+                wandb.summary["model/sdf_film_n_scalars"] = config.sdf_film_n_scalars
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1262,6 +1303,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_geom_film_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**SDF Scalar FiLM Conditioning of Volume Hidden States**

PR #797 identified that the 4 OOD test cases (run_133, run_158, run_203, run_226) that drive ~92% of squared volume_pressure error have a distinctive SDF signature: `sdf_min ≈ 0` (−0.0009 to −0.0148) vs bulk training range (−0.27 to −0.45), and `sdf_negative_frac` ~10× lower than typical training cases. These cases arise from a data-pipeline difference (SDF computed differently), not from genuinely novel car geometries.

Critically, 6 "restored" training cases share this same SDF signature — meaning the model *can* learn to distinguish them if given the right conditioning signal.

The hypothesis: extract per-case SDF scalar statistics from `volume_x[:,:,3]` (SDF is already channel 3 of volume_x, no extra data loading needed), encode through a small 2-layer MLP, and apply FiLM (Feature-wise Linear Modulation — scale+shift) to the volume token hidden states **before** the surf→vol cross-attention. This gives the model a learnable "pipeline-mode" indicator that lets it adapt its volume predictions for OOD-signature cases.

FiLM is the right tool here: it's a global, multiplicative conditioning mechanism proven in domain adaptation and meta-learning. The identity-at-init (zero-init scale MLP output) means the baseline model behavior is exactly preserved at epoch 0.

## Implementation Instructions

### 1. Add flag to `train.py`

Add a new flag `--use-sdf-geom-film` (bool, default=False) to the argparse section. Also add this flag when constructing the model (pass to `SurfaceTransolver.__init__`).

### 2. Implement `GeomFiLMBlock` in `model.py`

Add a new module. Insert it near the top of the file (after imports):

```python
class GeomFiLMBlock(nn.Module):
    """
    FiLM conditioning from per-case SDF scalar statistics.
    Computes sdf_min and sdf_negative_frac on-the-fly from the SDF field,
    encodes via a 2-layer MLP, and applies scale+shift to hidden states.
    Identity at initialization (zero-init output layer).
    """
    def __init__(self, n_scalars: int, n_hidden: int):
        super().__init__()
        self.mlp = nn.Sequential(
            nn.Linear(n_scalars, n_hidden),
            nn.SiLU(),
            nn.Linear(n_hidden, n_hidden * 2),  # outputs [scale, shift]
        )
        # Zero-init: model starts as identity transformation
        nn.init.zeros_(self.mlp[-1].weight)
        nn.init.zeros_(self.mlp[-1].bias)

    def forward(self, hidden: torch.Tensor, volume_x: torch.Tensor) -> torch.Tensor:
        """
        hidden:   [B, N_vol, D]
        volume_x: [B, N_vol, 4]  (xyz + sdf)
        returns:  [B, N_vol, D]  modulated hidden states
        """
        sdf = volume_x[:, :, 3]  # [B, N_vol]
        sdf_min = sdf.min(dim=1).values          # [B]
        sdf_neg_frac = (sdf < 0.0).float().mean(dim=1)  # [B]
        scalars = torch.stack([sdf_min, sdf_neg_frac], dim=1)  # [B, 2]
        params = self.mlp(scalars)  # [B, 2*D]
        scale, shift = params.chunk(2, dim=-1)  # [B, D] each
        # FiLM: (1 + scale) * hidden + shift, with unsqueeze for token dim
        return hidden * (1.0 + scale.unsqueeze(1)) + shift.unsqueeze(1)
```

**Note on Arm B (4-scalar variant):** For Arm B, change `n_scalars=4` and the scalar computation to:
```python
sdf_min = sdf.min(dim=1).values                          # [B]
sdf_neg_frac = (sdf < 0.0).float().mean(dim=1)           # [B]
sdf_q05 = torch.quantile(sdf, 0.05, dim=1)               # [B]
sdf_near_surf_frac = ((sdf > -0.05) & (sdf < 0.05)).float().mean(dim=1)  # [B]
scalars = torch.stack([sdf_min, sdf_neg_frac, sdf_q05, sdf_near_surf_frac], dim=1)
```

### 3. Add to `SurfaceTransolver.__init__`

In `SurfaceTransolver.__init__`, add the new parameter and module:

```python
def __init__(self, ..., use_sdf_geom_film: bool = False, sdf_film_n_scalars: int = 2):
    ...
    self.use_sdf_geom_film = use_sdf_geom_film
    if use_sdf_geom_film:
        self.geom_film = GeomFiLMBlock(n_scalars=sdf_film_n_scalars, n_hidden=n_hidden)
```

### 4. Apply in `forward()`

In `SurfaceTransolver.forward()`, after the backbone split (where `volume_hidden` is split from `surface_hidden`) and **before** the surf→vol cross-attention, insert:

```python
# --- SDF FiLM conditioning (before surf→vol xattn) ---
if self.use_sdf_geom_film:
    volume_hidden = self.geom_film(volume_hidden, volume_x)
```

The `volume_x` tensor is already available in `forward()` as a parameter — double-check the signature and use the correct variable name.

### 5. Two training arms

**Arm A — 2-scalar FiLM (sdf_min + sdf_negative_frac):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-sdf-geom-film \
  --wandb-group edward-sdf-film-vol-conditioning
```

**Arm B — 4-scalar FiLM (add sdf_q05 + sdf_near_surface_frac):**
Same as Arm A but also pass `--sdf-film-n-scalars 4` (you'll need to add this int flag too).

Run Arm A first. If EP3 `val_primary/volume_pressure_rel_l2_pct < 5.5%` (val only, not test), launch Arm B immediately in parallel.

### 6. EP3 gate

After epoch 3, check val metrics. If `val_primary/volume_pressure_rel_l2_pct > 6.5%` AND `val_abupt > 6.8%`, the conditioning signal isn't helping — stop and report NEGATIVE. Otherwise continue to epoch 13.

## Current Baseline (gate to beat)

| Metric | Current best (PR #958) | AB-UPT reference target |
|--------|----------------------|------------------------|
| val_abupt | **6.2868%** | — |
| val surface_pressure | 4.1766% | 3.82% |
| val volume_pressure | 3.9152% | — |
| val wall_shear | 7.0476% | 7.29% |
| **test volume_pressure** | **12.0063%** | **6.08%** |
| test surface_pressure | 3.9100% | 3.82% |
| test wall_shear | 6.9848% | 7.29% |

**Reproduce command for current single-model SOTA (PR #958, W&B: 29nohj67):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group nezuko-vol-aux-decoder-head
```

## Motivation (from PR #797)

The OOD-4 test cases have `sdf_min ≈ 0` (range −0.0009 to −0.0148) vs training bulk (−0.27 to −0.45). This 20-100× difference in sdf_min, and ~10× lower `sdf_negative_frac`, flags a data-pipeline inconsistency where SDF was computed with a different sign convention or clipping. The model cannot detect this from geometry alone — but it CAN detect it from the SDF statistics that are already in `volume_x[:,:,3]`. FiLM conditioning gives the model a learnable detector+adapter for these cases.

The 6 "restored" training cases with matching SDF signature are the key training signal. These cases have geometries from the bulk distribution but SDF signatures matching the OOD-4 — they provide supervision for learning the FiLM adaptation.

## Expected Outcome

- **Best case**: Model learns to scale/shift volume hidden states for OOD-signature cases, driving `test_vol_p` from ~12.0% toward the val distribution (~3.9%), significantly closing the val/test gap
- **Likely case**: Modest improvement on val_abupt (currently 6.2868%), with larger improvement on the 4 OOD test cases
- **Null case**: FiLM weights stay near zero (identity), no change — PR shows NEGATIVE, close cleanly

## Results

Please report your results after each epoch gate as a PR comment, and post a terminal SENPAI-RESULT when training is complete:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_primary/volume_pressure_rel_l2_pct","value":<number>}}
```
