### PR TITLE
tanjiro: FNO vol pressure decoder (spectral correction for OOD gap)

### DIFF
--- a/model.py
+++ b/model.py
@@ -11,6 +11,7 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.fft
 
 from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
 
@@ -188,6 +189,214 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+def normalize_to_unit_cube(
+    xyz: torch.Tensor, mask: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Normalize vol coords to [-1, 1]^3 per batch using per-sample bbox.
+
+    Padded tokens (mask=0) are excluded from the min/max computation by
+    replacing them with +/-inf sentinels before the reduction.
+    """
+    if mask is not None:
+        m = mask.unsqueeze(-1).bool().to(device=xyz.device)
+        inf_pos = torch.full_like(xyz, float("inf"))
+        inf_neg = torch.full_like(xyz, float("-inf"))
+        xyz_for_min = torch.where(m, xyz, inf_pos)
+        xyz_for_max = torch.where(m, xyz, inf_neg)
+        mins = xyz_for_min.amin(dim=1, keepdim=True)
+        maxs = xyz_for_max.amax(dim=1, keepdim=True)
+    else:
+        mins = xyz.amin(dim=1, keepdim=True)
+        maxs = xyz.amax(dim=1, keepdim=True)
+    span = (maxs - mins).clamp(min=1e-6)
+    return 2.0 * (xyz - mins) / span - 1.0
+
+
+class SpectralConv3d(nn.Module):
+    """3D Fourier spectral convolution layer (FNO building block).
+
+    Weights stored as float32 with trailing dim=2 (real, imag) for Lion
+    optimizer compatibility (Lion errors on torch.cfloat parameters).
+    Uses torch.view_as_complex() at forward time. norm="ortho" is used in
+    both rfftn and irfftn for spectral energy stability.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, modes: int):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.modes = modes
+
+        scale = 1.0 / (in_channels * out_channels)
+        self.weights = nn.Parameter(
+            scale * torch.randn(in_channels, out_channels, modes, modes, modes, 2)
+        )
+
+    def _get_complex_weights(self) -> torch.Tensor:
+        return torch.view_as_complex(self.weights.contiguous())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, C, D, H, W]; FFT runs in float32 regardless of autocast dtype
+        B, _, D, H, W = x.shape
+        x_ft = torch.fft.rfftn(x.float(), dim=[-3, -2, -1], norm="ortho")
+        w = self._get_complex_weights()  # [in_C, out_C, m, m, m] complex64
+        m = self.modes
+        out_ft = torch.zeros(
+            B, self.out_channels, D, H, W // 2 + 1,
+            dtype=x_ft.dtype, device=x_ft.device,
+        )
+        out_ft[:, :, :m, :m, :m] = torch.einsum(
+            "bixyz,ioxyz->boxyz",
+            x_ft[:, :, :m, :m, :m],
+            w,
+        )
+        x_out = torch.fft.irfftn(out_ft, s=[D, H, W], dim=[-3, -2, -1], norm="ortho")
+        return x_out.to(dtype=x.dtype)
+
+
+class FNOVolDecoder(nn.Module):
+    """FNO-based volume pressure decoder (residual correction head).
+
+    Scatter point features to a regular 3D grid (trilinear splatting), run
+    a stack of spectral convolutions, query back at point positions
+    (trilinear via F.grid_sample), and project to a scalar correction.
+
+    Designed as an additive residual on top of the existing MLP vol head.
+    The final Linear is zero-initialised so the FNO output is exactly zero
+    at init -- the model starts as the plain MLP and learns the spectral
+    correction.
+
+    Grid layout: [B, C, Z, Y, X] (z-outermost) so F.grid_sample receives
+    coords in the natural (x, y, z) order. See implementation notes inline.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        grid_res: int = 32,
+        modes: int = 12,
+        fno_width: int = 32,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+        self.grid_res = grid_res
+        self.modes = modes
+        self.fno_width = fno_width
+        if modes * 2 > grid_res:
+            raise ValueError(
+                f"FNO modes ({modes}) must be <= grid_res//2 ({grid_res // 2})"
+            )
+
+        self.lift = nn.Linear(hidden_dim, fno_width)
+
+        self.spectral_convs = nn.ModuleList(
+            [SpectralConv3d(fno_width, fno_width, modes) for _ in range(num_layers)]
+        )
+        self.w_convs = nn.ModuleList(
+            [nn.Conv3d(fno_width, fno_width, kernel_size=1) for _ in range(num_layers)]
+        )
+        self.norms = nn.ModuleList(
+            [nn.GroupNorm(min(8, fno_width), fno_width) for _ in range(num_layers)]
+        )
+
+        self.proj = nn.Sequential(
+            nn.Linear(fno_width, fno_width),
+            nn.GELU(),
+            nn.Linear(fno_width, 1),
+        )
+        # Identity init: zero the final Linear so the FNO correction is 0 at start.
+        nn.init.zeros_(self.proj[-1].weight)
+        nn.init.zeros_(self.proj[-1].bias)
+
+    def _scatter_to_grid(
+        self, h: torch.Tensor, xyz_norm: torch.Tensor
+    ) -> torch.Tensor:
+        """Trilinear splat point features to a [B, C, Z, Y, X] grid.
+
+        flat_idx = iz*R*R + iy*R + ix so the resulting tensor has Z as the
+        outer-most spatial dim. When that grid is later passed to
+        F.grid_sample (which treats the 5D input as [B, C, D, H, W] and
+        expects the query last-dim as (x, y, z) -> (W, H, D)), the natural
+        (x_norm, y_norm, z_norm) query maps correctly: x -> W -> ix axis,
+        y -> H -> iy axis, z -> D -> iz axis.
+        """
+        B, N, C = h.shape
+        R = self.grid_res
+        device = h.device
+        dtype = h.dtype
+
+        # Map [-1, 1] -> [0, R-1] voxel coords
+        xyz_grid = (xyz_norm + 1.0) * 0.5 * (R - 1)  # [B, N, 3]
+        idx = xyz_grid.long().clamp(0, R - 2)  # [B, N, 3]
+        frac = xyz_grid - idx.to(dtype=xyz_grid.dtype)  # [B, N, 3]
+
+        grid_flat = torch.zeros(B, C, R * R * R, device=device, dtype=dtype)
+
+        for dx in range(2):
+            wx = (1 - frac[..., 0]) if dx == 0 else frac[..., 0]
+            for dy in range(2):
+                wy = (1 - frac[..., 1]) if dy == 0 else frac[..., 1]
+                for dz in range(2):
+                    wz = (1 - frac[..., 2]) if dz == 0 else frac[..., 2]
+                    w = (wx * wy * wz).unsqueeze(-1)  # [B, N, 1]
+                    ix = (idx[..., 0] + dx).clamp(0, R - 1)
+                    iy = (idx[..., 1] + dy).clamp(0, R - 1)
+                    iz = (idx[..., 2] + dz).clamp(0, R - 1)
+                    flat_idx = iz * R * R + iy * R + ix  # [B, N]
+                    grid_flat.scatter_add_(
+                        2,
+                        flat_idx.unsqueeze(1).expand(B, C, N),
+                        (h * w.to(dtype=dtype)).permute(0, 2, 1),
+                    )
+
+        return grid_flat.view(B, C, R, R, R)
+
+    def _query_grid(
+        self, grid: torch.Tensor, xyz_norm: torch.Tensor
+    ) -> torch.Tensor:
+        """Trilinear sample [B, C, Z, Y, X] grid at xyz_norm in [-1, 1]^3.
+
+        F.grid_sample 5D last-dim is (x, y, z) -> (W, H, D); our grid has
+        Z=D, Y=H, X=W, so passing xyz_norm in (x, y, z) order is correct.
+        """
+        query = xyz_norm[:, None, None, :, :]  # [B, 1, 1, N, 3]
+        sampled = F.grid_sample(
+            grid, query,
+            mode="bilinear",
+            padding_mode="border",
+            align_corners=True,
+        )  # [B, C, 1, 1, N]
+        return sampled[:, :, 0, 0, :].permute(0, 2, 1)  # [B, N, C]
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        vol_xyz: torch.Tensor,
+        vol_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            h: [B, N, hidden_dim] vol token features from the backbone.
+            vol_xyz: [B, N, 3] vol coords in physical units.
+            vol_mask: [B, N] mask (1=real, 0=padding) or None.
+        Returns:
+            correction: [B, N, 1] additive correction for the MLP head.
+        """
+        xyz_norm = normalize_to_unit_cube(vol_xyz, vol_mask)
+
+        h_fno = self.lift(h)  # [B, N, fno_width]
+        if vol_mask is not None:
+            h_fno = h_fno * vol_mask.unsqueeze(-1).to(dtype=h_fno.dtype)
+
+        grid = self._scatter_to_grid(h_fno, xyz_norm)  # [B, fno_width, R, R, R]
+
+        for spec, w_conv, norm in zip(self.spectral_convs, self.w_convs, self.norms):
+            grid = F.gelu(norm(spec(grid) + w_conv(grid)))
+
+        h_out = self._query_grid(grid, xyz_norm)  # [B, N, fno_width]
+        return self.proj(h_out)  # [B, N, 1]
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -343,6 +552,10 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_fno_vol_decoder: bool = False,
+        fno_grid_resolution: int = 32,
+        fno_modes: int = 12,
+        fno_width: int = 32,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +569,10 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_fno_vol_decoder = use_fno_vol_decoder
+        self.fno_grid_resolution = fno_grid_resolution
+        self.fno_modes = fno_modes
+        self.fno_width = fno_width
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -459,6 +676,21 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # PR #1040: FNO spectral residual decoder for volume pressure.
+        # Scatter vol token features to a regular 3D grid, run spectral
+        # convolutions, query back at point positions, and add to the MLP
+        # vol head output. Final Linear is zero-initialised inside
+        # FNOVolDecoder so the model starts identical to the plain MLP.
+        if use_fno_vol_decoder:
+            self.fno_vol_decoder = FNOVolDecoder(
+                hidden_dim=n_hidden,
+                grid_res=fno_grid_resolution,
+                modes=fno_modes,
+                fno_width=fno_width,
+            )
+        else:
+            self.fno_vol_decoder = None
 
     def _encode_group(
         self,
@@ -569,7 +801,14 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
-            volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            volume_logits = self.volume_out(volume_hidden)
+            if self.fno_vol_decoder is not None:
+                vol_xyz = volume_x[:, :, : self.space_dim]
+                fno_correction = self.fno_vol_decoder(
+                    volume_hidden, vol_xyz, volume_mask
+                )
+                volume_logits = volume_logits + fno_correction
+            volume_preds = volume_logits * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,10 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_fno_vol_decoder: bool = False
+    fno_grid_resolution: int = 32
+    fno_modes: int = 12
+    fno_width: int = 32
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +233,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_fno_vol_decoder": (
+            "Enable FNO spectral residual decoder for volume pressure "
+            "(PR #1040). Scatters volume token features to a regular 3D "
+            "grid (trilinear splat), runs spectral convolutions (FFT-space "
+            "weights, mode truncation), and queries back at point "
+            "positions; output is added as a residual to the MLP vol head. "
+            "Final Linear is zero-initialised so the model starts as the "
+            "plain MLP baseline. Spectral weights are stored as float32 "
+            "with trailing dim=2 (real, imag) for Lion compatibility."
+        ),
+        "fno_grid_resolution": (
+            "3D grid resolution per axis for FNO splatting (R). Default 32. "
+            "Memory cost scales as O(R^3). Must satisfy 2*--fno-modes <= R."
+        ),
+        "fno_modes": (
+            "Number of Fourier modes per spatial axis retained in the FNO "
+            "spectral conv. Default 12. Must satisfy 2*modes <= "
+            "--fno-grid-resolution (Nyquist)."
+        ),
+        "fno_width": (
+            "FNO channel width (lifted-feature dim used inside the spectral "
+            "conv stack). Default 32."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +335,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_fno_vol_decoder=config.use_fno_vol_decoder,
+        fno_grid_resolution=config.fno_grid_resolution,
+        fno_modes=config.fno_modes,
+        fno_width=config.fno_width,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current vol pressure decoder is a pointwise MLP head applied independently to each volume token — spatially agnostic, with no coupling between neighboring points. Volume pressure in external aerodynamics CFD is governed by the Poisson equation (∇²p = f), whose solution has well-defined spectral structure: long-wavelength mean pressure gradients plus shorter-wavelength perturbations around the body.

We hypothesize that replacing the pointwise MLP vol decoder with a **Fourier Neural Operator (FNO)** will improve vol_pressure fidelity by explicitly modeling the spectral (frequency-space) components of the 3D pressure field.

**Scientific motivation:**
- FNO was designed precisely for PDE solution operators (Li et al. 2021) — pressure IS a PDE solution (Poisson)
- The 4 OOD geometries (run_133, run_226, run_203, run_158) account for ~92% of squared test_vol_p deviation. These geometries have unusual pressure wave patterns that a spectral method captures more naturally than a pointwise MLP
- Every prior vol_p approach has operated pointwise: MLP head (baseline), aux head (PR #958), mid-backbone xattn (#917 — NEGATIVE). None operate in frequency space
- GINO / Geo-FNO (Li et al. 2023) has shown FNO works well when points are irregular (scattered, not on a regular grid) by splatting to a grid, applying FNO, then querying back

**Prior attempt**: PR #1022 (frieren, closed). That run crashed at EP1 validation boundary — the crash traceback was never recovered. Separate from the architecture: a Lion optimizer incompatibility with `torch.cfloat` parameters was discovered and a fix committed (`8c0e6a8`). **This PR is the clean attempt on the `tay` branch with the Lion-compatibility fix in place from the start.**

**Why now**: The val/test gap on vol_p is ~3× (val ~3.9%, test ~12.0%). This strongly suggests the model has learned point-local features that don't generalize to OOD pressure distributions. An FNO decoder that models global spectral correlations across the volume should generalize better.

## Implementation

Add the following to `target/train.py` (CLI flags):

```python
parser.add_argument(
    "--use-fno-vol-decoder",
    action="store_true",
    default=False,
    help="Augment vol pressure decoder with an FNO spectral correction on a 3D grid.",
)
parser.add_argument(
    "--fno-grid-resolution",
    type=int,
    default=32,
    help="3D grid resolution per axis for the FNO splatting step. Default: 32.",
)
parser.add_argument(
    "--fno-modes",
    type=int,
    default=12,
    help="Number of Fourier modes per spatial axis kept in the FNO spectral conv. Default: 12.",
)
parser.add_argument(
    "--fno-width",
    type=int,
    default=32,
    help="FNO channel width. Default: 32.",
)
```

Add the following to `target/model.py`:

```python
import torch.fft

def normalize_to_unit_cube(xyz: torch.Tensor) -> torch.Tensor:
    """Normalize vol coords to [-1, 1]^3 per batch using per-sample bbox."""
    # xyz: [B, N, 3]
    mins = xyz.min(dim=1, keepdim=True).values   # [B, 1, 3]
    maxs = xyz.max(dim=1, keepdim=True).values   # [B, 1, 3]
    return 2.0 * (xyz - mins) / (maxs - mins + 1e-6) - 1.0


class SpectralConv3d(nn.Module):
    """3D Fourier spectral convolution layer (FNO building block).
    
    CRITICAL: Weights stored as float32 with trailing dim=2 (real, imag).
    Use torch.view_as_complex() to form complex tensors at forward time.
    This is required for Lion optimizer compatibility — Lion cannot handle
    torch.cfloat parameters (Lion grads must be real-valued).
    """
    def __init__(self, in_channels: int, out_channels: int, modes: int):
        super().__init__()
        self.in_channels = in_channels
        self.out_channels = out_channels
        self.modes = modes  # modes per axis

        scale = 1.0 / (in_channels * out_channels)
        # Store as float32 [..., 2] (real, imag) — NOT torch.cfloat
        # to keep Lion optimizer happy (cfloat params cause gradient type errors)
        self.weights = nn.Parameter(
            scale * torch.randn(in_channels, out_channels, modes, modes, modes, 2)
        )

    def _get_complex_weights(self) -> torch.Tensor:
        """View float32 weights as complex."""
        return torch.view_as_complex(self.weights.contiguous())

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        # x: [B, C, R, R, R]
        B, C, R1, R2, R3 = x.shape
        x_ft = torch.fft.rfftn(x, dim=[-3, -2, -1])  # [B, C, R, R, R//2+1]

        w = self._get_complex_weights()  # [in_C, out_C, m, m, m] complex
        m = self.modes
        out_ft = torch.zeros(
            B, self.out_channels, R1, R2, R3 // 2 + 1,
            dtype=x_ft.dtype, device=x.device
        )
        # Apply spectral weights on the low-frequency corner
        out_ft[:, :, :m, :m, :m] = torch.einsum(
            "bixyz,ioxyz->boxyz", x_ft[:, :, :m, :m, :m], w
        )
        x_out = torch.fft.irfftn(out_ft, s=[R1, R2, R3], dim=[-3, -2, -1])
        return x_out


class FNOVolDecoder(nn.Module):
    """FNO-based vol pressure decoder: scatter → FNO → query → project.
    
    Designed as an additive residual correction on top of the existing
    MLP vol pressure head. Zero-initializes the output projection so the
    model starts as the plain MLP and learns the FNO correction.
    """
    def __init__(
        self,
        hidden_dim: int,
        grid_res: int = 32,
        modes: int = 12,
        fno_width: int = 32,
        num_layers: int = 2,
    ):
        super().__init__()
        self.grid_res = grid_res
        self.modes = modes

        # Lift from backbone hidden dim to FNO width
        self.lift = nn.Linear(hidden_dim, fno_width)

        # FNO layers
        self.spectral_convs = nn.ModuleList(
            [SpectralConv3d(fno_width, fno_width, modes) for _ in range(num_layers)]
        )
        self.w_convs = nn.ModuleList(
            [nn.Conv3d(fno_width, fno_width, kernel_size=1) for _ in range(num_layers)]
        )
        self.norms = nn.ModuleList(
            [nn.GroupNorm(min(8, fno_width), fno_width) for _ in range(num_layers)]
        )

        # Project FNO features to pressure correction
        self.proj = nn.Sequential(
            nn.Linear(fno_width, fno_width),
            nn.GELU(),
            nn.Linear(fno_width, 1),
        )
        # Zero-init final linear so FNO correction starts at zero (identity init)
        nn.init.zeros_(self.proj[-1].weight)
        nn.init.zeros_(self.proj[-1].bias)

    def _scatter_to_grid(
        self, h: torch.Tensor, xyz_norm: torch.Tensor
    ) -> torch.Tensor:
        """Trilinear splatting: scatter point features to a regular 3D grid.
        
        Args:
            h: [B, N, C] point features
            xyz_norm: [B, N, 3] coords in [-1, 1]^3
        Returns:
            grid: [B, C, R, R, R]
        """
        B, N, C = h.shape
        R = self.grid_res
        device = h.device

        # Map [-1, 1] -> [0, R-1] voxel indices
        xyz_grid = (xyz_norm + 1.0) / 2.0 * (R - 1)  # [B, N, 3]
        # Floor indices and fractional weights for trilinear interp
        idx = xyz_grid.long().clamp(0, R - 2)   # [B, N, 3]
        frac = xyz_grid - idx.float()            # [B, N, 3]

        grid = torch.zeros(B, C, R, R, R, device=device, dtype=h.dtype)

        # Scatter to 8 corners with trilinear weights
        for dx in range(2):
            wx = (1 - frac[..., 0]) if dx == 0 else frac[..., 0]
            for dy in range(2):
                wy = (1 - frac[..., 1]) if dy == 0 else frac[..., 1]
                for dz in range(2):
                    wz = (1 - frac[..., 2]) if dz == 0 else frac[..., 2]
                    w = (wx * wy * wz).unsqueeze(-1)  # [B, N, 1]
                    ix = (idx[..., 0] + dx).clamp(0, R - 1)
                    iy = (idx[..., 1] + dy).clamp(0, R - 1)
                    iz = (idx[..., 2] + dz).clamp(0, R - 1)
                    flat_idx = ix * R * R + iy * R + iz  # [B, N]
                    # scatter_add on flattened spatial dim
                    grid_flat = grid.reshape(B, C, R * R * R)
                    grid_flat.scatter_add_(
                        2,
                        flat_idx.unsqueeze(1).expand(B, C, N),
                        (h * w).permute(0, 2, 1)
                    )
                    grid[:] = grid_flat.reshape(B, C, R, R, R)

        return grid  # [B, C, R, R, R]

    def _query_grid(
        self, grid: torch.Tensor, xyz_norm: torch.Tensor
    ) -> torch.Tensor:
        """Trilinear interpolation: query grid at arbitrary point positions.
        
        Uses F.grid_sample which expects coords in [-1, 1]^3.
        """
        # grid: [B, C, R, R, R]
        # xyz_norm: [B, N, 3] in [-1, 1]^3
        B, N, _ = xyz_norm.shape
        # grid_sample query shape: [B, 1, 1, N, 3] for 5D input
        query = xyz_norm[:, None, None, :, :]  # [B, 1, 1, N, 3]
        sampled = F.grid_sample(
            grid, query,
            mode='bilinear', padding_mode='border', align_corners=True
        )  # [B, C, 1, 1, N]
        return sampled[:, :, 0, 0, :].permute(0, 2, 1)  # [B, N, C]

    def forward(self, h: torch.Tensor, xyz_norm: torch.Tensor) -> torch.Tensor:
        """
        Args:
            h: [B, N, D] vol token features from Transolver backbone
            xyz_norm: [B, N, 3] vol coords normalized to [-1, 1]^3
        Returns:
            pressure_correction: [B, N, 1] additive correction to MLP head
        """
        h_fno = self.lift(h)  # [B, N, fno_width]

        grid = self._scatter_to_grid(h_fno, xyz_norm)  # [B, fno_width, R, R, R]

        for spec, w_conv, norm in zip(self.spectral_convs, self.w_convs, self.norms):
            grid = F.gelu(norm(spec(grid) + w_conv(grid)))

        h_out = self._query_grid(grid, xyz_norm)  # [B, N, fno_width]
        return self.proj(h_out)  # [B, N, 1]
```

In the model class `__init__`, add:
```python
self.fno_vol_decoder = FNOVolDecoder(
    hidden_dim=config.model_hidden_dim,
    grid_res=config.fno_grid_resolution,
    modes=config.fno_modes,
    fno_width=config.fno_width,
) if config.use_fno_vol_decoder else None
```

In the model `forward`, after computing `vol_pressure_mlp` (the existing MLP head output):
```python
if self.fno_vol_decoder is not None:
    xyz_norm = normalize_to_unit_cube(vol_xyz)   # vol_xyz: [B, N, 3]
    fno_correction = self.fno_vol_decoder(vol_tokens, xyz_norm)  # [B, N, 1]
    vol_pressure = vol_pressure_mlp + fno_correction
else:
    vol_pressure = vol_pressure_mlp
```

You will need to locate where `vol_xyz` (the volume point coordinates) are available in the forward pass and pass them through. They are likely the same coords used in the Transolver slice assignment.

## Training Commands

### Arm A — baseline FNO (grid=32, modes=12, fno_width=32)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-fno-vol-decoder --fno-grid-resolution 32 --fno-modes 12 --fno-width 32 \
  --wandb-group tanjiro-fno-vol-decoder
```

### Arm B — larger FNO capacity (grid=48, modes=16, fno_width=64)

Only run if Arm A passes the EP3 kill gate (see below). Start after Arm A is confirmed stable at EP1.

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-fno-vol-decoder --fno-grid-resolution 48 --fno-modes 16 --fno-width 64 \
  --wandb-group tanjiro-fno-vol-decoder
```

## Kill Gates

**After EP1** (~10,864 steps at vol=16K): Kill immediately if `val_abupt > 40%` or training loss is diverging (loss > 3× EP0 start). This catches the EP1 crash scenario from PR #1022 early.

**After EP3** (kill gate): Kill any arm that does NOT meet **both**:
- `val_abupt ≤ 7.5%`
- `val_vol_p ≤ 5.5%`

**Memory note**: 3D grid at res=32 occupies 32³ × fno_width=32 × 4 bytes ≈ 4 MB per sample — negligible on 96GB VRAM. Arm B at res=48 is ~6× larger (~24 MB/sample) still fine. If CUDA OOM occurs, reduce `--fno-grid-resolution`.

## Important Implementation Notes

1. **Lion-compatibility fix (CRITICAL)**: Store FNO spectral weights as `float32` with trailing dim 2 (real, imag): `nn.Parameter(torch.randn(..., 2))`. Use `torch.view_as_complex(weights.contiguous())` at forward time. **Do NOT use `dtype=torch.cfloat` for Parameter declaration** — Lion optimizer cannot handle complex-typed parameters (raises gradient type mismatch error at step 0).

2. **Zero-init output projection**: The `proj[-1]` Linear layer must be zero-initialized so FNO correction starts at zero. This ensures the model begins as the plain MLP and learns the FNO correction as a bonus — safe initialization.

3. **EP1 crash diagnostic**: If the run crashes at EP1 validation boundary (as PR #1022 did), check: (a) `vol_xyz` shape/normalization — ensure coords are actually passed to `normalize_to_unit_cube`; (b) `grid_sample` expects input in 5D for 3D volumes (`[B, C, D, H, W]`); (c) `scatter_add_` index shape must match exactly.

4. **Report `val_vol_p` and `test_vol_p` explicitly** in your results — this is the primary metric we're targeting with this experiment.

## Baseline

Current best metrics — single-model SOTA (PR #958, run `29nohj67`):

| Metric | Val | Test |
|--------|-----|------|
| **abupt (primary)** | **6.2868%** | 7.7445% |
| surface_pressure | 4.1766% | 3.9100% |
| volume_pressure | 3.9152% | **12.0063%** |
| wall_shear | 7.0476% | 6.9848% |

Gate to beat: `val_abupt < 6.2868%`

OOD gap target: `test_vol_p < 12.0063%` (current 3× val/test multiplier)

AB-UPT reference: vol_pressure = 6.08% (test)

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
