### PR TITLE
Surface curvature features (H+K) for WSS improvement

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -275,6 +275,7 @@ def load_case(
     *,
     surface_rows: np.ndarray | None = None,
     volume_rows: np.ndarray | None = None,
+    use_surface_curvature: bool = False,
 ) -> DrivAerMLCase:
     case_dir = _case_dir(Path(root), case_id)
     xyz = _load_npy_rows(case_dir / "surface_xyz.npy", surface_rows)
@@ -286,6 +287,22 @@ def load_case(
         "surface_wallshearstress.npy",
     )
     surface_x = np.concatenate([xyz, normals, area], axis=1)
+    if use_surface_curvature:
+        # H and K span ~6 orders of magnitude with heavy tails (K up to ±10M).
+        # Compute per-case stats on the FULL array (so sampled views see the same
+        # normalisation), then row-index after normalising.
+        full_curv = np.load(
+            _resolve_artifact_path(case_dir / "curvature_HK_v2.npy"), mmap_mode="r"
+        )
+        full_curv = np.asarray(full_curv, dtype=np.float32).copy()
+        for ch in range(full_curv.shape[1]):
+            lo, hi = np.percentile(full_curv[:, ch], [1, 99])
+            np.clip(full_curv[:, ch], lo, hi, out=full_curv[:, ch])
+            mu = full_curv[:, ch].mean()
+            sigma = full_curv[:, ch].std() + 1e-8
+            full_curv[:, ch] = (full_curv[:, ch] - mu) / sigma
+        curv = full_curv if surface_rows is None else full_curv[surface_rows]
+        surface_x = np.concatenate([surface_x, curv], axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [
@@ -338,8 +355,15 @@ class DrivAerMLCaseStore:
         *,
         surface_rows: np.ndarray | None = None,
         volume_rows: np.ndarray | None = None,
+        use_surface_curvature: bool = False,
     ) -> DrivAerMLCase:
-        return load_case(self.root, case_id, surface_rows=surface_rows, volume_rows=volume_rows)
+        return load_case(
+            self.root,
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+            use_surface_curvature=use_surface_curvature,
+        )
 
     def case_point_counts(self, case_id: str) -> dict[str, int]:
         cached = self._point_count_cache.get(case_id)
@@ -367,6 +391,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_surface_curvature: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +401,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_surface_curvature = use_surface_curvature
+        self.surface_input_dim = SURFACE_X_DIM + (2 if use_surface_curvature else 0)
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -444,6 +471,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             view.case_id,
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
+            use_surface_curvature=self.use_surface_curvature,
         )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
@@ -473,7 +501,8 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
     max_surface_n = max(sample.surface_x.shape[0] for sample in samples)
     max_volume_n = max(sample.volume_x.shape[0] for sample in samples)
     batch_size = len(samples)
-    surface_x = torch.zeros(batch_size, max_surface_n, SURFACE_X_DIM, dtype=samples[0].surface_x.dtype)
+    surface_x_dim = samples[0].surface_x.shape[1]
+    surface_x = torch.zeros(batch_size, max_surface_n, surface_x_dim, dtype=samples[0].surface_x.dtype)
     surface_y = torch.zeros(batch_size, max_surface_n, SURFACE_Y_DIM, dtype=samples[0].surface_y.dtype)
     surface_mask = torch.zeros(batch_size, max_surface_n, dtype=torch.bool)
     volume_x = torch.zeros(batch_size, max_volume_n, VOLUME_X_DIM, dtype=samples[0].volume_x.dtype)
@@ -544,6 +573,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_surface_curvature: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +598,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_surface_curvature=use_surface_curvature,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +607,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_surface_curvature=use_surface_curvature,
         )
     }
     test_splits = {
@@ -585,6 +617,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_surface_curvature=use_surface_curvature,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/data/loader.py
+++ b/data/loader.py
@@ -240,6 +240,19 @@ def _resolve_artifact_path(path: Path) -> Path:
     raise FileNotFoundError(f"Could not resolve DrivAerML artifact {path}; checked {checked}")
 
 
+_MISSING_CURVATURE_WARNED: set[str] = set()
+
+
+def _warn_missing_curvature(case_id: str) -> None:
+    if case_id in _MISSING_CURVATURE_WARNED:
+        return
+    _MISSING_CURVATURE_WARNED.add(case_id)
+    print(
+        f"[loader] curvature_HK_v2.npy missing for {case_id}; falling back to zeros",
+        flush=True,
+    )
+
+
 def _load_npy_rows(path: Path, rows: np.ndarray | None = None) -> np.ndarray:
     resolved = _resolve_artifact_path(path)
     if rows is None:
@@ -288,19 +301,26 @@ def load_case(
     )
     surface_x = np.concatenate([xyz, normals, area], axis=1)
     if use_surface_curvature:
-        # H and K span ~6 orders of magnitude with heavy tails (K up to ±10M).
-        # Compute per-case stats on the FULL array (so sampled views see the same
-        # normalisation), then row-index after normalising.
-        full_curv = np.load(
-            _resolve_artifact_path(case_dir / "curvature_HK_v2.npy"), mmap_mode="r"
-        )
-        full_curv = np.asarray(full_curv, dtype=np.float32).copy()
-        for ch in range(full_curv.shape[1]):
-            lo, hi = np.percentile(full_curv[:, ch], [1, 99])
-            np.clip(full_curv[:, ch], lo, hi, out=full_curv[:, ch])
-            mu = full_curv[:, ch].mean()
-            sigma = full_curv[:, ch].std() + 1e-8
-            full_curv[:, ch] = (full_curv[:, ch] - mu) / sigma
+        # 62 / 484 cases in the corrected split lack curvature_HK_v2.npy; fall back
+        # to zeros for those (post per-case z-score, 0 ≡ case-mean curvature, i.e.
+        # a constant per case, so the model can simply ignore the feature there).
+        try:
+            curv_path = _resolve_artifact_path(case_dir / "curvature_HK_v2.npy")
+        except FileNotFoundError:
+            _warn_missing_curvature(case_dir.name)
+            n_full = _npy_row_count(case_dir / "surface_xyz.npy")
+            full_curv = np.zeros((n_full, 2), dtype=np.float32)
+        else:
+            # H and K span ~6 orders of magnitude with heavy tails (K up to ±10M).
+            # Compute per-case stats on the FULL array (so sampled views see the same
+            # normalisation), then row-index after normalising.
+            full_curv = np.asarray(np.load(curv_path, mmap_mode="r"), dtype=np.float32).copy()
+            for ch in range(full_curv.shape[1]):
+                lo, hi = np.percentile(full_curv[:, ch], [1, 99])
+                np.clip(full_curv[:, ch], lo, hi, out=full_curv[:, ch])
+                mu = full_curv[:, ch].mean()
+                sigma = full_curv[:, ch].std() + 1e-8
+                full_curv[:, ch] = (full_curv[:, ch] - mu) / sigma
         curv = full_curv if surface_rows is None else full_curv[surface_rows]
         surface_x = np.concatenate([surface_x, curv], axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)

--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import SURFACE_X_DIM, DrivAerMLSurfaceDataset
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_surface_curvature: bool = False
     debug: bool = False
 
 
@@ -295,7 +296,9 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
 
 
 def build_model(config: Config) -> SurfaceTransolver:
+    surface_input_dim = SURFACE_X_DIM + (2 if config.use_surface_curvature else 0)
     return SurfaceTransolver(
+        surface_input_dim=surface_input_dim,
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
         dropout=config.model_dropout,
@@ -683,6 +686,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        use_surface_curvature=getattr(old_ds, "use_surface_curvature", False),
     )
     train_sampler = None
     train_shuffle = True

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -281,6 +281,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_surface_curvature=getattr(config, "use_surface_curvature", False),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

Surface curvature (mean curvature H and Gaussian curvature K) encodes how sharply a car body bends at each point. Boundary layer thickness, local flow separation, and wall shear stress are all strongly modulated by geometric curvature — high curvature regions (sharp edges, pillars, wheel arches) are precisely where WSS prediction errors are largest. `curvature_HK_v2.npy` already exists in all 422 dataset cases, computed per surface point. Currently the loader ignores it.

Hypothesis: appending H and K as two additional surface input channels (SURFACE_X_DIM 7→9) will help the model identify high-curvature edges and corners as high-importance regions for WSS prediction, reducing test_WSS without hurting vol_p or SP.

**Why this should work:**
- The model's `SurfaceTransolver` uses `surface_extra_dim = max(0, surface_input_dim - space_dim)` and projects additional features through `LinearProjection(surface_proj_in, n_hidden)` — the architecture already handles variable-dim surface input with zero code change to `model.py`.
- Mean curvature H measures local surface bending (related to normal curvature and pressure gradient onset); Gaussian curvature K distinguishes saddle points, ridges, and flat regions — together they give the model richer shape context than normals alone.
- This is a zero-overhead feature — no new data files to generate, no extra network parameters of consequence, just a 2-channel concat.

## Instructions

**Dataset:** All new runs must use `/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511` (corrected split).

### Step 1: Update `data/loader.py`

1. At the top of the file, change the constant:
   ```python
   # OLD:
   SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
   # NEW — controlled by flag, but update the module-level default for --use-surface-curvature:
   ```
   Actually, keep `SURFACE_X_DIM = 7` as the default. You will handle the dim change in `train.py` by passing `surface_input_dim` to the model.

2. In `load_case()` (the function that builds `surface_x`), after loading xyz/normals/area, add curvature loading with robust normalization:

   ```python
   # --- Surface curvature (optional) ---
   if use_surface_curvature:
       curv_path = case_dir / "curvature_HK_v2.npy"
       curv = np.load(curv_path).astype(np.float32)  # shape (N, 2)  H, K
       # Robust normalization: winsorize to [p1, p99] per channel, then z-score
       for ch in range(2):
           p1, p99 = np.percentile(curv[:, ch], [1, 99])
           curv[:, ch] = np.clip(curv[:, ch], p1, p99)
           mu = curv[:, ch].mean()
           sigma = curv[:, ch].std() + 1e-8
           curv[:, ch] = (curv[:, ch] - mu) / sigma
       surface_x = np.concatenate([surface_x, curv], axis=1)  # (N, 9)
   ```

   `load_case()` needs to accept a `use_surface_curvature: bool = False` argument. Thread this argument through whatever calls `load_case()` (typically `Dataset.__init__` or `__getitem__`).

3. The `collate_fn` uses `SURFACE_X_DIM` to allocate zero-pad tensors. When curvature is active, you need to pass the actual surface_input_dim (9) to collate. You can do this by storing `dataset.surface_input_dim` on the dataset object and referencing it in collate, or by passing it as a partial closure argument.

### Step 2: Update `train.py`

1. Add a new config field to the `Config` dataclass:
   ```python
   use_surface_curvature: bool = False
   ```

2. In `build_model()`, pass the surface input dimension:
   ```python
   def build_model(config: Config) -> SurfaceTransolver:
       surface_input_dim = SURFACE_X_DIM + (2 if config.use_surface_curvature else 0)
       return SurfaceTransolver(
           n_layers=config.model_layers,
           n_hidden=config.model_hidden_dim,
           ...
           surface_input_dim=surface_input_dim,
           ...
       )
   ```
   Import `SURFACE_X_DIM` from `data` at the top of train.py if not already imported.

3. When constructing the dataset/dataloader, pass `use_surface_curvature=config.use_surface_curvature` so the loader knows to load the extra channels.

4. In the collate function path, ensure the surface tensor allocation uses `surface_input_dim` rather than the hardcoded constant when curvature is on.

### Step 3: Run configuration

Run a full training with the curvature flag enabled using the SOTA stack flags. Use 8 GPUs:

```bash
cd target/ && python train.py \
  --dataset /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --use-surface-curvature \
  --wandb_group edward-curvature-features
```

### EP gates

- **EP1 kill:** val_abupt > 12% — stop immediately, something has gone wrong with the feature loading or normalization
- **EP3 gate:**
  - PASS: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% → run to full budget
  - MARGINAL: val_abupt ≤ 6.5% AND val_vol_p ≤ 5.0% → continue with advisor approval
  - KILL: val_abupt > 6.5% → stop, the curvature features are not helping

Report EP3 metrics and W&B run IDs in a PR comment and wait for advisor go/no-go before proceeding past EP3.

### Debugging tips

If you encounter shape mismatches:
- Check `surface_x.shape[-1]` in `load_case()` after concatenation — should be 9.
- Check that `collate_fn` allocates surface tensors of shape `(B, N, 9)` not `(B, N, 7)`.
- Verify `model.surface_input_dim == 9` after `build_model()`.
- The curvature file has extreme outliers (e.g. K up to ±10M) — the p1/p99 winsorizing is essential. If you see NaN losses, check normalization first.

## Baseline

**Single-model SOTA (corrected split) — PR #972**
| Metric | Value |
|--------|-------|
| val_abupt | 6.126% |
| test_abupt | 5.844% |
| test_vol_p | 3.643% |
| test_SP | 3.577% |
| test_WSS | 6.727% |

**W&B run:** `56bcqp3m`

**Ensemble SOTA (corrected split) — PR #1064 K=3**
| Metric | Value |
|--------|-------|
| val_abupt | 5.7758% |
| test_abupt | 5.5199% |
| test_vol_p | 3.3630% |

**W&B run:** `88dinf0n`

**Target for this experiment:** val_abupt ≤ 6.126% (beat single-model SOTA), test_WSS ≤ 6.727%

**Primary objective:** Improve test_WSS while keeping test_vol_p ≤ 3.643% and test_SP ≤ 3.577%.
