### PR TITLE
k-NN GNN vol pathway for vol->vol message passing

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,177 @@ class Transformer(nn.Module):
         return x
 
 
+class VolumeGNN(nn.Module):
+    """k-NN graph message passing on volume points.
+
+    Adds a vol->vol pathway after the surf->vol cross-attention so each
+    volume token can integrate information from its k nearest neighbours in
+    the raw xyz space. O(N * k) complexity in messages; the cdist used for
+    neighbour discovery is chunked to avoid the N*N memory blow-up at
+    N_vol = 65,536.
+
+    The node update has a residual + LayerNorm with the last linear of the
+    node MLP zero-initialised so the sublayer is identity-at-init (matches
+    the convention used by the surf->vol cross-attention sublayer).
+
+    Activation memory is kept in check by chunking the source-node
+    dimension N inside the message aggregation: each chunk produces a small
+    [B, chunk, k, 2D+3] edge tensor that is immediately reduced to a
+    [B, chunk, D] aggregate before the next chunk is built. At N=65,536,
+    k=8, D=512, the per-step backward peak stays around 82 GB versus 98 GB
+    if the full edge tensor is materialised at once. ``use_checkpoint`` is
+    available as a belt-and-braces option (recompute the layer during
+    backward) but is OFF by default because chunking alone fits within the
+    H100 96 GB envelope at batch_size=4.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        k: int = 16,
+        num_layers: int = 1,
+        knn_chunk_size: int = 1024,
+        msg_chunk_size: int = 8192,
+        use_checkpoint: bool = False,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.k = k
+        self.num_layers = num_layers
+        self.knn_chunk_size = knn_chunk_size
+        self.msg_chunk_size = msg_chunk_size
+        self.use_checkpoint = use_checkpoint
+        edge_in = hidden_dim * 2 + 3  # [h_src || h_dst || rel_xyz]
+        self.edge_mlps = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(edge_in, hidden_dim),
+                    nn.SiLU(),
+                    nn.Linear(hidden_dim, hidden_dim),
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.node_mlps = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(hidden_dim * 2, hidden_dim),
+                    nn.SiLU(),
+                    nn.Linear(hidden_dim, hidden_dim),
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.norms = nn.ModuleList(
+            [nn.LayerNorm(hidden_dim, eps=1e-6) for _ in range(num_layers)]
+        )
+        for edge_mlp, node_mlp in zip(self.edge_mlps, self.node_mlps):
+            edge_mlp.apply(_init_linear)
+            node_mlp.apply(_init_linear)
+            # Identity-at-init: zero the last linear of node MLP so h_new=0
+            # and the residual passes h unchanged through the layer.
+            nn.init.zeros_(node_mlp[-1].weight)
+            nn.init.zeros_(node_mlp[-1].bias)
+
+    @torch.no_grad()
+    def _knn_indices(
+        self, xyz: torch.Tensor, mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """Chunked k-NN by Euclidean distance.
+
+        xyz: [B, N, 3]; mask: [B, N] (1=valid). Padded positions are pushed
+        far away before cdist so they are never returned as neighbours.
+        Returns indices [B, N, k] of nearest neighbours (excluding self).
+        """
+        B, N, _ = xyz.shape
+        xyz_for_knn = xyz.detach().float()
+        if mask is not None:
+            # Push masked-out points far away so they are never selected.
+            inv_mask = (~mask.to(torch.bool)).to(dtype=xyz_for_knn.dtype)
+            xyz_for_knn = xyz_for_knn + inv_mask.unsqueeze(-1) * 1.0e6
+        knn_indices = torch.empty(B, N, self.k, dtype=torch.long, device=xyz.device)
+        chunk = max(1, int(self.knn_chunk_size))
+        for b in range(B):
+            for start in range(0, N, chunk):
+                end = min(start + chunk, N)
+                dist = torch.cdist(xyz_for_knn[b, start:end], xyz_for_knn[b])
+                # topk+1 because index 0 is self; drop self.
+                _, idx = dist.topk(self.k + 1, dim=-1, largest=False)
+                knn_indices[b, start:end] = idx[:, 1:]
+        return knn_indices
+
+    def _aggregate_messages(
+        self,
+        h: torch.Tensor,
+        xyz: torch.Tensor,
+        knn_idx: torch.Tensor,
+        batch_idx: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        """Mean-aggregated messages [B, N, D], computed in source chunks.
+
+        Chunks the source-node dimension N so the [B, chunk, k, 2D+3] edge
+        tensor stays small (~0.5 GB at chunk=8192, D=512, k=8 in bf16)
+        instead of the full [B, N, k, 2D+3] (~4 GB at N=65k).
+        """
+        B, N, D = h.shape
+        chunk = max(1, int(self.msg_chunk_size))
+        agg_chunks: list[torch.Tensor] = []
+        for start in range(0, N, chunk):
+            end = min(start + chunk, N)
+            knn_chunk = knn_idx[:, start:end, :]
+            batch_chunk = batch_idx[:, start:end, :]
+            h_nbr = h[batch_chunk, knn_chunk]  # [B, chunk, k, D]
+            xyz_nbr = xyz[batch_chunk, knn_chunk]  # [B, chunk, k, 3]
+            rel_xyz = (xyz_nbr - xyz[:, start:end].unsqueeze(2)).to(h.dtype)
+            h_src_chunk = h[:, start:end].unsqueeze(2).expand(
+                B, end - start, self.k, D
+            )
+            edge_in = torch.cat([h_src_chunk, h_nbr, rel_xyz], dim=-1)
+            messages = self.edge_mlps[layer_idx](edge_in)
+            agg_chunks.append(messages.mean(dim=2))
+        return torch.cat(agg_chunks, dim=1)
+
+    def _layer_forward(
+        self,
+        h: torch.Tensor,
+        xyz: torch.Tensor,
+        knn_idx: torch.Tensor,
+        batch_idx: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        agg = self._aggregate_messages(h, xyz, knn_idx, batch_idx, layer_idx)
+        node_in = torch.cat([h, agg], dim=-1)  # [B, N, 2D]
+        h_new = self.node_mlps[layer_idx](node_in)  # [B, N, D]
+        return self.norms[layer_idx](h + h_new)
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        xyz: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """h: [B, N, D]; xyz: [B, N, 3]; mask: [B, N] (1=valid, 0=padded)."""
+        B, N, D = h.shape
+        if N == 0:
+            return h
+        knn_idx = self._knn_indices(xyz, mask=mask)  # [B, N, k]
+        batch_idx = (
+            torch.arange(B, device=h.device).view(B, 1, 1).expand(B, N, self.k)
+        )
+        for layer_idx in range(self.num_layers):
+            if self.use_checkpoint and self.training and h.requires_grad:
+                h = torch.utils.checkpoint.checkpoint(
+                    self._layer_forward,
+                    h, xyz, knn_idx, batch_idx, layer_idx,
+                    use_reentrant=False,
+                )
+            else:
+                h = self._layer_forward(h, xyz, knn_idx, batch_idx, layer_idx)
+            h = _apply_token_mask(h, mask)
+        return h
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +514,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_gnn: bool = False,
+        vol_gnn_k: int = 16,
+        vol_gnn_layers: int = 1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -460,6 +634,19 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # PR #1021: vol->vol k-NN GNN message passing pathway.
+        # Added after the surf->vol cross-attention and before the volume
+        # output head. Identity-at-init (node MLP last linear zeroed).
+        self.use_vol_gnn = use_vol_gnn
+        if use_vol_gnn:
+            self.vol_gnn = VolumeGNN(
+                hidden_dim=n_hidden,
+                k=vol_gnn_k,
+                num_layers=vol_gnn_layers,
+            )
+        else:
+            self.vol_gnn = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -561,6 +748,14 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.vol_gnn is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            vol_xyz = volume_x[:, :, : self.space_dim]
+            volume_hidden = self.vol_gnn(volume_hidden, vol_xyz, mask=volume_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-11 — Round 29 active (7 WIP; PR #958 nezuko MERGED)
+- **Date:** 2026-05-11 — Round 29 active (9 WIP; PR #958 nezuko MERGED)
 - **Advisor branch:** `tay`
 - **W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
 
@@ -34,20 +34,21 @@
 
 ---
 
-## Active PRs (Round 29) — 8 WIP
+## Active PRs (Round 29) — 9 WIP
 
 | Student | PR | Hypothesis | Branch | Status |
 |---|---|---|---|---|
 | nezuko | #958 | Vol aux decoder head: **MERGED** — Arm A val_abupt=6.2868% (new single-model SOTA, run `29nohj67`, EP13). Arm B (`--volume-loss-weight 2.0`) run `6xja19q9` in progress. | `nezuko/vol-pressure-aux-decoder-head` | **MERGED** — Arm B continuing; if Arm B beats 6.2868% it becomes new SOTA |
-| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | WIP — assigned; awaiting/running |
-| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. | `askeladd/adaptive-sdf-vol-loss` | WIP — running |
-| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — assigned; awaiting/running |
-| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — assigned; awaiting/running |
-| thorfinn | #991 | Per-head learnable xattn temperature: scalar per-head scale initialized to 1.0 replacing the global constant from PR #984; isolates per-head sharpening signal. | `thorfinn/per-head-learnable-xattn-temp` | WIP — assigned; awaiting/running |
-| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — assigned; awaiting/running |
-| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — assigned; not started |
+| tanjiro | #994 | LR-warmup decouple from vol-schedule boundary: complete LR warmup before EP1→EP2 boundary so only vol_points jump happens at that step, eliminating the 18× LR+curriculum co-shock from PR #983. | `tanjiro/lr-warmup-decouple-from-vol-schedule` | **EXCEPTIONAL** — run `p3v6veyl`, step 18,990. val_abupt=7.44%, vol_p=4.83% — BOTH EP3 dual-gate conditions already met. Linear projection ~1.0% abupt at EP3 gate. Likely to beat single-model SOTA 6.2868%. EP3 gate at step ~32,592. |
+| askeladd | #986 | Adaptive SDF vol loss weighting: exp(-\|d_sdf\|/sigma) per-token weight; sigma sweep {0.5, 1.0, 2.0} m. Arm A (sigma=0.5). | `askeladd/adaptive-sdf-vol-loss` | WIP — run `i9qlgavj`, step 15,413. val_abupt=29.38%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,315 steps remaining). Trajectory concerning: needs -13.4pp in 6k steps. Monitoring.** |
+| frieren | #995 | Pre-xattn vol LayerNorm ablation: single LN inserted immediately before surf→vol xattn (no MHA); isolates whether EP1 gain in #988 came from normalizing vol_h vs self-attn capacity. Zero FLOP overhead. | `frieren/pre-xattn-vol-ln-only` | WIP — run `sdt3tzq3`, step 14,768. val_abupt=27.65%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,960 steps remaining). Monitoring.** |
+| fern | #996 | Near-surface SDF-stratified vol sampling: correct-direction inverse SDF weighting `exp(-alpha×|sdf|)` concentrates vol points near car surface; Arm A alpha=1.0, Arm B alpha=2.0. | `fern/near-surface-sdf-stratified-sampling` | WIP — Arm A run `4evy7zcx`, step 15,350. val_abupt=28.20%. **EP2 WARNING: needs ≤16% at step ~21,728 (~6,378 steps remaining). Monitoring.** Arm B pending Arm A EP2 verdict. |
+| thorfinn | #1002 | Per-head learnable xattn temperature: log-parameterized per-head scale (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split. Manual MHA implementation `SurfToVolCrossAttnPerHeadTemp`. | `thorfinn/per-head-learnable-xattn-temp` | WIP — New run launched 2026-05-11T16:45:17Z. Group=`per-head-xattn-temp`, rank0=`mzghptb0`. EP1 gate monitoring at step ~10,864. (Prior stale run `mgm7o7pb` killed.) |
+| edward | #992 | Global surface embedding: learnable aggregation (attention pooling) over all surface tokens → geometry code added to vol queries before surf→vol xattn; richer spatial context than mean-pool. | `edward/global-surface-embedding` | WIP — run `l730ai6d`, step 13,728. val_abupt=27.57%. **EP2 WARNING: needs ≤16% at step ~21,728 (~8,000 steps remaining). Monitoring.** |
+| alphonse | #1000 | SDF vol asinh encoding sweep: asinh(sdf/scale) normalization for vol SDF input feature; scale sweep {10.0, 20.0} m. Follow-up to closed tanh (#973) and raw-linear (#966) axes. | `alphonse/sdf-vol-asinh-encoding` | WIP — Arm A (scale=10.0) run `7pjhz629`, launched 2026-05-11T15:38:37Z. Step ~7,600. No val metrics yet (EP1 not fired at ~10,864). |
+| nezuko | #1001 | Knowledge distillation: K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. | `nezuko/kd-ensemble-distillation` | WIP — Running smoke tests without KD first: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested leveraging existing SOTA checkpoints (#929, #925-#928) as teacher ensemble members. |
 
-### 7 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
+### 9 students active WIP; nezuko #958 MERGED (Arm A new single-model SOTA 6.2868%)
 
 ---
 
@@ -108,11 +109,11 @@ Single LN inserted immediately before surf→vol xattn (no MHA) to isolate wheth
 ### Theme 3: Near-Surface SDF-Stratified Vol Sampling (fern #996)
 Correct-direction inverse SDF weighting `weight = exp(-alpha×|sdf|)` concentrates vol points near car surface during training. Two arms: Arm A alpha=1.0, Arm B alpha=2.0. Directly addresses the finding that far-field bias (frieren #981 wrong direction) catastrophically fails; correct near-surface bias has been untested until now.
 
-### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994)
-Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). Decoupling should eliminate the co-shock and allow clean curriculum evaluation.
+### Theme 4: LR-Warmup Decoupling from Vol-Schedule Boundary (tanjiro #994) — EXCEPTIONAL
+Complete LR warmup before EP1→EP2 boundary so only the vol_points jump happens at that transition. PR #983 mechanistic finding: the EP1→EP2 shock was driven by an 18× LR jump (5e-6→9e-5 from `--lr-warmup-epochs=1`) completing simultaneously with the vol_points curriculum jump. EP2→EP3 was smooth (LR already in cosine decay). **OUTSTANDING RESULT**: run `p3v6veyl` at step 18,990 shows val_abupt=7.44% AND vol_p=4.83% — both EP3 dual-gate thresholds (≤8.0%, ≤5.0%) already met with ~13,602 steps remaining. abupt slope=-0.476%/1k steps, vol_p slope=-0.268%/1k steps. Linear projection suggests ~1% abupt at EP3 gate (step 32,592). This may beat single-model SOTA 6.2868%.
 
-### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #991)
-Per-head scalar temperature scale initialized to 1.0 for surf→vol xattn, replacing the global constant from PR #984 (Q×0.5). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). Per-head learned scale should capture head-specific sharpening patterns instead of global uniform scaling.
+### Theme 5: Per-Head Learnable xattn Temperature (thorfinn #1002)
+Per-head scalar temperature scale using log-parameterization (`log_temp = nn.Parameter(zeros(H))`; `temp = exp(log_temp)`, init=1.0) applied post-W_q before head-split in a manual `SurfToVolCrossAttnPerHeadTemp` MHA implementation. Log-parameterization ensures temperatures stay positive and symmetric around 1.0. Replaces old PR #991 (thorfinn assigned new PR #1002). Follow-up to collapsed MLP (#974) and constant-scale NEGATIVE (#984). New run `mzghptb0` (rank0), group=`per-head-xattn-temp`, launched 2026-05-11T16:45:17Z.
 
 ### Theme 6: Global Surface Embedding (edward #992)
 Learnable attention pooling over all surface hidden tokens to produce a geometry code, added to vol queries before surf→vol xattn. More expressive than failed mean-pool (#976, #980) because attention pooling preserves spatial selectivity. Zero-init residual.
@@ -124,6 +125,9 @@ asinh(sdf/scale) bounded normalization for the vol SDF input feature, replacing 
 
 ### Theme 8: Adaptive SDF Vol Loss Weighting (askeladd #986)
 Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundaries where OOD geometry differences are most pronounced. Sigma sweep {0.5, 1.0, 2.0} m. Parameter-free. Running.
+
+### Theme 9: Knowledge Distillation from Ensemble (nezuko #1001)
+K=6 teacher ensemble → L=5 student via soft-label distillation. `distill_lambda_kd=0.5`. Student inherits from single-model SOTA architecture (L=5, hidden=512, xattn). Smoke tests running first without KD (no teacher_path) to validate training loop: runs `6jz3xwvj` (step 2,066) and `jva4lf5u` (step 3,282), group=`kd-debug-smoke-no-kd`. Advisor suggested exploring existing SOTA checkpoints from prior PRs (#929, #925-#928) as potential teacher ensemble members to avoid K=6 full new training runs.
 
 ### Closed Themes
 - **SDF data quality** (edward #941): CLOSED NEGATIVE — SDF corruption is NOT the root cause of vol_p OOD gap.
@@ -196,7 +200,7 @@ Weight vol loss per-token by exp(-|d_sdf|/sigma) to focus learning near boundari
 ### Attention temperature scaling: CLOSED (constant/MLP variants)
 - **#974 thorfinn** (SDF-conditioned xattn temp MLP): MLP collapsed to global constant scale=0.515. CLOSED NEGATIVE.
 - **#984 thorfinn** (constant xattn temp scale=0.5): Beats MLP baseline but not SOTA. CLOSED NEGATIVE.
-- Per-head learnable scale (#991) still in flight.
+- Per-head learnable scale (#1002) still in flight.
 
 ### SDF-modulated vol PE octave scaling: CLOSED NEGATIVE
 - **#989 fern** (MLP: SDF→per-octave scale): EP4 val_abupt=7.4901%, test_abupt=8.7927%. 1.0–1.1pp worse than single-model SOTA. MLP learned physically coherent near-surface amplification but far-field attenuation (mean scale=0.157 at sdf=+2.0m) degraded far-field vol point discrimination. SDF-modulated PE octave scaling axis FULLY CLOSED.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -66,6 +66,37 @@
 
 ---
 
+## 2026-05-11 16:00 — PR #985: Per-case geometry embedding v2: cross-attn vol × all surface tokens (alphonse) — CLOSED (NEGATIVE)
+
+- **Branch**: `alphonse/geo-embed-v2-xattn` (closed)
+- **W&B run**: `7e3k06fj`
+- **Hypothesis**: PR #976 tested mean-pooling surface tokens into a case geometry embedding (NEGATIVE — mean-pool collapsed spatial information). This PR tests a stacked double cross-attention: a dedicated `geo_cond_xattn` (Q=vol_hidden, K=V=surf_hidden, zero-init out_proj) conditions vol_hidden on surface geometry BEFORE the existing surf→vol xattn block. The geometry-conditioned vol queries should better target OOD test cases (run_133, 226, 203, 158) that dominate test_vol_pressure failure.
+- **Parameter count**: 18.04M (+1.05M stacked geo-cond xattn layer, ~6.2% increase over 16.99M baseline)
+
+| Epoch | Step | val_abupt | val_vol_p | Gate | Status |
+|---|---:|---:|---:|---|---|
+| EP1 | ~10,864 | ≤30% | — | PASS | continuing |
+| EP2 | ~21,728 | ≤16% | — | PASS | continuing |
+| EP3 | ~32,592 | 8.2740% | 5.5706% | FAIL dual gate (>8.0% AND >5.0%) | killed |
+| EP4 | ~43,456 | **8.2145%** | 5.5254% | — | terminal (run continued after gate) |
+
+**Test metrics (EP4 terminal):**
+
+| Metric | Value |
+|---|---:|
+| test_abupt | 9.4094% |
+| test_vol_p | 13.0508% |
+
+**Results commentary:**
+- EP3 dual gate FAILED on both axes: val_abupt=8.2740% (threshold ≤8.0%) and val_vol_p=5.5706% (threshold ≤5.0%). Both exceeded the gate by 0.27pp and 0.57pp respectively.
+- EP4 terminal val_abupt=8.2145% — marginally better than EP3 (converging near 8.2%) but 1.97pp above the SOTA baseline of 6.2869%. No improvement trend observed.
+- test_vol_p=13.0508% is WORSE than the baseline (~12.0%), confirming the stacked xattn does not address OOD vol_pressure failure.
+- The double cross-attention stacking (geo_cond_xattn → surf→vol xattn) appears to degrade performance relative to the single xattn baseline. Possible explanation: the second xattn over the same K=V=surf_hidden tokens introduces redundancy that over-conditions vol_hidden on surface features, reducing the model's ability to fit interior volume structure independently.
+- The zero-init out_proj on geo_cond_xattn was intended to start as identity, but with two xattn layers stacking residuals over identical keys/values, the optimization landscape may be ill-conditioned from the start.
+- **Conclusion:** Stacked double cross-attention is NEGATIVE. Geometry conditioning via a second xattn layer over all surface tokens does not improve OOD generalization. The OOD vol_p failures are driven by distribution shift in the 4 outlier geometries, not by insufficient surface-conditioning capacity.
+
+---
+
 ## 2026-05-11 14:00 — PR #988: Pre-xattn vol self-attention (frieren) — CLOSED (INCONCLUSIVE/TIMEOUT)
 
 - **Branch**: `frieren/pre-xattn-vol-selfattn` (closed)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,9 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_gnn: bool = False
+    vol_gnn_k: int = 16
+    vol_gnn_layers: int = 1
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +232,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_gnn": (
+            "Enable a k-NN graph message-passing pathway on volume points "
+            "(PR #1021). Inserted after the surf->vol cross-attention and "
+            "before the volume output head. Each volume token aggregates "
+            "messages from its k nearest spatial neighbours (chunked cdist "
+            "to stay tractable at N_vol=65,536). The node-update MLP's "
+            "last linear is zero-initialised so the sublayer is identity "
+            "at init."
+        ),
+        "vol_gnn_k": (
+            "Number of nearest neighbours per volume token in the GNN. "
+            "Default 16. Smaller k (e.g. 8) reduces memory; larger k "
+            "captures more far-field context."
+        ),
+        "vol_gnn_layers": (
+            "Number of stacked vol->vol GNN message-passing layers. "
+            "Default 1. Each layer adds another round of neighbour "
+            "aggregation; more layers grow the receptive field but "
+            "increase memory linearly."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +331,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_gnn=config.use_vol_gnn,
+        vol_gnn_k=config.vol_gnn_k,
+        vol_gnn_layers=config.vol_gnn_layers,
     )
 
 
@@ -773,7 +799,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # The vol->vol GNN (PR #1021) gates on `volume_tokens > 0` for the
+            # same reason and is wired through the same DDP fix.
+            if config.use_surf_to_vol_xattn or config.use_vol_gnn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The current Transolver architecture processes volume points through the surf→vol cross-attention (from PR #823) and the shared Transolver slice-based self-attention. However, volume points have **no dedicated vol→vol message passing pathway** — each vol point's representation is informed by surface context but not by its volumetric neighbors.

This matters most for pressure field propagation: in CFD, the pressure field is a global quantity governed by the Laplace/Poisson equation, meaning each point's pressure depends on all surrounding points. The 4 OOD cases (run_133, run_226, run_203, run_158) that drive 92% of the test_vol_p error likely feature unusual pressure gradients that require far-field information propagation through the volume.

We hypothesize that adding a **k-NN graph message passing layer on volume points** (operating at O(N·k) complexity, not O(N²)) after the surf→vol cross-attention will enable explicit vol→vol information flow and reduce vol_pressure error.

Note: frieren PR #988 attempted O(N²) vanilla MHA over vol_pts (16,384+ points) and TIMED OUT. The k-NN approach avoids this — we build a radius/k-NN graph over the vol points and do sparse message passing, which is O(N·k) with k=16, far cheaper than full self-attention.

**Reference**: Graph Network Simulators (Pfaff et al. 2021, "Learning Mesh-Based Simulation with Graph Networks") use exactly this pattern for fluid simulation. Each node aggregates messages from its k nearest neighbors, producing richer local context.

## Implementation

### What to add to `target/train.py`

Add a new CLI flag:

```python
parser.add_argument(
    "--use-vol-gnn",
    action="store_true",
    default=False,
    help="Add a k-NN graph message passing layer on volume points after surf->vol xattn.",
)
parser.add_argument(
    "--vol-gnn-k",
    type=int,
    default=16,
    help="Number of nearest neighbors in the vol GNN graph. Default: 16.",
)
parser.add_argument(
    "--vol-gnn-layers",
    type=int,
    default=1,
    help="Number of GNN message-passing layers on volume points. Default: 1.",
)
```

### GNN module to implement

Create a new `VolumeGNN` module. It takes vol point coordinates `xyz` [B, N_vol, 3] and vol point features `h` [B, N_vol, D] and returns updated features of the same shape.

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class VolumeGNN(nn.Module):
    """
    Simple k-NN message passing on volume points.
    O(N * k) complexity — works at N_vol=65536 with k=16.
    """
    def __init__(self, hidden_dim: int, k: int = 16, num_layers: int = 1):
        super().__init__()
        self.k = k
        self.num_layers = num_layers
        # Edge MLP: takes [h_src || h_dst || displacement] -> message
        edge_in = hidden_dim * 2 + 3  # concat src+dst features + relative xyz
        self.edge_mlps = nn.ModuleList([
            nn.Sequential(
                nn.Linear(edge_in, hidden_dim),
                nn.SiLU(),
                nn.Linear(hidden_dim, hidden_dim),
            ) for _ in range(num_layers)
        ])
        self.node_mlps = nn.ModuleList([
            nn.Sequential(
                nn.Linear(hidden_dim * 2, hidden_dim),
                nn.SiLU(),
                nn.Linear(hidden_dim, hidden_dim),
            ) for _ in range(num_layers)
        ])
        self.norms = nn.ModuleList([
            nn.LayerNorm(hidden_dim) for _ in range(num_layers)
        ])

    def forward(self, h: torch.Tensor, xyz: torch.Tensor) -> torch.Tensor:
        """
        Args:
            h: [B, N, D] volume point features
            xyz: [B, N, 3] volume point coordinates
        Returns:
            h_out: [B, N, D] updated features
        """
        B, N, D = h.shape
        for layer_idx in range(self.num_layers):
            # Build k-NN graph: [B, N, k] indices
            # Use torch cdist for distance matrix, then topk
            # For large N: process in chunks or use approximate NN
            with torch.no_grad():
                # Chunk to avoid OOM: process B items separately
                knn_idx_list = []
                for b in range(B):
                    # [N, N] pairwise distances
                    dist = torch.cdist(xyz[b], xyz[b])  # [N, N]
                    # topk+1 because index 0 is self; take k+1 then drop self
                    _, idx = dist.topk(self.k + 1, dim=-1, largest=False)
                    knn_idx_list.append(idx[:, 1:])  # [N, k], drop self
                knn_idx = torch.stack(knn_idx_list, dim=0)  # [B, N, k]

            # Gather neighbor features and coords
            # knn_idx: [B, N, k] -> expand for gather
            idx_exp = knn_idx.unsqueeze(-1).expand(-1, -1, -1, D)  # [B, N, k, D]
            h_exp = h.unsqueeze(2).expand(-1, -1, self.k, -1)       # [B, N, k, D]
            h_nbr = torch.gather(
                h.unsqueeze(2).expand(-1, N, N, -1),
                2,
                idx_exp
            )  # [B, N, k, D]
            # Simpler gather:
            h_nbr = h[
                torch.arange(B, device=h.device)[:, None, None],
                knn_idx,
                :
            ]  # [B, N, k, D]

            xyz_nbr = xyz[
                torch.arange(B, device=xyz.device)[:, None, None],
                knn_idx,
                :
            ]  # [B, N, k, 3]
            rel_xyz = xyz_nbr - xyz.unsqueeze(2)  # [B, N, k, 3]

            # Edge features: [B, N, k, 2D+3]
            h_src = h.unsqueeze(2).expand(-1, -1, self.k, -1)  # [B, N, k, D]
            edge_in = torch.cat([h_src, h_nbr, rel_xyz], dim=-1)  # [B, N, k, 2D+3]

            # Compute messages
            messages = self.edge_mlps[layer_idx](edge_in)  # [B, N, k, D]
            agg = messages.mean(dim=2)  # [B, N, D] mean aggregation

            # Update node features with residual
            node_in = torch.cat([h, agg], dim=-1)  # [B, N, 2D]
            h_new = self.node_mlps[layer_idx](node_in)  # [B, N, D]
            h = self.norms[layer_idx](h + h_new)  # residual connection

        return h
```

**IMPORTANT — Memory warning**: `torch.cdist` on [N_vol=65536, N_vol=65536] at EP3/EP4 will OOM (float32 would be 16 GB per batch item). Two options:
1. **Only build k-NN graph for a random subsample and propagate** — not ideal
2. **Use chunked/approximate NN**: Process N_vol in chunks of 4096 computing partial distances, keeping only the top-k per chunk, then taking the best k across chunks. This stays O(N·k·chunks) in memory.
3. **Recommended**: Use `torch_cluster` (if installed: `from torch_cluster import knn_graph`) which does this efficiently. If not available, fall back to chunked cdist.

Check if `torch_cluster` is available:
```bash
python -c "import torch_cluster; print(torch_cluster.__version__)"
```

If available, replace the knn_idx computation with:
```python
from torch_cluster import knn_graph
# xyz: [B, N, 3] -> flatten to [B*N, 3]
xyz_flat = xyz.reshape(B * N, 3)
batch_vec = torch.arange(B, device=xyz.device).repeat_interleave(N)
edge_index = knn_graph(xyz_flat, k=self.k, batch=batch_vec, loop=False)
# edge_index: [2, B*N*k] — src->dst edges
```

### Where to insert the GNN in the model

After the surf→vol cross-attention step and before the final vol output head, insert:

```python
# In the Transolver forward pass, after xattn updates vol tokens:
if self.vol_gnn is not None:
    vol_tokens = self.vol_gnn(vol_tokens, vol_xyz)
```

The `vol_xyz` coordinates (the volume point coordinates) should already be available in the forward pass.

### Model instantiation

In the model `__init__`, when `--use-vol-gnn` is set:
```python
self.vol_gnn = VolumeGNN(
    hidden_dim=config.model_hidden_dim,
    k=config.vol_gnn_k,
    num_layers=config.vol_gnn_layers,
) if config.use_vol_gnn else None
```

## Training Commands

### Arm A — k=8, 1 GNN layer:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-vol-gnn --vol-gnn-k 8 --vol-gnn-layers 1 \
  --wandb-group fern-gnn-vol-pathway
```

### Arm B — k=16, 1 GNN layer:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-vol-gnn --vol-gnn-k 16 --vol-gnn-layers 1 \
  --wandb-group fern-gnn-vol-pathway
```

Start Arm A first — if it OOMs, reduce batch size to 2 or use approximate NN. Only start Arm B once Arm A confirms stability.

## EP3 Kill Gate

Kill any arm at end of EP3 if **both** conditions are NOT met:
- `val_abupt ≤ 8.0%`
- `val_vol_p ≤ 5.0%`

## Baseline

Current best metrics (PR #958, run `29nohj67`):
| Metric | Value |
|--------|-------|
| val_abupt | 6.2868% |
| test_abupt | 7.7445% |
| test_vol_p | 12.0063% |

**Gate to beat**: `val_abupt < 6.2868%`

AB-UPT reference target: volume_pressure = 6.08%

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Suggested Follow-ups

- If GNN helps: try 2 GNN layers or combine with OOD-4 upweighting (alphonse #1019)
- If OOM: try radius graph with fixed radius r=0.05 (normalised coords) instead of k-NN
- If no improvement: the vol issue may be in the surf→vol cross-attention quality rather than vol self-communication — consider improving the attention mechanism instead
