### PR TITLE
Dedicated WSS surface decoder head: 2-arm tau-weight sweep

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_dedicated_wss_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,11 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_dedicated_wss_head = use_dedicated_wss_head
+        if use_dedicated_wss_head and self.surface_output_dim != 4:
+            raise ValueError(
+                "use_dedicated_wss_head expects surface_output_dim=4 ([cp, tau_x, tau_y, tau_z])"
+            )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,12 +487,35 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if use_dedicated_wss_head:
+                # PR #1068: split the surface head into a shallow cp head and
+                # a deeper WSS head so shear and pressure don't share output
+                # capacity. Concatenated as [cp, tau_x, tau_y, tau_z] so the
+                # training-loop loss/metric code is unchanged.
+                self.surface_out = None
+                self.surface_pressure_head = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden // 2),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden // 2, 1),
+                )
+                self.surface_pressure_head.apply(_init_linear)
+                self.wss_head = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden // 2),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden // 2, n_hidden // 4),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden // 4, 3),
+                )
+                self.wss_head.apply(_init_linear)
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
+                self.surface_pressure_head = None
+                self.wss_head = None
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),
@@ -496,8 +525,14 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
+            if use_dedicated_wss_head:
+                raise ValueError(
+                    "use_dedicated_wss_head requires use_aux_decoder_heads=True"
+                )
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+            self.surface_pressure_head = None
+            self.wss_head = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -622,7 +657,13 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_dedicated_wss_head:
+                cp_preds = self.surface_pressure_head(surface_hidden)
+                wss_preds = self.wss_head(surface_hidden)
+                surface_preds = torch.cat([cp_preds, wss_preds], dim=-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_dedicated_wss_head: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_dedicated_wss_head": (
+            "Enable dedicated WSS auxiliary decoder head (PR #1068). "
+            "Splits the surface output head into a shallow 2-layer MLP "
+            "that predicts surface pressure (cp) only and a deeper 3-layer "
+            "MLP that predicts the 3 wall-shear-stress channels "
+            "(tau_x, tau_y, tau_z). Output is concatenated back into the "
+            "[cp, tau_x, tau_y, tau_z] channel order expected by the "
+            "training loss and metric code. Requires use_aux_decoder_heads."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_dedicated_wss_head=config.use_dedicated_wss_head,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Wall shear stress (WSS = tau_x, tau_y, tau_z) prediction is currently bottlenecked by a **shared surface decoder MLP** that must simultaneously predict surface_pressure (cp) and all WSS channels from the same hidden state. Surface pressure and WSS have fundamentally different physics: cp reflects boundary-layer attachment and global pressure distribution, while WSS reflects near-wall velocity gradients and local shear layers. Forcing a single output head to learn both creates inter-task interference that is particularly costly for the harder WSS channels (tau_y and tau_z errors are currently 2–3× tau_x).

We hypothesize that a **dedicated auxiliary WSS decoder head** — an independent MLP branch that takes surface-point latent tokens and outputs a refined WSS estimate (3 channels: tau_x, tau_y, tau_z) — will improve WSS prediction quality by allowing gradient-isolated specialization for shear prediction. The main surface head retains surface_pressure (cp) only (1 channel), freeing its capacity.

This is directly analogous to the **dedicated vol_p aux decoder head** in PR #958 (tay SOTA), which improved test_vol_p by reducing shared-head interference. Here we apply the same principle to the surface/WSS domain.

**Primary target (Issue #1056):** Beat Transolver-3 WSS SOTA of **5.85%** (test_WSS). Current best: 6.727% (PR #972). ~13% relative improvement required.
**Hard floors (must not violate):** test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%.

## Implementation Instructions

**Student: implement a dedicated WSS auxiliary decoder head in `model.py`.**

### Architecture change

After the final Transolver layer, split the surface output into two heads:

```python
# In your model's __init__:

# Head 1: Surface pressure only (cp) — 1 channel
self.surface_pressure_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim // 2),
    nn.SiLU(),
    nn.Linear(hidden_dim // 2, 1),   # [cp]
)

# Head 2: WSS (wall shear stress) — 3 channels
self.wss_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim // 2),
    nn.SiLU(),
    nn.Linear(hidden_dim // 2, hidden_dim // 4),
    nn.SiLU(),
    nn.Linear(hidden_dim // 4, 3),   # [tau_x, tau_y, tau_z]
)
```

### Forward pass change

```python
# surface_tokens: [B, N_s, hidden_dim]  (from Transolver layers)

# Surface pressure prediction (1 channel)
cp_preds = self.surface_pressure_head(surface_tokens)     # [B, N_s, 1]

# WSS prediction (3 channels)
wss_preds = self.wss_head(surface_tokens)                 # [B, N_s, 3]

# Concatenate back to [cp, tau_x, tau_y, tau_z] = 4 channels
surface_preds = torch.cat([cp_preds, wss_preds], dim=-1)  # [B, N_s, 4]
```

The volume path (vol_p) is unchanged — it still uses its own existing head. Only the surface output is being split here.

### Loss weighting

With the dedicated WSS head, the existing `--tau-y-loss-weight` and `--tau-z-loss-weight` flags still apply and are respected per-channel. Use the current SOTA weights as baseline:

- **Arm A** — standard tau weights: `--tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0` (SOTA default — isolate the effect of the separate head only)
- **Arm B** — elevated tau weights: `--tau-y-loss-weight 2.0 --tau-z-loss-weight 3.0` (separate head + mild WSS upweighting)

Use `--wandb-group fern-wss-aux-decoder-head` for both arms.

### Full reproduce command (Arm A — WSS aux head, tau weights=1.5/2.0):

```bash
python train.py \
  --dataset-path /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --vol-points-min 16384 --vol-points-max 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --wandb-group fern-wss-aux-decoder-head \
  --wandb-name fern/wss-aux-head-armA-tau1.5-2.0
```

### Arm B command:
Same as Arm A but change:
- `--tau-y-loss-weight 2.0 --tau-z-loss-weight 3.0`
- `--wandb-name fern/wss-aux-head-armB-tau2.0-3.0`

### Architecture notes

- The `wss_head` is a **3-layer MLP** (deeper than the shared head) to give it more capacity for the harder shear prediction task. The `surface_pressure_head` is a 2-layer MLP (shallower, cp is easier).
- The concatenated output must preserve channel order: `[cp=0, tau_x=1, tau_y=2, tau_z=3]` to remain compatible with existing loss computation in `train.py`.
- Parameter count increase is modest: two small MLPs ≈ 2×(512×256 + 256×1) + (512×256 + 256×128 + 128×3) ≈ 300K total (~3% of ~10M param model).
- Do **NOT** use `--compile-model` (may cause issues with custom architecture).
- The vol_p auxiliary head in `train.py` (if present from PR #958) is UNCHANGED — this PR only modifies the surface output.

### EP3 gate (check at real epoch 3)

| Metric | PASS | MARGINAL | KILL |
|--------|------|----------|------|
| val_abupt | ≤ 6.2% | ≤ 6.5% | > 6.5% |
| val_vol_p | ≤ 4.5% | ≤ 5.0% | > 5.0% |

Kill Arm B at EP3 if both arms are worse than Arm A. Kill both if KILL threshold breached.

### What to report

At EP3 and EP13:
1. `val_abupt`, `val_vol_p`, `val_surf_p`, `val_WSS` (all four)
2. Any per-channel WSS breakdown (val_tau_x, val_tau_y, val_tau_z) if available
3. Whether the WSS head gradients are healthy (not vanishing or exploding)

## Baseline

Current tay-native single-model SOTA: **PR #958** (dedicated vol_p aux decoder head)

| Metric | Val | Test |
|--------|-----|------|
| val_abupt | 6.285% | test_abupt=6.107% |
| val_vol_p | — | test_vol_p=**3.818%** |
| test_WSS | — | **6.727%** (target: < 5.85%) |
| test_surf_p | — | 3.577% (hard floor) |

W&B: `29nohj67` (training) / `fkjc12c8` (eval)

**Ensemble SOTA (PR #1064, K=3):** val_abupt=5.7758%, test_abupt=5.5199%, test_vol_p=3.363%, test_WSS=6.330%

**Primary target for this PR:** val_abupt < 6.285% AND val_vol_p < 3.818%, with test_WSS ideally < 6.5% (moving toward 5.85% target).

**Hard floors that must not be violated:** test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%.
