### PR TITLE
fix: backport EMA warm-start shadow re-init to drivaerml-long-20260504

### DIFF
--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -50,6 +50,11 @@ class EMA:
         self.step_counter += 1
         if self.step_counter < self.start_step:
             return
+        if self.step_counter == self.start_step:
+            for name, param in model.named_parameters():
+                if param.requires_grad and name in self.shadow:
+                    self.shadow[name].copy_(param.detach())
+            return
         for name, param in model.named_parameters():
             if param.requires_grad and name in self.shadow:
                 self.shadow[name].mul_(self.decay).add_(param.detach(), alpha=1 - self.decay)


### PR DESCRIPTION
## Summary

Backports commit `860d08f` (`fix: EMA warm-start bug — re-init shadow from model weights at start_step`) from `main` to `drivaerml-long-20260504`. Discovered while implementing PR #1086 (EMA(0.999) re-test on corrected split).

## The bug

`EMA.update()` in `trainer_runtime.py` never re-syncs the shadow buffers when `step_counter == start_step`. The shadow stays at the construction-time `param.detach().clone()` snapshot (i.e. random init weights for a fresh training run) until the first EMA blend fires at step `start_step`. The result:

```
ema_shadow(start_step) = decay * random_init_weights + (1 - decay) * params(start_step)
```

With `decay=0.999` and `start_step=500`, the shadow is **~99.9% random init + 0.1% trained** at step 500, and by step ~7400 still contains ~0.1% random contamination. This systematically corrupts the early-epoch val metrics that our kill-thresholds feed off (EP1 / EP2 gates at steps 10,975 / 21,950).

This is exactly the PR #944 contamination pattern — that fix landed on `main` (commit `860d08f`) but never propagated to `drivaerml-long-20260504`.

## The fix

```python
@torch.no_grad()
def update(self, model: nn.Module) -> None:
    self.step_counter += 1
    if self.step_counter < self.start_step:
        return
    if self.step_counter == self.start_step:
        for name, param in model.named_parameters():
            if param.requires_grad and name in self.shadow:
                self.shadow[name].copy_(param.detach())
        return
    for name, param in model.named_parameters():
        if param.requires_grad and name in self.shadow:
            self.shadow[name].mul_(self.decay).add_(param.detach(), alpha=1 - self.decay)
```

Re-syncs the shadow from live model weights on the exact step where EMA tracking begins, then skips the blend for that step. Matches the convention used by `timm.utils.ModelEmaV2` and HF `EMAModel`.

## Verification

Applied identically on PR #1086 branch (`dl24-tanjiro/ema-0999-productive-stack-corrected`). Smoke run `ugbkg660` confirmed via W&B:
- `ema_warmstart_fix_active: True`
- `ema_decay: 0.999`, `ema_start_step: 500`
- No NaN / divergence
- All 8 DDP ranks running cleanly

Advisor confirmed the fix logic is correct in the PR #1086 thread.

## Implications for past results

Any prior EMA run on this branch carried the contamination. Late-training (step >> 7400) numbers are minimally affected (~0.1% residual decays fast), but early-epoch val_abupt curves used for gate thresholds and any short-run EMA verdicts are suspect. PR #972 SOTA (`56bcqp3m`, test_abupt=5.844%) is likely unaffected because it ran ~330K steps — contamination decays to ~0% well before terminal.

## Test plan

- [x] Unit-tested EMA update logic locally: shadow stays at init for step < start_step, resets to live params at step == start_step, normal blend thereafter
- [x] Smoke run `ugbkg660` passed all advisor checklist items
- [ ] Long run on PR #1086 will confirm gate metrics behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)