### PR TITLE
Per-channel rel_l2 loss on τ axes: auto-weight high-shear surface regions

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    per_channel_relative_l2_loss,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -105,6 +106,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_rel_l2_loss: bool = False
+    tau_rel_l2_eps: float = 1e-8
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,10 +324,13 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_rel_l2_loss: bool = False,
+    tau_rel_l2_eps: float = 1e-8,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    extra_metrics: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,27 +338,63 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        surface_pred = out["surface_preds"]
+        if tau_rel_l2_loss:
+            # cp (channel 0): masked MSE, weighted by surface_channel_weights[0]
+            cp_weight = (
+                float(surface_channel_weights[0].item())
+                if surface_channel_weights is not None
+                else 1.0
+            )
+            cp_mse = masked_mse(
+                surface_pred[..., 0:1],
+                surface_target[..., 0:1],
+                batch.surface_mask,
+            )
+            # tau channels (1..3): per-axis per-sample rel-L2, weighted per-axis
+            if surface_channel_weights is not None:
+                tau_weights = surface_channel_weights[1:4]
+            else:
+                tau_weights = torch.ones(3, device=device, dtype=surface_pred.dtype)
+            tau_loss_weighted, tau_per_channel = per_channel_relative_l2_loss(
+                surface_pred[..., 1:4],
+                surface_target[..., 1:4],
+                batch.surface_mask,
+                tau_weights,
+                eps=tau_rel_l2_eps,
+            )
+            surface_loss = cp_weight * cp_mse + tau_loss_weighted
+            extra_metrics["cp_mse"] = float(cp_mse.detach().cpu().item())
+            extra_metrics["tau_rel_l2_weighted"] = float(
+                tau_loss_weighted.detach().cpu().item()
+            )
+            tau_pc_cpu = tau_per_channel.detach().cpu().tolist()
+            extra_metrics["tau_x_rel_l2"] = float(tau_pc_cpu[0])
+            extra_metrics["tau_y_rel_l2"] = float(tau_pc_cpu[1])
+            extra_metrics["tau_z_rel_l2"] = float(tau_pc_cpu[2])
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_pred,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(extra_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +894,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.tau_rel_l2_loss:
+                print(
+                    "Tau loss: per-axis per-sample relative-L2 "
+                    f"(eps={config.tau_rel_l2_eps:.1e}); cp keeps MSE"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +930,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_rel_l2_loss"] = bool(config.tau_rel_l2_loss)
+            wandb.summary["loss/tau_rel_l2_eps"] = float(config.tau_rel_l2_eps)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1021,6 +1070,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    surface_weights_for_loss = (
+                        surface_channel_weights
+                        if (use_channel_weights or config.tau_rel_l2_loss)
+                        else None
+                    )
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1029,7 +1083,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         config.amp_mode,
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
-                        surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        surface_channel_weights=surface_weights_for_loss,
+                        tau_rel_l2_loss=config.tau_rel_l2_loss,
+                        tau_rel_l2_eps=config.tau_rel_l2_eps,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1126,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for tau_key in (
+                        "cp_mse",
+                        "tau_rel_l2_weighted",
+                        "tau_x_rel_l2",
+                        "tau_y_rel_l2",
+                        "tau_z_rel_l2",
+                    ):
+                        if tau_key in batch_loss_metrics:
+                            train_log[f"train/{tau_key}"] = batch_loss_metrics[tau_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -896,14 +896,17 @@ def per_channel_relative_l2_loss(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Per-channel per-sample relative-L2 norm, weighted across channels.
 
-    For each channel ``c`` and sample ``b``:
-        rel_l2_{b,c} = sqrt(sum_n mask_{b,n} (pred_{b,n,c} - target_{b,n,c})^2)
+    For each channel ``c`` and sample ``b`` with at least one valid point:
+        rel_l2_{b,c} = sqrt(sum_n mask_{b,n} (pred_{b,n,c} - target_{b,n,c})^2 + eps^2)
                       / sqrt(sum_n mask_{b,n} target_{b,n,c}^2 + eps^2)
 
-    Returns ``(weighted_loss, per_channel_loss)`` where ``weighted_loss`` is the
-    scalar ``mean_b(sum_c channel_weights[c] * rel_l2_{b,c})`` and
-    ``per_channel_loss`` is the unweighted per-channel mean ``mean_b(rel_l2_{b,c})``
-    for logging.
+    The ``+ eps^2`` inside both square roots keeps the backward pass numerically
+    stable when a batch has no valid surface points (mask all zero) — without
+    it, ``sqrt(0)`` has an infinite gradient and the multiplication by the
+    zero mask produces NaN, which is what we observed in run ``48ylgpfb``.
+
+    Samples whose target norm is zero (no valid points) are excluded from the
+    per-channel mean so the floor introduced by ``eps`` cannot bias the loss.
     """
     if pred.numel() == 0:
         zero = pred.sum() * 0.0
@@ -914,12 +917,14 @@ def per_channel_relative_l2_loss(
     diff_norm_sq = diff_sq.sum(dim=1)  # [B, C]
     target_norm_sq = target_sq.sum(dim=1)  # [B, C]
     eps_sq = float(eps) * float(eps)
-    rel_l2 = torch.sqrt(diff_norm_sq.clamp_min(0.0)) / torch.sqrt(
-        target_norm_sq.clamp_min(eps_sq)
+    rel_l2 = torch.sqrt(diff_norm_sq + eps_sq) / torch.sqrt(
+        target_norm_sq + eps_sq
     )  # [B, C], dimensionless
-    per_channel_mean = rel_l2.mean(dim=0)  # [C]
+    valid = (target_norm_sq > 0).to(dtype=rel_l2.dtype)  # [B, C]
+    valid_count = valid.sum(dim=0).clamp_min(1.0)  # [C]
+    per_channel_mean = (rel_l2 * valid).sum(dim=0) / valid_count  # [C]
     weights = channel_weights.to(device=pred.device, dtype=rel_l2.dtype)
-    weighted = (rel_l2 * weights).sum(dim=-1).mean()
+    weighted = (per_channel_mean * weights).sum()
     return weighted.to(pred.dtype), per_channel_mean.detach().to(pred.dtype)
 
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -887,6 +887,42 @@ def squared_relative_l2_loss(
     return pred.sum() * 0.0
 
 
+def per_channel_relative_l2_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    channel_weights: torch.Tensor,
+    eps: float = 1e-8,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-channel per-sample relative-L2 norm, weighted across channels.
+
+    For each channel ``c`` and sample ``b``:
+        rel_l2_{b,c} = sqrt(sum_n mask_{b,n} (pred_{b,n,c} - target_{b,n,c})^2)
+                      / sqrt(sum_n mask_{b,n} target_{b,n,c}^2 + eps^2)
+
+    Returns ``(weighted_loss, per_channel_loss)`` where ``weighted_loss`` is the
+    scalar ``mean_b(sum_c channel_weights[c] * rel_l2_{b,c})`` and
+    ``per_channel_loss`` is the unweighted per-channel mean ``mean_b(rel_l2_{b,c})``
+    for logging.
+    """
+    if pred.numel() == 0:
+        zero = pred.sum() * 0.0
+        return zero, zero.new_zeros(pred.shape[-1])
+    mask_float = mask.to(device=pred.device, dtype=torch.float32).unsqueeze(-1)
+    diff_sq = (pred.float() - target.float()).square() * mask_float  # [B, N, C]
+    target_sq = target.float().square() * mask_float  # [B, N, C]
+    diff_norm_sq = diff_sq.sum(dim=1)  # [B, C]
+    target_norm_sq = target_sq.sum(dim=1)  # [B, C]
+    eps_sq = float(eps) * float(eps)
+    rel_l2 = torch.sqrt(diff_norm_sq.clamp_min(0.0)) / torch.sqrt(
+        target_norm_sq.clamp_min(eps_sq)
+    )  # [B, C], dimensionless
+    per_channel_mean = rel_l2.mean(dim=0)  # [C]
+    weights = channel_weights.to(device=pred.device, dtype=rel_l2.dtype)
+    weighted = (rel_l2 * weights).sum(dim=-1).mean()
+    return weighted.to(pred.dtype), per_channel_mean.detach().to(pred.dtype)
+
+
 EVAL_KEYS = (
     "surface_pressure",
     "wall_shear",


### PR DESCRIPTION
## Hypothesis

The current training loss for WSS uses MSE (mean squared error) on each τ axis equally. MSE penalises absolute error, which means **low-WSS surface regions** (flat underbody panels, gentle A-surfaces) dominate the gradient simply because they have more surface area — even though their absolute WSS values are small and physically less important.

The key insight from PR #1097 (tanjiro, direction-loss experiment): WSS residual is 91–96% magnitude error, and it's concentrated on **high-shear regions** (wheel arches, A-pillar, underbody edges) where τ magnitudes are large. MSE gradient at those points ∝ (pred − gt)², but relative error (pred − gt) / ‖gt‖ is what we actually care about for the DrivAerML metric.

**Proposal:** Replace MSE with **relative L2 loss** (rel_l2) on τ axes:

```
L_rel_l2 = mean( ‖τ_pred − τ_gt‖₂ / (‖τ_gt‖₂ + ε) )
```

This auto-scales the gradient signal by the ground-truth magnitude — high-shear points get proportionally more gradient, low-shear points less, without any manual weighting. It directly targets the relative percentage error that the DrivAerML benchmark evaluates (rel_l2_pct).

## Instructions

### Implementation

In the training loss computation section of `train.py` or `trainer_runtime.py`, locate where the surface channel losses are computed. Add a `--tau-rel-l2-loss` flag that replaces the per-channel MSE on tau_x/tau_y/tau_z with rel_l2:

```python
if getattr(args, 'tau_rel_l2_loss', False):
    # Replace tau channel MSE with relative L2 loss
    # tau_pred, tau_gt: [B, N_surf, 3] (tau_x, tau_y, tau_z channels)
    eps = 1e-6
    tau_gt_norm = torch.norm(tau_gt, dim=-1, keepdim=True).clamp(min=eps)
    tau_rel_l2 = torch.norm(tau_pred - tau_gt, dim=-1) / tau_gt_norm.squeeze(-1)
    tau_loss = tau_rel_l2.mean()
    # Apply channel weights as before: tau_y *= 1.5, tau_z *= 2.0
    # For rel_l2 version, apply per-axis weights to per-component errors:
    # tau_rel_l2_x = |tau_pred_x - tau_gt_x| / (|tau_gt_x| + eps)  * w_x
    # tau_rel_l2_y = |tau_pred_y - tau_gt_y| / (|tau_gt_y| + eps)  * w_y
    # tau_rel_l2_z = |tau_pred_z - tau_gt_z| / (|tau_gt_z| + eps)  * w_z
else:
    # existing MSE tau loss
```

More precisely: compute per-channel relative L2, then apply the existing tau_y/tau_z loss weights:
```python
# Arm A: tau-rel-l2 on all tau channels, keep MSE for surf_p and vol_p
eps = 1e-6
tau_loss_x = torch.abs(tau_pred_x - tau_gt_x) / (torch.abs(tau_gt_x) + eps)
tau_loss_y = torch.abs(tau_pred_y - tau_gt_y) / (torch.abs(tau_gt_y) + eps) * args.tau_y_loss_weight
tau_loss_z = torch.abs(tau_pred_z - tau_gt_z) / (torch.abs(tau_gt_z) + eps) * args.tau_z_loss_weight
tau_loss = (tau_loss_x + tau_loss_y + tau_loss_z).mean()
```

Add CLI flag: `--tau-rel-l2-loss` (boolean, default False).

### Arm A: rel_l2 on tau axes only (MSE for surf_p and vol_p unchanged)

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent tanjiro \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --sdf-importance-sampling --sdf-alpha 4.0 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --tau-rel-l2-loss \
  --wandb-group tanjiro-tau-rel-l2-loss \
  --wandb-name tanjiro/tau-rel-l2-arm-a
```

### Arm B (optional, if Arm A passes EP3 and shows WSS improvement vs baseline):

Same command, but also replace surf_p with rel_l2 (add `--all-rel-l2-loss` flag that applies rel_l2 to ALL surface channels). Run only if Arm A is PASS and shows WSS improvement trend.

### EP3 Gate

At EP3, report val_abupt and val_vol_p:
- **PASS:** val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% → continue to EP13
- **MARGINAL:** val_abupt ≤ 6.5% AND val_vol_p ≤ 5.0% → continue if loss slope healthy
- **KILL:** otherwise → stop, report

### Win criterion (new pool member)

- test_WSS ≤ 6.50% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND val_abupt ≤ 6.20%

## Baseline Metrics

| Metric | Single-model SOTA (PR #972) | Ensemble SOTA (PR #1102 K=8) |
|--------|----------------------------:|-----------------------------:|
| val_abupt | 6.126% | 5.7452% |
| test_abupt | 5.844% | 5.5196% |
| test_vol_p | 3.643% | 3.5397% |
| test_SP | 3.577% | 3.3529% |
| **test_WSS** | **6.727%** | **6.3263%** |
| test_tau_z | — | 8.2585% |

**Stretch goal (Issue #1056):** test_WSS < 5.85%. Current gap = 0.476pp.
**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
**Baseline W&B run (PR #972):** `56bcqp3m`

## Background

This experiment follows directly from your own mechanism analysis in PR #1097 (WSS direction loss). You identified that 91–96% of WSS residual is magnitude error, and suggested rel_l2 as the natural successor to direction loss. The MSE loss treats all surface points equally by absolute error — rel_l2 re-weights by GT magnitude, which is exactly what the DrivAerML evaluation metric measures. High-τ regions (edges, wheel arches) get proportionally more gradient without any manual specification.

## Deliverables

1. W&B run ID for Arm A (and B if run)
2. EP3 gate result (val_abupt, val_vol_p)
3. Final test metrics: abupt, vol_p, SP, WSS, tau_x, tau_y, tau_z
4. Commentary: does rel_l2 shift gradient to high-τ regions (check loss curves per region if available)?
5. SENPAI-RESULT terminal marker
