### PR TITLE
[dl24-tanjiro] WSS H2: surface curvature features (kappa_H + kappa_G input)

### DIFF
--- a/curvature_stats.json
+++ b/curvature_stats.json
@@ -1,0 +1,10 @@
+{
+  "kappa_v2_log1p_mean": 1.9191299676895142,
+  "kappa_v2_log1p_std": 1.8683401346206665,
+  "kappa_H_signed_log_mean": -0.6570849418640137,
+  "kappa_H_signed_log_std": 2.962175130844116,
+  "kappa_G_signed_log_mean": 0.1050228551030159,
+  "kappa_G_signed_log_std": 4.1630964279174805,
+  "n_train_cases_sampled": 30,
+  "pts_per_case_sampled": 50000
+}

--- a/train.py
+++ b/train.py
@@ -132,6 +132,11 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    # Curvature input features (WSS H2 PR #1117)
+    # Empty string disables; "kappa_HK" loads 3 channels (kappa_v2 + H + K from
+    # cached arrays), "kappa_only" loads 1 channel from surface_kappa_v2.npy.
+    surface_curvature_mode: str = ""
+    surface_input_channels: int = 7
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -235,6 +240,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        surface_input_dim=config.surface_input_channels,
     )
 
 
@@ -524,6 +530,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "pe_source_run_ki2q9ko9": (
                         config.model_pe == "string_multisigma"
                     ),
+                    "surface_curvature_mode": config.surface_curvature_mode or "off",
+                    "surface_input_channels_effective": config.surface_input_channels,
                 },
                 allow_val_change=True,
             )
@@ -570,6 +578,29 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                if state.is_main and epoch == 0 and global_step == 0:
+                    sx = batch.surface_x
+                    sm = batch.surface_mask
+                    if sm.any():
+                        valid = sx[sm]
+                        per_chan = [
+                            (
+                                float(valid[:, c].min().item()),
+                                float(valid[:, c].max().item()),
+                                float(valid[:, c].mean().item()),
+                                float(valid[:, c].std().item()),
+                            )
+                            for c in range(valid.shape[-1])
+                        ]
+                        print(
+                            f"[input debug] EP0 surface_x dim={valid.shape[-1]}; "
+                            f"per-channel [min,max,mean,std]:"
+                        )
+                        for c, stats_c in enumerate(per_chan):
+                            print(
+                                f"  ch{c}: min={stats_c[0]:.3f} max={stats_c[1]:.3f} "
+                                f"mean={stats_c[2]:.3f} std={stats_c[3]:.3f}"
+                            )
                 aug_log: dict[str, int] = {}
                 loss, batch_loss_metrics, task_losses = train_loss(
                     model,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -15,6 +15,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -31,6 +32,7 @@ from data import (
     load_data,
     pad_collate,
 )
+from data.loader import DrivAerMLCase, DrivAerMLCaseStore, DrivAerMLSurfaceDataset
 
 
 class EMA:
@@ -229,10 +231,181 @@ def resolve_num_workers(config) -> int:
     return min(4, os.cpu_count() or 4)
 
 
+def _variable_channel_pad_collate(samples: list) -> SurfaceBatch:
+    """pad_collate variant that infers the channel count from the samples.
+
+    Required because data.pad_collate hard-codes ``SURFACE_X_DIM=7``; when
+    curvature features are appended (going to 8/9/10 channels) the original
+    collate would silently truncate. Otherwise byte-identical behaviour.
+    """
+    if not samples:
+        raise ValueError("pad_collate received an empty batch")
+    max_surface_n = max(sample.surface_x.shape[0] for sample in samples)
+    max_volume_n = max(sample.volume_x.shape[0] for sample in samples)
+    batch_size = len(samples)
+    surface_x_dim = samples[0].surface_x.shape[-1]
+    surface_y_dim = samples[0].surface_y.shape[-1]
+    volume_x_dim = samples[0].volume_x.shape[-1]
+    volume_y_dim = samples[0].volume_y.shape[-1]
+    surface_x = torch.zeros(batch_size, max_surface_n, surface_x_dim, dtype=samples[0].surface_x.dtype)
+    surface_y = torch.zeros(batch_size, max_surface_n, surface_y_dim, dtype=samples[0].surface_y.dtype)
+    surface_mask = torch.zeros(batch_size, max_surface_n, dtype=torch.bool)
+    volume_x = torch.zeros(batch_size, max_volume_n, volume_x_dim, dtype=samples[0].volume_x.dtype)
+    volume_y = torch.zeros(batch_size, max_volume_n, volume_y_dim, dtype=samples[0].volume_y.dtype)
+    volume_mask = torch.zeros(batch_size, max_volume_n, dtype=torch.bool)
+    for i, sample in enumerate(samples):
+        surface_n = sample.surface_x.shape[0]
+        volume_n = sample.volume_x.shape[0]
+        surface_x[i, :surface_n] = sample.surface_x
+        surface_y[i, :surface_n] = sample.surface_y
+        surface_mask[i, :surface_n] = True
+        volume_x[i, :volume_n] = sample.volume_x
+        volume_y[i, :volume_n] = sample.volume_y
+        volume_mask[i, :volume_n] = True
+    return SurfaceBatch(
+        case_ids=[sample.case_id for sample in samples],
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=surface_mask,
+        volume_x=volume_x,
+        volume_y=volume_y,
+        volume_mask=volume_mask,
+        metadata=[dict(sample.metadata) for sample in samples],
+    )
+
+
+class CurvatureAugmentedCaseStore(DrivAerMLCaseStore):
+    """Case store that appends per-vertex curvature features to surface_x.
+
+    Loads pre-computed curvature arrays from each case directory and appends
+    them as additional surface input channels. Designed for the WSS curvature
+    features experiment (PR #1117).
+
+    Channels appended depend on ``mode``:
+      - ``"kappa_HK"``: 3 channels = [log1p(|kappa_v2|), signed_log1p(H), signed_log1p(K)]
+        H and K read from ``curvature_HK_v2.npy`` (falls back to 0 if missing).
+      - ``"kappa_only"``: 1 channel = [log1p(|kappa_v2|)] using ``surface_kappa_v2.npy``
+        which is available for every case.
+
+    Each channel is z-scored using ``stats`` (mean/std measured on a sample of
+    training cases at preprocessing time). This ensures curvature features have
+    similar scale to the existing 7 surface channels and the model can learn
+    them on equal footing.
+    """
+
+    def __init__(
+        self,
+        manifest_path: str | Path,
+        root: str | Path | None = None,
+        *,
+        mode: str = "kappa_HK",
+        stats: dict[str, float] | None = None,
+    ):
+        super().__init__(manifest_path=manifest_path, root=root)
+        if mode not in ("kappa_HK", "kappa_only"):
+            raise ValueError(f"Unknown curvature mode: {mode}")
+        self.mode = mode
+        if stats is None:
+            stats_path = Path(__file__).with_name("curvature_stats.json")
+            if not stats_path.exists():
+                raise FileNotFoundError(
+                    f"Curvature stats file missing: {stats_path}. Run the stats helper first."
+                )
+            import json
+            with stats_path.open() as f:
+                stats = json.load(f)
+        self.stats = stats
+        self._kappa_mean = float(stats["kappa_v2_log1p_mean"])
+        self._kappa_std = max(float(stats["kappa_v2_log1p_std"]), 1e-6)
+        self._H_mean = float(stats.get("kappa_H_signed_log_mean", 0.0))
+        self._H_std = max(float(stats.get("kappa_H_signed_log_std", 1.0)), 1e-6)
+        self._K_mean = float(stats.get("kappa_G_signed_log_mean", 0.0))
+        self._K_std = max(float(stats.get("kappa_G_signed_log_std", 1.0)), 1e-6)
+
+    @property
+    def extra_surface_channels(self) -> int:
+        return 3 if self.mode == "kappa_HK" else 1
+
+    def _load_curvature_channels(
+        self,
+        case_id: str,
+        surface_rows: np.ndarray | None,
+        n_surface: int,
+    ) -> np.ndarray:
+        case_dir = self.root / case_id
+        kappa_path = case_dir / "surface_kappa_v2.npy"
+        if not kappa_path.exists():
+            raise FileNotFoundError(f"Missing surface_kappa_v2.npy for case {case_id}")
+        if surface_rows is None:
+            kappa = np.asarray(np.load(kappa_path), dtype=np.float32)
+        else:
+            mm = np.load(kappa_path, mmap_mode="r")
+            kappa = np.asarray(mm[surface_rows], dtype=np.float32)
+        kappa = np.nan_to_num(kappa, nan=0.0, posinf=0.0, neginf=0.0)
+        # log1p(|x|) is fine since kappa is non-negative; preserve any sign just in case.
+        kappa_feat = (np.sign(kappa) * np.log1p(np.abs(kappa)) - self._kappa_mean) / self._kappa_std
+
+        if self.mode == "kappa_only":
+            return kappa_feat.reshape(-1, 1)
+
+        hk_path = case_dir / "curvature_HK_v2.npy"
+        if hk_path.exists():
+            if surface_rows is None:
+                HK = np.asarray(np.load(hk_path), dtype=np.float32)
+            else:
+                mm = np.load(hk_path, mmap_mode="r")
+                HK = np.asarray(mm[surface_rows], dtype=np.float32)
+            HK = np.nan_to_num(HK, nan=0.0, posinf=0.0, neginf=0.0)
+            H_feat = (np.sign(HK[:, 0]) * np.log1p(np.abs(HK[:, 0])) - self._H_mean) / self._H_std
+            K_feat = (np.sign(HK[:, 1]) * np.log1p(np.abs(HK[:, 1])) - self._K_mean) / self._K_std
+        else:
+            # Missing HK file: fill with zero (post-standardisation that means "mean log curvature");
+            # the always-present kappa channel still carries curvature magnitude.
+            target_n = kappa.shape[0]
+            H_feat = np.zeros(target_n, dtype=np.float32)
+            K_feat = np.zeros(target_n, dtype=np.float32)
+        return np.stack([kappa_feat, H_feat, K_feat], axis=1)
+
+    def load_case(
+        self,
+        case_id: str,
+        *,
+        surface_rows: np.ndarray | None = None,
+        volume_rows: np.ndarray | None = None,
+    ) -> DrivAerMLCase:
+        case = super().load_case(
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+        )
+        n_surface = case.surface_x.shape[0]
+        curv = self._load_curvature_channels(case_id, surface_rows, n_surface)
+        if curv.shape[0] != n_surface:
+            raise RuntimeError(
+                f"Curvature rows for {case_id} mismatch surface rows: "
+                f"{curv.shape[0]} vs {n_surface}"
+            )
+        curv_t = torch.from_numpy(np.ascontiguousarray(curv))
+        surface_x_aug = torch.cat([case.surface_x, curv_t], dim=-1)
+        metadata = dict(case.metadata)
+        metadata["surface_x_dim"] = int(surface_x_aug.shape[-1])
+        metadata["surface_curvature_mode"] = self.mode
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=surface_x_aug,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+
 def loader_kwargs(config) -> dict[str, object]:
     num_workers = resolve_num_workers(config)
+    # Always use the variable-channel collate so the loader handles 7/8/9/10-channel
+    # surface inputs without truncation.
     kwargs: dict[str, object] = {
-        "collate_fn": pad_collate,
+        "collate_fn": _variable_channel_pad_collate,
         "num_workers": num_workers,
         "pin_memory": config.pin_memory and torch.cuda.is_available(),
     }
@@ -274,6 +447,46 @@ def full_eval_loaders_from(
     }
 
 
+def _surface_curvature_mode(config) -> str | None:
+    """Resolve the requested curvature mode from the config.
+
+    Returns ``None`` when curvature features are disabled, otherwise the mode
+    name (``"kappa_HK"`` or ``"kappa_only"``).
+    """
+    mode = getattr(config, "surface_curvature_mode", "") or ""
+    mode = mode.strip()
+    return mode or None
+
+
+def _maybe_swap_store_for_curvature(
+    config,
+    train_ds,
+    val_splits,
+    test_splits,
+):
+    """If curvature features are enabled, replace each dataset's store in place.
+
+    Returns the curvature-augmented store (or None if not requested).
+    """
+    mode = _surface_curvature_mode(config)
+    if mode is None:
+        return None
+    store = CurvatureAugmentedCaseStore(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        mode=mode,
+    )
+    # Reuse the cached point counts that load_data already gathered, so we don't
+    # re-walk the PVC.
+    store._point_count_cache.update(train_ds.store._point_count_cache)
+    train_ds.store = store
+    for ds in val_splits.values():
+        ds.store = store
+    for ds in test_splits.values():
+        ds.store = store
+    return store
+
+
 def make_loaders(
     config,
     distributed_state: DistributedState | None = None,
@@ -287,6 +500,7 @@ def make_loaders(
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
     )
+    _maybe_swap_store_for_curvature(config, train_ds, val_splits, test_splits)
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:


### PR DESCRIPTION
## Hypothesis

**Surface curvature features (kappa_H + kappa_G): 2 extra input channels targeting WSS at geometric separation edges**

Your terminal run `fby84xtu` gave us a critical insight: **tau_y=7.36% and tau_z=8.75% dominate WSS error, while tau_x is only 5.97%**. Cross-flow shear errors are 1.5–1.8× larger than streamwise. These errors concentrate at regions of high surface curvature: A-pillar transitions, leading edges, wheel arch lips, underbody strakes, and rear diffuser — precisely where the surface curves sharply and the local flow separates.

The current 7-channel surface input `[x, y, z, nx, ny, nz, area]` encodes the **normal direction** of each element but not the **rate of change** of that normal — i.e., the local curvature. We add two zero-cost scalar channels computed from the mesh geometry:

1. **`kappa_H` (mean curvature)** = `(kappa_1 + kappa_2) / 2` — half the trace of the shape operator. Large |kappa_H| at convex/concave ridges. Distinguishes flat panels (kappa_H ≈ 0) from curved transitions.

2. **`kappa_G` (Gaussian curvature)** = `kappa_1 * kappa_2` — determinant of the shape operator. Positive on elliptic surfaces (dome-like), zero on cylindrical panels, negative on saddle regions. Sign encodes local geometry type.

Together (kappa_H, kappa_G) fully characterise the local curvature type at each surface point. Regions with |kappa_H| >> 0 and kappa_G < 0 (saddle/hyperbolic) are precisely the A-pillar transitions and rear-wing junctions where tau_y/tau_z spikes are observed.

**Mechanism:** The network will learn that high-curvature elements need richer WSS representations — the curvature features act as an explicit attention signal for "this is a hard region".

**Prior art:** Suk et al. (arXiv 2109.04797) encode curvature on mesh surface inputs for biomedical WSS prediction; DoMINO (NVIDIA, 2025) uses boundary curvature in near-wall feature injection.

**Safety profile (Wave 27 lessons):**
- ✅ Additive input feature — no loss change, no loss conflict
- ✅ No feature rotation — wind direction preserved, no yaw/orientation change
- ✅ No near-zero numeric explosion risk (curvature is well-defined away from degenerate edges)

## Instructions

### 1. Compute kappa_H and kappa_G via cotangent-weighted Laplace-Beltrami operator

Add this function to your preprocessing or dataset code (runs once per case at data-load time):

```python
import numpy as np

def compute_surface_curvatures(vertices: np.ndarray,
                                faces: np.ndarray,
                                clamp_abs: float = 10.0) -> np.ndarray:
    """
    Compute per-vertex mean (kappa_H) and Gaussian (kappa_G) curvatures
    from a triangulated surface mesh using the cotangent Laplacian.

    vertices: (V, 3) float array of vertex positions
    faces:    (F, 3) int array of triangle vertex indices
    clamp_abs: clamp raw curvature to [-clamp_abs, clamp_abs] before normalizing

    Returns: (V, 2) array of [kappa_H, kappa_G] per vertex
    """
    V = len(vertices)
    kappa_H = np.zeros(V)
    kappa_G = np.zeros(V)
    area_sum = np.zeros(V)

    for tri in faces:
        i, j, k = tri
        p0, p1, p2 = vertices[i], vertices[j], vertices[k]

        # Edge vectors
        e0 = p2 - p1  # edge opposite to p0
        e1 = p0 - p2  # edge opposite to p1
        e2 = p1 - p0  # edge opposite to p2

        # Cotangent weights
        def cot(u, v):
            c = np.dot(u, v)
            s = np.linalg.norm(np.cross(u, v))
            return c / (s + 1e-12)

        cot0 = cot(-e1, -e2)  # angle at p0
        cot1 = cot(-e0, -e2)  # angle at p1
        cot2 = cot(-e0, -e1)  # angle at p2

        # Triangle area
        area = 0.5 * np.linalg.norm(np.cross(p1 - p0, p2 - p0))
        area_sum[[i, j, k]] += area / 3.0

        # Accumulate Laplacian (mean curvature normal direction)
        kappa_H[i] += 0.5 * (cot1 * (p0 - p2) + cot2 * (p0 - p1)).dot(
            np.cross(e1, e2) / (np.linalg.norm(np.cross(e1, e2)) + 1e-12))
        kappa_H[j] += 0.5 * (cot0 * (p1 - p2) + cot2 * (p1 - p0)).dot(
            np.cross(e0, e2) / (np.linalg.norm(np.cross(e0, e2)) + 1e-12))
        kappa_H[k] += 0.5 * (cot0 * (p2 - p1) + cot1 * (p2 - p0)).dot(
            np.cross(e0, e1) / (np.linalg.norm(np.cross(e0, e1)) + 1e-12))

        # Gaussian curvature: angle defect method (approximate per-triangle contribution)
        # This is a simplified version; a full implementation sums angle defects per vertex
        # For the DrivAerML mesh, a simple approximation is sufficient

    # Normalize by area
    safe_area = np.maximum(area_sum, 1e-10)
    kappa_H = kappa_H / safe_area

    # Gaussian curvature via angle defect (full per-vertex computation)
    # Simple approximation: kappa_G ≈ 0 for most panels; compute from angle sum
    # For production: use trimesh.curvature.discrete_gaussian_curvature_measure
    # Here we use the cotangent Laplacian magnitude as a proxy for kappa_G
    kappa_G = np.abs(kappa_H) * np.sign(kappa_H)  # fallback: use mean curv magnitude

    # Clamp to remove degenerate edge artefacts
    kappa_H = np.clip(kappa_H, -clamp_abs, clamp_abs)
    kappa_G = np.clip(kappa_G, -clamp_abs, clamp_abs)

    return np.stack([kappa_H, kappa_G], axis=1)  # (V, 2)
```

**Simpler option (recommended):** Use `trimesh` if available in your environment:
```python
import trimesh

def compute_surface_curvatures_trimesh(vertices: np.ndarray,
                                        faces: np.ndarray,
                                        clamp_abs: float = 10.0) -> np.ndarray:
    mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
    kappa_H = trimesh.curvature.discrete_mean_curvature_measure(
        mesh, mesh.vertices, radius=0.02)  # radius in metres, ~2cm
    kappa_G = trimesh.curvature.discrete_gaussian_curvature_measure(
        mesh, mesh.vertices, radius=0.02)
    kappa_H = np.clip(kappa_H, -clamp_abs, clamp_abs)
    kappa_G = np.clip(kappa_G, -clamp_abs, clamp_abs)
    return np.stack([kappa_H, kappa_G], axis=1)
```

If neither trimesh nor custom implementation is feasible, use a simpler proxy:
```python
# Simple normal-variation proxy for curvature (cheaper, less accurate)
def compute_curvature_proxy(normals: np.ndarray,
                             positions: np.ndarray,
                             k: int = 16) -> np.ndarray:
    """Use local k-NN normal variation as a curvature proxy."""
    from sklearn.neighbors import NearestNeighbors
    nbrs = NearestNeighbors(n_neighbors=k).fit(positions)
    dists, idxs = nbrs.kneighbors(positions)
    # Mean curvature proxy: mean normal variation in neighborhood
    kappa_H = np.array([
        np.mean(1.0 - np.clip(normals[idxs[i]] @ normals[i], -1, 1))
        for i in range(len(normals))
    ])
    # Gaussian curvature proxy: variance of normal variation
    kappa_G = np.array([
        np.var(normals[idxs[i]] @ normals[i])
        for i in range(len(normals))
    ])
    return np.stack([kappa_H, kappa_G], axis=1)
```

**Recommendation:** Try the trimesh approach first. If trimesh isn't installed, use the k-NN normal variation proxy (simpler, always available).

### 2. Integrate into the surface feature pipeline

After computing curvature features (V, 2), append them to the per-point surface feature matrix. The surface input becomes **9-channel**: `[x, y, z, nx, ny, nz, area, kappa_H, kappa_G]`.

Make sure the new channels go through the same per-channel normalization as the other surface inputs.

**Sanity check at EP0:**
```python
# Check curvature value ranges (should be mostly in [-2, 2] for DrivAerML panels)
print(f"kappa_H range: [{kappa_H.min():.3f}, {kappa_H.max():.3f}], mean={kappa_H.mean():.3f}")
print(f"kappa_G range: [{kappa_G.min():.3f}, {kappa_G.max():.3f}], mean={kappa_G.mean():.3f}")
# If values are >10, clamp or re-check normalization
assert not np.any(np.isnan(kappa_H)), "NaN in kappa_H — check for non-manifold edges"
assert not np.any(np.isnan(kappa_G)), "NaN in kappa_G — check for non-manifold edges"
```

If NaN values appear, clamp before normalization: `kappa_H = np.nan_to_num(kappa_H, nan=0.0, posinf=10.0, neginf=-10.0)`.

### 3. Run command (all other params identical to PR #972 baseline)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --ema-decay 0.999 --ema-start-step 5000 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --surface-input-channels 9 \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h2-curvature-features \
  --wandb-name "dl24-tanjiro/wss-curvature-features" \
  --agent dl24-tanjiro
```

> **Key difference:** `--surface-input-channels 9` (was 7). Verify your model handles this automatically or set it explicitly.

### 4. Primary metric to watch: `val_primary/wall_shear_rel_l2_pct`

A strong signal: val_wss < 6.8% by EP10 (vs the baseline plateau of ~6.9-7.1%). Also monitor val_tau_y and val_tau_z specifically if your trainer logs per-axis WSS — these are the 7.36%/8.75% components from your previous run that curvature features should help most.

## Gate schedule

| Gate | val_abupt | val_wss | val_vol_p | Action |
|------|----------:|--------:|----------:|--------|
| EP3  | ≤ 7.5% | ≤ 7.5% | ≤ 5.5% | Kill if over |
| EP6  | ≤ 7.0% | ≤ 7.2% | ≤ 4.8% | Kill if over |
| EP10 | ≤ 6.6% | ≤ 7.0% | ≤ 4.5% | Kill if over |
| EP15 | ≤ 6.4% | ≤ 6.9% | ≤ 4.3% | Kill if over |
| EP20 | ≤ 6.3% | ≤ 6.75% | ≤ 4.2% | Kill if over |
| EP25 | ≤ 6.25% | ≤ 6.65% | ≤ 4.1% | Kill if over |
| EP30 | — | target < 6.5% | ≤ 3.75% | Terminal eval |

At each gate post: `EP<N> gate: val_abupt=X%, val_wss=X%, val_vol_p=X%, val_surf_p=X% [PASS/FAIL]`

## Terminal evaluation

At EP30 (or from best-val checkpoint):
1. Run test evaluation with `eval_surface_points=65536`, `eval_volume_points=65536`
2. Report test_abupt, test_wss, test_vol_p, test_surf_p, AND per-axis test_tau_x, test_tau_y, test_tau_z
3. Post SENPAI-RESULT marker **before** flipping label to review:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val-number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-number>}}
```

## Baseline

Current corrected-split SOTA (rawcanon_20260511):

| Metric | Value | W&B |
|--------|------:|-----|
| test_abupt | **5.844%** | PR #972 `56bcqp3m` |
| test_surf_p | 3.577% | floor: hold |
| test_vol_p | **3.643%** | **floor: must not exceed** |
| test_wss | 6.727% | **primary target: beat** |
| test_tau_x | ~6.5% (est) | reference |
| test_tau_y | ~7.9% (est) | **highest priority** |
| test_tau_z | ~9.5% (est) | **highest priority** |

**WSS directive (Issue #1056):** target test_wss < 5.85% (Transolver-3). Intermediate milestone: test_wss < 6.5%. Floors: test_vol_p ≤ 3.643% and test_surf_p ≤ 3.577%.

**From your previous run (fby84xtu):** tau_y=7.362%, tau_z=8.747%, tau_x=5.971%. Curvature features target the tau_y/tau_z bottleneck directly.
