### PR TITLE
vol-backbone-soft-grad-scale: 0.1x backbone grad scaling from vol loss

### DIFF
--- a/model.py
+++ b/model.py
@@ -441,7 +441,10 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            # Soft gradient scaling: backbone receives 0.1x gradient from vol loss
+            # (PR #1011 — replaces hard detach in #1007 which blocked bootstrapping).
+            volume_hidden_for_out = volume_hidden * 0.1 + volume_hidden.detach() * 0.9
+            volume_preds = self.volume_out(volume_hidden_for_out) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)


### PR DESCRIPTION
## Hypothesis

Replace the hard stop-gradient on the vol tower's backbone input with a **0.1× soft gradient scaling** factor.

PR #1007 confirmed that hard `detach()` creates a bootstrapping failure: the vol tower must learn from scratch against backbone representations that haven't been tuned for vol prediction yet (chicken-and-egg problem). With 0.1× scaling, the backbone still receives gradient signal from vol loss (preserving early bootstrapping), but at 1/10th the magnitude (reducing interference with surface/wall signals).

## Instructions

In `target/train.py` (or the model forward pass), find where `backbone_features` is passed to the vol decoder tower. Replace:

```python
vol_preds = vol_tower(backbone_features.detach())
```

with:

```python
backbone_feats_for_vol = backbone_features * 0.1 + backbone_features.detach() * 0.9
vol_preds = vol_tower(backbone_feats_for_vol)
```

This is the only change required. Use the standard production config for all other hyperparameters.

**Kill gates:**
- EP2 (step ~21,950): `val_primary/abupt_axis_mean_rel_l2_pct` ≤ 16.0% AND `val_primary/volume_pressure_rel_l2_pct` ≤ 12.0%
- EP5 (step ~54,875): abupt ≤ 9.0% AND vol_p ≤ 7.0%
- EP10 (step ~109,750): abupt ≤ 7.5% AND vol_p ≤ 5.5%

If any gate fails, stop the run and post results.

## Baseline

| Metric | Wave SOTA (PR #740, `5x8wofzm`) | Val Leader (#972, `56bcqp3m` EP20) |
|--------|----------------------------------|-------------------------------------|
| abupt  | test=7.5195%                     | val=6.127%                          |
| vol_p  | test=10.758%                     | val=3.815%                          |
| surf_p | test=3.881%                      | —                                   |
| wall   | test=7.061%                      | —                                   |

Prior hard stop-grad (PR #1007): KILLED EP2, abupt=8.984%, vol_p=8.999% — bootstrapping failure confirmed.

## Reproduce command

```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-warmup-epochs 1 --seed 42 \
  --agent tanjiro --wandb-group vol-backbone-soft-grad-scale
```

## Expected outcome

If the soft gradient scaling fixes the bootstrapping problem, we expect:
- EP2 gates to PASS (unlike PR #1007 which failed immediately)
- vol_p to converge towards baseline or better
- abupt to remain competitive with the wave val leader (~6.1%)
