### PR TITLE
WSS tangent frame features: e1 e2 surface input augmentation

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -35,7 +35,7 @@ from torch.utils.data import Dataset
 from .split_utils import expand_pvc_candidates, first_existing
 
 DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest.json")
-SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM = 13  # xyz(3) + normals(3) + panel area(1) + tangent_frame(6: e1[3]+e2[3])
 SURFACE_Y_DIM = 4  # cp(1) + wall shear stress(3)
 VOLUME_X_DIM = 4  # xyz(3) + sdf(1)
 VOLUME_Y_DIM = 1  # volume pressure
@@ -269,6 +269,33 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+def _compute_tangent_frame(normals_arr: np.ndarray) -> np.ndarray:
+    """Two orthonormal tangent vectors per surface point.
+
+    e1 = normalize(cross(n, z_hat)), falls back to cross(n, x_hat) when
+    |cross(n, z_hat)| < 1e-6 (nearly vertical normals on roof/underbody).
+    e2 = cross(n, e1) — already unit length since n and e1 are unit and orthogonal.
+
+    Returns (N, 6) tensor: [e1_x, e1_y, e1_z, e2_x, e2_y, e2_z].
+    """
+    z_hat = np.array([0.0, 0.0, 1.0], dtype=normals_arr.dtype)
+    x_hat = np.array([1.0, 0.0, 0.0], dtype=normals_arr.dtype)
+
+    e1 = np.cross(normals_arr, z_hat)
+    e1_norm = np.linalg.norm(e1, axis=1, keepdims=True)
+
+    e1_fallback = np.cross(normals_arr, x_hat)
+    e1_fallback_norm = np.linalg.norm(e1_fallback, axis=1, keepdims=True)
+
+    use_fallback = (e1_norm < 1e-6).squeeze(1)
+    e1[use_fallback] = e1_fallback[use_fallback]
+    e1_norm[use_fallback] = e1_fallback_norm[use_fallback]
+
+    e1 = e1 / (e1_norm + 1e-12)
+    e2 = np.cross(normals_arr, e1)
+    return np.concatenate([e1, e2], axis=1)
+
+
 def load_case(
     root: str | Path,
     case_id: str,
@@ -285,7 +312,8 @@ def load_case(
         _load_npy_rows(case_dir / "surface_wallshearstress.npy", surface_rows),
         "surface_wallshearstress.npy",
     )
-    surface_x = np.concatenate([xyz, normals, area], axis=1)
+    tangent_frame = _compute_tangent_frame(normals.astype(np.float32, copy=False))
+    surface_x = np.concatenate([xyz, normals, area, tangent_frame], axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [


### PR DESCRIPTION
## Hypothesis

WSS (wall shear stress) is a 3-component vector field (τ_x, τ_y, τ_z). The model currently predicts it from surface features that include xyz + surface normals + panel area — but **no local coordinate frame**. The model must learn the tangent plane implicitly from the normal vector alone, which is hard. z-axis shear (τ_z) is consistently the hardest channel to predict.

We hypothesize that appending **two orthonormal tangent vectors** (e₁, e₂) to each surface point's input features will give the model an explicit local coordinate frame, making it significantly easier to predict the 3-component WSS vector in a physically grounded way. This is a pure **input augmentation** — no output head changes, no cold-start risk.

Construction (per surface point):
- `e₁ = normalize(cross(n, ẑ))` where `ẑ = [0,0,1]`. Falls back to `cross(n, x̂)` when `|cross(n, ẑ)| < 1e-6` (nearly vertical normals on roof/underbody).
- `e₂ = cross(n, e₁)` (third orthogonal axis, already unit-length since n and e₁ are unit vectors)

This expands `SURFACE_X_DIM` from 7 to 13 (adding 6 extra channels: e₁[3] + e₂[3]). The model's `SurfaceTransolver` parametrically supports arbitrary `surface_input_dim`, so only `data/loader.py` and the model init call need changes.

**Why this should work:** WSS direction errors dominate the WSS MAE. Giving the model an explicit tangent frame reduces the representational burden — it can now learn WSS as a decomposition into (e₁, e₂, n) components rather than global (x,y,z). This is standard practice in physics-informed ML for surface vector quantities.

**Reference:** Analogous to the approach in "Learning Mesh-Based Simulation with Graph Networks" (Pfaff et al. 2020) which appends edge direction vectors to node features for improved vector-field prediction on meshes.

## Instructions

### 1. Modify `target/data/loader.py`

Locate line 288:
```python
surface_x = np.concatenate([xyz, normals, area], axis=1)
```

Replace with:
```python
# Compute tangent frame from surface normals
def _compute_tangent_frame(normals_arr: np.ndarray) -> np.ndarray:
    """Compute two orthonormal tangent vectors per surface point.
    
    normals_arr: (N, 3) unit normals
    Returns: (N, 6) — e1 (3) + e2 (3)
    """
    z_hat = np.array([0.0, 0.0, 1.0], dtype=normals_arr.dtype)
    x_hat = np.array([1.0, 0.0, 0.0], dtype=normals_arr.dtype)
    
    # e1 = cross(n, z_hat)
    e1 = np.cross(normals_arr, z_hat)  # (N, 3)
    e1_norm = np.linalg.norm(e1, axis=1, keepdims=True)  # (N, 1)
    
    # Fallback to cross(n, x_hat) for nearly-vertical normals (roof, underbody)
    e1_fallback = np.cross(normals_arr, x_hat)
    e1_fallback_norm = np.linalg.norm(e1_fallback, axis=1, keepdims=True)
    
    use_fallback = (e1_norm < 1e-6).squeeze(1)  # (N,) bool
    e1[use_fallback] = e1_fallback[use_fallback]
    e1_norm[use_fallback] = e1_fallback_norm[use_fallback]
    
    e1 = e1 / (e1_norm + 1e-12)  # normalize
    
    # e2 = cross(n, e1) — already unit length
    e2 = np.cross(normals_arr, e1)  # (N, 3)
    
    return np.concatenate([e1, e2], axis=1)  # (N, 6)

tangent_frame = _compute_tangent_frame(normals)  # (N, 6)
surface_x = np.concatenate([xyz, normals, area, tangent_frame], axis=1)  # (N, 13)
```

Also update the constant at line 38:
```python
SURFACE_X_DIM = 13  # xyz(3) + normals(3) + panel area(1) + tangent_frame(6)
```

### 2. Modify `target/train.py`

In `build_model()` (line ~298), pass the updated dim explicitly:
```python
return SurfaceTransolver(
    ...
    surface_input_dim=13,  # xyz(3) + normals(3) + area(1) + tangent_frame(6)
)
```

Alternatively, since `model.py` imports `SURFACE_X_DIM` from `data`, updating `SURFACE_X_DIM` in `data/loader.py` will automatically propagate — verify that `model.py` still uses `SURFACE_X_DIM` as the default for `surface_input_dim`. If so, no change to `train.py` is needed.

### 3. Verify nothing else uses SURFACE_X_DIM as a hard-coded 7

Run:
```bash
grep -rn "SURFACE_X_DIM\|surface_x_dim\|surface_input_dim" target/
```

If `train.py`'s `build_model()` passes `surface_input_dim` explicitly, update it to 13. The collation in `loader.py` line 476 uses `SURFACE_X_DIM` for the batch tensor init — that will auto-update.

### 4. Run two arms

**Arm A** — tangent frame features, standard tau loss weights:
```bash
torchrun --nproc_per_node=8 target/train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-sdf-importance-sampling --sdf-importance-alpha 0.25 \
  --grad-clip-norm 0.5 \
  --wandb-group edward-wss-tangent-frame
```

**Arm B** — tangent frame features + higher tau-z weight (testing whether explicit frame amplifies benefit of tau-z upweighting):
```bash
torchrun --nproc_per_node=8 target/train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
  --tau-y-loss-weight 2.0 --tau-z-loss-weight 3.0 \
  --use-sdf-importance-sampling --sdf-importance-alpha 0.25 \
  --grad-clip-norm 0.5 \
  --wandb-group edward-wss-tangent-frame
```

### EP gates

- **EP1 gate** (steps ~10,864 = ~⅓ epoch 3): val_abupt ≤ 30% — this is a pure input augmentation so should easily pass
- **EP3 gate**: val_abupt ≤ 6.5% AND val_vol_p ≤ 5.0% (MARGINAL); PASS = val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
- **Kill either arm early** if val_abupt > 30% at EP1 or val_vol_p explodes above 20%

## Baseline

**Single-model SOTA** (PR #972, W&B `56bcqp3m`):
| Metric | Value |
|--------|-------|
| val_abupt | 6.126% |
| test_abupt | 5.844% |
| test_vol_p | 3.643% |
| test_surf_p | 3.577% |
| **test_WSS** | **6.727%** |

**Hard floor constraints (must NOT be violated):**
- test_vol_p ≤ 3.643%
- test_surf_p ≤ 3.577%

**Primary target:** test_WSS < 5.85% (Transolver-3 SOTA)

**Note:** PR #1084 tested surface curvature features (H+K appended to surface input). That experiment was NEGATIVE — val_abupt degraded to 6.39% vs baseline 6.126%. Tangent frame features are geometrically different: curvature is a scalar property measuring shape, while tangent vectors define the local coordinate system for vector predictions. Tangent vectors are zero-cost to compute (just cross products of normals) and are physically motivated for WSS as a vector field.

Reproduce baseline:
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-sdf-importance-sampling --sdf-importance-alpha 0.25 \
  --grad-clip-norm 0.5
```
