### PR TITLE
Linear vol self-attn (FAVOR+ Performer) — follow-up to #988 EP1 signal

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,151 @@ class Transformer(nn.Module):
         return x
 
 
+class LinearVolSelfAttn(nn.Module):
+    """Performer-style FAVOR+ linear self-attention over volume tokens.
+
+    Complexity O(N * m * d) vs O(N^2 * d) for vanilla MHA, where m is the
+    number of random features. PR #1010 follow-up to #988: that PR showed a
+    strong EP1 signal from vanilla self-attn over volume tokens but timed
+    out because O(N^2) was infeasible at N=65k.
+
+    Ref: Choromanski et al. ICLR 2021, "Rethinking Attention with Performers".
+    https://arxiv.org/abs/2009.14794
+
+    The kernel map uses the paper's softmax-approximation form
+    phi(x) = exp(d^{-1/4} * x.omega - ||x||^2 / (2*sqrt(d))) / sqrt(m)
+    which approximates exp(x.y / sqrt(d)) (the softmax temperature). We add
+    the per-token (query) and global (key) max-subtraction for numerical
+    stability, an eps floor on the denominator, and an eps=1e-4 jitter
+    inside the exp output to keep gradients well-defined.
+
+    The output projection is zero-initialised so the whole module is the
+    identity at init (preserves baseline behaviour at epoch 0), matching
+    the pattern used by surf_to_vol_xattn in this file.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int = 4,
+        num_features: int = 64,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.num_features = num_features
+
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.k_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.v_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+        self.register_buffer(
+            "omega",
+            self._generate_orthogonal_features(self.head_dim, num_features),
+        )
+
+    @staticmethod
+    def _generate_orthogonal_features(d: int, m: int) -> torch.Tensor:
+        """Orthogonal Gaussian random features (Yu et al. 2016).
+
+        Builds ``ceil(m / d)`` independent random orthogonal d x d blocks
+        via QR decomposition, stacks their rows, and rescales each row to
+        norm sqrt(d). Returns a [d, m] buffer so the einsum
+        ``... d, dm -> ... m`` runs without an extra transpose.
+        """
+        num_blocks = (m + d - 1) // d
+        blocks: list[torch.Tensor] = []
+        for _ in range(num_blocks):
+            g = torch.randn(d, d)
+            q, _ = torch.linalg.qr(g)
+            blocks.append(q.t())  # rows are orthonormal
+        omega = torch.cat(blocks, dim=0)[:m]  # [m, d]
+        omega = omega * math.sqrt(d)
+        return omega.t().contiguous()  # [d, m]
+
+    def _favor_plus(self, x: torch.Tensor, is_query: bool) -> torch.Tensor:
+        """Apply the FAVOR+ positive feature map.
+
+        x: [B, H, N, d] (float32) -> phi(x): [B, H, N, m] (float32).
+        Query and key shifts differ: queries use a per-token max
+        (independent attention rows), keys use a global max across
+        sequence and feature dims (preserves the shared sum_j phi(K_j)).
+        """
+        d = x.shape[-1]
+        proj_scale = d ** -0.25
+        norm_scale = d ** -0.5
+        omega = self.omega.to(dtype=x.dtype)
+        xw = torch.einsum("bhnd,dm->bhnm", x * proj_scale, omega)
+        norm_sq = (x * x).sum(dim=-1, keepdim=True) * (norm_scale * 0.5)
+        diff = xw - norm_sq
+        if is_query:
+            stabilizer = diff.amax(dim=-1, keepdim=True).detach()
+        else:
+            stabilizer = diff.amax(dim=(-2, -1), keepdim=True).detach()
+        phi = torch.exp(diff - stabilizer) + 1e-4
+        return phi * (self.num_features ** -0.5)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Pre-norm + FAVOR+ linear self-attention with residual.
+
+        x: [B, N, hidden_dim] volume hidden states.
+        mask: [B, N] (1 = valid, 0 = padding) so padded positions never
+        contribute to the K/V running sums and outputs at padded indices
+        are zeroed before the residual add.
+        """
+        residual = x
+        x_norm = self.norm(x)
+        B, N, _ = x_norm.shape
+        H, D = self.num_heads, self.head_dim
+
+        # [B, N, H*D] -> [B, H, N, D]
+        Q = self.q_proj(x_norm).view(B, N, H, D).permute(0, 2, 1, 3)
+        K = self.k_proj(x_norm).view(B, N, H, D).permute(0, 2, 1, 3)
+        V = self.v_proj(x_norm).view(B, N, H, D).permute(0, 2, 1, 3)
+
+        # Upcast for the exp/sum kernel — bf16 underflows below ~1e-2.
+        compute_dtype = torch.float32
+        Q_f = Q.to(dtype=compute_dtype)
+        K_f = K.to(dtype=compute_dtype)
+        V_f = V.to(dtype=compute_dtype)
+
+        Q_prime = self._favor_plus(Q_f, is_query=True)   # [B, H, N, m]
+        K_prime = self._favor_plus(K_f, is_query=False)  # [B, H, N, m]
+
+        if mask is not None:
+            mask_kv = mask.to(dtype=compute_dtype, device=K_prime.device).view(B, 1, N, 1)
+            K_prime = K_prime * mask_kv
+            V_f = V_f * mask_kv
+
+        # Numerator: KV = sum_j phi(K_j) V_j^T  -> [B, H, m, D]
+        KV = torch.einsum("bhnm,bhnd->bhmd", K_prime, V_f)
+        out_num = torch.einsum("bhnm,bhmd->bhnd", Q_prime, KV)  # [B, H, N, D]
+        # Denominator: phi(Q) . sum_j phi(K_j)  -> [B, H, N, 1]
+        K_sum = K_prime.sum(dim=-2)  # [B, H, m]
+        out_den = torch.einsum("bhnm,bhm->bhn", Q_prime, K_sum).unsqueeze(-1)
+        out = out_num / out_den.clamp(min=1e-6)
+
+        out = out.to(dtype=residual.dtype)
+        out = out.permute(0, 2, 1, 3).contiguous().view(B, N, self.hidden_dim)
+        out = self.out_proj(out)
+
+        if mask is not None:
+            out = out * mask.to(dtype=out.dtype, device=out.device).unsqueeze(-1)
+
+        return residual + out
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +488,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_linear_vol_self_attn: bool = False,
+        linear_vol_attn_features: int = 64,
+        linear_vol_attn_heads: int = 4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -460,6 +608,21 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # PR #1010: Performer-style FAVOR+ linear self-attention over volume
+        # tokens applied BEFORE the surf->vol cross-attention. PR #988 showed
+        # the direction works but vanilla O(N^2) MHA timed out at N=65k;
+        # FAVOR+ reduces compute to O(N*m). Zero-init out_proj keeps the
+        # module identity-at-init.
+        self.use_linear_vol_self_attn = use_linear_vol_self_attn
+        if use_linear_vol_self_attn:
+            self.linear_vol_self_attn = LinearVolSelfAttn(
+                hidden_dim=n_hidden,
+                num_heads=linear_vol_attn_heads,
+                num_features=linear_vol_attn_features,
+            )
+        else:
+            self.linear_vol_self_attn = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -544,6 +707,20 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        # PR #1010: pre-xattn linear (FAVOR+) self-attention over volume tokens.
+        # Gated on volume_tokens > 0 so volume-empty views (max(surface_views,
+        # volume_views) >= volume_views) skip the layer; DDP needs
+        # find_unused_parameters=True (set in train.py).
+        if (
+            self.linear_vol_self_attn is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            volume_hidden = self.linear_vol_self_attn(
+                volume_hidden, mask=volume_mask
+            )
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_linear_vol_self_attn: bool = False
+    linear_vol_attn_features: int = 64
+    linear_vol_attn_heads: int = 4
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,28 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_linear_vol_self_attn": (
+            "Enable Performer-style (FAVOR+) linear self-attention over "
+            "volume tokens applied BEFORE the surf->vol cross-attention "
+            "(PR #1010 follow-up to #988). Complexity O(N*m*d) vs O(N^2*d) "
+            "for vanilla MHA, where m = --linear-vol-attn-features and N "
+            "is the volume token count. out_proj is zero-init so the "
+            "module is identity at epoch 0. Forces "
+            "find_unused_parameters=True in the DDP wrapper because "
+            "volume-empty views skip the layer."
+        ),
+        "linear_vol_attn_features": (
+            "Number of FAVOR+ random features m for the linear vol "
+            "self-attention. Cost scales as O(N*m*d); approximation "
+            "quality improves with m. Choromanski et al. 2021 recommend "
+            "m >= d for stable approximation, m >= 2d for <5%% kernel "
+            "error; head_dim is hidden_dim/heads. Default 64 trades "
+            "approximation for speed in the 4-epoch screen."
+        ),
+        "linear_vol_attn_heads": (
+            "Number of heads for the linear vol self-attention. "
+            "hidden_dim must be divisible by this. Default 4."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +333,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_linear_vol_self_attn=config.use_linear_vol_self_attn,
+        linear_vol_attn_features=config.linear_vol_attn_features,
+        linear_vol_attn_heads=config.linear_vol_attn_heads,
     )
 
 
@@ -772,8 +800,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # batch, so DDP's default find_unused_parameters=False deadlocks
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
-            # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # params across ranks, at a small per-step overhead. PR #1010's
+            # linear vol self-attn has the mirror issue (gated on
+            # `volume_tokens > 0`), so we union the flags.
+            if config.use_surf_to_vol_xattn or config.use_linear_vol_self_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

PR #988 (frieren, pre-xattn vol self-attention) showed a strong EP1 signal of −1.99pp on val_abupt (from ~9.5% → ~7.5%) using vanilla O(N²) MHA over volume tokens before the surf→vol cross-attention. However, O(N²) attention over N≈32K–65K volume points is computationally infeasible — EP1 wall time hit 7103s vs baseline ~3500s, causing the run to time out.

**The fix: linear attention via Performer-style FAVOR+ kernel trick.** Instead of softmax(QKᵀ)V in O(N²·d), we approximate with φ(Q)(φ(K)ᵀV) in O(N·m·d) where m is the number of random features. This reduces vol self-attn from O(N²) to O(N·m), making it feasible within the 270-min budget even at N=65K.

The mechanistic motivation is clear: vol self-attn lets volume hidden states propagate spatial context globally before the surf→vol xattn injects surface information. The strong EP1 signal from #988 validates the direction; only the computational cost was blocking it.

**References:**
- "Rethinking Attention with Performers" (Choromanski et al., ICLR 2021): https://arxiv.org/abs/2009.14794
- FAVOR+: positive random features φ(x) = exp(x·ω − ||x||²/2) / sqrt(m) guarantee non-negative attention weights and preserve expectation of softmax attention

## Instructions

Implement a `LinearVolSelfAttn` module using positive orthogonal random features (FAVOR+) and add it as an optional pre-xattn vol self-attention block:

### 1. Implement `LinearVolSelfAttn` in `train.py`

Add a new class after the existing cross-attention code:

```python
class LinearVolSelfAttn(nn.Module):
    """
    Linear (Performer-style FAVOR+) self-attention over volume tokens.
    Complexity: O(N * m * d) vs O(N^2 * d) for vanilla MHA.
    Ref: Choromanski et al. 2021 "Rethinking Attention with Performers"
    """
    def __init__(self, hidden_dim: int, num_heads: int = 4, num_features: int = 64):
        super().__init__()
        self.hidden_dim = hidden_dim
        self.num_heads = num_heads
        self.head_dim = hidden_dim // num_heads
        self.num_features = num_features
        self.scale = self.head_dim ** -0.5

        self.q_proj = nn.Linear(hidden_dim, hidden_dim)
        self.k_proj = nn.Linear(hidden_dim, hidden_dim)
        self.v_proj = nn.Linear(hidden_dim, hidden_dim)
        # Zero-init output projection so this is an identity at init
        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
        nn.init.zeros_(self.out_proj.weight)
        nn.init.zeros_(self.out_proj.bias)

        # Pre-generate random features (fixed, not learnable)
        # Shape: [head_dim, num_features]
        self.register_buffer(
            "omega",
            self._generate_orthogonal_features(self.head_dim, num_features)
        )

        self.norm = nn.LayerNorm(hidden_dim)

    @staticmethod
    def _generate_orthogonal_features(d: int, m: int) -> torch.Tensor:
        """Generate orthogonal random features via QR decomposition."""
        num_blocks = (m + d - 1) // d
        blocks = []
        for _ in range(num_blocks):
            g = torch.randn(d, d)
            q, _ = torch.linalg.qr(g)
            s = torch.sqrt(torch.tensor(d, dtype=torch.float32)) * torch.ones(d)
            blocks.append(q * s.unsqueeze(0))
        omega = torch.cat(blocks, dim=1)[:, :m]  # [d, m]
        return omega

    def _favor_plus(self, x: torch.Tensor) -> torch.Tensor:
        """Apply FAVOR+ kernel map. x: [..., d] -> [..., m]"""
        # φ(x) = exp(x·ω/sqrt(d) - ||x||²/2) / sqrt(m)
        # Clamp for numerical stability
        xw = x @ self.omega * self.scale  # [..., m]
        norm_sq = (x * x).sum(dim=-1, keepdim=True) * 0.5  # [..., 1]
        return torch.exp(torch.clamp(xw - norm_sq, min=-30, max=30)) / (self.num_features ** 0.5)

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        """
        x: [B, N, hidden_dim] (volume tokens)
        Returns: x + linear-attn(x) (residual connection)
        """
        residual = x
        x = self.norm(x)
        B, N, _ = x.shape

        Q = self.q_proj(x).view(B, N, self.num_heads, self.head_dim)  # [B,N,H,d]
        K = self.k_proj(x).view(B, N, self.num_heads, self.head_dim)
        V = self.v_proj(x).view(B, N, self.num_heads, self.head_dim)

        # Apply FAVOR+ feature map
        Q_prime = self._favor_plus(Q)  # [B,N,H,m]
        K_prime = self._favor_plus(K)  # [B,N,H,m]

        # Linear attention: φ(Q) * (φ(K)^T * V) — O(N*m*d)
        # KV = sum_i φ(K_i)^T V_i, shape [B,H,m,d]
        KV = torch.einsum('bnhm,bnhd->bhmд', K_prime, V)  # [B,H,m,d]
        # Out = φ(Q) * KV: [B,N,H,m] x [B,H,m,d] -> [B,N,H,d]
        out = torch.einsum('bnhm,bhmd->bnhd', Q_prime, KV)

        # Normalizer (denominator): φ(Q) * sum_i φ(K_i) — [B,N,H]
        K_sum = K_prime.sum(dim=1)  # [B,H,m]
        denom = torch.einsum('bnhm,bhm->bnh', Q_prime, K_sum).unsqueeze(-1).clamp(min=1e-6)
        out = out / denom  # [B,N,H,d]

        out = out.reshape(B, N, self.hidden_dim)
        out = self.out_proj(out)
        return residual + out
```

**Note:** The einsum `'bnhm,bnhd->bhmд'` has a Unicode character — use ASCII `d` not `д`. Write it as: `torch.einsum('bnhm,bnhd->bhmd', K_prime, V)`.

### 2. Add `--use-linear-vol-self-attn` flag

In the `argparse` section, add:
```python
parser.add_argument("--use-linear-vol-self-attn", action="store_true", default=False,
    help="Add a Performer-style (FAVOR+) linear self-attention over volume tokens "
         "before the surf->vol cross-attention (PR #988 follow-up). O(N*m) complexity.")
parser.add_argument("--linear-vol-attn-features", type=int, default=64,
    help="Number of random features m for linear vol self-attention (default: 64).")
parser.add_argument("--linear-vol-attn-heads", type=int, default=4,
    help="Number of heads for linear vol self-attention (default: 4).")
```

### 3. Instantiate and call `LinearVolSelfAttn` in the model

Find where `--use-surf-to-vol-xattn` is instantiated in the Transolver model. Add the `LinearVolSelfAttn` module as an attribute of the same class (or the top-level model):

```python
# In model __init__:
self.linear_vol_self_attn = None
if args.use_linear_vol_self_attn:
    self.linear_vol_self_attn = LinearVolSelfAttn(
        hidden_dim=args.model_hidden_dim,
        num_heads=args.linear_vol_attn_heads,
        num_features=args.linear_vol_attn_features,
    )
```

In the forward pass, insert before the surf→vol cross-attention call:
```python
# Before surf->vol xattn:
if self.linear_vol_self_attn is not None:
    vol_hidden = self.linear_vol_self_attn(vol_hidden)  # [B, N_vol, hidden_dim]
```

If `find_unused_parameters=True` is not already set in the DDP wrapper, add it to avoid DDP errors when the module is enabled.

### 4. Run 4-epoch screen

Use the SOTA #958 config plus the new flag:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-linear-vol-self-attn \
  --linear-vol-attn-features 64 \
  --linear-vol-attn-heads 4 \
  --wandb-group fern-linear-vol-self-attn
```

### 5. Gate schedule

- **EP1 gate** (step ~10,864): val_abupt ≤ 30% — kill if exceeded
- **EP2 gate** (step ~21,728): val_abupt ≤ 16% — kill if exceeded
- **EP3 dual gate** (step ~32,592): val_abupt ≤ 8.0% AND vol_p ≤ 5.0% — kill if both exceeded, or extend if promising
- **EP4 terminal** (step ~43,456): Report final results

The key signal to watch: EP1 vol_p should show improvement vs baseline ~14.9%. PR #988 saw EP1 vol_p drop by ~1.99pp with O(N²) MHA — with linear attention at O(N·m=64) the compute cost should be ~20× lower, well within budget.

### 6. Check timing at EP1

At EP1 (~10,864 steps), report wall-clock time. If EP1 time > 4000s, the attention module may still be too slow — try reducing `--linear-vol-attn-features 32` (Arm B). If EP1 time < 3500s, proceed normally.

### 7. Post results

When complete, post a comment with:
- W&B run ID
- EP1, EP2, EP3, EP4 metrics: val_abupt and vol_pressure_rel_l2_pct
- EP1 wall-clock time
- Final structured `SENPAI-RESULT` marker

## Baseline (PR #958, nezuko — current SINGLE-MODEL SOTA)

| Metric | Baseline |
|--------|---------|
| val_abupt | 6.2868% |
| test_abupt | 7.7445% |
| test surface_pressure | 3.9100% |
| test volume_pressure | 12.0063% |
| test wall_shear | 6.9848% |
| W&B run | `29nohj67` |

**Gate: val_abupt < 6.2868% to beat single-model SOTA.**

Reproduce baseline:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0
```
