### PR TITLE
FNO vol decoder: spectral 3D grid correction for vol pressure

### DIFF
--- a/model.py
+++ b/model.py
@@ -172,6 +172,278 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+class SpectralConv3d(nn.Module):
+    """3D Fourier spectral convolution layer (Li et al. 2021, FNO).
+
+    Keeps the (2*modes1) x (2*modes2) x (modes3) lowest Fourier modes of the
+    real-valued input. The last spatial axis uses rfft, so only the positive
+    half (+modes3) needs to be parametrised; the other two axes need both the
+    positive (:modes) and negative (-modes:) corners. This follows the
+    canonical Zongyi Li implementation with 4 corner weight blocks.
+
+    FFT operations are performed in float32 to avoid bf16/fp16 precision
+    issues in torch.fft.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int,
+                 modes1: int, modes2: int, modes3: int):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.modes1 = modes1
+        self.modes2 = modes2
+        self.modes3 = modes3
+        scale = 1.0 / (in_channels * out_channels)
+        shape = (in_channels, out_channels, modes1, modes2, modes3)
+        self.weights1 = nn.Parameter(
+            scale * torch.randn(*shape, dtype=torch.cfloat)
+        )
+        self.weights2 = nn.Parameter(
+            scale * torch.randn(*shape, dtype=torch.cfloat)
+        )
+        self.weights3 = nn.Parameter(
+            scale * torch.randn(*shape, dtype=torch.cfloat)
+        )
+        self.weights4 = nn.Parameter(
+            scale * torch.randn(*shape, dtype=torch.cfloat)
+        )
+
+    @staticmethod
+    def _compl_mul3d(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+        return torch.einsum("bixyz,ioxyz->boxyz", x, w)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, _, H, W, D = x.shape
+        in_dtype = x.dtype
+        x_fp32 = x.float()
+        x_ft = torch.fft.rfftn(x_fp32, dim=[-3, -2, -1])
+        out_ft = torch.zeros(
+            B, self.out_channels, H, W, D // 2 + 1,
+            dtype=torch.cfloat, device=x.device,
+        )
+        m1, m2, m3 = self.modes1, self.modes2, self.modes3
+        out_ft[:, :, :m1, :m2, :m3] = self._compl_mul3d(
+            x_ft[:, :, :m1, :m2, :m3], self.weights1
+        )
+        out_ft[:, :, -m1:, :m2, :m3] = self._compl_mul3d(
+            x_ft[:, :, -m1:, :m2, :m3], self.weights2
+        )
+        out_ft[:, :, :m1, -m2:, :m3] = self._compl_mul3d(
+            x_ft[:, :, :m1, -m2:, :m3], self.weights3
+        )
+        out_ft[:, :, -m1:, -m2:, :m3] = self._compl_mul3d(
+            x_ft[:, :, -m1:, -m2:, :m3], self.weights4
+        )
+        x_out = torch.fft.irfftn(out_ft, s=(H, W, D), dim=[-3, -2, -1])
+        return x_out.to(dtype=in_dtype)
+
+
+def _normalize_to_unit_cube(
+    xyz: torch.Tensor, mask: torch.Tensor | None
+) -> torch.Tensor:
+    if mask is not None:
+        m = mask.to(dtype=torch.bool).unsqueeze(-1)
+        big = torch.full_like(xyz, float("inf"))
+        neg_big = torch.full_like(xyz, float("-inf"))
+        masked_for_min = torch.where(m, xyz, big)
+        masked_for_max = torch.where(m, xyz, neg_big)
+        mins = masked_for_min.min(dim=1, keepdim=True).values
+        maxs = masked_for_max.max(dim=1, keepdim=True).values
+    else:
+        mins = xyz.min(dim=1, keepdim=True).values
+        maxs = xyz.max(dim=1, keepdim=True).values
+    return 2.0 * (xyz - mins) / (maxs - mins + 1e-6) - 1.0
+
+
+class FNOVolDecoder(nn.Module):
+    """FNO-based vol pressure residual decoder.
+
+    Operates on a regular 3D grid interpolated from scattered volume tokens
+    via trilinear splat, applies `num_layers` FNO blocks, and queries the
+    grid back at the original point positions with trilinear interpolation.
+
+    The final projection is zero-initialised so the residual starts at zero
+    and the model trains from baseline behaviour, with the FNO learning an
+    additive correction.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        out_dim: int = 1,
+        grid_res: int = 32,
+        modes: int = 12,
+        fno_width: int = 32,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.out_dim = out_dim
+        self.grid_res = grid_res
+        self.modes = modes
+        self.fno_width = fno_width
+        self.num_layers = num_layers
+
+        self.lift = nn.Linear(hidden_dim, fno_width)
+        nn.init.trunc_normal_(self.lift.weight, std=0.02)
+        nn.init.zeros_(self.lift.bias)
+
+        self.spectral_convs = nn.ModuleList([
+            SpectralConv3d(fno_width, fno_width, modes, modes, modes)
+            for _ in range(num_layers)
+        ])
+        self.w_convs = nn.ModuleList([
+            nn.Conv3d(fno_width, fno_width, kernel_size=1)
+            for _ in range(num_layers)
+        ])
+        self.norms = nn.ModuleList([
+            nn.GroupNorm(num_groups=min(8, fno_width), num_channels=fno_width)
+            for _ in range(num_layers)
+        ])
+        for w in self.w_convs:
+            nn.init.trunc_normal_(w.weight, std=0.02)
+            nn.init.zeros_(w.bias)
+
+        self.proj_mid = nn.Linear(fno_width, fno_width)
+        self.proj_out = nn.Linear(fno_width, out_dim)
+        nn.init.trunc_normal_(self.proj_mid.weight, std=0.02)
+        nn.init.zeros_(self.proj_mid.bias)
+        # Zero-init proj_out so the residual starts at exactly zero. The
+        # baseline MLP head is preserved at step 0; the FNO learns from there.
+        nn.init.zeros_(self.proj_out.weight)
+        nn.init.zeros_(self.proj_out.bias)
+
+    def scatter_to_grid(
+        self,
+        h: torch.Tensor,
+        xyz_norm: torch.Tensor,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Trilinear-splat scattered point features to a regular 3D grid.
+
+        Args:
+            h: [B, N, C] point features (after lift).
+            xyz_norm: [B, N, 3] normalised coords in [-1, 1].
+            mask: [B, N] optional 0/1 mask (1 = valid point).
+
+        Returns:
+            grid: [B, C, R, R, R] normalised by accumulated trilinear weight
+                per voxel (empty voxels stay zero).
+        """
+        B, N, C = h.shape
+        R = self.grid_res
+        device, dtype = h.device, h.dtype
+
+        coords = (xyz_norm + 1.0) * 0.5 * (R - 1)
+        coords = coords.clamp(0.0, float(R - 1))
+        x0 = coords[..., 0].floor().long().clamp(0, R - 2)
+        y0 = coords[..., 1].floor().long().clamp(0, R - 2)
+        z0 = coords[..., 2].floor().long().clamp(0, R - 2)
+        x1, y1, z1 = x0 + 1, y0 + 1, z0 + 1
+
+        fx = coords[..., 0] - x0.to(coords.dtype)
+        fy = coords[..., 1] - y0.to(coords.dtype)
+        fz = coords[..., 2] - z0.to(coords.dtype)
+        one_minus = lambda t: 1.0 - t  # noqa: E731
+
+        w000 = one_minus(fx) * one_minus(fy) * one_minus(fz)
+        w001 = one_minus(fx) * one_minus(fy) * fz
+        w010 = one_minus(fx) * fy * one_minus(fz)
+        w011 = one_minus(fx) * fy * fz
+        w100 = fx * one_minus(fy) * one_minus(fz)
+        w101 = fx * one_minus(fy) * fz
+        w110 = fx * fy * one_minus(fz)
+        w111 = fx * fy * fz
+
+        if mask is not None:
+            m = mask.to(dtype=coords.dtype)
+            w000, w001, w010, w011 = w000 * m, w001 * m, w010 * m, w011 * m
+            w100, w101, w110, w111 = w100 * m, w101 * m, w110 * m, w111 * m
+
+        batch_idx = (
+            torch.arange(B, device=device).view(B, 1).expand(B, N)
+        )
+
+        def flat(xi: torch.Tensor, yi: torch.Tensor, zi: torch.Tensor) -> torch.Tensor:
+            return ((batch_idx * R + xi) * R + yi) * R + zi
+
+        grid_feat = torch.zeros(
+            B * R * R * R, C, device=device, dtype=dtype
+        )
+        grid_w = torch.zeros(B * R * R * R, device=device, dtype=dtype)
+
+        for xi, yi, zi, wi in (
+            (x0, y0, z0, w000),
+            (x0, y0, z1, w001),
+            (x0, y1, z0, w010),
+            (x0, y1, z1, w011),
+            (x1, y0, z0, w100),
+            (x1, y0, z1, w101),
+            (x1, y1, z0, w110),
+            (x1, y1, z1, w111),
+        ):
+            idx_flat = flat(xi, yi, zi).reshape(-1)
+            h_weighted = (h * wi.to(dtype=dtype).unsqueeze(-1)).reshape(-1, C)
+            grid_feat.index_add_(0, idx_flat, h_weighted)
+            grid_w.index_add_(0, idx_flat, wi.to(dtype=dtype).reshape(-1))
+
+        grid_feat = grid_feat / grid_w.unsqueeze(-1).clamp_min(1e-6)
+        return grid_feat.view(B, R, R, R, C).permute(0, 4, 1, 2, 3).contiguous()
+
+    def query_grid(
+        self, grid: torch.Tensor, xyz_norm: torch.Tensor
+    ) -> torch.Tensor:
+        """Trilinearly sample the regular 3D grid at point positions.
+
+        Args:
+            grid: [B, C, R, R, R].
+            xyz_norm: [B, N, 3] in [-1, 1].
+
+        Returns:
+            features: [B, N, C].
+        """
+        B, N, _ = xyz_norm.shape
+        # grid_sample expects input shape [B, C, D, H, W] and points as
+        # [B, D_out, H_out, W_out, 3] with last dim (x, y, z) where x maps
+        # to W axis, y to H, z to D. We treat axis order (x, y, z) on the
+        # grid the same way it was scattered: scatter used index ((b*R + x)*R + y)*R + z
+        # so axis 1 = x, axis 2 = y, axis 3 = z in [B, C, X, Y, Z]. grid_sample
+        # interprets coords as (x_W, y_H, z_D) -> samples grid[:, :, z, y, x].
+        # We need to permute coords from (x, y, z) to (z, y, x) before sampling.
+        coords = xyz_norm.flip(-1)  # (x, y, z) -> (z, y, x)
+        query = coords[:, :, None, None, :]  # [B, N, 1, 1, 3]
+        sampled = F.grid_sample(
+            grid.float(), query.float(),
+            mode="bilinear", padding_mode="border", align_corners=True,
+        )  # [B, C, N, 1, 1]
+        return sampled[:, :, :, 0, 0].permute(0, 2, 1).to(dtype=grid.dtype)
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        xyz: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Predict per-point vol-pressure residual.
+
+        Args:
+            h: [B, N, hidden_dim] volume token features.
+            xyz: [B, N, 3] raw volume point coords.
+            mask: [B, N] 0/1 mask.
+
+        Returns:
+            residual: [B, N, out_dim] additive correction.
+        """
+        xyz_norm = _normalize_to_unit_cube(xyz, mask)
+        h_lifted = self.lift(h)
+        grid = self.scatter_to_grid(h_lifted, xyz_norm, mask)
+        for sc, wc, n in zip(self.spectral_convs, self.w_convs, self.norms):
+            grid = F.gelu(n(sc(grid) + wc(grid)))
+        h_q = self.query_grid(grid, xyz_norm)
+        h_q = F.gelu(self.proj_mid(h_q))
+        return self.proj_out(h_q)
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -315,6 +587,11 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        use_fno_vol_decoder: bool = False,
+        fno_grid_resolution: int = 32,
+        fno_modes: int = 12,
+        fno_width: int = 32,
+        fno_num_layers: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -325,6 +602,11 @@ class SurfaceTransolver(nn.Module):
         self.pe_kind = pe_kind
         self.pe_num_features = pe_num_features
         self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        self.use_fno_vol_decoder = use_fno_vol_decoder
+        self.fno_grid_resolution = fno_grid_resolution
+        self.fno_modes = fno_modes
+        self.fno_width = fno_width
+        self.fno_num_layers = fno_num_layers
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -364,6 +646,18 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.fno_vol_decoder: FNOVolDecoder | None = (
+            FNOVolDecoder(
+                hidden_dim=n_hidden,
+                out_dim=self.volume_output_dim,
+                grid_res=fno_grid_resolution,
+                modes=fno_modes,
+                fno_width=fno_width,
+                num_layers=fno_num_layers,
+            )
+            if use_fno_vol_decoder
+            else None
+        )
 
     def _encode_group(
         self,
@@ -441,7 +735,15 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            volume_preds_mlp = self.volume_out(volume_hidden)
+            if self.fno_vol_decoder is not None:
+                volume_coords = volume_x[:, :, : self.space_dim]
+                fno_residual = self.fno_vol_decoder(
+                    volume_hidden, volume_coords, mask=volume_mask
+                )
+                volume_preds = (volume_preds_mlp + fno_residual) * volume_mask.unsqueeze(-1)
+            else:
+                volume_preds = volume_preds_mlp * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/model.py
+++ b/model.py
@@ -181,6 +181,11 @@ class SpectralConv3d(nn.Module):
     positive (:modes) and negative (-modes:) corners. This follows the
     canonical Zongyi Li implementation with 4 corner weight blocks.
 
+    Weights are stored as real float32 tensors with a trailing ``2`` dim
+    (real, imag) so optimizers that do not support complex parameters
+    (e.g. Lion's ``sign_()``) can still train them. ``torch.view_as_complex``
+    forms the complex view on each forward without copy.
+
     FFT operations are performed in float32 to avoid bf16/fp16 precision
     issues in torch.fft.
     """
@@ -194,22 +199,17 @@ class SpectralConv3d(nn.Module):
         self.modes2 = modes2
         self.modes3 = modes3
         scale = 1.0 / (in_channels * out_channels)
-        shape = (in_channels, out_channels, modes1, modes2, modes3)
-        self.weights1 = nn.Parameter(
-            scale * torch.randn(*shape, dtype=torch.cfloat)
-        )
-        self.weights2 = nn.Parameter(
-            scale * torch.randn(*shape, dtype=torch.cfloat)
-        )
-        self.weights3 = nn.Parameter(
-            scale * torch.randn(*shape, dtype=torch.cfloat)
-        )
-        self.weights4 = nn.Parameter(
-            scale * torch.randn(*shape, dtype=torch.cfloat)
-        )
+        real_shape = (in_channels, out_channels, modes1, modes2, modes3, 2)
+        self.weights1 = nn.Parameter(scale * torch.randn(*real_shape))
+        self.weights2 = nn.Parameter(scale * torch.randn(*real_shape))
+        self.weights3 = nn.Parameter(scale * torch.randn(*real_shape))
+        self.weights4 = nn.Parameter(scale * torch.randn(*real_shape))
 
     @staticmethod
-    def _compl_mul3d(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    def _compl_mul3d(x: torch.Tensor, w_real: torch.Tensor) -> torch.Tensor:
+        # x: [B, C_in, m1, m2, m3] complex
+        # w_real: [C_in, C_out, m1, m2, m3, 2] real
+        w = torch.view_as_complex(w_real)
         return torch.einsum("bixyz,ioxyz->boxyz", x, w)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/train.py
+++ b/train.py
@@ -132,6 +132,11 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_fno_vol_decoder: bool = False
+    fno_grid_resolution: int = 32
+    fno_modes: int = 12
+    fno_width: int = 32
+    fno_num_layers: int = 2
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -235,6 +240,11 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_fno_vol_decoder=config.use_fno_vol_decoder,
+        fno_grid_resolution=config.fno_grid_resolution,
+        fno_modes=config.fno_modes,
+        fno_width=config.fno_width,
+        fno_num_layers=config.fno_num_layers,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current vol pressure decoder is a standard MLP head applied pointwise to each volume token. This is spatially agnostic — it doesn't model frequency content of the pressure field across the volume. Volume pressure in CFD is governed by the Poisson equation (∇²p = f), whose solution has characteristic multi-scale frequency content: long-wavelength mean pressure gradients plus short-wavelength near-body perturbations.

We hypothesize that replacing the pointwise MLP vol decoder with a **Fourier Neural Operator (FNO)** on the volume point cloud will improve vol_pressure fidelity by explicitly modeling spectral components of the pressure field.

**Why FNO specifically:**
- FNO was designed for PDE solution operators (Li et al. 2021, "Fourier Neural Operator for Parametric Partial Differential Equations")
- Pressure fields are PDE solutions — the Poisson operator has a well-defined spectral structure
- The test_vol_p gap on the 4 OOD cases suggests the model fails on unusual pressure wave patterns that a spectral method would capture more naturally
- Previous vol approaches: pointwise MLP head (current), aux head (PR #958), mid-backbone xattn (#917 — NEGATIVE). None operate in frequency space

**The approach**: After the Transolver encodes vol tokens `h_vol` [B, N_vol, D], instead of `MLP(h_vol) -> vol_pressure`, we:
1. Project `h_vol` to a regular 3D grid via trilinear scattering (or Gaussian kernel splatting)
2. Apply 3D FNO spectral convolution layers on the grid (O(N·log N) via FFT)
3. Query the grid back at the original vol point positions via trilinear interpolation
4. Add the FNO output to the MLP output as a residual (so the base MLP still works as a fallback)

This follows the "GINO" (Geo-FNO / Grid-based Implicit Neural Operator) pattern from Li et al. 2023.

## Implementation

### New CLI flags for `train.py`

```python
parser.add_argument(
    "--use-fno-vol-decoder",
    action="store_true",
    default=False,
    help="Replace pointwise MLP vol decoder with FNO spectral decoder on vol pressure.",
)
parser.add_argument(
    "--fno-grid-resolution",
    type=int,
    default=32,
    help="Resolution of the 3D grid used by the FNO decoder on each spatial axis. Default: 32.",
)
parser.add_argument(
    "--fno-modes",
    type=int,
    default=12,
    help="Number of Fourier modes to keep per spatial axis in the FNO. Default: 12.",
)
parser.add_argument(
    "--fno-width",
    type=int,
    default=32,
    help="Channel width of the FNO decoder. Default: 32.",
)
```

### FNO Spectral Convolution Layer

Implement a 3D spectral convolution layer and FNO vol decoder module:

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class SpectralConv3d(nn.Module):
    """3D Fourier spectral convolution layer."""
    def __init__(self, in_channels, out_channels, modes1, modes2, modes3):
        super().__init__()
        self.in_channels = in_channels
        self.out_channels = out_channels
        self.modes1, self.modes2, self.modes3 = modes1, modes2, modes3
        scale = 1.0 / (in_channels * out_channels)
        self.weights = nn.Parameter(
            scale * torch.randn(in_channels, out_channels, modes1, modes2, modes3, dtype=torch.cfloat)
        )

    def compl_mul3d(self, x, w):
        # x: [B, C_in, modes1, modes2, modes3]
        # w: [C_in, C_out, modes1, modes2, modes3]
        return torch.einsum("bixyz,ioxyz->boxyz", x, w)

    def forward(self, x):
        # x: [B, C, H, W, D]
        B, C, H, W, D = x.shape
        x_ft = torch.fft.rfftn(x, dim=[-3, -2, -1])
        # Keep only the first `modes` Fourier modes
        out_ft = torch.zeros(B, self.out_channels, H, W, D // 2 + 1,
                             dtype=torch.cfloat, device=x.device)
        out_ft[:, :, :self.modes1, :self.modes2, :self.modes3] = \
            self.compl_mul3d(
                x_ft[:, :, :self.modes1, :self.modes2, :self.modes3],
                self.weights
            )
        x_out = torch.fft.irfftn(out_ft, s=(H, W, D), dim=[-3, -2, -1])
        return x_out


class FNOVolDecoder(nn.Module):
    """
    FNO-based vol pressure decoder.
    Operates on a regular 3D grid interpolated from scattered vol point features.
    """
    def __init__(self, hidden_dim: int, grid_res: int = 32,
                 modes: int = 12, fno_width: int = 32, num_layers: int = 2):
        super().__init__()
        self.grid_res = grid_res
        self.num_layers = num_layers
        # Lift from hidden_dim to fno_width
        self.lift = nn.Linear(hidden_dim, fno_width)
        # FNO layers
        self.spectral_convs = nn.ModuleList([
            SpectralConv3d(fno_width, fno_width, modes, modes, modes)
            for _ in range(num_layers)
        ])
        self.w_convs = nn.ModuleList([
            nn.Conv3d(fno_width, fno_width, kernel_size=1)
            for _ in range(num_layers)
        ])
        self.norms = nn.ModuleList([
            nn.InstanceNorm3d(fno_width, affine=True)
            for _ in range(num_layers)
        ])
        # Project back to scalar pressure
        self.proj = nn.Sequential(
            nn.Linear(fno_width, fno_width),
            nn.GELU(),
            nn.Linear(fno_width, 1),
        )

    def scatter_to_grid(self, h: torch.Tensor, xyz: torch.Tensor) -> torch.Tensor:
        """
        Scatter point features to a regular 3D grid via trilinear splat.
        Args:
            h: [B, N, C] point features
            xyz: [B, N, 3] normalized coordinates in [-1, 1]^3
        Returns:
            grid: [B, C, R, R, R] where R = grid_res
        """
        B, N, C = h.shape
        R = self.grid_res
        # Normalize xyz to [0, R-1] grid indices
        grid_coords = (xyz + 1.0) * 0.5 * (R - 1)  # [B, N, 3] in [0, R-1]
        grid_coords = grid_coords.clamp(0, R - 1)

        # Trilinear splat: for each point, scatter to 8 surrounding voxels
        # Use grid_coords floor/ceil for the 8 corners
        x0 = grid_coords[:, :, 0].long().clamp(0, R - 2)
        y0 = grid_coords[:, :, 1].long().clamp(0, R - 2)
        z0 = grid_coords[:, :, 2].long().clamp(0, R - 2)
        x1, y1, z1 = x0 + 1, y0 + 1, z0 + 1

        # Interpolation weights
        wx1 = grid_coords[:, :, 0] - x0.float()  # [B, N]
        wy1 = grid_coords[:, :, 1] - y0.float()
        wz1 = grid_coords[:, :, 2] - z0.float()
        wx0, wy0, wz0 = 1 - wx1, 1 - wy1, 1 - wz1

        grid = torch.zeros(B, C, R, R, R, device=h.device, dtype=h.dtype)
        weight_sum = torch.zeros(B, 1, R, R, R, device=h.device, dtype=h.dtype)

        def splat(ix, iy, iz, w):
            idx = (torch.arange(B, device=h.device)[:, None].expand_as(ix))
            flat_idx = ix * R * R + iy * R + iz  # [B, N]
            for b in range(B):
                grid[b].reshape(C, -1).scatter_add_(
                    1, flat_idx[b:b+1].expand(C, -1),
                    (h[b] * w[b:b+1].T).T.reshape(C, -1)
                )
                weight_sum[b, 0].reshape(-1).scatter_add_(
                    0, flat_idx[b], w[b]
                )

        splat(x0, y0, z0, wx0 * wy0 * wz0)
        splat(x0, y0, z1, wx0 * wy0 * wz1)
        splat(x0, y1, z0, wx0 * wy1 * wz0)
        splat(x0, y1, z1, wx0 * wy1 * wz1)
        splat(x1, y0, z0, wx1 * wy0 * wz0)
        splat(x1, y0, z1, wx1 * wy0 * wz1)
        splat(x1, y1, z0, wx1 * wy1 * wz0)
        splat(x1, y1, z1, wx1 * wy1 * wz1)

        # Normalize by weight sum to get mean (avoid division by zero)
        grid = grid / (weight_sum + 1e-6)
        return grid

    def query_grid(self, grid: torch.Tensor, xyz: torch.Tensor) -> torch.Tensor:
        """
        Query the 3D grid at point positions via trilinear interpolation.
        Args:
            grid: [B, C, R, R, R]
            xyz: [B, N, 3] coordinates in [-1, 1]^3
        Returns:
            features: [B, N, C]
        """
        # Use F.grid_sample — expects input in [-1, 1]
        # grid_sample expects [B, C, D, H, W] and points as [B, N, 1, 1, 3]
        B, N, _ = xyz.shape
        query = xyz[:, :, None, None, :]  # [B, N, 1, 1, 3]
        # grid_sample expects (x, y, z) order matching (W, H, D)
        sampled = F.grid_sample(
            grid, query,
            mode='bilinear', padding_mode='border', align_corners=True
        )  # [B, C, N, 1, 1]
        return sampled[:, :, :, 0, 0].permute(0, 2, 1)  # [B, N, C]

    def forward(self, h: torch.Tensor, xyz: torch.Tensor) -> torch.Tensor:
        """
        Args:
            h: [B, N, D] vol token features from Transolver
            xyz: [B, N, 3] vol point coords, normalized to [-1, 1]^3
        Returns:
            pressure: [B, N, 1] vol pressure predictions (residual additive)
        """
        # Lift to FNO width
        h_fno = self.lift(h)  # [B, N, fno_width]

        # Scatter to 3D grid
        grid = self.scatter_to_grid(h_fno, xyz)  # [B, fno_width, R, R, R]

        # Apply FNO layers
        for i in range(self.num_layers):
            grid1 = self.spectral_convs[i](grid)
            grid2 = self.w_convs[i](grid)
            grid = F.gelu(self.norms[i](grid1 + grid2))

        # Query back at point positions
        h_out = self.query_grid(grid, xyz)  # [B, N, fno_width]

        # Project to pressure
        pressure = self.proj(h_out)  # [B, N, 1]
        return pressure
```

### Integrate into the model

In the model, keep the existing MLP vol head and **add the FNO decoder as a residual correction**:

```python
# In model __init__:
self.fno_vol_decoder = FNOVolDecoder(
    hidden_dim=config.model_hidden_dim,
    grid_res=config.fno_grid_resolution,
    modes=config.fno_modes,
    fno_width=config.fno_width,
) if config.use_fno_vol_decoder else None

# In forward pass, after computing vol_pressure_mlp from existing head:
if self.fno_vol_decoder is not None:
    # xyz must be normalized to [-1, 1]^3 using the bounding box
    xyz_norm = normalize_to_unit_cube(vol_xyz)  # implement this
    fno_correction = self.fno_vol_decoder(vol_tokens, xyz_norm)  # [B, N, 1]
    vol_pressure = vol_pressure_mlp + fno_correction
else:
    vol_pressure = vol_pressure_mlp
```

You need to add a `normalize_to_unit_cube` helper that maps the vol_xyz coordinates to [-1, 1] using the per-batch bounding box:
```python
def normalize_to_unit_cube(xyz):
    # xyz: [B, N, 3]
    mins = xyz.min(dim=1, keepdim=True).values  # [B, 1, 3]
    maxs = xyz.max(dim=1, keepdim=True).values
    return 2.0 * (xyz - mins) / (maxs - mins + 1e-6) - 1.0
```

## Training Commands

### Arm A — grid=32, modes=12, fno_width=32:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-fno-vol-decoder --fno-grid-resolution 32 --fno-modes 12 --fno-width 32 \
  --wandb-group frieren-fno-vol-decoder
```

### Arm B — grid=48, modes=16, fno_width=64 (larger capacity):

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 4 --epochs 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-fno-vol-decoder --fno-grid-resolution 48 --fno-modes 16 --fno-width 64 \
  --wandb-group frieren-fno-vol-decoder
```

Run Arm A first. Monitor EP0 training loss to verify the FNO is learning (not outputting zero residuals). If Arm A is stable, start Arm B.

**Memory note**: The 3D grid at res=32 is 32³=32,768 voxels × fno_width=32 channels = ~4 MB per sample, which is negligible. The FFT of a 32³ grid is very fast. Arm B at res=48 is ~6× larger but still tractable.

## EP3 Kill Gate

Kill any arm at end of EP3 if **both** conditions are NOT met:
- `val_abupt ≤ 8.0%`
- `val_vol_p ≤ 5.0%`

## Baseline

Current best metrics (PR #958, run `29nohj67`):
| Metric | Value |
|--------|-------|
| val_abupt | 6.2868% |
| test_abupt | 7.7445% |
| test_vol_p | 12.0063% |

**Gate to beat**: `val_abupt < 6.2868%`

AB-UPT reference target: volume_pressure = 6.08%

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Suggested Follow-ups

- If FNO helps: try deeper FNO (num_layers=3) or increase modes to 24
- If FNO grid resolution matters: ablate 16 vs 32 vs 64
- Combine FNO decoder with OOD-4 upweighting (alphonse #1019) for the 4 hard geometries
- Consider replacing the splat/query with a learned projection (implicit neural function query)
