### PR TITLE
SDF-Stratified Alpha Sweep: α=1.5, 3.0, 4.0 (corrected dataset)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-12 ~20:30 UTC
+- 2026-05-12 ~22:30 UTC
 
 ## Human Research Directive (Issue #882)
 **TOP PRIORITY — Volume Pressure Focus:**
@@ -17,6 +17,8 @@ The persistent +7–8pp val→test volume pressure gap reported across all prior
 **Corrected dataset path (MANDATORY for all new and active experiments):**
 `/mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511`
 
+> NOTE: There is a potential discrepancy between `/mnt/pvc/` and `/mnt/new-pvc/` paths. Recent ping to frieren used `/mnt/new-pvc/`. Resolve by checking pod mounts before next run.
+
 **Corrected eval parameters:** `eval_surface_points=65536`, `eval_volume_points=65536` (chunk sizes, not caps), 34 val cases / 7,295 views, 50 test cases / 11,091 views.
 
 **Impact on prior results:**
@@ -25,73 +27,99 @@ The persistent +7–8pp val→test volume pressure gap reported across all prior
 - All "AXIS FULLY CLOSED" labels on sampling strategies are **RETRACTED**.
 - The 15+ "falsified" interventions were not tested on a valid dataset split.
 
+## CRITICAL DISCOVERY (2026-05-12 ~22:00 UTC): SDF Monkey-Patch Was a No-Op
+
+**PR #972 did NOT implement SDF-stratified sampling. It used uniform sampling.**
+
+Two bugs were discovered in the `types.MethodType` monkey-patch used in PR #972 and copied to PRs #1054 and #1055:
+
+### Bug 1: Python dunder method resolution no-op
+`types.MethodType(__getitem__, dataset)` installs the function in the **instance dict**. Python resolves dunder methods (`__getitem__`) via **type MRO**, not instance dict. PyTorch DataLoader subscript access `dataset[idx]` calls the **class's** `__getitem__`, not the instance attribute. The monkey-patch is silently ignored.
+
+**Fix**: Dynamically create a subclass and reassign `__class__`:
+```python
+class _SDFStratifiedDataset(type(train_dataset)):
+    def __getitem__(self, idx):
+        ...
+train_dataset._sdf_alpha = args.sdf_stratified_alpha
+train_dataset._sdf_n_vol = args.train_volume_points
+train_dataset.__class__ = _SDFStratifiedDataset
+```
+
+### Bug 2: SDF formula direction inverted
+`volume_sdf.npy` stores **unnormalized** SDF values with `max(|sdf|) ≈ 80m` per case. The original formula:
+```
+weight = 1.0 + α * |sdf[i]|
+```
+...upweights **far-field** points (weight ≈ 321 at α=4.0 and |sdf|=80), not near-surface. This is opposite to the stated hypothesis.
+
+**Correct near-surface emphasis formula:**
+```
+weight = 1.0 / (1.0 + α * |sdf[i]|)
+```
+Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
+
+### Implication for SOTA table
+**ALL three top corrected-split results used uniform sampling.** No true SDF-stratified experiment has run to date. The SDF-stratified hypothesis remains untested. This is an opportunity, not a setback — the near-surface SDF sampling idea is still virgin territory.
+
 ## Wave SOTA (Corrected Split — rawcanon_20260511)
 
-**PR #972** (SDF-stratified far-field sampling, α=2.0, run `56bcqp3m`, eval `zxnhtagj`): `abupt_axis_mean_rel_l2_pct` = **5.844%**
-
-| Metric | Value |
-|--------|-------|
-| test_abupt | **5.844%** |
-| test_surf_p | 3.577% |
-| test_vol_p | **3.643%** |
-| test_wss | 6.727% |
-
-> Note: PR #972 is CLOSED (was falsely closed under old dataset). The SDF-stratified sampling technique is the current SOTA and must be treated as the baseline configuration for new experiments.
-
-**Top 5 on corrected split:**
+All top results are **uniform sampling**. No SDF-stratified experiment has produced a valid result yet.
 
 | Rank | PR | test_ABUPT | test_vol_p | Notes |
 |------|----|------------|------------|-------|
-| 1 | **#972** | **5.844%** | 3.643% | SDF-stratified far-field sampling (α=2.0) — **CLOSED, FALSELY** |
-| 2 | #968 | 5.986% | 3.957% | Stochastic vol subsampling — **CLOSED, FALSELY** |
-| 3 | #880 | 6.010% | 4.501% | (see BASELINE.md for full run IDs) — CLOSED |
-| 4 | #958 | 6.107% | 3.818% | — CLOSED |
-| 5 | #939 | 6.242% | — | — CLOSED |
-| … | … | … | … | … |
-| 22 | #740 | 8.165% | 13.660% | Old "SOTA" — NOW ARTIFACT |
+| 1 | **#972** | **5.844%** | 3.643% | run `56bcqp3m`, eval `zxnhtagj` — UNIFORM (monkey-patch was no-op) |
+| 2 | #968 | 5.986% | 3.957% | run `a0yoxy85`, eval `qbg9pkmx` — Stochastic vol subsampling |
+| 3 | #880 | 6.010% | 4.501% | run `zst3y2mp`, eval `x78xbsfn` — Uniform |
+| 4 | #958 | 6.107% | 3.818% | — |
+| 5 | #939 | 6.242% | — | — |
 
-## Active Experiments (2026-05-12 ~20:30 UTC)
+**Primary SOTA:** test_ABUPT=5.844%, test_vol_p=3.643%, test_surf_p=3.577%, test_wss=6.727%
 
-> **ACTION REQUIRED FOR ALL ACTIVE EXPERIMENTS**: Switch dataset to corrected split path
-> `/mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511`
-> Existing runs trained on old split should be restarted from scratch on corrected split.
+## Active Experiments (2026-05-12 ~22:30 UTC)
 
 | PR | Student | Hypothesis | Run ID | Status | Latest Val | Notes |
 |----|---------|------------|--------|--------|------------|-------|
-| #1025 | dl24-frieren | **Vol-token LayerNorm WITHOUT GradNorm** | `ttnva184` | Running — EP23.2 | val_abupt=6.3639%, val_vol_p=3.5467% | **MUST RESTART** on corrected dataset. Old-split results not comparable. |
-| #1035 | dl24-fern | **Independent vol_p transformer tower** | `1dijs6g1` | Running — EP2.02 | val_abupt=10.378%, val_vol_p=11.213% | **MUST RESTART** on corrected dataset. Early enough to restart cleanly. |
-| TBD | dl24-tanjiro | **DETR-style learned query positions** | TBD | Assigning | — | **ASSIGN ON CORRECTED DATASET from the start.** |
-| TBD | dl24-nezuko | **Pure FNO for vol_p** | TBD | Assigning | — | **ASSIGN ON CORRECTED DATASET from the start.** |
+| #1025 | dl24-frieren | **Vol-token LayerNorm WITHOUT GradNorm (eval-only)** | `ttnva184` | **AWAITING EVAL** — EP23.2 | val_abupt≈6.35%, val_vol_p=3.547% | 3rd escalation ping posted 22:26Z. Checkpoint exists, needs eval-only on corrected dataset. 3rd ping: if no response next cycle, reassign slot. |
+| #1035 | dl24-fern | **Independent vol_p transformer tower** | `1dijs6g1` | **KILL ORDER SENT** — EP2 | val_abupt=10.378%, val_vol_p=11.213% | Kill order posted 22:04Z. EP3 gate (≤8%) will not be met. Awaiting kill confirmation. |
+| #1054 | dl24-nezuko | **SDF-stratified (α=2.0) + Stochastic combined** | TBD | **LAUNCHED, no run ID yet** | — | Formula direction question raised: which formula was used (`1+α·|sdf|` or `1/(1+α·|sdf|)`)? Awaiting W&B run ID and formula confirmation. Corrected dataset. |
+| #1055 | dl24-tanjiro | **SDF-stratified α sweep: α=1.5, 3.0, 4.0** | arms killed | **KILL + RESTART PENDING** | — | Kill order for 3 arms (q2vet888, 92nd8zrn, z8a6ckv6) posted 22:19Z. Two bugs found: monkey-patch no-op + formula direction. Correct fix posted. Needs sequential 8-GPU restart with `__class__` fix and `weight=1/(1+α·|sdf|)`. |
 
-## Key Insights (Post-Artifact-Resolution)
+## Pending Actions (Next Cycle)
 
-1. **The val→test vol_p gap was entirely artificial.** Under `rawcanon_20260511`, test_vol_p tracks val_vol_p closely (~3.6–4.0% range). No covariate shift hypothesis needed.
+1. **Frieren (#1025)**: If no response by next cycle, reassign slot. Vol-token LN on corrected dataset is still valuable — consider assigning to another student if frieren remains unresponsive.
+2. **Fern (#1035)**: Once kill confirmed, design new corrected-dataset experiment. Candidate: vol tower architecture (6L vol-only decoder) on corrected split, baseline config.
+3. **Nezuko (#1054)**: Confirm formula direction. If `1+α·|sdf|` was used, the run is far-field biased (like PR #972 no-op but worse — at least PR #972 actually was uniform). May need restart with `1/(1+α·|sdf|)`.
+4. **Tanjiro (#1055)**: Await kill confirmations. Restart sequentially with fixed code: Arm A (α=1.5) first on all 8 GPUs, then arms B and C once A is complete or killed at gate.
 
-2. **SDF-stratified far-field sampling (PR #972) is the SOTA technique.** α=2.0 upweighting of far-field volume points yields test_abupt=5.844%. This must be treated as the baseline config.
+## Key Insights (Post-Monkey-Patch-Discovery)
 
-3. **Stochastic vol subsampling (PR #968) is the #2 technique.** Fresh random draw every batch: test_abupt=5.986%. Complementary to SDF stratification — combining them is Tier 1.
+1. **The val→test vol_p gap was entirely artificial.** Under `rawcanon_20260511`, test_vol_p tracks val_vol_p closely. No covariate shift hypothesis needed.
 
-4. **The 15+ "falsified" interventions need re-evaluation.** WD variants, GradNorm α-variants, EMA, BBox norm, DropPath, vol coord noise, etc. — all were tested on a broken dataset. Some may still be dead ends; others may show benefit on the corrected split.
+2. **PR #972 "SDF-stratified" = UNIFORM sampling.** The monkey-patch was a Python dunder resolution no-op. All top-3 corrected-split results used uniform sampling. "SDF-stratified far-field sampling" label in prior state was **incorrect**.
 
-5. **GradNorm + AdamW = catastrophic instability**: CONFIRMED HARDWARE-LEVEL. Not dataset-dependent. Use Lion when using GradNorm.
+3. **First true SDF near-surface experiment is nezuko (#1054).** If nezuko used the correct `1/(1+α·|sdf|)` formula (which is not confirmed yet), it will be the first valid SDF-stratified near-surface run. If it used the wrong formula, it will behave like PR #972 (uniform) or worse.
 
-6. **String multisigma PE (5-octave) is confirmed best.** σ=[0.25, 0.5, 1.0, 2.0, 4.0]. Not dataset-dependent.
+4. **Stochastic vol subsampling (PR #968) is independently confirmed #2.** Fresh random draw every batch is a real technique that works and the monkey-patch was NOT used in PR #968 (different implementation). test_abupt=5.986%.
 
-7. **Vol-token LayerNorm** (PR #1025) showed val_vol_p=3.547% on old dataset at EP23 — promising but needs re-run on corrected split to determine true rank.
+5. **Near-surface SDF hypothesis is UNTESTED.** This is the single highest-value experiment to run correctly. Given that PR #972's apparent SOTA was actually uniform, true near-surface SDF emphasis may push vol_p well below 3.643%.
 
-## Tier 1 Follow-Ups (Highest Priority — Assign Immediately)
+6. **GradNorm + AdamW = catastrophic instability**: CONFIRMED HARDWARE-LEVEL. Not dataset-dependent. Use Lion when using GradNorm.
 
-1. **SDF-stratified + Stochastic combined** — combine PR #972's α=2.0 SDF upweighting with PR #968's fresh random draw every batch. Neither was tried together. Expected: ≤5.7% test_abupt.
-2. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine the #1 sampling technique with the independent vol tower architecture (#1035). Tests whether the vol tower benefit stacks with better sampling.
-3. **SDF α sweep on corrected split** — try α=1.5, 3.0, 4.0 to identify optimal far-field upweighting. α=2.0 was the only value tested.
+7. **String multisigma PE (5-octave) is confirmed best.** σ=[0.25, 0.5, 1.0, 2.0, 4.0]. Not dataset-dependent.
+
+## Tier 1 Follow-Ups (Current Priority)
+
+1. **True near-surface SDF sampling** — nezuko (#1054) if formula is correct, tanjiro (#1055) restart with correct fix. This is now the PRIMARY open question.
+2. **Vol-token LayerNorm eval on corrected split** — frieren (#1025) eval-only run.
+3. **Combined SDF-near-surface + stochastic** — if nezuko's formula is wrong, restart with `1/(1+α·|sdf|)` AND fresh per-batch stochastic draw.
 
 ## Tier 2 Follow-Ups (After Tier 1 Results)
 
-4. **Re-run vol-token LN (PR #1025 config) on corrected split from scratch** — corrected-split val_vol_p likely to be ~3.5% (already promising on old split).
-5. **SDF + 5L depth** — lighter model may generalize better with strong SDF sampling.
-6. **Ensemble refresh on corrected split** — new ensemble from top corrected-split checkpoints (#972, #968, #880, #958) could push below 5.5%.
-7. **WD=0.005 re-test on corrected split** — may show genuine benefit now that the dataset artifact is removed.
-8. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
+4. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine near-surface SDF sampling with independent vol tower architecture. Tests whether vol tower benefit stacks with better sampling.
+5. **Re-run vol-token LN (PR #1025 config) from scratch on corrected split** — assign to fern after kill confirmed.
+6. **WD=0.005 re-test on corrected split** — may show genuine benefit now that the dataset artifact is removed.
+7. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
 
 ## Gate Schedule
 
@@ -121,6 +149,8 @@ The persistent +7–8pp val→test volume pressure gap reported across all prior
 11. **Vol curriculum steps/epoch** (measured from chunked data loading, 400 cases × views ÷ 8 ranks ÷ batch 2): 16,384→10,864; 32,768→5,435; 49,152→3,625; 65,536→2,720.
 12. **Steps/epoch at bs=1 DDP8**: ~10,975–10,986.
 13. **Steps/epoch at bs=2 DDP8 (standard)**: ~10,975.
+14. **SDF monkey-patch MUST use `__class__` reassignment**: `types.MethodType(__getitem__, dataset)` is a Python dunder no-op. Always use dynamic subclass + `train_dataset.__class__ = _SDFStratifiedDataset`.
+15. **SDF near-surface formula**: `weight = 1.0 / (1.0 + α * |sdf|)`. NOT `1.0 + α * |sdf|` (which upweights far-field since volume_sdf.npy has max|sdf|≈80m unnormalized).
 
 ## Confirmed Dead Ends (Hardware/Architecture — Not Dataset-Dependent)
 
@@ -152,7 +182,7 @@ These results are confirmed on multiple runs and are likely dataset-independent:
 
 The following were previously listed as dead ends but were tested on the broken pre-20260511 dataset split. They are **NOT confirmed dead ends** and some are now SOTA techniques:
 
-- ~~SDF-stratified importance sampling (PR #972)~~: **NOW RANK 1 SOTA** (test_abupt=5.844%)
+- ~~SDF-stratified importance sampling (PR #972)~~: **NOW RANK 1 SOTA** (test_abupt=5.844%) — but was actually uniform sampling due to monkey-patch bug. True near-surface SDF is untested.
 - ~~Stochastic vol subsampling (PR #968)~~: **NOW RANK 2 SOTA** (test_abupt=5.986%)
 - WD=0.01 (PR #900): needs re-test on corrected split before concluding
 - WD=0.005 (PR #914): needs re-test on corrected split before concluding
@@ -161,4 +191,4 @@ The following were previously listed as dead ends but were tested on the broken 
 - Bbox normalization (PR #978): may need re-test
 - EMA decay=0.999 (PR #954): needs re-test on corrected split
 
-_Last updated: 2026-05-12 ~20:30 UTC. MAJOR UPDATE: Dataset artifact resolved (Issue #1053). Corrected split `rawcanon_20260511` shows no val→test vol_p gap. PR #972 (SDF-stratified sampling) is new SOTA at test_abupt=5.844%. All "AXIS FULLY CLOSED" labels on sampling strategies RETRACTED. PR #740 old SOTA now ranks 22 at 8.165% (artifact). All active experiments must restart on corrected dataset path._
+_Last updated: 2026-05-12 ~22:30 UTC. MAJOR UPDATE: Discovered Python dunder no-op bug in types.MethodType monkey-patch — PR #972 "SDF-stratified" was actually uniform sampling. Also discovered SDF formula direction bug (far-field vs near-surface). All top-3 corrected-split results are uniform sampling. True near-surface SDF experiment is UNTESTED. Kill orders posted to fern (#1035) and tanjiro (#1055). Third escalation ping to frieren (#1025). Nezuko (#1054) formula direction question pending._


### PR DESCRIPTION
# Hypothesis: SDF-Stratified Importance Sampling — Alpha Sweep (α=1.5, 3.0, 4.0)

## Background

**PR #972** (`56bcqp3m`, eval `zxnhtagj`) established the current corrected-split SOTA with SDF-stratified volume importance sampling at **α=2.0**: test_ABUPT=**5.844%**, test_vol_p=3.643%.

The sampling weight formula is:
```
weight[i] = 1.0 + α * |sdf[i]|
```

At α=2.0, points near sdf=0 (surface boundary) get weight≈1.0 while points far from the surface (|sdf|≈1.0) get weight≈3.0. The choice of α=2.0 was made without a systematic sweep.

**This experiment sweeps α** to find the optimal emphasis on near-surface volume points:
- **α=1.5**: Lighter boundary emphasis — more uniform than α=2.0
- **α=3.0**: Stronger boundary emphasis — more aggressively upweights near-surface points
- **α=4.0**: Very strong boundary emphasis — extreme near-surface concentration

The hypothesis is that the optimal α may not be 2.0 — either a lighter touch (α=1.5) is sufficient or a stronger emphasis (α=3.0 or 4.0) pushes test_vol_p further below 3.643%.

## Dataset

**CRITICAL**: Use the corrected dataset:
```
--data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511
```
Do NOT use any older dataset path.

## Implementation

The SDF-stratified monkey-patch from PR #972 is already confirmed working. You only need to vary `--sdf-stratified-alpha`. Add these CLI args to `train.py` if not already present:

```python
parser.add_argument("--use-sdf-stratified-vol-sampling", action="store_true", default=False)
parser.add_argument("--sdf-stratified-alpha", type=float, default=2.0)
```

After dataset construction but before DataLoader build:
```python
if args.use_sdf_stratified_vol_sampling:
    import types
    _ALPHA = args.sdf_stratified_alpha
    _N_VOL = args.train_volume_points

    def _sdf_stratified_getitem(self, idx):
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)
        surface_idx = self._indices(
            counts["n_surface"], self.max_surface_points, view,
            group_view_count=view.surface_view_count,
        )
        case = self.store.load_case(
            view.case_id,
            surface_rows=None if surface_idx is None else surface_idx.numpy(),
            volume_rows=None,  # load ALL volume points
        )
        n_total = case.volume_x.shape[0]
        n_sample = min(_N_VOL, n_total)
        sdf_vals = case.volume_x[:, 3].abs()  # channel 3 = SDF
        weights = 1.0 + _ALPHA * sdf_vals
        vol_idx = torch.multinomial(weights, n_sample, replacement=True)
        vol_idx = vol_idx.sort().values
        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case.case_id,
            surface_x=case.surface_x, surface_y=case.surface_y,
            volume_x=case.volume_x[vol_idx], volume_y=case.volume_y[vol_idx],
            metadata={},
        )
    train_dataset.__getitem__ = types.MethodType(_sdf_stratified_getitem, train_dataset)
```

## Run commands — three parallel arms

You have 8 GPUs. Run all three arms in parallel using DDP. Each arm uses 2-3 GPUs.

### Arm A: α=1.5

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 1.5 \
  --wandb-group sdf-alpha-sweep \
  --wandb-name tanjiro-sdf-alpha1.5 \
  --kill-thresholds "1:30,2:16,3:8,5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

### Arm B: α=3.0

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 3.0 \
  --wandb-group sdf-alpha-sweep \
  --wandb-name tanjiro-sdf-alpha3.0 \
  --kill-thresholds "1:30,2:16,3:8,5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

### Arm C: α=4.0

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --batch-size 1 \
  --epochs 30 \
  --train-surface-points 65000 \
  --eval-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-volume-points 65000 \
  --model-layers 6 \
  --model-pe string \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug \
  --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 \
  --lr-min 1e-6 \
  --lr-warmup-epochs 1 \
  --amp-mode bf16 \
  --seed 42 \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 4.0 \
  --wandb-group sdf-alpha-sweep \
  --wandb-name tanjiro-sdf-alpha4.0 \
  --kill-thresholds "1:30,2:16,3:8,5:7.5,10:7.2,15:6.80,20:6.70,25:6.65,30:6.60"
```

## Kill gates (STRICT — apply to each arm independently)

| Epoch | val_ABUPT threshold | Action |
|-------|---------------------|--------|
| EP1   | ≤30%                | Kill if missed |
| EP2   | ≤16%                | Kill if missed |
| EP3   | ≤8%                 | Kill if missed |
| EP5   | ≤7.5%               | Kill if missed |
| EP10  | ≤7.2%               | Kill if missed |
| EP15  | ≤6.80%              | Kill if missed |
| EP20  | ≤6.70%              | Kill if missed |
| EP25  | ≤6.65%              | Kill if missed |
| EP30  | ≤6.60%              | Terminal |

Kill any arm that misses its EP gate. Do not wait for other arms before reporting.

If all three arms fail EP3, report immediately with interim metrics — do not run to EP30.

## Baseline to beat (corrected-split scoreboard)

| Rank | PR   | W&B source run | W&B eval run | test_ABUPT  | test_vol_p | test_surf_p | test_WSS |
|------|------|----------------|--------------|-------------|-----------|-------------|---------|
| 1    | #972 | `56bcqp3m`     | `zxnhtagj`   | **5.844%**  | 3.643%    | 3.577%      | 6.727%  |
| 2    | #968 | `a0yoxy85`     | `qbg9pkmx`   | 5.986%      | 3.957%    | —           | —       |
| 3    | #880 | `zst3y2mp`     | `x78xbsfn`   | 6.010%      | 4.501%    | —           | —       |

**Target: beat test_ABUPT < 5.844% and test_vol_p < 3.643%**

Note: α=2.0 achieved test_ABUPT=5.844%. If any arm beats this, we have a new SOTA.

AB-UPT reference targets: surf_p=3.82%, wall=7.29%, vol_p=6.08%

## Suggested observables

1. **test_vol_p across arms**: Does heavier α reduce vol_p further, or does it start hurting (model ignores far-field volume entirely)?
2. **test_surf_p across arms**: Surface should be unaffected by volume sampling strategy — if it degrades at high α, that's a sign of gradient interference.
3. **GradNorm w_vol trajectory**: Does w_vol differ across α values? Higher α = more near-surface volume gradient = different effective task balance.
4. **Convergence speed at EP1–EP3**: Higher α may slow early convergence due to higher-variance gradient estimates.

## Reporting

Report all three arms in a single table:

| Arm | α   | W&B run | EP5 gate | EP10 gate | terminal val_ABUPT | test_ABUPT | test_vol_p |
|-----|-----|---------|----------|-----------|---------------------|------------|-----------|
| A   | 1.5 | ...     | pass/fail | ...      | ...                | ...        | ...       |
| B   | 3.0 | ...     | pass/fail | ...      | ...                | ...        | ...       |
| C   | 4.0 | ...     | pass/fail | ...      | ...                | ...        | ...       |

If any arm passes all gates, also report: test_surf_p, test_WSS, val→test vol_p gap explicitly.

**Only post a terminal SENPAI-RESULT when all surviving arms have finished** (or all have been killed):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-A-run-id>","<arm-B-run-id>","<arm-C-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best-arm-value>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<best-arm-value>}}
```
