### PR TITLE
[edward] τ_z spatial focal loss: per-point magnitude weighting (α=2.0 / α=4.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -57,6 +57,7 @@ from trainer_runtime import (
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
+    focal_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -105,6 +106,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_z_focal_alpha: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,10 +323,13 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_z_focal_alpha: float = 0.0,
+    tau_z_channel_idx: int = 3,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    tau_z_focal_mean_w: float = 1.0
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -333,12 +338,25 @@ def train_loss(
             volume_mask=batch.volume_mask,
         )
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
-            )
+            if tau_z_focal_alpha > 0.0:
+                focal_target = surface_target[..., tau_z_channel_idx]
+                surface_loss, mean_w = focal_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                    focal_target=focal_target,
+                    focal_channel_idx=tau_z_channel_idx,
+                    focal_alpha=tau_z_focal_alpha,
+                )
+                tau_z_focal_mean_w = float(mean_w.detach().cpu().item())
+            else:
+                surface_loss = weighted_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
@@ -352,6 +370,7 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "tau_z_focal_mean_w": tau_z_focal_mean_w,
     }
 
 
@@ -852,6 +871,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.tau_z_focal_alpha > 0.0:
+                print(
+                    f"Spatial focal loss enabled on tau_z (channel idx=3): "
+                    f"alpha={config.tau_z_focal_alpha}, "
+                    f"w_i = 1 + alpha * |tau_z_gt_i| / mean(|tau_z_gt|)"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +908,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_z_focal_alpha"] = config.tau_z_focal_alpha
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1056,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_z_focal_alpha=config.tau_z_focal_alpha,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1068,8 +1095,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/tau_z_focal_alpha": config.tau_z_focal_alpha,
                         }
                     )
+                    if (
+                        config.tau_z_focal_alpha > 0.0
+                        and "tau_z_focal_mean_w" in batch_loss_metrics
+                    ):
+                        train_log["train/tau_z_focal_mean_w"] = batch_loss_metrics[
+                            "tau_z_focal_mean_w"
+                        ]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -870,6 +870,87 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def focal_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    channel_weights: torch.Tensor,
+    focal_target: torch.Tensor,
+    focal_channel_idx: int,
+    focal_alpha: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-channel weighted masked MSE with extra per-point spatial weighting on one focal channel.
+
+    Identical to :func:`weighted_channel_mse` except the channel at
+    ``focal_channel_idx`` receives an additional per-point multiplier
+    ``w_i = 1 + focal_alpha * |focal_target_i| / (mean(|focal_target|) + eps)``
+    where the mean is computed per-sample over valid (non-masked) points.
+    Other channels keep their uniform ``channel_weights[c]`` multiplier.
+
+    The focal weight is derived only from ``focal_target`` (the GT tensor for
+    that channel) so no gradient flows through ``w_i`` — only the magnitude of
+    the squared error is rescaled.
+
+    Args:
+        pred / target: [B, N, C].
+        mask: [B, N] (1=valid, 0=pad).
+        channel_weights: [C] uniform per-channel scalars.
+        focal_target: [B, N] — GT values for the focal channel (typically
+            ``target[..., focal_channel_idx]``; pass ``.abs()`` is unnecessary
+            since this function takes ``abs`` internally).
+        focal_channel_idx: which channel to apply spatial weighting to.
+        focal_alpha: concentration parameter. 0.0 reduces to weighted_channel_mse.
+
+    Returns:
+        (loss, mean_spatial_weight) — loss is the scalar averaged over
+        (valid points × channels); mean_spatial_weight is the masked mean of
+        the per-point focal weight, useful as a diagnostic (should be ≈ 1 + α
+        when |focal_target| ≈ mean, and substantially > 1 if the distribution
+        has a heavy tail). When pred is empty, returns (0, 1.0).
+    """
+    if pred.numel() == 0:
+        zero = pred.sum() * 0.0
+        return zero, zero + 1.0
+    channel_weights_dev = channel_weights.to(device=pred.device, dtype=pred.dtype)
+    if channel_weights_dev.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"channel_weights last-dim {channel_weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    if focal_channel_idx < 0 or focal_channel_idx >= pred.shape[-1]:
+        raise ValueError(
+            f"focal_channel_idx {focal_channel_idx} out of range for pred with C={pred.shape[-1]}"
+        )
+
+    eps = 1e-8
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype)  # [B, N]
+    mask_3d = mask_dev.unsqueeze(-1)  # [B, N, 1]
+
+    sq_err = (pred - target).square()  # [B, N, C]
+
+    focal_target_dev = focal_target.to(device=pred.device, dtype=pred.dtype)  # [B, N]
+    abs_focal = focal_target_dev.abs()
+    valid_sum = (abs_focal * mask_dev).sum(dim=1, keepdim=True)  # [B, 1]
+    valid_count = mask_dev.sum(dim=1, keepdim=True).clamp_min(1.0)  # [B, 1]
+    mean_abs_focal = valid_sum / valid_count  # [B, 1]
+    spatial_w = 1.0 + focal_alpha * abs_focal / (mean_abs_focal + eps)  # [B, N]
+
+    per_channel_w = channel_weights_dev.view(1, 1, -1).expand_as(sq_err).clone()  # [B, N, C]
+    per_channel_w[..., focal_channel_idx] = (
+        channel_weights_dev[focal_channel_idx] * spatial_w
+    )
+
+    weighted = sq_err * per_channel_w * mask_3d  # [B, N, C]
+    valid_points = mask_3d.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+
+    masked_w_sum = (spatial_w * mask_dev).sum()
+    mean_spatial_w = masked_w_sum / mask_dev.sum().clamp_min(1.0)
+
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator, mean_spatial_w
+    return pred.sum() * 0.0, mean_spatial_w
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

All prior scalar-weight experiments on τ_z (tau_z×2.0 baseline, ×3.0, ×4.0 sweeps in PRs #793, #1000 series) have applied a **uniform per-channel multiplier** — every surface point gets the same increased gradient weight for τ_z, regardless of whether that point is in a high-shear region (wheel arch, underbody edge) or a low-shear region (roof, hood). This is the fundamental limitation of `weighted_channel_mse`: it broadcasts a scalar weight over all N surface points equally.

The τ_z bottleneck is **spatially concentrated**: wheel arches, underbody edges, and A-pillar reattachment zones account for the majority of τ_z residual error. Uniform weighting wastes gradient budget on low-shear points where the model is already accurate.

**Spatial focal loss** concentrates gradient on the hard high-shear regions by making the per-point weight for τ_z proportional to the local GT τ_z magnitude:

```
w_i = 1 + α · |τ_z_gt_i| / (mean(|τ_z_gt_valid|) + ε)
```

This is analogous to focal loss in object detection: regions where τ_z is large and structurally hard to predict receive proportionally more gradient. Low-shear regions get w≈1 (normal weight). The parameter α controls the concentration intensity.

This is **orthogonal** to all previous loss-weight experiments: those tuned the global scalar; this changes the *spatial distribution* of gradient within the channel. It is also orthogonal to all Wave 27 experiments (yaw augmentation, WSS magnitude penalty, rotation equivariance, channel positional encoding).

## Background — Why Scalar Weights Failed

From the EXPERIMENTS_LOG:
- PR #793: τ_y×2.5 + τ_z×3.0 combined → NEGATIVE (competing pulls degrade all channels)
- Alphonse sweep: τ_z×3.0 and ×4.0 both tried
- Thorfinn #1100 τ_z×3.0 arm: `8j9kt5w1` val_tau_z=10.062% — insufficient

**Conclusion:** Per-axis loss weights cannot fix structural z-axis difficulty because uniformly amplifying gradient from easy low-shear points does not help. Spatial focal loss addresses the root cause.

## Current Baseline (PR #1102 K=8 Caruana Ensemble)

| Metric | Value |
|--------|-------|
| val_abupt | **5.7452%** |
| val_WSS | 6.5195% |
| val_SP | 3.7234% |
| val_vol_p | 3.4360% |
| test_abupt | 5.5196% |
| **test_WSS** | **6.3263%** |
| test_vol_p | 3.5397% |
| test_SP | 3.3529% |
| test_tau_x | 5.6071% |
| test_tau_y | 6.8397% |
| test_tau_z | 8.2585% |

**Single-model SOTA for comparison:**
- val_abupt=6.126%, test_WSS=6.727% (W&B `56bcqp3m`, PR #972)

**Thorfinn #1100 EP3 reference (τ_z×3.0 arm, no spatial weighting):**
- val_wss=7.661%, val_wss_z=10.206% at EP3

**EP3 gate (recalibrated for tay — no SDF flags):**
- PASS: val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5%
- MARGINAL: val_abupt ≤ 7.6% AND val_vol_p ≤ 5.0%
- KILL: otherwise

**Win criteria (Issue #1056 — WSS campaign):**
val_abupt < 6.126% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS < 6.727% (single-model improvement over PR #972)
Long-term target: test_WSS < 6.3263% (beat ensemble SOTA with a single model → new ensemble member)

## Instructions

### Step 1 — Implementation

Add a new function `focal_channel_mse` to `trainer_runtime.py` immediately after the existing `weighted_channel_mse` function (around line 865):

```python
def focal_channel_mse(
    pred: torch.Tensor,          # [B, N, C]
    target: torch.Tensor,        # [B, N, C]
    mask: torch.Tensor,          # [B, N]  (1=valid surface point, 0=pad)
    channel_weights: torch.Tensor,   # [C] uniform per-channel scalars (same as weighted_channel_mse)
    focal_target: torch.Tensor,  # [B, N] — GT values for the focal channel (e.g. tau_z GT magnitude)
    focal_channel_idx: int,      # which channel index to apply spatial weighting to (e.g. 3 for tau_z)
    focal_alpha: float,          # concentration parameter (0.0 = same as weighted_channel_mse)
) -> torch.Tensor:
    """
    Like weighted_channel_mse, but applies additional per-point spatial weighting
    to one designated focal channel based on GT magnitude.
    
    w_i = 1 + alpha * |focal_target_i| / (mean(|focal_target_valid|) + eps)
    
    Applied only to the focal_channel_idx channel. Other channels use uniform weights.
    """
    if pred.numel() == 0:
        return pred.sum() * 0.0
    
    eps = 1e-8
    mask_dev = mask.to(device=pred.device, dtype=pred.dtype)  # [B, N]
    channel_weights_dev = channel_weights.to(device=pred.device, dtype=pred.dtype)  # [C]
    sq_err = (pred - target).square()  # [B, N, C]
    
    # Compute spatial focal weights for the designated channel
    focal_target_dev = focal_target.to(device=pred.device, dtype=pred.dtype)  # [B, N]
    abs_focal = focal_target_dev.abs()  # [B, N]
    
    # Mean over valid (non-masked) points only, per batch
    valid_sum = (abs_focal * mask_dev).sum(dim=1, keepdim=True)  # [B, 1]
    valid_count = mask_dev.sum(dim=1, keepdim=True).clamp_min(1.0)  # [B, 1]
    mean_abs_focal = valid_sum / valid_count  # [B, 1] — per-sample mean
    
    # Spatial focal weight: w_i = 1 + alpha * |tau_z_gt_i| / (mean_abs + eps)
    spatial_w = 1.0 + focal_alpha * abs_focal / (mean_abs_focal + eps)  # [B, N]
    
    # Build per-point, per-channel weight tensor
    # Default: broadcast channel_weights_dev [C] over all points
    # For focal channel: multiply by spatial_w [B, N]
    mask_3d = mask_dev.unsqueeze(-1)  # [B, N, 1]
    weighted = sq_err * channel_weights_dev * mask_3d  # [B, N, C] — uniform spatial
    
    # Override focal channel with spatial weighting
    # spatial_w_3d: [B, N, 1] → applies only to focal channel slice
    spatial_w_3d = spatial_w.unsqueeze(-1)  # [B, N, 1]
    focal_sq_err = sq_err[..., focal_channel_idx:focal_channel_idx+1]  # [B, N, 1]
    focal_w_scalar = channel_weights_dev[focal_channel_idx]
    focal_weighted = focal_sq_err * focal_w_scalar * spatial_w_3d * mask_3d  # [B, N, 1]
    
    # Replace focal channel in weighted
    weighted = torch.cat([
        weighted[..., :focal_channel_idx],
        focal_weighted,
        weighted[..., focal_channel_idx+1:]
    ], dim=-1)  # [B, N, C]
    
    valid_points = mask_3d.sum()
    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
    if bool(valid_points.detach().cpu().item() > 0):
        return weighted.sum() / denominator
    return pred.sum() * 0.0
```

Add a new CLI config field to the `TrainingConfig` dataclass (after `tau_z_loss_weight`):
```python
tau_z_focal_alpha: float = 0.0   # spatial focal weight concentration (0=disabled)
```

Add the CLI argument to the parser (after `--tau-z-loss-weight`):
```python
parser.add_argument('--tau-z-focal-alpha', type=float, default=0.0,
    help='Spatial focal weight concentration for tau_z channel. '
         'w_i = 1 + alpha * |tau_z_gt_i| / mean(|tau_z_gt|). 0=disabled.')
```

In the training loss computation, find where `weighted_channel_mse` is called for the surface WSS loss (the call that passes `tau_y_loss_weight`/`tau_z_loss_weight` weights). Replace it with a conditional call:

```python
# Current call (approximately):
# surf_wss_loss = weighted_channel_mse(tau_pred, tau_gt, surf_mask, wss_weights)
#
# Replace with:
if args.tau_z_focal_alpha > 0.0:
    # tau_z is channel index 2 in the [tau_x, tau_y, tau_z] stacking
    # focal_target = GT tau_z magnitudes [B, N]
    tau_z_gt_magnitude = tau_gt[..., 2].abs()   # tau_z is the 3rd channel
    surf_wss_loss = focal_channel_mse(
        tau_pred, tau_gt, surf_mask, wss_weights,
        focal_target=tau_z_gt_magnitude,
        focal_channel_idx=2,
        focal_alpha=args.tau_z_focal_alpha,
    )
else:
    surf_wss_loss = weighted_channel_mse(tau_pred, tau_gt, surf_mask, wss_weights)
```

**Important:** Verify the actual tau_z channel index in the WSS tensor by checking how `tau_pred`/`tau_gt` are constructed in `trainer_runtime.py`. If the stacking order is different (e.g. [tau_x=0, tau_y=1, tau_z=2] or some other order), adjust `focal_channel_idx` accordingly. Log the channel index used with a `print` or `logging.info` statement at startup for verification.

Add W&B logging of the focal alpha value:
```python
wandb.config.update({"tau_z_focal_alpha": args.tau_z_focal_alpha})
```

Also log the mean spatial weight per step (diagnostic):
```python
if args.tau_z_focal_alpha > 0.0:
    wandb.log({"train/tau_z_focal_mean_w": spatial_w.mean().item()})
```

### Step 2 — Arm A: α=2.0 (moderate concentration)

**Note:** The SDF flags (`--sdf-importance-sampling --sdf-alpha 4.0`) do NOT exist on `tay`. Drop them entirely — the `tay` branch does not have the PR #972 SDF sampling code.

```bash
cd /workspace/senpai/target
torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --tau-z-focal-alpha 2.0 \
  --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group edward-tau-z-spatial-focal \
  --wandb-name edward/tau-z-focal-alpha-2p0
```

### Step 3 — EP3 Gate Check (after EP3)

Post a comment with:
- val_abupt, val_vol_p (gate check)
- **Per-axis WSS breakdown**: val_wss, val_wss_x, val_wss_y, val_wss_z (if logged)
- Mean τ_z focal weight (from `train/tau_z_focal_mean_w` W&B log) — should be > 1.0 at high-shear points
- Compare val_wss_z vs thorfinn #1100 EP3 baseline (10.206%)

**PASS gate:** val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5% → continue to EP13
**MARGINAL gate:** val_abupt ≤ 7.6% AND val_vol_p ≤ 5.0% → check with advisor
**KILL:** otherwise → stop, do not launch Arm B

### Step 4 — Arm B: α=4.0 (aggressive concentration) — only if Arm A passes EP3

Same command, with:
```
--tau-z-focal-alpha 4.0
--wandb-name edward/tau-z-focal-alpha-4p0
```

Run Arm B sequentially after Arm A completes (or after Arm A EP13 if confirming final metrics).
If Arm A kills at EP3, check with advisor before launching Arm B.

### Step 5 — EP3 Diagnostic Analysis

At EP3 for Arm A, check:
1. **Mean focal weight (`train/tau_z_focal_mean_w`)**: Should be substantially > 1.0. If it's close to 1.0, the GT τ_z distribution is nearly flat (unlikely for DrivAerML — wheel arches should be 3–5× mean). If mean weight ≈ 1.0, raise with advisor.
2. **val_wss_z trajectory vs thorfinn #1100 `8j9kt5w1`**: The baseline τ_z×3.0 scalar arm had val_wss_z=10.206% at EP3 and final=10.062%. If the spatial focal arm shows val_wss_z < 10.0% at EP3 with val_abupt still under gate, this is a meaningful improvement signal.
3. **vol_p stability**: Focal loss is applied only to the surface WSS channel. vol_p should be unaffected. If val_vol_p degrades (> 4.5%), investigate whether the focal weight is somehow affecting gradient flow to the volume head.

### Step 6 — Terminal Results

After Arm A (and Arm B if launched) reaches EP13, post results in the PR comment with the terminal marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<arm-a-run-id>","<arm-b-run-id>"],"primary_metric":{"name":"val_abupt","value":<value>},"test_metric":{"name":"test_WSS","value":<value>}}
```

If only Arm A completes (Arm B killed at EP3), set `wandb_run_ids` to just the Arm A run ID.

Include the full val + test metric table:
- val_abupt, val_WSS, val_wss_x, val_wss_y, val_wss_z, val_vol_p, val_SP
- test_abupt, test_WSS, test_tau_x, test_tau_y, test_tau_z, test_vol_p, test_SP

And compare val_wss_z to the thorfinn #1100 τ_z×3.0 scalar arm as the key diagnostic.

## Implementation Notes

- The `focal_channel_mse` function replaces `weighted_channel_mse` only for the surface WSS loss. All other losses (SP, vol_p) remain unchanged and continue using `weighted_channel_mse` or their existing formulations.
- The existing `--tau-z-loss-weight 2.0` is kept — it sets the baseline per-channel scalar for τ_z. The focal alpha then adds an *additional* spatially-varying multiplier on top. So a point with τ_z magnitude 3× the mean gets weight: `tau_z_loss_weight × (1 + alpha × 3) = 2.0 × (1 + 2.0 × 3) = 14.0` vs low-shear point: `2.0 × 1.0 = 2.0`.
- If the tau_z channel index is not 2 (0-indexed in the WSS tensor), adjust `focal_channel_idx` accordingly. The most likely orderings are `[tau_x=0, tau_y=1, tau_z=2]` or `[tau_z=0, tau_y=1, tau_x=2]` — verify in the code before launching.
- No changes to validation/test evaluation — only training loss is modified.
