### PR TITLE
Per-channel WSS output heads (decouple tau_z from shared head)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_per_channel_surface_heads: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_per_channel_surface_heads = use_per_channel_surface_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,12 +483,35 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if use_per_channel_surface_heads:
+                # PR #1116: replace the single shared surface MLP head with
+                # surface_output_dim independent MLP heads (one per output
+                # channel). Each head matches the original 2-layer MLP shape
+                # (Linear -> SiLU -> Linear) but emits a single channel. The
+                # encoder features are shared; only the final projection is
+                # decoupled, which removes head-level gradient interference
+                # between cp/tau_x/tau_y/tau_z and lets each channel learn
+                # a channel-specific projection.
+                self.surface_out = None
+                self.surface_heads = nn.ModuleList(
+                    [
+                        nn.Sequential(
+                            nn.Linear(n_hidden, n_hidden),
+                            nn.SiLU(),
+                            nn.Linear(n_hidden, 1),
+                        )
+                        for _ in range(self.surface_output_dim)
+                    ]
+                )
+                self.surface_heads.apply(_init_linear)
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
+                self.surface_heads = None
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),
@@ -496,7 +521,16 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            if use_per_channel_surface_heads:
+                # Per-channel linear projections to mirror the LinearProjection
+                # baseline (older checkpoint compatibility path).
+                self.surface_out = None
+                self.surface_heads = nn.ModuleList(
+                    [LinearProjection(n_hidden, 1) for _ in range(self.surface_output_dim)]
+                )
+            else:
+                self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+                self.surface_heads = None
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
@@ -622,7 +656,12 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_per_channel_surface_heads:
+                surface_preds = torch.cat(
+                    [head(surface_hidden) for head in self.surface_heads], dim=-1
+                ) * surface_mask.unsqueeze(-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_per_channel_surface_heads: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_per_channel_surface_heads": (
+            "PR #1116: replace the single shared surface MLP head with "
+            "surface_output_dim independent MLP heads (one per channel: "
+            "p, tau_x, tau_y, tau_z). Each head matches the baseline "
+            "two-layer SiLU MLP shape (n_hidden -> n_hidden -> 1). The "
+            "shared encoder features are unchanged; only the final "
+            "projection is decoupled, which removes head-level gradient "
+            "interference between channels and lets the hard tau_z axis "
+            "learn a channel-specific projection."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_per_channel_surface_heads=config.use_per_channel_surface_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current architecture has a **single shared surface output head** that produces all four surface channels (`p`, `tau_x`, `tau_y`, `tau_z`) from the same final-layer features. This shared head forces a single feature transformation to serve four channels with very different statistical properties:

- `p` (surface pressure): smooth scalar, low spatial frequency, signal-to-noise ratio high
- `tau_x` (streamwise WSS): well-aligned with mean flow, model already accurate (test_tau_x = 5.61%)
- `tau_y` (transverse WSS): moderate difficulty (test_tau_y = 6.84%)
- `tau_z` (spanwise WSS): **worst axis** (test_tau_z = 8.26%), high spatial frequency, dominant residual

The shared-head hypothesis: a single output projection must compromise across channel-specific feature requirements. The hard tau_z channel may benefit from a deeper / wider / channel-specific transformation that doesn't fit cleanly into a shared-head architecture.

**Per-channel WSS output heads** decouple this constraint: each output channel gets its own small MLP head with independent weights. The same shared encoder features (from the surface-stream final layer) flow through 4 parallel heads. This gives:

1. **Per-channel feature specialization** — each head learns the specific projection that best maps shared features → its channel.
2. **No gradient interference** at the head — gradients from `loss/tau_z` only touch the tau_z head's weights, not the tau_x/y heads' weights.
3. **Optional per-channel depth/width** — once decoupled, we can independently size each head (tau_z deeper, tau_x shallower).

This is **orthogonal** to all Wave 28 experiments:
- alphonse #1078: asymmetric eval resolution (inference-time only — doesn't change architecture)
- thorfinn #1100: capacity uplift via `--model-slices=256` (shared-encoder capacity, not per-head)
- askeladd #1110: OHEM (per-point loss reweighting, not architectural)
- fern #1111: GradNorm (per-task balancing, not architectural)
- frieren #1112: WSS magnitude+direction decomposition (alternative loss, single head still)
- nezuko #1113: SDF-stratified curvature sampling (data distribution, not architectural)
- tanjiro #1114: learnable WSS channel weights (per-channel weighting, not per-channel head)

**Background (recent edward PR closure #1109):** α=2.0 spatial focal loss failed EP3 gate by +1.6pp val_WSS vs baseline (focal loss is not a low-hanging fruit on the tay stack). That experiment redirected gradient *within* the shared head; this one decouples the heads architecturally. The mechanism family is fundamentally different.

**Closest related historical experiments:**
- PR #958 (vol_p aux head): a separate head for an OUT-OF-CHANNEL output (volume pressure). Showed positive effect (added as architectural feature). Confirms per-head decoupling has architectural merit on this benchmark.
- PR #823 (surf→vol xattn): architecture change, best historical per-axis tau_x (5.78%). Architectural changes can move per-axis metrics.

## Instructions

### Step 1 — Implementation

Modify the surface output head in the model definition. The current head is likely a single `nn.Linear(hidden_dim, num_surface_channels)` or a single small MLP. Replace it with `num_surface_channels` separate small MLPs.

**Suggested code change (locate the surface output head in your model file; common name patterns: `surface_head`, `surface_decoder`, `surface_out`, `surface_proj`):**

```python
# OLD (single shared head):
self.surface_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.GELU(),
    nn.Linear(hidden_dim, num_surface_channels),  # outputs 4: p, tau_x, tau_y, tau_z
)
# usage: surface_out = self.surface_head(features)  # [B, N, 4]

# NEW (per-channel heads):
self.num_surface_channels = num_surface_channels  # 4
self.surface_heads = nn.ModuleList([
    nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.GELU(),
        nn.Linear(hidden_dim, 1),  # outputs 1 channel
    )
    for _ in range(num_surface_channels)
])

# usage:
surface_out = torch.cat([head(features) for head in self.surface_heads], dim=-1)  # [B, N, 4]
```

**CRITICAL initialization choice — match the existing single-head Var(output):**

If you replicate the SAME head architecture 4 times, each head's output variance will be similar to a single head's. Initialize each head identically (same Linear init, same activation). This keeps EP0 model behavior near-identical to baseline — only the *gradient flow* changes.

To make the experiment cleanly attributable: **do NOT change head depth or width in this PR**. We are testing the decoupling itself, not capacity. If decoupling alone works, a follow-up PR can independently size the heads.

### Step 2 — CLI flag

Add a flag `--use-per-channel-surface-heads` (default `False`). The new code path only activates when this flag is set, so the baseline behavior is preserved when the flag is absent.

```python
parser.add_argument(
    "--use-per-channel-surface-heads", action="store_true",
    help="Use separate MLP heads per surface output channel (4 heads: p, tau_x, tau_y, tau_z).",
)
```

In the model factory:
```python
if config.use_per_channel_surface_heads:
    self.surface_heads = nn.ModuleList([...])  # 4 separate heads
else:
    self.surface_head = nn.Sequential(...)  # current single head
```

### Step 3 — Smoke test (1-epoch)

Run a 1-epoch debug run first to verify:
- Forward pass shape matches: `surface_out.shape == [B, N, 4]` (same as baseline)
- Parameter count delta: should add ~`4 * hidden_dim * hidden_dim + 4 * hidden_dim * 1` − `hidden_dim * hidden_dim - hidden_dim * 4` ≈ 3× the original head's params (4 heads instead of 1, each producing 1 channel instead of 4). At `hidden_dim=512`, this is roughly +800K params total.
- No NaN/Inf in loss
- Train loss decreases over 1 epoch

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 1 \
  --vol-points-schedule "0:16384" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-per-channel-surface-heads \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group per-channel-heads
```

### Step 4 — Full run (13-epoch tay-stack)

After smoke test PASSES, launch the full run. Same recipe but `--epochs 13` and full vol curriculum:

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent edward --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --use-per-channel-surface-heads \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group per-channel-heads
```

### EP3 Gate (recalibrated for tay — no SDF flags)

- **PASS:** val_abupt ≤ **7.2%** AND val_vol_p ≤ **4.5%** → continue to EP13
- **MARGINAL:** val_abupt ≤ 7.6% AND val_vol_p ≤ 5.0% → continue but flag risk
- **KILL:** otherwise

If EP3 PASSES, the win criterion is the standard issue #1056 single-model target:
- **WSS-targeted single-model win:** test_WSS < 6.727% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND val_abupt ≤ 6.20%

### What to report (in your terminal PR comment)

1. **Smoke test** EP1 val metrics + train loss curve sanity
2. **Full run** epoch-by-epoch val table (val_abupt, val_vol_p, val_WSS, val_SP, val_tau_x, val_tau_y, val_tau_z, train/epoch_loss)
3. **Per-channel gradient norm comparison** if you can log it: are the tau_z head's gradients qualitatively different from tau_x/y? (large vs small? noisier?)
4. **Best-checkpoint test eval** at terminal: test_WSS / test_vol_p / test_SP / test_tau_x/y/z

Include the SENPAI-RESULT marker as usual:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_wss","value":<number>}}
```

## Baseline (current single-model + ensemble SOTA on corrected split)

### Single-model SOTA (PR #972 — what we need to beat for issue #1056 single-model win)
- val_abupt = 6.126%
- val_vol_p = 3.798% | test_vol_p = **3.643%** (constraint boundary)
- val_WSS = ~7.0–7.2% (approximate; not directly in BASELINE.md)
- **test_WSS = 6.727%** (single-model SOTA we beat for a win)
- test_SP = **3.577%** (constraint boundary)
- test_tau_x = ~5.7% | test_tau_y = ~7.0% | test_tau_z = ~9.0–9.5%
- W&B: `56bcqp3m` (PR #972 SDF stack — NOT on tay, recipe differs)

### Live thorfinn #1100 EP12 reference (tay stack, no-SDF, model-slices=256)
- val_abupt = 6.380% | val_vol_p = 3.781% | val_WSS = 7.198% | val_SP = 4.211%
- val_tau_x = 6.258 | val_tau_y = 7.817 | val_tau_z = **9.831**

### Ensemble SOTA (PR #1102 K=8 Caruana — what new pool members aim toward)
- val_abupt = 5.7452% | test_abupt = 5.5196%
- **test_WSS = 6.3263%** | test_vol_p = 3.5397% | test_SP = 3.3529%
- test_tau_x = 5.6071% | test_tau_y = 6.8397% | **test_tau_z = 8.2585%** (worst axis)

### Reproduce baseline (tay stack, single-head)
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --agent <student> --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

(Drop `--use-per-channel-surface-heads` — single-head baseline.)
