### PR TITLE
SDF Inverse Vol Sampling α=3.0: near-surface concentration sweep

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -259,6 +261,84 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     raise ValueError(
         f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
     )
+
+
+def apply_sdf_stratified_vol_sampling(
+    train_dataset,
+    *,
+    alpha: float,
+    n_volume_points: int,
+) -> None:
+    """Patch the training dataset to draw volume points with near-surface
+    emphasis: weight = 1 / (1 + alpha * |sdf|).
+
+    At |sdf|=0 (surface boundary) weight=1.0. As |sdf| grows, weight decays
+    toward 0, concentrating samples near the surface boundary. Larger alpha =
+    sharper near-surface concentration.
+
+    Uses __class__ reassignment to a dynamic subclass because Python resolves
+    dunder methods (__getitem__) via the type MRO, not the instance dict — an
+    instance-level types.MethodType assignment is silently bypassed by
+    DataLoader's `dataset[idx]` call.
+
+    SDF lives at channel 3 of volume_x (xyz + sdf). Surface sampling untouched.
+    Replaces train volume sampling only — val/test loaders use original
+    deterministic chunked sampling.
+    """
+    from data.loader import DrivAerMLCase
+
+    _alpha = float(alpha)
+    _n_vol = int(n_volume_points)
+
+    class _SDFStratifiedDataset(type(train_dataset)):
+        def __getitem__(self, idx: int) -> DrivAerMLCase:
+            view = self.views[idx]
+            counts = self.store.case_point_counts(view.case_id)
+            surface_idx = self._indices(
+                counts["n_surface"],
+                self.max_surface_points,
+                view,
+                group_view_count=view.surface_view_count,
+            )
+            case = self.store.load_case(
+                view.case_id,
+                surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                volume_rows=None,
+            )
+            n_total = case.volume_x.shape[0]
+            n_sample = min(self._sdf_n_vol, n_total)
+            sdf_vals = case.volume_x[:, 3].abs().float()
+            weights = 1.0 / (1.0 + self._sdf_alpha * sdf_vals)
+            vol_idx = torch.multinomial(weights, n_sample, replacement=False)
+            vol_idx = vol_idx.sort().values
+            metadata = {
+                "case_id": case.case_id,
+                "n_surface_full": int(counts["n_surface"]),
+                "n_surface_loaded": int(case.surface_x.shape[0]),
+                "surface_view_index": int(view.view_index),
+                "surface_view_count": int(view.surface_view_count),
+                "surface_sampling_mode": view.sampling_mode,
+                "n_volume_full": int(n_total),
+                "n_volume_loaded": int(n_sample),
+                "volume_view_index": int(view.view_index),
+                "volume_view_count": int(view.volume_view_count),
+                "volume_sampling_mode": "sdf_stratified_inv",
+                "joint_view_count": int(view.view_count),
+                "sdf_stratified_alpha": self._sdf_alpha,
+            }
+            return DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=case.surface_x,
+                surface_y=case.surface_y,
+                volume_x=case.volume_x[vol_idx],
+                volume_y=case.volume_y[vol_idx],
+                metadata=metadata,
+            )
+
+    train_dataset._sdf_alpha = _alpha
+    train_dataset._sdf_n_vol = _n_vol
+    train_dataset.__class__ = _SDFStratifiedDataset
+    assert type(train_dataset).__name__ == "_SDFStratifiedDataset", "SDF patch not active"
 
 
 def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
@@ -451,6 +531,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            apply_sdf_stratified_vol_sampling(
+                train_loader.dataset,
+                alpha=config.sdf_stratified_alpha,
+                n_volume_points=config.train_volume_points,
+            )
+            if state.is_main:
+                print(
+                    "[SDF] inverse near-surface vol sampling enabled: "
+                    f"alpha={config.sdf_stratified_alpha}, "
+                    f"n_vol={config.train_volume_points}, "
+                    f"dataset class={type(train_loader.dataset).__name__}"
+                )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(


### PR DESCRIPTION
## Hypothesis

Near-surface SDF-inverse weighted volume sampling — `weight = 1.0 / (1.0 + α * |sdf|)` — concentrates training signal close to the car surface, where aerodynamic quantities (pressure, WSS) vary most sharply. We are sweeping α to understand the trade-off: low α (0.25, fern) gives mild concentration; high α gives stronger near-surface bias.

- **fern** (PR #1063): α=0.25 → EP9 val_ABUPT=6.274% (run `xfykblf9`, still running)
- **nezuko** (PR #1072): α=0.5 → EP3 val_ABUPT=6.675% (run `yp383yq2`, still running)
- **this PR**: α=3.0 — strong near-surface emphasis

At α=3.0: weight ≈ 0.91 at |sdf|=0.033m, ≈ 0.77 at |sdf|=0.1m, ≈ 0.25 at |sdf|=1.0m. This gives meaningful boundary-layer emphasis without extreme sparsity in the far-field.

## Baseline

Current SOTA (corrected dataset `rawcanon_20260511`):
- **PR #972**, run `56bcqp3m`, eval `zxnhtagj`
- test_ABUPT=5.844%, test_VP=3.643%, test_SP=3.577%, test_WSS=6.727%
- Dataset: `/mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511`

## Implementation Instructions

`--use-sdf-stratified-vol-sampling` and `--sdf-stratified-alpha` are NOT in train.py's argparser. You must:

**Step 1: Add CLI args to train.py** (after the existing argparse block, before `args = parser.parse_args()`):

```python
parser.add_argument("--use-sdf-stratified-vol-sampling", action="store_true", default=False)
parser.add_argument("--sdf-stratified-alpha", type=float, default=1.0)
```

**Step 2: Add monkey-patch block after `train_dataset` is constructed** (just before the DataLoader is created):

```python
if args.use_sdf_stratified_vol_sampling:
    import torch as _torch

    _ALPHA = args.sdf_stratified_alpha
    _N_VOL = args.train_volume_points

    class _SDFStratifiedDataset(type(train_dataset)):
        def __getitem__(self, idx):
            view = self.views[idx]
            counts = self.store.case_point_counts(view.case_id)
            surface_idx = self._indices(
                counts["n_surface"], self.max_surface_points, view,
                group_view_count=view.surface_view_count,
            )
            case = self.store.load_case(
                view.case_id,
                surface_rows=None if surface_idx is None else surface_idx.numpy(),
                volume_rows=None,
            )
            n_total = case.volume_x.shape[0]
            n_sample = min(self._sdf_n_vol, n_total)
            sdf_vals = case.volume_x[:, 3].abs()
            weights = 1.0 / (1.0 + self._sdf_alpha * sdf_vals)
            vol_idx = _torch.multinomial(weights, n_sample, replacement=False)
            vol_idx = vol_idx.sort().values
            from data.loader import DrivAerMLCase
            return DrivAerMLCase(
                case_id=case.case_id,
                surface_x=case.surface_x, surface_y=case.surface_y,
                volume_x=case.volume_x[vol_idx], volume_y=case.volume_y[vol_idx],
                metadata={},
            )

    train_dataset._sdf_alpha = _ALPHA
    train_dataset._sdf_n_vol = _N_VOL
    train_dataset.__class__ = _SDFStratifiedDataset
```

**CRITICAL implementation notes:**
- Use `__class__` reassignment (NOT `types.MethodType`) — dunder methods like `__getitem__` are only found via the MRO, not instance attributes
- The formula MUST be `1.0 / (1.0 + α * |sdf|)` — near-surface gets HIGH weight, far-field LOW weight
- Set `_sdf_alpha` and `_sdf_n_vol` as instance attributes BEFORE reassigning `__class__`
- The `sdf_vals` are at `volume_x[:, 3]` (column index 3 is the SDF channel)

## Launch Command

```bash
cd /workspace/senpai/target

torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511/manifest.json \
  --model-layers 6 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --train-volume-points 6144 \
  --eval-volume-points 6144 \
  --train-surface-points 4096 \
  --eval-surface-points 4096 \
  --batch-size 2 \
  --epochs 30 \
  --lr 3e-4 \
  --weight-decay 1e-4 \
  --optimizer lion \
  --amp-mode bf16 \
  --use-y-symmetry-aug \
  --wandb-group sdf-inverse-vol-sampling \
  --use-sdf-stratified-vol-sampling \
  --sdf-stratified-alpha 3.0 \
  --kill-thresholds "10975:val_primary/abupt_axis_mean_rel_l2_pct<=30,21950:val_primary/abupt_axis_mean_rel_l2_pct<=16,32925:val_primary/abupt_axis_mean_rel_l2_pct<=8,54875:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,109750:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,164625:val_primary/abupt_axis_mean_rel_l2_pct<=6.8,219500:val_primary/abupt_axis_mean_rel_l2_pct<=6.7,274375:val_primary/abupt_axis_mean_rel_l2_pct<=6.65,329250:val_primary/abupt_axis_mean_rel_l2_pct<=6.6"
```

## Kill Thresholds

| Gate | Step | val_ABUPT threshold |
|------|------|---------------------|
| EP1  | 10,975 | ≤30% |
| EP2  | 21,950 | ≤16% |
| EP3  | 32,925 | ≤8%  |
| EP5  | 54,875 | ≤7.5% |
| EP10 | 109,750 | ≤7.2% |
| EP15 | 164,625 | ≤6.8% |
| EP20 | 219,500 | ≤6.7% |
| EP25 | 274,375 | ≤6.65% |
| EP30 | 329,250 | ≤6.6% |

Format: `STEP:METRIC<=THRESHOLD` — PASS if metric ≤ threshold.

## Reporting

After each epoch gate, post a comment with:
```
EP<N> GATE: val_ABUPT=X.XXX%, val_SP=X.XXX%, val_VP=X.XXX%, val_WSS=X.XXX% — PASS/KILL
```

When fully complete (EP30 or early stop), post terminal result:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```
