### PR TITLE
Physics-informed Poisson pressure regularisation

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,9 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    lambda_poisson: float = 0.0
+    poisson_k: int = 8
+    poisson_subsample_m: int = 2048
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -207,6 +210,37 @@ class GradNormWeights(nn.Module):
     @property
     def weights(self) -> torch.Tensor:
         return torch.exp(self.log_weights)
+
+
+def laplacian_smoothness_loss(
+    vol_preds: torch.Tensor,
+    vol_coords: torch.Tensor,
+    k: int = 8,
+    n_subsample: int = 2048,
+) -> torch.Tensor:
+    """Approximate ∇²p via k-NN finite differences over predicted volume pressure.
+
+    vol_preds:  (N, 1) predicted (normalized) pressure at *valid* volume points.
+    vol_coords: (N, 3) 3D coordinates of those same valid volume points.
+    Returns the mean squared discrete Laplacian: ``mean( (mean(NN) - self)^2 )``.
+
+    Implements the physics-motivated smoothness prior described in PR #1014.
+    Pairwise distance is computed in fp32 for stability under bf16 autocast.
+    """
+    N = vol_preds.shape[0]
+    if N <= k:
+        return vol_preds.new_zeros(())
+    M = min(n_subsample, N)
+    idx = torch.randperm(N, device=vol_preds.device)[:M]
+    coords_sub = vol_coords[idx].float()  # (M, 3)
+    preds_sub = vol_preds[idx]            # (M, 1)
+    diff = coords_sub.unsqueeze(1) - coords_sub.unsqueeze(0)  # (M, M, 3)
+    dist2 = (diff * diff).sum(-1)                              # (M, M)
+    dist2.fill_diagonal_(float("inf"))
+    _, nn_idx = dist2.topk(k, dim=1, largest=False)            # (M, k)
+    nn_preds = preds_sub[nn_idx]                               # (M, k, 1)
+    laplacian = nn_preds.mean(dim=1) - preds_sub               # (M, 1)
+    return (laplacian * laplacian).mean()
 
 
 def per_channel_masked_mse(
@@ -301,6 +335,9 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    lambda_poisson: float = 0.0,
+    poisson_k: int = 8,
+    poisson_subsample_m: int = 2048,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
@@ -337,12 +374,40 @@ def train_loss(
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+    poisson_loss_value = 0.0
+    poisson_n_samples = 0
+    if lambda_poisson > 0.0:
+        vol_preds_full = out["volume_preds"]  # [B, N, 1]
+        per_sample_losses: list[torch.Tensor] = []
+        for b in range(vol_preds_full.shape[0]):
+            mask_b = batch.volume_mask[b].bool()
+            n_valid = int(mask_b.sum().item())
+            if n_valid > poisson_k:
+                preds_b = vol_preds_full[b][mask_b]            # [N_valid, 1]
+                coords_b = batch.volume_x[b, :, :3][mask_b]    # [N_valid, 3]
+                per_sample_losses.append(
+                    laplacian_smoothness_loss(
+                        preds_b,
+                        coords_b,
+                        k=poisson_k,
+                        n_subsample=poisson_subsample_m,
+                    )
+                )
+        if per_sample_losses:
+            poisson_loss_tensor = torch.stack(per_sample_losses).mean()
+            loss = loss + lambda_poisson * poisson_loss_tensor
+            poisson_loss_value = float(poisson_loss_tensor.detach().cpu().item())
+            poisson_n_samples = len(per_sample_losses)
+
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "poisson_loss": poisson_loss_value,
+        "poisson_n_samples": float(poisson_n_samples),
     }, task_losses
 
 
@@ -583,6 +648,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    lambda_poisson=config.lambda_poisson,
+                    poisson_k=config.poisson_k,
+                    poisson_subsample_m=config.poisson_subsample_m,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -634,6 +702,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if config.lambda_poisson > 0.0:
+                        train_log["train/poisson_loss"] = batch_loss_metrics["poisson_loss"]
+                        train_log["train/poisson_loss_weighted"] = (
+                            config.lambda_poisson * batch_loss_metrics["poisson_loss"]
+                        )
+                        train_log["train/poisson_n_samples"] = batch_loss_metrics["poisson_n_samples"]
                 if config.use_y_symmetry_aug and aug_log:
                     bs = max(1, aug_log.get("batch_size", 0))
                     train_log["train/aug/y_symmetry_flip_rate"] = (


### PR DESCRIPTION
## Hypothesis

The persistent **+7–8 percentage-point val→test gap on volume pressure** (`val_primary/volume_pressure_rel_l2_pct` ≈ 3.8–4.0% vs test ≈ 10.7–11%) is a structural data distribution problem: the model learns to exploit distributional shortcuts in the training volume point cloud that don't generalise to OOD test geometries.

We hypothesise that adding an **explicit physics residual loss** — the incompressible Navier-Stokes pressure Poisson equation — as an auxiliary regulariser will force the volume pressure field to satisfy physical consistency constraints that are geometry-agnostic, thereby reducing the val→test gap without requiring any changes to data augmentation or architecture.

The pressure Poisson equation for incompressible flow is:
```
∇²p = -ρ (∂u_i/∂x_j)(∂u_j/∂x_i)
```
In practice, the velocity field is not available at volume query points, so we use a **simplified divergence-free residual** derived only from the predicted pressure field. The auxiliary loss penalises non-smooth pressure predictions that violate Laplacian regularity:

```
L_Poisson = mean( ||∇²p_pred||² )
```

where ∇²p_pred is approximated via finite differences over the k-nearest predicted volume pressure neighbours (k=8). This acts as a physics-motivated smoothness prior on the volume pressure field rather than a direct data-driven constraint, and should generalise better to unseen test geometries.

**Expected effect:** The physics regulariser should suppress spurious high-frequency pressure artefacts that overfit to training geometry distributions, improving test vol_p without degrading surf_p or wall_shear.

Reference: Physics-informed neural networks for pressure field reconstruction are well established (Raissi et al., JCP 2019; https://doi.org/10.1016/j.jcp.2018.10.045). The Laplacian smoothness proxy is a lightweight approximation that avoids needing the velocity field.

## Instructions

Implement a Poisson pressure regularisation auxiliary loss in `target/train.py`. This is the **only** change to make — do not modify learning rate, architecture, GradNorm weights, or any other hyperparameter.

### Step 1 — Implement the Laplacian approximation

In `target/train.py` (or the appropriate loss module), add a helper function to compute a discrete Laplacian of the predicted volume pressure field using k-nearest neighbours:

```python
def laplacian_smoothness_loss(vol_preds, vol_coords, k=8):
    """
    Approximate ∇²p via k-NN finite differences over the predicted volume
    pressure field. Returns mean squared Laplacian residual.
    
    vol_preds: (N, 1) predicted pressure values at volume points
    vol_coords: (N, 3) 3D coordinates of volume query points
    k: number of nearest neighbours for finite difference stencil
    """
    import torch
    # Compute pairwise distances (batched over the N points in the volume)
    # Use only a random subsample of M points for efficiency
    M = min(2048, vol_preds.shape[0])
    idx = torch.randperm(vol_preds.shape[0], device=vol_preds.device)[:M]
    coords_sub = vol_coords[idx]        # (M, 3)
    preds_sub = vol_preds[idx]          # (M, 1)
    
    # Pairwise squared distances
    diff = coords_sub.unsqueeze(1) - coords_sub.unsqueeze(0)  # (M, M, 3)
    dist2 = (diff ** 2).sum(-1)                                # (M, M)
    
    # k-NN (exclude self with large self-distance)
    dist2.fill_diagonal_(float('inf'))
    _, nn_idx = dist2.topk(k, dim=1, largest=False)            # (M, k)
    
    # Neighbour pressure values
    nn_preds = preds_sub[nn_idx]                               # (M, k, 1)
    
    # Discrete Laplacian: mean(neighbours) - self
    laplacian = nn_preds.mean(dim=1) - preds_sub               # (M, 1)
    
    return (laplacian ** 2).mean()
```

### Step 2 — Add to the training loss

In the training loop, after computing the main loss, add the auxiliary Poisson loss **weighted by λ=0.01** (small so it regularises without dominating):

```python
# vol_preds shape: (N_vol, 1) — predicted volume pressure for this sample
# vol_coords shape: (N_vol, 3) — volume query point coordinates
# Add this inside the per-sample or per-batch loss computation:

lambda_poisson = 0.01
if vol_preds is not None and vol_coords is not None and vol_preds.shape[0] > 8:
    poisson_loss = laplacian_smoothness_loss(vol_preds, vol_coords, k=8)
    total_loss = total_loss + lambda_poisson * poisson_loss
```

You will need to identify where `vol_preds` and `vol_coords` are available in the training loop and pass `vol_coords` through if it isn't already accessible at loss-computation time.

### Step 3 — Log the auxiliary loss

Log `poisson_loss` to W&B as `train/poisson_loss` so we can verify it is non-zero and decreasing:
```python
wandb.log({"train/poisson_loss": poisson_loss.item()}, step=global_step)
```

### Step 4 — Run configuration

Use **exactly** the production config:
```bash
cd target/
python train.py \
  --epochs 30 \
  --batch-size 1 \
  --train-volume-points 65536 \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --optimizer lion \
  --lr 1e-4 \
  --lr-scheduler cosine \
  --cosine-t-max 30 \
  --seed 42 \
  --wandb_group poisson-pressure-reg
```

DDP8 launch (8 GPUs):
```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 30 \
  --batch-size 1 \
  --train-volume-points 65536 \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --optimizer lion \
  --lr 1e-4 \
  --lr-scheduler cosine \
  --cosine-t-max 30 \
  --seed 42 \
  --wandb_group poisson-pressure-reg
```

### EP10 kill gate (≤7.2% abupt AND vol_p)

Post an interim update at EP10 (~step 109,750). **Kill and post terminal SENPAI-RESULT if:**
- `val_primary/abupt_axis_mean_rel_l2_pct` > 7.2%, OR
- `val_primary/volume_pressure_rel_l2_pct` > 8.0%

The key diagnostic is whether `val_primary/volume_pressure_rel_l2_pct` at EP10 is lower than the baseline (≈3.8–4.2% for a healthy run). If it is higher than baseline, the Poisson regulariser may be hurting the vol_p fit — kill and report.

### What to report

At EP10 gate and terminal, report:
1. `train/poisson_loss` trend (is it decreasing? what magnitude?)
2. All four val_primary metrics: abupt, vol_p, surf_p, wall_shear
3. Comparison vs baseline run `5x8wofzm`

## Baseline

Current wave SOTA (PR #740, run `5x8wofzm`):
| Metric | Test value |
|---|---|
| val_primary/abupt_axis_mean_rel_l2_pct | **7.5195%** |
| val_primary/volume_pressure_rel_l2_pct | **10.758%** |
| val_primary/surface_pressure_rel_l2_pct | **3.881%** |
| val_primary/wall_shear_rel_l2_pct | **7.061%** |

In-wave val leader (frieren PR #972, run `56bcqp3m`, EP~29):
- val_primary/abupt = 6.1913%

**Primary goal:** Reduce test vol_p below 10.758% without degrading surf_p (>3.881%) or wall_shear (>7.061%).

**Do NOT optimise for val vol_p alone** — this metric is unreliable due to the +7–8pp val→test gap. Focus on whether `train/poisson_loss` is converging and whether the test vol_p at terminal is lower than baseline.

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
Baseline run link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/5x8wofzm
