### PR TITLE
OOD-4 per-case vol loss upweighting (run_133/226/203/158 ×2–×3)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    ood_case_ids: str = ""
+    ood_vol_loss_scale: float = 1.0
     debug: bool = False
 
 
@@ -229,6 +231,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "ood_case_ids": (
+            "PR #1019: comma-separated train-split case IDs whose volumetric "
+            "loss is multiplied by --ood-vol-loss-scale. Empty string "
+            "disables per-case vol upweighting (baseline behaviour). Note: "
+            "these IDs must be present in the TRAIN split — IDs that resolve "
+            "to val/test cases are never sampled at train time and would be "
+            "silent no-ops. Example: "
+            "'run_184,run_249,run_310,run_416,run_44,run_484' (SDF-Mahalanobis "
+            "K=4 nearest-train-neighbours of the 4 OOD test cases run_133/158/"
+            "203/226)."
+        ),
+        "ood_vol_loss_scale": (
+            "PR #1019: per-case multiplier applied to vol_loss for cases "
+            "listed in --ood-case-ids. Default 1.0 is a no-op (matches "
+            "baseline). Surface loss is left untouched — only the volumetric "
+            "gradient is amplified, which is the genuinely-new angle versus "
+            "the NEGATIVE PR #888 (which scaled surface + volume combined)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +331,25 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def _masked_mse_per_sample(
+    pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Per-sample masked MSE for shape [B, N, C]. Returns shape [B].
+
+    Each sample's MSE is averaged over its valid (N × C) entries independently.
+    When all samples have the same valid-point count this matches the global
+    ``masked_mse`` after a ``.mean()`` so non-OOD batches stay identical to the
+    baseline path.
+    """
+
+    sq_err = (pred - target).square()
+    mask_dev = mask.to(device=sq_err.device, dtype=sq_err.dtype).unsqueeze(-1)
+    weighted = sq_err * mask_dev
+    sum_per_sample = weighted.sum(dim=(1, 2))
+    count_per_sample = mask_dev.expand_as(sq_err).sum(dim=(1, 2)).clamp_min(1.0)
+    return sum_per_sample / count_per_sample
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,10 +360,18 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    ood_case_id_set: frozenset[str] | None = None,
+    ood_vol_loss_scale: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    apply_ood_scaling = (
+        ood_case_id_set is not None
+        and len(ood_case_id_set) > 0
+        and not math.isclose(ood_vol_loss_scale, 1.0)
+    )
+    ood_cases_in_batch = 0
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -341,7 +388,20 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        if apply_ood_scaling:
+            vol_per_sample = _masked_mse_per_sample(
+                out["volume_preds"], volume_target, batch.volume_mask
+            )
+            ood_flags = torch.tensor(
+                [cid in ood_case_id_set for cid in batch.case_ids],
+                device=vol_per_sample.device,
+                dtype=vol_per_sample.dtype,
+            )
+            ood_cases_in_batch = int(ood_flags.sum().item())
+            per_sample_scale = 1.0 + (ood_vol_loss_scale - 1.0) * ood_flags
+            volume_loss = (vol_per_sample * per_sample_scale).mean()
+        else:
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -352,6 +412,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "ood_cases_in_batch": float(ood_cases_in_batch),
     }
 
 
@@ -758,6 +819,34 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        ood_case_id_set = frozenset(
+            cid.strip() for cid in config.ood_case_ids.split(",") if cid.strip()
+        )
+        if ood_case_id_set:
+            # PR #888 silently no-op'd by passing test-split IDs that the train
+            # DataLoader never samples; we hard-fail on every rank for real runs
+            # and warn in --debug mode (which subsets the train set to 4 cases).
+            train_case_ids = set(train_loader.dataset.case_ids)
+            missing_in_train = sorted(ood_case_id_set - train_case_ids)
+            if missing_in_train and not config.debug:
+                raise ValueError(
+                    "PR #1019: --ood-case-ids contains IDs not present in the "
+                    f"train split, which would be silent no-ops: {missing_in_train}. "
+                    "If you intended OOD test geometries, pass their nearest "
+                    "train-split SDF neighbours instead."
+                )
+            if state.is_main:
+                if missing_in_train:
+                    print(
+                        f"OOD per-case vol upweighting [DEBUG]: scale={config.ood_vol_loss_scale}, "
+                        f"{len(ood_case_id_set) - len(missing_in_train)}/{len(ood_case_id_set)} "
+                        f"target IDs hit the debug train subset; missing={missing_in_train}"
+                    )
+                else:
+                    print(
+                        f"OOD per-case vol upweighting: scale={config.ood_vol_loss_scale} "
+                        f"on {len(ood_case_id_set)} train case(s): {sorted(ood_case_id_set)}"
+                    )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1030,6 +1119,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        ood_case_id_set=ood_case_id_set,
+                        ood_vol_loss_scale=config.ood_vol_loss_scale,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1161,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if ood_case_id_set:
+                        train_log["train/ood_vol_loss_scale"] = config.ood_vol_loss_scale
+                        train_log["train/ood_cases_in_batch"] = batch_loss_metrics.get(
+                            "ood_cases_in_batch", 0.0
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis (CORRECTED 2026-05-12 — see pre-flight blocker comment + advisor sign-off)

The 4 OOD test cases (`run_133, run_226, run_203, run_158`) account for ~92% of the squared `test_vol_pressure` deviation, driving the ~3× val/test gap (val≈3.9% vs test≈12.0%). These IDs are in the **test split** and are never sampled at train time, so loss upweighting on those IDs directly would be a silent no-op (this is the bug from PR #888 that the pre-flight comment caught).

The corrected hypothesis: **upweight only the volumetric loss for the 6 nearest-train-neighbour cases of those 4 OOD geometries**, leaving the surface loss for those cases untouched. The 6 IDs are the union of K=4 Mahalanobis-nearest-neighbours over `(sdf_mean, sdf_std, sdf_min, sdf_max)`:

```
run_184, run_249, run_310, run_416, run_44, run_484
```

This is the same train-side proxy set used by PR #888 Option 1, but with a different intervention: PR #888 amplified the **total** per-sample loss at scale=3.0 (surface + volume combined) → NEGATIVE. This PR isolates **only `vol_loss_per_sample`**, so the gradient amplification flows exclusively to the dedicated vol_p auxiliary decoder head (PR #958 baseline) without distorting the surface prediction quality on those 6 cases. That vol-only scoping is the genuinely-new angle versus PR #888 and is the reason it is worth re-running on the PR #958 stack.

## Implementation (in `target/train.py` only)

1. **New CLI flags** on the `Config` dataclass:
   - `--ood-case-ids` (str, default `""`): comma-separated train-split case IDs.
   - `--ood-vol-loss-scale` (float, default `1.0`): per-case vol_loss multiplier.

2. **Hard fail on no-op**: at startup, if any `--ood-case-ids` entry is not present in the train split, raise `ValueError` on every rank rather than silently no-op'ing like PR #888 did. This catches future copy-paste bugs.

3. **Per-sample vol loss scaling in `train_loss`**:
   - New helper `_masked_mse_per_sample(pred, target, mask) -> [B]` returns per-sample MSE; equivalent to `masked_mse(...).mean()` when batch samples have equal valid-point counts (which holds for point-limited training).
   - When `--ood-case-ids` is non-empty AND `--ood-vol-loss-scale != 1.0`, the trainer computes `vol_per_sample` (shape `[B]`), builds an `ood_mask` from `batch.case_ids ∈ ood_set`, and forms `per_sample_scale = 1.0 + (ood_vol_loss_scale - 1.0) * ood_mask`, then `volume_loss = (vol_per_sample * per_sample_scale).mean()`. Surface loss is untouched.
   - When `--ood-case-ids` is empty (default), the original global `masked_mse` path is used so baseline runs reproduce identically.

4. **Telemetry**: `train/ood_vol_loss_scale` and `train/ood_cases_in_batch` are logged per step when the feature is on. Per-sample MSE math was sanity-checked against `masked_mse` (matches to 1e-6 on synthetic equal-mask batches).

## Arms (advisor-confirmed)

Drop scale=3.0 entirely — PR #888 already established it is harmful. Run **two arms** in parallel on the PR #958 baseline stack:

- **Arm A**: `--ood-vol-loss-scale 2.0` — moderate vol upweight.
- **Arm B**: `--ood-vol-loss-scale 1.5` — conservative; look for the inflection point.

Both arms use the same 6 SDF-neighbour train IDs and the standard fast vol-curriculum 4-epoch screen.

## Training Command

```bash
cd target/ && torchrun --standalone --nproc_per_node=4 train.py \
  --agent alphonse \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --volume-loss-weight 1.0 \
  --ood-case-ids "run_184,run_249,run_310,run_416,run_44,run_484" \
  --ood-vol-loss-scale <2.0 or 1.5> \
  --wandb-name "alphonse/ood-vol-only-scale-<2.0 or 1.5>" \
  --wandb-group alphonse-ood-vol-only-upweighting
```

Arms are split across the 8 H100s by setting `CUDA_VISIBLE_DEVICES=0,1,2,3` (Arm A) and `CUDA_VISIBLE_DEVICES=4,5,6,7` (Arm B), each running `torchrun --nproc_per_node=4`. `--use-vol-pressure-aux-head` from the original PR command is dropped because PR #958 made the deeper vol head unconditional.

## EP3 Kill Gate

Kill the run at the end of EP3 if **both** conditions are NOT met:
- `val_abupt ≤ 8.0%`
- `val_vol_p ≤ 5.0%`

If both gate conditions are met at EP3, continue to EP4.

## Baseline

Current best metrics (PR #958, run `29nohj67`):
| Metric | Value |
|--------|-------|
| val_abupt | 6.2868% |
| test_abupt | 7.7445% |
| test_vol_p | 12.0063% |
| test_surf_p | ~3.82% (AB-UPT ref) |

Prior best single-model (PR #823, run `ghh0s4ne`):
| Metric | Value |
|--------|-------|
| val_abupt | 6.4407% |
| test_vol_p | 11.6704% |

**Gate to beat**: `val_abupt < 6.2868%`

AB-UPT reference targets: surface_pressure=3.82%, wall_shear=7.29%, volume_pressure=6.08%

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Suggested Follow-ups

- If Arm A (scale=2.0) wins, sweep scale ∈ {1.75, 2.25} for a finer inflection-point read.
- If both arms regress vs baseline, the conclusion is "even surface-decoupled per-case vol upweighting on the SDF-neighbour proxy set doesn't help the OOD geometries" — at that point try **per-sample re-weighting based on online vol_loss magnitude** (data-driven focal-style) instead of a fixed train-time proxy set.
- If Arm A wins on val but loses on test_vol_p, suspect the 6 SDF-neighbour proxies are not actually surrogates for the 4 OOD test geometries; revisit the Mahalanobis embedding (maybe include curvature/bbox features) before any more train-time upweighting.
