### PR TITLE
GradNorm ema_proxy + slw=1.0 (alpha=2.0): clean GradNorm baseline, EMA mode

### DIFF
--- a/run_post_kill_eval.py
+++ b/run_post_kill_eval.py
@@ -1,0 +1,93 @@
+"""Run final val + test evaluation on the EP3 best checkpoint after the run was killed."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from train import Config, build_model
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    full_eval_loaders_from,
+    make_loaders,
+    primary_metric_log,
+    metric_namespace,
+)
+
+
+def main() -> None:
+    ckpt_dir = Path("/mnt/new-pvc/checkpoints/nezuko-gradnorm-ema-proxy-slw1-v3/run-eihfy5od")
+    with (ckpt_dir / "config.yaml").open() as fh:
+        cfg_dict = yaml.safe_load(fh)
+    # Drop fields that the Config dataclass doesn't know about.
+    valid = {f for f in Config.__dataclass_fields__}
+    cfg_dict = {k: v for k, v in cfg_dict.items() if k in valid}
+    config = Config(**cfg_dict)
+
+    device = torch.device("cuda:0")
+
+    # Re-load data (using same config the run was launched with).
+    train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=None)
+    final_val_loaders = full_eval_loaders_from(val_loaders, config)
+    final_test_loaders = full_eval_loaders_from(test_loaders, config)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(config).to(device)
+    ckpt = torch.load(ckpt_dir / "checkpoint.pt", map_location=device, weights_only=True)
+    missing, unexpected = model.load_state_dict(ckpt["model"], strict=True)
+    assert not missing and not unexpected, f"missing={missing}, unexpected={unexpected}"
+    print(f"Loaded checkpoint epoch={ckpt['epoch']} source={ckpt['checkpoint_source']}")
+
+    wandb.init(
+        entity="wandb-applied-ai-team",
+        project="senpai-v1-drivaerml-ddp8",
+        group="nezuko-gradnorm-ema-proxy-slw1",
+        name="nezuko/gradnorm-ema-proxy-slw1-v3-post-kill-eval",
+        config={**cfg_dict, "post_kill_eval_for_run": "eihfy5od", "post_kill_eval_epoch": ckpt["epoch"]},
+    )
+
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in final_val_loaders.items()
+    }
+    val_log: dict = {**primary_metric_log("full_val_primary", val_metrics["val_surface"])}
+    for split_name, metrics in val_metrics.items():
+        val_log.update(metric_namespace("full_val", split_name, metrics))
+
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in final_test_loaders.items()
+    }
+    test_log: dict = {**primary_metric_log("test_primary", test_metrics["test_surface"])}
+    for split_name, metrics in test_metrics.items():
+        test_log.update(metric_namespace("test", split_name, metrics))
+
+    summary = {**val_log, **test_log}
+    print("\n=== FULL VAL METRICS (val_surface) ===")
+    for k, v in sorted(val_log.items()):
+        if isinstance(v, (int, float)):
+            print(f"  {k}: {v:.6f}")
+    print("\n=== TEST METRICS (test_surface) ===")
+    for k, v in sorted(test_log.items()):
+        if isinstance(v, (int, float)):
+            print(f"  {k}: {v:.6f}")
+
+    wandb.log(summary)
+    wandb.summary.update({k: v for k, v in summary.items() if isinstance(v, (int, float))})
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

GradNorm (Chen & Kolter, 2018) dynamically rebalances per-task loss weights so that each task trains at the same relative gradient magnitude. PR #1079 (fern) tested `ema_proxy` mode with `alpha=2.0` — but crucially it uses the **default `--surface-loss-weight`**, which in the SOTA stack is 2.0. PR #1083 (fern) showed that GradNorm `full` mode with `slw=2.0` catastrophically collapses to near-equal weights (0.93–1.05 range), because GradNorm actively "corrects" away from the static 2× multiplier it perceives as imbalance.

The fix is simple: set `--surface-loss-weight 1.0` so GradNorm starts from a clean baseline and is free to discover the optimal surface/volume weight ratio from gradient statistics alone. PR #1088 (fern) is testing `full` mode with `slw=1.0`. This PR tests the **complementary** `ema_proxy` mode with `slw=1.0`.

**Why `ema_proxy` vs `full`?**
- `ema_proxy` uses EMA-smoothed gradient norms rather than computing exact per-task Jacobians, meaning ~2× less compute overhead per step than `full` mode.
- The EMA smoothing also provides implicit regularization of the weight trajectory, which may reduce oscillation.
- Together with PR #1088, this experiment gives a direct `full` vs `ema_proxy` mode comparison under clean conditions (slw=1.0 in both cases).

WSS is a wall-tangential quantity that requires the model to resolve near-wall gradients more precisely than bulk pressure. GradNorm's dynamic rebalancing should push WSS training harder when WSS gradient norms lag behind volume pressure norms.

## Instructions

Use the **tay-branch SOTA configuration** from PR #958 as the base. Add GradNorm `ema_proxy` mode with `slw=1.0` and `alpha=2.0`:

```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --dataset drivaerml \
  --data-dir /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir /mnt/pvc/checkpoints/nezuko-gradnorm-ema-proxy-slw1 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --batch-size 4 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --lr 9e-5 \
  --surface-loss-weight 1.0 \
  --use-gradnorm \
  --gradnorm-mode ema_proxy \
  --gradnorm-alpha 2.0 \
  --gradnorm-lr 1e-3 \
  --gradnorm-min-weight 0.1 \
  --use-ema \
  --no-compile-model \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_entity wandb-applied-ai-team \
  --wandb_group nezuko-gradnorm-ema-proxy-slw1
```

### Key flags
| Flag | Value | Note |
|------|-------|------|
| `--surface-loss-weight` | 1.0 | **Critical fix**: lets GradNorm start balanced, no static 2× fighting |
| `--use-gradnorm` | (flag) | Enable GradNorm dynamic loss rebalancing |
| `--gradnorm-mode` | ema_proxy | EMA-smoothed gradient norms (~2× less overhead than `full`) |
| `--gradnorm-alpha` | 2.0 | Aggressive balancing (same as PR #1079, PR #1088) |
| `--gradnorm-lr` | 1e-3 | GradNorm weight optimizer LR |
| `--gradnorm-min-weight` | 0.1 | Floor to prevent any task collapsing to zero |
| `--use-ema` | (flag) | Required for ema_proxy mode |

### What to watch for
- **GradNorm weights** (`gradnorm/weight_*`): should diverge from 1.0 and stabilize — surface weight expected to land > 1.0 if WSS is underfit. If weights collapse back to ~1.0 (as in PR #1083), kill and report.
- **GradNorm loss** (`gradnorm/loss`): should decay from ~0.5 to <0.1 over training. Plateau around 0.01–0.05 indicates convergence.
- Compare against fern's PR #1088 (same slw=1.0 + alpha=2.0, but `full` mode) to see which mode better resolves WSS.

### Early-stop gates (kill if val_abupt exceeds threshold)
| Epoch | Kill threshold |
|-------|----------------|
| EP1 | val_abupt > 12% |
| EP3 | val_abupt > 8.5% |
| EP6 | val_abupt > 7.2% |
| EP10 | val_abupt > 6.9% |
| EP15 | val_abupt > 6.6% |
| EP20 | val_abupt > 6.4% |
| EP30 | primary result |

Use the `--kill-on-metric-threshold` flag if available:
`"500:train/loss<5,10974:val_primary/abupt_axis_mean_rel_l2_pct<12"`

### Reporting
Post val_abupt, val_vol_p, val_WSS, and GradNorm weights at every gate epoch.

At EP30 (or terminal gate), post a final SENPAI-RESULT marker:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline

**Single-model SOTA (PR #972, corrected split):**
- val_abupt: **6.126%** ← beat this
- val_vol_p: **3.798%**
- test_ABUPT: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: 6.727% ← **primary target to improve**
- W&B run: `56bcqp3m`

**Tay-branch single-model SOTA (PR #958):**
- val_abupt: 6.285%, val_vol_p: 3.818%
- W&B run: `29nohj67`

**EP3 pass gate (corrected split):** val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%

**Reproduce baseline:**
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --dataset drivaerml \
  --data-dir /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 9e-5 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536"
```
