### PR TITLE
Perceiver-IO slot-based vol aggregation: geometry bottleneck for OOD vol_p

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,52 @@ class Transformer(nn.Module):
         return x
 
 
+class SlotVolAttention(nn.Module):
+    """Perceiver-IO style slot pooling for volume tokens (PR #1043).
+
+    S learnable slot queries compress N_vol volume tokens into a geometry
+    bottleneck, then broadcast back to the volume tokens via cross-attention.
+    This geometry bottleneck is hypothesised to improve OOD vol_p generalisation
+    by forcing the model to route volume pressure through a compact latent space.
+
+    Zero-init on vol_to_slots_attn.out_proj ensures the broadcast MHA outputs
+    zero at init; the final ``vol_norm`` then renormalises the vol features
+    before the vol_p head, so the module is *not* strictly identity at init
+    (the LayerNorm restandardises magnitudes). This matches the PR body spec.
+
+    Architecturally related to Perceiver IO (Jaegle et al. 2107.14795) and
+    Set Transformer (Lee et al. 1810.00825).
+    """
+
+    def __init__(self, d_model: int, num_slots: int = 64, num_heads: int = 4):
+        super().__init__()
+        self.slots = nn.Parameter(torch.randn(num_slots, d_model) * 0.02)
+        self.slots_to_vol_attn = nn.MultiheadAttention(d_model, num_heads, batch_first=True)
+        self.slots_norm1 = nn.LayerNorm(d_model)
+        self.slots_ff = nn.Sequential(
+            nn.Linear(d_model, d_model * 4), nn.GELU(), nn.Linear(d_model * 4, d_model)
+        )
+        self.slots_norm2 = nn.LayerNorm(d_model)
+        self.vol_to_slots_attn = nn.MultiheadAttention(d_model, num_heads, batch_first=True)
+        self.vol_norm = nn.LayerNorm(d_model)
+        # Zero-init output projection for safe residual initialisation.
+        nn.init.zeros_(self.vol_to_slots_attn.out_proj.weight)
+        nn.init.zeros_(self.vol_to_slots_attn.out_proj.bias)
+
+    def forward(self, vol_hidden: torch.Tensor) -> torch.Tensor:
+        # vol_hidden: (B, N_vol, d_model)
+        B = vol_hidden.shape[0]
+        slots = self.slots.unsqueeze(0).expand(B, -1, -1)  # (B, S, d)
+        # Slots aggregate vol tokens (compress to bottleneck).
+        s_out, _ = self.slots_to_vol_attn(slots, vol_hidden, vol_hidden)
+        slots = self.slots_norm1(slots + s_out)
+        slots = self.slots_norm2(slots + self.slots_ff(slots))
+        # Vol tokens read from slots (residual broadcast from bottleneck).
+        v_out, _ = self.vol_to_slots_attn(vol_hidden, slots, slots)
+        vol_hidden = self.vol_norm(vol_hidden + v_out)
+        return vol_hidden
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -343,6 +389,9 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_slot_vol_attn: bool = False,
+        slot_vol_num_slots: int = 64,
+        slot_vol_num_heads: int = 4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -460,6 +509,18 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Slot attention geometry bottleneck for volume tokens (PR #1043).
+        # SlotVolAttention runs after the backbone and surf_to_vol_xattn,
+        # immediately before the vol_p output head.
+        if use_slot_vol_attn:
+            self.slot_vol_attn = SlotVolAttention(
+                d_model=n_hidden,
+                num_slots=slot_vol_num_slots,
+                num_heads=slot_vol_num_heads,
+            )
+        else:
+            self.slot_vol_attn = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -560,6 +621,13 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # Slot attention geometry bottleneck (PR #1043): compress 65 k vol
+        # tokens through S latent slots, then broadcast back. Applied after
+        # surf_to_vol_xattn and before the vol_p output head.
+        if self.slot_vol_attn is not None and volume_x is not None and volume_tokens > 0:
+            volume_hidden = self.slot_vol_attn(volume_hidden)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,10 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_slot_vol_attn: bool = False
+    slot_vol_num_slots: int = 64
+    slot_vol_num_heads: int = 4
+    use_vol_pressure_aux_head: bool = True
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +233,32 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_slot_vol_attn": (
+            "Enable Perceiver-IO style slot-based volume-token bottleneck "
+            "(PR #1043). After the backbone (and optional surf->vol xattn) "
+            "and before the vol_p head, S learnable slot queries cross-"
+            "attend to N_vol volume tokens, run a slot self-attention + MLP "
+            "block, and then the vol tokens cross-attend back to the slots. "
+            "The vol-to-slots out_proj weight and bias are zero-init so the "
+            "module is identity at init (preserves baseline at epoch 0). "
+            "Hypothesis: forcing vol_p through a compact latent set improves "
+            "OOD generalisation by discouraging per-token memorisation of "
+            "training-set flow topology."
+        ),
+        "slot_vol_num_slots": (
+            "Number of learnable slot queries (default 64). Sweep S to "
+            "balance bottleneck strength (smaller -> stronger compression) "
+            "vs capacity (larger -> richer global summary)."
+        ),
+        "slot_vol_num_heads": (
+            "Number of attention heads inside SlotVolAttention (default 4). "
+            "Must divide --model-hidden-dim evenly."
+        ),
+        "use_vol_pressure_aux_head": (
+            "No-op kept for back-compat with PR #958 launch commands. The "
+            "deeper 3-layer vol_p decoder head (PR #958) is now always "
+            "active in model.SurfaceTransolver.volume_out."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +338,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_slot_vol_attn=config.use_slot_vol_attn,
+        slot_vol_num_slots=config.slot_vol_num_slots,
+        slot_vol_num_heads=config.slot_vol_num_heads,
     )
 
 
@@ -773,7 +806,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_slot_vol_attn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The current volume pathway applies Transolver slice-based self-attention directly on all N_vol ≈ 65k tokens. Each token is processed roughly independently — the backbone does aggregate spatial context via attention, but there is no explicit *bottleneck* that forces the model to summarise the global geometric character of the volume.

The 4 OOD test cases (run_133, run_226, run_203, run_158) that account for ~92% of the squared vol_p error are geometrically unlike the training distribution — they have different global flow topology. A model that processes volume tokens without a global geometry bottleneck may "memorise" local per-case patterns from the training distribution, leading to large errors when the overall flow topology changes OOD.

**Proposed fix**: introduce Perceiver-IO style slot-based aggregation on the volume tokens. Specifically:

- Initialise S=64 learned "slot" queries (shape `(S, d_hidden)`).
- Apply cross-attention: slots attend to all N_vol volume tokens → shape `(S, d_hidden)`.
- Apply a small slot self-attention block `(S, S)` for slot communication.
- Expand back: volume tokens attend to the S slots → updated vol tokens.

This creates a geometric bottleneck: the model must distil the entire N_vol=65k vol-token volume into just 64 latent geometric "concepts" before broadcasting back. Because the slots are trained to capture recurring global geometric structures (flow fields, wake regions, etc.), this should generalise better OOD — the global geometry shapes what slots are activated, rather than per-token local memorisation.

This is architecturally related to Perceiver IO (Jaegle et al. 2021) and Set Transformer (Lee et al. 2019).

## Instructions to the Student

**Goal**: Implement slot-based vol-token aggregation with a geometry bottleneck and check whether it reduces the val/test vol_p OOD gap (val≈3.9%, test≈12.0%, target 6.08%).

### Implementation

Add a `SlotVolAttention` module that runs *after* the standard Transolver layers, applied to the volume tokens only before the vol_p head:

```python
class SlotVolAttention(nn.Module):
    """Perceiver-IO style slot pooling for volume tokens."""

    def __init__(self, d_model: int, num_slots: int = 64, num_heads: int = 4):
        super().__init__()
        self.slots = nn.Parameter(torch.randn(num_slots, d_model) * 0.02)
        # Cross-attn: slots attend to vol tokens
        self.slots_to_vol_attn = nn.MultiheadAttention(d_model, num_heads, batch_first=True)
        self.slots_norm1 = nn.LayerNorm(d_model)
        self.slots_ff = nn.Sequential(
            nn.Linear(d_model, d_model * 4), nn.GELU(), nn.Linear(d_model * 4, d_model)
        )
        self.slots_norm2 = nn.LayerNorm(d_model)
        # Cross-attn: vol tokens attend to slots
        self.vol_to_slots_attn = nn.MultiheadAttention(d_model, num_heads, batch_first=True)
        self.vol_norm = nn.LayerNorm(d_model)
        # Zero-init output projection for safe initialisation
        nn.init.zeros_(self.vol_to_slots_attn.out_proj.weight)
        nn.init.zeros_(self.vol_to_slots_attn.out_proj.bias)

    def forward(self, vol_hidden: torch.Tensor) -> torch.Tensor:
        # vol_hidden: (B, N_vol, d_model)
        B = vol_hidden.shape[0]
        slots = self.slots.unsqueeze(0).expand(B, -1, -1)  # (B, S, d)

        # Slots aggregate vol tokens
        s_out, _ = self.slots_to_vol_attn(slots, vol_hidden, vol_hidden)
        slots = self.slots_norm1(slots + s_out)
        slots = self.slots_norm2(slots + self.slots_ff(slots))

        # Vol tokens read from slots (residual)
        v_out, _ = self.vol_to_slots_attn(vol_hidden, slots, slots)
        vol_hidden = self.vol_norm(vol_hidden + v_out)
        return vol_hidden
```

Insert one call to `SlotVolAttention` between the last backbone layer and the vol_p head. The vol_p head then operates on the slot-refined vol tokens.

Make this togglable with `--use-slot-vol-attn` (default off). Expose `--slot-vol-num-slots` (default 64) and `--slot-vol-num-heads` (default 4) for sweep-readiness.

### Training run

Use the full SOTA stack from PR #958 plus the new flag:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent nezuko \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-vol-pressure-aux-head --volume-loss-weight 1.0 \
  --use-slot-vol-attn --slot-vol-num-slots 64 \
  --wandb-group nezuko-slot-attn-vol-perceiver
```

**Key flags**:
- `--use-slot-vol-attn` — enables the slot-based vol aggregation module (new flag you implement)
- `--slot-vol-num-slots 64` — number of slot queries
- `--no-compile-model` — required (torch.compile + DDP deadlock at step 1)

### What to check

1. **Primary gate**: does `val_primary/volume_pressure_rel_l2_pct` drop below 3.9152%?
2. **OOD gap**: compare val vs test `volume_pressure_rel_l2_pct` — is the ratio improving?
3. **Overall abupt**: does `val_abupt` stay below 6.2868%?
4. **Per-OOD-case analysis** (if possible): log per-case vol_p error for run_133, run_226, run_203, run_158 — these 4 cases account for ~92% of the squared test vol_p error.

Please report per-channel metrics for both val and test sets, and note the W&B run ID.

### Suggested follow-up (if Arm A shows promise)

Try S=128 slots to see if more capacity helps. Also consider applying the slot module at multiple backbone layers rather than just the final layer.

## Baseline

Current single-model SOTA (PR #958, W&B run `29nohj67`):

| Metric | val | test |
|---|---|---|
| abupt (primary) | 6.2868% | 7.7445% |
| volume_pressure | **3.9152%** | **12.0063%** |
| surface_pressure | 3.5747% | 3.9100% |
| wall_shear | 6.9848% | 6.9848% |

AB-UPT public reference targets: surface_pressure 3.82%, wall_shear 7.29%, volume_pressure **6.08%**.

The val/test vol_p gap (3.9% → 12.0%, ~3× multiplier) is the binding constraint for the overall test metric. Closing this gap is the primary goal.
