### PR TITLE
WSS magnitude penalty: L1 auxiliary loss on |τ| magnitude error (λ=0.1/0.3 sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -55,6 +55,7 @@ from trainer_runtime import (
     loader_kwargs,
     make_loaders,
     masked_mse,
+    masked_wss_magnitude_l1_loss,
     metric_namespace,
     weighted_channel_mse,
     parse_kill_thresholds,
@@ -105,6 +106,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_magnitude_loss_weight: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,6 +323,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_magnitude_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,13 +349,26 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        if wss_magnitude_loss_weight > 0:
+            mag_loss = masked_wss_magnitude_l1_loss(
+                out["surface_preds"], surface_target, batch.surface_mask
+            )
+            weighted_mag_loss = wss_magnitude_loss_weight * mag_loss
+            loss = loss + weighted_mag_loss
+        else:
+            mag_loss = None
+            weighted_mag_loss = None
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if mag_loss is not None:
+        metrics["wss_magnitude_loss"] = float(mag_loss.detach().cpu().item())
+        metrics["wss_magnitude_loss_weighted"] = float(weighted_mag_loss.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -787,6 +803,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
         if config.use_gradnorm:
+            if config.wss_magnitude_loss_weight > 0:
+                raise ValueError(
+                    "--wss-magnitude-loss-weight is not implemented for the "
+                    "--use-gradnorm path (which bypasses train_loss). Disable "
+                    "one of the two."
+                )
             if config.gradnorm_mode == "full" and config.compile_model:
                 raise ValueError(
                     "--use-gradnorm --gradnorm-mode full requires --no-compile-model "
@@ -883,6 +905,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_magnitude_loss_weight"] = config.wss_magnitude_loss_weight
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1053,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_magnitude_loss_weight=config.wss_magnitude_loss_weight,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1094,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_magnitude_loss" in batch_loss_metrics:
+                        train_log["train/wss_magnitude_loss"] = batch_loss_metrics["wss_magnitude_loss"]
+                        train_log["train/wss_magnitude_loss_weighted"] = batch_loss_metrics["wss_magnitude_loss_weighted"]
+                        train_log["train/wss_magnitude_loss_weight"] = config.wss_magnitude_loss_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -870,6 +870,36 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def masked_wss_magnitude_l1_loss(
+    surface_pred: torch.Tensor,
+    surface_target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    tau_start: int = 1,
+    tau_end: int = 4,
+) -> torch.Tensor:
+    """L1 loss on the per-point magnitude error of the wall-shear-stress vector.
+
+    surface_pred / surface_target: [B, N, C] (C >= 4 with cp at 0 and tau_x,y,z at 1:4).
+    mask: [B, N] boolean. Returns mean( |‖τ_pred‖₂ − ‖τ_gt‖₂| ) over valid points.
+    Mirrors the empty-batch guard in ``masked_mse`` so the surface-curriculum
+    case (B with N_surf=0) and a fully-masked batch both contribute a zeroed
+    differentiable term instead of NaN.
+    """
+    if surface_pred.numel() == 0 or surface_pred.shape[1] == 0:
+        return surface_pred.sum() * 0.0
+    tau_pred = surface_pred[..., tau_start:tau_end]
+    tau_gt = surface_target[..., tau_start:tau_end]
+    mag_pred = torch.linalg.vector_norm(tau_pred, dim=-1)
+    mag_gt = torch.linalg.vector_norm(tau_gt, dim=-1)
+    mask_float = mask.to(device=surface_pred.device, dtype=surface_pred.dtype)
+    per_point = torch.abs(mag_pred - mag_gt) * mask_float
+    valid = mask_float.sum()
+    if bool(valid.detach().cpu().item() > 0):
+        return per_point.sum() / valid.clamp_min(1.0)
+    return surface_pred.sum() * 0.0
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Tanjiro's PR #1097 (closed NEGATIVE) established via mechanism analysis that WSS **direction** is already solved by per-channel weighted MSE (cos_sim=0.996, ~5° angular error by EP2). 91–96% of remaining WSS residual is **magnitude error** — the model consistently over/under-estimates the magnitude of τ vectors, particularly for τ_z (spanwise shear, historically worst axis).

The natural direct attack: add an auxiliary L1 loss term that explicitly penalises magnitude error:

```
L_mag = λ · mean( |‖τ_pred‖₂ − ‖τ_gt‖₂| )
```

where ‖τ‖₂ = sqrt(tau_x² + tau_y² + tau_z²) per surface point. L1 (not L2) is chosen for robustness in high-WSS outlier regions.

We sweep λ ∈ {0.1, 0.3} to assess sensitivity.

## Instructions

### Implementation (add to `train.py` or `trainer_runtime.py`)

In the training loss computation section, after computing the standard per-channel WSS MSE, add:

```python
# WSS magnitude penalty (L1 on per-point magnitude error)
if getattr(args, 'wss_magnitude_loss_weight', 0.0) > 0:
    # tau_pred and tau_gt are shape [B, N_surf, 3] (tau_x, tau_y, tau_z)
    tau_pred_mag = torch.norm(tau_pred, dim=-1)   # [B, N_surf]
    tau_gt_mag   = torch.norm(tau_gt,   dim=-1)   # [B, N_surf]
    mag_loss = torch.abs(tau_pred_mag - tau_gt_mag).mean()
    total_loss = total_loss + args.wss_magnitude_loss_weight * mag_loss
    # Log to W&B: wandb.log({"train/wss_magnitude_loss": mag_loss.item()})
```

Add the CLI flag:
```python
parser.add_argument('--wss-magnitude-loss-weight', type=float, default=0.0,
    help='L1 penalty weight on WSS magnitude error (0=disabled)')
```

### Arm A (λ=0.1, moderate)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent fern \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --sdf-importance-sampling --sdf-alpha 4.0 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wss-magnitude-loss-weight 0.1 \
  --wandb-group fern-wss-magnitude-penalty \
  --wandb-name fern/wss-mag-penalty-lam01
```

### Arm B (λ=0.3, aggressive)

Same command, change:
- `--wss-magnitude-loss-weight 0.3`
- `--wandb-name fern/wss-mag-penalty-lam03`

Run Arm A first (use all 8 GPUs for one run at a time). If Arm A passes EP3 gate, run Arm B after. If Arm A is killed, Arm B is likely also dead — check with advisor.

### EP3 Gate

At EP3, report val_abupt and val_vol_p:
- **PASS:** val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% → continue to EP13
- **MARGINAL:** val_abupt ≤ 6.5% AND val_vol_p ≤ 5.0% → continue only if loss slope still negative
- **KILL:** otherwise → stop, report, ask for guidance

### Win criterion

Any arm qualifies as a **new pool member** (for ensemble expansion) if:
- test_WSS ≤ 6.50% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND val_abupt ≤ 6.20%

A true SOTA would be: test_WSS < 6.3263% (current ensemble SOTA PR #1102).

## Baseline Metrics

| Metric | Single-model SOTA (PR #972) | Ensemble SOTA (PR #1102 K=8) |
|--------|----------------------------:|-----------------------------:|
| val_abupt | 6.126% | 5.7452% |
| test_abupt | 5.844% | 5.5196% |
| test_vol_p | 3.643% | 3.5397% |
| test_SP | 3.577% | 3.3529% |
| **test_WSS** | **6.727%** | **6.3263%** |
| test_tau_z | — | 8.2585% |

**Stretch goal (Issue #1056):** test_WSS < 5.85%. Current gap = 0.476pp from ensemble SOTA.

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
**Baseline W&B run (PR #972):** `56bcqp3m`

## Deliverables

1. W&B run IDs for both arms
2. EP3 gate result (val_abupt, val_vol_p) per arm
3. Final test metrics per arm (val + test): abupt, vol_p, SP, WSS, tau_x, tau_y, tau_z
4. Commentary: does the magnitude penalty visibly reduce train/wss_magnitude_loss, and which τ axis benefits most?
5. SENPAI-RESULT terminal marker after final test eval
