### PR TITLE
Vol k-NN local spatial attn pre-pass before Transolver slices

### DIFF
--- a/model.py
+++ b/model.py
@@ -188,6 +188,130 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class VolumeKNNPreAttn(nn.Module):
+    """Local k-NN spatial attention over volume tokens, applied before the Transolver backbone.
+
+    For each volume token, attends over its k nearest spatial neighbours in 3D.
+    Injects a geometry-invariant local inductive bias (local pressure physics
+    are the same on OOD shapes), reducing the OOD burden on the global slice
+    router.
+
+    Implementation notes:
+    - Chunked cdist (default chunk_size=512) avoids the O(N^2) distance
+      matrix at N~65k.
+    - Attention itself is computed manually (q.k / softmax / .v einsums) in
+      chunks of ``attn_chunk_size`` along the N dim. This keeps the effective
+      batch dim of every CUDA kernel below the gridDim.y ceiling of 65535,
+      which a naive ``[B*N, 1, D]`` reshape into nn.MultiheadAttention would
+      blow past at N>=16k.
+    - Mask-aware: padded candidates are pushed to +inf distance so they are
+      never selected; padded queries are zeroed via ``_apply_token_mask``
+      before the residual + LayerNorm.
+    - Zero-init ``out_proj`` => identity at init, preserving baseline
+      behaviour at epoch 0.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        k: int = 16,
+        chunk_size: int = 512,
+        attn_chunk_size: int = 4096,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.k = k
+        self.chunk_size = chunk_size
+        self.attn_chunk_size = attn_chunk_size
+        self.scale = self.head_dim ** -0.5
+        self.qkv_proj = nn.Linear(hidden_dim, 3 * hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        # Standard init for qkv; zero-init out_proj so the module is identity
+        # (modulo the post-norm) at step 0.
+        _init_linear(self.qkv_proj)
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+
+    def _knn_indices(
+        self,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Compute k-NN indices via chunked cdist. Returns [B, N, k] indices.
+
+        Mask handling: when ``mask`` is provided, padded candidates are pushed
+        to +inf distance so they are never selected as neighbours. Padded
+        queries still produce indices; their output is zeroed downstream by
+        ``_apply_token_mask`` before the residual + LayerNorm.
+        """
+        B, N, _ = coords.shape
+        k = min(self.k, max(N - 1, 1))
+        knn_indices = torch.zeros(B, N, k, dtype=torch.long, device=coords.device)
+        coords_f = coords.float()
+        if mask is not None:
+            cand_inf = (1.0 - mask.float()) * float("inf")  # [B, N], 0 for real, inf for padded
+        else:
+            cand_inf = None
+        for start in range(0, N, self.chunk_size):
+            end = min(start + self.chunk_size, N)
+            dists = torch.cdist(coords_f[:, start:end], coords_f)  # [B, chunk, N]
+            row_idx = torch.arange(start, end, device=coords.device)
+            col_idx = torch.arange(end - start, device=coords.device)
+            dists[:, col_idx, row_idx] = float("inf")
+            if cand_inf is not None:
+                dists = dists + cand_inf[:, None, :]
+            knn_indices[:, start:end] = dists.topk(k, dim=-1, largest=False).indices
+        return knn_indices
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        coords: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, N, D = x.shape
+        if N == 0:
+            return x
+        k = min(self.k, max(N - 1, 1))
+        knn_indices = self._knn_indices(coords, mask)  # [B, N, k]
+
+        qkv = self.qkv_proj(x).view(B, N, 3, self.num_heads, self.head_dim)
+        q = qkv[:, :, 0]  # [B, N, H, hd]
+        k_full = qkv[:, :, 1]  # [B, N, H, hd]
+        v_full = qkv[:, :, 2]  # [B, N, H, hd]
+
+        batch_arange = torch.arange(B, device=x.device)[:, None, None]  # [B, 1, 1]
+        out = torch.empty(B, N, self.num_heads, self.head_dim, dtype=q.dtype, device=x.device)
+
+        # Chunk along N so per-chunk neighbour gather stays small. With
+        # chunk=4096, k=16, H=4, hd=128: gathered K+V ~= 4*4096*16*4*128*2
+        # = 268M elements ~= 0.5 GB in bf16. Fits comfortably alongside the
+        # rest of the model on H100 80GB.
+        chunk = self.attn_chunk_size
+        for start in range(0, N, chunk):
+            end = min(start + chunk, N)
+            knn_chunk = knn_indices[:, start:end]  # [B, chunk, k]
+            chunk_n = end - start
+            batch_idx_chunk = batch_arange.expand(B, chunk_n, k)
+            k_n = k_full[batch_idx_chunk, knn_chunk]  # [B, chunk, k, H, hd]
+            v_n = v_full[batch_idx_chunk, knn_chunk]  # [B, chunk, k, H, hd]
+            q_chunk = q[:, start:end]  # [B, chunk, H, hd]
+            scores = torch.einsum("bnhd,bnkhd->bnhk", q_chunk, k_n) * self.scale
+            attn = F.softmax(scores, dim=-1)
+            out[:, start:end] = torch.einsum("bnhk,bnkhd->bnhd", attn, v_n)
+
+        out = out.reshape(B, N, D)
+        out = self.out_proj(out)
+        out = _apply_token_mask(out, mask)
+        return self.norm(x + out)
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -343,6 +467,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_knn_preattn: bool = False,
+        vol_knn_k: int = 16,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +482,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_knn_preattn = use_vol_knn_preattn
+        self.vol_knn_k = vol_knn_k
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -440,6 +568,20 @@ class SurfaceTransolver(nn.Module):
         )
         self.volume_out.apply(_init_linear)
 
+        # Volume k-NN local spatial pre-attention (PR #1012): mixes each volume
+        # token with its k spatial neighbours BEFORE the global Transolver
+        # backbone, injecting a geometry-invariant local inductive bias to
+        # reduce the OOD burden on the global slice router. Zero-init out_proj
+        # => identity at init.
+        if use_vol_knn_preattn:
+            self.vol_knn_preattn = VolumeKNNPreAttn(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                k=vol_knn_k,
+            )
+        else:
+            self.vol_knn_preattn = None
+
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
         # Bridges geometry-aware surface features into the volume decoder
@@ -522,16 +664,20 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    volume_x,
-                    rff=self.volume_rff,
-                    string_sep=self.volume_string_sep,
-                    project_features=self.project_volume_features,
-                    bias=self.volume_bias,
-                    placeholder=self.volume_placeholder,
-                )
+            volume_hidden_pre = self._encode_group(
+                volume_x,
+                rff=self.volume_rff,
+                string_sep=self.volume_string_sep,
+                project_features=self.project_volume_features,
+                bias=self.volume_bias,
+                placeholder=self.volume_placeholder,
             )
+            if self.vol_knn_preattn is not None and volume_tokens > 0:
+                vol_coords = volume_x[:, :, : self.space_dim]
+                volume_hidden_pre = self.vol_knn_preattn(
+                    volume_hidden_pre, vol_coords, volume_mask
+                )
+            tokens.append(volume_hidden_pre)
             masks.append(volume_mask)
 
         attn_mask = torch.cat(masks, dim=1)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_knn_preattn: bool = False
+    vol_knn_k: int = 16
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_knn_preattn": (
+            "Enable volume k-NN local spatial pre-attention (PR #1012). "
+            "Before the shared Transolver backbone, each volume token "
+            "attends to its k=--vol-knn-k nearest 3D-space neighbours via "
+            "one nn.MultiheadAttention pass. Injects a geometry-invariant "
+            "local inductive bias to reduce the OOD burden on the global "
+            "slice router. Zero-init out_proj => identity at init. "
+            "embed_dim follows --model-hidden-dim, num_heads follows "
+            "--model-heads, chunked cdist avoids O(N^2) memory."
+        ),
+        "vol_knn_k": (
+            "Number of spatial neighbours per volume token in the k-NN "
+            "pre-attention module (PR #1012). Default 16 follows PTv3 / "
+            "Point Transformer conventions. Only used when "
+            "--use-vol-knn-preattn is set."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +326,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_knn_preattn=config.use_vol_knn_preattn,
+        vol_knn_k=config.vol_knn_k,
     )
 
 
@@ -773,7 +793,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_knn_preattn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The primary bottleneck is the test-time vol_pressure OOD gap (val_vol_p≈3.9% vs test_vol_p≈12.0%, a 3.2× ratio) on 4 geometrically atypical test cases. The global Transolver slice-attention router assigns tokens to 128 learned slices based on global shape statistics; on OOD geometries those statistics shift, degrading volume pressure predictions in ways that surface attention cannot compensate.

**Key insight:** Local pressure physics (e.g. the Navier-Stokes PDE connecting nearby pressure values) are the same regardless of global shape. A k-nearest-neighbour pre-attention pass over volume tokens enforces this local invariance *before* the global slice-attention sees the tokens. By pre-mixing information from spatial neighbours, each token arrives at the Transolver backbone already partially resolved from its local physical context — reducing the burden on the global router to discover spatial structure it has never seen at training time.

This is a two-level hierarchical attention:
1. **Local (k-NN spatial pre-pass):** each volume token attends to its k=16 nearest 3D-space neighbours
2. **Global (Transolver slice-attention):** standard backbone over the pre-mixed tokens

Similar hierarchies appear in Point Transformer (Zhao et al., CVPR 2021), PCT (Guo et al., 2021), and GAT (Veličković et al., ICLR 2018), all showing that local graph structure improves generalisation on unseen shapes.

## Implementation

Add two new config flags:

```python
use_vol_knn_preattn: bool = False
vol_knn_k: int = 16
```

Add a new module `VolumeKNNPreAttn`:

```python
class VolumeKNNPreAttn(nn.Module):
    """Local k-NN spatial attention over volume tokens, applied before the Transolver backbone.

    For each volume token, attends over its k nearest spatial neighbours.
    This injects a local inductive bias that is geometry-invariant (local
    physics are the same on OOD shapes), reducing the OOD burden on the
    global Transolver slice-attention router.

    Memory: chunked cdist (chunk_size=512) avoids the O(N²) 16 GB matrix
    for N=65536. Cost: ~128 cdist calls per sample, each [512, N, 3].
    """

    def __init__(self, hidden_dim: int, num_heads: int, k: int = 16):
        super().__init__()
        self.k = k
        self.attn = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            batch_first=True,
            dropout=0.0,
        )
        # Zero-init output projection → identity at init, avoids early disruption
        nn.init.zeros_(self.attn.out_proj.weight)
        nn.init.zeros_(self.attn.out_proj.bias)
        self.norm = nn.LayerNorm(hidden_dim)

    def forward(self, x: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
        """
        Args:
            x:      [B, N, D]  volume token features
            coords: [B, N, 3]  volume token 3D coordinates
        Returns:
            x:      [B, N, D]  locally-attended features
        """
        B, N, D = x.shape
        k = min(self.k, N)

        # Build k-NN graph with chunked cdist to avoid O(N²) memory
        chunk_size = 512
        knn_indices = torch.zeros(B, N, k, dtype=torch.long, device=x.device)
        for start in range(0, N, chunk_size):
            end = min(start + chunk_size, N)
            # [B, chunk, N]
            dists = torch.cdist(coords[:, start:end], coords)
            # Exclude self: set diagonal to large value
            for i in range(start, end):
                dists[:, i - start, i] = float('inf')
            # [B, chunk, k]
            knn_indices[:, start:end] = dists.topk(k, dim=-1, largest=False).indices

        # Gather neighbour features: [B, N, k, D]
        batch_idx = torch.arange(B, device=x.device)[:, None, None].expand(B, N, k)
        x_neighbours = x[batch_idx, knn_indices]          # [B, N, k, D]

        # Run MHA: Q=self, K=V=neighbours
        # Reshape to [B*N, *, D] for batch MHA
        q = x.reshape(B * N, 1, D)
        kv = x_neighbours.reshape(B * N, k, D)
        attn_out, _ = self.attn(q, kv, kv, need_weights=False)  # [B*N, 1, D]
        attn_out = attn_out.reshape(B, N, D)

        # Residual + LayerNorm
        x = self.norm(x + attn_out)
        return x
```

**Integration point** — after the initial linear projection of vol features to `hidden_dim`, before the first Transolver layer:

```python
if self.use_vol_knn_preattn:
    self.vol_knn_preattn = VolumeKNNPreAttn(
        hidden_dim=hidden_dim,
        num_heads=num_heads,
        k=vol_knn_k,
    )
else:
    self.vol_knn_preattn = None

# In forward():
if self.vol_knn_preattn is not None:
    vol_hidden = self.vol_knn_preattn(vol_hidden, vol_coords)
# ... then proceed to Transolver layers as normal
```

## Training Command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-knn-preattn --vol-knn-k 16 \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group fern-vol-knn-local-slice-attention
```

## Current Baseline to Beat

**Single-model SOTA (PR #958):** val_abupt=**6.2868%**, test_abupt=**7.7445%** (W&B: `29nohj67`)
- val: surface_pressure=4.1766%, volume_pressure=3.9152%, wall_shear=7.0476%
- test: surface_pressure=3.9100%, **volume_pressure=12.0063%**, wall_shear=6.9848%

**Ensemble SOTA (PR #880):** val_abupt=**6.0289%**, test_abupt=**7.3693%**
- test: surface_pressure=3.6007%, **volume_pressure=11.3478%**, wall_shear=6.6939%

The primary target is reducing **test_vol_p** from 12.0% toward the AB-UPT target of 6.08%. The val_vol_p / test_vol_p gap (3.9% vs 12.0%) is the main signal — if this gap closes, we are on the right track.

## Expected Outcome

- If k-NN pre-attention helps with OOD: val_vol_p ≈ same, but test_vol_p should drop meaningfully (target: below 10%)
- If the hypothesis is correct, the pre-attention module produces tokens that are more geometry-agnostic, allowing the Transolver backbone to generalise to the 4 OOD test geometries

## References

- Veličković et al., "Graph Attention Networks," ICLR 2018
- Zhao et al., "Point Transformer," CVPR 2021
- Guo et al., "PCT: Point Cloud Transformer," Computational Visual Media 2021
