### PR TITLE
Coord frame augmentation: random yaw+scale for orientation invariance

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    coord_aug_rot_std: float = 0.0
+    coord_aug_scale_std: float = 0.0
+    coord_aug_prob: float = 1.0
     debug: bool = False
 
 
@@ -229,6 +232,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "coord_aug_rot_std": (
+            "Standard deviation (radians) of per-sample random yaw "
+            "rotation applied to surface/volume coordinates during "
+            "training only (PR #1029). 0.0 disables. Yaw is around the z "
+            "(vertical) axis, preserving ground-plane priors. Normals are "
+            "rotated by R (preserving unit length). Wall-shear targets "
+            "(tau_x, tau_y, tau_z) are rotated by R as a 3-vector. "
+            "Scalar targets (surface_pressure, volume_pressure) and "
+            "scalar features (area, sdf) are not rotated. Eval/test "
+            "remain on the canonical frame."
+        ),
+        "coord_aug_scale_std": (
+            "Standard deviation of per-sample log-normal isotropic "
+            "scale applied to surface/volume coordinates during training "
+            "only (PR #1029). 0.0 disables. scale = exp(N(0, std**2)). "
+            "Coordinates xyz and the SDF channel scale by the same "
+            "factor (signed distance scales with geometry). Normals and "
+            "scalar targets/features are not scaled. Wall-shear vectors "
+            "are not scaled (stress is not geometry-scale-dependent)."
+        ),
+        "coord_aug_prob": (
+            "Per-batch probability of applying coord-frame augmentation "
+            "(PR #1029). Default 1.0 (always on when std>0)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +338,89 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def apply_coord_augmentation(
+    batch,
+    *,
+    rot_std: float,
+    scale_std: float,
+    prob: float,
+) -> None:
+    """Apply random yaw rotation + isotropic scale to coordinate frames in-place.
+
+    Per-sample (per batch element) augmentation. Yaw is rotation around z
+    (vertical) only — DrivAerML vehicles are ground-aligned. Scale is
+    log-normal with std=scale_std (so ~exp(0)=1 mean factor, multiplicative).
+
+    surface_x layout: [xyz(3), normals(3), area(1)] (7 channels)
+    volume_x  layout: [xyz(3), sdf(1)] (4 channels)
+    surface_y layout: [surface_pressure(1), tau_x, tau_y, tau_z]
+    volume_y  layout: [volume_pressure(1)]
+
+    Transforms:
+      xyz coords (surface, volume) -> rotate + scale
+      normals                       -> rotate only (preserve unit length)
+      sdf                           -> scale only (distance scales with geometry)
+      tau_x/y/z target              -> rotate only (vector target)
+      area, surface_pressure,
+       volume_pressure              -> unchanged (scalar)
+
+    Padded rows are zero and remain zero after rotation/scale, so the
+    surface_mask / volume_mask semantics are preserved.
+    """
+    if rot_std <= 0.0 and scale_std <= 0.0:
+        return
+    if prob < 1.0:
+        if torch.rand(()).item() > prob:
+            return
+
+    B = batch.surface_x.shape[0]
+    device = batch.surface_x.device
+    dtype = batch.surface_x.dtype
+
+    if rot_std > 0.0:
+        theta = torch.randn(B, device=device, dtype=dtype) * rot_std
+        cos_t = torch.cos(theta)
+        sin_t = torch.sin(theta)
+        zeros = torch.zeros(B, device=device, dtype=dtype)
+        ones = torch.ones(B, device=device, dtype=dtype)
+        R = torch.stack(
+            [
+                torch.stack([cos_t, -sin_t, zeros], dim=-1),
+                torch.stack([sin_t, cos_t, zeros], dim=-1),
+                torch.stack([zeros, zeros, ones], dim=-1),
+            ],
+            dim=1,
+        )
+    else:
+        R = torch.eye(3, device=device, dtype=dtype).unsqueeze(0).expand(B, -1, -1).contiguous()
+
+    if scale_std > 0.0:
+        scale = torch.exp(torch.randn(B, device=device, dtype=dtype) * scale_std)
+    else:
+        scale = torch.ones(B, device=device, dtype=dtype)
+
+    R_T = R.transpose(1, 2)
+    R_scaled_T = R_T * scale.view(B, 1, 1)
+    scale_b11 = scale.view(B, 1, 1)
+
+    surf = batch.surface_x
+    surf_xyz_aug = torch.bmm(surf[..., 0:3], R_scaled_T)
+    surf_normals_aug = torch.bmm(surf[..., 3:6], R_T)
+    new_surface_x = torch.cat([surf_xyz_aug, surf_normals_aug, surf[..., 6:]], dim=-1)
+    batch.surface_x = new_surface_x
+
+    surf_y = batch.surface_y
+    tau_aug = torch.bmm(surf_y[..., 1:4], R_T)
+    new_surface_y = torch.cat([surf_y[..., 0:1], tau_aug], dim=-1)
+    batch.surface_y = new_surface_y
+
+    vol = batch.volume_x
+    vol_xyz_aug = torch.bmm(vol[..., 0:3], R_scaled_T)
+    vol_sdf_aug = vol[..., 3:4] * scale_b11
+    new_volume_x = torch.cat([vol_xyz_aug, vol_sdf_aug, vol[..., 4:]], dim=-1)
+    batch.volume_x = new_volume_x
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,8 +431,17 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    coord_aug_rot_std: float = 0.0,
+    coord_aug_scale_std: float = 0.0,
+    coord_aug_prob: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
+    apply_coord_augmentation(
+        batch,
+        rot_std=coord_aug_rot_std,
+        scale_std=coord_aug_scale_std,
+        prob=coord_aug_prob,
+    )
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -364,6 +483,10 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    coord_aug_rot_std: float = 0.0,
+    coord_aug_scale_std: float = 0.0,
+    coord_aug_prob: float = 1.0,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -374,6 +497,12 @@ def per_task_train_losses(
     """
 
     batch = batch.to(device)
+    apply_coord_augmentation(
+        batch,
+        rot_std=coord_aug_rot_std,
+        scale_std=coord_aug_scale_std,
+        prob=coord_aug_prob,
+    )
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
     with autocast_context(device, amp_mode):
@@ -883,6 +1012,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["coord_aug/rot_std"] = config.coord_aug_rot_std
+            wandb.summary["coord_aug/scale_std"] = config.coord_aug_scale_std
+            wandb.summary["coord_aug/prob"] = config.coord_aug_prob
+            wandb.summary["coord_aug/enabled"] = float(
+                config.coord_aug_rot_std > 0.0 or config.coord_aug_scale_std > 0.0
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -939,7 +1074,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        coord_aug_rot_std=config.coord_aug_rot_std,
+                        coord_aug_scale_std=config.coord_aug_scale_std,
+                        coord_aug_prob=config.coord_aug_prob,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1172,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        coord_aug_rot_std=config.coord_aug_rot_std,
+                        coord_aug_scale_std=config.coord_aug_scale_std,
+                        coord_aug_prob=config.coord_aug_prob,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1


### PR DESCRIPTION
# Coordinate Frame Augmentation: Random Yaw + Scale for Orientation Invariance

## Hypothesis

The Transolver model currently trains on a fixed canonical coordinate frame (x = streamwise, y = spanwise, z = vertical). All 400 training vehicles share the same orientation, so the model can exploit frame-specific biases — e.g., absolute x/y/z position correlates strongly with aerodynamic zones. At test time, the same frame is used, so this isn't a generalization gap per se. But the model likely memorizes frame-specific coordinate patterns rather than learning geometry-relative representations, which:

1. Limits the quality of learned positional features (model relies on absolute position rather than relative geometry)
2. May contribute to the large test_vol_p gap (12.0% vs val_vol_p 3.9%), if volume pressure is particularly sensitive to positional encoding alignment

**Proposed fix:** Apply random rotation (yaw only — vehicles are all ground-plane-aligned) and random isotropic scale during training, forcing the model to learn orientation-invariant representations. Wall-shear targets (tau_x/tau_y/tau_z) are vector components and must be rotated consistently with the coordinate transform. Surface pressure and volume pressure are scalars and are frame-invariant.

**Why yaw only (not full SO(3)):** DrivAerML vehicles are all upright, ground-plane-aligned. A full 3D rotation would create unrealistic configurations. Yaw rotation is physically valid: any real vehicle measurement could be re-expressed in a rotated horizontal reference frame.

**Why scale:** Uniform scale changes don't change aerodynamic physics (Mach/Re correction aside), so the model should be invariant. Random log-scale perturbations at ±2% prevent the model from relying on absolute coordinate magnitudes for positional encoding.

## Implementation

The student needs to:

1. **Add new CLI flags** to `train.py`:
   - `--coord-aug-rot-std FLOAT` — standard deviation of yaw rotation angle in radians (default: `0.0`, disabled). Arm A: `0.1` (~±6°), Arm B: `0.25` (~±14°)
   - `--coord-aug-scale-std FLOAT` — standard deviation of log-scale perturbation (default: `0.0`, disabled). Use `0.02` in both arms (≈±2%)
   - `--coord-aug-prob FLOAT` — probability of applying augmentation per batch (default: `1.0`)

2. **Apply augmentation in the training forward pass** (NOT in eval). In both `train_step()` and `per_task_train_losses()` (lines ~315 and ~362 of `train.py`), after `batch = batch.to(device)` but BEFORE the model forward:

```python
def apply_coord_augmentation(batch, rot_std: float, scale_std: float, prob: float = 1.0):
    """Apply random yaw rotation + isotropic scale to coordinate frames.
    
    - surface_x[:, :, :3] and volume_x[:, :, :3] are XYZ coords — rotate + scale
    - surface_y[:, :, 1:4] are tau_x/tau_y/tau_z vector components — rotate only
    - surface_y[:, :, 0] is surface pressure (scalar) — unchanged
    - volume_y is volume pressure (scalar) — unchanged
    """
    if rot_std <= 0.0 and scale_std <= 0.0:
        return batch
    if prob < 1.0 and torch.rand(()).item() > prob:
        return batch
    
    B = batch.surface_x.shape[0]
    device = batch.surface_x.device
    dtype = batch.surface_x.dtype
    
    # Build per-batch yaw rotation matrices [B, 3, 3]
    if rot_std > 0.0:
        theta = torch.randn(B, device=device, dtype=dtype) * rot_std  # [B]
        cos_t = torch.cos(theta)  # [B]
        sin_t = torch.sin(theta)  # [B]
        zeros = torch.zeros(B, device=device, dtype=dtype)
        ones = torch.ones(B, device=device, dtype=dtype)
        # Yaw rotation around Z axis: [[cos, -sin, 0], [sin, cos, 0], [0, 0, 1]]
        R = torch.stack([
            torch.stack([cos_t, -sin_t, zeros], dim=-1),
            torch.stack([sin_t,  cos_t, zeros], dim=-1),
            torch.stack([zeros,  zeros,   ones], dim=-1),
        ], dim=1)  # [B, 3, 3]
    else:
        R = torch.eye(3, device=device, dtype=dtype).unsqueeze(0).expand(B, -1, -1)  # [B, 3, 3]
    
    # Random isotropic scale per batch [B]
    if scale_std > 0.0:
        log_scale = torch.randn(B, device=device, dtype=dtype) * scale_std
        scale = torch.exp(log_scale)  # [B], positive
    else:
        scale = torch.ones(B, device=device, dtype=dtype)
    
    scale_R = R * scale.view(B, 1, 1)  # [B, 3, 3], combines rotation and scale
    
    # Apply to surface XYZ: [B, N_surf, D] -> rotate+scale first 3 dims
    surf_xyz = batch.surface_x[:, :, :3]  # [B, N_surf, 3]
    surf_xyz_rot = torch.bmm(surf_xyz, scale_R.transpose(1, 2))  # [B, N_surf, 3]
    batch.surface_x = torch.cat([surf_xyz_rot, batch.surface_x[:, :, 3:]], dim=-1)
    
    # Apply to volume XYZ: [B, N_vol, D]
    vol_xyz = batch.volume_x[:, :, :3]  # [B, N_vol, 3]
    vol_xyz_rot = torch.bmm(vol_xyz, scale_R.transpose(1, 2))  # [B, N_vol, 3]
    batch.volume_x = torch.cat([vol_xyz_rot, batch.volume_x[:, :, 3:]], dim=-1)
    
    # Apply rotation ONLY to tau_x/y/z (vector targets, indices 1:4); pressure index 0 is scalar
    tau = batch.surface_y[:, :, 1:4]  # [B, N_surf, 3]
    # Note: R only (no scale) for physical stress vector components
    tau_rot = torch.bmm(tau, R.transpose(1, 2))  # [B, N_surf, 3]
    batch.surface_y = torch.cat([
        batch.surface_y[:, :, 0:1],  # surface pressure, unchanged
        tau_rot,                      # tau_x/y/z, rotated
    ], dim=-1)
    
    return batch
```

Add the `apply_coord_augmentation` call in both `train_step()` and `per_task_train_losses()` after `batch = batch.to(device)`:

```python
    batch = batch.to(device)
    # --- Coordinate frame augmentation (training only) ---
    if config.coord_aug_rot_std > 0.0 or config.coord_aug_scale_std > 0.0:
        batch = apply_coord_augmentation(
            batch,
            rot_std=config.coord_aug_rot_std,
            scale_std=config.coord_aug_scale_std,
            prob=config.coord_aug_prob,
        )
    # --- end augmentation ---
    surface_target = transform.apply_surface(batch.surface_y)
```

**Important:** `SurfaceBatch` objects may be frozen dataclasses. If `batch.surface_x = ...` fails, the student should construct a new batch object or add a helper to clone+replace fields.

The `evaluate_split` call in the eval path does NOT get augmentation — no changes needed there.

## Training Commands

**Baseline (SOTA reference):**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0
```
Note: `--use-vol-pressure-aux-head` was in the SOTA reproduce command but may not be in current `train.py`. Confirm with `python train.py --help | grep aux`. If absent, omit it.

**Arm A: rot_std=0.1, scale_std=0.02 (conservative, ~±6° yaw)**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --volume-loss-weight 1.0 \
  --coord-aug-rot-std 0.1 --coord-aug-scale-std 0.02 \
  --wandb-group frieren-coord-aug
```

**Arm B: rot_std=0.25, scale_std=0.02 (aggressive, ~±14° yaw)**
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --volume-loss-weight 1.0 \
  --coord-aug-rot-std 0.25 --coord-aug-scale-std 0.02 \
  --wandb-group frieren-coord-aug
```

## Kill Gates (EP3 dual-gate)

Check after epoch 3. Kill an arm early if:
- `val/abupt_axis_mean_rel_l2_pct` > **8.0%** (more than 27% worse than SOTA 6.2868%), OR
- `val/volume_pressure_rel_l2_pct` > **5.5%** (more than 40% above val baseline 3.9152%)

If both arms fail EP3, report NEGATIVE immediately. If only one fails, continue with the surviving arm to full epochs.

## Current Baseline to Beat

| Metric | Val | Test |
|--------|-----|------|
| **val_abupt** (primary) | **6.2868%** | 7.7445% |
| surface_pressure | 4.1766% | 3.9100% |
| volume_pressure | 3.9152% | 12.0063% |
| wall_shear | 7.0476% | 6.9848% |
| tau_x | 6.1726% | 6.2092% |
| tau_y | 7.6648% | 7.5689% |
| tau_z | 9.5053% | 9.0280% |

Source: SOTA single-model — PR #958, W&B run `29nohj67`

## Success Criteria

A PR is a **winner** if `val_abupt_axis_mean_rel_l2_pct` < **6.2868%** with a terminal `SENPAI-RESULT` block (terminal=true, pending_arms=false).

## Reporting

Post a `SENPAI-RESULT` when all surviving arms are done:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id-A>","<run-id-B>"],"primary_metric":{"name":"val/abupt_axis_mean_rel_l2_pct","value":<best_value>},"test_metric":{"name":"test/abupt_axis_mean_rel_l2_pct","value":<value>}}
```
