### PR TITLE
OOD-4 case vol-loss upweighting (run_133/226/203/158 × 3×)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)


### PR DESCRIPTION
## Hypothesis

The 4 geometrically OOD test cases — **run_133, run_226, run_203, run_158** — account for **92% of the squared test_vol_p deviation** (diagnostic from PR #717). When these cases are excluded, test_vol_p drops to ~3.9–4.2%, comparable to val_vol_p. This means the test_vol_p gap is almost entirely explained by model failure on these 4 geometrically extreme cases.

**Hypothesis**: Up-weighting the volume pressure loss for these 4 cases during training will force the model to allocate more gradient budget toward the cases where it currently fails worst, reducing the OOD vol_p gap without hurting the in-distribution performance.

This is a targeted, minimal-complexity intervention: no architecture change, no new module — just a per-case loss multiplier applied during training.

## Instructions

### Implementation

You need to add two new CLI flags to `target/train.py`:

1. `--ood-case-ids` — comma-separated list of run IDs to upweight (default: empty, i.e. no upweighting)
2. `--ood-vol-loss-weight` — float multiplier applied to the vol_p loss for the OOD cases (default: `1.0`)

**Step 1: Add the flags** (in the argparse section of `train.py`):
```python
parser.add_argument("--ood-case-ids", type=str, default="",
    help="Comma-separated run IDs to upweight in vol loss, e.g. 'run_133,run_226,run_203,run_158'")
parser.add_argument("--ood-vol-loss-weight", type=float, default=1.0,
    help="Loss multiplier for OOD case vol_p loss (applied when --ood-case-ids is set)")
```

**Step 2: Apply the per-case multiplier in the training loop**

In the trainer, after computing the per-sample or per-case vol_p loss (before reduction/mean), look up whether the current batch's case ID(s) are in the OOD list. If yes, multiply the vol_p loss contribution for those cases by `ood_vol_loss_weight`. Keep the surface loss and wall shear loss unchanged.

Implementation note: The batch will contain case IDs (run_XXX strings) alongside the point cloud data. If the dataloader includes a `case_id` field in each batch, use that. If not, you may need to add it. The per-case weighting should be applied before the loss reduction (mean/sum) so that gradient flow is correctly scaled.

### Training run

Run a **4-epoch screen** first. If the EP3 dual-gate is met (val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0%), continue to the full 13-epoch run.

**Screen run (EP3 gate check):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --ood-case-ids "run_133,run_226,run_203,run_158" \
  --ood-vol-loss-weight 3.0 \
  --wandb-group thorfinn-ood-upweighting
```

**EP3 dual-gate**: val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0%

**Full 13-epoch run** (if EP3 gate passes):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --ood-case-ids "run_133,run_226,run_203,run_158" \
  --ood-vol-loss-weight 3.0 \
  --wandb-group thorfinn-ood-upweighting
```

### What to watch
- **Primary**: `val_abupt` (single-model gate: < 6.2868%)
- **Key indicator**: `val_vol_p` and `test_vol_p` — does the OOD gap narrow?
- **Check per-case breakdowns if available**: run_133, run_226, run_203, run_158 individual errors
- If EP3 val_abupt > 8.0% OR val_vol_p > 5.0%: stop and report. The upweighting may be too aggressive or hurting other channels.

### Optional follow-up arm (if time permits after 13-epoch run)

If the 3× upweighting hurts val_abupt (in-distribution performance suffers), try a gentler 2× multiplier:
```
--ood-vol-loss-weight 2.0
```
Use `--wandb-group thorfinn-ood-upweighting` for all arms.

## Current Baseline

**Single-model SOTA** (PR #958, nezuko, Arm A, run `29nohj67`, EP13):
| Metric | Value |
|---|---|
| val_abupt | **6.2868%** |
| test_abupt | 7.7445% |
| val_surf_p | 4.1766% |
| val_vol_p | 3.9152% |
| val_wall_shear | 7.0476% |
| test_surf_p | 3.9100% |
| test_vol_p | 12.0063% ← OOD gap target |
| test_wall_shear | — |

**Single-model gate**: val_abupt < **6.2868%**

**Vol-pressure improvement ladder**:
- test_vol_p ≤ 11.0% → weak improvement
- test_vol_p ≤ 10.0% → solid improvement
- test_vol_p ≤ 8.5% → major improvement
- test_vol_p ≤ 6.08% → matches AB-UPT ensemble target

**Ensemble SOTA** (PR #880, K=6 greedy pool-32):
| Metric | Value |
|---|---|
| val_abupt | **6.0289%** |
| test_abupt | 7.3693% |

## Terminal result format

Please post your final result as:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
