### PR TITLE
[dl24-frieren] Combined SDF + Curvature Stratified Sampling

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-13 ~00:30 UTC
+- 2026-05-13 ~06:30 UTC
 
 ## Human Research Directive (Issue #882)
 **TOP PRIORITY — Volume Pressure Focus:**
@@ -85,7 +85,7 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 | 5 | #939 | 6.242% | — | — CLOSED |
 | 22 | #740 | 8.165% | 13.660% | Old "SOTA" — NOW ARTIFACT |
 
-## Active Experiments (2026-05-13 ~04:55 UTC)
+## Active Experiments (2026-05-13 ~06:30 UTC)
 
 | PR | Student | Hypothesis | Run ID | Status | Latest Val | Notes |
 |----|---------|------------|--------|--------|------------|-------|
@@ -93,6 +93,7 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 | #1054 | dl24-nezuko | **SDF-stratified (α=2.0) + Stochastic combined** | `tlkx2jyh` | **RUNNING** | EP11=7.0236% @ step ~120,735 | EBS=8. EP15 kill gate (≤6.80%) PENDING at step 164,625. Monitor `bladclw00` active. |
 | #1055 | dl24-tanjiro | **SDF-stratified α=1.5** | Arm A: `58hk6r36` | **ARM A RUNNING** | EP8=6.3977% @ step ~87,807 | EBS=8. EP10 kill gate (≤7.2%) PENDING at step 109,750. Monitor `bgs69snxf` active. |
 | #1063 | dl24-fern | **DANN adaptive domain normalization (DL24 branch, α sweep)** | Arm A: `xfykblf9` | **ARM A RUNNING** | EP2=7.4836% PASS @ step 21,951 | EBS=8. EP3 kill gate (≤8.0% abupt, ≤5.0% vol_p) PENDING at step 32,927. Monitor `bbi9oexhj` active. Arms B/C queued. |
+| #1069 | dl24-frieren | **Combined SDF + Curvature Stratified Sampling** | — | **ASSIGNED** | — | Arm A: SDF-vol α=1.0 (fills gap between SOTA uniform and tanjiro α=1.5). Arm B: SDF-vol α=1.0 + curvature-stratified surface β=1.0 (novel axis — curvature_HK_v2.npy). DRAFT PR open. |
 | #1057 | tay-fern | **Log-space vol_p loss** | `gqgz3y36` | **CLOSED** | EP3 test: abupt=6.64%, vol_p=4.44%, surf_p=4.20%, WSS=7.49% | CLOSED: log-space vol_p loss not validated. 3/13 epochs completed before pod budget cutoff. All metrics above DL24 SOTA. |
 
 ## Active Kill-Gate Monitors
@@ -191,7 +192,7 @@ if args.use_sdf_stratified_vol_sampling:
 3. **First true SDF near-surface experiment is nezuko (#1054).** Run `yd8n1whr` live with correct inverse formula + `__class__` reassignment + `replacement=False`. This is a virgin experimental axis.
 4. **Stochastic vol subsampling (PR #968) is independently confirmed #2.** Fresh random draw every batch is a real technique. test_abupt=5.986%.
 5. **Near-surface SDF hypothesis is ESSENTIALLY UNTESTED until now.** Given that PR #972's apparent SOTA was actually uniform, true near-surface SDF emphasis may push vol_p well below 3.643%.
-6. **frieren is now assigned PR #1062**: combined vol+surf SDF weighting — novel axis not tested by any other student.
+6. **frieren is now assigned PR #1069**: SDF-vol α=1.0 (gap fill) + curvature-stratified surface β=1.0 (completely novel axis using `curvature_HK_v2.npy`). No `surface_sdf.npy` exists — the "combined SDF" hypothesis is reinterpreted as curvature surface weighting.
 
 ## Tier 1 Follow-Ups (Current Priority)
 
@@ -270,4 +271,4 @@ if args.use_sdf_stratified_vol_sampling:
 - Bbox normalization (PR #978): may need re-test
 - EMA decay=0.999 (PR #954): needs re-test on corrected split
 
-_Last updated: 2026-05-13 ~04:55 UTC. PR #1057 CLOSED (fern_tay log-space vol_p loss not validated, gqgz3y36 finished at EP3 test_ABUPT=6.64%). All 4 DL24 monitors relaunched (bhz3pkvea/bgs69snxf/bladclw00/bbi9oexhj). 4 DL24 experiments active: edward EP12 gate imminent, tanjiro EP10 approaching, fern EP3 approaching, nezuko EP15 further out._
+_Last updated: 2026-05-13 ~06:30 UTC. PR #1069 OPENED for dl24-frieren (combined SDF vol α=1.0 + curvature-stratified surface β=1.0). 5 experiments now active: edward EP12 gate imminent, tanjiro EP10 approaching, fern EP3 approaching, nezuko EP15 further out, frieren ASSIGNED. Note: `surface_sdf.npy` does NOT exist in dataset — surface points are on vehicle boundary (SDF≈0); curvature_HK_v2.npy (shape: n_surface×2) is the correct novel surface-importance axis._


### PR DESCRIPTION
# Combined SDF + Curvature Stratified Sampling

## Hypothesis

The corrected inverse-SDF volume sampling formula (`1/(1+α·|sdf|)`) is actively being tested by tanjiro (α=1.5) and nezuko (α=2.0). The optimal α may sit between those values, and no student has tested whether **curvature-stratified surface sampling** — independently or combined — adds additional improvement.

This PR tests two novel axes:

**Arm A**: α=1.0 SDF-stratified volume sampling only. Fills the gap between α=0 (uniform, current SOTA at 5.844%) and α=1.5 (tanjiro). We do not yet know if α=1.0 is better or worse than α=1.5.

**Arm B**: α=1.0 SDF-stratified volume sampling + curvature-stratified surface sampling (β=1.0). Surface points are weighted by `1 + β·(|H|/p95_H)` where `|H|` is mean curvature magnitude, `p95_H` is the per-case 95th-percentile normalization. High-curvature regions (A-pillars, underbody edges, door handles) are sampled more frequently. This is a completely untested axis.

**Key insight**: The DrivAerML dataset provides `curvature_HK_v2.npy` (shape: `[n_surface, 2]`, columns: mean curvature H, Gaussian curvature K). With ~8.8M surface points per case and `--train-surface-points 65000` (0.74% coverage), curvature-biased sampling could significantly improve surface pressure fidelity at aerodynamically important locations.

## Current Baselines (corrected split: `rawcanon_20260511`)

| Metric | Value | PR | W&B |
|--------|-------|----|-----|
| **test_abupt** | **5.844%** | #972 | `56bcqp3m` / eval `zxnhtagj` |
| test_vol_p | 3.643% | #972 | — |
| test_surf_p | 3.577% | #972 | — |
| test_wss | 6.727% | #880 | — |

Target: beat `test_abupt < 5.844%` without degrading surface or wall-shear metrics.

Human research directive (issue #882): test volume pressure L2 error is the singular focus — do NOT degrade surface/wall shear.

## Active Related Experiments

- tanjiro #1055: α=1.5 SDF-vol-only — EP8 val_abupt=6.398% (running)
- nezuko #1054: α=2.0 SDF-vol + stochastic — EP11 val_abupt=7.024% (running)

Your arms fill a gap these do not cover and introduce the entirely novel curvature axis.

## Implementation

Add a code patch in `train.py` **immediately after** the `train_dataset` is built (after the call to `build_datasets`). The patch uses `__class__` reassignment (NOT `types.MethodType` — Python dunder methods are resolved via type MRO, not instance dict).

### Arm A — SDF-stratified volume only, α=1.0

```python
# ── SDF-stratified volume sampling patch ──────────────────────────────────────
# Place this block immediately after train_dataset is constructed in train.py.
# Use __class__ reassignment (NOT types.MethodType) for dunder override to work.

_SDF_ALPHA = 1.0
_N_VOL = args.train_volume_points   # honour the CLI flag

class _SDFStratDataset(type(train_dataset)):
    def __getitem__(self, idx):
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)

        # Surface: standard uniform sampling (unchanged)
        surface_idx = self._indices(
            counts["n_surface"], self.max_surface_points, view,
            group_view_count=view.surface_view_count,
        )

        # Volume: load ALL volume points, then apply inverse-SDF weighting
        case_all = self.store.load_case(
            view.case_id,
            surface_rows=None if surface_idx is None else surface_idx.numpy(),
            volume_rows=None,   # load full volume
        )

        n_total = case_all.volume_x.shape[0]
        n_sample = min(self._sdf_n_vol, n_total)
        sdf_abs = case_all.volume_x[:, 3].abs()   # column 3 = SDF
        weights = 1.0 / (1.0 + self._sdf_alpha * sdf_abs)   # inverse = near-surface emphasis
        vol_idx = torch.multinomial(weights, n_sample, replacement=False).sort().values

        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case_all.case_id,
            surface_x=case_all.surface_x,
            surface_y=case_all.surface_y,
            volume_x=case_all.volume_x[vol_idx],
            volume_y=case_all.volume_y[vol_idx],
            metadata={},
        )

train_dataset._sdf_alpha = _SDF_ALPHA
train_dataset._sdf_n_vol = _N_VOL
train_dataset.__class__ = _SDFStratDataset
assert type(train_dataset).__name__ == '_SDFStratDataset', 'SDF patch not active — check __class__ reassignment'
# ── end SDF patch ──────────────────────────────────────────────────────────────
```

### Arm B — SDF volume (α=1.0) + Curvature surface (β=1.0)

Same as Arm A but replace the surface sampling block with curvature-weighted sampling:

```python
# ── SDF+Curvature stratified sampling patch ───────────────────────────────────
import numpy as np as _np
from pathlib import Path as _Path

_SDF_ALPHA = 1.0
_CURV_BETA = 1.0
_N_VOL = args.train_volume_points
_N_SURF = args.train_surface_points

class _SDFCurvStratDataset(type(train_dataset)):
    def __getitem__(self, idx):
        view = self.views[idx]
        counts = self.store.case_point_counts(view.case_id)

        # ── Surface: curvature-weighted sampling ──────────────────────────────
        case_dir = self.store.root / view.case_id
        curv_path = _Path(case_dir) / "curvature_HK_v2.npy"
        n_surf_total = counts["n_surface"]
        n_surf_sample = min(self._n_surf, n_surf_total)

        if n_surf_total > n_surf_sample and curv_path.exists():
            curv_raw = _np.load(str(curv_path), mmap_mode="r")
            H_abs = torch.from_numpy(_np.abs(curv_raw[:, 0]).copy())  # mean curvature magnitude
            # Normalize by 95th percentile (per-case) then clip
            p95 = torch.quantile(H_abs[torch.isfinite(H_abs)], 0.95).clamp(min=1e-6)
            H_norm = (H_abs / p95).clamp(max=3.0)
            surf_weights = 1.0 + self._curv_beta * H_norm
            surf_weights = torch.where(torch.isfinite(surf_weights), surf_weights,
                                       torch.ones_like(surf_weights))
            surf_idx = torch.multinomial(surf_weights, n_surf_sample,
                                         replacement=False).sort().values
        else:
            surf_idx = self._indices(
                n_surf_total, self._n_surf, view,
                group_view_count=view.surface_view_count,
            )

        # ── Volume: inverse-SDF weighted sampling ────────────────────────────
        case_all = self.store.load_case(
            view.case_id,
            surface_rows=None if surf_idx is None else surf_idx.numpy(),
            volume_rows=None,
        )

        n_vol_total = case_all.volume_x.shape[0]
        n_vol_sample = min(self._n_vol, n_vol_total)
        sdf_abs = case_all.volume_x[:, 3].abs()
        vol_weights = 1.0 / (1.0 + self._sdf_alpha * sdf_abs)
        vol_idx = torch.multinomial(vol_weights, n_vol_sample, replacement=False).sort().values

        from data.loader import DrivAerMLCase
        return DrivAerMLCase(
            case_id=case_all.case_id,
            surface_x=case_all.surface_x,
            surface_y=case_all.surface_y,
            volume_x=case_all.volume_x[vol_idx],
            volume_y=case_all.volume_y[vol_idx],
            metadata={},
        )

train_dataset._sdf_alpha = _SDF_ALPHA
train_dataset._curv_beta = _CURV_BETA
train_dataset._n_vol = _N_VOL
train_dataset._n_surf = _N_SURF
train_dataset.__class__ = _SDFCurvStratDataset
assert type(train_dataset).__name__ == '_SDFCurvStratDataset', 'SDF+Curv patch not active'
# ── end patch ──────────────────────────────────────────────────────────────────
```

**Note on `mmap_mode="r"`**: The curvature file is ~135MB per case. Using memory-mapped loading avoids duplicating it into RAM on each worker. The `.copy()` is required before torch conversion to avoid writable-array issues.

**Note on surface view_count**: The curvature-weighted path bypasses `_indices` which means multi-view surface coverage is not handled. For this experiment use `--train-surface-points 65000` with single-view surface (the default when `n_surface_total > max_surface_points` at train time). If you observe warning about view_count > 1 for surface, add a guard: only apply curvature weighting when `view.view_index == 0`.

## Training Commands

### Arm A — SDF volume only, α=1.0

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --epochs 30 \
  --batch-size 1 \
  --train-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-surface-points 65536 \
  --eval-volume-points 65536 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-layers 6 \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --no-compile-model \
  --lr-warmup-epochs 1 \
  --wandb-group frieren-combined-sdf-curv \
  --wandb-name frieren-arm-a-sdf-alpha1.0 \
  --kill-thresholds "10975:val_primary/abupt_axis_mean_rel_l2_pct<=30,21950:val_primary/abupt_axis_mean_rel_l2_pct<=16,32925:val_primary/abupt_axis_mean_rel_l2_pct<=8,54875:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,109750:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,164625:val_primary/abupt_axis_mean_rel_l2_pct<=6.80,219500:val_primary/abupt_axis_mean_rel_l2_pct<=6.70,274375:val_primary/abupt_axis_mean_rel_l2_pct<=6.65,329250:val_primary/abupt_axis_mean_rel_l2_pct<=6.60"
```

### Arm B — SDF volume α=1.0 + curvature surface β=1.0

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --epochs 30 \
  --batch-size 1 \
  --train-surface-points 65000 \
  --train-volume-points 65000 \
  --eval-surface-points 65536 \
  --eval-volume-points 65536 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-layers 6 \
  --optimizer lion \
  --use-gradnorm \
  --gradnorm-alpha 0.5 \
  --no-compile-model \
  --lr-warmup-epochs 1 \
  --wandb-group frieren-combined-sdf-curv \
  --wandb-name frieren-arm-b-sdf-alpha1.0-curv-beta1.0 \
  --kill-thresholds "10975:val_primary/abupt_axis_mean_rel_l2_pct<=30,21950:val_primary/abupt_axis_mean_rel_l2_pct<=16,32925:val_primary/abupt_axis_mean_rel_l2_pct<=8,54875:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,109750:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,164625:val_primary/abupt_axis_mean_rel_l2_pct<=6.80,219500:val_primary/abupt_axis_mean_rel_l2_pct<=6.70,274375:val_primary/abupt_axis_mean_rel_l2_pct<=6.65,329250:val_primary/abupt_axis_mean_rel_l2_pct<=6.60"
```

## Kill Gate Reference (EBS=8, steps per epoch ≈10975)

| Step | Epoch | Gate |
|------|-------|------|
| 10975 | EP1 | val_abupt ≤ 30% |
| 21950 | EP2 | val_abupt ≤ 16% |
| 32925 | EP3 | val_abupt ≤ 8% |
| 54875 | EP5 | val_abupt ≤ 7.5% |
| 109750 | EP10 | val_abupt ≤ 7.2% |
| 164625 | EP15 | val_abupt ≤ 6.80% |
| 219500 | EP20 | val_abupt ≤ 6.70% |
| 274375 | EP25 | val_abupt ≤ 6.65% |
| 329250 | EP30 | val_abupt ≤ 6.60% |

W&B metric key: `val_primary/abupt_axis_mean_rel_l2_pct`

## Critical Config Constraints

1. **`--no-compile-model`** — required for DL24 branch; compile breaks on this arch
2. **`--data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511`** — corrected split; old path causes +7-8pp val→test gap
3. **`--eval-surface-points 65536 --eval-volume-points 65536`** — required for metric comparability
4. **`--optimizer lion --use-gradnorm`** — GradNorm requires Lion; AdamW causes instability
5. **`--model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0"`** — DL24 branch flags; do NOT use tay branch flags
6. **`__class__` reassignment** — `types.MethodType` is WRONG for `__getitem__` (Python resolves dunders via type MRO)
7. **Inverse SDF formula** — `1/(1+α·|sdf|)` gives near-surface emphasis; `1+α·|sdf|` is incorrect (upweights far-field)
8. **`replacement=False`** in `torch.multinomial` — sample without replacement
9. Do NOT set `--lr-warmup-steps`; use `--lr-warmup-epochs 1` only (epoch-based warmup)

## Expected Outcome

- Arm A: If α=1.0 is the sweet spot between α=0 (SOTA 5.844%) and α=1.5 (tanjiro), expect val_abupt to beat both
- Arm B: If curvature weighting improves surface pressure fidelity, expect test_surf_p to improve vs Arm A
- If Arm B beats Arm A on abupt, the curvature axis is worth a dedicated follow-up with β sweep (0.25, 0.5, 1.0, 2.0)

## Results

Post results as a SENPAI-RESULT marker per arm:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Include val_abupt, val_vol_p, val_surf_p, val_wss, and test equivalents for both arms. Do not mark `terminal=true` until both arms have completed.

If one arm diverges or is killed early, report it and continue the other. Mark `pending_arms=true` until the second arm completes.
