### PR TITLE
[frieren] Adaptive per-point WSS loss weighting via surface curvature

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -305,17 +305,23 @@ def load_case(
     volume_y = _column(_load_npy_rows(case_dir / "volume_pressure.npy", volume_rows))
     surface_curvature_tensor: torch.Tensor | None = None
     if load_surface_curvature:
-        curv = _load_npy_rows(case_dir / "curvature_HK_v2.npy", surface_rows)
-        if curv.ndim != 2 or curv.shape[1] != 2:
-            raise ValueError(
-                f"curvature_HK_v2.npy must have shape [N, 2], got {curv.shape}"
+        curv_path = case_dir / "curvature_HK_v2.npy"
+        if curv_path.exists():
+            curv = _load_npy_rows(curv_path, surface_rows)
+            if curv.ndim != 2 or curv.shape[1] != 2:
+                raise ValueError(
+                    f"curvature_HK_v2.npy must have shape [N, 2], got {curv.shape}"
+                )
+            if curv.shape[0] != surface_x.shape[0]:
+                raise ValueError(
+                    f"curvature row count {curv.shape[0]} != surface row count "
+                    f"{surface_x.shape[0]} for case {case_id}"
+                )
+            surface_curvature_tensor = torch.from_numpy(np.ascontiguousarray(curv))
+        else:
+            surface_curvature_tensor = torch.zeros(
+                (surface_x.shape[0], 2), dtype=torch.float32
             )
-        if curv.shape[0] != surface_x.shape[0]:
-            raise ValueError(
-                f"curvature row count {curv.shape[0]} != surface row count "
-                f"{surface_x.shape[0]} for case {case_id}"
-            )
-        surface_curvature_tensor = torch.from_numpy(np.ascontiguousarray(curv))
     return DrivAerMLCase(
         case_id=case_id,
         surface_x=torch.from_numpy(surface_x),

--- a/data/loader.py
+++ b/data/loader.py
@@ -67,6 +67,7 @@ class DrivAerMLCase:
     volume_x: torch.Tensor
     volume_y: torch.Tensor
     metadata: dict[str, Any]
+    surface_curvature: torch.Tensor | None = None
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,7 @@ class SurfaceBatch:
     volume_y: torch.Tensor
     volume_mask: torch.Tensor
     metadata: list[dict[str, Any]]
+    surface_curvature: torch.Tensor | None = None
 
     def to(self, device: torch.device | str) -> "SurfaceBatch":
         return SurfaceBatch(
@@ -100,6 +102,11 @@ class SurfaceBatch:
             volume_y=self.volume_y.to(device),
             volume_mask=self.volume_mask.to(device),
             metadata=list(self.metadata),
+            surface_curvature=(
+                self.surface_curvature.to(device)
+                if self.surface_curvature is not None
+                else None
+            ),
         )
 
     @property
@@ -275,6 +282,7 @@ def load_case(
     *,
     surface_rows: np.ndarray | None = None,
     volume_rows: np.ndarray | None = None,
+    load_surface_curvature: bool = False,
 ) -> DrivAerMLCase:
     case_dir = _case_dir(Path(root), case_id)
     xyz = _load_npy_rows(case_dir / "surface_xyz.npy", surface_rows)
@@ -295,6 +303,19 @@ def load_case(
         axis=1,
     )
     volume_y = _column(_load_npy_rows(case_dir / "volume_pressure.npy", volume_rows))
+    surface_curvature_tensor: torch.Tensor | None = None
+    if load_surface_curvature:
+        curv = _load_npy_rows(case_dir / "curvature_HK_v2.npy", surface_rows)
+        if curv.ndim != 2 or curv.shape[1] != 2:
+            raise ValueError(
+                f"curvature_HK_v2.npy must have shape [N, 2], got {curv.shape}"
+            )
+        if curv.shape[0] != surface_x.shape[0]:
+            raise ValueError(
+                f"curvature row count {curv.shape[0]} != surface row count "
+                f"{surface_x.shape[0]} for case {case_id}"
+            )
+        surface_curvature_tensor = torch.from_numpy(np.ascontiguousarray(curv))
     return DrivAerMLCase(
         case_id=case_id,
         surface_x=torch.from_numpy(surface_x),
@@ -306,6 +327,7 @@ def load_case(
             "n_surface": int(surface_x.shape[0]),
             "n_volume": int(volume_x.shape[0]),
         },
+        surface_curvature=surface_curvature_tensor,
     )
 
 
@@ -338,8 +360,15 @@ class DrivAerMLCaseStore:
         *,
         surface_rows: np.ndarray | None = None,
         volume_rows: np.ndarray | None = None,
+        load_surface_curvature: bool = False,
     ) -> DrivAerMLCase:
-        return load_case(self.root, case_id, surface_rows=surface_rows, volume_rows=volume_rows)
+        return load_case(
+            self.root,
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+            load_surface_curvature=load_surface_curvature,
+        )
 
     def case_point_counts(self, case_id: str) -> dict[str, int]:
         cached = self._point_count_cache.get(case_id)
@@ -367,6 +396,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        load_surface_curvature: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +406,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.load_surface_curvature = load_surface_curvature
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -444,6 +475,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             view.case_id,
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
+            load_surface_curvature=self.load_surface_curvature,
         )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
@@ -464,6 +496,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             volume_x=case.volume_x,
             volume_y=case.volume_y,
             metadata=metadata,
+            surface_curvature=case.surface_curvature,
         )
 
 
@@ -479,6 +512,11 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
     volume_x = torch.zeros(batch_size, max_volume_n, VOLUME_X_DIM, dtype=samples[0].volume_x.dtype)
     volume_y = torch.zeros(batch_size, max_volume_n, VOLUME_Y_DIM, dtype=samples[0].volume_y.dtype)
     volume_mask = torch.zeros(batch_size, max_volume_n, dtype=torch.bool)
+    has_curvature = all(sample.surface_curvature is not None for sample in samples)
+    surface_curvature: torch.Tensor | None = None
+    if has_curvature:
+        curv_dtype = samples[0].surface_curvature.dtype
+        surface_curvature = torch.zeros(batch_size, max_surface_n, 2, dtype=curv_dtype)
     for i, sample in enumerate(samples):
         surface_n = sample.surface_x.shape[0]
         volume_n = sample.volume_x.shape[0]
@@ -488,6 +526,8 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
         volume_x[i, :volume_n] = sample.volume_x
         volume_y[i, :volume_n] = sample.volume_y
         volume_mask[i, :volume_n] = True
+        if surface_curvature is not None:
+            surface_curvature[i, :surface_n] = sample.surface_curvature
     return SurfaceBatch(
         case_ids=[sample.case_id for sample in samples],
         surface_x=surface_x,
@@ -497,6 +537,7 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
         volume_y=volume_y,
         volume_mask=volume_mask,
         metadata=[dict(sample.metadata) for sample in samples],
+        surface_curvature=surface_curvature,
     )
 
 
@@ -544,6 +585,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    load_surface_curvature: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +610,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        load_surface_curvature=load_surface_curvature,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -57,6 +57,7 @@ from trainer_runtime import (
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
+    weighted_point_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -105,6 +106,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_curvature_weight_scale: float = 0.0
+    wss_curvature_mode: str = "H"
+    wss_curvature_clip_percentile: float = 95.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -220,6 +224,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "wss_curvature_weight_scale": (
+            "Scale factor for curvature-adaptive per-point loss weighting on "
+            "surface targets (cp + tau). 0.0 (default) disables the feature; "
+            "the loss path falls back exactly to the standard "
+            "weighted_channel_mse and the curvature .npy is not loaded. When "
+            "> 0, each surface point i receives a multiplier w_i = "
+            "1 + scale * mag_norm_i where mag_norm_i is the per-sample "
+            "percentile-clipped (default p95) curvature magnitude normalised "
+            "to [0, 1]. scale=1.0 yields max weight 2.0x at the most curved "
+            "points; scale=2.0 yields 3.0x."
+        ),
+        "wss_curvature_mode": (
+            "Which curvature signal feeds the per-point weight when "
+            "--wss-curvature-weight-scale > 0. 'H' uses |mean curvature|; "
+            "'K' uses sqrt(|Gaussian curvature|) (sqrt compresses the tail); "
+            "'HK' adds the two. The signal is then per-sample percentile-"
+            "clipped and normalised; see --wss-curvature-clip-percentile."
+        ),
+        "wss_curvature_clip_percentile": (
+            "Per-sample percentile used to clip and normalise the curvature "
+            "magnitude before turning it into the per-point weight. Default "
+            "95.0 caps the top 5% of points to weight 1 + scale (prevents "
+            "mesh-edge / panel-gap outliers from dominating the gradient)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -311,6 +339,61 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+WSS_CURVATURE_MODES = ("H", "K", "HK")
+
+
+def curvature_wss_weights(
+    curvature_HK: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    scale: float,
+    mode: str = "H",
+    clip_percentile: float = 95.0,
+) -> torch.Tensor:
+    """Return per-point loss weights derived from surface curvature.
+
+    curvature_HK: [B, N, 2] — columns [mean curvature H, Gaussian curvature K]
+    mask: [B, N] — surface validity mask
+    scale: when 0 the function returns ones (no-op); otherwise the weight is
+        ``1 + scale * mag_norm`` where ``mag_norm`` is the per-sample
+        percentile-clipped curvature magnitude rescaled to [0, 1].
+    mode: which curvature scalar drives the weight (``H`` | ``K`` | ``HK``).
+        ``K`` is mapped through ``sqrt(|K|)`` to compress the heavy tail.
+    clip_percentile: per-sample quantile used to clip and renormalise the
+        magnitude (default 95.0).
+    """
+
+    if mode not in WSS_CURVATURE_MODES:
+        raise ValueError(
+            f"Unknown wss_curvature_mode '{mode}'. Supported: {WSS_CURVATURE_MODES}."
+        )
+    if scale <= 0.0 or curvature_HK.shape[-2] == 0:
+        return torch.ones_like(mask, dtype=curvature_HK.dtype)
+
+    H = curvature_HK[..., 0]
+    K = curvature_HK[..., 1]
+    if mode == "H":
+        mag = H.abs()
+    elif mode == "K":
+        mag = K.abs().clamp_min(0.0).sqrt()
+    else:  # mode == "HK"
+        mag = H.abs() + K.abs().clamp_min(0.0).sqrt()
+
+    mask_float = mask.to(mag.dtype)
+    # Zero out the padding rows; their values are arbitrary after pad_collate.
+    mag = mag * mask_float
+    flat = mag.reshape(mag.shape[0], -1)
+    q = max(min(clip_percentile, 100.0), 0.0) / 100.0
+    # torch.quantile fails on bf16/fp16 in some torch versions — cast to fp32.
+    flat_f32 = flat.float()
+    clip_val = torch.quantile(flat_f32, q, dim=1, keepdim=True).to(mag.dtype)
+    clip_val_safe = clip_val.clamp_min(1e-12)
+    mag_clipped = torch.minimum(mag, clip_val)
+    mag_norm = (mag_clipped / clip_val_safe).clamp(0.0, 1.0)
+    weight = 1.0 + scale * mag_norm
+    return weight
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,6 +404,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    surface_point_weights: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,7 +416,24 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if surface_point_weights is not None:
+            channel_weights = (
+                surface_channel_weights
+                if surface_channel_weights is not None
+                else torch.ones(
+                    out["surface_preds"].shape[-1],
+                    device=device,
+                    dtype=out["surface_preds"].dtype,
+                )
+            )
+            surface_loss = weighted_point_channel_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                channel_weights=channel_weights,
+                point_weights=surface_point_weights,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -683,6 +784,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        load_surface_curvature=getattr(old_ds, "load_surface_curvature", False),
     )
     train_sampler = None
     train_shuffle = True
@@ -852,6 +954,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.wss_curvature_weight_scale > 0.0:
+                print(
+                    f"Curvature-adaptive surface loss enabled: "
+                    f"scale={config.wss_curvature_weight_scale} "
+                    f"mode={config.wss_curvature_mode} "
+                    f"clip_percentile={config.wss_curvature_clip_percentile} "
+                    f"(max weight = {1.0 + config.wss_curvature_weight_scale:.2f}x)"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +993,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_curvature_weight_scale"] = config.wss_curvature_weight_scale
+            wandb.summary["loss/wss_curvature_mode"] = config.wss_curvature_mode
+            wandb.summary["loss/wss_curvature_clip_percentile"] = config.wss_curvature_clip_percentile
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1021,6 +1134,28 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    curvature_point_weights: torch.Tensor | None = None
+                    curvature_metrics: dict[str, float] = {}
+                    if (
+                        config.wss_curvature_weight_scale > 0.0
+                        and getattr(batch, "surface_curvature", None) is not None
+                    ):
+                        curvature_point_weights = curvature_wss_weights(
+                            batch.surface_curvature.to(device),
+                            batch.surface_mask.to(device),
+                            scale=config.wss_curvature_weight_scale,
+                            mode=config.wss_curvature_mode,
+                            clip_percentile=config.wss_curvature_clip_percentile,
+                        )
+                        # Stats are mask-aware so padding doesn't dilute them.
+                        valid_w = curvature_point_weights[batch.surface_mask.to(device)]
+                        if valid_w.numel() > 0:
+                            curvature_metrics = {
+                                "train/curvature_weight_mean": float(valid_w.mean().detach().cpu().item()),
+                                "train/curvature_weight_max": float(valid_w.max().detach().cpu().item()),
+                                "train/curvature_weight_min": float(valid_w.min().detach().cpu().item()),
+                                "train/curvature_weight_std": float(valid_w.std().detach().cpu().item()),
+                            }
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1030,7 +1165,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        surface_point_weights=curvature_point_weights,
                     )
+                    if curvature_metrics:
+                        batch_loss_metrics.update(curvature_metrics)
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1070,6 +1208,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for curv_key in (
+                        "train/curvature_weight_mean",
+                        "train/curvature_weight_max",
+                        "train/curvature_weight_min",
+                        "train/curvature_weight_std",
+                    ):
+                        if curv_key in batch_loss_metrics:
+                            train_log[curv_key] = batch_loss_metrics[curv_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -281,6 +281,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        load_surface_curvature=float(getattr(config, "wss_curvature_weight_scale", 0.0)) > 0.0,
     )
     train_sampler = None
     train_shuffle = True
@@ -861,6 +862,45 @@ def weighted_channel_mse(
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
+def weighted_point_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    channel_weights: torch.Tensor,
+    point_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Per-channel and per-point weighted masked MSE.
+
+    pred / target: [B, N, C]; mask: [B, N]; channel_weights: [C]; point_weights: [B, N].
+    Computes a weighted mean of squared errors where the per-sample weight of a
+    given (point, channel) entry is ``mask * point_weights * channel_weights``.
+    The denominator is ``sum(mask * point_weights) * C`` so that when
+    ``point_weights ≡ 1`` this collapses exactly to ``weighted_channel_mse`` and
+    the overall loss magnitude is preserved under non-uniform point weighting.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    ch_w = channel_weights.to(device=pred.device, dtype=pred.dtype)
+    if ch_w.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"channel_weights last-dim {ch_w.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    pt_w = point_weights.to(device=pred.device, dtype=pred.dtype)
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype)
+    if pt_w.shape != mask_dev.shape:
+        raise ValueError(
+            f"point_weights shape {tuple(pt_w.shape)} must match mask shape {tuple(mask_dev.shape)}"
+        )
+    sq_err = (pred - target).square()
+    combined = (mask_dev * pt_w).unsqueeze(-1)  # [B, N, 1]
+    weighted = sq_err * ch_w.view(1, 1, -1) * combined
+    weighted_valid = (mask_dev * pt_w).sum()
+    denominator = (weighted_valid * pred.shape[-1]).clamp_min(1.0)
+    if bool(mask_dev.sum().detach().cpu().item() > 0):
         return weighted.sum() / denominator
     return pred.sum() * 0.0
 


### PR DESCRIPTION
# Adaptive Per-Point WSS Loss Weighting via Surface Curvature

## Hypothesis

The current WSS loss (`masked_mse` / `weighted_channel_mse`) treats every surface point equally. But WSS error is highly non-uniform across the car body: geometrically complex regions — wheel arches, A-pillars, mirror stalks, and door seams — exhibit the highest prediction errors because they have sharp curvature and complex boundary-layer separation patterns.

The dataset already provides `curvature_HK_v2.npy` (shape `(N_surface, 2)`, columns: mean curvature H, Gaussian curvature K) for every case. This experiment up-weights the WSS loss (τ_x, τ_y, τ_z channels) at high-curvature surface points, so the model is explicitly penalised more for errors in the regions where it currently struggles most. No architectural changes — purely a loss modification in `trainer_runtime.py` and `loader.py`.

**Key distinction from prior experiments:**
- PR #1026 (focal vol reweight) and PR #1033 (EMA vol reweight): both modified **volume** loss at the **case** level
- This experiment modifies **surface/WSS** loss at the **point** level using a geometry signal from the mesh
- PR #1068 (dedicated WSS decoder head): architectural split that failed EP1 due to convergence; this experiment has **zero** architectural changes

## Implementation

### Step 1 — Load curvature in `data/loader.py`

In the `load_case()` function (around line 276), load `curvature_HK_v2.npy` alongside the existing surface arrays:

```python
# After loading xyz, normals, area, cp, wall_shear...
curvature_HK = _load_npy_rows(case_dir / "curvature_HK_v2.npy", surface_rows)
# shape: (N, 2), columns: [mean_curvature_H, gaussian_curvature_K]
```

Add a `surface_curvature` field to the `CaseData` / `CaseBatch` dataclass (or equivalent), storing this as a `torch.Tensor` of shape `(N_surface, 2)`.

### Step 2 — Compute per-point WSS weights in training

In `train.py` (or a helper), compute a per-point weight tensor from curvature magnitude before the loss call:

```python
def curvature_wss_weights(
    curvature_HK: torch.Tensor,   # (B, N, 2) — mean curvature H, Gaussian K
    scale: float = 1.0,
    mode: str = "H",               # "H", "K", "HK", or "absH"
    clip_percentile: float = 95.0, # prevent extreme outliers dominating
) -> torch.Tensor:
    """Returns per-point weight tensor (B, N), min=1.0, up-weights high-curvature points."""
    if mode == "H":
        mag = curvature_HK[..., 0].abs()
    elif mode == "absH":
        mag = curvature_HK[..., 0].abs()
    elif mode == "K":
        mag = curvature_HK[..., 1].abs().sqrt()  # sqrt to reduce dynamic range
    elif mode == "HK":
        mag = curvature_HK[..., 0].abs() + curvature_HK[..., 1].abs().sqrt()
    
    # Normalize within each sample by a robust quantile to avoid batch variance
    # Use a simple percentile clip: set max to clip_percentile-th percentile
    B = mag.shape[0]
    flat = mag.reshape(B, -1)
    # robust max per sample: 95th percentile
    clip_val = torch.quantile(flat, clip_percentile / 100.0, dim=1, keepdim=True)  # (B, 1)
    mag_clipped = mag.clamp(max=clip_val)
    # Normalize to [0, 1] per sample
    mag_norm = mag_clipped / (clip_val + 1e-8)  # (B, N), in [0, 1]
    # Map to weight: 1.0 + scale * normalized_magnitude
    # When scale=0: uniform (baseline). scale=1.0: max weight=2.0 at highest curvature.
    weight = 1.0 + scale * mag_norm  # (B, N)
    return weight
```

### Step 3 — New weighted-point loss function in `trainer_runtime.py`

Add alongside `weighted_channel_mse`:

```python
def weighted_point_channel_mse(
    pred: torch.Tensor,       # (B, N, C)
    target: torch.Tensor,     # (B, N, C)
    mask: torch.Tensor,       # (B, N)
    channel_weights: torch.Tensor,  # (C,) — e.g. [1.0, 1.0, 1.5, 2.0] for sp/tx/ty/tz
    point_weights: torch.Tensor,    # (B, N) — per-point multiplier
) -> torch.Tensor:
    """MSE with both per-channel and per-point weighting.
    
    Denominator: sum of (mask * point_weights) * C so that the expected
    loss magnitude matches masked_mse when point_weights are all 1.0.
    """
    if pred.numel() == 0:
        return pred.sum() * 0.0
    ch_w = channel_weights.to(pred.device, pred.dtype)      # (C,)
    pt_w = point_weights.to(pred.device, pred.dtype)        # (B, N)
    mask_dev = mask.to(pred.device, pred.dtype)             # (B, N)
    sq_err = (pred - target).square()                       # (B, N, C)
    combined_mask = mask_dev * pt_w                         # (B, N)
    weighted = sq_err * ch_w.unsqueeze(0).unsqueeze(0) * combined_mask.unsqueeze(-1)  # (B, N, C)
    denominator = (combined_mask.sum() * pred.shape[-1]).clamp_min(1.0)
    return weighted.sum() / denominator
```

### Step 4 — Wire it up in `train.py`

Add CLI flags:
```
--wss-curvature-weight-scale  float, default 0.0 (0=disabled, baseline; 1.0=max weight 2x at highest curvature)
--wss-curvature-mode          str, default "H" (choices: H, K, HK)
```

In the loss computation (around line 336), when `wss_curvature_weight_scale > 0` and `batch.surface_curvature is not None`:
```python
point_weights = curvature_wss_weights(batch.surface_curvature, scale=config.wss_curvature_weight_scale, mode=config.wss_curvature_mode)
surface_loss = weighted_point_channel_mse(
    out["surface_preds"], surface_target, batch.surface_mask,
    channel_weights=channel_weights_tensor,
    point_weights=point_weights,
)
```
When `wss_curvature_weight_scale == 0.0`, fall back to the existing `weighted_channel_mse` path (no regression).

## Experimental Arms

Run with the full SOTA stack as base. Use `--wandb-group frieren-curvature-wss-weight`.

**Arm A — Moderate curvature upweighting (scale=1.0, mode="H")**
```bash
SENPAI_MAX_EPOCHS=30 SENPAI_TIMEOUT_MINUTES=480 python train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511/manifest.csv \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --wss-curvature-weight-scale 1.0 --wss-curvature-mode H \
  --wandb-group frieren-curvature-wss-weight \
  --wandb-name arm-a-scale1.0-modeH
```

**EP3 gate for Arm A:**
- PASS: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% → continue to EP30
- MARGINAL (6.2–6.5%): continue with advisor check-in
- KILL: val_abupt > 6.5%

**Arm B — Strong curvature upweighting (scale=2.0, mode="HK")** — run in parallel with Arm A:
```bash
SENPAI_MAX_EPOCHS=30 SENPAI_TIMEOUT_MINUTES=480 python train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511/manifest.csv \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --wss-curvature-weight-scale 2.0 --wss-curvature-mode HK \
  --wandb-group frieren-curvature-wss-weight \
  --wandb-name arm-b-scale2.0-modeHK
```

**EP3 gate for Arm B:** same thresholds as Arm A.

## Current Baseline (must beat to merge)

| Metric | Single-model SOTA (PR #972) | Ensemble SOTA (PR #1064) |
|--------|----------------------------:|------------------------:|
| val_abupt | 6.126% | 5.7758% |
| test_abupt | 5.844% | 5.5199% |
| test_vol_p | 3.643% | 3.363% |
| test_SP | 3.577% | — |
| test_WSS | 6.727% | 6.330% |

**EP3 gate (single-model):** val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
**Primary target (WSS campaign):** test_WSS < 5.85% (Transolver-3 SOTA)

## Rationale

The geometric intuition is direct: CFD WSS errors peak at regions of high curvature because:
1. Velocity gradients change rapidly near curved surfaces
2. Boundary layer separation and reattachment correlate with curvature extrema
3. The model sees fewer high-curvature points (they're a small fraction of total surface), so it underfits them

`curvature_HK_v2.npy` gives us H (mean) and K (Gaussian) curvature — both of which encode geometric complexity. By up-weighting these points in the loss, we force the model to allocate more representational capacity to them.

The scale parameter controls the maximum weight ratio: scale=1.0 → max weight 2.0× at highest-curvature point, scale=2.0 → max weight 3.0×. Normalizing within each sample by a robust 95th percentile quantile prevents the extremely high-curvature singularities (e.g. sharp mesh edges) from dominating.

## Notes

- Curvature data is already precomputed in the corrected dataset — no preprocessing needed
- The implementation adds a fallback when `wss_curvature_weight_scale == 0.0` so existing runs are unaffected
- Log `train/curvature_weight_mean` and `train/curvature_weight_max` per step to monitor the adaptive weighting in W&B
- If Arm A or B PASS EP3 gate, report full EP30 metrics via `SENPAI-RESULT` marker
- Use `--kill-thresholds "3:val_primary/abupt_axis_mean_rel_l2_pct<6.5"` for the EP3 kill gate
