### PR TITLE
EMA(0.999) on productive SDF α=0.25 stack — corrected-split re-test

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -222,6 +224,78 @@ def per_channel_masked_mse(
     weighted = diff_sq * mask_f  # broadcast [B, N, C]
     denom = mask_f.sum().clamp_min(1.0)
     return weighted.sum(dim=(0, 1)) / denom  # [C]
+
+
+def install_sdf_stratified_vol_sampling(
+    train_dataset, *, alpha: float, n_vol: int, is_main: bool
+) -> None:
+    """Override the train dataset's __getitem__ to draw volume points with
+    inverse near-surface SDF weighting: weight = 1 / (1 + alpha * |sdf|).
+
+    Surface sampling is unchanged. Volume sampling is replaced: load full
+    volume arrays, draw n_vol indices via torch.multinomial weighted by the
+    inverse-SDF weights, then return only those volume rows. The full
+    n_volume count is logged into metadata so downstream telemetry remains
+    coherent. Implemented via __class__ reassignment because Python only
+    dispatches dunder methods through type(self), not the instance dict.
+    """
+    from data.loader import DrivAerMLCase
+
+    base_cls = type(train_dataset)
+
+    class _SDFStratifiedDataset(base_cls):
+        def __getitem__(self, idx: int):
+            view = self.views[idx]
+            counts = self.store.case_point_counts(view.case_id)
+            surface_idx = self._indices(
+                counts["n_surface"],
+                self.max_surface_points,
+                view,
+                group_view_count=view.surface_view_count,
+            )
+            case = self.store.load_case(
+                view.case_id,
+                surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                volume_rows=None,
+            )
+            n_total = case.volume_x.shape[0]
+            n_sample = min(self._sdf_n_vol, n_total)
+            sdf_vals = case.volume_x[:, 3].abs()
+            weights = 1.0 / (1.0 + self._sdf_alpha * sdf_vals)
+            vol_idx = torch.multinomial(weights, n_sample, replacement=False).sort().values
+            metadata = dict(case.metadata)
+            metadata["n_surface_full"] = int(counts["n_surface"])
+            metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+            metadata["surface_view_index"] = int(view.view_index)
+            metadata["surface_view_count"] = int(view.surface_view_count)
+            metadata["surface_sampling_mode"] = view.sampling_mode
+            metadata["n_volume_full"] = int(n_total)
+            metadata["n_volume_loaded"] = int(n_sample)
+            metadata["volume_view_index"] = int(view.view_index)
+            metadata["volume_view_count"] = int(view.volume_view_count)
+            metadata["volume_sampling_mode"] = "sdf_stratified"
+            metadata["joint_view_count"] = int(view.view_count)
+            metadata["sdf_stratified_alpha"] = float(self._sdf_alpha)
+            return DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=case.surface_x,
+                surface_y=case.surface_y,
+                volume_x=case.volume_x[vol_idx],
+                volume_y=case.volume_y[vol_idx],
+                metadata=metadata,
+            )
+
+    train_dataset._sdf_alpha = float(alpha)
+    train_dataset._sdf_n_vol = int(n_vol)
+    train_dataset.__class__ = _SDFStratifiedDataset
+    assert type(train_dataset).__name__ == "_SDFStratifiedDataset", (
+        "SDF stratified patch not active"
+    )
+    if is_main:
+        print(
+            f"[SDF] inverse near-surface vol sampling enabled: "
+            f"alpha={alpha}, n_vol={n_vol}, dataset class={type(train_dataset).__name__}"
+        )
 
 
 def build_model(config: Config) -> SurfaceTransolver:
@@ -451,6 +525,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            install_sdf_stratified_vol_sampling(
+                train_loader.dataset,
+                alpha=config.sdf_stratified_alpha,
+                n_vol=config.train_volume_points,
+                is_main=state.is_main,
+            )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(
@@ -524,6 +605,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "pe_source_run_ki2q9ko9": (
                         config.model_pe == "string_multisigma"
                     ),
+                    "sdf_stratified_active": bool(config.use_sdf_stratified_vol_sampling),
+                    "sdf_stratified_alpha_runtime": float(config.sdf_stratified_alpha),
+                    "sdf_stratified_n_vol_runtime": int(config.train_volume_points),
+                    "ema_warmstart_fix_active": bool(config.use_ema),
+                    "train_dataset_class": type(train_loader.dataset).__name__,
                 },
                 allow_val_change=True,
             )

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -50,6 +50,11 @@ class EMA:
         self.step_counter += 1
         if self.step_counter < self.start_step:
             return
+        if self.step_counter == self.start_step:
+            for name, param in model.named_parameters():
+                if param.requires_grad and name in self.shadow:
+                    self.shadow[name].copy_(param.detach())
+            return
         for name, param in model.named_parameters():
             if param.requires_grad and name in self.shadow:
                 self.shadow[name].mul_(self.decay).add_(param.detach(), alpha=1 - self.decay)


### PR DESCRIPTION
## Hypothesis

EMA (Exponential Moving Average) with decay=0.999 gives a ~1,000-step shadow model that serves as a smoothed checkpoint for evaluation, reducing sensitivity to training noise. The wave SOTA (PR #972, run `56bcqp3m`, test_abupt=5.844%) **already uses EMA decay=0.999** — but none of the currently running SDF α-sweep arms (fern #1063 α=0.25, nezuko #1072 α=0.5, frieren #1077 α=1.0) include EMA.

PR #954's previous "EMA dead-end" verdict was from the **pre-20260511 split** (the case-split bug that caused a spurious +7-8pp val→test vol_p gap). Per Issue #1053 and `CURRENT_RESEARCH_STATE.md`, EMA decay=0.999 is **explicitly RETRACTED from dead-ends** — it needs a clean re-test on the corrected dataset.

This experiment is a direct **A/B vs fern's PR #1063** (same stack, same SDF α=0.25, same optimization config), with EMA layered on top. If EMA helps on the corrected split, this is potentially the single lever that gets us under 5.844% test_abupt without any code work.

## Current Baseline (wave SOTA — corrected split rawcanon_20260511)

| Metric | Value |
|--------|-------|
| **test_abupt** | **5.844%** |
| test_surf_p | 3.577% |
| test_vol_p | **3.643%** |
| test_wss | 6.727% |

**Source:** PR #972, run `56bcqp3m`, eval `zxnhtagj`  
**Dataset:** `/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511`

**A/B reference (fern, no EMA):** PR #1063 run `xfykblf9`, val_abupt best = 6.2647% at EP11, still running.

## Instructions

### Step 0: Verify existing SDF monkey-patch code
The SDF stratified-sampling code path is already implemented in `train.py` via a monkey-patch (from PR #1054+). Copy the exact block from fern's PR #1063 or tanjiro's prior PR #1076. Use `__class__` reassignment (NOT `types.MethodType`) with α=0.25 (matching fern exactly for clean A/B). The inverse formula MUST be `weight = 1.0 / (1.0 + α * |sdf|)` — near-surface gets HIGH weight, far-field LOW weight. Look for the `_SDFStratifiedDataset` class.

The SDF column is at `volume_x[:, 3]` (column index 3).

Confirm at startup: log line `[SDF] inverse near-surface vol sampling enabled: alpha=0.25, n_vol=65000, dataset class=_SDFStratifiedDataset`

### Step 1: Add EMA flags to launch
Add only `--use-ema --ema-decay 0.999 --ema-start-step 500` vs fern's launch. Everything else stays identical.

**Critical — confirm EMA shadow initialization:** In PR #944, the EMA bug was warm-start from random weights. PR #954 fixed this. Verify that `ema-start-step=500` means the EMA shadow is initialized from the current model weights at step 500 (not from `torch.zeros_like` or a fresh init). Check `train.py` EMA initialization before launching.

If `--eval-raw-vs-ema` is available, use it — you want both raw and EMA val metrics per epoch to detect EMA divergence.

### Step 2: Run DDP8 smoke test (≤30 min, REQUIRED before long run)

```bash
cd /workspace/senpai/target
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 1 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 0.25 \
  --wandb-group ema-corrected-retest \
  --wandb-name "dl24-tanjiro/ema-0999-sdf-alpha-0.25-smoke" \
  --agent dl24-tanjiro
```

**Smoke checklist:**
- [ ] All 8 DDP ranks initialize cleanly
- [ ] `[SDF] inverse near-surface vol sampling enabled: alpha=0.25` log line fires
- [ ] W&B logs run config including `ema_decay=0.999`
- [ ] EMA shadow initializes from model weights at step 500 (not zeros)
- [ ] No NaN/nonfinite losses or gradients
- [ ] Checkpoint saves successfully

### Step 3: Long run (≤24h)

```bash
cd /workspace/senpai/target
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 0.25 \
  --wandb-group ema-corrected-retest \
  --wandb-name "dl24-tanjiro/ema-0999-sdf-alpha-0.25" \
  --agent dl24-tanjiro \
  --kill-thresholds "10975:val_primary/abupt_axis_mean_rel_l2_pct<=30,21950:val_primary/abupt_axis_mean_rel_l2_pct<=16,32925:val_primary/abupt_axis_mean_rel_l2_pct<=8,54875:val_primary/abupt_axis_mean_rel_l2_pct<=7.5,109750:val_primary/abupt_axis_mean_rel_l2_pct<=7.2,164625:val_primary/abupt_axis_mean_rel_l2_pct<=6.8,219500:val_primary/abupt_axis_mean_rel_l2_pct<=6.7,274375:val_primary/abupt_axis_mean_rel_l2_pct<=6.65,329250:val_primary/abupt_axis_mean_rel_l2_pct<=6.6"
```

**Important:**
- Do NOT use `--volume-loss-weight` — it is a no-op when `--use-gradnorm` is active.
- `--no-compile-model` is the default on DL24; if `compile_model` is somehow enabled, disable it — it causes NCCL ALLREDUCE deadlock with DDP8.
- Test harvest must use the **best EMA checkpoint** (not raw). Report both raw and EMA val at terminal epoch.

### Step 4: Test harvest from best-EMA-val checkpoint
At run completion (or early stop), load the checkpoint with the best EMA validation abupt and run the full test evaluation:

```bash
torchrun --standalone --nproc_per_node=8 eval.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --checkpoint <path-to-best-ema-checkpoint> \
  --wandb-group ema-corrected-retest \
  --wandb-name "dl24-tanjiro/ema-0999-sdf-alpha-0.25-eval"
```

## Gate schedule

| Gate | Step | Threshold |
|------|------|-----------|
| EP1  | 10,975 | ≤30% |
| EP2  | 21,950 | ≤16% |
| EP3  | 32,925 | ≤8% |
| EP5  | 54,875 | ≤7.5% |
| EP10 | 109,750 | ≤7.2% |
| EP15 | 164,625 | ≤6.80% |
| EP20 | 219,500 | ≤6.70% |
| EP25 | 274,375 | ≤6.65% |
| EP30 | 329,250 | ≤6.60% |

Use `--kill-thresholds` as written in the long run command above.

## Reporting at completion

Post a PR comment with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>","<eval-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<ema-val>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-value>}}
```

Plus a human-readable table with **all TEST metrics**:
- test_abupt, test_surf_p, test_vol_p, test_wss
- test_tau_x, test_tau_y, test_tau_z
- W&B run URL
- EMA val vs raw val at terminal epoch
- Whether run was still improving at cutoff
- Smoke test passed: yes/no
- Total wall time

## Success criterion
- **Merge:** test_abupt ≤ 5.844% (beats wave SOTA) AND terminal SENPAI-RESULT with `terminal=true`, `pending_arms=false`, `test_metric` populated.
- **Request changes:** val_abupt at EP20 is ≥0.1pp better than fern's matched-epoch val_abupt (≈6.27%) — EMA is helping; advisor will guide next variation.
- **Close:** EP5/EP10 gate failure, OR test_abupt regresses >5% vs SOTA after full run.

## Why this experiment
The SOTA (PR #972) uses EMA 0.999. Our active runs don't. The prior negative verdict was on a broken dataset split. This is the minimum-change, zero-code-change A/B to confirm whether EMA is load-bearing in the SOTA or incidental. 24h budget, verified-working code path.
