### PR TITLE
thorfinn: per-case vol_pressure instance normalization (RevIN)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -38,6 +38,7 @@ from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
     TargetTransform,
+    apply_vol_p_instance_norm,
     autocast_context,
     build_lr_scheduler,
     check_kill_thresholds,
@@ -64,6 +65,7 @@ from trainer_runtime import (
     should_update_best_checkpoint,
     timeout_budget_minutes,
     unwrap_model,
+    vol_p_instance_stats,
 )
 
 
@@ -103,6 +105,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_pressure_instance_norm: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -138,6 +141,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    init_from_checkpoint: str = ""
     debug: bool = False
 
 
@@ -228,6 +232,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_vol_pressure_instance_norm": (
+            "RevIN-style per-case instance norm on volume_pressure targets "
+            "(Kim et al., ICLR 2022). After the global TargetTransform, each "
+            "sample's vol_p is re-normalized to zero-mean/unit-std over its "
+            "valid volume points; the model is supervised in this space. At "
+            "inference, per-sample mean/std are computed from ground-truth "
+            "vol_p (in global-normalized space) and used to invert the "
+            "prediction before metric computation. Targets case-level "
+            "absolute-pressure shift hypothesised to drive the test_vol_p "
+            "OOD gap."
+        ),
+        "init_from_checkpoint": (
+            "Optional path to a checkpoint.pt file. If set, model weights are "
+            "loaded via load_state_dict before training begins. Optimizer and "
+            "EMA state are NOT restored (intentional: optimizer/EMA cold-start "
+            "is acceptable for short-tail run-chaining). Use --lr-cosine-t-max "
+            "to control the LR schedule of the continuation run."
         ),
     }
     for field in fields(Config):
@@ -321,10 +343,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_vol_pressure_instance_norm: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_vol_pressure_instance_norm:
+        vol_p_mean, vol_p_std = vol_p_instance_stats(volume_target, batch.volume_mask)
+        volume_target = apply_vol_p_instance_norm(volume_target, vol_p_mean, vol_p_std)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -364,6 +390,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_vol_pressure_instance_norm: bool = False,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -376,6 +404,9 @@ def per_task_train_losses(
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_vol_pressure_instance_norm:
+        vol_p_mean, vol_p_std = vol_p_instance_stats(volume_target, batch.volume_mask)
+        volume_target = apply_vol_p_instance_norm(volume_target, vol_p_mean, vol_p_std)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -747,6 +778,26 @@ def main(argv: Iterable[str] | None = None) -> None:
         )
 
         model: nn.Module = build_model(config).to(device)
+        if config.init_from_checkpoint:
+            ckpt_path = Path(config.init_from_checkpoint)
+            if not ckpt_path.is_file():
+                raise FileNotFoundError(
+                    f"--init-from-checkpoint not found: {ckpt_path}"
+                )
+            ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
+            ckpt_state = ckpt["model"] if isinstance(ckpt, dict) and "model" in ckpt else ckpt
+            missing, unexpected = model.load_state_dict(ckpt_state, strict=False)
+            if state.is_main:
+                print(
+                    f"Loaded weights from {ckpt_path} "
+                    f"(missing={len(missing)}, unexpected={len(unexpected)})"
+                )
+                if missing:
+                    print(f"  missing keys (first 5): {list(missing)[:5]}")
+                if unexpected:
+                    print(f"  unexpected keys (first 5): {list(unexpected)[:5]}")
+                if isinstance(ckpt, dict) and "epoch" in ckpt:
+                    print(f"  source checkpoint epoch={ckpt['epoch']}")
         n_params = sum(param.numel() for param in model.parameters())
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
@@ -939,7 +990,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        use_vol_pressure_instance_norm=config.use_vol_pressure_instance_norm,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1086,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_vol_pressure_instance_norm=config.use_vol_pressure_instance_norm,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1233,6 +1290,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        use_vol_pressure_instance_norm=config.use_vol_pressure_instance_norm,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1247,6 +1305,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    use_vol_pressure_instance_norm=config.use_vol_pressure_instance_norm,
                 )
                 for name, loader in val_loaders.items()
             }

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -882,6 +882,49 @@ def squared_relative_l2_loss(
     return pred.sum() * 0.0
 
 
+def vol_p_instance_stats(
+    volume_target: torch.Tensor,
+    volume_mask: torch.Tensor,
+    eps: float = 1e-8,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-sample mean / std of the volume_pressure channel over valid points.
+
+    volume_target: [B, N, C_vol] in globally-normalized space; channel 0 is vol_p.
+    volume_mask:   [B, N] bool/float; only valid points participate.
+    Returns (vol_p_mean, vol_p_std), each shaped [B, 1] in volume_target's dtype.
+    """
+    vol_p = volume_target[..., 0]
+    mask = volume_mask.to(device=vol_p.device, dtype=vol_p.dtype)
+    n_valid = mask.sum(dim=-1, keepdim=True).clamp_min(1.0)
+    vol_p_mean = (vol_p * mask).sum(dim=-1, keepdim=True) / n_valid
+    diff = (vol_p - vol_p_mean) * mask
+    vol_p_var = (diff * diff).sum(dim=-1, keepdim=True) / n_valid
+    vol_p_std = (vol_p_var + eps).sqrt()
+    return vol_p_mean, vol_p_std
+
+
+def apply_vol_p_instance_norm(
+    volume_target: torch.Tensor,
+    vol_p_mean: torch.Tensor,
+    vol_p_std: torch.Tensor,
+) -> torch.Tensor:
+    """RevIN-normalise volume_pressure channel (channel 0) using provided per-sample stats."""
+    out = volume_target.clone()
+    out[..., 0] = (volume_target[..., 0] - vol_p_mean) / vol_p_std
+    return out
+
+
+def invert_vol_p_instance_norm(
+    volume_pred: torch.Tensor,
+    vol_p_mean: torch.Tensor,
+    vol_p_std: torch.Tensor,
+) -> torch.Tensor:
+    """Invert RevIN on the volume_pressure channel of a prediction tensor."""
+    out = volume_pred.clone()
+    out[..., 0] = volume_pred[..., 0] * vol_p_std + vol_p_mean
+    return out
+
+
 EVAL_KEYS = (
     "surface_pressure",
     "wall_shear",
@@ -955,6 +998,7 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    use_vol_pressure_instance_norm: bool = False,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -969,6 +1013,12 @@ def accumulate_eval_batch(
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
+    if use_vol_pressure_instance_norm:
+        # Model was trained to predict instance-normalised vol_p. Invert
+        # using per-sample stats computed from GT vol_p in globally-normalised
+        # space (standard RevIN test-time protocol).
+        vol_p_mean, vol_p_std = vol_p_instance_stats(volume_target_norm, batch.volume_mask)
+        volume_pred_norm = invert_vol_p_instance_norm(volume_pred_norm, vol_p_mean, vol_p_std)
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
     volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     accumulator.surface_loss_sse += surface_sse
@@ -1121,6 +1171,7 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    use_vol_pressure_instance_norm: bool = False,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1132,6 +1183,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            use_vol_pressure_instance_norm=use_vol_pressure_instance_norm,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1466,7 +1518,14 @@ def run_final_evaluation(
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_vol_pressure_instance_norm=getattr(config, "use_vol_pressure_instance_norm", False),
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1486,7 +1545,14 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_vol_pressure_instance_norm=getattr(config, "use_vol_pressure_instance_norm", False),
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

The ~3× OOD gap between val_vol_p (~3.9%) and test_vol_p (~12.0%) is driven by absolute pressure-level shift: the 4 OOD test cases (run_133, run_226, run_203, run_158) have different mean pressure magnitudes than the training distribution. A global `TargetTransform` normalizes across all training cases but cannot account for per-case distributional shift. **RevIN-style per-case instance normalization** of `volume_pressure` targets removes the global pressure offset as a confounding factor, forcing the model to learn geometry-driven *relative* pressure structure instead of absolute scale.

Inspired by: Kim et al., "Reversible Instance Normalization for Accurate Time-Series Forecasting against Distribution Shift" (NeurIPS 2022 / ICLR 2022).

**What we expect**: If the OOD test cases differ from val cases mainly in absolute pressure level, instance norm at training time + inversion at inference should produce better test_vol_p. Val metrics should be roughly preserved because the normalization is invertible.

## Background

- All prior architectural approaches to close the vol_p OOD gap have been NEGATIVE:
  - PR #958 (dedicated 3-layer MLP vol head): test_vol_p 12.0063% — MERGED (SOTA), but no OOD gap reduction
  - PR #823 (surf→vol xattn): NEGATIVE for OOD gap
  - PR #888 (nearest-neighbor proxy upweighting): test_vol_p 12.609% — NEGATIVE
  - PR #1016 (--ood-case-ids flag): no-op — stale option, closed
- The aux head from PR #958 is now **always-on** in model.py (not conditional). The `--use-vol-pressure-aux-head` flag in BASELINE.md is stale; do NOT add it.
- Options A (dataset-level upweighting) and B (case-ID upweighting) are exhausted. This is **Option D**: representation normalization.

## Current Baselines

| Metric | Single-model SOTA (PR #958, run `29nohj67`) | Ensemble SOTA (PR #880) |
|--------|---------------------------------------------|--------------------------|
| val_abupt | **6.2868%** | 6.0289% |
| test_abupt | 7.7445% | 7.3693% |
| val_surface_p | 4.1766% | 3.8550% |
| val_vol_p | 3.9152% | 3.5678% |
| val_wall_shear | 7.0476% | 6.8719% |
| test_surface_p | 3.9100% | 3.6007% |
| **test_vol_p** | **12.0063%** | **11.3478%** |
| test_wall_shear | 6.9848% | 6.6939% |

**Target to beat**: val_abupt < 6.2868% AND test_vol_p < 12.0063%.

## Implementation Instructions

You will implement RevIN-style per-case instance normalization for `volume_pressure` only. This requires changes in 3 places: `train.py` (Config + train_loss), and `dataset.py` (batch metadata).

### Step 1 — Add Config flag to `train.py`

In the `Config` dataclass, add:
```python
use_vol_pressure_instance_norm: bool = False
```

In the `ARG_HELP` dict, add:
```python
"use_vol_pressure_instance_norm": "RevIN-style per-case instance norm on volume_pressure targets. Normalizes each case's vol_p to zero-mean/unit-std at train time; inverts at inference using stored per-sample statistics.",
```

### Step 2 — Modify `train_loss` in `train.py`

The current `train_loss` applies `transform.apply_volume(batch.volume_y)` globally. When `use_vol_pressure_instance_norm=True`, we instead:
1. Apply the global transform to `volume_y` as usual (it handles surface_pressure, tau_x, tau_y, tau_z channels)
2. For the `volume_pressure` channel only (channel index 0 of volume_y after transform), compute per-sample mean/std and re-normalize

```python
def train_loss(model, batch, transform, device, amp_mode, *, surface_loss_weight, volume_loss_weight, surface_channel_weights, use_vol_pressure_instance_norm=False):
    batch = batch.to(device)
    surface_target = transform.apply_surface(batch.surface_y)
    volume_target = transform.apply_volume(batch.volume_y)

    if use_vol_pressure_instance_norm:
        # volume_target shape: [B, N_vol, C_vol] — vol_pressure is channel 0
        # Compute per-sample stats over valid volume points only
        vol_mask = batch.volume_mask  # [B, N_vol], bool or float
        vol_p = volume_target[..., 0]  # [B, N_vol]
        
        # Per-sample mean and std over valid points
        if vol_mask is not None:
            masked_vol_p = vol_p * vol_mask
            n_valid = vol_mask.sum(dim=-1, keepdim=True).clamp(min=1)  # [B, 1]
            vol_p_mean = masked_vol_p.sum(dim=-1, keepdim=True) / n_valid  # [B, 1]
            vol_p_var = ((vol_p - vol_p_mean) ** 2 * vol_mask).sum(dim=-1, keepdim=True) / n_valid
        else:
            vol_p_mean = vol_p.mean(dim=-1, keepdim=True)  # [B, 1]
            vol_p_var = vol_p.var(dim=-1, keepdim=True)
        
        vol_p_std = (vol_p_var + 1e-8).sqrt()  # [B, 1]
        
        # Instance-normalize vol_pressure channel in target
        volume_target = volume_target.clone()
        volume_target[..., 0] = (vol_p - vol_p_mean) / vol_p_std
        
        # Store stats on batch object for inference inversion
        batch._vol_p_mean = vol_p_mean  # [B, 1]
        batch._vol_p_std = vol_p_std    # [B, 1]
    
    # ... rest of train_loss unchanged ...
```

Also pass the flag through the train loop call site:
```python
loss = train_loss(model, batch, transform, device, amp_mode,
                  surface_loss_weight=config.surface_loss_weight,
                  volume_loss_weight=config.volume_loss_weight,
                  surface_channel_weights=surface_channel_weights,
                  use_vol_pressure_instance_norm=config.use_vol_pressure_instance_norm)
```

### Step 3 — Modify inference / validation

In the `evaluate` function (or wherever `model(batch)` is called to produce predictions), when `use_vol_pressure_instance_norm=True`:

1. At eval time, compute per-sample `vol_p_mean` and `vol_p_std` from the **ground truth** volume_y (after global transform). This is the same stats computation as Step 2.
2. After the model produces `out["volume_preds"]`, invert the normalization for channel 0:
   ```python
   if config.use_vol_pressure_instance_norm:
       # Re-scale vol_pressure prediction back to original space
       vol_p_pred = out["volume_preds"][..., 0]
       out["volume_preds"][..., 0] = vol_p_pred * vol_p_std + vol_p_mean
   ```
3. The metric computation then proceeds as normal against the un-normalized targets.

**Important**: At inference time on OOD test cases, the per-sample stats are computed from the ground truth (which IS available in the test set labels). The model sees the normalized target during training; at test time we normalize the same way using per-case stats from the test labels, run the model, then invert. This is the standard RevIN evaluation protocol.

### Step 4 — Run screening experiment first

Screen with 4-epoch fast vol-schedule to confirm viability before committing to full 13-epoch run.

**EP3 gates** (must pass both at epoch 3):
- val_abupt ≤ 8.0%
- val_vol_p ≤ 5.0%

**Screen command** (4 epochs, fast vol schedule):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-instance-norm \
  --volume-loss-weight 1.0 \
  --wandb-group thorfinn-vol-pressure-instance-norm
```

**If EP3 gates pass**, continue with full 13-epoch run:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-instance-norm \
  --volume-loss-weight 1.0 \
  --wandb-group thorfinn-vol-pressure-instance-norm
```

**Full run gate** (EP7): val_abupt ≤ 7.3% — if not met, kill and report results.

## Reporting

Report results in a PR comment using the terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_vol_p","value":<number>}}
```

Include a table with all per-channel val and test metrics. Also note whether test_vol_p improved relative to the 12.0063% baseline — this is the primary signal we are looking for.
