### PR TITLE
[frieren] GradNorm dynamic loss balancing on corrected dataset

### DIFF
--- a/experiments/frieren-gradnorm-corrected.txt
+++ b/experiments/frieren-gradnorm-corrected.txt
@@ -1,0 +1,4 @@
+GradNorm corrected-dataset experiment
+
+Training with --use-gradnorm --gradnorm-mode ema_proxy --gradnorm-alpha 1.5
+Data: /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511


### PR DESCRIPTION
## Hypothesis

GradNorm dynamically reweights the 5 task losses (surface_p, tau_x, tau_y, tau_z, vol_p) during training based on gradient norms, preventing any single task from dominating. The `ema_proxy` mode uses an exponential moving average of per-task gradient norms to estimate the ideal weighting, with `alpha=1.5` providing moderate restoring force. This should improve vol_p accuracy without degrading surface metrics.

This is the first test of GradNorm on the **corrected dataset** (`drivaerml_processed_rawcanon_20260511`). All prior GradNorm experiments used the old dataset with the case-split bug.

## Background

The corrected dataset eliminates the ~3× val→test vol_p OOD gap that was a data artifact. Current SOTA on corrected split (PR #972): val_abupt=6.126%, val_vol_p=3.798%, test_vol_p=3.643%, test_abupt=5.844%.

GradNorm is already implemented in tay train.py via `--use-gradnorm --gradnorm-mode ema_proxy --gradnorm-alpha 1.5`.

## Gate to Beat (PR #972 corrected-split SOTA)
- val_abupt < 6.126% AND val_vol_p < 3.798%
- W&B source run: `56bcqp3m`

## EP1 Gate (Epoch 5 check)
- PASS: val_abupt ≤ 7.5%
- KILL: val_abupt > 7.5% (loss divergence / GradNorm instability)

## Training Command

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --use-gradnorm \
  --gradnorm-mode ema_proxy \
  --gradnorm-alpha 1.5 \
  --wandb-group frieren-gradnorm-corrected
```

## Current Baseline Metrics (corrected dataset, PR #972)

| Metric | Val | Test |
|--------|-----|------|
| abupt | 6.126% | 5.844% |
| vol_p | 3.798% | 3.643% |
| surf_p | — | 3.577% |
| WSS | — | 6.727% |

## Instructions to Student

1. Run the training command above on the corrected dataset path.
2. Check EP1 gate at epoch 5: kill if val_abupt > 7.5%.
3. Run to completion (EP3 standard epochs).
4. Report final metrics in a PR comment with the standard SENPAI-RESULT marker.

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```