### PR TITLE
tanjiro: step-warmup-8000 vs SOTA epoch-warmup (13ep full budget)

### DIFF
--- a/train.py
+++ b/train.py
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    init_from_checkpoint: str = ""
     debug: bool = False
 
 
@@ -237,6 +238,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "init_from_checkpoint": (
+            "Optional path to a checkpoint .pt file. When set, loads "
+            "``ckpt['model']`` (or the file itself if it is a raw "
+            "state_dict) into the model with ``strict=False`` before "
+            "optimizer/EMA construction. Optimizer state, scheduler "
+            "state, and the epoch counter are NOT loaded; the cosine "
+            "schedule restarts from epoch 0 on the warm weights. This "
+            "is the chain-run mechanism for continuing a previous "
+            "training run with a fresh LR schedule."
         ),
     }
     for field in fields(Config):
@@ -788,6 +799,35 @@ def main(argv: Iterable[str] | None = None) -> None:
         base_model = unwrap_model(model)
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+
+        if config.init_from_checkpoint:
+            ckpt = torch.load(
+                config.init_from_checkpoint, map_location="cpu", weights_only=False
+            )
+            if isinstance(ckpt, dict) and "model" in ckpt:
+                state_dict = ckpt["model"]
+                ckpt_epoch = ckpt.get("epoch")
+                ckpt_source = ckpt.get("checkpoint_source")
+            else:
+                state_dict = ckpt
+                ckpt_epoch = None
+                ckpt_source = None
+            missing, unexpected = base_model.load_state_dict(state_dict, strict=False)
+            if state.is_main:
+                print(f"[init-from-checkpoint] loaded {config.init_from_checkpoint}")
+                if ckpt_epoch is not None:
+                    print(
+                        f"[init-from-checkpoint] source-epoch={ckpt_epoch} "
+                        f"source-checkpoint={ckpt_source}"
+                    )
+                print(
+                    f"[init-from-checkpoint] missing keys: {len(missing)} "
+                    f"(e.g. {missing[:3]})"
+                )
+                print(
+                    f"[init-from-checkpoint] unexpected keys: {len(unexpected)} "
+                    f"(e.g. {unexpected[:3]})"
+                )
 
         optimizer = build_optimizer(base_model, config)
         initial_steps_per_epoch = max(1, len(train_loader))

--- a/train.py
+++ b/train.py
@@ -115,6 +115,7 @@ class Config:
     ema_start_step: int = 50
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
+    lr_warmup_steps: int = 0
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
     grad_clip_norm: float = 1.0
@@ -160,6 +161,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "lr_warmup_steps": (
+            "Complete LR warmup after this many optimizer steps. When >0, "
+            "the scheduler is stepped once per optimizer step (not per "
+            "epoch) and both warmup and cosine annealing run in step units. "
+            "Decouples LR warmup completion from epoch-boundary curriculum "
+            "events such as `--vol-points-schedule` jumps. 0 (default) "
+            "falls back to `--lr-warmup-epochs` (epoch-granular scheduling)."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -781,7 +790,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
-        scheduler = build_lr_scheduler(optimizer, config, max_epochs)
+        initial_steps_per_epoch = max(1, len(train_loader))
+        scheduler = build_lr_scheduler(
+            optimizer, config, max_epochs, steps_per_epoch=initial_steps_per_epoch
+        )
+        scheduler_step_per_batch = bool(getattr(scheduler, "_step_per_batch", False))
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
         balancer: GradNormBalancer | None = None
@@ -1112,6 +1125,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         optimizer.zero_grad(set_to_none=True)
                     else:
                         optimizer.step()
+                        if scheduler_step_per_batch:
+                            scheduler.step()
                         if ema is not None:
                             ema.update(base_model)
                         weight_metrics = (
@@ -1164,7 +1179,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         )
                     break
 
-            scheduler.step()
+            if not scheduler_step_per_batch:
+                scheduler.step()
             epoch_train_loss = train_loss_sum / max(n_batches, 1)
             dt = time.time() - t0
             peak_gb = torch.cuda.max_memory_allocated(device) / 1e9 if torch.cuda.is_available() else 0.0

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1284,7 +1284,32 @@ def build_lr_scheduler(
     optimizer: torch.optim.Optimizer,
     config,
     max_epochs: int,
+    steps_per_epoch: int = 1,
 ) -> torch.optim.lr_scheduler.LRScheduler:
+    lr_warmup_steps = int(getattr(config, "lr_warmup_steps", 0))
+    if lr_warmup_steps > 0:
+        # Step-granular warmup: complete after exactly N optimizer steps and
+        # run cosine annealing in step units for the remainder of training.
+        total_steps = max(1, max_epochs * max(1, steps_per_epoch))
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=0.05,
+            end_factor=1.0,
+            total_iters=max(1, lr_warmup_steps),
+        )
+        cosine_steps = max(1, total_steps - lr_warmup_steps)
+        cosine_scheduler_steps = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer,
+            T_max=cosine_steps,
+            eta_min=config.lr_min,
+        )
+        combined = torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup_scheduler, cosine_scheduler_steps],
+            milestones=[lr_warmup_steps],
+        )
+        combined._step_per_batch = True
+        return combined
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer,


### PR DESCRIPTION
## Hypothesis

The current single-model SOTA (PR #958, val_abupt=6.2868%) uses `--lr-warmup-epochs 1`, which completes warmup at the end of EP0 — exactly at the epoch boundary. PR #994 proved that `--lr-warmup-steps N` infrastructure works correctly and that step-based warmup is technically sound.

However, PR #994 tested step-warmup on top of the **slow vol schedule** (`"0:16384:3:32768:6:49152:9:65536"`) where the warmup/vol-boundary coupling problem doesn't exist in the first place. The hypothesis that step-warmup enables a smoother EP0 transition compared to epoch-warmup was tested at a 4-epoch budget (Arms B vs A of PR #994: val=7.508% vs 6.898%) and at a 13-epoch budget but with only 4 epochs actually trained (timeout).

**This PR tests a clean comparison: full 13-epoch SOTA-stack run with `--lr-warmup-steps 8000` vs the baseline epoch-warmup.** With the slow vol schedule, the vol_points jump happens at EP3 — step-warmup-8000 completes warmup at step 8,000 (~74% through EP0), giving the LR a full 2+ epochs at its peak value before the first vol jump. Epoch-warmup completes at EP1 start (step 10,864), one epoch before the first jump.

The key difference: with step-warmup-8000, the LR reaches its final value (`9e-5`) while `vol_points=16,384` — the model gets to "learn the slow regime" at full LR before being asked to handle larger volumes. With epoch-warmup, the first vol expansion (EP3) happens after only 2 full epochs at peak LR.

Expected gain: modest but real — 0.1–0.2 pp improvement on val_abupt over 6.2868%.

## Instructions

Run a single arm — the full SOTA stack (PR #958) with `--lr-warmup-steps 8000` replacing `--lr-warmup-epochs 1`. All other hyperparameters are **identical** to the current SOTA reproduce command.

**Use `--wandb-group tanjiro-step-warmup-full-budget` so runs are grouped.**

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-steps 8000 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group tanjiro-step-warmup-full-budget \
  --wandb-name tanjiro/step-warmup-8k-13ep
```

**Key change from SOTA:** `--lr-warmup-steps 8000` replaces `--lr-warmup-epochs 1`.

Steps-per-epoch at vol=16K is 10,864 (chunked loading). So step 8,000 = 73.6% through EP0. The LR reaches `9e-5` before EP1 and stays there for EP1, EP2 before the first vol expansion at EP3.

**Kill gate at EP3:** val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0%. If either condition fails at EP3, stop and report. Otherwise continue to 13 epochs.

## EP3 dual kill gate

Stop early if at EP3 either:
- val_abupt > 8.0% 
- val_vol_p > 5.0%

## Baseline

**Single-model SOTA (PR #958, Arm A):**
- val_abupt = 6.2868% ← **beat this**
- val surface_pressure = 4.1766%
- val volume_pressure = 3.9152%
- val wall_shear = 7.0476%
- val tau_x = 6.1726%, tau_y = 7.6648%, tau_z = 9.5053%
- test_abupt = 7.7445%, test_vol_p = 12.0063%
- W&B run: `29nohj67` (group `nezuko-vol-aux-decoder-head`)

**Ensemble SOTA (PR #880):** val_abupt=6.0289% / test_abupt=7.3693% (K=6, run `zst3y2mp`)

## Context

- `--lr-warmup-steps` flag was added in PR #994; it is fully implemented and validated (no bugs found)
- With this flag, the LR scheduler is tagged `_step_per_batch=True` and stepped every optimizer step rather than every epoch
- Steps calibration: vol=16K → 10,864 steps/epoch; vol=32K → 5,435; vol=49K → 3,625; vol=65K → 2,720
- Step 8,000 ≈ EP0 step 8,000 (74% through EP0) — warmup completes while still in 16K-vol phase
- `--no-compile-model` is required (torch.compile + DDP NCCL deadlock)

## Expected result format

Post a `SENPAI-RESULT` marker when the run completes:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
