### PR TITLE
frieren/pre-xattn-vol-self-attn: pre-cross-attn volume self-attention (Perceiver-IO)

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_pre_xattn_vol_self_attn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -460,6 +462,26 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Pre-xattn vol self-attention (PR #988): lets vol hidden states
+        # coordinate among themselves BEFORE feeding into surf->vol xattn as
+        # queries. Pre-norm residual `vol_h + MHA(LN(vol_h))` with zero-init
+        # out_proj (identity-at-init). key_padding_mask=~volume_mask is
+        # semantically required for self-attention (padding keys would
+        # otherwise contaminate non-padding queries through softmax).
+        if use_pre_xattn_vol_self_attn:
+            self.pre_xattn_vol_ln = nn.LayerNorm(n_hidden, eps=1e-6)
+            self.pre_xattn_vol_mha = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.weight)
+            nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.bias)
+        else:
+            self.pre_xattn_vol_ln = None
+            self.pre_xattn_vol_mha = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -544,6 +566,23 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.pre_xattn_vol_mha is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            vol_h_norm = self.pre_xattn_vol_ln(volume_hidden)
+            vol_h_out, _ = self.pre_xattn_vol_mha(
+                vol_h_norm,
+                vol_h_norm,
+                vol_h_norm,
+                key_padding_mask=~volume_mask,
+                need_weights=False,
+            )
+            vol_h_out = _apply_token_mask(vol_h_out, volume_mask)
+            volume_hidden = volume_hidden + vol_h_out
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_pre_xattn_vol_self_attn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_pre_xattn_vol_self_attn": (
+            "Enable pre-xattn vol self-attention (PR #988). After the "
+            "post-backbone LayerNorm split and BEFORE the surf->vol "
+            "cross-attention, a single nn.MultiheadAttention block lets "
+            "volume hidden states attend to themselves (Q=K=V=vol_hidden) "
+            "with key_padding_mask=~volume_mask, so vol queries become "
+            "context-aware before extracting surface information. Pre-norm "
+            "residual `vol_h + MHA(LN(vol_h))` with zero-initialised "
+            "out_proj weight and bias (identity-at-init). embed_dim follows "
+            "--model-hidden-dim and num_heads follows --model-heads. "
+            "Requires DDP find_unused_parameters=True."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_pre_xattn_vol_self_attn=config.use_pre_xattn_vol_self_attn,
     )
 
 
@@ -773,7 +787,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_pre_xattn_vol_self_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**Pre-cross-attention Volume Self-Attention (Perceiver-IO pattern)**

The current surf→vol cross-attention (Q=volume, K/V=surface) directly maps surface features onto raw backbone volume hidden states. The backbone processes surface and volume tokens together via global slice-attention, but volume tokens may benefit from first attending to each other to build coherent spatial representations **before** absorbing surface information.

This is the Perceiver-IO pattern: a "latent self-attention" step on the query side before cross-attention. For our problem, volume tokens self-attending before surf→vol xattn allows the volume representation to:
1. Propagate geometric context (pressure gradients, wake structure) across volume tokens
2. Present a more informed query set to the surface cross-attention
3. Separate "what structure exists in the volume" from "how does the surface modulate it"

Prior experiments (PR #884, #891, #906) added capacity **after** the xattn — 0-for-3 NEGATIVE. This hypothesis adds capacity **before** the xattn, which is mechanistically different: it conditions the query side rather than the output.

## Implementation Instructions

### 1. Add flag to `train.py`

Add `--use-pre-xattn-vol-self-attn` (bool, default=False) to argparse. Pass it to `SurfaceTransolver.__init__`.

### 2. Add pre-xattn vol self-attention in `model.py`

In `SurfaceTransolver.__init__`, add new parameter `use_pre_xattn_vol_self_attn: bool = False`:

```python
self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
if use_pre_xattn_vol_self_attn:
    self.pre_xattn_vol_self_attn = nn.MultiheadAttention(
        embed_dim=n_hidden, num_heads=n_head, batch_first=True, dropout=dropout
    )
    self.pre_xattn_vol_self_attn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    # Zero-init: identity at initialization
    nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.weight)
    nn.init.zeros_(self.pre_xattn_vol_self_attn.out_proj.bias)
```

### 3. Apply in `forward()`

In `SurfaceTransolver.forward()`, after the backbone split (where `volume_hidden` is split from `surface_hidden`) and **before** the surf→vol cross-attention block, insert:

```python
# --- Pre-xattn volume self-attention (Perceiver-IO pattern) ---
if self.use_pre_xattn_vol_self_attn:
    vol_q = self.pre_xattn_vol_self_attn_norm(volume_hidden)
    # Self-attention: Q=K=V=volume hidden states
    attn_out, _ = self.pre_xattn_vol_self_attn(
        vol_q, vol_q, vol_q,
        key_padding_mask=volume_mask  # use volume mask if available
    )
    volume_hidden = volume_hidden + attn_out  # residual connection
```

The `key_padding_mask` should be `~volume_mask` (inverted) if the mask convention is True=valid. Check the existing surf→vol xattn code to match the mask convention used there.

### 4. Training run — single arm first

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-pre-xattn-vol-self-attn \
  --wandb-group frieren-pre-xattn-vol-self-attn
```

### 5. EP3 gate

After epoch 3, check val metrics:
- If `val_primary/volume_pressure_rel_l2_pct > 6.5%` AND `val_abupt > 6.8%` → stop and report NEGATIVE
- Otherwise continue to epoch 13

## Current Baseline (gate to beat)

| Metric | Current best (PR #958) | AB-UPT reference target |
|--------|----------------------|------------------------|
| val_abupt | **6.2868%** | — |
| val surface_pressure | 4.1766% | 3.82% |
| val volume_pressure | 3.9152% | — |
| val wall_shear | 7.0476% | 7.29% |
| **test volume_pressure** | **12.0063%** | **6.08%** |
| test surface_pressure | 3.9100% | 3.82% |
| test wall_shear | 6.9848% | 7.29% |

**Current single-model SOTA (PR #958, W&B: `29nohj67`)** — reproduce command:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group nezuko-vol-aux-decoder-head
```

## Motivation

Post-xattn capacity additions have been 0-for-3 NEGATIVE (PR #884 kill-gate, PR #891 detach-KV, PR #906). The failure mode in all cases was adding complexity to the output side after the xattn had already done its work. This hypothesis takes a fundamentally different approach: improving the **query representation** before xattn runs. A self-coherent volume representation going into the cross-attention should lead to more precise surface→volume feature mapping, especially for pressure gradient propagation across the volume domain.

## Expected Outcome

- **Best case**: Pre-xattn self-attention enables volume tokens to develop coherent spatial structure, improving both val and test volume_pressure metrics
- **Likely**: Modest improvement in `val_abupt`, primary gains on volume_pressure channel
- **Null case**: Zero-init ensures clean NEGATIVE result with no degradation

## Results

Please report EP3 gate metrics as a PR comment, and post a terminal SENPAI-RESULT when complete:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_primary/volume_pressure_rel_l2_pct","value":<number>}}
```
