### PR TITLE
frieren: WSS magnitude + direction decomposition heads (supplementary additive)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-14 (latest invocation: 2026-05-14 ~15:15 UTC)
+- **Date:** 2026-05-14 (latest invocation: 2026-05-14 ~15:45 UTC)
 - **Branch:** tay
 - **W&B project:** wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
 
@@ -117,10 +117,14 @@ All 4 Wave 27 PRs failed at EP3 with val_abupt 27–32% (4× above gate). See Wa
 |----|---------|------------|--------|
 | **#1109** | edward | **τ_z focal loss α=2.0** (upweight hard high-shear surface points via focal modulation) | EP3 gate pending |
 
-### Wave 28 — launched 2026-05-14 ~15:00Z
+### Wave 28 — launched 2026-05-14 ~15:00Z–15:45Z
 | PR | Student | Hypothesis | Status |
 |----|---------|------------|--------|
 | **#1110** | askeladd | **OHEM surface top-20% mining** — supplementary loss `L += 0.5 × L_hard_top20pct`; 2-ep warmup | Assigned; training not yet started |
+| **#1111** | fern | **GradNorm + vol-curriculum (curriculum-compatible)** — adaptive task balancing with schedule intact; freeze-guard at EP3/EP6/EP9; `--use-gradnorm --gradnorm-alpha 0.12` | Assigned; training not yet started |
+| **#1112** | frieren | **WSS magnitude + direction decomposition heads (supplementary additive)** — `log(1+‖τ‖)` mag loss + cosine dir loss; λ_mag=0.1, λ_dir=0.05; never replaces base MSE | Assigned; training not yet started |
+| **#1113** | nezuko | **SDF-stratified curvature-weighted surface sampling** — oversample high-curvature / high-WSS surface regions; `--surface-importance-alpha 3.0 --surface-importance-mode curvature` | Assigned; training not yet started |
+| **#1114** | tanjiro | **Learnable WSS channel loss weights** — learn w_x, w_y, w_z jointly with model (not fixed 1.5/2.0); softplus-parameterised; LR=1e-3 weight group; targets tau_z | Assigned; training not yet started |
 
 ---
 
@@ -183,16 +187,17 @@ The PR #972 single-model SOTA W&B run `56bcqp3m` was trained with SDF-stratified
 
 ## Next-Wave Hypothesis Queue
 
-Wave 28 #1 is NOW IN FLIGHT (askeladd PR #1110). Remaining queue ordered by expected WSS impact + low complexity:
+Wave 28 is FULLY IN FLIGHT (PRs #1110–#1114, all 5 students). All 5 Wave 28 ideas have been assigned. Remaining queue for Wave 29:
 
 1. ~~**OHEM hard-example mining for high-WSS regions**~~ — **IN FLIGHT as PR #1110** (askeladd, Wave 28)
-2. **GradNorm + curriculum + freeze-on-transitions** — nezuko's PR #1095 follow-up #1; unify cheap-early-epochs advantage with adaptive task balancing; this time use curriculum-compatible vol schedule.
-3. **WSS magnitude + direction decomposition heads** — separate magnitude scalar head + 3-direction L2-normalised head, MSE on log(1+|τ|) + cosine loss on direction; must NOT replace base MSE loss (Wave 27 lesson: supplement, never replace).
-4. **SDF-stratified SURFACE sampling** — analogous to PR #972 vol-side, oversample high-curvature / high-WSS surface regions; could directly target tau_z at separation points.
-5. **Learnable WSS channel loss weights** — learn `w_x, w_y, w_z` jointly with model (not fixed 1.5/2.0); backprop through weights; targets tau_z systematically.
+2. ~~**GradNorm + curriculum + freeze-on-transitions**~~ — **IN FLIGHT as PR #1111** (fern, Wave 28)
+3. ~~**WSS magnitude + direction decomposition heads**~~ — **IN FLIGHT as PR #1112** (frieren, Wave 28)
+4. ~~**SDF-stratified SURFACE sampling**~~ — **IN FLIGHT as PR #1113** (nezuko, Wave 28)
+5. ~~**Learnable WSS channel loss weights**~~ — **IN FLIGHT as PR #1114** (tanjiro, Wave 28)
 6. **Multi-scale surface attention** — second surface encoder at 0.5× token density to capture macro-flow features.
 7. **WSS-loss-aware EMA half-life** — vary `--ema-decay` so EMA captures late-training WSS-specialised weights better.
 8. **Heteroscedastic WSS loss** — model both mean and variance per surface point; downweight high-aleatoric regions.
+9. **τ_z frequency analysis** — Fourier decompose tau_z predictions vs GT to find spatial frequency bands where error is concentrated; use to motivate loss or architecture changes.
 
 ⚠️ Hypotheses #6-#8 from Wave 27 are **permanently retired** (yaw aug, magnitude penalty, rel_l2, normal-frame rotation all demonstrated catastrophic failure). Do not reassign.
 

--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_decomp_lambda_mag: float = 0.0
+    wss_decomp_lambda_dir: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +232,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "wss_decomp_lambda_mag": (
+            "Supplementary additive WSS magnitude head weight (PR #1112). "
+            "When > 0, adds lambda_mag * MSE(log1p(||tau_pred||), "
+            "log1p(||tau_gt||)) to the total loss. ||tau|| is the L2 norm "
+            "of the 3-vector WSS prediction, computed in PHYSICAL "
+            "(denormalised) space so the log1p magnitude reflects physical "
+            "Pa and is not distorted by per-channel standardisation. The "
+            "base weighted_channel_mse loss is preserved (NEVER replaced) "
+            "— this is strictly an additive supervision signal targeting "
+            "the magnitude scalar that carries 91-96%% of remaining WSS "
+            "residual (PR #1097 finding). Recommended initial 0.1; "
+            "reduce to 0.05 if val_abupt rises at EP3."
+        ),
+        "wss_decomp_lambda_dir": (
+            "Supplementary additive WSS direction head weight (PR #1112). "
+            "When > 0, adds lambda_dir * (1 - cos_sim(tau_hat_pred, "
+            "tau_hat_gt)) per valid point, with tau_hat = tau / "
+            "max(||tau||, 1e-3) (Wave 27 safeguard against garbage "
+            "gradients in near-zero WSS zones). Computed in PHYSICAL "
+            "space. Provides scale-invariant direction signal in "
+            "low-magnitude regions where plain MSE vanishes — useful "
+            "for vortex/separation identification. Recommended 0.05."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -321,6 +347,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_decomp_lambda_mag: float = 0.0,
+    wss_decomp_lambda_dir: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,26 +360,71 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred = out["surface_preds"]
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_pred,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+    extra_metrics: dict[str, float] = {}
+    if wss_decomp_lambda_mag > 0.0 or wss_decomp_lambda_dir > 0.0:
+        # WSS magnitude + direction decomposition heads (PR #1112). Compute in
+        # PHYSICAL (denormalised) Pa so the log1p magnitude reflects physical
+        # range and the cosine angle is not distorted by per-channel std
+        # rotation (tau_x, tau_y, tau_z have different stds in normalizers).
+        # Upcast to float32 outside the autocast block — bf16 norm/log1p loses
+        # precision on small WSS values and is the only ~free safety move.
+        tau_pred_phys = transform.invert_surface(surface_pred.float())[..., 1:4]
+        tau_gt_phys = transform.invert_surface(surface_target.float())[..., 1:4]
+        mask_f = batch.surface_mask.to(device=tau_pred_phys.device, dtype=torch.float32)
+        mag_pred = torch.linalg.vector_norm(tau_pred_phys, dim=-1)
+        mag_gt = torch.linalg.vector_norm(tau_gt_phys, dim=-1)
+        # Magnitude term: MSE on log1p of physical magnitudes (compresses the
+        # ~3-orders-of-magnitude WSS range so high-tau regions stop dominating).
+        log_mag_sq_err = (torch.log1p(mag_pred) - torch.log1p(mag_gt)).square()
+        mag_loss = masked_mean(log_mag_sq_err, mask_f)
+        # Direction term: 1 - cos_sim with eps=1e-3 floor on the denominator
+        # (Wave 27 safeguard — eps suppresses garbage-direction gradients from
+        # essentially-zero WSS points without weighting them out entirely).
+        eps_dir = 1e-3
+        tau_pred_hat = tau_pred_phys / mag_pred.unsqueeze(-1).clamp_min(eps_dir)
+        tau_gt_hat = tau_gt_phys / mag_gt.unsqueeze(-1).clamp_min(eps_dir)
+        cos_sim = (tau_pred_hat * tau_gt_hat).sum(dim=-1)
+        dir_loss = masked_mean(1.0 - cos_sim, mask_f)
+
+        weighted_mag = wss_decomp_lambda_mag * mag_loss
+        weighted_dir = wss_decomp_lambda_dir * dir_loss
+        loss = loss + weighted_mag.to(loss.dtype) + weighted_dir.to(loss.dtype)
+
+        extra_metrics["wss_decomp_mag_loss"] = float(mag_loss.detach().cpu().item())
+        extra_metrics["wss_decomp_dir_loss"] = float(dir_loss.detach().cpu().item())
+        extra_metrics["wss_decomp_mag_loss_weighted"] = float(weighted_mag.detach().cpu().item())
+        extra_metrics["wss_decomp_dir_loss_weighted"] = float(weighted_dir.detach().cpu().item())
+        with torch.no_grad():
+            extra_metrics["wss_decomp_mag_pred_mean"] = float(
+                ((mag_pred * mask_f).sum() / mask_f.sum().clamp_min(1.0)).detach().cpu().item()
+            )
+            extra_metrics["wss_decomp_mag_gt_mean"] = float(
+                ((mag_gt * mask_f).sum() / mask_f.sum().clamp_min(1.0)).detach().cpu().item()
+            )
+
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **extra_metrics,
     }
 
 
@@ -852,6 +925,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.wss_decomp_lambda_mag > 0.0 or config.wss_decomp_lambda_dir > 0.0:
+                print(
+                    f"WSS decomposition heads (PR #1112, supplementary additive): "
+                    f"lambda_mag={config.wss_decomp_lambda_mag} (log1p magnitude in physical Pa), "
+                    f"lambda_dir={config.wss_decomp_lambda_dir} (cos-sim direction with eps=1e-3 floor)."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -1030,6 +1109,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_decomp_lambda_mag=config.wss_decomp_lambda_mag,
+                        wss_decomp_lambda_dir=config.wss_decomp_lambda_dir,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1151,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_decomp_mag_loss" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "train/wss_decomp_mag_loss": batch_loss_metrics["wss_decomp_mag_loss"],
+                                "train/wss_decomp_dir_loss": batch_loss_metrics["wss_decomp_dir_loss"],
+                                "train/wss_decomp_mag_loss_weighted": batch_loss_metrics["wss_decomp_mag_loss_weighted"],
+                                "train/wss_decomp_dir_loss_weighted": batch_loss_metrics["wss_decomp_dir_loss_weighted"],
+                                "train/wss_decomp_mag_pred_mean": batch_loss_metrics["wss_decomp_mag_pred_mean"],
+                                "train/wss_decomp_mag_gt_mean": batch_loss_metrics["wss_decomp_mag_gt_mean"],
+                                "train/wss_decomp_lambda_mag": config.wss_decomp_lambda_mag,
+                                "train/wss_decomp_lambda_dir": config.wss_decomp_lambda_dir,
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**WSS magnitude + direction decomposition heads (supplementary, additive)**

WSS direction is essentially solved — cosine similarity stabilises at 0.996 (~5° angular error) by EP2 (PR #1097 finding). 91–96% of remaining WSS residual is **magnitude error**. This experiment adds a supplementary decomposition loss that explicitly supervises both the magnitude scalar `‖τ‖` and the unit direction vector `τ/‖τ‖` separately.

**Core idea:**
- Supplement the base `weighted_channel_mse` loss with two additive terms
- Magnitude term: MSE on `log(1 + ‖τ‖)` — log-transform compresses the range, prevents large-magnitude points from dominating
- Direction term: cosine similarity on normalised τ vector — direction head provides gradient signal even in low-magnitude regions
- **NEVER replace base MSE loss** — Wave 27 lesson: supplementary/additive only; λ_mag and λ_dir scale these terms ≤ 0.2 to avoid destabilising training

**Why log(1+‖τ‖) for magnitude:**
- WSS magnitude spans ~3 orders of magnitude on a car surface
- Plain MSE magnitude loss would focus entirely on high-τ regions (bumpers, sills, wheel arches)
- Log-transform makes the loss sensitive to relative error across all magnitudes
- Avoids numerical issues (unlike relative L2 which divides by near-zero GT)

**Why cosine loss for direction:**
- Low-magnitude regions have negligible MSE contribution from τ itself
- But direction errors in low-WSS zones can still matter for vortex/separation identification
- Cosine loss is scale-invariant — provides gradient in zero-crossing zones where MSE vanishes

**Wave 27 safeguards applied:**
- Use GT magnitude in the denominator for direction normalisation ONLY with a floor: `τ_hat = τ / max(‖τ‖, ε)` where ε=1e-3
- λ_mag=0.1, λ_dir=0.05 — these are supplementary; if val_abupt rises at EP3, reduce λ_mag to 0.05

---

## Current Baseline

- **Branch:** `tay` (no SDF flags — do NOT add `--sdf-importance-sampling`)
- **Single-model SOTA:** PR #972 — val_abupt=6.126%, test_WSS=6.727%
- **Primary target:** test_WSS ≤ 6.50%
- **Constraints:** test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%

**EP3 Gate (PASS):** val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5%
**EP10 Gate (PASS):** val_abupt ≤ 6.5%

---

## Implementation

### Changes in `trainer_runtime.py`

Add two supplementary loss terms after the main `weighted_channel_mse` call:

```python
# In the loss computation block, after weighted_channel_mse:

# WSS channel indices in your output tensor: tau_x=0, tau_y=1, tau_z=2
# (adjust to actual indices in your implementation)

if cfg.wss_decomp_lambda_mag > 0 or cfg.wss_decomp_lambda_dir > 0:
    # Extract predicted and GT WSS vectors [B, N, 3] (tau_x, tau_y, tau_z)
    tau_pred = pred[..., tau_start:tau_start+3]  # adjust slice indices
    tau_gt = target[..., tau_start:tau_start+3]
    
    # Magnitude term: MSE on log(1 + magnitude)
    mag_pred = torch.norm(tau_pred, dim=-1)  # [B, N]
    mag_gt = torch.norm(tau_gt, dim=-1)      # [B, N]
    log_mag_loss = F.mse_loss(
        torch.log1p(mag_pred) * mask,
        torch.log1p(mag_gt) * mask
    )
    
    # Direction term: 1 - cosine_similarity (in [0,2] range)
    eps_dir = 1e-3
    tau_pred_hat = tau_pred / (mag_pred.unsqueeze(-1).clamp_min(eps_dir))
    tau_gt_hat = tau_gt / (mag_gt.unsqueeze(-1).clamp_min(eps_dir))
    dir_loss = (1.0 - (tau_pred_hat * tau_gt_hat * mask.unsqueeze(-1)).sum(-1)).mean()
    
    total_loss = total_loss + cfg.wss_decomp_lambda_mag * log_mag_loss
    total_loss = total_loss + cfg.wss_decomp_lambda_dir * dir_loss
```

### New CLI Args

```python
wss_decomp_lambda_mag: float = 0.0   # default off
wss_decomp_lambda_dir: float = 0.0   # default off
```

### Training Command

```bash
python train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --wss-decomp-lambda-mag 0.1 --wss-decomp-lambda-dir 0.05 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 30 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb_group wss-decomp-heads
```

---

## EP3 Diagnostic Checkpoint

After epoch 3, post a comment with `val_abupt` and `val_vol_p` from `run.summary`.
- If `val_abupt > 7.6%`, reduce `--wss-decomp-lambda-mag 0.05` and try a fresh run before killing.
- PASS: val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5%

---

## Success Criteria

**WIN:** test_WSS ≤ 6.50% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND val_abupt ≤ 6.20%

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_WSS","value":<number>}}
```

---

student:frieren
