### PR TITLE
Top-K val checkpoint averaging (K=5) for OOD generalisation

### DIFF
--- a/train.py
+++ b/train.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import heapq
 import math
 import os
 import random
@@ -53,6 +54,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    numeric_metric_items,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -132,6 +134,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    topk_avg_k: int = 5
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -543,6 +546,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         early_stop_reason: str | None = None
         timeout_hit = False
         train_start = time.time()
+
+        # Top-K val-checkpoint heap: items are (-primary_val, counter, path).
+        # heapq is a min-heap; pushing the negated val makes heappop() evict the
+        # WORST (largest) val so the K best (lowest val) checkpoints are retained.
+        topk_heap: list[tuple[float, int, Path]] = []
+        topk_counter = 0
+        topk_k = max(1, int(config.topk_avg_k))
 
         for epoch in range(max_epochs):
             if isinstance(train_loader.sampler, DistributedSampler):
@@ -969,6 +979,32 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
                 log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+                # Top-K val-checkpoint tracking: save every valid val epoch, evict
+                # worst (largest val) when heap exceeds K. base_model holds EMA
+                # weights here when EMA is enabled (ema.copy_to was called above).
+                if is_valid_primary_metric(primary_val):
+                    topk_ckpt_path = output_dir / f"checkpoint_topk_{topk_counter:03d}.pt"
+                    torch.save(
+                        {
+                            "model": base_model.state_dict(),
+                            "epoch": epoch + 1,
+                            "val_primary": primary_val,
+                            "checkpoint_source": best_checkpoint_source,
+                        },
+                        topk_ckpt_path,
+                    )
+                    heapq.heappush(topk_heap, (-primary_val, topk_counter, topk_ckpt_path))
+                    topk_counter += 1
+                    if len(topk_heap) > topk_k:
+                        _, _, worst_path = heapq.heappop(topk_heap)
+                        worst_path.unlink(missing_ok=True)
+                    log_metrics["topk/heap_size"] = float(len(topk_heap))
+                    log_metrics["topk/saved_total"] = float(topk_counter)
+                    if topk_heap:
+                        worst_kept = max(-neg for (neg, _, _) in topk_heap)
+                        best_kept = min(-neg for (neg, _, _) in topk_heap)
+                        log_metrics["topk/heap_worst_val"] = float(worst_kept)
+                        log_metrics["topk/heap_best_val"] = float(best_kept)
                 wandb.log(log_metrics)
                 tag = " *" if improved else ""
                 print(
@@ -1041,6 +1077,106 @@ def main(argv: Iterable[str] | None = None) -> None:
             global_step=global_step,
             total_minutes=total_minutes,
         )
+
+        # Top-K checkpoint averaging: arithmetic-average state_dicts of the K
+        # best-by-val checkpoints, then run val + test eval on rank 0. This is
+        # additive to run_final_evaluation (which already evaluated the single
+        # best-val checkpoint and left it loaded into base_model).
+        if topk_heap:
+            topk_sorted = sorted(topk_heap, key=lambda x: -x[0])
+            topk_paths = [p for (_, _, p) in topk_sorted]
+            topk_vals = [-neg_v for (neg_v, _, _) in topk_sorted]
+            K = len(topk_paths)
+            print(f"\n[TopK] Averaging K={K} best-by-val checkpoints:")
+            for p, v in zip(topk_paths, topk_vals):
+                print(f"  val_abupt={v:.4f}%  ->  {p.name}")
+
+            state_dicts = [
+                torch.load(p, map_location="cpu", weights_only=True)["model"]
+                for p in topk_paths
+            ]
+            avg_state: dict[str, torch.Tensor] = {}
+            for key, ref in state_dicts[0].items():
+                if ref.dtype.is_floating_point:
+                    stacked = torch.stack([sd[key].float() for sd in state_dicts])
+                    avg_state[key] = stacked.mean(dim=0).to(ref.dtype)
+                else:
+                    avg_state[key] = ref.clone()
+
+            avg_ckpt_path = output_dir / "checkpoint_topk_avg.pt"
+            torch.save(
+                {
+                    "model": avg_state,
+                    "config": asdict(config),
+                    "epoch": "topk_avg",
+                    "k": K,
+                    "topk_val_scores": topk_vals,
+                    "checkpoint_source": "topk_avg",
+                },
+                avg_ckpt_path,
+            )
+            print(f"[TopK] Saved averaged checkpoint to {avg_ckpt_path}")
+
+            base_model.load_state_dict(avg_state)
+            print("[TopK] Running val + test evaluation on averaged checkpoint...")
+            avg_full_val_metrics = {
+                name: evaluate_split(
+                    base_model, loader, transform, device, amp_mode=config.amp_mode
+                )
+                for name, loader in final_val_loaders.items()
+            }
+            avg_test_metrics = {
+                name: evaluate_split(
+                    base_model, loader, transform, device, amp_mode=config.amp_mode
+                )
+                for name, loader in final_test_loaders.items()
+            }
+
+            topk_log: dict[str, object] = {
+                "global_step": global_step,
+                "topk_avg/k": K,
+                "topk_avg/val_score_mean": float(sum(topk_vals) / K),
+                "topk_avg/val_score_best": float(min(topk_vals)),
+                "topk_avg/val_score_worst": float(max(topk_vals)),
+            }
+            for i, v in enumerate(topk_vals):
+                topk_log[f"topk_avg/val_score_rank_{i}"] = float(v)
+            topk_log.update(
+                primary_metric_log(
+                    "topk_avg_full_val_primary", avg_full_val_metrics["val_surface"]
+                )
+            )
+            for split_name, metrics in avg_full_val_metrics.items():
+                topk_log.update(
+                    metric_namespace("topk_avg_full_val", split_name, metrics)
+                )
+            topk_log.update(
+                primary_metric_log(
+                    "topk_avg_test_primary", avg_test_metrics["test_surface"]
+                )
+            )
+            for split_name, metrics in avg_test_metrics.items():
+                topk_log.update(metric_namespace("topk_avg_test", split_name, metrics))
+            wandb.log(topk_log)
+            wandb.summary.update(numeric_metric_items(topk_log))
+
+            test_surface = avg_test_metrics["test_surface"]
+            topk_test_abupt = float(test_surface["abupt_axis_mean_rel_l2_pct"])
+            wandb.summary.update(
+                {
+                    "topk_avg/test_abupt": topk_test_abupt,
+                    "topk_avg/test_vol_p": float(test_surface["volume_pressure_rel_l2_pct"]),
+                    "topk_avg/test_surf_p": float(test_surface["surface_pressure_rel_l2_pct"]),
+                    "topk_avg/test_wall": float(test_surface["wall_shear_rel_l2_pct"]),
+                    "topk_avg/full_val_abupt": float(
+                        avg_full_val_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
+                    ),
+                }
+            )
+            print_metrics("topk_avg/val", avg_full_val_metrics["val_surface"])
+            print_metrics("topk_avg/test", avg_test_metrics["test_surface"])
+            print(f"[TopK] avg-over-K={K} test_abupt={topk_test_abupt:.4f}%")
+
         wandb.finish()
     finally:
         cleanup_distributed(state)


### PR DESCRIPTION
## Hypothesis

Averaging the K best-by-val checkpoints (K=5) will generalise better out-of-distribution than the single best-val checkpoint, by smoothing sharp minima in the loss landscape. This is orthogonal to nezuko's SWA experiment (PR #999), which averages epoch snapshots uniformly over EP20–EP30. Top-K checkpoint averaging selects the K best checkpoints by the primary val metric (`val_primary/abupt_axis_mean_rel_l2_pct`) throughout all 30 epochs, then arithmetic-averages their state_dicts at terminal time.

**Why this is different from EMA (PR #954, falsified):** EMA is an exponential moving average of weights during the forward pass (exponential decay over steps). Top-K averaging is discrete averaging of K saved checkpoints that happened to be the best by val score — a completely different mechanism that does not interfere with training dynamics at all.

**Why this might close the val→test gap:** The best single checkpoint may lie at a sharp minimum that generalises poorly OOD. Averaging K nearby-best checkpoints implicitly moves toward a wider basin with better OOD behaviour. This is the "flat minima → better generalisation" principle behind SWA, applied via selection rather than trajectory.

References:
- Izmailov et al., "Averaging Weights Leads to Wider Optima and Better Generalization" (SWA, ICLR 2018)
- Wortsman et al., "Model soups: averaging weights of multiple fine-tuned models improves accuracy without increasing inference time" (ICML 2022)

---

## Instructions

**Architecture / config: no changes.** Use the same TransolverWithVolume config as the wave SOTA (PR #740). The only change is checkpoint management.

### Step 1 — Modify `train.py` to maintain a Top-K checkpoint heap

Add the following near the top of `train.py` (after existing imports):

```python
import heapq
TOPK_K = 5
```

In the training loop initialisation (near `best_val = float("inf")`), add:

```python
# Top-K checkpoint heap: list of (val_score, rank, path)
# min-heap so we can evict the worst of the K when a new best enters
topk_heap = []   # items are (val_score, counter, ckpt_path)
topk_counter = 0  # tie-break counter to avoid comparing Path objects
```

In the checkpoint-save block (currently only saves `checkpoint.pt` on improvement), **add** the Top-K save logic **after** the existing best-checkpoint save (do not remove the existing `checkpoint.pt` logic — keep it intact):

```python
# --- Top-K checkpoint tracking ---
topk_ckpt_path = output_dir / f"checkpoint_topk_{topk_counter}.pt"
torch.save(
    {
        "epoch": epoch,
        "model_state_dict": (ema.module.state_dict() if best_checkpoint_source == "ema"
                             else model.module.state_dict() if hasattr(model, "module")
                             else model.state_dict()),
        "val_metrics": val_metrics,
        "checkpoint_source": best_checkpoint_source,
    },
    topk_ckpt_path,
)
heapq.heappush(topk_heap, (primary_val, topk_counter, topk_ckpt_path))
topk_counter += 1
# Evict worst checkpoint if heap exceeds K
if len(topk_heap) > TOPK_K:
    _, _, worst_path = heapq.heappop(topk_heap)  # pops smallest val = worst if lower-is-better — BUT heapq is a min-heap, so we need max-heap for val scores
    # NOTE: since lower val is better, we want to evict the HIGHEST val score
    # Rewrite as negated min-heap: push (-val_score, counter, path)
    worst_path.unlink(missing_ok=True)
```

**Important: the heap must evict the WORST (highest) val score, not the best.** Since Python's `heapq` is a min-heap and lower val is better, push negated scores:

```python
# Corrected Top-K implementation
# Push negated val so heapq.heappop() returns the highest (worst) val
topk_ckpt_path = output_dir / f"checkpoint_topk_{topk_counter}.pt"
torch.save({...as above...}, topk_ckpt_path)
heapq.heappush(topk_heap, (-primary_val, topk_counter, topk_ckpt_path))
topk_counter += 1
if len(topk_heap) > TOPK_K:
    neg_score, _, worst_path = heapq.heappop(topk_heap)  # removes worst (highest val = worst)
    worst_path.unlink(missing_ok=True)
```

**Only save a Top-K checkpoint when there is an improvement** (inside the `if improved:` block), OR save every validation epoch and let the heap manage eviction. The latter is preferable because it ensures the K best from all 30 epochs are retained. Place the Top-K save at every validation step (not just improvement), outside the `if improved:` block, so that late-epoch improvements are not missed.

### Step 2 — At EP30 terminal, average the Top-K checkpoints and run eval

At the end of training (after the final epoch loop), add:

```python
# --- Top-K checkpoint averaging ---
if len(topk_heap) > 0 and (not dist.is_initialized() or dist.get_rank() == 0):
    topk_paths = [p for (_, _, p) in topk_heap]
    print(f"[TopK] Averaging {len(topk_paths)} checkpoints: {[str(p) for p in topk_paths]}")
    # Load all state dicts
    state_dicts = []
    for p in topk_paths:
        ckpt = torch.load(p, map_location="cpu", weights_only=True)
        state_dicts.append(ckpt["model_state_dict"])
    # Arithmetic average tensor by tensor
    avg_state = {}
    for key in state_dicts[0].keys():
        avg_state[key] = torch.stack([sd[key].float() for sd in state_dicts]).mean(dim=0)
    avg_ckpt_path = output_dir / "checkpoint_topk_avg.pt"
    torch.save({"model_state_dict": avg_state, "epoch": "topk_avg", "val_metrics": {}}, avg_ckpt_path)
    print(f"[TopK] Saved averaged checkpoint to {avg_ckpt_path}")
```

### Step 3 — Run eval on the averaged checkpoint

After saving `checkpoint_topk_avg.pt`, trigger a full val+test eval:

```python
    # Run eval on the averaged checkpoint (rank 0 only in DDP)
    # Re-load model with averaged weights and run evaluate_model(...)
    if hasattr(model, "module"):
        model.module.load_state_dict(avg_state)
    else:
        model.load_state_dict(avg_state)
    print("[TopK] Running eval on averaged checkpoint...")
    topk_val_metrics = evaluate_model(model, val_loader, device, amp_mode, args, split="val")
    topk_test_metrics = evaluate_model(model, test_loader, device, amp_mode, args, split="test")
    # Log to W&B
    wandb.log({"topk_avg/val_abupt": topk_val_metrics.get("val_primary/abupt_axis_mean_rel_l2_pct"),
               "topk_avg/test_abupt": topk_test_metrics.get("test/abupt_axis_mean_rel_l2_pct"),
               "topk_avg/test_vol_p": topk_test_metrics.get("test/vol_p_rel_l2_pct"),
               "topk_avg/test_surf_p": topk_test_metrics.get("test/surf_p_rel_l2_pct"),
               "topk_avg/test_wall": topk_test_metrics.get("test/wall_shear_rel_l2_pct"),
               "topk_avg/k": len(topk_paths)})
    print(f"[TopK] val_abupt={topk_val_metrics.get('val_primary/abupt_axis_mean_rel_l2_pct'):.4f}% | "
          f"test_abupt={topk_test_metrics.get('test/abupt_axis_mean_rel_l2_pct'):.4f}%")
```

**If `evaluate_model` is not easily callable post-loop**, alternatively save `checkpoint_topk_avg.pt` and then invoke `--eval-only --eval-checkpoint checkpoint_topk_avg.pt` as a subprocess or separate script run — but the inline approach above is strongly preferred to avoid a second process.

### Step 4 — Training config (same as SOTA)

Use exact same config as PR #740 run `5x8wofzm`:

```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --epochs 30 \
  --lr 5e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --train-volume-points 65000 \
  --model-layers 6 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --model-pe string_multisigma \
  --no-compile-model \
  --no-use-gradnorm \
  --wandb-group topk-val-ckpt-avg \
  --wandb-name topk-K5-run1
```

### Kill gates (same as all long runs)

| Epoch | Step     | Val abupt threshold |
|-------|----------|---------------------|
| EP5   | ~54,930  | ≤ 7.5%              |
| EP10  | ~109,860 | ≤ 7.2%              |
| EP15  | ~164,790 | ≤ 6.80%             |
| EP20  | ~219,720 | ≤ 6.70%             |

Kill if any gate is missed. Do not continue past a failed gate.

### CODE-FIRST REQUIREMENT

**You MUST commit your `train.py` modifications to this branch and post the commit SHA as a comment BEFORE step 54,930 (EP5 gate).** Do not let EP5 pass without the code committed. The advisor will check. If the code is not committed by EP5, the run will be terminated.

---

## Baseline (Wave SOTA — PR #740, run `5x8wofzm`)

| Metric         | Value     |
|----------------|-----------|
| test_abupt     | 7.5195%   |
| test_vol_p     | 10.7580%  |
| test_surf_p    | 3.8810%   |
| test_wall      | 7.0610%   |

W&B run: `5x8wofzm` — https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/5x8wofzm

To beat baseline, you need: **test_abupt < 7.5195%** AND **test_vol_p < 10.7580%**

---

## What to report

At EP30 terminal, report **both** the standard single best-val checkpoint metrics AND the Top-K averaged checkpoint metrics side by side. This lets us directly measure the effect of the averaging.

Terminal result marker format:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"test_abupt","value":<number>},"test_metric":{"name":"test_vol_p","value":<number>}}
```

Use the **lower** test_abupt of the two (single best vs Top-K avg) as your primary metric in the terminal result marker.
