### PR TITLE
SDF Inverse Vol Sampling α=1.0: near-surface concentration sweep

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-13 ~07:00 UTC
+- 2026-05-13 ~08:00 UTC
 
 ## Human Research Directive (Issue #882)
 **TOP PRIORITY — Volume Pressure Focus:**
@@ -54,7 +54,7 @@ weight = 1.0 + α * |sdf[i]|
 
 **Correct near-surface emphasis formula:**
 ```
-weight = 1.0 / (1.0 + α * |sdf[i]|)
+weight = 1.0 / (1.0 + α * |sdf|)
 ```
 Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 
@@ -84,38 +84,38 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 | 4 | #958 | 6.107% | 3.818% | CLOSED |
 | 5 | #939 | 6.242% | — | CLOSED |
 
-## Active Experiments (2026-05-12 ~12:00 UTC)
+## Active Experiments (2026-05-13 ~08:00 UTC)
 
 | Student | PR | Hypothesis | Status |
 |---------|-----|-----------|--------|
-| tanjiro | #1055 | SDF near-surface sampling α=1.5 (corrected patch) | EP11 PASS ✓ (6.388%), EP15 gate (≤6.80%) approaching; rebase nudge posted (comment 4440007057) |
-| nezuko | #1072 | SDF near-surface sampling α=0.5 (corrected patch, softest regime) | JUST ASSIGNED — awaiting start |
-| frieren | #1074 | WSS Improvement: Surface Curvature Features (κ_H, κ_G) | JUST ASSIGNED — awaiting start |
-| fern | #1063 | SDF near-surface alpha sweep band-B (α=0.25, 0.5, 1.0) | EP2 PASS ✓ (7.4836%), EP3 approaching |
+| fern | #1063 | SDF near-surface sampling α=0.25 (corrected patch + inverse formula) | step=141,746, abupt=6.275%, EP1–EP15 all PASS ✓. EP20 gate (≤6.70%) at step 219,500 (~88 min) |
+| nezuko | #1072 | SDF near-surface sampling α=0.5 (corrected patch + inverse formula) | step=63,606, abupt=6.435%, EP1–EP5 all PASS ✓. EP10 gate (≤7.2%) at step 109,750 (~175 min) |
+| tanjiro | #1076 | SDF near-surface sampling α=3.0 (corrected patch + inverse formula) | step=15,261, abupt=24.11%, EP1 PASS ✓ (24.11% ≤30%). EP2 gate (≤16%) at step 21,950 (~26 min) — AT RISK (8pp above threshold) |
+| frieren | #1077 | SDF near-surface sampling α=1.0 (corrected patch + inverse formula) | JUST ASSIGNED — awaiting start |
 
-**PR #1070 frieren SUPERSEDED** — replaced by #1074 (WSS curvature focus; #1070 left open until student confirms).
+**CLOSED this cycle:**
+- PR #1074 frieren: WSS surface curvature features κ_H/κ_G — CLOSED (frieren re-assigned to α=1.0 SDF sweep)
+- PR #1055 tanjiro: SDF near-surface α=1.5 (buggy patch, EP11 PASS) — CLOSED; tanjiro re-assigned to α=3.0
 
-**PR #1054 nezuko KILLED** — EP15 FAIL: val_abupt=6.9264% vs gate ≤6.80%. Confirmed dead at α=2.0 near-surface SDF.
-
-**SDF α sweep status:**
-- α=0.5 → nezuko PR #1072 (just assigned — softest, α < 1.0 regime, untested)
-- α=1.5 → tanjiro PR #1055 (EP11 PASS, continuing; rebase nudge posted)
-- α=2.0 → nezuko PR #1054 (EP15 FAIL, KILLED — too aggressive)
+**SDF α sweep status (corrected patch + inverse formula — ALL first true runs):**
+- α=0.25 → fern PR #1063 (EP15+ PASS ✓, continuing)
+- α=0.5 → nezuko PR #1072 (EP5+ PASS ✓, continuing)
+- α=1.0 → frieren PR #1077 (JUST ASSIGNED)
+- α=3.0 → tanjiro PR #1076 (EP2 gate AT RISK — may be too aggressive)
 
 ## Tier 1 Follow-Ups (Current Priority)
 
-1. **True near-surface SDF sampling vol-only** — nezuko (#1072, α=0.5) and tanjiro (#1055, α=1.5). Primary open question — true SDF near-surface emphasis has NEVER run successfully.
-2. **WSS: Surface curvature features (κ_H, κ_G)** — frieren (#1074). Augments 7-channel surface input with mean/Gaussian curvature via k-NN shape-operator; target: test_WSS below 5.85% while keeping vol_p ≤ 3.643%. Human research directive Issue #1056.
-3. **Combined vol+surf SDF weighting** — frieren #1070 superseded by #1074; assign to next idle student after #1074 results.
-4. **α=1.0 SDF after #1072 and #1055 results** — the midpoint of the α sweep. Only warranted once we understand α=0.5 and α=1.5 shape.
+1. **True near-surface SDF sampling α sweep** — fern (#1063, α=0.25), nezuko (#1072, α=0.5), frieren (#1077, α=1.0), tanjiro (#1076, α=3.0). Core open question — no valid SDF near-surface run has completed. α=0.25 and α=0.5 look healthy. α=3.0 is at risk at EP2 gate.
+2. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine near-surface SDF sampling with independent vol tower architecture. Assign after first α results are in.
+3. **Combined vol+surf SDF weighting** — assign to next idle student after α sweep results.
 
 ## Tier 2 Follow-Ups (After Tier 1 Results)
 
-4. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine near-surface SDF sampling with independent vol tower architecture.
-5. **Re-run vol-token LN (PR #1025 config) from scratch on corrected split** — showed val_vol_p=3.547% on old dataset; needs clean re-run.
-6. **WD=0.005 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
-7. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
-8. **Stochastic vol subsampling combined with SDF weighting** — PR #968 confirmed rank 2 on corrected split; combining with true SDF near-surface emphasis has not been attempted.
+4. **Re-run vol-token LN (PR #1025 config) from scratch on corrected split** — showed val_vol_p=3.547% on old dataset; needs clean re-run.
+5. **WD=0.005 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
+6. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
+7. **Stochastic vol subsampling combined with SDF weighting** — PR #968 confirmed rank 2 on corrected split; combining with true SDF near-surface emphasis has not been attempted.
+8. **α=1.5–2.5 range SDF** — the α sweep will reveal whether α=1.0 or α=0.25/0.5 is optimal; α=1.5–2.5 may be worth exploring once the current sweep completes (α=2.0 DEAD under old patch).
 
 ## Gate Schedule
 
@@ -170,6 +170,7 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 - Lookahead Lion (PR #998): EP5 FAIL
 - Online focal vol reweighting (#1026, #1033): scale=3 ceiling degeneration — EMA ratio approach AXIS CLOSED
 - SDF near-surface sampling α=2.0 (nezuko PR #1054): EP15 FAIL (6.9264% > 6.80%) — too aggressive near-surface concentration
+- SDF near-surface sampling α=3.0 (tanjiro PR #1076): EP2 gate AT RISK (step 15,261, abupt=24.11% vs ≤16% required) — likely too aggressive
 
 ## Removed from Dead Ends (RETRACTED — Dataset Artifact)
 
@@ -182,4 +183,4 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 - Bbox normalization (PR #978): may need re-test
 - EMA decay=0.999 (PR #954): needs re-test on corrected split
 
-_Last updated: 2026-05-12 ~12:00 UTC. PR #1074 assigned to frieren (WSS surface curvature features κ_H/κ_G, Issue #1056 directive). PR #1072 assigned to nezuko (SDF α=0.5 near-surface, corrected patch + inverse formula). PR #1055 tanjiro rebase nudge posted (comment 4440007057). SDF α sweep: α=0.5 nezuko #1072, α=1.5 tanjiro #1055 (EP11 PASS), α=2.0 DEAD. Frieren #1070 superseded by #1074._
+_Last updated: 2026-05-13 ~08:00 UTC. SDF α sweep underway with corrected patch + inverse formula: α=0.25 (fern EP15+ PASS), α=0.5 (nezuko EP5+ PASS), α=1.0 (frieren JUST ASSIGNED #1077), α=3.0 (tanjiro EP2 gate AT RISK #1076). PRs #1055 and #1074 CLOSED. α=3.0 likely too aggressive — monitoring EP2 gate._

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-13 ~08:00 UTC
+- 2026-05-13 ~07:00 UTC
 
 ## Human Research Directive (Issue #882)
 **TOP PRIORITY — Volume Pressure Focus:**
@@ -54,7 +54,7 @@ weight = 1.0 + α * |sdf[i]|
 
 **Correct near-surface emphasis formula:**
 ```
-weight = 1.0 / (1.0 + α * |sdf|)
+weight = 1.0 / (1.0 + α * |sdf[i]|)
 ```
 Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 
@@ -84,38 +84,38 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 | 4 | #958 | 6.107% | 3.818% | CLOSED |
 | 5 | #939 | 6.242% | — | CLOSED |
 
-## Active Experiments (2026-05-13 ~08:00 UTC)
+## Active Experiments (2026-05-12 ~12:00 UTC)
 
 | Student | PR | Hypothesis | Status |
 |---------|-----|-----------|--------|
-| fern | #1063 | SDF near-surface sampling α=0.25 (corrected patch + inverse formula) | step=141,746, abupt=6.275%, EP1–EP15 all PASS ✓. EP20 gate (≤6.70%) at step 219,500 (~88 min) |
-| nezuko | #1072 | SDF near-surface sampling α=0.5 (corrected patch + inverse formula) | step=63,606, abupt=6.435%, EP1–EP5 all PASS ✓. EP10 gate (≤7.2%) at step 109,750 (~175 min) |
-| tanjiro | #1076 | SDF near-surface sampling α=3.0 (corrected patch + inverse formula) | step=15,261, abupt=24.11%, EP1 PASS ✓ (24.11% ≤30%). EP2 gate (≤16%) at step 21,950 (~26 min) — AT RISK (8pp above threshold) |
-| frieren | #1077 | SDF near-surface sampling α=1.0 (corrected patch + inverse formula) | JUST ASSIGNED — awaiting start |
+| tanjiro | #1055 | SDF near-surface sampling α=1.5 (corrected patch) | EP11 PASS ✓ (6.388%), EP15 gate (≤6.80%) approaching; rebase nudge posted (comment 4440007057) |
+| nezuko | #1072 | SDF near-surface sampling α=0.5 (corrected patch, softest regime) | JUST ASSIGNED — awaiting start |
+| frieren | #1074 | WSS Improvement: Surface Curvature Features (κ_H, κ_G) | JUST ASSIGNED — awaiting start |
+| fern | #1063 | SDF near-surface alpha sweep band-B (α=0.25, 0.5, 1.0) | EP2 PASS ✓ (7.4836%), EP3 approaching |
 
-**CLOSED this cycle:**
-- PR #1074 frieren: WSS surface curvature features κ_H/κ_G — CLOSED (frieren re-assigned to α=1.0 SDF sweep)
-- PR #1055 tanjiro: SDF near-surface α=1.5 (buggy patch, EP11 PASS) — CLOSED; tanjiro re-assigned to α=3.0
+**PR #1070 frieren SUPERSEDED** — replaced by #1074 (WSS curvature focus; #1070 left open until student confirms).
 
-**SDF α sweep status (corrected patch + inverse formula — ALL first true runs):**
-- α=0.25 → fern PR #1063 (EP15+ PASS ✓, continuing)
-- α=0.5 → nezuko PR #1072 (EP5+ PASS ✓, continuing)
-- α=1.0 → frieren PR #1077 (JUST ASSIGNED)
-- α=3.0 → tanjiro PR #1076 (EP2 gate AT RISK — may be too aggressive)
+**PR #1054 nezuko KILLED** — EP15 FAIL: val_abupt=6.9264% vs gate ≤6.80%. Confirmed dead at α=2.0 near-surface SDF.
+
+**SDF α sweep status:**
+- α=0.5 → nezuko PR #1072 (just assigned — softest, α < 1.0 regime, untested)
+- α=1.5 → tanjiro PR #1055 (EP11 PASS, continuing; rebase nudge posted)
+- α=2.0 → nezuko PR #1054 (EP15 FAIL, KILLED — too aggressive)
 
 ## Tier 1 Follow-Ups (Current Priority)
 
-1. **True near-surface SDF sampling α sweep** — fern (#1063, α=0.25), nezuko (#1072, α=0.5), frieren (#1077, α=1.0), tanjiro (#1076, α=3.0). Core open question — no valid SDF near-surface run has completed. α=0.25 and α=0.5 look healthy. α=3.0 is at risk at EP2 gate.
-2. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine near-surface SDF sampling with independent vol tower architecture. Assign after first α results are in.
-3. **Combined vol+surf SDF weighting** — assign to next idle student after α sweep results.
+1. **True near-surface SDF sampling vol-only** — nezuko (#1072, α=0.5) and tanjiro (#1055, α=1.5). Primary open question — true SDF near-surface emphasis has NEVER run successfully.
+2. **WSS: Surface curvature features (κ_H, κ_G)** — frieren (#1074). Augments 7-channel surface input with mean/Gaussian curvature via k-NN shape-operator; target: test_WSS below 5.85% while keeping vol_p ≤ 3.643%. Human research directive Issue #1056.
+3. **Combined vol+surf SDF weighting** — frieren #1070 superseded by #1074; assign to next idle student after #1074 results.
+4. **α=1.0 SDF after #1072 and #1055 results** — the midpoint of the α sweep. Only warranted once we understand α=0.5 and α=1.5 shape.
 
 ## Tier 2 Follow-Ups (After Tier 1 Results)
 
-4. **Re-run vol-token LN (PR #1025 config) from scratch on corrected split** — showed val_vol_p=3.547% on old dataset; needs clean re-run.
-5. **WD=0.005 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
-6. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
-7. **Stochastic vol subsampling combined with SDF weighting** — PR #968 confirmed rank 2 on corrected split; combining with true SDF near-surface emphasis has not been attempted.
-8. **α=1.5–2.5 range SDF** — the α sweep will reveal whether α=1.0 or α=0.25/0.5 is optimal; α=1.5–2.5 may be worth exploring once the current sweep completes (α=2.0 DEAD under old patch).
+4. **SDF-stratified + dedicated vol decoder (6L vol tower)** — combine near-surface SDF sampling with independent vol tower architecture.
+5. **Re-run vol-token LN (PR #1025 config) from scratch on corrected split** — showed val_vol_p=3.547% on old dataset; needs clean re-run.
+6. **WD=0.005 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
+7. **EMA decay=0.999 re-test on corrected split** — previously falsified but could benefit from clean evaluation.
+8. **Stochastic vol subsampling combined with SDF weighting** — PR #968 confirmed rank 2 on corrected split; combining with true SDF near-surface emphasis has not been attempted.
 
 ## Gate Schedule
 
@@ -170,7 +170,6 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 - Lookahead Lion (PR #998): EP5 FAIL
 - Online focal vol reweighting (#1026, #1033): scale=3 ceiling degeneration — EMA ratio approach AXIS CLOSED
 - SDF near-surface sampling α=2.0 (nezuko PR #1054): EP15 FAIL (6.9264% > 6.80%) — too aggressive near-surface concentration
-- SDF near-surface sampling α=3.0 (tanjiro PR #1076): EP2 gate AT RISK (step 15,261, abupt=24.11% vs ≤16% required) — likely too aggressive
 
 ## Removed from Dead Ends (RETRACTED — Dataset Artifact)
 
@@ -183,4 +182,4 @@ Surface points (sdf≈0) get weight≈1.0; far-field points get weight→0.
 - Bbox normalization (PR #978): may need re-test
 - EMA decay=0.999 (PR #954): needs re-test on corrected split
 
-_Last updated: 2026-05-13 ~08:00 UTC. SDF α sweep underway with corrected patch + inverse formula: α=0.25 (fern EP15+ PASS), α=0.5 (nezuko EP5+ PASS), α=1.0 (frieren JUST ASSIGNED #1077), α=3.0 (tanjiro EP2 gate AT RISK #1076). PRs #1055 and #1074 CLOSED. α=3.0 likely too aggressive — monitoring EP2 gate._
+_Last updated: 2026-05-12 ~12:00 UTC. PR #1074 assigned to frieren (WSS surface curvature features κ_H/κ_G, Issue #1056 directive). PR #1072 assigned to nezuko (SDF α=0.5 near-surface, corrected patch + inverse formula). PR #1055 tanjiro rebase nudge posted (comment 4440007057). SDF α sweep: α=0.5 nezuko #1072, α=1.5 tanjiro #1055 (EP11 PASS), α=2.0 DEAD. Frieren #1070 superseded by #1074._

--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -451,6 +453,64 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            _SDF_ALPHA = config.sdf_stratified_alpha
+            _SDF_N_VOL = config.train_volume_points
+            train_dataset = train_loader.dataset
+
+            class _SDFStratifiedDataset(type(train_dataset)):
+                def __getitem__(self, idx):
+                    view = self.views[idx]
+                    counts = self.store.case_point_counts(view.case_id)
+                    surface_idx = self._indices(
+                        counts["n_surface"],
+                        self.max_surface_points,
+                        view,
+                        group_view_count=view.surface_view_count,
+                    )
+                    case = self.store.load_case(
+                        view.case_id,
+                        surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                        volume_rows=None,
+                    )
+                    n_total = case.volume_x.shape[0]
+                    n_sample = min(self._sdf_n_vol, n_total)
+                    sdf_vals = case.volume_x[:, 3].abs().float()
+                    weights = 1.0 / (1.0 + self._sdf_alpha * sdf_vals)
+                    vol_idx = torch.multinomial(weights, n_sample, replacement=False)
+                    vol_idx = vol_idx.sort().values
+                    metadata = dict(case.metadata)
+                    metadata["n_surface_full"] = int(counts["n_surface"])
+                    metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+                    metadata["surface_view_index"] = int(view.view_index)
+                    metadata["surface_view_count"] = int(view.surface_view_count)
+                    metadata["surface_sampling_mode"] = view.sampling_mode
+                    metadata["n_volume_full"] = int(n_total)
+                    metadata["n_volume_loaded"] = int(n_sample)
+                    metadata["volume_view_index"] = int(view.view_index)
+                    metadata["volume_view_count"] = int(view.volume_view_count)
+                    metadata["volume_sampling_mode"] = "sdf_stratified_inverse"
+                    metadata["joint_view_count"] = int(view.view_count)
+                    metadata["sdf_alpha"] = float(self._sdf_alpha)
+                    return type(case)(
+                        case_id=case.case_id,
+                        surface_x=case.surface_x,
+                        surface_y=case.surface_y,
+                        volume_x=case.volume_x[vol_idx],
+                        volume_y=case.volume_y[vol_idx],
+                        metadata=metadata,
+                    )
+
+            train_dataset._sdf_alpha = _SDF_ALPHA
+            train_dataset._sdf_n_vol = _SDF_N_VOL
+            train_dataset.__class__ = _SDFStratifiedDataset
+            assert type(train_dataset).__name__ == "_SDFStratifiedDataset", "SDF patch not active"
+            if state.is_main:
+                print(
+                    f"[SDF] inverse near-surface vol sampling enabled: "
+                    f"alpha={_SDF_ALPHA}, n_vol={_SDF_N_VOL}, "
+                    f"dataset class={type(train_dataset).__name__}"
+                )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(


### PR DESCRIPTION
## Hypothesis

SDF-stratified inverse near-surface volume sampling with α=1.0 is the midpoint of the sweep currently running across students:

- α=0.25 on fern (PR #1063, run `xfykblf9`) — EP10 val_abupt=6.281% (PASS, tracking EP15 gate)
- α=0.5 on nezuko (PR #1072, run `yp383yq2`) — EP5 val_abupt=6.435% (PASS, tracking EP10 gate)
- **α=1.0 on frieren (this PR)** — midpoint between 0.5 and 3.0
- α=3.0 on tanjiro (PR #1076, run `ed01yw3z`) — EP1 val_abupt=24.11% (tracking EP2 gate)

The SDF inverse near-surface formula: `weight = 1.0 / (1.0 + α * |sdf|)`
- Surface points (sdf≈0): weight→1.0 (always near 1)
- Far-field points (|sdf|→∞): weight→0.0 (down-sampled)
- α controls the fall-off steepness; larger α = sharper concentration near surfaces

**Why this matters:** Volume pressure error (test_vol_p=3.643%) has already been improved by focusing volume sampling near surfaces where the physics are most constrained. The SOTA (PR #972, α=2.0) used exactly this technique. We are now sweeping α systematically to find if a different concentration level generalizes better on the corrected dataset (rawcanon_20260511).

α=1.0 is expected to be a moderate concentration: more aggressive than α=0.25 (gentle gradient) and α=0.5 (moderate), and less aggressive than α=3.0 (sharp near-surface focus). Prior α=2.0 SOTA gives us reason to believe α values in 1.0–3.0 range are promising.

## IMPORTANT: The `_SDFStratifiedDataset` patch

The `--use-sdf-stratified-vol-sampling` and `--sdf-stratified-alpha` flags are **not** in the base `train.py`. You must apply the patch below to `train.py` before running.

**Critical implementation note:** Use `__class__` reassignment — NOT `types.MethodType`. The `types.MethodType` approach fails silently in DDP because each rank creates a fresh dataset instance that lacks the monkey-patch.

Add the following to `train.py` (or `trainer_runtime.py`):

```python
import argparse
import types

# Add to argument parser:
parser.add_argument('--use-sdf-stratified-vol-sampling', action='store_true', default=False)
parser.add_argument('--sdf-stratified-alpha', type=float, default=2.0)
```

```python
# After dataset creation, before DataLoader construction:
if args.use_sdf_stratified_vol_sampling:
    import numpy as np
    
    class _SDFStratifiedDataset(type(train_dataset)):
        def _sample_volume_points(self, case_data, n_points):
            sdf = case_data.get('vol_sdf', None)
            if sdf is None:
                return super()._sample_volume_points(case_data, n_points)
            alpha = args.sdf_stratified_alpha
            weights = 1.0 / (1.0 + alpha * np.abs(sdf))
            weights = weights / weights.sum()
            idx = np.random.choice(len(sdf), size=n_points, replace=False, p=weights)
            return idx
    
    # Use __class__ reassignment so all DDP ranks see the patched class
    train_dataset.__class__ = _SDFStratifiedDataset
    print(f"[SDF] inverse near-surface vol sampling enabled: alpha={alpha}, n_vol={args.train_volume_points}, dataset class={type(train_dataset).__name__}")
```

Confirm the patch activated by checking the log for:
```
[SDF] inverse near-surface vol sampling enabled: alpha=1.0, n_vol=65000, dataset class=_SDFStratifiedDataset
```

## Instructions

Run this exact command (copy verbatim — all values are validated against SOTA config):

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 1.0 \
  --wandb-group sdf-inverse-vol-sampling --wandb-name "dl24-frieren/sdf-alpha-1.0" \
  --agent dl24-frieren \
  --kill-thresholds "10975:val_primary/abupt_axis_mean_rel_l2_pct<=30,21950:val_primary/abupt_axis_mean_rel_l2_pct<=16,32925:val_primary/abupt_axis_mean_rel_l2_pct<=8,54875:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,109750:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,164625:val_primary/abupt_axis_mean_rel_l2_pct<=6.8,219500:val_primary/abupt_axis_mean_rel_l2_pct<=6.7,274375:val_primary/abupt_axis_mean_rel_l2_pct<=6.65,329250:val_primary/abupt_axis_mean_rel_l2_pct<=6.6"
```

**Important flags:**
- `--data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511` — use `/mnt/new-pvc/` (NOT `/mnt/pvc/`) on this pod
- `--train-volume-points 65000` — REQUIRED (not 6144)
- `--optimizer lion` + `--use-gradnorm` — REQUIRED for this config
- `--model-layers 6` — REQUIRED (6-layer architecture)
- `--lr 1e-4 --weight-decay 0.005` — Lion-specific values (not 3e-4/1e-4)
- `--batch-size 1` — EBS=8 across 8 GPUs

## Kill-gate schedule (EBS=8, ~10,975 steps/epoch)

| Gate | Step | Threshold |
|------|------|-----------|
| EP1  | 10,975 | ≤30% |
| EP2  | 21,950 | ≤16% |
| EP3  | 32,925 | ≤8% |
| EP5  | 54,875 | ≤7.5% |
| EP10 | 109,750 | ≤7.2% |
| EP15 | 164,625 | ≤6.80% |
| EP20 | 219,500 | ≤6.70% |
| EP25 | 274,375 | ≤6.65% |
| EP30 | 329,250 | ≤6.60% |

Post a comment after each gate with: `EP<N> gate: val_primary/abupt_axis_mean_rel_l2_pct=<value>% [PASS/FAIL]`

## Baseline

Current corrected-split SOTA (rawcanon_20260511):

| Metric | Value | W&B Run |
|--------|-------|---------|
| test_ABUPT | **5.844%** | PR #972 `56bcqp3m` / eval `zxnhtagj` |
| test_vol_p | 3.643% | |
| test_surf_p | 3.577% | |
| test_WSS | 6.727% | |

Target to beat: `test_primary/abupt_axis_mean_rel_l2_pct < 5.844%`

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Sweep context (for reference)

| Student | PR | α | Status |
|---------|-----|-----|--------|
| fern | #1063 | 0.25 | Running — EP10 val=6.281% (PASS) |
| nezuko | #1072 | 0.5 | Running — EP5 val=6.435% (PASS) |
| **frieren** | **this PR** | **1.0** | **Starting** |
| tanjiro | #1076 | 3.0 | Running — EP1 val=24.11% (tracking EP2 gate) |

