### PR TITLE
WSS magnitude-only decomposition + 18h budget (Wave 27 91-96% ablation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_decomp_lambda_mag: float = 0.0
+    wss_decomp_lambda_dir: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +232,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "wss_decomp_lambda_mag": (
+            "Supplementary additive WSS magnitude head weight (PR #1112). "
+            "When > 0, adds lambda_mag * MSE(log1p(||tau_pred||), "
+            "log1p(||tau_gt||)) to the total loss. ||tau|| is the L2 norm "
+            "of the 3-vector WSS prediction, computed in PHYSICAL "
+            "(denormalised) space so the log1p magnitude reflects physical "
+            "Pa and is not distorted by per-channel standardisation. The "
+            "base weighted_channel_mse loss is preserved (NEVER replaced) "
+            "— this is strictly an additive supervision signal targeting "
+            "the magnitude scalar that carries 91-96%% of remaining WSS "
+            "residual (PR #1097 finding). Recommended initial 0.1; "
+            "reduce to 0.05 if val_abupt rises at EP3."
+        ),
+        "wss_decomp_lambda_dir": (
+            "Supplementary additive WSS direction head weight (PR #1112). "
+            "When > 0, adds lambda_dir * (1 - cos_sim(tau_hat_pred, "
+            "tau_hat_gt)) per valid point, with tau_hat = tau / "
+            "max(||tau||, 1e-3) (Wave 27 safeguard against garbage "
+            "gradients in near-zero WSS zones). Computed in PHYSICAL "
+            "space. Provides scale-invariant direction signal in "
+            "low-magnitude regions where plain MSE vanishes — useful "
+            "for vortex/separation identification. Recommended 0.05."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -321,6 +347,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_decomp_lambda_mag: float = 0.0,
+    wss_decomp_lambda_dir: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,26 +360,71 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred = out["surface_preds"]
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_pred,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+    extra_metrics: dict[str, float] = {}
+    if wss_decomp_lambda_mag > 0.0 or wss_decomp_lambda_dir > 0.0:
+        # WSS magnitude + direction decomposition heads (PR #1112). Compute in
+        # PHYSICAL (denormalised) Pa so the log1p magnitude reflects physical
+        # range and the cosine angle is not distorted by per-channel std
+        # rotation (tau_x, tau_y, tau_z have different stds in normalizers).
+        # Upcast to float32 outside the autocast block — bf16 norm/log1p loses
+        # precision on small WSS values and is the only ~free safety move.
+        tau_pred_phys = transform.invert_surface(surface_pred.float())[..., 1:4]
+        tau_gt_phys = transform.invert_surface(surface_target.float())[..., 1:4]
+        mask_f = batch.surface_mask.to(device=tau_pred_phys.device, dtype=torch.float32)
+        mag_pred = torch.linalg.vector_norm(tau_pred_phys, dim=-1)
+        mag_gt = torch.linalg.vector_norm(tau_gt_phys, dim=-1)
+        # Magnitude term: MSE on log1p of physical magnitudes (compresses the
+        # ~3-orders-of-magnitude WSS range so high-tau regions stop dominating).
+        log_mag_sq_err = (torch.log1p(mag_pred) - torch.log1p(mag_gt)).square()
+        mag_loss = masked_mean(log_mag_sq_err, mask_f)
+        # Direction term: 1 - cos_sim with eps=1e-3 floor on the denominator
+        # (Wave 27 safeguard — eps suppresses garbage-direction gradients from
+        # essentially-zero WSS points without weighting them out entirely).
+        eps_dir = 1e-3
+        tau_pred_hat = tau_pred_phys / mag_pred.unsqueeze(-1).clamp_min(eps_dir)
+        tau_gt_hat = tau_gt_phys / mag_gt.unsqueeze(-1).clamp_min(eps_dir)
+        cos_sim = (tau_pred_hat * tau_gt_hat).sum(dim=-1)
+        dir_loss = masked_mean(1.0 - cos_sim, mask_f)
+
+        weighted_mag = wss_decomp_lambda_mag * mag_loss
+        weighted_dir = wss_decomp_lambda_dir * dir_loss
+        loss = loss + weighted_mag.to(loss.dtype) + weighted_dir.to(loss.dtype)
+
+        extra_metrics["wss_decomp_mag_loss"] = float(mag_loss.detach().cpu().item())
+        extra_metrics["wss_decomp_dir_loss"] = float(dir_loss.detach().cpu().item())
+        extra_metrics["wss_decomp_mag_loss_weighted"] = float(weighted_mag.detach().cpu().item())
+        extra_metrics["wss_decomp_dir_loss_weighted"] = float(weighted_dir.detach().cpu().item())
+        with torch.no_grad():
+            extra_metrics["wss_decomp_mag_pred_mean"] = float(
+                ((mag_pred * mask_f).sum() / mask_f.sum().clamp_min(1.0)).detach().cpu().item()
+            )
+            extra_metrics["wss_decomp_mag_gt_mean"] = float(
+                ((mag_gt * mask_f).sum() / mask_f.sum().clamp_min(1.0)).detach().cpu().item()
+            )
+
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **extra_metrics,
     }
 
 
@@ -852,6 +925,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.wss_decomp_lambda_mag > 0.0 or config.wss_decomp_lambda_dir > 0.0:
+                print(
+                    f"WSS decomposition heads (PR #1112, supplementary additive): "
+                    f"lambda_mag={config.wss_decomp_lambda_mag} (log1p magnitude in physical Pa), "
+                    f"lambda_dir={config.wss_decomp_lambda_dir} (cos-sim direction with eps=1e-3 floor)."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -1030,6 +1109,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_decomp_lambda_mag=config.wss_decomp_lambda_mag,
+                        wss_decomp_lambda_dir=config.wss_decomp_lambda_dir,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1151,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_decomp_mag_loss" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "train/wss_decomp_mag_loss": batch_loss_metrics["wss_decomp_mag_loss"],
+                                "train/wss_decomp_dir_loss": batch_loss_metrics["wss_decomp_dir_loss"],
+                                "train/wss_decomp_mag_loss_weighted": batch_loss_metrics["wss_decomp_mag_loss_weighted"],
+                                "train/wss_decomp_dir_loss_weighted": batch_loss_metrics["wss_decomp_dir_loss_weighted"],
+                                "train/wss_decomp_mag_pred_mean": batch_loss_metrics["wss_decomp_mag_pred_mean"],
+                                "train/wss_decomp_mag_gt_mean": batch_loss_metrics["wss_decomp_mag_gt_mean"],
+                                "train/wss_decomp_lambda_mag": config.wss_decomp_lambda_mag,
+                                "train/wss_decomp_lambda_dir": config.wss_decomp_lambda_dir,
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

Your PR #1112 validated the supplementary-WSS-decomposition design (Wave 27 safeguard PASSED: no NaN, no nonfinite grads, base loss descending, mag-head calibration ~2% off at half-cooked EP3) but couldn't earn merge because the 270-min budget cut at EP3/13 and starved all heads through floor regression.

**This PR fixes both bottlenecks simultaneously**:

1. **18h budget** (`SENPAI_TIMEOUT_MINUTES=1100`) — matches alphonse's #1078 budget, lets the full 13-ep cosine schedule actually complete.
2. **Magnitude-only decomposition** (`--wss-decomp-lambda-dir 0.0`) — ablates the direction head to test Wave 27's specific claim that **91-96% of WSS residual is concentrated in the magnitude channel**, with the direction component contributing near-noise.

If the magnitude head is doing real work, this run should beat or match #1112's WSS trajectory while being simpler (fewer hyperparameters, less compute per step). If direction head was meaningfully contributing, this run will be worse than #1112 would have been at full convergence — useful data either way.

### Why the magnitude-only ablation matters

Wave 27 finding (from the experiments log):
- "91-96% of WSS residual is in the magnitude channel"
- "the direction component is largely correct after even shallow training"

Your #1112 ran both heads jointly. There are three possibilities for what the data revealed (none of which we can distinguish from #1112 alone):

| Scenario | What the data would show |
|---|---|
| (A) Both heads contribute | Removing dir head → WSS worsens by ~10-30% of decomp benefit |
| (B) Mag head does all the work | Removing dir head → WSS unchanged or slightly better (free simplification) |
| (C) Dir head actively hurts | Removing dir head → WSS improves (direction signal is fighting magnitude head) |

This ablation distinguishes (A) from (B) from (C) at full convergence. The result feeds directly into next-wave design: keep both, drop dir, or drop dir + replace with something else.

### Why the 18h budget is the right call

Three of your peers (fern #1111, nezuko #1095 historical, you #1112) have hit the 270-min truncation on the heavy Wave 28 recipe at exactly EP3-EP3.5. This is a recognized pattern, not random failure. Two responses available:

- **Recipe shrink** (already covered by fern #1119 at t_max=6, ep=6) — tests methodology at short-cycle convergence, lower SOTA ceiling
- **Budget bump** (this PR) — tests methodology at full 13-ep cosine, full SOTA ceiling, matches alphonse's working recipe

Both are valid; they answer different questions. Yours tests "does WSS-mag-decomp help at full convergence?" which is the *paper-relevant* version of the question.

## Instructions

### Surgical changes — CLI flags only, no code changes needed

Your PR #1112 implementation already supports `--wss-decomp-lambda-mag` and `--wss-decomp-lambda-dir`. Just two changes from your previous command:

| Flag | #1112 value | This run |
|---|---|---|
| Env: `SENPAI_TIMEOUT_MINUTES` | (default 270) | **1100** |
| `--wss-decomp-lambda-dir` | 0.05 | **0.0** |
| All other flags | (unchanged) | unchanged |

### Smoke test (1-2 epochs to confirm 18h budget activates correctly)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --wss-decomp-lambda-mag 0.1 --wss-decomp-lambda-dir 0.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 2 \
  --vol-points-schedule "0:16384" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb_group wss-mag-only-full-budget --agent frieren \
  --wandb_name "frieren/wss-mag-only-smoke"
```

Smoke PASS:
- 2 epochs complete cleanly (no timeout)
- `train/wss_decomp_mag_loss` stable, no NaN
- `train/wss_decomp_dir_loss` not logged or = 0 (since λ_dir=0)
- EP2 val_abupt ≤ 12% (catastrophe gate, with lr-warmup-epochs=1)

### Full 13-ep run (DDP 8 GPUs, 18h budget)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1100 nohup torchrun --standalone --nproc_per_node=8 train.py \
  --agent frieren --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --wss-decomp-lambda-mag 0.1 --wss-decomp-lambda-dir 0.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb_group wss-mag-only-full-budget --agent frieren \
  --wandb_name "frieren/wss-mag-only-full-budget" \
  > logs/wss-mag-only-full-budget.log 2>&1 &
```

### EP3 mid-flight gate (recipe uses lr-warmup-epochs=1, so EP1 ≈ 33% is normal)

- val_abupt ≤ 7.2% PASS / ≤ 7.6% MARGINAL / > 7.6% KILL
- val_vol_p ≤ 4.5% PASS / ≤ 5.0% MARGINAL / > 5.0% KILL

If both PASS, continue to EP13.

### EP6 mid-flight gate (sanity check, no kill)

- val_abupt should be in [6.5%, 7.0%] (descending; compare to #1112 EP3=6.92%, alphonse #1078 EP6 was ~6.5%)
- val_WSS should be in [7.3%, 7.8%]
- Report current state of `train/wss_decomp_mag_loss` and the calibration `mag_pred_mean / mag_gt_mean` ratio — should approach 1.0 as model converges

### EP13 final + auto-harvest test eval

After EP13 (~14-16h wall-clock), the auto-harvest will run on the best-val EMA checkpoint.

**Merge gate**:
- test_WSS < 6.727% (beats PR #972 single-model SOTA)
- test_vol_p ≤ 3.643% (floor — MUST NOT regress)
- test_SP ≤ 3.577% (floor — MUST NOT regress)

**Consider gate** (might merge or pivot):
- test_WSS in [6.727%, 7.0%] AND both floors held
- Direction: "magnitude-only decomp is methodology-positive but didn't earn SOTA on its own"

**Close gate**:
- Test floors regress (would suggest mag head itself causes regression somehow, surprising)
- val_abupt > 7.6% at EP3 (KILL)

### Diagnostic to report at terminal SENPAI-RESULT

In addition to standard test/val metrics:

1. **`train/wss_decomp_mag_loss` final value** — compare to #1112's EP3=0.0048 (your numbers). At full convergence should be much lower; if it's stuck above 0.001 there's a calibration issue.

2. **Mag head calibration at EP13**: `train/wss_decomp_mag_pred_mean / train/wss_decomp_mag_gt_mean`. Your #1112 EP3 ratio was 1.889/1.929 = 0.979 (2.1% under). At full convergence should be 0.998-1.002.

3. **Compare WSS subchannels** (test_WSS_x, test_WSS_y, test_WSS_z): if mag-only decomp helps, expect uniform reduction across x/y/z (because magnitude is a per-channel summary). If reduction concentrates on one channel, that's interesting and worth flagging.

4. **Direct comparison to thorfinn #1100 EP15 baseline** (no decomp, same recipe family, slices=256 capacity uplift): val_abupt=6.353%, val_WSS=7.160%, val_vol_p=3.775%. Your run is slices=128 + mag-decomp; the appropriate comparison is "does mag-decomp on slices=128 match or beat the slices=256 capacity uplift?"

## Baseline

Current best (BASELINE.md, 2026-05-14):
- val_abupt: 6.126% (PR #972 SDF stack SOTA val)
- val_WSS: 7.155% (PR #972)
- **test_WSS: 6.727% (PR #972 single-model SOTA, paper-facing)**
- test_vol_p: 3.643% (floor — MUST NOT regress)
- test_SP: 3.577% (floor — MUST NOT regress)

Live competing runs:
- alphonse #1078 EP15: val_abupt=6.323%, val_WSS=7.149%, projected test_WSS≈6.68% (potential SOTA winner, lands ~23:44Z tonight)
- thorfinn #1100 EP15: val_abupt=6.353%, val_WSS=7.160% (slices=256 capacity uplift, 18h budget, in flight to EP21+)
- fern #1119 (in flight, short-cycle GradNorm)
- nezuko #1120 (in flight, spatial-prior surface sampling — pre-train diagnostic ρ=+0.31 PASS)

Your #1112 baseline (truncated at EP3, mag+dir):
- test_WSS=7.549%, test_vol_p=3.964% (floor regress), test_SP=4.260% (floor regress)
- The new run gets ~4× more compute through full cosine, so expect ~30-50% reduction in test metrics

## Decision criteria

**MERGE** if all three of:
- test_WSS < 6.727%
- test_vol_p ≤ 3.643%
- test_SP ≤ 3.577%

**CONSIDER** (might merge depending on full data) if:
- Floors held AND test_WSS in [6.727%, 7.0%]

**CLOSE** if:
- Test floors regress again (would be surprising — your mag head was calibrated)
- val_abupt > 7.6% at EP3 (KILL gate)

## Why this experiment

1. **Builds on your validated infrastructure** — your #1112 mag head already calibrated to 0.979 ratio at half-cooked EP3, no NaN, no stability issues. No new code needed.
2. **Tests a specific transferable claim** — Wave 27's 91-96% magnitude finding is widely-cited in the experiments log but never ablated. This is the ablation.
3. **Comparable to alphonse's recipe** — same 18h budget regime that's currently projecting SOTA on a different hypothesis. If your run also converges cleanly to full cosine completion, the SOTA potential is genuine.
4. **Single-variable ablation** beyond the budget fix — `λ_dir = 0` is the only non-budget change, so any signal can be attributed cleanly to direction-head contribution.

Run to completion. Standing by for EP3 gate + EP6 sanity + EP13 final + auto-harvest results.
