### PR TITLE
Port SDF importance sampling (alpha=4.0) from PR #972 to tay

### DIFF
--- a/eval_from_checkpoint.py
+++ b/eval_from_checkpoint.py
@@ -1,0 +1,202 @@
+"""Truncation-safety eval: load local best-EMA checkpoint, run full val + test, log to existing W&B run.
+
+Used when training is truncated mid-budget (e.g. EP10 hard truncate) and the in-process
+run_final_evaluation has not executed. Single-GPU evaluation only (the full-eval loaders
+already run on rank 0 in the normal path).
+
+Usage:
+    python eval_from_checkpoint.py \
+        --run-dir outputs/drivaerml/run-vvv84p32 \
+        --run-id vvv84p32 \
+        --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import fields
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+from data import load_data
+from torch.utils.data import DataLoader
+
+from train import Config, build_model, parse_rff_init_sigmas  # noqa: F401
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    eval_loader_for_dataset,
+    log_model_artifact,
+    metric_namespace,
+    numeric_metric_items,
+    primary_metric_log,
+    print_metrics,
+    assert_required_finite_metrics,
+)
+
+
+def _config_from_yaml(config_path: Path) -> Config:
+    with config_path.open("r") as f:
+        raw = yaml.safe_load(f)
+    valid = {f.name for f in fields(Config)}
+    kwargs = {k: v for k, v in raw.items() if k in valid}
+    return Config(**kwargs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True, help="outputs/drivaerml/run-<id>")
+    parser.add_argument("--run-id", required=True, help="W&B run id to resume")
+    parser.add_argument("--data-root", default="")
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument(
+        "--entity", default=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    )
+    parser.add_argument(
+        "--project", default=os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    )
+    parser.add_argument(
+        "--no-artifact",
+        action="store_true",
+        help="Skip artifact upload (faster; logs metrics only).",
+    )
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    config_path = run_dir / "config.yaml"
+    model_path = run_dir / "checkpoint.pt"
+    if not model_path.exists():
+        raise FileNotFoundError(f"missing checkpoint: {model_path}")
+
+    config = _config_from_yaml(config_path)
+    if args.data_root:
+        config.data_root = args.data_root
+    config.num_workers = args.num_workers
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    print(f"Loading data (eval_surface_points={config.eval_surface_points}, "
+          f"eval_volume_points={config.eval_volume_points}) ...")
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    val_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in val_splits.items()
+    }
+    test_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in test_splits.items()
+    }
+    print(f"Val splits: {list(val_loaders)}  Test splits: {list(test_loaders)}")
+
+    print(f"Loading checkpoint from {model_path} ...")
+    checkpoint = torch.load(model_path, map_location=device, weights_only=False)
+    if "model" not in checkpoint:
+        raise RuntimeError("checkpoint missing 'model' state dict")
+    model = build_model(config).to(device)
+    model.load_state_dict(checkpoint["model"], strict=True)
+    model.eval()
+    best_epoch = int(checkpoint.get("epoch", -1))
+    src = checkpoint.get("checkpoint_source", "?")
+    print(f"Loaded checkpoint: epoch={best_epoch}, source={src}")
+    n_params = sum(p.numel() for p in model.parameters())
+
+    print(f"Resuming W&B run {args.run_id} ...")
+    run = wandb.init(
+        entity=args.entity,
+        project=args.project,
+        id=args.run_id,
+        resume="must",
+    )
+
+    # Full val
+    print("\n=== Full val ===")
+    t0 = time.time()
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in val_loaders.items()
+    }
+    full_val_log: dict[str, object] = {
+        **primary_metric_log("full_val_primary", val_metrics["val_surface"]),
+    }
+    for split_name, metrics in val_metrics.items():
+        full_val_log.update(metric_namespace("full_val", split_name, metrics))
+    assert_required_finite_metrics(full_val_log, "full_val_primary")
+    wandb.log(full_val_log)
+    wandb.summary.update(numeric_metric_items(full_val_log))
+    print_metrics("full_val", val_metrics["val_surface"])
+    print(f"full val seconds: {time.time() - t0:.1f}")
+
+    # Test
+    print("\n=== Full test ===")
+    t0 = time.time()
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in test_loaders.items()
+    }
+    test_log: dict[str, object] = {
+        **primary_metric_log("test_primary", test_metrics["test_surface"]),
+    }
+    for split_name, metrics in test_metrics.items():
+        test_log.update(metric_namespace("test", split_name, metrics))
+    assert_required_finite_metrics(test_log, "test_primary")
+    wandb.log(test_log)
+    wandb.summary.update(numeric_metric_items(test_log))
+    print_metrics("test_surface", test_metrics["test_surface"])
+    print(f"test seconds: {time.time() - t0:.1f}")
+
+    # Summary annotations
+    wandb.summary.update(
+        {
+            "truncated_post_hoc_eval": 1.0,
+            "truncated_best_epoch": best_epoch,
+            "truncated_best_checkpoint_source": src,
+        }
+    )
+
+    # Artifact upload
+    if not args.no_artifact:
+        best_metrics_for_artifact = {
+            "epoch": best_epoch,
+            "abupt_axis_mean_rel_l2_pct": val_metrics["val_surface"][
+                "abupt_axis_mean_rel_l2_pct"
+            ],
+            "surface_pressure_mae": val_metrics["val_surface"]["surface_pressure_mae"],
+            "wall_shear_mae": val_metrics["val_surface"]["wall_shear_mae"],
+            "volume_pressure_mae": val_metrics["val_surface"]["volume_pressure_mae"],
+        }
+        print("\nUploading model artifact ...")
+        log_model_artifact(
+            run=run,
+            model_path=model_path,
+            config_path=config_path,
+            config=config,
+            best_metrics=best_metrics_for_artifact,
+            test_metrics=test_metrics,
+            n_params=n_params,
+        )
+
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -232,17 +232,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
         "use_sdf_stratified_vol_sampling": (
-            "Enable SDF-stratified inverse-distance volume importance "
-            "sampling (PR #972 mechanism). Train-time __getitem__ draws "
-            "volume points with weights = 1 / (1 + alpha * |sdf|), "
-            "over-sampling near-surface points where the pressure field "
-            "has steep gradients vs the uniform far field. Eval splits "
+            "Enable SDF-stratified FAR-field volume importance sampling "
+            "(PR #972 SOTA mechanism, run 56bcqp3m). Train-time __getitem__ "
+            "draws volume points with weights = 1 + alpha * |sdf|, "
+            "biasing toward the far field to correct the CFD mesh's "
+            "intrinsic near-surface over-representation. Eval splits "
             "are untouched (full-fidelity deterministic chunks)."
         ),
         "sdf_stratified_alpha": (
-            "Concentration parameter for SDF-stratified sampling weights. "
-            "Higher alpha = more surface-concentrated; alpha=0 reduces to "
-            "uniform. PR #972 SOTA used alpha=4.0."
+            "Concentration parameter for SDF-stratified FAR-field sampling "
+            "weights. Higher alpha = more far-field-concentrated; alpha=0 "
+            "reduces to uniform. PR #972 SOTA used alpha=2.0."
         ),
     }
     for field in fields(Config):
@@ -266,25 +266,32 @@ def install_sdf_stratified_vol_sampling(
     is_main: bool = False,
 ) -> None:
     """Swap ``train_dataset.__class__`` with a subclass that does SDF-stratified
-    inverse-distance volume importance sampling (PR #972 mechanism).
+    FAR-field volume importance sampling (PR #972 SOTA mechanism, run 56bcqp3m).
 
     For each train-mode ``__getitem__`` call, volume indices are drawn with
-    weights = 1 / (1 + alpha * |sdf|) so near-surface points (small |sdf|) are
-    up-weighted in the multinomial draw. Vehicle aerodynamics has steep
-    gradients near the surface (boundary layer, wake) and gentle gradients
-    in the far field, so uniform sampling wastes resolution on smooth regions
-    and under-samples where vol_p actually has structure.
+    weights = 1 + alpha * |sdf| so far-field points (large |sdf|) are
+    up-weighted in the multinomial draw. CFD meshes are refined near the
+    surface, so uniform vertex-sampling over-represents near-surface; the
+    FAR-field bias corrects this and lets the model learn the global
+    pressure field properly.
 
     Eval datasets (sampling_mode != "train_random") fall back to the
     original deterministic chunked behaviour, so val/test remain full-fidelity.
 
-    IO optimisation vs. the literal PR-body code: instead of loading every
-    volume point per call (~294 MB/case), we load only volume_sdf.npy to
-    compute weights, sample indices, then call store.load_case with
-    volume_rows= so only the chosen rows are read for xyz / sdf / pressure.
-    Functionally identical, ~5x faster IO.
+    IO path matches PR #972 verbatim: full case load via ``volume_rows=None``,
+    weights computed from in-memory ``case.volume_x[:, 3]`` (SDF column from
+    data/loader.py's volume_x = [xyz | sdf] concat), multinomial draw across
+    the full pool, then in-memory ``volume_x[vol_idx]`` slice. The transient
+    page-cache pressure washes out after epoch 1 and the contiguous reads
+    avoid the per-row syscall overhead that fancy-indexed memmap incurs on
+    the PVC.
+
+    A per-call mean of the sampled and population weights is stashed into
+    metadata so the training loop can log a per-batch diagnostic confirming
+    the FAR-field bias is alive and the right strength (~3-5 expected at
+    alpha=2.0 for the dataset's |sdf| range).
     """
-    from data.loader import DrivAerMLCase, _case_dir, _load_npy_rows
+    from data.loader import DrivAerMLCase
 
     base_cls = type(train_dataset)
 
@@ -298,6 +305,7 @@ def install_sdf_stratified_vol_sampling(
             n_vol_local = self.max_volume_points
 
             counts = self.store.case_point_counts(view.case_id)
+            n_total = int(counts["n_volume"])
             surface_idx = self._indices(
                 counts["n_surface"],
                 self.max_surface_points,
@@ -305,22 +313,22 @@ def install_sdf_stratified_vol_sampling(
                 group_view_count=view.surface_view_count,
             )
 
-            case_dir = _case_dir(self.store.root, view.case_id)
-            sdf_arr = _load_npy_rows(case_dir / "volume_sdf.npy", rows=None)
-            sdf_flat = sdf_arr.reshape(-1) if sdf_arr.ndim > 1 else sdf_arr
-            sdf_abs = torch.from_numpy(sdf_flat).abs()
-            weights = 1.0 / (1.0 + alpha_local * sdf_abs)
+            case = self.store.load_case(
+                view.case_id,
+                surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                volume_rows=None,
+            )
 
-            n_total = int(sdf_abs.shape[0])
+            sdf_abs = case.volume_x[:, 3].abs()
+            weights = 1.0 + alpha_local * sdf_abs
             n_sample = min(n_vol_local, n_total) if n_vol_local > 0 else n_total
             vol_idx = torch.multinomial(weights, n_sample, replacement=False)
             vol_idx, _ = torch.sort(vol_idx)
 
-            case = self.store.load_case(
-                view.case_id,
-                surface_rows=None if surface_idx is None else surface_idx.numpy(),
-                volume_rows=vol_idx.numpy(),
-            )
+            selected_weights = weights[vol_idx]
+            mean_selected_weight = float(selected_weights.mean().item())
+            mean_population_weight = float(weights.mean().item())
+            max_population_weight = float(weights.max().item())
 
             metadata = dict(case.metadata)
             metadata["n_surface_full"] = int(counts["n_surface"])
@@ -329,20 +337,23 @@ def install_sdf_stratified_vol_sampling(
             metadata["surface_view_count"] = int(view.surface_view_count)
             metadata["surface_sampling_mode"] = view.sampling_mode
             metadata["n_volume_full"] = n_total
-            metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+            metadata["n_volume_loaded"] = int(n_sample)
             metadata["volume_view_index"] = int(view.view_index)
             metadata["volume_view_count"] = int(view.volume_view_count)
-            metadata["volume_sampling_mode"] = "sdf_stratified_inverse"
+            metadata["volume_sampling_mode"] = "sdf_stratified_far_field"
             metadata["joint_view_count"] = int(view.view_count)
             metadata["sdf_stratified_alpha"] = float(alpha_local)
-            metadata["sdf_stratified_weight_form"] = "1/(1+alpha*|sdf|)"
+            metadata["sdf_stratified_weight_form"] = "1+alpha*|sdf|"
+            metadata["sdf_stratified_mean_weight"] = mean_selected_weight
+            metadata["sdf_stratified_population_mean_weight"] = mean_population_weight
+            metadata["sdf_stratified_population_max_weight"] = max_population_weight
 
             return DrivAerMLCase(
                 case_id=case.case_id,
                 surface_x=case.surface_x,
                 surface_y=case.surface_y,
-                volume_x=case.volume_x,
-                volume_y=case.volume_y,
+                volume_x=case.volume_x[vol_idx],
+                volume_y=case.volume_y[vol_idx],
                 metadata=metadata,
             )
 
@@ -354,11 +365,12 @@ def install_sdf_stratified_vol_sampling(
 
     if is_main:
         print(
-            f"[SDF] inverse near-surface vol sampling enabled: alpha={alpha}, "
+            f"[SDF] FAR-field vol sampling enabled: alpha={alpha}, "
             f"n_vol={n_volume}, dataset class=_SDFStratifiedDataset"
         )
         print(
-            "[SDF] weight_form=1/(1+alpha*|sdf|) (near-surface emphasis), "
+            "[SDF] weight_form=1+alpha*|sdf| (far-field emphasis, PR #972 SOTA mechanism), "
+            "IO=full-case load + in-memory multinomial sub-sample, "
             "multinomial replacement=False"
         )
 
@@ -1027,6 +1039,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if config.use_sdf_stratified_vol_sampling
                 else 0.0
             )
+            wandb.summary["sdf_stratified_weight_form"] = (
+                "1+alpha*|sdf|"
+                if config.use_sdf_stratified_vol_sampling
+                else "uniform"
+            )
             wandb.summary["train_dataset_class"] = type(train_loader.dataset).__name__
 
         best_val = float("inf")
@@ -1209,6 +1226,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                     train_log["train/sdf_stratified_alpha"] = float(
                         config.sdf_stratified_alpha
                     )
+                    sdf_batch_means: list[float] = []
+                    sdf_pop_means: list[float] = []
+                    for sample_meta in batch.metadata:
+                        if "sdf_stratified_mean_weight" in sample_meta:
+                            sdf_batch_means.append(
+                                float(sample_meta["sdf_stratified_mean_weight"])
+                            )
+                        if "sdf_stratified_population_mean_weight" in sample_meta:
+                            sdf_pop_means.append(
+                                float(sample_meta["sdf_stratified_population_mean_weight"])
+                            )
+                    if sdf_batch_means:
+                        train_log["train/sdf_stratified_sampled_mean_weight"] = (
+                            sum(sdf_batch_means) / len(sdf_batch_means)
+                        )
+                    if sdf_pop_means:
+                        train_log["train/sdf_stratified_population_mean_weight"] = (
+                            sum(sdf_pop_means) / len(sdf_pop_means)
+                        )
                 if not loss_is_nonfinite:
                     train_log.update(
                         {

--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
     debug: bool = False
 
 
@@ -229,6 +231,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_sdf_stratified_vol_sampling": (
+            "Enable SDF-stratified inverse-distance volume importance "
+            "sampling (PR #972 mechanism). Train-time __getitem__ draws "
+            "volume points with weights = 1 / (1 + alpha * |sdf|), "
+            "over-sampling near-surface points where the pressure field "
+            "has steep gradients vs the uniform far field. Eval splits "
+            "are untouched (full-fidelity deterministic chunks)."
+        ),
+        "sdf_stratified_alpha": (
+            "Concentration parameter for SDF-stratified sampling weights. "
+            "Higher alpha = more surface-concentrated; alpha=0 reduces to "
+            "uniform. PR #972 SOTA used alpha=4.0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -241,6 +256,111 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
+
+
+def install_sdf_stratified_vol_sampling(
+    train_dataset,
+    *,
+    alpha: float,
+    n_volume: int,
+    is_main: bool = False,
+) -> None:
+    """Swap ``train_dataset.__class__`` with a subclass that does SDF-stratified
+    inverse-distance volume importance sampling (PR #972 mechanism).
+
+    For each train-mode ``__getitem__`` call, volume indices are drawn with
+    weights = 1 / (1 + alpha * |sdf|) so near-surface points (small |sdf|) are
+    up-weighted in the multinomial draw. Vehicle aerodynamics has steep
+    gradients near the surface (boundary layer, wake) and gentle gradients
+    in the far field, so uniform sampling wastes resolution on smooth regions
+    and under-samples where vol_p actually has structure.
+
+    Eval datasets (sampling_mode != "train_random") fall back to the
+    original deterministic chunked behaviour, so val/test remain full-fidelity.
+
+    IO optimisation vs. the literal PR-body code: instead of loading every
+    volume point per call (~294 MB/case), we load only volume_sdf.npy to
+    compute weights, sample indices, then call store.load_case with
+    volume_rows= so only the chosen rows are read for xyz / sdf / pressure.
+    Functionally identical, ~5x faster IO.
+    """
+    from data.loader import DrivAerMLCase, _case_dir, _load_npy_rows
+
+    base_cls = type(train_dataset)
+
+    class _SDFStratifiedDataset(base_cls):
+        def __getitem__(self, idx: int) -> DrivAerMLCase:
+            view = self.views[idx]
+            if view.sampling_mode != "train_random":
+                return base_cls.__getitem__(self, idx)
+
+            alpha_local = type(self)._sdf_stratified_alpha
+            n_vol_local = self.max_volume_points
+
+            counts = self.store.case_point_counts(view.case_id)
+            surface_idx = self._indices(
+                counts["n_surface"],
+                self.max_surface_points,
+                view,
+                group_view_count=view.surface_view_count,
+            )
+
+            case_dir = _case_dir(self.store.root, view.case_id)
+            sdf_arr = _load_npy_rows(case_dir / "volume_sdf.npy", rows=None)
+            sdf_flat = sdf_arr.reshape(-1) if sdf_arr.ndim > 1 else sdf_arr
+            sdf_abs = torch.from_numpy(sdf_flat).abs()
+            weights = 1.0 / (1.0 + alpha_local * sdf_abs)
+
+            n_total = int(sdf_abs.shape[0])
+            n_sample = min(n_vol_local, n_total) if n_vol_local > 0 else n_total
+            vol_idx = torch.multinomial(weights, n_sample, replacement=False)
+            vol_idx, _ = torch.sort(vol_idx)
+
+            case = self.store.load_case(
+                view.case_id,
+                surface_rows=None if surface_idx is None else surface_idx.numpy(),
+                volume_rows=vol_idx.numpy(),
+            )
+
+            metadata = dict(case.metadata)
+            metadata["n_surface_full"] = int(counts["n_surface"])
+            metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+            metadata["surface_view_index"] = int(view.view_index)
+            metadata["surface_view_count"] = int(view.surface_view_count)
+            metadata["surface_sampling_mode"] = view.sampling_mode
+            metadata["n_volume_full"] = n_total
+            metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+            metadata["volume_view_index"] = int(view.view_index)
+            metadata["volume_view_count"] = int(view.volume_view_count)
+            metadata["volume_sampling_mode"] = "sdf_stratified_inverse"
+            metadata["joint_view_count"] = int(view.view_count)
+            metadata["sdf_stratified_alpha"] = float(alpha_local)
+            metadata["sdf_stratified_weight_form"] = "1/(1+alpha*|sdf|)"
+
+            return DrivAerMLCase(
+                case_id=case.case_id,
+                surface_x=case.surface_x,
+                surface_y=case.surface_y,
+                volume_x=case.volume_x,
+                volume_y=case.volume_y,
+                metadata=metadata,
+            )
+
+    _SDFStratifiedDataset.__name__ = "_SDFStratifiedDataset"
+    _SDFStratifiedDataset.__qualname__ = "_SDFStratifiedDataset"
+    _SDFStratifiedDataset._sdf_stratified_alpha = float(alpha)
+
+    train_dataset.__class__ = _SDFStratifiedDataset
+
+    if is_main:
+        print(
+            f"[SDF] inverse near-surface vol sampling enabled: alpha={alpha}, "
+            f"n_vol={n_volume}, dataset class=_SDFStratifiedDataset"
+        )
+        print(
+            "[SDF] weight_form=1/(1+alpha*|sdf|) (near-surface emphasis), "
+            "multinomial replacement=False"
+        )
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -695,7 +815,7 @@ def rebuild_train_loader_with_vol_points(
             drop_last=True,
         )
         train_shuffle = False
-    return DataLoader(
+    new_loader = DataLoader(
         train_ds,
         batch_size=config.batch_size,
         shuffle=train_shuffle,
@@ -703,6 +823,15 @@ def rebuild_train_loader_with_vol_points(
         drop_last=True,
         **loader_kwargs(config),
     )
+    if config.use_sdf_stratified_vol_sampling:
+        is_main = distributed_state is not None and distributed_state.is_main
+        install_sdf_stratified_vol_sampling(
+            new_loader.dataset,
+            alpha=config.sdf_stratified_alpha,
+            n_volume=n_points,
+            is_main=is_main,
+        )
+    return new_loader
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -737,6 +866,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         current_train_vol_points = config.train_volume_points
 
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
+        if config.use_sdf_stratified_vol_sampling:
+            install_sdf_stratified_vol_sampling(
+                train_loader.dataset,
+                alpha=config.sdf_stratified_alpha,
+                n_volume=config.train_volume_points,
+                is_main=state.is_main,
+            )
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}
         transform = TargetTransform(
@@ -883,6 +1019,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["sdf_stratified_active"] = bool(
+                config.use_sdf_stratified_vol_sampling
+            )
+            wandb.summary["sdf_stratified_alpha_runtime"] = (
+                float(config.sdf_stratified_alpha)
+                if config.use_sdf_stratified_vol_sampling
+                else 0.0
+            )
+            wandb.summary["train_dataset_class"] = type(train_loader.dataset).__name__
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1057,6 +1202,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                 }
+                if config.use_sdf_stratified_vol_sampling:
+                    train_log["train/sdf_stratified_n_vol_runtime"] = float(
+                        current_train_vol_points
+                    )
+                    train_log["train/sdf_stratified_alpha"] = float(
+                        config.sdf_stratified_alpha
+                    )
                 if not loss_is_nonfinite:
                     train_log.update(
                         {


### PR DESCRIPTION
## Hypothesis

**Port SDF importance sampling from PR #972's branch to tay.** This is the single largest known-working lever that has NOT been merged onto tay, and it's the mechanism that drove PR #972 to the single-model SOTA val_abupt=6.126% / test_WSS=6.727% that the entire program has been chasing.

Your asymmetric-eval-131k run #1078 (closed) confirmed that capacity-uplift alone tops out around 6.31% val_abupt on the no-SDF tay stack — that's ~19bp short of the PR #972 SOTA on val_abupt, and your test_WSS landed at 6.996% (+26.8bp above SOTA). Capacity-uplift is hitting a ceiling because the training-time sampling is uniform; the dataset has strong spatial structure that uniform vol sampling fails to exploit.

### What SDF stratified importance sampling does (per PR #972)

- Original train dataset draws `train_volume_points` uniformly from each case's full volume.
- **SDF stratified** replaces uniform sampling with `weight = 1 / (1 + alpha * |sdf|)`, where `sdf` is the signed distance to the surface. Points near the surface get higher weight; points in the far field get lower weight.
- The intuition: vehicle aerodynamics has steep gradients near the surface (boundary layer, wake) and gentle gradients in the far field. Uniform sampling wastes resolution on smooth regions and under-samples the regions where vol_p actually has structure.
- PR #972 ran with `alpha=4.0`. Lower alpha = more uniform; higher alpha = more surface-concentrated.

### Why this is the biggest available lever

| Lever | On tay? | Result |
|---|---|---|
| Asymmetric eval 131k (alphonse #1078) | yes (your code) | FAILED: test_WSS 6.996% > 6.727% SOTA |
| Capacity uplift slices=256 (thorfinn #1100) | yes (your peer's code) | EP16 val_abupt 6.330% — best no-SDF result so far |
| WSS loss mechanisms (Wave 28.5, 6 PRs) | yes | TBD; all targeting WSS not vol_p |
| **SDF importance sampling (PR #972)** | **NO** | drove SOTA val_abupt 6.126% on non-tay branch |
| Long-budget recipe (18h) | yes (your #1078) | validated |

Everyone in the program has been working around the missing SDF lever. **Bring it onto tay** and the entire program gets a new baseline.

## Instructions

### Reference implementation

The exact code that produced PR #972's SOTA is in commit `023f766` on the `drivaerml-long-20260504` branch. To inspect:

```bash
git show 023f766 -- train.py
git show 023f766 -- trainer_runtime.py
```

Two files change in that commit:
1. **`train.py`** (+86 lines): adds `Config.use_sdf_stratified_vol_sampling`, `Config.sdf_stratified_alpha`, `install_sdf_stratified_vol_sampling()` function, plumbs through CLI parsing and main(), adds W&B config telemetry
2. **`trainer_runtime.py`** (+5 lines): EMA warm-start fix (re-sync shadow from live params at `step_counter == start_step`) — **already on tay** (commit 860d08f, PR #1087). Do not re-port this part.

### Port to tay

Copy the `install_sdf_stratified_vol_sampling()` function, the two `Config` flags, the CLI parsing additions, and the `main()` hook from commit `023f766` into tay's `train.py`. **Verify** the imports it uses (`from data.loader import DrivAerMLCase`) work on tay — if `DrivAerMLCase` has been renamed/restructured, adapt accordingly.

### CLI flags expected after port

- `--use-sdf-stratified-vol-sampling` (default False — gate the new path)
- `--sdf-stratified-alpha` (default 2.0; this run will use **4.0** per PR #972)

### Smoke test (1-2 epochs to confirm port is functional)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=270 torchrun --standalone --nproc-per-node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 2 \
  --vol-points-schedule "0:16384" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 4.0 \
  --wandb_group sdf-importance-sampling-port --agent alphonse \
  --wandb_name "alphonse/sdf-port-smoke"
```

Smoke PASS:
- Rank-0 stdout prints `[SDF] inverse near-surface vol sampling enabled: alpha=4.0, n_vol=16384, dataset class=_SDFStratifiedDataset`
- 2 epochs complete cleanly (no NaN, no monkey-patch crash)
- W&B config logs `sdf_stratified_active=True`, `sdf_stratified_alpha_runtime=4.0`, `train_dataset_class=_SDFStratifiedDataset`
- EP1 val_abupt ≤ 35% (gentle catastrophe gate since lr-warmup-epochs=1 mechanically lands ~33%)
- EP2 val_abupt ≤ 12% (post-warmup signal — if mechanism is functional, should already be diverging from no-SDF baseline)

### Full 13-ep run (DDP 8 GPUs, 18h budget — your validated configuration)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1100 nohup torchrun --standalone --nproc_per_node=8 train.py \
  --agent alphonse --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 4.0 \
  --wandb_group sdf-importance-sampling-port --agent alphonse \
  --wandb_name "alphonse/sdf-port-alpha4-full13ep" \
  > logs/sdf-port-alpha4.log 2>&1 &
```

### EP3 mid-flight gate (recipe uses lr-warmup-epochs=1)

PR #972 SDF stack EP3 was 6.2% val_abupt. With 18h budget recipe + SDF importance sampling:
- val_abupt ≤ **6.5%** PASS / ≤ **7.0%** MARGINAL / > 7.0% KILL
- val_vol_p ≤ **4.0%** PASS / ≤ **4.5%** MARGINAL / > 4.5% KILL

If both PASS, continue to EP13. If KILL on either, post a comment with EP3 metrics and the W&B config block (especially `sdf_stratified_active`) — sometimes the monkey-patch silently fails to attach, and we need to verify the SDF path is actually active before declaring "SDF doesn't help."

### EP13 final + auto-harvest

After EP13 (~13-14h wall-clock at your recent ~62 min/ep cadence on 18h budget), auto-harvest runs test eval from best-val EMA checkpoint.

**Merge gate (target: reproduce PR #972 baseline on tay):**
- test_WSS ≤ **6.727%** AND test_vol_p ≤ **3.643%** AND test_SP ≤ **3.577%**
- If test_WSS < 6.727% (genuine improvement vs SOTA), even better — but reproducing is sufficient because the new baseline opens up new compounding directions for the program.

**Consider gate (might merge or do a quick alpha sweep):**
- Floors held AND test_WSS in [6.727%, 6.85%]
- Means SDF port is methodology-correct but alpha=4.0 isn't optimal on tay; would assign quick `alpha ∈ {2.0, 3.0, 6.0}` sweep.

**Close gate:**
- Floors regress (would suggest a bug in the port — e.g. SDF column index is wrong on tay, since `case.volume_x[:, 3]` assumes SDF is the 4th column of volume features and you should verify)
- val_abupt > 7.6% at EP3 KILL

### Diagnostic to report at terminal SENPAI-RESULT

1. **Verify SDF path actually active** — paste the W&B config block showing `sdf_stratified_active=True` and the `[SDF] inverse near-surface vol sampling enabled: ...` startup print
2. **Final per-channel breakdown** — test_WSSx, test_WSSy, test_WSSz, test_vol_p_OOD, test_SP — the entire metric table, since this is a baseline-rebasing PR not just a hypothesis test
3. **val→test ratio** for val_abupt and val_WSS — does the 0.935 ratio that PR #972 had hold when SDF is on tay's no-SDF-substitute features (RFF, QK-norm, string_separable)? If not, the program's projection methodology needs further work.
4. **train/sdf_stratified_n_vol_runtime** at terminal step — confirm the curriculum (16384→32768→49152→65536) is interacting correctly with the SDF sampling.

## Baseline

Current best (BASELINE.md, 2026-05-14):
- val_abupt: 6.126% (PR #972 SDF stack SOTA val)
- val_WSS: 7.155% (PR #972)
- **test_WSS: 6.727% (PR #972 single-model SOTA, paper-facing)**
- test_vol_p: 3.643% (floor — MUST NOT regress)
- test_SP: 3.577% (floor — MUST NOT regress)

Live competing runs (potentially landing before yours):
- thorfinn #1100 EP16 in flight: val_abupt=6.330%, val_WSS=7.134%; projected test_WSS [6.37%, 6.51%] band (potential SOTA win at slices=256, no SDF)
- Wave 28.5 (6 PRs in flight): edward #1116, askeladd #1118, fern #1119, nezuko #1120, frieren #1121, tanjiro #1114 — all testing WSS-side mechanisms

**Your run's role:** rebase the tay baseline to the PR #972 SDF stack so future single-model experiments inherit the SDF lever. Even if thorfinn lands SOTA on slices=256 (no SDF), porting SDF to tay opens up `slices=256 + SDF` as the immediate next compounding direction.

## Decision criteria

**MERGE** if:
- test_WSS ≤ 6.727% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%

**MERGE** (rebase-baseline justification) even at parity with PR #972 if SDF is verified active and floors hold — this PR's value is bringing the lever onto tay, not strictly improving on it.

**CONSIDER** (might merge or alpha-sweep):
- Floors held AND test_WSS in [6.727%, 6.85%]
- Direction: "SDF port functional, alpha needs tuning on tay"

**CLOSE** if:
- Test floors regress (port has a bug)
- val_abupt > 7.6% at EP3 KILL

## Why this experiment now

1. **Largest known-working lever not on tay** — every other student is testing speculative WSS mechanisms; you're bringing the proven mechanism that drove the existing SOTA.
2. **Your asymmetric-eval result is the strongest argument** — the data showed capacity-uplift tops out at val_abupt=6.31% on no-SDF tay (the program's strongest no-SDF result on 17 epochs). Beyond capacity, the next lever is data sampling, which is what SDF does.
3. **Compounds with everything in flight** — once SDF is on tay, thorfinn's slices=256 result + SDF, frieren's mag-only decomp + SDF, edward's per-channel heads + SDF all become testable.
4. **Single engineering task with a known-good reference** — commit `023f766` is the exact code that worked on PR #972. The only port risk is verifying `case.volume_x[:, 3]` (SDF column index) is still correct on tay's data loader; everything else is mechanical.
5. **You're the right student for it** — you just demonstrated infrastructure competence with the asymmetric-eval setup, and your 18h budget is validated.

Run to completion. Standing by for smoke PASS confirmation, then EP3 gate + EP13 final + auto-harvest results.
