### PR TITLE
SDF-Stratified + Stochastic Volume Sampling Combined (corrected dataset)

### DIFF
--- a/train.py
+++ b/train.py
@@ -207,8 +207,11 @@ def apply_sdf_stratified_stochastic_sampling(
     corrected-split DrivAerML wave:
 
     1. **SDF-stratified weighting** (PR #972): per-call weights are
-       ``1 + alpha * |sdf|`` so far-field / boundary-adjacent points are
-       up-weighted in the multinomial draw.
+       ``1 / (1 + alpha * |sdf|)`` so near-surface volume points (small
+       ``|sdf|``) are up-weighted in the multinomial draw. In this dataset
+       ``|sdf|`` reaches ~80m while the median is ~5mm, so an additive
+       ``1 + alpha * |sdf|`` would instead concentrate draws in the far
+       field, which is the opposite of the physical intuition.
     2. **Stochastic freshness** (PR #968): no manual reseeding before the
        multinomial; the global torch RNG advances with each call, and each
        DDP rank + DataLoader worker carries a distinct RNG state.
@@ -248,7 +251,7 @@ def apply_sdf_stratified_stochastic_sampling(
             sdf_arr = _load_npy_rows(case_dir / "volume_sdf.npy", rows=None)
             sdf_flat = sdf_arr.reshape(-1) if sdf_arr.ndim > 1 else sdf_arr
             sdf_abs = torch.from_numpy(sdf_flat).abs()
-            weights = 1.0 + alpha_local * sdf_abs
+            weights = 1.0 / (1.0 + alpha_local * sdf_abs)
 
             n_total = int(sdf_abs.shape[0])
             n_sample = min(n_vol_local, n_total) if n_vol_local > 0 else n_total
@@ -271,9 +274,10 @@ def apply_sdf_stratified_stochastic_sampling(
             metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
             metadata["volume_view_index"] = int(view.view_index)
             metadata["volume_view_count"] = int(view.volume_view_count)
-            metadata["volume_sampling_mode"] = "sdf_stratified_stochastic"
+            metadata["volume_sampling_mode"] = "sdf_stratified_stochastic_inv"
             metadata["joint_view_count"] = int(view.view_count)
             metadata["sdf_stratified_alpha"] = float(alpha_local)
+            metadata["sdf_stratified_weight_form"] = "1/(1+alpha*|sdf|)"
 
             return DrivAerMLCase(
                 case_id=case.case_id,

--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -189,6 +191,112 @@ def parse_pe_init_sigmas(spec: str) -> list[float] | None:
         return None
     sigmas = [float(s) for s in spec.split(",") if s.strip()]
     return sigmas or None
+
+
+def apply_sdf_stratified_stochastic_sampling(
+    train_dataset,
+    *,
+    alpha: float,
+    n_volume: int,
+    is_main: bool = False,
+) -> None:
+    """Swap ``train_dataset.__class__`` with a subclass that does SDF-stratified
+    stochastic volume sampling.
+
+    Combines two mechanisms shown to independently improve test_vol_p on the
+    corrected-split DrivAerML wave:
+
+    1. **SDF-stratified weighting** (PR #972): per-call weights are
+       ``1 + alpha * |sdf|`` so far-field / boundary-adjacent points are
+       up-weighted in the multinomial draw.
+    2. **Stochastic freshness** (PR #968): no manual reseeding before the
+       multinomial; the global torch RNG advances with each call, and each
+       DDP rank + DataLoader worker carries a distinct RNG state.
+
+    Implementation note: instance-level monkey-patching of ``__getitem__``
+    via ``types.MethodType`` does NOT take effect when DataLoader uses
+    ``dataset[idx]`` subscript (Python special-method lookup goes through
+    the type, not the instance). We therefore install the new behaviour by
+    reassigning ``train_dataset.__class__`` to a freshly built subclass.
+
+    IO optimisation vs. the literal PR-body code: instead of loading every
+    volume point per ``__getitem__`` (~294 MB/case), we load only
+    ``volume_sdf.npy`` to compute weights, sample indices, then call
+    ``store.load_case`` with ``volume_rows=`` so only the chosen rows are
+    read for xyz / sdf / pressure. Functionally identical, ~5x faster IO.
+    """
+    from data.loader import DrivAerMLCase, _case_dir, _load_npy_rows
+
+    base_cls = type(train_dataset)
+
+    class _SDFStratifiedStochasticDataset(base_cls):
+        def __getitem__(self, idx: int) -> DrivAerMLCase:
+            alpha_local = self._sdf_stratified_alpha
+            n_vol_local = self._sdf_stratified_n_volume
+
+            view = self.views[idx]
+            counts = self.store.case_point_counts(view.case_id)
+
+            surface_idx = self._indices(
+                counts["n_surface"],
+                self.max_surface_points,
+                view,
+                group_view_count=view.surface_view_count,
+            )
+
+            case_dir = _case_dir(self.store.root, view.case_id)
+            sdf_arr = _load_npy_rows(case_dir / "volume_sdf.npy", rows=None)
+            sdf_flat = sdf_arr.reshape(-1) if sdf_arr.ndim > 1 else sdf_arr
+            sdf_abs = torch.from_numpy(sdf_flat).abs()
+            weights = 1.0 + alpha_local * sdf_abs
+
+            n_total = int(sdf_abs.shape[0])
+            n_sample = min(n_vol_local, n_total) if n_vol_local > 0 else n_total
+            vol_idx = torch.multinomial(weights, n_sample, replacement=True)
+            vol_idx, _ = torch.sort(vol_idx)
+
+            case = self.store.load_case(
+                view.case_id,
+                surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                volume_rows=vol_idx.numpy(),
+            )
+
+            metadata = dict(case.metadata)
+            metadata["n_surface_full"] = int(counts["n_surface"])
+            metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+            metadata["surface_view_index"] = int(view.view_index)
+            metadata["surface_view_count"] = int(view.surface_view_count)
+            metadata["surface_sampling_mode"] = view.sampling_mode
+            metadata["n_volume_full"] = n_total
+            metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+            metadata["volume_view_index"] = int(view.view_index)
+            metadata["volume_view_count"] = int(view.volume_view_count)
+            metadata["volume_sampling_mode"] = "sdf_stratified_stochastic"
+            metadata["joint_view_count"] = int(view.view_count)
+            metadata["sdf_stratified_alpha"] = float(alpha_local)
+
+            return DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=case.surface_x,
+                surface_y=case.surface_y,
+                volume_x=case.volume_x,
+                volume_y=case.volume_y,
+                metadata=metadata,
+            )
+
+    _SDFStratifiedStochasticDataset.__name__ = (
+        f"{base_cls.__name__}_SDFStratifiedStochastic"
+    )
+
+    train_dataset._sdf_stratified_alpha = float(alpha)
+    train_dataset._sdf_stratified_n_volume = int(n_volume)
+    train_dataset.__class__ = _SDFStratifiedStochasticDataset
+
+    if is_main:
+        print(
+            f"[sdf-stratified-stochastic] enabled: alpha={alpha}, "
+            f"n_volume={n_volume} (subclass={_SDFStratifiedStochasticDataset.__name__})"
+        )
 
 
 class GradNormWeights(nn.Module):
@@ -438,7 +546,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             run_eval_only(config, state)
             return
         if config.seed >= 0:
-            seed_everything(config.seed)
+            rank_offset = state.rank if state.enabled else 0
+            seed_everything(config.seed + rank_offset)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
@@ -451,6 +560,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            apply_sdf_stratified_stochastic_sampling(
+                train_loader.dataset,
+                alpha=config.sdf_stratified_alpha,
+                n_volume=config.train_volume_points,
+                is_main=state.is_main,
+            )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(

--- a/train.py
+++ b/train.py
@@ -255,7 +255,7 @@ def apply_sdf_stratified_stochastic_sampling(
 
             n_total = int(sdf_abs.shape[0])
             n_sample = min(n_vol_local, n_total) if n_vol_local > 0 else n_total
-            vol_idx = torch.multinomial(weights, n_sample, replacement=True)
+            vol_idx = torch.multinomial(weights, n_sample, replacement=False)
             vol_idx, _ = torch.sort(vol_idx)
 
             case = self.store.load_case(
@@ -300,6 +300,10 @@ def apply_sdf_stratified_stochastic_sampling(
         print(
             f"[sdf-stratified-stochastic] enabled: alpha={alpha}, "
             f"n_volume={n_volume} (subclass={_SDFStratifiedStochasticDataset.__name__})"
+        )
+        print(
+            "[sdf-stratified-stochastic] weight_form=1/(1+alpha*|sdf|) (near-surface emphasis), "
+            "multinomial replacement=False"
         )
 
 


### PR DESCRIPTION
# Hypothesis: SDF-Stratified + Stochastic Volume Sampling Combined

## Background

Two recent experiments each independently improved on our corrected-split SOTA:

- **PR #972** (`56bcqp3m`, eval `zxnhtagj`): SDF-stratified importance sampling — weight[i] = 1 + α·|sdf[i]| for multinomial draw — achieved **test_ABUPT=5.844%**, test_vol_p=3.643%. This is currently the best result on the corrected dataset.
- **PR #968** (`a0yoxy85`, eval `qbg9pkmx`): Stochastic per-batch fresh random volume point draws — second best at test_ABUPT=5.986%, test_vol_p=3.957%.

Both experiments address the same root problem (model over-indexing on a fixed spatial distribution of volume query points) via complementary mechanisms:
- **SDF stratification** biases the *which* points get sampled toward boundary-adjacent regions
- **Stochastic sampling** eliminates the *memorization* of a fixed spatial locus by drawing fresh randomness each call

The hypothesis is that combining both mechanisms simultaneously will outperform either alone: the SDF-stratified weights will ensure physically important near-boundary volume points are well-represented, while the per-batch stochastic draw will prevent the model from memorizing which specific points it sees. Together they should push test_vol_p below PR #972's 3.643%.

## Dataset

**CRITICAL**: Use the corrected dataset:
```
--data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511
```
Do NOT use any older dataset path. The old dataset had a case-split bug causing a spurious ~7pp val→test vol_p gap in all pre-20260511 experiments.

## Implementation

### Part 1: SDF-stratified importance sampling (from PR #972)

Add CLI args to `train.py`:
```python
parser.add_argument("--use-sdf-stratified-vol-sampling", action="store_true", default=False)
parser.add_argument("--sdf-stratified-alpha", type=float, default=2.0)
```

After dataset construction but before DataLoader build, add this monkey-patch block:
```python
if args.use_sdf_stratified_vol_sampling:
    import types
    _ALPHA = args.sdf_stratified_alpha   # default 2.0
    _N_VOL = args.train_volume_points

    def _sdf_stratified_stochastic_getitem(self, idx):
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)
        surface_idx = self._indices(
            counts["n_surface"], self.max_surface_points, view,
            group_view_count=view.surface_view_count,
        )
        case = self.store.load_case(
            view.case_id,
            surface_rows=None if surface_idx is None else surface_idx.numpy(),
            volume_rows=None,  # load ALL volume points
        )
        n_total = case.volume_x.shape[0]
        n_sample = min(_N_VOL, n_total)
        sdf_vals = case.volume_x[:, 3].abs()  # channel 3 = SDF
        weights = 1.0 + _ALPHA * sdf_vals
        # Stochastic: fresh draw every call (no deterministic seeding)
        vol_idx = torch.multinomial(weights, n_sample, replacement=True)
        vol_idx = vol_idx.sort().values
        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case.case_id,
            surface_x=case.surface_x, surface_y=case.surface_y,
            volume_x=case.volume_x[vol_idx], volume_y=case.volume_y[vol_idx],
            metadata={},
        )
    train_dataset.__getitem__ = types.MethodType(
        _sdf_stratified_stochastic_getitem, train_dataset
    )
```

**Key difference from PR #972**: `torch.multinomial` with no manual seeding before the call = fresh stochastic draw every `__getitem__` call (PyTorch's global RNG advances with each step, so each call produces a different sample even with the same weights). This combines the SDF importance weights (Part 1) with the per-batch stochastic freshness (Part 2) in a single sampling call.

If you need more explicit freshness, you can explicitly reseed torch before the multinomial:
```python
# Option B: explicitly reseed for maximum stochasticity
torch.manual_seed(int(torch.randint(0, 2**31, (1,)).item()))
vol_idx = torch.multinomial(weights, n_sample, replacement=True)
```

Use Option B if the default `torch.multinomial` is deterministic in your DDP setup.

### Part 2: DDP rank seed offset

Ensure each DDP rank has a distinct seed to avoid all workers drawing identical samples:
```python
# After DDP init, before training loop:
if dist.is_initialized():
    rank_seed = args.seed + dist.get_rank()
    torch.manual_seed(rank_seed)
    np.random.seed(rank_seed)
```

## Run command

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 2.0 \
  --wandb-group sdf-stochastic-combined \
  --wandb-name nezuko-sdf-stochastic-alpha2 \
  --kill-thresholds "1:30,2:16,3:8,5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

## Kill gates (STRICT)

| Epoch | val_ABUPT threshold | Action |
|-------|---------------------|--------|
| EP1   | ≤30%                | Kill if missed |
| EP2   | ≤16%                | Kill if missed |
| EP3   | ≤8%                 | Kill if missed |
| EP5   | ≤7.5%               | Kill if missed |
| EP10  | ≤7.2%               | Kill if missed |
| EP15  | ≤6.80%              | Kill if missed |
| EP20  | ≤6.70%              | Kill if missed |
| EP25  | ≤6.65%              | Kill if missed |
| EP30  | ≤6.60%              | Terminal |

## Baseline to beat (corrected-split scoreboard)

| Rank | PR  | W&B source run | W&B eval run | test_ABUPT | test_vol_p | test_surf_p | test_WSS |
|------|-----|----------------|--------------|------------|-----------|-------------|---------|
| 1    | #972 | `56bcqp3m`    | `zxnhtagj`   | **5.844%** | 3.643%    | 3.577%      | 6.727%  |
| 2    | #968 | `a0yoxy85`    | `qbg9pkmx`   | 5.986%     | 3.957%    | —           | —       |
| 3    | #880 | `zst3y2mp`    | `x78xbsfn`   | 6.010%     | 4.501%    | —           | —       |

**Target: beat test_ABUPT < 5.844% and test_vol_p < 3.643%**

AB-UPT reference targets: surf_p=3.82%, wall=7.29%, vol_p=6.08%

## Suggested observables

1. **test_vol_p vs val_vol_p gap**: If the combined mechanism works, we expect test_vol_p to stay ≤ ~3.7% (matching or improving on PR #972's 3.643%).
2. **GradNorm w_vol trajectory**: Watch whether the vol task weight stabilizes faster with combined sampling — stochastic freshness may reduce gradient variance for the volume head.
3. **Convergence profile**: Log val_ABUPT at every epoch gate. Combined sampling may slow EP1–EP3 slightly vs. PR #972 (more variance), but EP5+ should be similar or better.

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
