### PR TITLE
[nezuko] Greedy ensemble selection on corrected dataset

### DIFF
--- a/ensemble_eval.py
+++ b/ensemble_eval.py
@@ -98,7 +98,36 @@ def parse_rff_init_sigmas(raw: object) -> list[float] | None:
     raise ValueError(f"Unsupported rff_init_sigmas value: {raw!r}")
 
 
-def build_model_from_config(config: dict) -> SurfaceTransolver:
+def resolve_pos_encoding_mode(config: dict) -> str:
+    """Normalize the PE mode across config-key variants used by historical runs.
+
+    Newer configs use ``pos_encoding_mode`` (``sincos`` | ``string_separable``).
+    Earlier multi-sigma runs (PR #968/#972) used ``model_pe`` with the value
+    ``string_multisigma``. Map both to the canonical key the model accepts.
+    """
+
+    mode = config.get("pos_encoding_mode")
+    if mode is not None:
+        return str(mode)
+    legacy = config.get("model_pe")
+    if legacy is not None:
+        return str(legacy)
+    return "sincos"
+
+
+def build_model_from_config(
+    config: dict,
+    *,
+    use_aux_decoder_heads: bool = False,
+) -> SurfaceTransolver:
+    rff_num_features = int(config.get("rff_num_features", 0))
+    # Historical configs that used MultiSigmaStringPosEmbed parked the feature
+    # count under ``pe_num_features``; fall back to it when rff_num_features=0.
+    if rff_num_features == 0:
+        rff_num_features = int(config.get("pe_num_features", 0))
+    init_sigmas = parse_rff_init_sigmas(
+        config.get("rff_init_sigmas") or config.get("pe_init_sigmas")
+    )
     return SurfaceTransolver(
         n_layers=int(config.get("model_layers", 3)),
         n_hidden=int(config.get("model_hidden_dim", 192)),
@@ -106,12 +135,13 @@ def build_model_from_config(config: dict) -> SurfaceTransolver:
         n_head=int(config.get("model_heads", 3)),
         mlp_ratio=int(config.get("model_mlp_ratio", 4)),
         slice_num=int(config.get("model_slices", 96)),
-        rff_num_features=int(config.get("rff_num_features", 0)),
+        rff_num_features=rff_num_features,
         rff_sigma=float(config.get("rff_sigma", 1.0)),
-        rff_init_sigmas=parse_rff_init_sigmas(config.get("rff_init_sigmas", None)),
-        pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
+        rff_init_sigmas=init_sigmas,
+        pos_encoding_mode=resolve_pos_encoding_mode(config),
         use_qk_norm=bool(config.get("use_qk_norm", False)),
         use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        use_aux_decoder_heads=use_aux_decoder_heads,
     )
 
 
@@ -126,11 +156,16 @@ def load_member(
     checkpoint_path = artifact_dir / "checkpoint.pt"
     with config_path.open("r") as fh:
         config = yaml.safe_load(fh)
-    model = build_model_from_config(config).to(device)
     checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
     if "model" not in checkpoint:
         raise RuntimeError(f"Checkpoint for run {run_id} is missing 'model' state dict")
     state_dict = {k: v for k, v in checkpoint["model"].items()}
+    # PR #958 used Sequential heads (e.g. ``surface_out.0.weight``) — not
+    # recorded in config, so detect it from the state dict directly.
+    use_aux_decoder_heads = "surface_out.0.weight" in state_dict
+    model = build_model_from_config(
+        config, use_aux_decoder_heads=use_aux_decoder_heads
+    ).to(device)
     missing, unexpected = model.load_state_dict(state_dict, strict=True)
     if missing or unexpected:
         raise RuntimeError(

--- a/model.py
+++ b/model.py
@@ -136,6 +136,44 @@ class StringSeparableEncoding(nn.Module):
         return enc.flatten(start_dim=-2)
 
 
+class MultiSigmaStringPosEmbed(nn.Module):
+    """Drop-in replacement for ContinuousSincosEmbed using multi-sigma STRING.
+
+    Wraps StringSeparableEncoding (per-axis learnable log-frequency basis with
+    multi-sigma init) plus a linear projection to ``hidden_dim`` so the
+    surrounding model sees the same [B, N, hidden_dim] interface.
+
+    Used only by ensemble_eval.py to load PR #968 / #972 checkpoints
+    (model_pe=string_multisigma); not exercised by the current trainer.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        input_dim: int,
+        num_features: int = 16,
+        init_sigmas: list[float] | None = None,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.input_dim = input_dim
+        self.num_features = num_features
+        self.init_sigmas = list(init_sigmas) if init_sigmas else None
+        self.string = StringSeparableEncoding(
+            in_dim=input_dim,
+            num_features=num_features,
+            init_sigmas=self.init_sigmas,
+        )
+        self.project = nn.Linear(self.string.output_dim, hidden_dim)
+        nn.init.trunc_normal_(self.project.weight, std=0.02)
+        nn.init.zeros_(self.project.bias)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coords_f = coords.float()
+        enc = self.string(coords_f)
+        return self.project(enc)
+
+
 class ContinuousSincosEmbed(nn.Module):
     def __init__(self, hidden_dim: int, input_dim: int, max_wavelength: int = 10_000):
         super().__init__()
@@ -343,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_aux_decoder_heads: bool = True,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,10 +395,24 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_aux_decoder_heads = use_aux_decoder_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
-        if pos_encoding_mode == "string_separable":
+        if pos_encoding_mode == "string_multisigma":
+            string_sep_features = rff_num_features if rff_num_features > 0 else 16
+            self.pos_embed = MultiSigmaStringPosEmbed(
+                hidden_dim=n_hidden,
+                input_dim=space_dim,
+                num_features=string_sep_features,
+                init_sigmas=self.rff_init_sigmas,
+            )
+            self.surface_string_sep = None
+            self.volume_string_sep = None
+            self.surface_rff = None
+            self.volume_rff = None
+            rff_out_dim = 0
+        elif pos_encoding_mode == "string_separable":
             # STRING-separable: learnable per-axis log_freq + phase,
             # replaces fixed isotropic Gaussian RFF.
             # num_features defaults to rff_num_features if provided, else 32.
@@ -421,24 +474,30 @@ class SurfaceTransolver(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        # PR #958: dedicated vol_p auxiliary decoder head.
-        # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
-        # Volume head is a deeper 3-layer MLP for the harder vol_p task —
-        # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
-        self.surface_out = nn.Sequential(
-            nn.Linear(n_hidden, n_hidden),
-            nn.SiLU(),
-            nn.Linear(n_hidden, self.surface_output_dim),
-        )
-        self.surface_out.apply(_init_linear)
-        self.volume_out = nn.Sequential(
-            nn.Linear(n_hidden, n_hidden // 2),
-            nn.SiLU(),
-            nn.Linear(n_hidden // 2, n_hidden // 4),
-            nn.SiLU(),
-            nn.Linear(n_hidden // 4, self.volume_output_dim),
-        )
-        self.volume_out.apply(_init_linear)
+        if use_aux_decoder_heads:
+            # PR #958: dedicated vol_p auxiliary decoder head.
+            # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
+            # Volume head is a deeper 3-layer MLP for the harder vol_p task —
+            # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
+            # Default for current training; older checkpoints (PR #823 era,
+            # e.g. ghh0s4ne) set this False to load LinearProjection heads.
+            self.surface_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, self.surface_output_dim),
+            )
+            self.surface_out.apply(_init_linear)
+            self.volume_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 2, n_hidden // 4),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 4, self.volume_output_dim),
+            )
+            self.volume_out.apply(_init_linear)
+        else:
+            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).


### PR DESCRIPTION
## Hypothesis

Run greedy ensemble selection on the corrected dataset using the best models from corrected-split experiments. The corrected dataset eliminated the data artifact that caused the ~3× val→test vol_p OOD gap. With genuine model diversity, ensemble averaging should give meaningful gains over any single model.

## Pool Members (from corrected-split runs)

| Run ID | Source PR | val_abupt | val_vol_p | test_abupt | test_vol_p |
|--------|-----------|-----------|-----------|------------|------------|
| 56bcqp3m | PR #972 | 6.126% | 3.798% | 5.844% | 3.643% |
| a0yoxy85 | PR #968 | 6.278% | ~3.9% | 5.986% | 3.957% |
| 29nohj67 | PR #958 | 6.285% | ~3.9% | 6.107% | 3.818% |
| ghh0s4ne | PR #823 | ~6.2% | — | ~6.2% | — |

## Gate to Beat (PR #972 single-model SOTA)
- val_abupt < 6.126% AND val_vol_p < 3.798%

## Eval Command

```bash
python ensemble_eval.py \
  --greedy \
  --candidate-run-ids "56bcqp3m,a0yoxy85,29nohj67,ghh0s4ne" \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --max-k 8 \
  --min-improvement 0.005 \
  --eval-surface-points 65536 \
  --eval-volume-points 65536 \
  --batch-size 4
```

## Instructions to Student

1. Run the greedy ensemble eval command above with the full pool of corrected-split models.
2. Report the greedy-selected ensemble members (K, run IDs) and their metrics.
3. If adding additional pool members improves results, run with extended pool.
4. Report final metrics in a PR comment with the standard SENPAI-RESULT marker.

## Current Baseline Metrics (corrected dataset)

| Metric | Val | Test |
|--------|-----|------|
| abupt | 6.126% | 5.844% |
| vol_p | 3.798% | 3.643% |
| surf_p | — | 3.577% |
| WSS | — | 6.727% |

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```