### PR TITLE
fern: pre-xattn vol self-attn before surf→vol cross-attn

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,8 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_pre_xattn_vol_self_attn: bool = False,
+        pre_xattn_vol_self_attn_layers: int = 1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +358,18 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_pre_xattn_vol_self_attn = use_pre_xattn_vol_self_attn
+        self.pre_xattn_vol_self_attn_layers = pre_xattn_vol_self_attn_layers
+        if use_pre_xattn_vol_self_attn and not use_surf_to_vol_xattn:
+            raise ValueError(
+                "use_pre_xattn_vol_self_attn=True requires use_surf_to_vol_xattn=True "
+                "(the pre-xattn self-attention is the 'pre' step of the cross-attention)."
+            )
+        if use_pre_xattn_vol_self_attn and pre_xattn_vol_self_attn_layers < 1:
+            raise ValueError(
+                "pre_xattn_vol_self_attn_layers must be >= 1 when "
+                "use_pre_xattn_vol_self_attn=True."
+            )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -460,6 +474,40 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Pre-xattn vol self-attention (PR #1031): one or more pre-norm
+        # nn.MultiheadAttention sublayers over the volume tokens that run
+        # BEFORE the surf->vol cross-attention. Lets each vol token pool
+        # local 3D context from other vol tokens before being queried by
+        # the surface side. Analogous to Perceiver IO's latent self-attn
+        # before output cross-attn (Jaegle et al. 2022, arXiv:2107.14795).
+        # Zero-init out_proj weight+bias => identity at init.
+        # need_weights=False at call time routes through SDPA / Flash and
+        # avoids NaN on key-padded rows (pytorch/pytorch#41508).
+        if use_pre_xattn_vol_self_attn:
+            self.pre_xattn_vol_lns = nn.ModuleList(
+                [
+                    nn.LayerNorm(n_hidden, eps=1e-6)
+                    for _ in range(pre_xattn_vol_self_attn_layers)
+                ]
+            )
+            self.pre_xattn_vol_mhas = nn.ModuleList(
+                [
+                    nn.MultiheadAttention(
+                        embed_dim=n_hidden,
+                        num_heads=n_head,
+                        batch_first=True,
+                        dropout=dropout,
+                    )
+                    for _ in range(pre_xattn_vol_self_attn_layers)
+                ]
+            )
+            for mha in self.pre_xattn_vol_mhas:
+                nn.init.zeros_(mha.out_proj.weight)
+                nn.init.zeros_(mha.out_proj.bias)
+        else:
+            self.pre_xattn_vol_lns = None
+            self.pre_xattn_vol_mhas = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -552,6 +600,24 @@ class SurfaceTransolver(nn.Module):
             and surface_tokens > 0
             and volume_tokens > 0
         ):
+            if self.pre_xattn_vol_mhas is not None:
+                # Pre-norm + residual self-attention over volume tokens.
+                # key_padding_mask convention: True = ignore. volume_mask
+                # is True at valid positions, so flip it.
+                vol_key_padding = ~volume_mask
+                for ln, mha in zip(self.pre_xattn_vol_lns, self.pre_xattn_vol_mhas):
+                    vol_h_in = ln(volume_hidden)
+                    vol_h_out, _ = mha(
+                        vol_h_in,
+                        vol_h_in,
+                        vol_h_in,
+                        key_padding_mask=vol_key_padding,
+                        need_weights=False,
+                    )
+                    vol_h_out = _apply_token_mask(vol_h_out, volume_mask)
+                    volume_hidden = volume_hidden + vol_h_out
+                    volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
             xattn_out, _ = self.surf_to_vol_xattn(
                 query=volume_hidden,
                 key=surface_hidden,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_pre_xattn_vol_self_attn: bool = False
+    pre_xattn_vol_self_attn_layers: int = 1
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_pre_xattn_vol_self_attn": (
+            "Enable pre-cross-attention volume self-attention (PR #1031). "
+            "Inserts --pre-xattn-vol-self-attn-layers pre-norm + residual "
+            "nn.MultiheadAttention blocks over the volume tokens BEFORE "
+            "the surf->vol cross-attention so vol tokens can pool local "
+            "3D context before being queried by the surface side "
+            "(Perceiver IO latent self-attn pattern, Jaegle et al. 2022). "
+            "Requires --use-surf-to-vol-xattn. out_proj weight+bias are "
+            "zero-init so the block is identity at init."
+        ),
+        "pre_xattn_vol_self_attn_layers": (
+            "Number of stacked pre-norm + residual self-attention blocks "
+            "in the pre-xattn vol self-attention stack. Only used when "
+            "--use-pre-xattn-vol-self-attn is set. Default 1."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +325,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_pre_xattn_vol_self_attn=config.use_pre_xattn_vol_self_attn,
+        pre_xattn_vol_self_attn_layers=config.pre_xattn_vol_self_attn_layers,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The volume tokens going into the surf→vol cross-attention layer are raw backbone outputs — they haven't had any chance to "talk to each other" before being queried by the surface tokens. Adding a lightweight self-attention pass over the volume tokens **before** the cross-attention should allow nearby vol tokens to pool spatial context, making the K/V representations richer. This is analogous to how Vision Transformers apply several self-attention layers before any cross-attention to a conditioning signal.

Mechanistically: the vol tokens form a scattered point cloud in 3D space; local flow structure (pressure gradients, boundary-layer thickness) is coherent over small neighborhoods. A single MHA pass lets each vol token attend to its ~50 nearest-feature neighbors in embedding space before the surface side queries it.

This is a low-risk, low-parameter change (~2.1M params for a single 4-head MHA over 512-dim, which amortizes over 65 k tokens). It should be especially helpful for OOD test cases where vol_p is the weak link (val=3.9%, test=12.0%, 3×gap).

**Reference:** Perceiver IO (Jaegle et al. 2022) uses exactly this pattern — a latent self-attention stack before cross-attention to sensory inputs. We apply the same idea but in the reverse direction (vol tokens are the "latent" side; surface tokens are the "input" side that queries them).

## Instructions

### New flag to add to `train.py` / `model.py`

Add `--use-pre-xattn-vol-self-attn` / `--no-use-pre-xattn-vol-self-attn` (default: `False`) that inserts **one multi-head self-attention block** over the volume tokens immediately **before** the existing surf→vol cross-attention.

The block sits between the post-backbone LayerNorm split and the cross-attention query. It should:
1. Apply a Pre-norm LayerNorm to `vol_h`
2. Run `nn.MultiheadAttention(embed_dim=512, num_heads=4, batch_first=True)` with `key_padding_mask=~volume_mask`
3. Add the residual back (identity-at-init via `nn.init.zeros_` on the output projection weight)

**Pseudocode** (add inside the `TransformerModel` / equivalent block where `--use-surf-to-vol-xattn` is handled):

```python
# -- pre-xattn vol self-attention (new) --
if self.use_pre_xattn_vol_self_attn:
    vol_h_res = vol_h
    vol_h = self.pre_xattn_vol_ln(vol_h)                           # LayerNorm
    vol_h_out, _ = self.pre_xattn_vol_mha(                         # MHA
        vol_h, vol_h, vol_h,
        key_padding_mask=~volume_mask                               # True = ignore
    )
    vol_h = vol_h_res + vol_h_out                                   # residual

# -- existing surf→vol cross-attention (unchanged) --
if self.use_surf_to_vol_xattn:
    ...
```

**Module init** (in `__init__`):

```python
if self.use_pre_xattn_vol_self_attn:
    self.pre_xattn_vol_ln  = nn.LayerNorm(hidden_dim)
    self.pre_xattn_vol_mha = nn.MultiheadAttention(
        embed_dim=hidden_dim, num_heads=num_heads, batch_first=True
    )
    nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.weight)
    nn.init.zeros_(self.pre_xattn_vol_mha.out_proj.bias)
```

**Important:** This block should **only activate when `--use-surf-to-vol-xattn` is also enabled** — it's the "pre" step of that cross-attention, so running it without the cross-attention is meaningless. Add a guard / assertion.

### Experiment arms

Run **two arms** using `--wandb-group fern-pre-xattn-vol-self-attn`. Start both together.

**Arm A — single self-attn head block** (primary):
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-pre-xattn-vol-self-attn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group fern-pre-xattn-vol-self-attn \
  --wandb-name fern/pre-xattn-vol-self-attn-armA
```

**Arm B — two stacked self-attn blocks** (ablation: does depth help?):

Same as Arm A, but add a second sequential pre-xattn self-attention block. In `model.py`, when `use_pre_xattn_vol_self_attn=True`, stack `N=2` blocks (controlled by a new `--pre-xattn-vol-self-attn-layers` arg defaulting to 1). For Arm B pass `--pre-xattn-vol-self-attn-layers 2`.

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-pre-xattn-vol-self-attn --pre-xattn-vol-self-attn-layers 2 \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group fern-pre-xattn-vol-self-attn \
  --wandb-name fern/pre-xattn-vol-self-attn-armB-2L
```

### EP3 kill gate

Kill if at EP3: `val_abupt > 8.0%` OR `val_vol_p > 5.0%` for either arm.

Check throughput: Arm A adds ~2.1M params and one extra attention pass over vol tokens (65 k tokens). If the per-step time increases by more than 25% vs the SOTA baseline, flag it — we may need to reduce vol token count during the self-attn pass (use a random subsample of 16 k tokens for the self-attn, then pass the full 65 k to the cross-attn).

## Baseline

| Metric | Single-model SOTA (PR #958, run `29nohj67`) |
|---|---:|
| val_abupt | **6.2868%** |
| test_abupt | **7.7445%** |
| val_surface_pressure | 4.1766% |
| val_volume_pressure | 3.9152% |
| val_wall_shear | 7.0476% |
| test_surface_pressure | 3.9100% |
| test_volume_pressure | 12.0063% |
| test_wall_shear | 6.9848% |

**Beat target:** val_abupt < 6.2868%

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

### Reproduce SOTA baseline

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --wandb-group nezuko-vol-aux-decoder-head
```

## Success criteria

- **Primary:** val_abupt < 6.2868% by EP13
- **Secondary:** test_vol_p < 12.0% — any reduction in the 3× val/test ratio on volume pressure
- **Ablation signal:** Arm A vs Arm B — does a second self-attn layer help or hurt?

## Terminal result format

When done, post a single-line marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA-run-id>","<armB-run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
