### PR TITLE
[frieren] Surface-normal frame WSS prediction (local τ frame)

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     TargetTransform,
     autocast_context,
     build_lr_scheduler,
+    build_surface_normal_frames,
     check_kill_thresholds,
     cleanup_distributed,
     collect_gradient_metrics,
@@ -56,6 +57,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    rotate_surface_wss,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -105,6 +107,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    surface_normal_frame_wss: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +232,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "surface_normal_frame_wss": (
+            "Predict WSS in a per-point local surface frame (n̂, t̂, b̂). "
+            "Rotates the WSS channels of both the prediction and the "
+            "(already-normalised) target into the local frame for loss; "
+            "evaluation rotates predictions back to world frame before "
+            "denormalisation so all metrics remain in physical units. The "
+            "(--tau-y-loss-weight, --tau-z-loss-weight) channel weights are "
+            "reinterpreted as (t̂, b̂) weights in the local frame; the "
+            "n̂-component weight stays at 1.0. PR #1094."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -321,6 +334,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    surface_normal_frame_wss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,15 +346,32 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred = out["surface_preds"]
+        local_frame_metrics: dict[str, float] = {}
+        if surface_normal_frame_wss:
+            normals = batch.surface_x[..., 3:6].to(device=device, dtype=torch.float32)
+            R = build_surface_normal_frames(normals)
+            surface_pred = rotate_surface_wss(surface_pred, R)
+            surface_target = rotate_surface_wss(surface_target, R)
+            # Diagnostic: the n-component of normalised target ≠ 0 (per-channel
+            # standardisation does not commute with rotation), but we still log
+            # it so it can be tracked across runs.
+            with torch.no_grad():
+                tau_n_target = surface_target[..., 1]
+                mask_f = batch.surface_mask.to(device=device, dtype=torch.float32)
+                denom = mask_f.sum().clamp_min(1.0)
+                local_frame_metrics["tau_n_target_abs_mean"] = float(
+                    (tau_n_target.abs() * mask_f).sum().detach().cpu().item() / float(denom.cpu().item())
+                )
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_pred,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
@@ -352,6 +383,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **local_frame_metrics,
     }
 
 
@@ -852,6 +884,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.surface_normal_frame_wss:
+                print(
+                    "Surface-normal frame WSS: rotating WSS channels to local "
+                    "(n̂, t̂, b̂) frame for loss; predictions rotated back to "
+                    "world frame at eval. tau_y/tau_z weights reinterpreted as "
+                    "(t̂, b̂) component weights."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -1030,6 +1069,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        surface_normal_frame_wss=config.surface_normal_frame_wss,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1110,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "tau_n_target_abs_mean" in batch_loss_metrics:
+                        train_log["train/tau_n_target_abs_mean"] = batch_loss_metrics[
+                            "tau_n_target_abs_mean"
+                        ]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1233,6 +1277,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        surface_normal_frame_wss=config.surface_normal_frame_wss,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1247,6 +1292,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    surface_normal_frame_wss=config.surface_normal_frame_wss,
                 )
                 for name, loader in val_loaders.items()
             }

--- a/train.py
+++ b/train.py
@@ -349,9 +349,13 @@ def train_loss(
         surface_pred = out["surface_preds"]
         local_frame_metrics: dict[str, float] = {}
         if surface_normal_frame_wss:
+            # The model output is interpreted as living in the per-point local
+            # surface frame (n̂, t̂, b̂). We only rotate the target into the
+            # local frame; the prediction is compared directly. At eval the
+            # prediction is rotated back to world frame by R^T before metrics
+            # — see trainer_runtime.accumulate_eval_batch.
             normals = batch.surface_x[..., 3:6].to(device=device, dtype=torch.float32)
             R = build_surface_normal_frames(normals)
-            surface_pred = rotate_surface_wss(surface_pred, R)
             surface_target = rotate_surface_wss(surface_target, R)
             # Diagnostic: the n-component of normalised target ≠ 0 (per-channel
             # standardisation does not commute with rotation), but we still log

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -832,6 +832,63 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def build_surface_normal_frames(normals: torch.Tensor) -> torch.Tensor:
+    """Per-point orthonormal frames R = [n̂, t̂, b̂] (row vectors) from unit normals.
+
+    For each surface point we pick a reference vector r — (0, 0, 1) by default,
+    swapped to (1, 0, 0) where the normal is near-parallel to r (|n̂_z| > 0.9) —
+    and build a tangent t̂ = normalize(r × n̂) plus binormal b̂ = n̂ × t̂. The
+    resulting rotation matrix maps a world-frame vector v_world into the local
+    surface frame via v_local = R @ v_world, and back via v_world = R^T @ v_local.
+
+    The (1, 0, 0) fallback introduces a coordinate discontinuity wherever the
+    threshold flips, but for a transformer that sees each point independently
+    this is acceptable — see PR #1094 research notes.
+
+    Args:
+        normals: [B, N, 3] unit surface normals.
+
+    Returns:
+        R: [B, N, 3, 3] rotation matrices with rows [n̂, t̂, b̂].
+    """
+
+    ref = torch.zeros_like(normals)
+    ref[..., 2] = 1.0
+    near_parallel = normals[..., 2].abs() > 0.9
+    if near_parallel.any():
+        fallback = torch.tensor(
+            [1.0, 0.0, 0.0], device=normals.device, dtype=normals.dtype
+        )
+        ref = torch.where(near_parallel.unsqueeze(-1), fallback.expand_as(ref), ref)
+    t = torch.cross(ref, normals, dim=-1)
+    t = t / (t.norm(dim=-1, keepdim=True) + 1e-8)
+    b = torch.cross(normals, t, dim=-1)
+    b = b / (b.norm(dim=-1, keepdim=True) + 1e-8)
+    return torch.stack([normals, t, b], dim=-2)
+
+
+def rotate_surface_wss(
+    surface: torch.Tensor, R: torch.Tensor, *, inverse: bool = False
+) -> torch.Tensor:
+    """Rotate the WSS channels (1:4) of a [B, N, 4] surface tensor by R.
+
+    Channel 0 (surface pressure / cp) is passed through unchanged. When
+    ``inverse=False`` the WSS is mapped world → local (v_local = R @ v_world);
+    when ``inverse=True`` it is mapped local → world (v_world = R^T @ v_local).
+    """
+
+    if surface.shape[-1] != 4:
+        raise ValueError(
+            f"rotate_surface_wss expects last dim 4 (cp + tau_xyz); got {surface.shape}"
+        )
+    cp = surface[..., 0:1]
+    wss = surface[..., 1:4]
+    matrix = R.transpose(-2, -1) if inverse else R
+    matrix = matrix.to(wss.dtype)
+    rotated = (matrix @ wss.unsqueeze(-1)).squeeze(-1)
+    return torch.cat([cp, rotated], dim=-1)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -955,6 +1012,7 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    surface_normal_frame_wss: bool = False,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -969,6 +1027,12 @@ def accumulate_eval_batch(
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
+    if surface_normal_frame_wss:
+        # Model predicts in local surface frame; rotate WSS channels back to
+        # world frame (still normalised) before denormalisation and metrics.
+        normals = batch.surface_x[..., 3:6].to(device=device, dtype=torch.float32)
+        R = build_surface_normal_frames(normals)
+        surface_pred_norm = rotate_surface_wss(surface_pred_norm, R, inverse=True)
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
     volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     accumulator.surface_loss_sse += surface_sse
@@ -1121,6 +1185,7 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    surface_normal_frame_wss: bool = False,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1132,6 +1197,7 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            surface_normal_frame_wss=surface_normal_frame_wss,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1466,7 +1532,14 @@ def run_final_evaluation(
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            surface_normal_frame_wss=getattr(config, "surface_normal_frame_wss", False),
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1486,7 +1559,14 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            surface_normal_frame_wss=getattr(config, "surface_normal_frame_wss", False),
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

Wall Shear Stress (WSS = [τ_x, τ_y, τ_z]) is currently predicted in world-frame Cartesian coordinates. However, by definition, WSS is a **purely tangential** surface quantity — the shear traction vector lies in the tangent plane of the surface, so τ · n̂ = 0 at every point. Predicting in world-frame XYZ forces the model to learn a per-point constraint implicitly. When two surface panels with different orientations have the same physical WSS magnitude but different orientations, the model sees different target vectors, creating an inconsistent learning signal.

**Proposed fix:** Transform WSS targets into a local orthonormal surface frame before computing the loss, and rotate predictions back for evaluation.

For each surface point:
1. n̂ = surface normal (unit, already in `batch.surface_x[:, :, 3:6]`)
2. Choose reference vector r = (0, 0, 1); if |n̂ · r| > 0.9, use r = (1, 0, 0)
3. t̂ = normalize(r × n̂)   (tangent)
4. b̂ = n̂ × t̂              (binormal)
5. Rotation matrix R per point (shape [B, N, 3, 3]) with rows [n̂, t̂, b̂]
6. τ_local = R @ τ_world → n-component should be ≈ 0 by physics, model predicts only t and b components
7. Loss computed in local frame; metrics computed after rotating predictions back: τ_world = R^T @ τ_local

**Physical insight:** τ_z (spanwise shear) is the worst WSS component because "z" means completely different things on the hood (roughly tangential) vs. the A-pillar (roughly normal). A local frame gives geometrically consistent targets across all panel orientations. Expected: −0.2 to −0.4pp WSS, especially helping τ_z.

This hypothesis was generated as H3 in the WSS Improvement Campaign (Issue #1056).

## Instructions

All changes go in **`target/train.py`** (and optionally `target/model.py` if needed for output dim).

### Step 1: Add CLI flag

Add this argument to the ArgumentParser (near the other surface flags, e.g. after `--sdf-importance-sampling`):

```python
parser.add_argument(
    "--surface-normal-frame-wss",
    action="store_true",
    default=False,
    help="Predict WSS in local surface-normal frame (n̂, t̂, b̂). Rotates targets to local "
         "frame before loss; rotates predictions back before metrics.",
)
```

### Step 2: Add frame-building helper function

Add this function somewhere near the top of train.py (before the training loop, after imports):

```python
def build_surface_normal_frames(normals: torch.Tensor) -> torch.Tensor:
    """Build per-point orthonormal frames from surface normals.

    Args:
        normals: [B, N, 3] unit surface normals

    Returns:
        R: [B, N, 3, 3] rotation matrices where R[..., 0, :] = n̂,
           R[..., 1, :] = t̂, R[..., 2, :] = b̂
    """
    B, N, _ = normals.shape
    # Reference vector: use (0,0,1), fall back to (1,0,0) where normal is near-parallel
    ref = torch.zeros_like(normals)
    ref[..., 2] = 1.0
    near_parallel = (normals[..., 2].abs() > 0.9)
    ref[near_parallel] = torch.tensor([1.0, 0.0, 0.0], device=normals.device, dtype=normals.dtype)
    # Tangent: t = normalize(ref × n)
    t = torch.cross(ref, normals, dim=-1)
    t = t / (t.norm(dim=-1, keepdim=True) + 1e-8)
    # Binormal: b = n × t
    b = torch.cross(normals, t, dim=-1)
    b = b / (b.norm(dim=-1, keepdim=True) + 1e-8)
    # Stack rows: R[i] = [n, t, b] as row vectors, shape [B, N, 3, 3]
    R = torch.stack([normals, t, b], dim=-2)  # [B, N, 3, 3]
    return R
```

### Step 3: Wrap WSS in frame transformation during training loss

In the `per_task_train_losses()` function (around lines 385–392 in the current train.py), modify the tau loss computation. The function receives `surface_pred` and `surface_target`. You need to also receive `normals` (pass it in from the call site).

**Modify the function signature** to accept an optional normals argument:

```python
def per_task_train_losses(out, batch, config, normals=None):
    ...
    surface_pred = out["surface_preds"]   # [B, N, 4]: [cp, tau_x, tau_y, tau_z]
    surface_target = batch.surface_y      # [B, N, 4]

    if config.surface_normal_frame_wss and normals is not None:
        # Build rotation matrices
        R = build_surface_normal_frames(normals)  # [B, N, 3, 3]
        # Rotate WSS targets to local frame: tau_local = R @ tau_world
        tau_world_target = surface_target[..., 1:4]  # [B, N, 3]
        tau_local_target = (R @ tau_world_target.unsqueeze(-1)).squeeze(-1)  # [B, N, 3]
        # Rotate WSS predictions to local frame for loss
        tau_world_pred = surface_pred[..., 1:4]  # [B, N, 3]
        tau_local_pred = (R @ tau_world_pred.unsqueeze(-1)).squeeze(-1)  # [B, N, 3]
        # Compute per-component loss in local frame
        taun_loss = masked_mse(tau_local_pred[..., 0:1], tau_local_target[..., 0:1], batch.surface_mask)
        taut_loss = masked_mse(tau_local_pred[..., 1:2], tau_local_target[..., 1:2], batch.surface_mask)
        taub_loss = masked_mse(tau_local_pred[..., 2:3], tau_local_target[..., 2:3], batch.surface_mask)
        # Note: use tau_y_loss_weight for t-component, tau_z_loss_weight for b-component
        # (they retain the role of "harder tangential directions")
        taux_loss = taun_loss  # n-component (≈0 by physics, lightweight signal)
        tauy_loss = taut_loss
        tauz_loss = taub_loss
    else:
        taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
        tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
        tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
    ...
```

**At the call site**, pass normals from `batch.surface_x[:, :, 3:6]`:

```python
normals = batch.surface_x[:, :, 3:6] if config.surface_normal_frame_wss else None
losses = per_task_train_losses(out, batch, config, normals=normals)
```

### Step 4: Rotate predictions back at eval time

In the evaluation loop (wherever WSS metrics are computed), before computing WSS MAE/MAPE metrics, rotate predictions back to world frame:

```python
if config.surface_normal_frame_wss:
    normals_eval = batch.surface_x[:, :, 3:6]
    R_eval = build_surface_normal_frames(normals_eval)
    tau_local_pred = surface_pred_eval[..., 1:4]
    # Rotate back: tau_world = R^T @ tau_local
    tau_world_pred = (R_eval.transpose(-2, -1) @ tau_local_pred.unsqueeze(-1)).squeeze(-1)
    surface_pred_eval = torch.cat([
        surface_pred_eval[..., 0:1],  # cp unchanged
        tau_world_pred,               # tau in world frame
    ], dim=-1)
```

### Step 5: Training command

Use the **exact PR #972 baseline recipe** with only the new flag added:

```bash
cd target/ && python train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --sdf-importance-sampling --sdf-alpha 4.0 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --surface-normal-frame-wss \
  --wandb-group frieren-normal-frame-wss
```

### Important implementation notes

1. **Normals are already unit-normalized** in the dataset — no need to normalize again, but keep the `+ 1e-8` eps in the cross-product normalization for numerical safety.
2. **The n-component of the loss (taun_loss) should converge to ≈ 0** by physics. If it doesn't, something is wrong with the frame construction — add a debug log: `print(f"tau_n mean abs: {tau_local_target[...,0].abs().mean():.4f}")` in the first batch.
3. **Keep `--tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0`** — in the local frame, map these weights to t̂ and b̂ components respectively, as done in the code above.
4. **surface_x normals location:** `batch.surface_x[:, :, 3:6]` (xyz at 0:3, normals at 3:6, area at 6:7).
5. **Do not change model output dim** — the model still outputs 4 channels [cp, t1, t2, t3]; we just change what the targets mean during training.

### EP5 gate
- PASS: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
- MARGINAL: val_abupt ≤ 6.5% AND val_vol_p ≤ 5.0%
- KILL: otherwise

If PASS at EP5, extend to full 13 epochs. If MARGINAL at EP5, seek advisor guidance before proceeding.

## Baseline

Current single-model SOTA — PR #972 (SDF-stratified vol importance sampling):

| Metric | val | test |
|--------|-----|------|
| abupt | 6.126% | 5.844% |
| vol_p | 3.798% | 3.643% ← constraint |
| SP | — | 3.577% ← constraint |
| WSS | — | 6.727% |

- Baseline W&B run: `56bcqp3m`
- W&B eval run: `zxnhtagj`
- **WSS target:** test_WSS < 5.85% (Transolver-3 SOTA); need −0.88pp from current best

**Non-negotiable constraints:**
- test_vol_p ≤ 3.643%
- test_SP ≤ 3.577%

## Expected outcome

- val_WSS improvement of 0.2–0.4pp relative to baseline due to geometrically consistent local-frame supervision
- τ_z improvement expected to be largest (spanwise shear mixes physical meaning across panel orientations)
- vol_p and SP should be unaffected (only WSS loss is changed)
