### PR TITLE
Log-space vol_p loss (sign*log1p) for OOD pressure generalization

### DIFF
--- a/train.py
+++ b/train.py
@@ -236,8 +236,8 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(index 0 of volume predictions/targets in normalized space) before "
             "computing the MSE training loss. Leaves all other channels and the "
             "surface losses untouched. Hypothesis: compressing large-magnitude "
-            "pressure outliers during training (val_vol_p ~ 3.9% vs test_vol_p ~ "
-            "12% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
+            "pressure outliers during training (val_vol_p ~ 3.9%% vs test_vol_p ~ "
+            "12%% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
             "heavy-tail residuals and improves OOD generalization. Eval metrics "
             "are unchanged (still raw MSE in denormalized space)."
         ),

--- a/train.py
+++ b/train.py
@@ -53,6 +53,7 @@ from trainer_runtime import (
     init_wandb_run,
     is_valid_primary_metric,
     loader_kwargs,
+    log1p_signed,
     make_loaders,
     masked_mse,
     metric_namespace,
@@ -138,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_p_log_space_loss: bool = False
     debug: bool = False
 
 
@@ -228,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "vol_p_log_space_loss": (
+            "Apply sign(x)*log1p(|x|) transform to the volume-pressure channel "
+            "(index 0 of volume predictions/targets in normalized space) before "
+            "computing the MSE training loss. Leaves all other channels and the "
+            "surface losses untouched. Hypothesis: compressing large-magnitude "
+            "pressure outliers during training (val_vol_p ~ 3.9% vs test_vol_p ~ "
+            "12% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
+            "heavy-tail residuals and improves OOD generalization. Eval metrics "
+            "are unchanged (still raw MSE in denormalized space)."
         ),
     }
     for field in fields(Config):
@@ -321,6 +333,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_p_log_space_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -341,7 +354,22 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        vol_pred_for_loss = out["volume_preds"]
+        vol_target_for_loss = volume_target
+        if vol_p_log_space_loss:
+            # Compress channel-0 (volume pressure) magnitudes in normalized space
+            # so MSE no longer weights heavy-tail residuals quadratically. Built
+            # via cat-of-slices to avoid in-place slice assignment, which
+            # invalidates autograd version counters on the cloned tensor.
+            vol_pred_for_loss = torch.cat(
+                [log1p_signed(vol_pred_for_loss[..., :1]), vol_pred_for_loss[..., 1:]],
+                dim=-1,
+            )
+            vol_target_for_loss = torch.cat(
+                [log1p_signed(vol_target_for_loss[..., :1]), vol_target_for_loss[..., 1:]],
+                dim=-1,
+            )
+        volume_loss = masked_mse(vol_pred_for_loss, vol_target_for_loss, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -1030,6 +1058,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_p_log_space_loss=config.vol_p_log_space_loss,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -865,6 +865,17 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def log1p_signed(x: torch.Tensor) -> torch.Tensor:
+    """sign(x) * log1p(|x|) — a smooth, symmetric log-space transform.
+
+    Compresses large-magnitude values while preserving sign and being well-behaved
+    at zero (f(0)=0). Gradient = 1/(1+|x|) almost everywhere, so large-magnitude
+    inputs receive smaller gradients than under the identity. Numerically stable
+    for any finite input.
+    """
+    return x.sign() * torch.log1p(x.abs())
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Log-space transform on vol_pressure channel before MSE loss may reduce the OOD test_vol_p gap.

**Motivation**: Volume pressure values in the DrivAerML dataset likely span multiple orders of magnitude, with large-magnitude outliers in OOD test geometries. The standard MSE loss penalizes large residuals quadratically, causing the model to over-fit to high-pressure-magnitude training examples and under-generalize to the shifted OOD pressure distribution. Applying a `sign(x) * log1p(|x|)` transform *before squaring* in the loss compresses large values, giving smaller gradients on outliers and effectively smoothing the loss landscape to improve OOD generalization.

This is analogous to the Huber loss / log-loss formulations used in regression tasks with heavy-tailed targets. The transform is applied only to the **volume pressure channel (index 0)** in normalized space, leaving wall-shear and surface predictions untouched.

**OOD gap context**: val_vol_p ≈ 3.9% vs test_vol_p ≈ 12.0% (~3× multiplier). We've confirmed this is NOT a capacity problem (aux head didn't help). It's a distribution shift problem — log-space loss may help the model be less sensitive to pressure magnitude scale.

---

## Baseline to Beat

From PR #958 (run `29nohj67`):

| Metric | Value |
|--------|-------|
| val_abupt | 6.2868% |
| val_vol_p | 3.9152% |
| val_surf_p | 4.1766% |
| test_abupt | 7.7445% |
| **test_vol_p** | **12.0063%** ← primary OOD target |
| test_surf_p | 3.9100% |

---

## Implementation Instructions

You need to add a `--vol-p-log-space-loss` flag and apply the transform inside `train.py`. Do **not** modify eval/validation code — only the training loss. Steps:

### Step 1: Add the flag to `Config` dataclass in `train.py`

After the `use_gradnorm: bool = False` field (around line 133), add:

```python
vol_p_log_space_loss: bool = False
```

### Step 2: Add help text in `parse_args` (optional but recommended)

In the `help_text` dict in `parse_args`, add:

```python
"vol_p_log_space_loss": (
    "Apply sign(x)*log1p(|x|) transform to the volume-pressure channel "
    "(index 0 of volume predictions/targets in normalized space) before "
    "computing the MSE training loss. Leaves all other channels untouched. "
    "Hypothesis: compressing large-magnitude pressure outliers during training "
    "improves OOD generalization."
),
```

### Step 3: Add helper function in `trainer_runtime.py`

After the `weighted_channel_mse` function (around line 865), add:

```python
def log1p_signed(x: torch.Tensor) -> torch.Tensor:
    """sign(x) * log1p(|x|) — a smooth, symmetric log-space transform.

    Compresses large-magnitude values while preserving sign and differentiability
    at zero. Gradient = 1/(1+|x|), so large values get smaller gradients.
    """
    return x.sign() * torch.log1p(x.abs())
```

### Step 4: Modify the training forward function in `train.py`

In the `compute_train_losses` function (around line 325), replace:

```python
    volume_target = transform.apply_volume(batch.volume_y)
```

with:

```python
    volume_target = transform.apply_volume(batch.volume_y)
```

Then after the model forward pass, before `volume_loss = masked_mse(...)`, apply the transform. The full modified block for volume loss (around line 344) should be:

```python
        vol_pred_for_loss = out["volume_preds"]
        vol_target_for_loss = volume_target
        if cfg.vol_p_log_space_loss:
            # Apply log-space transform to channel 0 (vol_pressure) only
            vol_pred_for_loss = vol_pred_for_loss.clone()
            vol_target_for_loss = vol_target_for_loss.clone()
            vol_pred_for_loss[..., 0] = log1p_signed(vol_pred_for_loss[..., 0])
            vol_target_for_loss[..., 0] = log1p_signed(vol_target_for_loss[..., 0])
        volume_loss = masked_mse(vol_pred_for_loss, vol_target_for_loss, batch.volume_mask)
```

**Important**: The function signature needs access to `cfg`. Check how other flags like `use_gradnorm` are passed through — you may need to add `cfg` or `vol_p_log_space_loss: bool = False` as a parameter to `compute_train_losses`.

Also import `log1p_signed` from `trainer_runtime` in `train.py`:
```python
from trainer_runtime import (
    ...,
    log1p_signed,
    ...
)
```

---

## Run Command

Full SOTA stack + new flag. Use `--wandb-group fern-logspace-vol-p-loss`:

```bash
python train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable \
  --use-qk-norm --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --use-surf-to-vol-xattn --no-compile-model \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-p-log-space-loss \
  --wandb-group fern-logspace-vol-p-loss
```

---

## Kill Gates

- **EP3** (~32,592 steps): kill if val_abupt > 8.5% OR val_vol_p > 4.7%
- **EP5**: kill if val_abupt > 7.5%
- **EP10**: kill if val_abupt > 6.8%

---

## SENPAI-RESULT Format

When your run completes (or is killed), post a single-line marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/volume_pressure_rel_l2_pct","value":<number>}}
```

**Metric name must be exactly** `val_primary/abupt_axis_mean_rel_l2_pct` (NOT `val/val_surface/...`).

Also report the full metric table:

| Metric | Value |
|--------|-------|
| val_abupt | |
| val_vol_p | |
| val_surf_p | |
| test_abupt | |
| test_vol_p | |
| test_surf_p | |

---

## Notes

- The log-space transform is applied **in normalized space** (after `transform.apply_volume`) — this is intentional, as we want to compress values in the space the model operates in.
- Eval/validation code uses raw MSE over the inverse-transformed predictions, so reported metrics remain comparable to baseline.
- If the run is numerically unstable (loss diverges/spikes early), check whether the transform needs clamping. `log1p(|x|)` is numerically well-behaved for any finite input, but if normalized vol_p values are very large, consider adding `.clamp(-50, 50)` after the transform.
- The hypothesis is that OOD test_vol_p should improve more than val_vol_p, since the transform specifically helps with out-of-distribution pressure magnitudes.
