### PR TITLE
OHEM v2: spike-clipped + reduced λ (scale-invariant by construction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    ohem_supplementary_loss_clipped,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -138,6 +139,11 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    ohem_surface_ratio: float = 1.0
+    ohem_warmup_epochs: int = 0
+    ohem_min_k: int = 100
+    ohem_lambda: float = 0.1
+    ohem_max_clip: float = 2.0
     debug: bool = False
 
 
@@ -228,6 +234,39 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "ohem_surface_ratio": (
+            "Top-K fraction of hardest surface points for the supplementary "
+            "OHEM (online hard example mining) loss term. 1.0 = disabled "
+            "(default). 0.20 = top-20%% hardest points per sample. The OHEM "
+            "term adds 'ohem_lambda * clamp(MSE(top-K), max_clip*surface_loss)' "
+            "on top of the standard surface_loss so all points still receive "
+            "gradient."
+        ),
+        "ohem_warmup_epochs": (
+            "Number of epochs before OHEM activates. During warmup the OHEM "
+            "supplementary term is zero so the model can calibrate its error "
+            "distribution before being asked to focus on hard examples. "
+            "Default 0 = no warmup."
+        ),
+        "ohem_min_k": (
+            "Minimum number of hard points to select per sample regardless "
+            "of ohem_surface_ratio. Prevents degenerate top-K selection at "
+            "very small surface views. Default 100."
+        ),
+        "ohem_lambda": (
+            "Weight multiplier on the spike-clipped OHEM supplementary loss "
+            "term. Final loss = surface_loss_weight*surface_loss + volume_loss_"
+            "weight*volume_loss + ohem_lambda*clip(ohem_hard_loss). Default "
+            "0.1 (5x reduction from v1's 0.5) keeps the supplementary term "
+            "clearly bounded."
+        ),
+        "ohem_max_clip": (
+            "Spike-clipping multiplier (OHEM v2). The raw top-K MSE is "
+            "clamped to max_clip * surface_loss.detach() per step, bounding "
+            "the OHEM term to at most max_clip * surface_loss regardless of "
+            "residual-distribution pathology. Default 2.0 gives a per-step "
+            "ceiling of 0.2 * surface_loss when combined with ohem_lambda=0.1."
         ),
     }
     for field in fields(Config):
@@ -321,6 +360,11 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    ohem_surface_ratio: float = 1.0,
+    ohem_warmup_active: bool = False,
+    ohem_min_k: int = 100,
+    ohem_lambda: float = 0.1,
+    ohem_max_clip: float = 2.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -342,9 +386,33 @@ def train_loss(
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+
+        ohem_active = (ohem_surface_ratio < 1.0) and (not ohem_warmup_active)
+        if ohem_active:
+            hard_loss_clipped, ohem_diag = ohem_supplementary_loss_clipped(
+                pred=out["surface_preds"],
+                target=surface_target,
+                mask=batch.surface_mask,
+                ohem_ratio=ohem_surface_ratio,
+                surface_loss_detach=surface_loss.detach(),
+                min_k=ohem_min_k,
+                max_clip=ohem_max_clip,
+                channel_weights=surface_channel_weights,
+            )
+            ohem_contribution = ohem_lambda * hard_loss_clipped
+        else:
+            hard_loss_clipped = torch.zeros((), device=device)
+            ohem_contribution = torch.zeros((), device=device)
+            ohem_diag = {
+                "hard_loss_raw": 0.0,
+                "hard_loss_clipped": 0.0,
+                "clip_active": 0.0,
+                "max_clip_value": 0.0,
+            }
+
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        loss = weighted_surface_loss + weighted_volume_loss + ohem_contribution
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
@@ -352,6 +420,13 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "ohem/active": float(ohem_active),
+        "ohem/in_warmup": float(ohem_warmup_active),
+        "ohem/hard_loss_raw": ohem_diag["hard_loss_raw"],
+        "ohem/hard_loss_clipped": ohem_diag["hard_loss_clipped"],
+        "ohem/clip_active": ohem_diag["clip_active"],
+        "ohem/max_clip_value": ohem_diag["max_clip_value"],
+        "ohem/contribution": float(ohem_contribution.detach().cpu().item()),
     }
 
 
@@ -913,6 +988,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     current_train_vol_points = desired_vol_points
             if isinstance(train_loader.sampler, DistributedSampler):
                 train_loader.sampler.set_epoch(epoch)
+            ohem_warmup_active = (
+                config.ohem_surface_ratio < 1.0
+                and config.ohem_warmup_epochs > 0
+                and epoch < config.ohem_warmup_epochs
+            )
             timeout_hit = distributed_any(
                 state,
                 (time.time() - train_start) / 60.0 >= timeout_minutes,
@@ -1030,6 +1110,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        ohem_surface_ratio=config.ohem_surface_ratio,
+                        ohem_warmup_active=ohem_warmup_active,
+                        ohem_min_k=config.ohem_min_k,
+                        ohem_lambda=config.ohem_lambda,
+                        ohem_max_clip=config.ohem_max_clip,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1155,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "ohem/active" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "train/ohem/active": batch_loss_metrics["ohem/active"],
+                                "train/ohem/in_warmup": batch_loss_metrics["ohem/in_warmup"],
+                                "train/ohem/hard_loss_raw": batch_loss_metrics["ohem/hard_loss_raw"],
+                                "train/ohem/hard_loss_clipped": batch_loss_metrics["ohem/hard_loss_clipped"],
+                                "train/ohem/clip_active": batch_loss_metrics["ohem/clip_active"],
+                                "train/ohem/max_clip_value": batch_loss_metrics["ohem/max_clip_value"],
+                                "train/ohem/contribution": batch_loss_metrics["ohem/contribution"],
+                                "train/ohem/ratio": config.ohem_surface_ratio,
+                                "train/ohem/lambda": config.ohem_lambda,
+                                "train/ohem/max_clip": config.ohem_max_clip,
+                                "train/ohem/min_k": float(config.ohem_min_k),
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -870,6 +870,74 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def ohem_supplementary_loss_clipped(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    ohem_ratio: float,
+    surface_loss_detach: torch.Tensor,
+    min_k: int = 100,
+    max_clip: float = 2.0,
+    channel_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Supplementary OHEM surface loss over top-K hardest points, spike-clipped.
+
+    pred / target: [B, N, C]; mask: [B, N] boolean.
+    ``ohem_ratio`` is the fraction of points selected as hard (e.g. 0.20).
+    ``min_k`` floors the per-sample count of hard points.
+    ``surface_loss_detach`` is the detached base surface MSE used to bound the
+    hard term: the raw top-K MSE is clamped to ``max_clip * surface_loss_detach``
+    so the OHEM contribution is at most ``ohem_lambda * max_clip * surface_loss``
+    regardless of how pathological the residual distribution is on a given step.
+
+    Returns:
+        clipped_hard_loss: scalar (clamped MSE over top-K hardest points), with
+            an unclipped backward path when not clipped and the clamp constant
+            otherwise (``clamp_max`` retains gradient through the smaller input).
+        diag: floats for logging — hard_loss_raw, hard_loss_clipped,
+            clip_active (0/1), max_clip_value (the per-step ceiling).
+    """
+    if pred.numel() == 0:
+        zero = pred.sum() * 0.0
+        return zero, {
+            "hard_loss_raw": 0.0,
+            "hard_loss_clipped": 0.0,
+            "clip_active": 0.0,
+            "max_clip_value": 0.0,
+        }
+
+    sq_err = (pred - target).square()
+    per_point_loss = sq_err.mean(dim=-1).float()
+
+    mask_dev = mask.to(device=pred.device).bool()
+    per_point_loss = per_point_loss.masked_fill(~mask_dev, float("-inf"))
+
+    valid_counts = mask_dev.float().sum(dim=1)
+    k = max(min_k, int(ohem_ratio * per_point_loss.shape[1]))
+    k = min(k, int(valid_counts.min().item()))
+    k = max(k, 1)
+
+    _, hard_indices = per_point_loss.topk(k, dim=1, largest=True, sorted=False)
+    idx_expanded = hard_indices.unsqueeze(-1).expand(-1, -1, pred.shape[-1])
+    hard_sq_err = sq_err.gather(1, idx_expanded.to(dtype=torch.long))
+
+    if channel_weights is not None:
+        weights_dev = channel_weights.to(device=pred.device, dtype=hard_sq_err.dtype)
+        hard_sq_err = hard_sq_err * weights_dev.unsqueeze(0).unsqueeze(0)
+
+    hard_loss_raw = hard_sq_err.mean()
+    max_clip_value = (max_clip * surface_loss_detach.to(hard_loss_raw.dtype)).clamp_min(1e-8)
+    hard_loss_clipped = hard_loss_raw.clamp_max(max_clip_value)
+
+    clip_active = float((hard_loss_raw.detach() > max_clip_value.detach()).item())
+    return hard_loss_clipped, {
+        "hard_loss_raw": float(hard_loss_raw.detach().cpu().item()),
+        "hard_loss_clipped": float(hard_loss_clipped.detach().cpu().item()),
+        "clip_active": clip_active,
+        "max_clip_value": float(max_clip_value.detach().cpu().item()),
+    }
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

Naive top-K OHEM (#1110) failed because `hard_loss = mean(top-20% sq_err)` is on an unpredictable scale relative to `surface_loss = mean(all sq_err)` — median ratio ~18-30×, max 88,000× during pathological batches. Lion's sign-of-momentum optimizer collapses the weight manifold the first time a 1000×+ spike hits.

**OHEM v2 fixes both failure modes from your own diagnostic (#1110 close comment):**

1. **Spike clipping**: `ohem_loss.clamp_max(MAX_CLIP × surface_loss.detach())` per step — guarantees the OHEM term is bounded by a fixed multiple of the base surface loss regardless of raw magnitude.
2. **Reduced λ**: 5× smaller (0.1 instead of 0.5), so typical contribution is ~0.1× base loss = clearly supplementary.

If MAX_CLIP=2.0 and λ=0.1, the max OHEM contribution per step is 0.2 × surface_loss — bounded, predictable, can never destabilize training even under worst-case batches.

**Test of mechanism**: log `train/ohem/clip_active_pct` (fraction of steps where clipping fired). High % (>50%) throughout = scale problem is intrinsic to this dataset's residual distribution → OHEM-family approaches fundamentally don't fit and we pivot away. Low % (<20%) after warmup = model is converging to a regime where top-K MSE is reasonable, and OHEM has a real shot at helping tau_z descent.

## Instructions

### Surgical changes to `target/train.py` (or wherever your OHEM contribution is computed in #1110's code path)

1. **Replace the OHEM contribution computation** with spike-clipped variant. The current PR #1110 implementation computes:
   ```python
   hard_loss = top_k_mse_over_surface(pred, target, ratio=ohem_surface_ratio)
   ohem_contribution = ohem_lambda * hard_loss
   total_loss = surface_loss + ohem_contribution + ...
   ```
   Change to:
   ```python
   hard_loss_raw = top_k_mse_over_surface(pred, target, ratio=ohem_surface_ratio)
   max_clip = ohem_max_clip * surface_loss.detach().clamp_min(1e-8)
   hard_loss_clipped = hard_loss_raw.clamp_max(max_clip)
   ohem_contribution = ohem_lambda * hard_loss_clipped
   total_loss = surface_loss + ohem_contribution + ...
   # Diagnostic logging
   clip_active = (hard_loss_raw > max_clip).float()
   self.log("train/ohem/hard_loss_raw", hard_loss_raw.item())
   self.log("train/ohem/hard_loss_clipped", hard_loss_clipped.item())
   self.log("train/ohem/clip_active", clip_active.item())
   self.log("train/ohem/contribution", ohem_contribution.item())
   ```

2. **Add new CLI flag** `--ohem-max-clip` (float, default 2.0) — the multiplier on `surface_loss.detach()` that caps the raw OHEM term.

3. **Change `--ohem-lambda` default to 0.1** (5× reduction from v1's 0.5).

4. **Keep all other settings identical to #1110**:
   - `--ohem-surface-ratio 0.20` (same top-20%)
   - `--ohem-warmup-epochs 2` (same EP1+EP2 standard training)
   - `--ohem-min-k 100` (same min size)

### Smoke test (1 epoch, debug data, single GPU is fine for quick smoke)

```bash
cd target/ && torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr-cosine-t-max 13 --epochs 3 \
  --vol-points-schedule 0:16384:3:32768 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --ohem-surface-ratio 0.20 --ohem-warmup-epochs 2 --ohem-min-k 100 \
  --ohem-lambda 0.1 --ohem-max-clip 2.0 \
  --wandb-group tay-wave28-ohem-v2 --wandb-name askeladd/ohem-v2-spike-clipped-smoke
```

Smoke test PASS criteria: EP3 val_abupt < 9% (must NOT diverge — this is the critical mechanism test). If smoke EP3 val_abupt < 9%, the spike clip is doing its job and you can proceed to full run.

### Full run (13 epochs, full data, DDP 8 ranks)

```bash
cd target/ && torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --ohem-surface-ratio 0.20 --ohem-warmup-epochs 2 --ohem-min-k 100 \
  --ohem-lambda 0.1 --ohem-max-clip 2.0 \
  --wandb-group tay-wave28-ohem-v2 --wandb-name askeladd/ohem-v2-spike-clipped
```

### EP3 gate (recipe uses `--lr-warmup-epochs 1`, so EP1 ≈ 33% is normal — gate is at EP3)

- val_abupt ≤ 7.2% PASS / ≤ 7.6% MARGINAL / > 7.6% KILL
- val_vol_p ≤ 4.5% PASS / ≤ 5.0% MARGINAL / > 5.0% KILL

If both PASS, run to EP13 and post final results with test metrics.

### Diagnostic posts (worth posting at EP3 even if PASS)

Report `train/ohem/clip_active_pct` (mean across active steps): 
- <20% across EP3+ → OHEM v2 mechanism healthy, scale-bound is the right fix
- 20-50% → borderline, λ=0.1 may need tuning
- >50% → spike-clipping is firing constantly, scale problem is intrinsic and OHEM-family approaches don't fit this dataset

Report `train/ohem/hard_loss_raw` percentile distribution (median, p95, p99, max) — directly comparable to v1's reading (median 5.6, p95 7.8, max 4411).

## Baseline

Current best metrics (from BASELINE.md as of 2026-05-14):
- val_abupt: 6.126% (PR #972 SDF stack, SOTA val)
- val_WSS: 7.155% (PR #972 SDF stack)
- test_WSS: 6.727% (PR #972 single-model SOTA, paper-facing)
- test_vol_p: 3.643% (PR #972 floor — MUST NOT regress)
- test_SP: 3.577% (PR #972 floor — MUST NOT regress)

Live reference for no-SDF tay stack (same recipe family as your run):
- thorfinn #1100 EP15: val_abupt=6.353%, val_WSS=7.160%, val_vol_p=3.775% (model-slices=256 capacity uplift, run still in flight to EP21-22)
- Recipe-matched baseline EP3: val_abupt≈7.0-7.2%, val_vol_p≈4.0-4.5%, val_WSS≈7.6-7.8% (Wave 28 recipe family)

## Why this is the right next experiment

Your v1 diagnostic was excellent. The spike-clipping + reduced-λ design is your own Approach #2 + #3, combined for maximum robustness. If this fails (either val_abupt > 7.6% at EP3 OR clip_active_pct stays >50% throughout), we have firm data that top-K OHEM does not fit this benchmark's residual distribution, and we pivot. If it PASSES, you get a chance at the SOTA test_WSS while teaching the model to focus gradient on hard regions — which is exactly the kind of architectural-orthogonal improvement we need on top of thorfinn's capacity uplift.

Run to completion. Standing by for results.
