### PR TITLE
[fern] Log-space vol_p loss on corrected dataset

### DIFF
--- a/train.py
+++ b/train.py
@@ -236,8 +236,8 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(index 0 of volume predictions/targets in normalized space) before "
             "computing the MSE training loss. Leaves all other channels and the "
             "surface losses untouched. Hypothesis: compressing large-magnitude "
-            "pressure outliers during training (val_vol_p ~ 3.9% vs test_vol_p ~ "
-            "12% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
+            "pressure outliers during training (val_vol_p ~ 3.9%% vs test_vol_p ~ "
+            "12%% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
             "heavy-tail residuals and improves OOD generalization. Eval metrics "
             "are unchanged (still raw MSE in denormalized space)."
         ),

--- a/train.py
+++ b/train.py
@@ -53,6 +53,7 @@ from trainer_runtime import (
     init_wandb_run,
     is_valid_primary_metric,
     loader_kwargs,
+    log1p_signed,
     make_loaders,
     masked_mse,
     metric_namespace,
@@ -138,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    vol_p_log_space_loss: bool = False
     debug: bool = False
 
 
@@ -228,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "vol_p_log_space_loss": (
+            "Apply sign(x)*log1p(|x|) transform to the volume-pressure channel "
+            "(index 0 of volume predictions/targets in normalized space) before "
+            "computing the MSE training loss. Leaves all other channels and the "
+            "surface losses untouched. Hypothesis: compressing large-magnitude "
+            "pressure outliers during training (val_vol_p ~ 3.9% vs test_vol_p ~ "
+            "12% on the SOTA baseline) reduces MSE's quadratic over-weighting of "
+            "heavy-tail residuals and improves OOD generalization. Eval metrics "
+            "are unchanged (still raw MSE in denormalized space)."
         ),
     }
     for field in fields(Config):
@@ -321,6 +333,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_p_log_space_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -341,7 +354,22 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        vol_pred_for_loss = out["volume_preds"]
+        vol_target_for_loss = volume_target
+        if vol_p_log_space_loss:
+            # Compress channel-0 (volume pressure) magnitudes in normalized space
+            # so MSE no longer weights heavy-tail residuals quadratically. Built
+            # via cat-of-slices to avoid in-place slice assignment, which
+            # invalidates autograd version counters on the cloned tensor.
+            vol_pred_for_loss = torch.cat(
+                [log1p_signed(vol_pred_for_loss[..., :1]), vol_pred_for_loss[..., 1:]],
+                dim=-1,
+            )
+            vol_target_for_loss = torch.cat(
+                [log1p_signed(vol_target_for_loss[..., :1]), vol_target_for_loss[..., 1:]],
+                dim=-1,
+            )
+        volume_loss = masked_mse(vol_pred_for_loss, vol_target_for_loss, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -1030,6 +1058,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_p_log_space_loss=config.vol_p_log_space_loss,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -865,6 +865,17 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def log1p_signed(x: torch.Tensor) -> torch.Tensor:
+    """sign(x) * log1p(|x|) — a smooth, symmetric log-space transform.
+
+    Compresses large-magnitude values while preserving sign and being well-behaved
+    at zero (f(0)=0). Gradient = 1/(1+|x|) almost everywhere, so large-magnitude
+    inputs receive smaller gradients than under the identity. Numerically stable
+    for any finite input.
+    """
+    return x.sign() * torch.log1p(x.abs())
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Apply a `sign(x)*log1p(|x|)` transform to the volume-pressure channel before computing the MSE training loss. This compresses pressure outliers and reduces sensitivity to magnitude scale, potentially improving generalisation to OOD geometries.

Previous attempt (PR #1048) was on the **old dataset** with the known case-split/indexing bug. This PR re-tests the hypothesis on the **corrected dataset** to get a clean signal.

## Assignment

**Branch:** `fern/logspace-vol-p-loss` (tip SHA: `0636eb2b144daeb6f5494e370e366d9ace9a6d6e`)

**Data:** `/mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511` (corrected split)

## Training Command

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --vol-p-log-space-loss \
  --wandb-group fern-logspace-vol-p-corrected
```

**Note:** `--vol-p-log-space-loss` is a store_true flag that lives on the `fern/logspace-vol-p-loss` branch only — it is NOT in the default `tay` train.py. Make sure you are on the correct branch. Eval metrics remain raw MSE in denormalized space (unchanged), so results are directly comparable to baseline.

## Current SOTA (Corrected Dataset — Gate to Beat)

| Metric | Corrected SOTA (PR #972) | Your Target |
|--------|--------------------------|-------------|
| val_abupt | 6.126% | < 6.126% |
| val_vol_p | 3.798% | < 3.798% |
| test_abupt | 5.844% | — |
| test_vol_p | 3.643% | — |
| test_surf_p | 3.577% | — |
| test_WSS | 6.727% | — |

W&B source run for SOTA: `56bcqp3m`

## EP3 Gates (Corrected Split)

| Gate | val_abupt | val_vol_p | Action |
|------|-----------|-----------|--------|
| PASS | ≤ 6.2% | ≤ 4.5% | Continue to EP3 |
| MARGINAL | ≤ 6.5% | ≤ 5.0% | Advisor review |
| KILL | > 6.5% | > 5.0% | Stop training |

## Reporting

When complete, post a comment with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_vol_p","value":<number>}}
```

Include a table of all metrics: val_abupt, val_vol_p, val_surf_p, test_abupt, test_vol_p, test_surf_p, test_WSS.