### PR TITLE
thorfinn: per-case vol_pressure RevIN re-run (clean rebase)

### DIFF
--- a/train.py
+++ b/train.py
@@ -38,6 +38,7 @@ from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
     TargetTransform,
+    apply_vol_revin,
     autocast_context,
     build_lr_scheduler,
     check_kill_thresholds,
@@ -56,6 +57,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    vol_revin_stats,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -138,6 +140,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_vol_revin: bool = False
     debug: bool = False
 
 
@@ -228,6 +231,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_vol_revin": (
+            "RevIN-style per-case instance normalization on volume_pressure "
+            "targets (Kim et al., ICLR 2022). At train time, normalize each "
+            "sample's vol_p to zero-mean/unit-std (computed in apply_volume "
+            "space, over the valid volume points). At inference, invert the "
+            "normalization using per-sample stats from the GT before metric "
+            "logging so metrics remain in physical units. Targets the ~3x "
+            "OOD val/test vol_p gap by removing absolute pressure-level shift."
         ),
     }
     for field in fields(Config):
@@ -321,10 +333,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_vol_revin: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_vol_revin:
+        vol_revin_mean, vol_revin_std = vol_revin_stats(volume_target, batch.volume_mask)
+        volume_target = apply_vol_revin(volume_target, vol_revin_mean, vol_revin_std)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -364,6 +380,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_vol_revin: bool = False,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -376,6 +394,9 @@ def per_task_train_losses(
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_vol_revin:
+        vol_revin_mean, vol_revin_std = vol_revin_stats(volume_target, batch.volume_mask)
+        volume_target = apply_vol_revin(volume_target, vol_revin_mean, vol_revin_std)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -939,7 +960,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        use_vol_revin=config.use_vol_revin,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1030,6 +1056,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_vol_revin=config.use_vol_revin,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1233,6 +1260,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        use_vol_revin=config.use_vol_revin,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1247,6 +1275,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    use_vol_revin=config.use_vol_revin,
                 )
                 for name, loader in val_loaders.items()
             }

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -832,6 +832,54 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+VOL_REVIN_EPS = 1e-6
+
+
+def vol_revin_stats(
+    volume_target_norm: torch.Tensor,
+    volume_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-sample mean/std of volume_pressure (channel 0) over valid points.
+
+    Computed in the ``transform.apply_volume`` (globally-normalized) space.
+    Returns ``(mean, std)`` each of shape ``[B, 1, 1]`` so they broadcast
+    directly against ``[B, N, 1]`` volume tensors.
+    """
+    vol_p = volume_target_norm[..., 0]
+    mask = volume_mask.to(device=vol_p.device, dtype=vol_p.dtype)
+    n_valid = mask.sum(dim=-1, keepdim=True).clamp(min=1.0)
+    mean = (vol_p * mask).sum(dim=-1, keepdim=True) / n_valid
+    centered = (vol_p - mean) * mask
+    var = (centered * centered).sum(dim=-1, keepdim=True) / n_valid
+    std = (var + VOL_REVIN_EPS * VOL_REVIN_EPS).sqrt()
+    return mean.unsqueeze(-1), std.unsqueeze(-1)
+
+
+def apply_vol_revin(
+    volume_target_norm: torch.Tensor,
+    mean: torch.Tensor,
+    std: torch.Tensor,
+) -> torch.Tensor:
+    """Apply per-sample instance norm to channel 0 (vol_p) of ``volume_target_norm``.
+
+    Other channels (none currently — VOLUME_Y_DIM == 1) pass through unchanged.
+    """
+    out = volume_target_norm.clone()
+    out[..., 0:1] = (out[..., 0:1] - mean) / (std + VOL_REVIN_EPS)
+    return out
+
+
+def invert_vol_revin(
+    volume_pred_norm: torch.Tensor,
+    mean: torch.Tensor,
+    std: torch.Tensor,
+) -> torch.Tensor:
+    """Invert per-sample instance norm on channel 0 (vol_p), back to apply_volume space."""
+    out = volume_pred_norm.clone()
+    out[..., 0:1] = out[..., 0:1] * (std + VOL_REVIN_EPS) + mean
+    return out
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -955,6 +1003,7 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    use_vol_revin: bool = False,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -969,8 +1018,21 @@ def accumulate_eval_batch(
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
+    if use_vol_revin:
+        # Model output is in instance-normalized + globally-normalized space.
+        # Invert the per-sample instance norm back to globally-normalized space
+        # using stats derived from the (globally-normalized) GT target. Loss is
+        # then computed against the instance-normalized target so train/val
+        # losses remain comparable.
+        vol_revin_mean, vol_revin_std = vol_revin_stats(volume_target_norm, batch.volume_mask)
+        volume_target_norm_inst = apply_vol_revin(volume_target_norm, vol_revin_mean, vol_revin_std)
+        volume_sse, volume_count = _masked_sse_count(
+            volume_pred_norm, volume_target_norm_inst, batch.volume_mask
+        )
+        volume_pred_norm = invert_vol_revin(volume_pred_norm, vol_revin_mean, vol_revin_std)
+    else:
+        volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
-    volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     accumulator.surface_loss_sse += surface_sse
     accumulator.surface_loss_count += surface_count
     accumulator.volume_loss_sse += volume_sse
@@ -1121,6 +1183,7 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    use_vol_revin: bool = False,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1132,6 +1195,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            use_vol_revin=use_vol_revin,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1465,8 +1529,16 @@ def run_final_evaluation(
         }
     )
 
+    use_vol_revin = bool(getattr(config, "use_vol_revin", False))
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_vol_revin=use_vol_revin,
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1486,7 +1558,14 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_vol_revin=use_vol_revin,
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

Re-submit per-case `volume_pressure` instance normalization (RevIN) from PR #1017 (closed due to merge conflict deadline, not scientific failure). Prior run `vhztrj1a` reached val_abupt=6.8116% at step 9,750 with slope −0.059%/1k steps — actively improving when closed.

The OOD test/val gap for vol_p (~3×: val≈3.9%, test≈12.0%) is the primary unsolved problem (Issue #717). RevIN hypothesis: absolute pressure level varies per car geometry/freestream condition; normalizing each case's vol_p targets to zero-mean/unit-variance at train time removes this confounding factor, forcing the model to learn geometry-driven relative pressure structure. At inference, invert the normalization to recover physical units. Kim et al. NeurIPS 2022.

## Instructions

Add a `--use-vol-revin` flag to `target/train.py`. When enabled:

1. **Per-case normalization at train time**: For each sample in the batch, compute `mean_i` and `std_i` of that case's `volume_pressure` target values. Normalize the vol_p targets to `(y - mean_i) / (std_i + eps)` before computing the loss. Store `mean_i` and `std_i` (detached) alongside the sample.
2. **Invert at inference**: After the model predicts vol_p, apply `pred_vol_p * (std_i + eps) + mean_i` to recover physical units before computing val/test metrics. This must happen before metric logging — metrics should be in physical (unnormalized) units.
3. `eps = 1e-6` to avoid div-by-zero on degenerate cases.
4. The normalization applies ONLY to `volume_pressure` — surface_pressure, tau_x/y/z are unaffected.
5. The `--use-vol-revin` flag should default to `False` so existing runs are unaffected.

Run with the full PR #958 SOTA stack plus `--use-vol-revin`, extended to 30 epochs:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent thorfinn --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 30 --epochs 30 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-vol-revin \
  --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<=8.0,32592:val_primary/volume_pressure_rel_l2_pct<=5.0,54320:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,86912:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,86912:val_primary/volume_pressure_rel_l2_pct<=4.5,108640:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,162960:val_primary/abupt_axis_mean_rel_l2_pct<=6.80,217280:val_primary/abupt_axis_mean_rel_l2_pct<=6.70,271600:val_primary/abupt_axis_mean_rel_l2_pct<=6.65" \
  --wandb-group thorfinn-revin-vol-pressure-rerun
```

## Kill Gates

| Epoch | ~Step | val_abupt ≤ | val_vol_p ≤ |
|-------|-------|-------------|-------------|
| EP3   | 32,592 | 8.0% | 5.0% |
| EP5   | 54,320 | 7.5% | — |
| EP8   | 86,912 | 7.5% | 4.5% |
| EP10  | 108,640 | 7.2% | — |
| EP15  | 162,960 | 6.80% | — |
| EP20  | 217,280 | 6.70% | — |
| EP25  | 271,600 | 6.65% | — |
| EP30  | 325,920 | terminal | — |

Note: Kill gate logic is `<=` (survive if metric ≤ threshold). Both EP3 conditions must be satisfied.

## Baseline

Single-model SOTA — PR #958, run `29nohj67`:
| Metric | Val | Test |
|--------|-----|------|
| abupt (primary) | 6.2868% | 7.7445% |
| surface_pressure | 4.1766% | 3.9100% |
| volume_pressure | 3.9152% | 12.0063% |
| wall_shear | 7.0476% | 6.9848% |

Training gate: val_abupt < **6.2868%**

OOD vol_p gap: val=3.92%, test=12.01% (~3.07×) — this is the gap RevIN targets.

Prior RevIN run (PR #1017, `vhztrj1a`, closed for merge conflicts only):
- Step 9,750: val_abupt=6.8116%, val_vol_p=4.2309%, slope=−0.059%/1k steps (actively improving when closed)
