### PR TITLE
Vol token instance normalisation to close OOD val/test gap

### DIFF
--- a/model.py
+++ b/model.py
@@ -188,6 +188,106 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class VolumeInstanceNorm(nn.Module):
+    """Per-sample (instance) normalisation for volume tokens.
+
+    Computes mean/var across the N token dimension independently for each
+    sample in the batch and channel d. Removes batch/global statistics that
+    cause OOD vol_p errors on geometrically atypical test cases. Honours an
+    optional [B, N] token mask so padded positions don't bias the statistics.
+    Learnable affine (``gamma``, ``beta``) lets the model re-introduce any
+    bias/scale the placeholder used to provide.
+    """
+
+    def __init__(self, hidden_dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.gamma = nn.Parameter(torch.ones(hidden_dim))
+        self.beta = nn.Parameter(torch.zeros(hidden_dim))
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        # x: [B, N, D]; mask: [B, N] (optional, bool/0-1).
+        if mask is None:
+            mean = x.mean(dim=1, keepdim=True)
+            var = x.var(dim=1, keepdim=True, unbiased=False)
+        else:
+            mask_f = mask.to(dtype=x.dtype, device=x.device).unsqueeze(-1)
+            valid_count = mask_f.sum(dim=1, keepdim=True).clamp(min=1.0)
+            mean = (x * mask_f).sum(dim=1, keepdim=True) / valid_count
+            centered = (x - mean) * mask_f
+            var = centered.pow(2).sum(dim=1, keepdim=True) / valid_count
+        x_norm = (x - mean) * torch.rsqrt(var + self.eps)
+        out = x_norm * self.gamma + self.beta
+        if mask is not None:
+            out = out * mask.to(dtype=x.dtype, device=x.device).unsqueeze(-1)
+        return out
+
+
+class VolumeZCAWhiten(nn.Module):
+    """Per-sample ZCA whitening of volume tokens in a projected subspace.
+
+    Projects [B, N, D] tokens down to [B, N, d] (``whiten_dim``), whitens the
+    per-sample covariance, projects back to [B, N, D] and adds the result as
+    a residual. ``proj_up`` is zero-initialised so the layer is identity at
+    init (preserves baseline). Honours an optional [B, N] mask.
+    Eigendecomposition is forced to fp32 for numerical stability under bf16
+    autocast.
+    """
+
+    def __init__(self, hidden_dim: int, whiten_dim: int = 64, eps: float = 1e-4):
+        super().__init__()
+        self.whiten_dim = whiten_dim
+        self.eps = eps
+        self.proj_down = nn.Linear(hidden_dim, whiten_dim, bias=False)
+        self.proj_up = nn.Linear(whiten_dim, hidden_dim, bias=False)
+        nn.init.trunc_normal_(self.proj_down.weight, std=0.02)
+        nn.init.zeros_(self.proj_up.weight)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        # x: [B, N, D]; mask: [B, N] (optional).
+        z = self.proj_down(x)  # [B, N, d]
+        # Compute masked mean / per-sample centered tokens.
+        if mask is None:
+            mean = z.mean(dim=1, keepdim=True)
+            z_c = z - mean
+            denom = float(z.shape[1])
+        else:
+            mask_f = mask.to(dtype=z.dtype, device=z.device).unsqueeze(-1)
+            valid_count = mask_f.sum(dim=1, keepdim=True).clamp(min=1.0)
+            mean = (z * mask_f).sum(dim=1, keepdim=True) / valid_count
+            z_c = (z - mean) * mask_f
+            denom = valid_count.squeeze(-1)  # [B, 1]
+        # Force fp32 for the covariance / eigh path for numerical stability
+        # (torch.linalg.eigh has no bf16 kernel; bmm under autocast would
+        # also drop to bf16 otherwise). The ZCA matrix is detached from
+        # autograd: eigh backward is numerically unstable when eigenvalues
+        # are close (1/(λ_i-λ_j) terms blow up), which produces NaN grads
+        # at init (zero proj_up means upstream grad=0, but 0*∞=NaN). With
+        # zca.detach(), learning still flows back through z_c via the bmm
+        # — proj_down and the surrounding parameters update normally, only
+        # the eigendecomposition itself is treated as a fixed (per-batch)
+        # operator. This is the same trick used in Barlow Twins / DBN.
+        with torch.amp.autocast(device_type=x.device.type, enabled=False):
+            z_c_fp32 = z_c.float()
+            with torch.no_grad():
+                cov = torch.bmm(z_c_fp32.transpose(1, 2), z_c_fp32)
+                if isinstance(denom, torch.Tensor):
+                    cov = cov / denom.to(cov.dtype).unsqueeze(-1)
+                else:
+                    cov = cov / denom
+                eye = torch.eye(self.whiten_dim, device=cov.device, dtype=cov.dtype).unsqueeze(0)
+                cov = cov + self.eps * eye
+                eigvals, eigvecs = torch.linalg.eigh(cov)
+                inv_sqrt = eigvals.clamp(min=self.eps).rsqrt()  # [B, d]
+                zca = eigvecs @ torch.diag_embed(inv_sqrt) @ eigvecs.transpose(-1, -2)  # [B, d, d]
+            z_white = torch.bmm(z_c_fp32, zca.transpose(-1, -2))  # [B, N, d]
+        z_white = z_white.to(dtype=x.dtype)
+        delta = self.proj_up(z_white)  # [B, N, D]
+        if mask is not None:
+            delta = delta * mask.to(dtype=delta.dtype, device=delta.device).unsqueeze(-1)
+        return x + delta
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -343,6 +443,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_instance_norm: bool = False,
+        use_vol_zca_whiten: bool = False,
+        vol_zca_whiten_dim: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +459,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_instance_norm = use_vol_instance_norm
+        self.use_vol_zca_whiten = use_vol_zca_whiten
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -460,6 +565,24 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # PR #1013 Arm A: per-sample (instance) normalisation of volume tokens
+        # before the Transolver backbone. Targets the OOD test_vol_p gap
+        # (val=3.9%, test=12.0%) by adapting feature statistics to each shape
+        # at inference time. Identity at init (gamma=1, beta=0).
+        if use_vol_instance_norm:
+            self.vol_instance_norm = VolumeInstanceNorm(hidden_dim=n_hidden)
+        else:
+            self.vol_instance_norm = None
+        # PR #1013 Arm B: per-sample ZCA whitening of vol tokens projected
+        # into a low-dim subspace (whiten_dim=64), with a zero-init residual
+        # path (identity at init).
+        if use_vol_zca_whiten:
+            self.vol_zca_whiten = VolumeZCAWhiten(
+                hidden_dim=n_hidden, whiten_dim=vol_zca_whiten_dim
+            )
+        else:
+            self.vol_zca_whiten = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -522,16 +645,20 @@ class SurfaceTransolver(nn.Module):
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    volume_x,
-                    rff=self.volume_rff,
-                    string_sep=self.volume_string_sep,
-                    project_features=self.project_volume_features,
-                    bias=self.volume_bias,
-                    placeholder=self.volume_placeholder,
-                )
+            vol_initial = self._encode_group(
+                volume_x,
+                rff=self.volume_rff,
+                string_sep=self.volume_string_sep,
+                project_features=self.project_volume_features,
+                bias=self.volume_bias,
+                placeholder=self.volume_placeholder,
             )
+            # PR #1013: per-sample normalisation of vol tokens before backbone.
+            if self.vol_instance_norm is not None:
+                vol_initial = self.vol_instance_norm(vol_initial, mask=volume_mask)
+            if self.vol_zca_whiten is not None:
+                vol_initial = self.vol_zca_whiten(vol_initial, mask=volume_mask)
+            tokens.append(vol_initial)
             masks.append(volume_mask)
 
         attn_mask = torch.cat(masks, dim=1)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_instance_norm: bool = False
+    use_vol_zca_whiten: bool = False
+    vol_zca_whiten_dim: int = 64
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_instance_norm": (
+            "PR #1013 Arm A: per-sample (instance) normalisation of volume "
+            "tokens before the Transolver backbone. Normalises mean/var "
+            "across N tokens independently per (B, D) — eliminates "
+            "batch/global statistics that cause OOD vol_p errors on "
+            "geometrically atypical test cases. Learnable affine "
+            "(gamma=1, beta=0 at init) so identity at init."
+        ),
+        "use_vol_zca_whiten": (
+            "PR #1013 Arm B: per-sample ZCA whitening of volume tokens via "
+            "a projected subspace (whiten_dim, default 64). Computes per-"
+            "sample covariance in the projected space, applies the ZCA "
+            "transform via eigendecomposition, and adds a zero-init "
+            "residual back to the full hidden dim. More aggressive than "
+            "InstanceNorm (decorrelates as well as scales) but ~10x "
+            "compute overhead on the whitening path."
+        ),
+        "vol_zca_whiten_dim": (
+            "ZCA whitening subspace dim for --use-vol-zca-whiten. Default 64."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +317,32 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_vol_norm_metrics(model: nn.Module) -> dict[str, float]:
+    """Log gamma/beta / projection-norm statistics for the volume-token
+    normalisation modules (PR #1013). Tracks how far each affine drifts from
+    identity over training."""
+    metrics: dict[str, float] = {}
+    inst = getattr(model, "vol_instance_norm", None)
+    if inst is not None:
+        gamma = inst.gamma.detach().float()
+        beta = inst.beta.detach().float()
+        metrics["vol_instance_norm/gamma_mean"] = float(gamma.mean().item())
+        metrics["vol_instance_norm/gamma_std"] = float(gamma.std().item())
+        metrics["vol_instance_norm/gamma_min"] = float(gamma.min().item())
+        metrics["vol_instance_norm/gamma_max"] = float(gamma.max().item())
+        metrics["vol_instance_norm/beta_mean"] = float(beta.mean().item())
+        metrics["vol_instance_norm/beta_std"] = float(beta.std().item())
+        metrics["vol_instance_norm/beta_abs_max"] = float(beta.abs().max().item())
+    zca = getattr(model, "vol_zca_whiten", None)
+    if zca is not None:
+        proj_down = zca.proj_down.weight.detach().float()
+        proj_up = zca.proj_up.weight.detach().float()
+        metrics["vol_zca_whiten/proj_down_fro"] = float(proj_down.norm().item())
+        metrics["vol_zca_whiten/proj_up_fro"] = float(proj_up.norm().item())
+        metrics["vol_zca_whiten/proj_up_abs_max"] = float(proj_up.abs().max().item())
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +357,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_instance_norm=config.use_vol_instance_norm,
+        use_vol_zca_whiten=config.use_vol_zca_whiten,
+        vol_zca_whiten_dim=config.vol_zca_whiten_dim,
     )
 
 
@@ -1262,6 +1314,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_vol_norm_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

The test_vol_p OOD gap (val_vol_p≈3.9% vs test_vol_p≈12.0%) is driven by 4 geometrically atypical test cases whose **volume hidden-state distributions** differ substantially from training cases. Batch normalisation (or layer normalisation with batch-derived scale/shift) uses global statistics that are off-distribution for these shapes.

**Key idea:** Replace batch-level normalisation statistics for volume tokens with **per-sample (instance-level) statistics**, computed on-the-fly from each individual shape's volume token distribution. This eliminates the dependence on training-set global statistics and adapts to any geometry at inference time — without any gradient updates.

This is related to:
- **Instance Normalization** (Ulyanov et al. 2017) which eliminated batch-level style information and improved style transfer generalisation dramatically
- **Test-Time Normalisation** in domain adaptation literature (Nado et al. 2020, Schneider et al. 2020), where simply updating BN statistics at test time on OOD data recovers most of the performance gap
- **AdaIN** (Huang & Belongie 2017): adaptive instance normalisation transfers style by matching mean/variance of content features to style features

The hypothesis is that the 4 OOD geometries have systematically shifted volume-feature statistics. If we normalise each shape's volume tokens independently (instance norm), the backbone processes a feature distribution that is consistent across both training and test shapes — eliminating the statistical shift that is causing the high test_vol_p.

## Implementation

Two complementary mechanisms to test together:

### 1. Volume Token Instance Normalisation Layer

Add a new config flag:

```python
use_vol_instance_norm: bool = False
```

Add a module to normalise volume tokens per-sample before the Transolver backbone:

```python
class VolumeInstanceNorm(nn.Module):
    """Per-sample instance normalisation for volume tokens.
    
    Computes mean/std over the N token dimension independently for each
    sample in the batch. This eliminates batch-level distribution shift
    that causes OOD vol_p errors on geometrically atypical test cases.
    
    Applied after the initial feature projection, before Transolver layers.
    Uses learnable affine parameters (gamma/beta) so the model can undo
    the normalisation if it hurts training.
    """

    def __init__(self, hidden_dim: int, eps: float = 1e-5):
        super().__init__()
        self.eps = eps
        # Learnable affine — init to identity (gamma=1, beta=0)
        self.gamma = nn.Parameter(torch.ones(hidden_dim))
        self.beta = nn.Parameter(torch.zeros(hidden_dim))

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        """
        Args:
            x: [B, N, D]  volume token features
        Returns:
            x: [B, N, D]  per-sample normalised features
        """
        # Compute per-sample statistics over N tokens
        mean = x.mean(dim=1, keepdim=True)       # [B, 1, D]
        var  = x.var(dim=1, keepdim=True, unbiased=False)  # [B, 1, D]
        x_norm = (x - mean) / (var + self.eps).sqrt()      # [B, N, D]
        # Learnable affine rescaling
        return x_norm * self.gamma + self.beta
```

**Integration point** — after initial feature projection of vol tokens to hidden_dim, before first Transolver layer:

```python
# In __init__:
if self.use_vol_instance_norm:
    self.vol_instance_norm = VolumeInstanceNorm(hidden_dim=hidden_dim)
else:
    self.vol_instance_norm = None

# In forward():
if self.vol_instance_norm is not None:
    vol_hidden = self.vol_instance_norm(vol_hidden)
# ... then proceed to Transolver layers as normal
```

### 2. Vol-Token Feature Whitening (optional second arm)

As a second arm (same PR, report both), try **volume token ZCA whitening**: instead of just scaling by std, compute a per-sample covariance and decorrelate features. This is more aggressive than instance norm and may help more with OOD shifts.

New flag: `--use-vol-zca-whiten`

Since ZCA whitening of D=512-dim features requires computing a 512×512 covariance per sample, limit this to a projected lower-dimensional space (project to 64-dim, whiten, project back) to keep cost manageable:

```python
class VolumeZCAWhiten(nn.Module):
    def __init__(self, hidden_dim: int, whiten_dim: int = 64, eps: float = 1e-4):
        super().__init__()
        self.proj_down = nn.Linear(hidden_dim, whiten_dim, bias=False)
        self.proj_up   = nn.Linear(whiten_dim, hidden_dim, bias=False)
        nn.init.zeros_(self.proj_up.weight)  # zero-init residual path
        self.eps = eps

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: [B, N, D]
        z = self.proj_down(x)                          # [B, N, d]
        mean = z.mean(dim=1, keepdim=True)             # [B, 1, d]
        z_c = z - mean                                 # [B, N, d]
        # Per-sample covariance [B, d, d]
        cov = torch.bmm(z_c.transpose(1, 2), z_c) / z_c.shape[1]
        # Symmetric ZCA: C^{-1/2} via eigendecomposition
        eigvals, eigvecs = torch.linalg.eigh(cov + self.eps * torch.eye(
            cov.shape[-1], device=cov.device).unsqueeze(0))
        zca = eigvecs @ torch.diag_embed(eigvals.clamp(min=self.eps).rsqrt()) @ eigvecs.transpose(-1, -2)
        z_white = torch.bmm(z_c, zca.transpose(-1, -2))  # [B, N, d]
        return x + self.proj_up(z_white)                  # residual
```

If ZCA whitening is too slow (>15% training overhead), skip Arm B and report only Arm A.

## Training Commands

### Arm A — Instance Norm only (start this first)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-vol-instance-norm \
  --wandb-group thorfinn-vol-instance-norm-adaptation
```

### Arm B — ZCA Whitening (run in parallel if GPUs permit, else after Arm A)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-vol-zca-whiten \
  --wandb-group thorfinn-vol-instance-norm-adaptation
```

**Report results from whichever arm(s) complete.** If Arm B's ZCA whitening causes >15% wall-clock overhead per epoch compared to Arm A, skip it and note this in the results.

## Current Baseline to Beat

**Single-model SOTA (PR #958):** val_abupt=**6.2868%**, test_abupt=**7.7445%** (W&B: `29nohj67`)
- val: surface_pressure=4.1766%, volume_pressure=3.9152%, wall_shear=7.0476%
- test: surface_pressure=3.9100%, **volume_pressure=12.0063%**, wall_shear=6.9848%

**Ensemble SOTA (PR #880):** val_abupt=**6.0289%**, test_abupt=**7.3693%**
- test: surface_pressure=3.6007%, **volume_pressure=11.3478%**, wall_shear=6.6939%

## Expected Outcome

The key signal to watch is whether **test_vol_p** drops relative to the SOTA, and whether the val_vol_p/test_vol_p ratio shrinks (from its current 3.2× gap). A good result would be:
- test_vol_p below 10% (currently 12.0%)
- val_vol_p approximately maintained (≈3.9%)

If val_vol_p degrades significantly (e.g. rises above 5%), that's a sign the instance norm disrupts the learned feature structure too much — in that case, try reducing the strength with a learnable skip gate:

```python
# In VolumeInstanceNorm.forward:
# Add learnable gate to control strength
gate = torch.sigmoid(self.gate)  # init gate to 0 → sigmoid(0)=0.5
return gate * (x_norm * self.gamma + self.beta) + (1 - gate) * x
```

## References

- Ulyanov et al., "Instance Normalization: The Missing Ingredient for Fast Stylization," arXiv 2017
- Huang & Belongie, "Arbitrary Style Transfer in Real-time with Adaptive Instance Normalization," ICCV 2017
- Schneider et al., "Improving robustness against common corruptions by covariate shift adaptation," NeurIPS 2020
- Nado et al., "Evaluating Prediction-Time Batch Normalization for Robustness under Covariate Shift," arXiv 2020
