### PR TITLE
OHEM surface top-20% hard mining for WSS (Wave 28)

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    ohem_supplementary_loss,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -138,6 +139,10 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    ohem_surface_ratio: float = 1.0
+    ohem_warmup_epochs: int = 0
+    ohem_min_k: int = 100
+    ohem_lambda: float = 0.5
     debug: bool = False
 
 
@@ -219,6 +224,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "ohem_surface_ratio": (
+            "Top-K fraction of hardest surface points for the supplementary "
+            "OHEM (online hard example mining) loss term. 1.0 = disabled "
+            "(default). 0.20 = top-20%% hardest points per sample. The OHEM "
+            "term adds 'ohem_lambda * MSE(top-K hardest)' on top of the "
+            "standard surface_loss so all points still receive gradient."
+        ),
+        "ohem_warmup_epochs": (
+            "Number of epochs before OHEM activates. During warmup the OHEM "
+            "supplementary term is zero so the model can calibrate its error "
+            "distribution before being asked to focus on hard examples. "
+            "Default 0 = no warmup."
+        ),
+        "ohem_min_k": (
+            "Minimum number of hard points to select per sample regardless "
+            "of ohem_surface_ratio. Prevents degenerate top-K selection at "
+            "very small surface views. Default 100."
+        ),
+        "ohem_lambda": (
+            "Weight multiplier on the OHEM supplementary loss term. Final "
+            "loss = surface_loss_weight*surface_loss + volume_loss_weight*"
+            "volume_loss + ohem_lambda*ohem_hard_loss. Default 0.5 keeps "
+            "the supplementary term from dominating."
         ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
@@ -321,6 +350,10 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    ohem_surface_ratio: float = 1.0,
+    ohem_warmup_active: bool = False,
+    ohem_min_k: int = 100,
+    ohem_lambda: float = 0.5,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -342,9 +375,25 @@ def train_loss(
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+
+        ohem_active = (ohem_surface_ratio < 1.0) and (not ohem_warmup_active)
+        if ohem_active:
+            ohem_loss = ohem_supplementary_loss(
+                pred=out["surface_preds"],
+                target=surface_target,
+                mask=batch.surface_mask,
+                ohem_ratio=ohem_surface_ratio,
+                min_k=ohem_min_k,
+                channel_weights=surface_channel_weights,
+            )
+            ohem_contribution = ohem_lambda * ohem_loss
+        else:
+            ohem_loss = torch.zeros((), device=device)
+            ohem_contribution = torch.zeros((), device=device)
+
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        loss = weighted_surface_loss + weighted_volume_loss + ohem_contribution
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
@@ -352,6 +401,10 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "ohem/active": float(ohem_active),
+        "ohem/in_warmup": float(ohem_warmup_active),
+        "ohem/hard_loss": float(ohem_loss.detach().cpu().item()),
+        "ohem/lambda_contribution": float(ohem_contribution.detach().cpu().item()),
     }
 
 
@@ -913,6 +966,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     current_train_vol_points = desired_vol_points
             if isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
+            ohem_warmup_active = (
+                config.ohem_surface_ratio < 1.0
+                and config.ohem_warmup_epochs > 0
+                and epoch < config.ohem_warmup_epochs
+            )
             timeout_hit = distributed_any(
                 state,
                 (time.time() - train_start) / 60.0 >= timeout_minutes,
@@ -1030,6 +1088,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        ohem_surface_ratio=config.ohem_surface_ratio,
+                        ohem_warmup_active=ohem_warmup_active,
+                        ohem_min_k=config.ohem_min_k,
+                        ohem_lambda=config.ohem_lambda,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1132,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "ohem/active" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "train/ohem/active": batch_loss_metrics["ohem/active"],
+                                "train/ohem/in_warmup": batch_loss_metrics["ohem/in_warmup"],
+                                "train/ohem/hard_loss": batch_loss_metrics["ohem/hard_loss"],
+                                "train/ohem/lambda_contribution": batch_loss_metrics["ohem/lambda_contribution"],
+                                "train/ohem/ratio": config.ohem_surface_ratio,
+                                "train/ohem/lambda": config.ohem_lambda,
+                                "train/ohem/min_k": float(config.ohem_min_k),
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -870,6 +870,47 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def ohem_supplementary_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    ohem_ratio: float,
+    min_k: int = 100,
+    channel_weights: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute supplementary OHEM surface loss over top-K% hardest points.
+
+    pred / target: [B, N, C]; mask: [B, N] boolean (True = valid point).
+    ``ohem_ratio`` is the fraction of points to select as hard (e.g. 0.20).
+    ``min_k`` is the per-sample floor on the number of hard points selected.
+    Returns a scalar mean squared error computed only over the top-K hardest
+    points per sample, optionally per-channel weighted to match the main loss.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+
+    sq_err = (pred - target).square()  # [B, N, C]
+    per_point_loss = sq_err.mean(dim=-1).float()  # [B, N], fp32 for stable ranking
+
+    mask_dev = mask.to(device=pred.device).bool()
+    per_point_loss = per_point_loss.masked_fill(~mask_dev, float("-inf"))
+
+    valid_counts = mask_dev.float().sum(dim=1)  # [B]
+    k = max(min_k, int(ohem_ratio * per_point_loss.shape[1]))
+    k = min(k, int(valid_counts.min().item()))
+    k = max(k, 1)
+
+    _, hard_indices = per_point_loss.topk(k, dim=1, largest=True, sorted=False)
+    idx_expanded = hard_indices.unsqueeze(-1).expand(-1, -1, pred.shape[-1])
+    hard_sq_err = sq_err.gather(1, idx_expanded.to(dtype=torch.long))  # [B, k, C]
+
+    if channel_weights is not None:
+        weights_dev = channel_weights.to(device=pred.device, dtype=hard_sq_err.dtype)
+        hard_sq_err = hard_sq_err * weights_dev.unsqueeze(0).unsqueeze(0)
+
+    return hard_sq_err.mean()
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**Online Hard Example Mining (OHEM) applied to surface point-level WSS loss will force the model to focus gradient budget on spatially-hard regions (flow separation zones, A-pillars, wheel arches, rear wake), reducing τ_y and τ_z error.**

Current surface loss averages L2 error uniformly across all ~65k surface points. However, the hardest WSS points — the ones driving our 6.727% test_WSS — are concentrated in ~10–20% of the surface. Uniform averaging gives them disproportionately weak gradient signal. OHEM selects the top-K% hardest points each step and adds a supplementary loss term to amplify gradient from those regions.

**Formulation (supplementary, not replacement):**
```
L_total = L_all + 0.5 * L_hard_top20pct
```
All points still receive gradient from `L_all`. The `L_hard_top20pct` term adds extra pressure on the 20% hardest surface points. λ=0.5 keeps the supplementary term from dominating.

**Key design choices vs PR #509 (bengio-era OHEM, closed without merge):**
- K=20% (not 50%) — more aggressive focus on truly hard regions
- Supplementary formulation (not replacement) — avoids training instability from dropping 50% of points
- 2-epoch warmup (not 0) — model needs to calibrate its error distribution before OHEM is meaningful
- Tay 13-epoch schedule, 5L/512d/4H, STRING-sep, Lion optimizer (completely different from PR #509 bengio recipe)
- OHEM is NOT in the current codebase — you must implement from scratch

**Why OHEM now?** Analysis of PR #1102 ensemble shows test_tau_z=8.26% is the dominant WSS axis failure. Per-point error is spatially concentrated. Uniform averaging means these hard points are overwhelmed by ~80% of easy laminar-flow surface points that are already well-fit.

---

## Implementation Instructions

### Step 1: Add CLI flags to `train.py`

Add these three arguments in the argparse section (near the existing `--surface-loss-weight` flag):

```python
parser.add_argument("--ohem-surface-ratio", type=float, default=1.0,
    help="Top-K fraction of hardest surface points for supplementary OHEM loss. "
         "1.0 = disabled (default). 0.20 = top-20%% hardest points.")
parser.add_argument("--ohem-warmup-epochs", type=int, default=0,
    help="Number of epochs before OHEM activates. During warmup OHEM contribution = 0.")
parser.add_argument("--ohem-min-k", type=int, default=100,
    help="Minimum number of hard points to select per sample (floor). "
         "Prevents degenerate selection at small batch sizes.")
```

### Step 2: Add OHEM loss function to `trainer_runtime.py`

Add the following function after the existing `weighted_channel_mse` function:

```python
def ohem_supplementary_loss(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    ohem_ratio: float,
    min_k: int = 100,
    channel_weights: torch.Tensor | None = None,
) -> torch.Tensor:
    """Compute supplementary OHEM surface loss over top-K% hardest points.

    Args:
        pred: [B, N, C] surface predictions
        target: [B, N, C] surface targets
        mask: [B, N] boolean mask (True = valid point)
        ohem_ratio: fraction of points to select as hard (e.g. 0.20)
        min_k: minimum hard points per sample regardless of ratio
        channel_weights: [C] per-channel weights (optional)

    Returns:
        Scalar supplementary loss over hard points only.
    """
    sq_err = (pred - target).square()  # [B, N, C]

    # Per-point scalar loss for ranking — use fp32 for numerical stability
    per_point_loss = sq_err.mean(dim=-1).float()  # [B, N]

    # Mask out invalid points so they cannot be selected
    mask_dev = mask.to(device=pred.device)
    per_point_loss = per_point_loss.masked_fill(~mask_dev, float('-inf'))

    # Compute k: ratio of total points, floored at min_k, capped at min valid count
    valid_counts = mask_dev.float().sum(dim=1)  # [B]
    k = max(min_k, int(ohem_ratio * per_point_loss.shape[1]))
    k = min(k, int(valid_counts.min().item()))
    k = max(k, 1)

    # Select top-k hardest indices per sample
    _, hard_indices = per_point_loss.topk(k, dim=1, largest=True, sorted=False)
    # hard_indices: [B, k]

    # Gather hard sq_err
    idx_expanded = hard_indices.unsqueeze(-1).expand(-1, -1, pred.shape[-1])
    hard_sq_err = sq_err.gather(1, idx_expanded.to(dtype=torch.long))  # [B, k, C]

    # Apply channel weights if provided
    if channel_weights is not None:
        weights_dev = channel_weights.to(device=pred.device, dtype=pred.dtype)
        hard_sq_err = hard_sq_err * weights_dev.unsqueeze(0).unsqueeze(0)

    return hard_sq_err.mean()
```

### Step 3: Modify `train_loss()` in `train.py`

**3a. Update the function signature** to accept ohem parameters:

```python
def train_loss(
    model: nn.Module,
    batch,
    transform: TargetTransform,
    device: torch.device,
    amp_mode: str,
    *,
    surface_loss_weight: float = 1.0,
    volume_loss_weight: float = 1.0,
    surface_channel_weights: torch.Tensor | None = None,
    ohem_surface_ratio: float = 1.0,        # NEW
    ohem_warmup_active: bool = False,        # NEW: True = still in warmup, OHEM disabled
    ohem_min_k: int = 100,                   # NEW
    ohem_lambda: float = 0.5,               # NEW: weight on supplementary term
) -> tuple[torch.Tensor, dict[str, float]]:
```

**3b. After the existing surface/volume loss, add the OHEM supplementary term.** Find the block where `loss = weighted_surface_loss + weighted_volume_loss` is computed and extend it:

```python
            # ... existing surface_loss and volume_loss computation unchanged ...

            # OHEM supplementary term
            ohem_active = (ohem_surface_ratio < 1.0) and (not ohem_warmup_active)
            if ohem_active:
                ohem_loss = ohem_supplementary_loss(
                    pred=out["surface_preds"],
                    target=surface_target,
                    mask=batch.surface_mask,
                    ohem_ratio=ohem_surface_ratio,
                    min_k=ohem_min_k,
                    channel_weights=surface_channel_weights,
                )
                ohem_contribution = ohem_lambda * ohem_loss
            else:
                ohem_loss = torch.zeros(1, device=device)
                ohem_contribution = torch.zeros(1, device=device)

            weighted_surface_loss = surface_loss_weight * surface_loss
            weighted_volume_loss = volume_loss_weight * volume_loss
            loss = weighted_surface_loss + weighted_volume_loss + ohem_contribution
            base_mse_loss = surface_loss + volume_loss
```

**3c. Add OHEM diagnostics** to the metrics dict before the return:

```python
    metrics["train/ohem/active"] = float(ohem_active)
    metrics["train/ohem/in_warmup"] = float(ohem_warmup_active)
    metrics["train/ohem/hard_loss"] = ohem_loss.item()
    metrics["train/ohem/lambda_contribution"] = ohem_contribution.item()
```

### Step 4: Thread ohem args through training loop call sites

In the main training loop where `train_loss` is called, compute the warmup flag from epoch count and pass all args:

```python
ohem_warmup_active = (args.ohem_warmup_epochs > 0) and (epoch < args.ohem_warmup_epochs)

loss_val, step_metrics = train_loss(
    model, batch, transform, device, amp_mode,
    surface_loss_weight=args.surface_loss_weight,
    volume_loss_weight=args.volume_loss_weight,
    surface_channel_weights=surface_channel_weights,  # existing
    ohem_surface_ratio=args.ohem_surface_ratio,
    ohem_warmup_active=ohem_warmup_active,
    ohem_min_k=args.ohem_min_k,
    ohem_lambda=0.5,
)
```

If there is a separate GradNorm training path (look for `use_gradnorm`), apply the same `ohem_warmup_active` logic there too.

---

## Run Command

```bash
cd target/ && torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --optimizer lion \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --use-ema \
  --ema-decay 0.999 \
  --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 \
  --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --batch-size 4 \
  --validation-every 1 \
  --train-surface-points 65536 \
  --eval-surface-points 65536 \
  --train-volume-points 65536 \
  --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --ohem-surface-ratio 0.20 \
  --ohem-warmup-epochs 2 \
  --ohem-min-k 100 \
  --wandb-group tay-wave28-ohem \
  --wandb-name askeladd/ohem-surface-top20pct
```

**IMPORTANT:** Do NOT add `--sdf-importance-sampling` or `--sdf-alpha` — those flags do not exist on the tay branch and will crash argparse.

---

## EP3 Gate (kill threshold)

Check at end of epoch 3:

| Condition | Decision |
|-----------|----------|
| val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5% | **PASS** — continue to EP10 |
| val_abupt ≤ 7.6% AND val_vol_p ≤ 5.0% | **MARGINAL** — continue but monitor closely |
| val_abupt > 7.6% OR val_vol_p > 5.0% | **KILL** — stop and report immediately |

**EP10 gate:** val_abupt ≤ 6.5% → PASS; ≤ 6.7% → MARGINAL; > 6.7% → KILL.

Also monitor `train/ohem/hard_loss` from EP3 onwards — if it diverges (>10× initial value) at the same time as `train/loss` spikes, kill and report. Do not wait for EP3 if training loss is clearly diverging.

---

## Win Criteria

A result qualifies as a new pool member if:
- test_WSS ≤ 6.50% AND
- test_vol_p ≤ 3.643% AND
- test_SP ≤ 3.577% AND
- val_abupt ≤ 6.20%

---

## Baseline Metrics (target to beat)

| Metric | Current SOTA (PR #972) |
|--------|------------------------|
| val_abupt | ~6.10% |
| test_abupt | 5.844% |
| test_vol_p | **3.643%** (must not exceed) |
| test_SP | **3.577%** (must not exceed) |
| test_WSS | **6.727%** ← primary target |
| test_tau_z | ~8.26% (worst axis, main bottleneck) |

---

## Reporting

After each epoch, report the full val breakdown:
- val_abupt, val_vol_p, val_SP, val_tau_y, val_tau_z
- train/ohem/hard_loss, train/ohem/active, train/ohem/in_warmup (report from EP1)

At run completion, include the terminal SENPAI-RESULT marker:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_pct","value":<number>},"test_metric":{"name":"test_WSS_pct","value":<number>}}
```

---

## Background & Prior Art

- **PR #509 (bengio branch, closed 2026-05-13, never merged):** Norman's OHEM on a 5L/256d FourierPE recipe. Key lessons: use fp32 for topk ranking, add `--ohem-min-k` floor, log diagnostics from step 1. That PR used K=50% replacement formulation — we are using K=20% supplementary instead.
- **Wave 27 lesson:** Loss function changes that create conflicting gradient objectives destabilize Transolver rapidly. The supplementary formulation preserves stable gradient signal from all points while adding focus on hard ones.
- **τ_z bottleneck:** test_tau_z=8.26% in the best ensemble (PR #1102). OHEM targets the spatially concentrated hard regions that drive this metric.