### PR TITLE
[dl24-frieren] WSS H1: wind-exposure geometric proxy (cross-flow attack features)

### DIFF
--- a/train.py
+++ b/train.py
@@ -31,6 +31,9 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+import data.loader as _data_loader
+import trainer_runtime as _trainer_runtime
+from data import SURFACE_X_DIM as DEFAULT_SURFACE_X_DIM
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -61,6 +64,8 @@ from trainer_runtime import (
     timeout_budget_minutes,
     unwrap_model,
 )
+
+WIND_EXPOSURE_EXTRA_CHANNELS = 2  # wind_exposure + abs_cross_normal
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +137,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_wind_exposure_features: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -225,7 +231,11 @@ def per_channel_masked_mse(
 
 
 def build_model(config: Config) -> SurfaceTransolver:
+    surface_input_dim = DEFAULT_SURFACE_X_DIM
+    if config.use_wind_exposure_features:
+        surface_input_dim = DEFAULT_SURFACE_X_DIM + WIND_EXPOSURE_EXTRA_CHANNELS
     return SurfaceTransolver(
+        surface_input_dim=surface_input_dim,
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
         dropout=config.model_dropout,
@@ -259,6 +269,114 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     raise ValueError(
         f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
     )
+
+
+_wind_exposure_first_batch_logged = False
+
+
+def _wind_exposure_features(surface_x: torch.Tensor) -> torch.Tensor:
+    """Compute [wind_exposure, abs_cross_normal] from surface_x[..., 3:5] (nx, ny).
+
+    surface_x: (..., 7) feature tensor laid out [x, y, z, nx, ny, nz, area].
+    Returns: (..., 2) tensor concatenating
+        wind_exposure   = max(0, -nx)   one-sided freestream attack
+        abs_cross_normal = |ny|         cross-flow exposure
+    Both are invariant under y-reflection (max(0,-nx) depends only on nx; |-ny|=|ny|).
+    """
+    nx = surface_x[..., 3:4]
+    ny = surface_x[..., 4:5]
+    wind_exposure = torch.clamp(-nx, min=0.0)
+    abs_cross_normal = torch.abs(ny)
+    return torch.cat([wind_exposure, abs_cross_normal], dim=-1)
+
+
+def _wind_exposure_pad_collate(samples):
+    """pad_collate wrapper that appends wind-exposure channels to surface_x.
+
+    The original pad_collate produces surface_x of shape [B, N, 7] with padded
+    rows zeroed. Padded rows have nx=ny=0, so the new channels are 0 there.
+    Surface mask is unchanged.
+    """
+    batch = _data_loader.pad_collate(samples)
+    extra = _wind_exposure_features(batch.surface_x)
+    batch.surface_x = torch.cat([batch.surface_x, extra], dim=-1)
+    return batch
+
+
+def maybe_install_wind_exposure_collate(config: Config) -> None:
+    """If wind-exposure features are enabled, patch trainer_runtime.pad_collate."""
+    if not config.use_wind_exposure_features:
+        return
+    _trainer_runtime.pad_collate = _wind_exposure_pad_collate
+
+
+def log_wind_exposure_sanity(
+    batch, *, is_main: bool, state_enabled: bool, run
+) -> None:
+    """One-shot diagnostic on the first batch: range/mean of new channels."""
+    global _wind_exposure_first_batch_logged
+    if _wind_exposure_first_batch_logged or not is_main:
+        return
+    _wind_exposure_first_batch_logged = True
+    mask = batch.surface_mask.bool()
+    if not mask.any():
+        return
+    surface_x = batch.surface_x
+    valid = surface_x[mask]  # [Nvalid, C]
+    if valid.shape[-1] < 9:
+        return
+    we = valid[:, 7].float()
+    ac = valid[:, 8].float()
+    we_min = float(we.min().item())
+    we_max = float(we.max().item())
+    we_mean = float(we.mean().item())
+    ac_min = float(ac.min().item())
+    ac_max = float(ac.max().item())
+    ac_mean = float(ac.mean().item())
+    nx = valid[:, 3].float()
+    ny = valid[:, 4].float()
+    nz = valid[:, 5].float()
+    norm_sq = (nx * nx + ny * ny + nz * nz)
+    norm_mean = float(norm_sq.sqrt().mean().item())
+    line = (
+        "[wind-exposure] EP0 step0: "
+        f"wind_exposure min={we_min:.4f} max={we_max:.4f} mean={we_mean:.4f}; "
+        f"abs_cross_normal min={ac_min:.4f} max={ac_max:.4f} mean={ac_mean:.4f}; "
+        f"||normal||_2 mean={norm_mean:.4f} (unit normals expect ~1.0)"
+    )
+    try:
+        tqdm.write(line)
+    except Exception:
+        print(line)
+    in_range = (
+        we_min >= 0.0 and we_max <= 1.0 + 1e-4
+        and ac_min >= 0.0 and ac_max <= 1.0 + 1e-4
+    )
+    if not in_range:
+        warn_msg = (
+            "[wind-exposure] WARNING: feature values outside [0, 1]; "
+            "normals likely not unit length"
+        )
+        try:
+            tqdm.write(warn_msg)
+        except Exception:
+            print(warn_msg)
+    if run is not None:
+        try:
+            wandb.log(
+                {
+                    "wind_exposure/init/wind_exposure_min": we_min,
+                    "wind_exposure/init/wind_exposure_max": we_max,
+                    "wind_exposure/init/wind_exposure_mean": we_mean,
+                    "wind_exposure/init/abs_cross_normal_min": ac_min,
+                    "wind_exposure/init/abs_cross_normal_max": ac_max,
+                    "wind_exposure/init/abs_cross_normal_mean": ac_mean,
+                    "wind_exposure/init/normal_norm_mean": norm_mean,
+                    "wind_exposure/init/values_in_unit_range": float(in_range),
+                }
+            )
+        except Exception:
+            pass
 
 
 def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
@@ -434,6 +552,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        maybe_install_wind_exposure_collate(config)
         if config.eval_only:
             run_eval_only(config, state)
             return
@@ -471,7 +590,11 @@ def main(argv: Iterable[str] | None = None) -> None:
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:
-            print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+            print(
+                f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params) "
+                f"surface_input_dim={base_model.surface_input_dim} "
+                f"wind_exposure_features={'on' if config.use_wind_exposure_features else 'off'}"
+            )
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
@@ -570,6 +693,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                if config.use_wind_exposure_features and epoch == 0 and global_step == 0:
+                    log_wind_exposure_sanity(
+                        batch,
+                        is_main=state.is_main,
+                        state_enabled=state.enabled,
+                        run=run,
+                    )
                 aug_log: dict[str, int] = {}
                 loss, batch_loss_metrics, task_losses = train_loss(
                     model,


### PR DESCRIPTION
## Hypothesis

**Wind-exposure geometric proxy: 2 extra surface input channels targeting tau_y/tau_z cross-flow shear gap**

The current 7-channel surface input `[x, y, z, nx, ny, nz, area]` has no explicit signal about how each surface element is oriented relative to the **freestream wind direction** (-X axis). Yet the WSS error is almost entirely in the cross-flow components: tau_y and tau_z account for ~80% of the total wall-shear error (tau_y ≈ 7.9%, tau_z ≈ 9.5% vs tau_x ≈ 6.5%). These large errors concentrate at swept surfaces, A-pillars, underbody transitions, and rear diffuser — precisely where the inflow angle is **oblique** to the surface normal.

We add two zero-cost scalar channels computed from the existing normals at data-load time:

1. **`wind_exposure` = `max(0, -nx)`** — one-sided freestream attack: equals 1 on blunt frontal faces (low WSS, stagnation), 0 on side/underbody/rear. This is a **nonlinear** function of nx (the clamp at 0 makes it structurally distinct from passing nx directly). Encodes "how directly does freestream hit this element?"

2. **`abs_cross_normal` = `|ny|`** — absolute cross-flow exposure: peaks on lateral side panels and underbody edges where tau_y/tau_z are steepest. Not algebraically equivalent to ny (absolute value is a new transformation). Encodes "how exposed is this element to cross-flow gradients?"

These two features are the most direct geometric priors the model is currently missing. They are:
- **Zero training cost** — computed at data-load time from existing normals
- **Architecture-neutral** — additive to the embedding layer, no structural change
- **Loss-neutral** — no modification to MSE objective (addresses the Wave 27 failure mode: conflicts from loss reformulation)
- **Physically valid** — no rotation, no augmentation change, wind direction preserved

**Root cause:** tau_y/tau_z gap is driven by the model not having explicit signal about cross-flow attack geometry. This is the lightest-weight fix before trying heavier curvature features or architectural cross-attention changes.

## Instructions

### 1. Modify `train.py` (or `dataset.py`) to compute and append the 2 new features

Add this function and call it during surface point feature construction:

```python
import numpy as np

def add_wind_exposure_features(surface_xyz: np.ndarray,
                                surface_normals: np.ndarray) -> np.ndarray:
    """
    Compute 2 extra wind-exposure features from surface normals.
    surface_normals: (N, 3) array of [nx, ny, nz] per surface point.
    Returns: (N, 2) array of [wind_exposure, abs_cross_normal]
    """
    nx = surface_normals[:, 0]   # x-component (aligned with freestream axis)
    ny = surface_normals[:, 1]   # y-component (cross-flow)
    
    # Feature 1: one-sided freestream attack angle (nonlinear in nx)
    wind_exposure = np.maximum(0.0, -nx)   # 1.0 on nose, 0.0 on sides/rear
    
    # Feature 2: absolute cross-flow exposure (nonlinear in ny)
    abs_cross_normal = np.abs(ny)           # peaks on lateral panels
    
    return np.stack([wind_exposure, abs_cross_normal], axis=1)  # (N, 2)
```

Then append these 2 columns to your surface feature matrix before constructing the input tensor. The surface input becomes **9-channel**: `[x, y, z, nx, ny, nz, area, wind_exposure, abs_cross_normal]`.

Make sure:
- The 2 new channels go through the **same normalization** as the other surface channels (standardize per-channel across the training set, or use the running stats from your existing normalizer — confirm the normalizer is applied to them).
- Confirm the model's surface input embedding layer handles the new input width automatically (most implementations use a linear projection from `in_channels` — just ensure `in_channels=9` is either set by config or inferred dynamically from the data tensor width).

### 2. Confirm feature values make sense at EP0

Before launching the full run, add a debug assert or a W&B histogram check at step 0:
```python
# Sanity: wind_exposure in [0, 1], abs_cross_normal in [0, 1]
assert np.all(wind_exposure >= 0.0) and np.all(wind_exposure <= 1.0)
assert np.all(abs_cross_normal >= 0.0) and np.all(abs_cross_normal <= 1.0)
```
If any values fall outside `[0, 1]` it means the normals are not unit-normalized — clamp or re-normalize before use.

### 3. Run command (all other params identical to PR #972 baseline)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --ema-decay 0.999 --ema-start-step 5000 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --surface-input-channels 9 \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h1-wind-exposure-proxy \
  --wandb-name "dl24-frieren/wss-wind-exposure-proxy" \
  --agent dl24-frieren
```

> **Key difference from baseline:** `--surface-input-channels 9` (was 7). If your model infers input width from data, this flag may not be needed — confirm.

### 4. Primary metric to watch: `val_primary/wall_shear_rel_l2_pct`

The goal is to see **val_wss decrease** faster or to a lower floor than the PR #972 baseline (which settled at ~6.9-7.1% val_wss across EP10-30). A strong signal would be val_wss < 6.8% by EP10. Keep an eye on vol_p and surf_p to confirm they don't degrade.

## Gate schedule

| Gate | val_abupt threshold | val_wss threshold | val_vol_p threshold | Action |
|------|--------------------:|------------------:|-------------------:|--------|
| EP3  | ≤ 7.5%             | ≤ 7.5%            | ≤ 5.5%             | Kill if over |
| EP6  | ≤ 7.0%             | ≤ 7.2%            | ≤ 4.8%             | Kill if over |
| EP10 | ≤ 6.6%             | ≤ 7.0%            | ≤ 4.5%             | Kill if over |
| EP15 | ≤ 6.4%             | ≤ 6.9%            | ≤ 4.3%             | Kill if over |
| EP20 | ≤ 6.3%             | ≤ 6.75%           | ≤ 4.2%             | Kill if over |
| EP25 | ≤ 6.25%            | ≤ 6.65%           | ≤ 4.1%             | Kill if over |
| EP30 | —                  | target < 6.5%     | ≤ 3.75%            | Terminal eval |

At each gate, post a comment with: EP<N> gate: val_abupt=X%, val_wss=X%, val_vol_p=X%, val_surf_p=X% [PASS/FAIL]

## Terminal evaluation

At EP30 (or from best-val checkpoint if training diverges late):

1. Run test evaluation with `eval_surface_points=65536`, `eval_volume_points=65536`
2. Post results as a comment on this PR
3. Post the SENPAI-RESULT marker before flipping the label to review:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val-number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-number>}}
```

## Baseline

Current corrected-split SOTA (rawcanon_20260511) — all new experiments must beat this:

| Metric | Value | W&B Run |
|--------|-------|---------|
| test_abupt | **5.844%** | PR #972 `56bcqp3m` / eval `zxnhtagj` |
| test_surf_p | 3.577% | |
| test_vol_p | **3.643%** | **floor: must not exceed** |
| test_wss   | 6.727% | **primary target: beat this** |

**New directive (Issue #1056):** test_wss must reach **< 5.85%** (Transolver-3 SOTA). The next immediate milestone is test_wss < 6.5% (≈ 3.3% relative improvement). Floors: test_vol_p ≤ 3.643% and test_surf_p ≤ 3.577% must be held.

## Why this is safe (Wave 27 lessons)

The other advisor's Wave 27 (May 14) failed catastrophically on 4/4 WSS experiments:
- L1 magnitude penalty → conflicting gradients, destabilized from EP1
- Relative L2 loss → numeric explosion near zero
- Normal-frame rotation → corrupted geometry signal
- Yaw augmentation → invalid physics (fixed wind direction)

This H1 experiment **avoids all four failure modes**: additive input only, no loss change, no feature rotation, no augmentation change. These features are a direct geometric prior, not a loss reformulation.
