### PR TITLE
Slot-based vol attention: S=64 slot queries aggregate vol tokens (Perceiver-IO style)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,86 @@ class Transformer(nn.Module):
         return x
 
 
+class SlotVolAttn(nn.Module):
+    """Perceiver-IO-style slot bottleneck for vol tokens (PR #1024).
+
+    vol->slot: S slot queries aggregate from N vol tokens (Q=slots, K=V=vol_normed).
+    slot->vol: N vol queries broadcast from S slot summaries (Q=vol_normed, K=V=updated_slots).
+
+    Both cross-attention sublayers have zero-initialised ``out_proj`` weight and
+    bias, so the module is the identity at initialisation. The slot embeddings
+    are initialised with a small Gaussian (std=0.02) to break symmetry while
+    staying close to zero. The projection cost drops from O(N * d^2) (naive
+    full-N attention) to O(S * d^2 + N * d^2) on the projections, but the
+    attention compute itself drops from O(N^2 * d) to O(N * S * d), the
+    Perceiver-IO bottleneck win.
+
+    Padding handling mirrors ``surf_to_vol_xattn``: we do NOT pass a
+    ``key_padding_mask`` to MHA because doing so forces the slower attention
+    kernel path (no flash / mem-efficient SDPA). Padded vol positions enter the
+    backbone already token-masked to zero, so their V contribution to the slot
+    aggregation is the MHA value-projection bias only (small). The slot_to_vol
+    output is re-masked with ``vol_mask`` before the residual add so padded
+    vol positions stay exactly zero downstream.
+    """
+
+    def __init__(self, hidden_dim: int, num_slots: int = 64, num_heads: int = 4):
+        super().__init__()
+        self.num_slots = num_slots
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+
+        self.slot_embeds = nn.Parameter(torch.randn(num_slots, hidden_dim) * 0.02)
+
+        self.vol_to_slot_attn = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            batch_first=True,
+        )
+        self.slot_to_vol_attn = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            batch_first=True,
+        )
+
+        self.norm_slots = nn.LayerNorm(hidden_dim, eps=1e-6)
+        self.norm_vol = nn.LayerNorm(hidden_dim, eps=1e-6)
+
+        nn.init.zeros_(self.vol_to_slot_attn.out_proj.weight)
+        nn.init.zeros_(self.vol_to_slot_attn.out_proj.bias)
+        nn.init.zeros_(self.slot_to_vol_attn.out_proj.weight)
+        nn.init.zeros_(self.slot_to_vol_attn.out_proj.bias)
+
+    def forward(
+        self,
+        vol_hidden: torch.Tensor,
+        vol_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch_size = vol_hidden.shape[0]
+        slots = self.slot_embeds.unsqueeze(0).expand(batch_size, -1, -1)
+
+        slots_normed = self.norm_slots(slots)
+        vol_normed = self.norm_vol(vol_hidden)
+
+        updated_slots, _ = self.vol_to_slot_attn(
+            query=slots_normed,
+            key=vol_normed,
+            value=vol_normed,
+            need_weights=False,
+        )
+        updated_slots = slots + updated_slots
+
+        vol_out, _ = self.slot_to_vol_attn(
+            query=vol_normed,
+            key=updated_slots,
+            value=updated_slots,
+            need_weights=False,
+        )
+        vol_out = _apply_token_mask(vol_out, vol_mask)
+        vol_hidden = vol_hidden + vol_out
+        return _apply_token_mask(vol_hidden, vol_mask)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +423,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_slot_vol_attn: bool = False,
+        slot_vol_attn_num_slots: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +438,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_slot_vol_attn = use_slot_vol_attn
+        self.slot_vol_attn_num_slots = slot_vol_attn_num_slots
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -460,6 +544,18 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Slot-based vol attention (PR #1024): Perceiver-IO bottleneck inserted
+        # between backbone vol_hidden and surf->vol xattn. Both attention
+        # sublayers are zero-init in out_proj for identity-at-init.
+        if use_slot_vol_attn:
+            self.slot_vol_attn = SlotVolAttn(
+                hidden_dim=n_hidden,
+                num_slots=slot_vol_attn_num_slots,
+                num_heads=n_head,
+            )
+        else:
+            self.slot_vol_attn = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -544,6 +640,13 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.slot_vol_attn is not None
+            and volume_x is not None
+            and volume_tokens > 0
+        ):
+            volume_hidden = self.slot_vol_attn(volume_hidden, vol_mask=volume_mask)
 
         if (
             self.surf_to_vol_xattn is not None

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_slot_vol_attn: bool = False
+    slot_vol_attn_num_slots: int = 64
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_slot_vol_attn": (
+            "Enable slot-based vol attention (PR #1024). Inserts a "
+            "Perceiver-IO-style bottleneck between the backbone vol_hidden "
+            "and the surf->vol xattn: S=64 learnable slot queries aggregate "
+            "from the full N vol tokens (vol->slot), then N vol queries "
+            "broadcast back from the S slot summaries (slot->vol). Both "
+            "MultiheadAttention sublayers have zero-init out_proj so the "
+            "module is identity at init. Drops attention compute from "
+            "O(N^2 * d) to O(N * S * d). num_heads follows --model-heads, "
+            "embed_dim follows --model-hidden-dim."
+        ),
+        "slot_vol_attn_num_slots": (
+            "Number of slot queries for --use-slot-vol-attn (default 64). "
+            "Acts as a bottleneck width: smaller S compresses vol context "
+            "more aggressively; larger S preserves more detail at higher "
+            "cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +327,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_slot_vol_attn=config.use_slot_vol_attn,
+        slot_vol_attn_num_slots=config.slot_vol_attn_num_slots,
     )
 
 
@@ -773,7 +794,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # Slot-vol attention (PR #1024) has the same problem on
+            # volume_tokens > 0 (and is itself an identity-at-init module
+            # whose params can be unused across the loss path early on), so it
+            # also requires find_unused_parameters.
+            if config.use_surf_to_vol_xattn or config.use_slot_vol_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
# Slot-based Vol Attention: S=64 Slot Queries Aggregate Vol Tokens (Perceiver-IO Style)

## Hypothesis

The existing `--use-surf-to-vol-xattn` flag adds a surface→volume cross-attention that helps the model fuse aerodynamic surface signals into the volumetric field. However, the volume tokens (up to N=65,536) create O(N·d²) projection costs and potentially an O(N²) attention complexity bottleneck.

This experiment tests **slot-based vol attention** — a Perceiver-IO-style bottleneck that inserts S=64 learnable slot queries between the backbone vol_hidden computation and the existing surf→vol xattn. The key insight: rather than attending over all N=65,536 vol tokens directly, we:

1. **vol→slot** (aggregation): S=64 slot queries attend over the full vol_hidden (K=V=vol_hidden, Q=slots). This compresses N tokens down to S=64 representative summaries.
2. **slot→vol** (broadcast): vol_hidden queries attend over the updated slots (K=V=updated_slots, Q=vol_hidden). This broadcasts the summarized context back to all vol tokens.

Both steps use zero-initialized `out_proj` so the module is an identity at initialization, preserving the existing trained path. This reduces projection cost from O(N·d²) to O(S·d²) where S=64 << N=65,536 (~1000× cheaper per pass).

**Expected benefit**: Richer vol-field context before surf→vol xattn fires — potentially helping the OOD vol_p gap (val_vol_p≈3.9% but test_vol_p≈12%, ~3× ratio). The slot compression provides a global vol-field summary that surface tokens can then query into.

This hypothesis was explicitly flagged in the closure of PR #1009 as the "correct fix for the O(N²) problem" and the next direction to pursue.

---

## Current Baseline (Beat This)

**Single-model SOTA: PR #958 (nezuko), W&B run `29nohj67`**

| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | **6.2868%** | 7.7445% |
| surface_pressure | 4.1766% | 3.9100% |
| volume_pressure | 3.9152% | 12.0063% |
| wall_shear | 7.0476% | 6.9848% |

**Ensemble SOTA: PR #880 (nezuko), W&B run `zst3y2mp`**
- val_abupt = 6.0289%, test_abupt = 7.3693%

**Target to beat: val_abupt < 6.2868%**

---

## Implementation Instructions

### Step 1: Add `SlotVolAttn` module to `target/model.py` (or the appropriate model file)

Add this module near the other cross-attention blocks:

```python
class SlotVolAttn(nn.Module):
    """Perceiver-IO-style slot bottleneck for vol tokens.

    vol->slot: S slot queries aggregate from N vol tokens (Q=slots, K=V=vol_hidden)
    slot->vol: N vol queries broadcast from S slot summaries (Q=vol_hidden, K=V=updated_slots)

    Both cross-attention blocks have zero-initialized out_proj for identity-at-init.
    """

    def __init__(self, hidden_dim: int, num_slots: int = 64, num_heads: int = 4):
        super().__init__()
        self.num_slots = num_slots
        self.hidden_dim = hidden_dim
        self.num_heads = num_heads

        # Learnable slot embeddings
        self.slot_embeds = nn.Parameter(torch.randn(num_slots, hidden_dim) * 0.02)

        # vol->slot cross-attention
        self.vol_to_slot_attn = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            batch_first=True,
        )
        # slot->vol cross-attention
        self.slot_to_vol_attn = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            batch_first=True,
        )

        # LayerNorm for stability
        self.norm_slots = nn.LayerNorm(hidden_dim)
        self.norm_vol = nn.LayerNorm(hidden_dim)

        # Zero-init out_proj for identity-at-initialization
        nn.init.zeros_(self.vol_to_slot_attn.out_proj.weight)
        nn.init.zeros_(self.vol_to_slot_attn.out_proj.bias)
        nn.init.zeros_(self.slot_to_vol_attn.out_proj.weight)
        nn.init.zeros_(self.slot_to_vol_attn.out_proj.bias)

    def forward(self, vol_hidden: torch.Tensor) -> torch.Tensor:
        """
        Args:
            vol_hidden: (B, N, D) vol token representations
        Returns:
            vol_hidden: (B, N, D) updated vol token representations
        """
        B = vol_hidden.shape[0]

        # Expand slot embeddings to batch
        slots = self.slot_embeds.unsqueeze(0).expand(B, -1, -1)  # (B, S, D)

        # vol -> slot: Q=slots, K=V=vol_hidden
        slots_normed = self.norm_slots(slots)
        vol_normed = self.norm_vol(vol_hidden)
        updated_slots, _ = self.vol_to_slot_attn(
            query=slots_normed,
            key=vol_normed,
            value=vol_normed,
        )
        updated_slots = slots + updated_slots  # residual

        # slot -> vol: Q=vol_hidden, K=V=updated_slots
        vol_out, _ = self.slot_to_vol_attn(
            query=vol_normed,
            key=updated_slots,
            value=updated_slots,
        )
        vol_hidden = vol_hidden + vol_out  # residual

        return vol_hidden
```

### Step 2: Add CLI flag to `target/train.py`

Add to the argument parser:

```python
parser.add_argument("--use-slot-vol-attn", action="store_true", default=False,
                    help="Insert Perceiver-IO slot-based vol attention before surf->vol xattn")
parser.add_argument("--slot-vol-attn-num-slots", type=int, default=64,
                    help="Number of slot queries for slot-based vol attention (default: 64)")
```

### Step 3: Instantiate and insert in model

In the model construction (wherever the SurfaceTransolver is built), instantiate the module:

```python
if args.use_slot_vol_attn:
    model.slot_vol_attn = SlotVolAttn(
        hidden_dim=args.model_hidden_dim,
        num_slots=args.slot_vol_attn_num_slots,
        num_heads=args.model_heads,
    )
```

In the model's `forward` method, insert the call **after** vol_hidden is computed by the backbone and **before** the existing surf→vol xattn:

```python
# After backbone vol_hidden computation
if self.use_slot_vol_attn:
    vol_hidden = self.slot_vol_attn(vol_hidden)

# Existing surf->vol xattn fires here
if self.use_surf_to_vol_xattn:
    vol_hidden = self.surf_to_vol_xattn(surf_hidden, vol_hidden)
```

### Step 4: DDP compatibility

Ensure `find_unused_parameters=True` is set in the DDP wrapper:

```python
model = torch.nn.parallel.DistributedDataParallel(
    model,
    device_ids=[local_rank],
    find_unused_parameters=True,  # required when slot attn may be gated off
)
```

This is already required by previous conditional modules. If it's already set, no change needed.

---

## Experiment Schedule

### Phase 1: 4-epoch screen (required)

Run a 4-epoch viability screen using the progressive vol schedule. This must complete within ~40 minutes.

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --epochs 4 --lr-cosine-t-max 4 \
  --vol-points-schedule "0:16384:1:32768:2:49152:3:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-slot-vol-attn --slot-vol-attn-num-slots 64 \
  --wandb-group askeladd-slot-vol-attn
```

**EP4 screen gates (from BASELINE.md EP4 reference):**
- val_abupt ≤ 8.5% (rough screen threshold at EP4)
- val_vol_p should be trending down; no divergence

If the screen passes, proceed to full 13-epoch training.

### Phase 2: Full 13-epoch run (if EP4 screen passes)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent askeladd \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --epochs 13 --lr-cosine-t-max 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-slot-vol-attn --slot-vol-attn-num-slots 64 \
  --wandb-group askeladd-slot-vol-attn
```

---

## Success Criteria

| Metric | Target |
|--------|--------|
| val_abupt | < 6.2868% (beat PR #958) |
| val_vol_p | ≤ 3.9152% (no regression on vol_p val) |
| test_vol_p | Monitor — any reduction from 12.0063% is valuable |

**Bonus**: If test_vol_p improves significantly (e.g., drops below 10%), that would indicate the slot mechanism is helping with OOD vol generalization.

---

## Notes

- `--no-compile-model` is **required**: torch.compile + DDP NCCL deadlock at step 1.
- `find_unused_parameters=True` in DDP is **required** when using zero-init conditional modules.
- The zero-initialized `out_proj` ensures the module starts as an identity — training begins exactly at the pre-trained baseline state.
- The slot queries (`self.slot_embeds`) are initialized with small Gaussian noise (std=0.02) to break symmetry while staying near zero.
- S=64 is the primary slot count to test. The slot count is a hyperparameter — if this screen passes, a follow-up could try S=32 or S=128 to find the optimal bottleneck size.
- Please report EP4 screen metrics in a PR comment before proceeding to Phase 2.

---

## Structured Result Template

When complete, post a comment with the following marker (fill in actual values):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
