### PR TITLE
WSS direction loss: cosine similarity penalty on τ vector

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_direction_loss_weight: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +231,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "wss_direction_loss_weight": (
+            "Weight for cosine-similarity direction penalty on WSS "
+            "(tau_x/y/z) vector predictions. Adds "
+            "lambda * mean(1 - cos_sim(pred_wss, target_wss)) to the total "
+            "loss, computed in normalized space over valid surface points. "
+            "0.0 disables (default). Typical range: 0.05 - 1.0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -321,6 +330,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_direction_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,13 +356,34 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        if wss_direction_loss_weight > 0.0:
+            # Compute cosine-similarity direction loss on WSS vector (tau_x,
+            # tau_y, tau_z) in normalized space. Channels 1:4 of the surface
+            # tensor are [tau_x, tau_y, tau_z]; channel 0 is cp.
+            wss_pred = out["surface_preds"][..., 1:4].float()
+            wss_gt = surface_target[..., 1:4].float()
+            cos_sim = torch.nn.functional.cosine_similarity(
+                wss_pred, wss_gt, dim=-1, eps=1e-8
+            )
+            wss_direction_loss = masked_mean(1.0 - cos_sim, batch.surface_mask)
+            weighted_wss_direction_loss = wss_direction_loss_weight * wss_direction_loss
+            loss = loss + weighted_wss_direction_loss
+        else:
+            wss_direction_loss = None
+            weighted_wss_direction_loss = None
+    loss_metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if wss_direction_loss is not None:
+        loss_metrics["wss_direction_loss"] = float(wss_direction_loss.detach().cpu().item())
+        loss_metrics["wss_direction_loss_weighted"] = float(
+            weighted_wss_direction_loss.detach().cpu().item()
+        )
+    return loss, loss_metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -883,6 +914,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_direction_loss_weight"] = config.wss_direction_loss_weight
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1062,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_direction_loss_weight=config.wss_direction_loss_weight,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1103,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_direction_loss" in batch_loss_metrics:
+                        train_log["train/wss_direction_loss"] = batch_loss_metrics[
+                            "wss_direction_loss"
+                        ]
+                        train_log["train/wss_direction_loss_weighted"] = batch_loss_metrics[
+                            "wss_direction_loss_weighted"
+                        ]
+                        train_log["train/wss_direction_loss_weight"] = (
+                            config.wss_direction_loss_weight
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

WSS (wall shear stress) is a 3-channel vector field (τ_x, τ_y, τ_z). The current loss treats each channel as an independent scalar prediction via per-channel weighted MSE. This means the loss has no concept of **direction** — a prediction that gets the magnitude right but the direction wrong is penalised the same as one that is entirely off. For physical quantities like shear stress, direction errors are just as meaningful as magnitude errors.

We hypothesise that adding a **cosine similarity penalty** on the WSS vector predictions will push the model to align the predicted shear stress direction with the ground truth, improving the WSS metric (currently 6.727% test, target <5.85%). The z-axis (vertical shear) is consistently the hardest channel — directional supervision may be especially effective there.

The direction loss is: `L_dir = mean(1 - cosine_similarity(pred_wss, target_wss))` over valid surface points. This is added as a scaled auxiliary term: `L_total = L_existing + λ * L_dir`, where λ is the direction loss weight.

We test two arms:
- **Arm A**: `--wss-direction-loss-weight 0.1` (light regularisation)
- **Arm B**: `--wss-direction-loss-weight 0.5` (stronger directional supervision)

## Implementation Instructions

In `target/train.py`:

**1. Add CLI flag** (in `TrainConfig` dataclass, near the existing `tau_y_loss_weight` / `tau_z_loss_weight` fields):
```python
wss_direction_loss_weight: float = 0.0
# --wss-direction-loss-weight: weight for cosine-similarity direction penalty on WSS vector.
# 0.0 disables (default). Typical range: 0.05 – 1.0.
```

And expose as argparse argument (following the same pattern as `--tau-z-loss-weight`):
```python
parser.add_argument("--wss-direction-loss-weight", type=float, default=0.0,
    help="Weight for cosine similarity direction penalty on WSS (tau_x/y/z) vector predictions.")
```

**2. Compute the direction loss** in `train_loss()` (in `train.py`, after computing `surface_loss`). WSS channels are indices 1, 2, 3 of the surface predictions (layout: `[sp, tau_x, tau_y, tau_z]`):
```python
if config.wss_direction_loss_weight > 0.0:
    # surface_pred shape: [B, N, 4]; surface_target shape: [B, N, 4]
    # WSS = channels 1:4
    wss_pred = out["surface_preds"][..., 1:4]   # [B, N, 3]
    wss_gt   = surface_target[..., 1:4]          # [B, N, 3]
    # cosine similarity over the vector dim; clamp denominator for zero-mag points
    cos_sim = torch.nn.functional.cosine_similarity(wss_pred, wss_gt, dim=-1)  # [B, N]
    # direction loss = 1 - cos_sim, masked to valid surface points
    dir_loss = masked_mean(1.0 - cos_sim, batch.surface_mask)
    loss = loss + config.wss_direction_loss_weight * dir_loss
    # Also log it:
    loss_dict["wss_direction_loss"] = float(dir_loss.detach().cpu().item())
```

**3. Log to W&B** — add a log line for `wss_direction_loss` in the existing per-step W&B log dict alongside the other loss components.

**4. Log config summary** — at the end of config logging (near where `tau_y_loss_weight` is logged to `wandb.summary`), add:
```python
wandb.summary["loss/wss_direction_loss_weight"] = config.wss_direction_loss_weight
```

**No other changes.** Use SOTA stack exactly.

## Reproduce Commands

**Arm A** (`--wss-direction-loss-weight 0.1`):
```bash
python train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-sdf-importance-sampling --sdf-importance-alpha 0.25 \
  --grad-clip-norm 0.5 \
  --wss-direction-loss-weight 0.1 \
  --wandb-group wss-direction-loss \
  --wandb-name arm-a-dir-0.1
```

**Arm B** (`--wss-direction-loss-weight 0.5`):
```bash
python train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-sdf-importance-sampling --sdf-importance-alpha 0.25 \
  --grad-clip-norm 0.5 \
  --wss-direction-loss-weight 0.5 \
  --wandb-group wss-direction-loss \
  --wandb-name arm-b-dir-0.5
```

## Baseline Metrics (Single-Model SOTA — PR #972)

| Metric | Value |
|--------|-------|
| val_abupt | 6.126% |
| test_abupt | 5.844% |
| test_vol_p | 3.643% (**floor — must not exceed**) |
| test_surf_p | 3.577% (**floor — must not exceed**) |
| **test_WSS** | **6.727%** |

**WSS target:** test_WSS < 5.85% (Transolver-3 SOTA)

EP3 gates: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% = PASS; ≤ 6.5% / 5.0% = MARGINAL; otherwise KILL.

Please report val_abupt, val_vol_p, and val_WSS at EP1, EP3, and final epoch for both arms.
W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
