### PR TITLE
INR coord-conditioned vol decoder: position-aware MLP for OOD vol_p

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,77 @@ class Transformer(nn.Module):
         return x
 
 
+class CoordConditionedVolDecoder(nn.Module):
+    """INR-style coordinate-conditioned volume decoder (PR #1028).
+
+    Each per-point volume hidden state ``h_i`` is concatenated with a
+    multi-scale Gaussian Fourier feature embedding ``gamma(xyz_i)`` of the raw
+    coordinate before a 4-layer SiLU MLP regresses the field value. Mirrors
+    NeRF/DeepSDF-style decoders, where the coordinate provides a continuous
+    spatial prior independent of the backbone tokenisation.
+
+    When ``init_sigmas`` is provided the encoder is a stack of independent
+    Gaussian RFF blocks, one per sigma, reusing the backbone's multi-scale
+    sigma layout. With a single sigma it falls back to a single fixed
+    Gaussian random Fourier projection (Tancik et al. 2020).
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        output_dim: int,
+        num_freq: int = 16,
+        init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim
+        if init_sigmas:
+            num_per = max(1, num_freq // len(init_sigmas))
+            self.coord_rffs = nn.ModuleList(
+                [
+                    RFFEncoding(in_dim=3, num_features=num_per, sigma=s)
+                    for s in init_sigmas
+                ]
+            )
+            coord_feat_dim = 2 * num_per * len(init_sigmas)
+            self.init_sigmas = list(init_sigmas)
+            self.num_features_per_sigma = num_per
+        else:
+            self.coord_rffs = nn.ModuleList(
+                [RFFEncoding(in_dim=3, num_features=num_freq, sigma=1.0)]
+            )
+            coord_feat_dim = 2 * num_freq
+            self.init_sigmas = None
+            self.num_features_per_sigma = num_freq
+        self.coord_feat_dim = coord_feat_dim
+
+        in_dim = hidden_dim + coord_feat_dim
+        hidden = hidden_dim // 2
+        self.mlp = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden // 2),
+            nn.SiLU(),
+            nn.Linear(hidden // 2, output_dim),
+        )
+        self.mlp.apply(_init_linear)
+
+    def _encode_coords(self, coords: torch.Tensor) -> torch.Tensor:
+        return torch.cat([rff(coords) for rff in self.coord_rffs], dim=-1)
+
+    def forward(
+        self,
+        volume_hidden: torch.Tensor,
+        vol_coords: torch.Tensor,
+    ) -> torch.Tensor:
+        coord_feats = self._encode_coords(vol_coords)
+        x = torch.cat([volume_hidden, coord_feats], dim=-1)
+        return self.mlp(x)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +414,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_coord_vol_decoder: bool = False,
+        coord_decoder_num_freq: int = 16,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +429,8 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_coord_vol_decoder = use_coord_vol_decoder
+        self.coord_decoder_num_freq = coord_decoder_num_freq
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -431,14 +506,26 @@ class SurfaceTransolver(nn.Module):
             nn.Linear(n_hidden, self.surface_output_dim),
         )
         self.surface_out.apply(_init_linear)
-        self.volume_out = nn.Sequential(
-            nn.Linear(n_hidden, n_hidden // 2),
-            nn.SiLU(),
-            nn.Linear(n_hidden // 2, n_hidden // 4),
-            nn.SiLU(),
-            nn.Linear(n_hidden // 4, self.volume_output_dim),
-        )
-        self.volume_out.apply(_init_linear)
+        if use_coord_vol_decoder:
+            # PR #1028: INR-style coord-conditioned decoder replaces the
+            # baseline volume_out MLP. Reuses the backbone's multi-scale
+            # sigma layout so the coord RFF spans the same spectral range as
+            # the tokeniser.
+            self.volume_out = CoordConditionedVolDecoder(
+                hidden_dim=n_hidden,
+                output_dim=self.volume_output_dim,
+                num_freq=coord_decoder_num_freq,
+                init_sigmas=self.rff_init_sigmas,
+            )
+        else:
+            self.volume_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 2, n_hidden // 4),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 4, self.volume_output_dim),
+            )
+            self.volume_out.apply(_init_linear)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -569,7 +656,11 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            if self.use_coord_vol_decoder:
+                vol_coords = volume_x[:, :, : self.space_dim]
+                volume_preds = self.volume_out(volume_hidden, vol_coords) * volume_mask.unsqueeze(-1)
+            else:
+                volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_coord_vol_decoder: bool = False
+    coord_decoder_num_freq: int = 16
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_coord_vol_decoder": (
+            "Enable INR-style coordinate-conditioned volume decoder "
+            "(PR #1028). Replaces the baseline 3-layer volume_out MLP with "
+            "a 4-layer SiLU MLP that takes [volume_hidden || gamma(xyz)] as "
+            "input, where gamma is a multi-scale Gaussian Fourier feature "
+            "encoding of the raw xyz coordinate. Reuses --rff-init-sigmas "
+            "(or sigma=1.0 with a single RFF if no init_sigmas are set). "
+            "Mirrors NeRF/DeepSDF/GINO-style coord decoders to add a "
+            "spatial prior at decode time. Best combined with "
+            "--use-surf-to-vol-xattn."
+        ),
+        "coord_decoder_num_freq": (
+            "Number of Fourier features per component in the coord-"
+            "conditioned vol decoder. With M init_sigmas the encoder "
+            "stacks M RFF blocks of (num_freq // M) features each => total "
+            "coord embedding dim = 2 * (num_freq // M) * M. Without "
+            "init_sigmas a single RFF of num_freq features is used "
+            "(coord dim = 2 * num_freq). Used only when "
+            "--use-coord-vol-decoder is set. Default 16."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +330,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_coord_vol_decoder=config.use_coord_vol_decoder,
+        coord_decoder_num_freq=config.coord_decoder_num_freq,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current vol decoder (`volume_out`) receives a 512-dim hidden state from the backbone but has no direct access to the raw 3D coordinate of the query point. We hypothesize that explicitly conditioning the volume decoder on the raw spatial coordinates — as an Implicit Neural Representation (INR) — will improve vol_p accuracy, especially on OOD test cases.

The intuition: the OOD test cases (run_133, run_226, run_203, run_158) occupy a different region of coordinate space (different flow/geometry) than training. A decoder that can directly see "where in 3D space is this query point?" has a geometry-prior shortcut that pure hidden-state decoding lacks. Coordinate conditioning is how NeRF, DeepSDF, and related INR methods achieve strong generalization — they directly regress from (latent_code, xyz) to field values.

Concretely: after the surf→vol cross-attention, each volume hidden state `h_i ∈ R^{512}` is concatenated with a Fourier feature embedding of the raw xyz coordinate `γ(xyz_i) ∈ R^{2*3*K}`. This `[h_i || γ(xyz_i)]` is fed to a coordinate-conditioned MLP instead of the existing `volume_out`. The Fourier frequencies encode multi-scale spatial information (low-freq = global position, high-freq = fine detail).

**Related work:**
- NeRF (Mildenhall et al. 2020): positional encoding + MLP achieves view-dependent neural radiance fields
- DeepSDF (Park et al. 2019): latent code + xyz → SDF value
- FNO (Li et al. 2021) and Geo-FNO (Li et al. 2022): coordinate conditioning in physics surrogates
- Transolver (Wu et al. 2024): the backbone already uses Fourier features for tokenization but NOT at decode time

**Expected benefit:**
- Better OOD vol_p: coordinate context helps distinguish OOD cases
- Primary target: reduce test_vol_p from 12.0% toward val_vol_p level (~3.9%)
- Secondary: potentially improve val_abupt below 6.2868%

## Implementation Instructions

This requires code changes to `model.py` and `train.py`. The student must implement these. No INR/coord-decoder flags currently exist in train.py.

### Step 1: Add `CoordConditionedVolDecoder` class to `model.py`

Add this new class above the `TransolverWrapper` class definition:

```python
class CoordConditionedVolDecoder(nn.Module):
    """
    INR-style coordinate-conditioned volume decoder.
    Input: (volume_hidden [B, N, hidden_dim], vol_coords [B, N, 3])
    Output: volume_preds [B, N, volume_output_dim]
    
    Concatenates Fourier features of raw xyz to each hidden state before MLP.
    Learnable log-frequency init avoids manual scale selection.
    """
    def __init__(
        self,
        hidden_dim: int,
        output_dim: int,
        num_freq: int = 16,
        init_sigmas: list[float] | None = None,
    ):
        super().__init__()
        # Fourier feature embedding for xyz (matches existing RFFEncoding in model.py)
        # Use learnable frequencies via StringSeparableEncoding or fixed RFF
        self.coord_rff = RFFEncoding(in_dim=3, num_features=num_freq, sigma=1.0)
        # init_sigmas override — set multiple scales
        if init_sigmas is not None:
            # Rebuild with mixture of sigmas (stack multiple RFF)
            self.coord_rffs = nn.ModuleList([
                RFFEncoding(in_dim=3, num_features=num_freq // len(init_sigmas), sigma=s)
                for s in init_sigmas
            ])
            coord_feat_dim = 2 * (num_freq // len(init_sigmas)) * len(init_sigmas)
            self.coord_rff = None
        else:
            self.coord_rffs = None
            coord_feat_dim = 2 * num_freq
        
        in_dim = hidden_dim + coord_feat_dim
        hidden = hidden_dim // 2
        self.mlp = nn.Sequential(
            nn.Linear(in_dim, hidden_dim),
            nn.SiLU(),
            nn.Linear(hidden_dim, hidden),
            nn.SiLU(),
            nn.Linear(hidden, hidden // 2),
            nn.SiLU(),
            nn.Linear(hidden // 2, output_dim),
        )
        self.mlp.apply(_init_linear)
    
    def _encode_coords(self, coords: torch.Tensor) -> torch.Tensor:
        if self.coord_rffs is not None:
            return torch.cat([rff(coords) for rff in self.coord_rffs], dim=-1)
        return self.coord_rff(coords)
    
    def forward(
        self,
        volume_hidden: torch.Tensor,  # [B, N, hidden_dim]
        vol_coords: torch.Tensor,     # [B, N, 3]
    ) -> torch.Tensor:                # [B, N, output_dim]
        coord_feats = self._encode_coords(vol_coords)  # [B, N, coord_feat_dim]
        x = torch.cat([volume_hidden, coord_feats], dim=-1)  # [B, N, hidden+coord_feat]
        return self.mlp(x)
```

### Step 2: Add `--use-coord-vol-decoder` and `--coord-decoder-num-freq` flags to `train.py`

In the argument parser section (near other model flags), add:

```python
parser.add_argument("--use-coord-vol-decoder", action="store_true", default=False,
    help="Replace volume_out MLP with coordinate-conditioned INR decoder. "
         "Concatenates RFF(xyz) to volume hidden state before MLP decoding. "
         "Requires --use-surf-to-vol-xattn for best results.")
parser.add_argument("--coord-decoder-num-freq", type=int, default=16,
    help="Number of Fourier features per component in coord-conditioned vol decoder. "
         "Total coord embedding dim = 2 * num_freq. Default 16 => 32-dim coord embed. "
         "Used only when --use-coord-vol-decoder is set.")
```

### Step 3: Wire up in `TransolverWrapper.__init__`

In the `TransolverWrapper.__init__` signature, add `use_coord_vol_decoder: bool = False` and `coord_decoder_num_freq: int = 16`.

After the existing `volume_out` definition, add a conditional override:

```python
self.use_coord_vol_decoder = use_coord_vol_decoder
if use_coord_vol_decoder:
    self.volume_out = CoordConditionedVolDecoder(
        hidden_dim=n_hidden,
        output_dim=self.volume_output_dim,
        num_freq=coord_decoder_num_freq,
        init_sigmas=self.rff_init_sigmas,  # reuse same sigmas as main model
    )
```

### Step 4: Pass raw vol coords in `forward()`

In `TransolverWrapper.forward()`, the volume input `volume_x` has shape `[B, N, VOLUME_X_DIM]` where the first 3 dims are xyz coordinates. Extract them:

```python
if volume_x is not None:
    if self.use_coord_vol_decoder:
        vol_coords = volume_x[:, :, :3]  # raw xyz, [B, N, 3]
        volume_preds = self.volume_out(volume_hidden, vol_coords) * volume_mask.unsqueeze(-1)
    else:
        volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
```

### Step 5: Pass `use_coord_vol_decoder` and `coord_decoder_num_freq` from `train.py` to model

In `train.py` where `TransolverWrapper` is instantiated (search for `TransolverWrapper(`), add the two new keyword arguments from the parsed args.

## Baseline (gate to beat)

**Single-model SOTA: PR #958 (run `29nohj67`):**
| Metric | Value |
|--------|-------|
| val_abupt | **6.2868%** |
| test_abupt | 7.7445% |
| val_surface_pressure | 4.1766% |
| val_volume_pressure | 3.9152% |
| val_wall_shear | 7.0476% |
| test_volume_pressure | **12.0063%** (3.07× val — primary OOD target) |

**EP3 dual kill gate:** val_abupt > 8.0% AND val_vol_p > 5.0% at EP3 → kill.

## Training Run

Use the full 13-epoch SOTA stack (Lion, lr=9e-5, vol-curriculum, surf→vol xattn, aux head). The student adds `--use-coord-vol-decoder`.

Run **Arm A** (default num-freq=16, sigmas reused from main model: 0.25,0.5,1.0,2.0,4.0) and **Arm B** (num-freq=32) in parallel on 4 GPUs each (use `--nproc_per_node=4 --batch-size 4`):

**Arm A (num-freq=16, 8 GPUs):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-coord-vol-decoder --coord-decoder-num-freq 16 \
  --wandb-group edward-inr-coord-vol-decoder \
  --wandb-name edward/inr-coord-freq16
```

**Arm B (num-freq=32, if Arm A shows promise at EP3):**
Same command but `--coord-decoder-num-freq 32 --wandb-name edward/inr-coord-freq32`.

Note: The `--use-vol-pressure-aux-head` flag from PR #958 may conflict with the INR decoder — the `volume_out` module is being replaced. Do NOT include `--use-vol-pressure-aux-head` unless you verify the two can coexist. If `--use-vol-pressure-aux-head` and `--use-coord-vol-decoder` are both set, the INR decoder should take priority (override `volume_out`). Verify this in the code.

## Kill Gates & Reporting

**EP3 dual kill gate:** val_abupt ≤ 8.0% AND val_vol_p ≤ 5.0% — if either fails, kill the run.

At EP13 (or at kill), post a comment with:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id-arm-a>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

Report per-channel val AND test metrics (surface_pressure, volume_pressure, wall_shear, tau_x, tau_y, tau_z). The primary target is test_vol_p — report whether the 3× val/test gap narrowed.
