### PR TITLE
Spatial-prior α=10 + 18h budget — stronger oversample at full convergence

### DIFF
--- a/data/spatial_prior_sampler.py
+++ b/data/spatial_prior_sampler.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Spatial-prior surface point sampling for DrivAerML.
+
+Wraps ``DrivAerMLSurfaceDataset`` so that during training the
+``--train-surface-points`` draw is biased toward (a) the front of the
+vehicle in the canonical x-axis and (b) far-from-ground-plane regions
+along the canonical z-axis. These coordinate priors carry the highest
+empirical Pearson correlation with |WSS| on DrivAerML
+(``pearson(-x, |WSS|) ≈ +0.236``, ``pearson(|z|, |WSS|) ≈ +0.176``;
+≈4x κ on the same 7-case sample, PR #1113 diagnostic).
+
+Per-point importance weight:
+
+    front_bias  = (x_max - x) / (x_max - x_min)   # 0 back, 1 front
+    ground_bias = (|z| - |z|_min) / (|z|_max - |z|_min)  # 0 ground, 1 far
+    weight = 1 + alpha * (front_bias + ground_bias) / 2
+
+Computed once per case (lazy on first access) and cached per worker.
+Eval ("eval_chunk") and "full" sampling modes are unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+from .loader import DrivAerMLCase, DrivAerMLSurfaceDataset, _resolve_artifact_path
+
+
+def compute_spatial_prior_weights_np(
+    xyz: np.ndarray,
+    *,
+    alpha: float,
+) -> np.ndarray:
+    """Return per-point spatial-prior weights given full surface xyz.
+
+    ``xyz`` is expected as float32 ``[N, 3]`` in the canonical vehicle frame:
+    +x toward the rear (so ``-x`` ranks front-of-car high), z aligned with
+    the vertical axis (|z| ranks far-from-ground high).
+    """
+
+    if alpha <= 0.0:
+        return np.ones(xyz.shape[0], dtype=np.float32)
+    x = xyz[:, 0]
+    z = xyz[:, 2]
+    x_min = float(x.min())
+    x_max = float(x.max())
+    x_range = max(x_max - x_min, 1e-8)
+    front_bias = (x_max - x) / x_range  # 0 at back, 1 at front
+    z_abs = np.abs(z)
+    z_abs_min = float(z_abs.min())
+    z_abs_max = float(z_abs.max())
+    z_range = max(z_abs_max - z_abs_min, 1e-8)
+    ground_bias = (z_abs - z_abs_min) / z_range  # 0 near ground, 1 far
+    combined = 0.5 * (front_bias + ground_bias)
+    weights = 1.0 + alpha * combined
+    return weights.astype(np.float32, copy=False)
+
+
+class SpatialPriorSurfaceDataset(DrivAerMLSurfaceDataset):
+    """Surface dataset that oversamples high spatial-prior surface regions.
+
+    During ``train_random`` sampling, surface row indices are drawn from
+    ``torch.multinomial(weights, num_samples, replacement=True)`` where
+    ``weights`` follow ``compute_spatial_prior_weights_np``. Volume
+    sampling and evaluation are unchanged.
+
+    ``spatial_alpha = 0`` recovers uniform behavior identical to the
+    parent class. ``replacement=True`` is intentional: it matches the
+    parent uniform sampler (which uses ``torch.randint`` with
+    replacement) and is ~10x faster than ``replacement=False`` on
+    N~10M surface meshes; expected duplicate count at 65k/8.8M is
+    negligible against gradient noise (PR #1113 throughput proven).
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        spatial_alpha: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.spatial_alpha = float(spatial_alpha)
+        self._weight_cache: dict[str, torch.Tensor] = {}
+
+    def _load_full_xyz(self, case_id: str) -> np.ndarray:
+        case_dir = self.store.root / case_id
+        path = _resolve_artifact_path(case_dir / "surface_xyz.npy")
+        arr = np.load(path, mmap_mode="r")
+        return np.asarray(arr, dtype=np.float32)
+
+    def _surface_weights(self, case_id: str) -> torch.Tensor:
+        cached = self._weight_cache.get(case_id)
+        if cached is not None:
+            return cached
+        xyz = self._load_full_xyz(case_id)
+        w = compute_spatial_prior_weights_np(xyz, alpha=self.spatial_alpha)
+        tensor = torch.from_numpy(w)
+        self._weight_cache[case_id] = tensor
+        return tensor
+
+    def __getitem__(self, idx: int) -> DrivAerMLCase:
+        if self.spatial_alpha <= 0.0:
+            return super().__getitem__(idx)
+        view = self.views[idx]
+        counts = self.store.case_point_counts(view.case_id)
+        n_surface = int(counts["n_surface"])
+        max_surface = int(self.max_surface_points)
+        use_weighted = (
+            view.sampling_mode == "train_random"
+            and max_surface > 0
+            and n_surface > max_surface
+            and view.view_index < view.surface_view_count
+        )
+        if use_weighted:
+            weights = self._surface_weights(view.case_id)
+            sampled = torch.multinomial(weights, max_surface, replacement=True)
+            surface_idx = sampled.sort().values
+        else:
+            surface_idx = self._indices(
+                n_surface,
+                max_surface,
+                view,
+                group_view_count=view.surface_view_count,
+            )
+        volume_idx = self._indices(
+            int(counts["n_volume"]),
+            int(self.max_volume_points),
+            view,
+            group_view_count=view.volume_view_count,
+        )
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=None if volume_idx is None else volume_idx.numpy(),
+        )
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = (
+            "train_spatial_prior" if use_weighted else view.sampling_mode
+        )
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = view.sampling_mode
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )

--- a/scripts/spatial_prior_diagnostic.py
+++ b/scripts/spatial_prior_diagnostic.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Pre-training diagnostic for the spatial-prior surface sampler (PR #1120).
+
+For each case in the 7-case sample used for the PR #1113 diagnostic, this
+script computes:
+
+- ``pearson(spatial_score, |WSS|)`` where ``spatial_score`` is the
+  pre-alpha combined bias ``(front_bias + ground_bias) / 2`` so the
+  ranking is independent of alpha. This is the green-light check the
+  advisor asked for (ρ ≥ +0.20).
+- ``pearson(spatial_score, |Cp|)`` for context.
+- Per-decile bin-occupancy of the spatial-prior weights with the chosen
+  alpha (the mechanism check the advisor asked for).
+
+Outputs are written to ``student_logs/spatial_prior_diagnostic.json``
+and a summary table to ``student_logs/spatial_prior_diagnostic.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from data.loader import _resolve_artifact_path  # noqa: PLC2701
+from data.spatial_prior_sampler import compute_spatial_prior_weights_np
+
+
+def _load_case_arrays(root: Path, case_id: str) -> dict[str, np.ndarray]:
+    case_dir = root / case_id
+    xyz = np.asarray(
+        np.load(_resolve_artifact_path(case_dir / "surface_xyz.npy"), mmap_mode="r"),
+        dtype=np.float32,
+    )
+    wss = np.asarray(
+        np.load(_resolve_artifact_path(case_dir / "surface_wallshearstress.npy"), mmap_mode="r"),
+        dtype=np.float32,
+    )
+    cp = np.asarray(
+        np.load(_resolve_artifact_path(case_dir / "surface_cp.npy"), mmap_mode="r"),
+        dtype=np.float32,
+    ).reshape(-1)
+    wss_mag = np.linalg.norm(wss, axis=1)
+    return {"xyz": xyz, "wss_mag": wss_mag, "cp_abs": np.abs(cp)}
+
+
+def _spatial_score(xyz: np.ndarray) -> np.ndarray:
+    """Pre-alpha combined bias used purely for correlation reporting."""
+    x = xyz[:, 0]
+    z = xyz[:, 2]
+    x_min = float(x.min())
+    x_max = float(x.max())
+    front_bias = (x_max - x) / max(x_max - x_min, 1e-8)
+    z_abs = np.abs(z)
+    z_abs_min = float(z_abs.min())
+    z_abs_max = float(z_abs.max())
+    ground_bias = (z_abs - z_abs_min) / max(z_abs_max - z_abs_min, 1e-8)
+    return 0.5 * (front_bias + ground_bias)
+
+
+def _pearson(a: np.ndarray, b: np.ndarray) -> float:
+    am = a - a.mean()
+    bm = b - b.mean()
+    denom = float(np.sqrt((am * am).sum()) * np.sqrt((bm * bm).sum()))
+    if denom <= 0.0:
+        return 0.0
+    return float((am * bm).sum() / denom)
+
+
+def _bin_occupancy(weights: np.ndarray) -> dict[str, float]:
+    """Per-decile sampling-mass share under the given weights."""
+    score_sorted = np.argsort(weights)[::-1]  # high-weight first
+    w = weights[score_sorted]
+    p = w / w.sum()
+    n = w.size
+    deciles = {}
+    for d in range(10):
+        lo = int(np.floor(d * n / 10))
+        hi = int(np.floor((d + 1) * n / 10))
+        deciles[f"d{d+1}_top{(d+1)*10}pct"] = float(p[:hi].sum())
+    deciles["bottom_50pct_share"] = float(p[int(0.5 * n) :].sum())
+    return deciles
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data-root",
+        default="/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511",
+    )
+    parser.add_argument(
+        "--cases",
+        default="run_1,run_50,run_100,run_200,run_300,run_400,run_485",
+    )
+    parser.add_argument("--alpha", type=float, default=3.0)
+    parser.add_argument("--out-json", default="student_logs/spatial_prior_diagnostic.json")
+    parser.add_argument("--out-md", default="student_logs/spatial_prior_diagnostic.md")
+    args = parser.parse_args()
+
+    root = Path(args.data_root)
+    case_ids = [c.strip() for c in args.cases.split(",") if c.strip()]
+    Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
+
+    per_case = []
+    for case_id in case_ids:
+        arrays = _load_case_arrays(root, case_id)
+        score = _spatial_score(arrays["xyz"])
+        weights = compute_spatial_prior_weights_np(arrays["xyz"], alpha=args.alpha)
+        bins = _bin_occupancy(weights)
+        record = {
+            "case_id": case_id,
+            "n_surface": int(arrays["xyz"].shape[0]),
+            "pearson_spatial_vs_WSS_mag": _pearson(score, arrays["wss_mag"]),
+            "pearson_spatial_vs_Cp_abs": _pearson(score, arrays["cp_abs"]),
+            "weights_min": float(weights.min()),
+            "weights_max": float(weights.max()),
+            "weights_mean": float(weights.mean()),
+            "bin_occupancy": bins,
+        }
+        per_case.append(record)
+        print(
+            f"{case_id:>10} | N={record['n_surface']:>8} | "
+            f"rho(spatial,|WSS|)={record['pearson_spatial_vs_WSS_mag']:+0.4f} | "
+            f"rho(spatial,|Cp|)={record['pearson_spatial_vs_Cp_abs']:+0.4f} | "
+            f"top10pct_mass={bins['d1_top10pct']:0.4f}"
+        )
+
+    mean_rho_wss = float(np.mean([r["pearson_spatial_vs_WSS_mag"] for r in per_case]))
+    mean_rho_cp = float(np.mean([r["pearson_spatial_vs_Cp_abs"] for r in per_case]))
+    mean_top10 = float(np.mean([r["bin_occupancy"]["d1_top10pct"] for r in per_case]))
+    mean_bottom50 = float(np.mean([r["bin_occupancy"]["bottom_50pct_share"] for r in per_case]))
+
+    summary = {
+        "alpha": args.alpha,
+        "n_cases": len(per_case),
+        "mean_pearson_spatial_vs_WSS_mag": mean_rho_wss,
+        "mean_pearson_spatial_vs_Cp_abs": mean_rho_cp,
+        "mean_top10pct_mass": mean_top10,
+        "mean_top10pct_oversample": mean_top10 / 0.10,
+        "mean_bottom50pct_mass": mean_bottom50,
+        "mean_bottom50pct_undersample": mean_bottom50 / 0.50,
+        "green_light_threshold_rho_ge_0_20": mean_rho_wss >= 0.20,
+        "per_case": per_case,
+    }
+    with open(args.out_json, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    lines = [
+        f"# Spatial-prior diagnostic (alpha={args.alpha})",
+        "",
+        f"Cases: {', '.join(case_ids)}",
+        "",
+        "## Pearson correlation (mean across cases)",
+        "",
+        "| Quantity | Mean |",
+        "|---|---:|",
+        f"| pearson(spatial_score, \\|WSS\\|) | {mean_rho_wss:+0.4f} |",
+        f"| pearson(spatial_score, \\|Cp\\|)  | {mean_rho_cp:+0.4f} |",
+        "",
+        f"Green light (ρ ≥ +0.20): **{'PASS' if mean_rho_wss >= 0.20 else 'FAIL'}**",
+        "",
+        "## Bin-occupancy (mean across cases)",
+        "",
+        "| Bin | Uniform | Weighted | Oversample |",
+        "|---|---:|---:|---:|",
+        f"| Top 10% | 10.00% | {100*mean_top10:0.2f}% | x{mean_top10/0.10:0.2f} |",
+        f"| Bottom 50% | 50.00% | {100*mean_bottom50:0.2f}% | x{mean_bottom50/0.50:0.2f} |",
+        "",
+        "## Per-case",
+        "",
+        "| Case | N | rho(spatial,\\|WSS\\|) | rho(spatial,\\|Cp\\|) | top10%_mass | bot50%_mass |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for r in per_case:
+        lines.append(
+            f"| {r['case_id']} | {r['n_surface']} | "
+            f"{r['pearson_spatial_vs_WSS_mag']:+0.4f} | "
+            f"{r['pearson_spatial_vs_Cp_abs']:+0.4f} | "
+            f"{100*r['bin_occupancy']['d1_top10pct']:0.2f}% | "
+            f"{100*r['bin_occupancy']['bottom_50pct_share']:0.2f}% |"
+        )
+    with open(args.out_md, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"\nMean rho(spatial,|WSS|) = {mean_rho_wss:+0.4f}")
+    print(f"Mean top10% mass = {mean_top10:0.4f} (oversample x{mean_top10/0.10:0.2f})")
+    print(f"Mean bot50% mass = {mean_bottom50:0.4f} (undersample x{mean_bottom50/0.50:0.2f})")
+    print(f"\nWrote {args.out_json} and {args.out_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/student_logs/spatial_prior_alpha10.log
+++ b/student_logs/spatial_prior_alpha10.log
@@ -1,0 +1,394 @@
+W0515 02:41:29.474000 452125 torch/distributed/run.py:851] 
+W0515 02:41:29.474000 452125 torch/distributed/run.py:851] *****************************************
+W0515 02:41:29.474000 452125 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0515 02:41:29.474000 452125 torch/distributed/run.py:851] *****************************************
+Device: cuda:0, DDP world_size=8
+Volume-points curriculum: ep0->16384, ep3->32768, ep6->49152, ep9->65536
+DrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=347657 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+Model: SurfaceTransolver grouped surface+volume (17.41M params)
+Surface channel weights: cp=1.0 tau_x=1.0 tau_y=1.5 tau_z=2.0
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024137-rp1op3z6
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank0
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/rp1op3z6
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024138-xpprgz8b
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank1
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/xpprgz8b
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024139-of9x0awu
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank2
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/of9x0awu
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run y5lforbj
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024140-y5lforbj
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank3
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/y5lforbj
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024141-cgowjoig
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank4
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/cgowjoig
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run jrdmjxlf
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024142-jrdmjxlf
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank5
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/jrdmjxlf
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024143-sveawoz1
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank6
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/sveawoz1
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run y803xlcc
+wandb: Tracking run with wandb version 0.26.1
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260515_024145-y803xlcc
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank7
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/y803xlcc
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+[rank1]:[W515 02:41:47.624442271 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /build/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
+  return torch.rms_norm(input, normalized_shape, weight, eps)
+[rank7]:[W515 02:41:47.881412864 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+[rank4]:[W515 02:41:47.881989510 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+[rank5]:[W515 02:41:47.896428889 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+[rank3]:[W515 02:41:47.905049146 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+Epoch 1/13:   0%|          | 1/10864 [00:01<5:12:47,  1.73s/it][rank2]:[W515 02:41:48.397053421 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+[rank6]:[W515 02:41:48.397889506 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+Epoch 1/13:   0%|          | 2/10864 [00:02<3:05:56,  1.03s/it][rank0]:[W515 02:41:48.920775768 reducer.cpp:1502] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
+val_surface    loss=0.10073 abupt_axis_rel_l2_pct=28.9145 surface_p_mae=0.06144 volume_p_mae=33.39017 wall_shear_mae=0.31031 cases=34
+val_surface    loss=0.00834 abupt_axis_rel_l2_pct=8.2365 surface_p_mae=0.01580 volume_p_mae=9.27200 wall_shear_mae=0.08483 cases=34
+val_surface    loss=0.00646 abupt_axis_rel_l2_pct=7.2286 surface_p_mae=0.01355 volume_p_mae=8.04314 wall_shear_mae=0.07289 cases=34
+Volume-points curriculum: epoch 3 -> train_volume_points=32768 (was 16384)
+val_surface    loss=0.00577 abupt_axis_rel_l2_pct=6.8139 surface_p_mae=0.01261 volume_p_mae=7.72332 wall_shear_mae=0.06806 cases=34
+val_surface    loss=0.00560 abupt_axis_rel_l2_pct=6.7039 surface_p_mae=0.01229 volume_p_mae=7.62988 wall_shear_mae=0.06649 cases=34
+val_surface    loss=0.00547 abupt_axis_rel_l2_pct=6.6169 surface_p_mae=0.01209 volume_p_mae=7.53666 wall_shear_mae=0.06532 cases=34
+Volume-points curriculum: epoch 6 -> train_volume_points=49152 (was 32768)
+val_surface    loss=0.00531 abupt_axis_rel_l2_pct=6.5122 surface_p_mae=0.01185 volume_p_mae=7.43809 wall_shear_mae=0.06400 cases=34
+val_surface    loss=0.00524 abupt_axis_rel_l2_pct=6.4696 surface_p_mae=0.01176 volume_p_mae=7.37787 wall_shear_mae=0.06353 cases=34
+val_surface    loss=0.00519 abupt_axis_rel_l2_pct=6.4390 surface_p_mae=0.01167 volume_p_mae=7.33760 wall_shear_mae=0.06311 cases=34
+Volume-points curriculum: epoch 9 -> train_volume_points=65536 (was 49152)
+val_surface    loss=0.00513 abupt_axis_rel_l2_pct=6.4039 surface_p_mae=0.01160 volume_p_mae=7.29800 wall_shear_mae=0.06263 cases=34
+val_surface    loss=0.00513 abupt_axis_rel_l2_pct=6.3973 surface_p_mae=0.01161 volume_p_mae=7.28665 wall_shear_mae=0.06247 cases=34
+val_surface    loss=0.00512 abupt_axis_rel_l2_pct=6.3896 surface_p_mae=0.01156 volume_p_mae=7.27088 wall_shear_mae=0.06233 cases=34
+val_surface    loss=0.00512 abupt_axis_rel_l2_pct=6.3920 surface_p_mae=0.01154 volume_p_mae=7.26453 wall_shear_mae=0.06230 cases=34
+Training done in 839.1 min
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+Best val: epoch 12, abupt_axis_mean_rel_l2_pct=6.3896
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: updating run metadata
+wandb: uploading output.log
+wandb: uploading output.log; uploading wandb-summary.json; uploading config.yaml
+wandb: uploading history steps 70664-70664, summary
+wandb: uploading output.log; uploading wandb-summary.json; uploading config.yaml
+wandb: uploading history steps 70664-70664, summary
+wandb: uploading history steps 70664-70664, summary
+wandb: uploading output.log; uploading wandb-summary.json
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇█████
+wandb:                              lr ▁▁▁▁▁▁▁▁▁███████████▇▇▇▆▆▆▆▆▆▅▅▅▅▄▃▂▂▂▁▁
+wandb:             train/base_mse_loss █▇▂▄▄▂▂▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip █▅▇▅▇▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss ▄▂▂▁▂▂▁▁█▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁████████████████▇▆▆▆▆▆▆▅▅▅▃▃▃▃▂▂▂▂▁▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.02295
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15224
+wandb:             train/base_mse_loss 0.00314
+wandb:                train/epoch_loss 0.00613
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00574
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▂▂▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▄▄▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇▇██
+wandb:                              lr ▁▁▁▁▁▁▁▁█████████████████▇▇▇▇▇▆▆▆▅▅▄▄▃▃▁
+wandb:             train/base_mse_loss █▂▂▃▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip ▇▆█▅▆▅▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss ▃█▇▇▂▂▄▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁▁▁▁████████████████▇▇▆▆▆▆▆▆▆▅▅▅▄▃▂▂▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.02309
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15224
+wandb:             train/base_mse_loss 0.00303
+wandb:                train/epoch_loss 0.00595
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00561
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank5 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/jrdmjxlf
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024142-jrdmjxlf/logs
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank6 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/sveawoz1
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024143-sveawoz1/logs
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▂▂▂▂▃▃▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇████
+wandb:                              lr ▁▁▁▁▁▁▁▁▁▁████████████████▇▇▇▆▆▆▆▅▄▄▃▂▂▁
+wandb:             train/base_mse_loss ▃█▃▃▃▂▅▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▂▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ██████████▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip ▇▇█▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss ██▇▄▄▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁▁▁▁████████████████████▇▇▆▆▆▆▅▅▄▃▂▂▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.02298
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15225
+wandb:             train/base_mse_loss 0.00343
+wandb:                train/epoch_loss 0.00596
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00629
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank7 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/y803xlcc
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024145-y803xlcc/logs
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▆▆▆▆▆▆▆▆▆▇▇██
+wandb:                              lr ▁▁▁▁█████████████████████▇▇▇▆▆▆▆▆▆▅▃▂▂▂▁
+wandb:             train/base_mse_loss ▅▂▄▁▁▁▂█▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ██████████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip ▂▄▇██▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss ▄▃▃▂█▆▂▅▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁▁▁▁▁▁▁███████████████▇▇▆▆▆▆▆▆▅▅▄▄▄▄▂
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.0231
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15224
+wandb:             train/base_mse_loss 0.00299
+wandb:                train/epoch_loss 0.00611
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00553
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank4 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/cgowjoig
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024141-cgowjoig/logs
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▄▄▅▅▅▅▅▅▅▅▅▆▆▆▆▇▇▇███
+wandb:                              lr ▁▁▁▁▁██████████████████▇▇▇▇▆▆▆▆▆▆▅▅▃▂▂▂▁
+wandb:             train/base_mse_loss ▃█▇▅▆▂▁▁▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped █████████▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip █▄▄▆▃▄▃▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss █▂▂▁▁▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁▁▁███████████████████▇▇▆▆▆▅▅▄▄▄▃▂▂▂▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.02312
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15224
+wandb:             train/base_mse_loss 0.00301
+wandb:                train/epoch_loss 0.00592
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00559
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank2 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/of9x0awu
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024139-of9x0awu/logs
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▇▇▇▇█
+wandb:                              lr ▁▁▁▁▁█████████████████▇▇▇▆▆▆▆▆▆▆▅▅▄▄▃▂▁▁
+wandb:             train/base_mse_loss █▁▂▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ██████████▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip ▆▇▆▇█▆▄▃▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss █▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁▁▁██████████████▇▇▇▆▆▆▆▆▆▆▅▅▅▄▃▂▂▂▂▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.02298
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15223
+wandb:             train/base_mse_loss 0.00317
+wandb:                train/epoch_loss 0.00625
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00584
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank3 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/y5lforbj
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024140-y5lforbj/logs
+wandb: 
+wandb: Run history:
+wandb:                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:                     global_step ▁▁▁▁▂▂▂▂▂▂▂▂▂▃▃▃▃▃▄▄▄▅▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇██
+wandb:                              lr ▁▁▁▁▁███████████████████▇▆▆▆▆▆▆▅▅▅▄▃▂▂▂▁
+wandb:             train/base_mse_loss █▆▄▂▂▂▃▃▁▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                train/epoch_loss █▃▁▁▁▁▁▁▁▁▁▁▁
+wandb:              train/grad/clipped ████████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb: train/grad/global_norm_pre_clip █▆▄▅▅▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                      train/loss ▂█▂▂▂▃▁▃▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                        train/lr ▁▁▁▁███████████████▇▆▆▆▆▅▅▅▅▄▄▃▃▃▃▃▂▂▂▂▁
+wandb:            train/nonfinite_grad ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                             +29 ...
+wandb: 
+wandb: Run summary:
+wandb:                    epoch_time_s 2845.0231
+wandb:                     global_step 70652
+wandb:                              lr 0.0
+wandb:             total_train_minutes 839.15222
+wandb:             train/base_mse_loss 0.00324
+wandb:                train/epoch_loss 0.00597
+wandb:              train/grad/clipped 0
+wandb: train/grad/global_norm_pre_clip 0.0375
+wandb:                      train/loss 0.00602
+wandb:                        train/lr 0.0
+wandb:                             +30 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank1 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/xpprgz8b
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024138-xpprgz8b/logs
+full_val       loss=0.00512 abupt_axis_rel_l2_pct=6.3896 surface_p_mae=0.01156 volume_p_mae=7.27093 wall_shear_mae=0.06233 cases=34
+test_surface   loss=0.00468 abupt_axis_rel_l2_pct=6.1563 surface_p_mae=0.01160 volume_p_mae=7.30597 wall_shear_mae=0.06062 cases=50
+Logged model artifact 'model-nezuko-spatial-prior-alpha10-18h-20260515T024128Z-rp1op3z6'
+wandb: uploading artifact model-nezuko-spatial-prior-alpha10-18h-20260515T024128Z-rp1op3z6; updating run metadata
+wandb: uploading artifact model-nezuko-spatial-prior-alpha10-18h-20260515T024128Z-rp1op3z6
+wandb: uploading history steps 70666-70666, summary, console lines 39-40
+wandb: uploading data
+wandb: 
+wandb: Run history:
+wandb:                         best_checkpoint/updated ████████████▁
+wandb:                   best_checkpoint/valid_primary ▁▁▁▁▁▁▁▁▁▁▁▁▁
+wandb:                                    epoch_time_s ███▃▃▃▂▂▂▁▁▁▁
+wandb:     full_val/val_surface/abupt_axis_mean_rel_l2 ▁
+wandb: full_val/val_surface/abupt_axis_mean_rel_l2_pct ▁
+wandb:                      full_val/val_surface/cases ▁
+wandb:                       full_val/val_surface/loss ▁
+wandb:              full_val/val_surface/surface_cases ▁
+wandb:               full_val/val_surface/surface_loss ▁
+wandb:       full_val/val_surface/surface_pressure_mae ▁
+wandb:                                          +6,679 ...
+wandb: 
+wandb: Run summary:
+wandb:            best_checkpoint/selection_metric val_primary/abupt_ax...
+wandb:                      best_checkpoint/source ema
+wandb:                     best_checkpoint/updated 0
+wandb:               best_checkpoint/valid_primary 1
+wandb:                                  best_epoch 12
+wandb:               best_val/surface_pressure_mae 0.01156
+wandb:                best_val/volume_pressure_mae 7.27088
+wandb:                     best_val/wall_shear_mae 0.06233
+wandb: best_val_primary/abupt_axis_mean_rel_l2_pct 6.38961
+wandb:                                epoch_time_s 2845.02351
+wandb:                                      +6,690 ...
+wandb: 
+wandb: 🚀 View run nezuko/spatial-prior-alpha10-18h-20260515T024128Z-rank0 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/rp1op3z6
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 7 W&B file(s), 0 media file(s), 3 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260515_024137-rp1op3z6/logs

--- a/student_logs/spatial_prior_diagnostic_alpha10.json
+++ b/student_logs/spatial_prior_diagnostic_alpha10.json
@@ -1,0 +1,167 @@
+{
+  "alpha": 10.0,
+  "n_cases": 7,
+  "mean_pearson_spatial_vs_WSS_mag": 0.3148751599448068,
+  "mean_pearson_spatial_vs_Cp_abs": 0.4529129479612623,
+  "mean_top10pct_mass": 0.1579660028219223,
+  "mean_top10pct_oversample": 1.579660028219223,
+  "mean_bottom50pct_mass": 0.33574094091142925,
+  "mean_bottom50pct_undersample": 0.6714818818228585,
+  "green_light_threshold_rho_ge_0_20": true,
+  "per_case": [
+    {
+      "case_id": "run_1",
+      "n_surface": 8828095,
+      "pearson_spatial_vs_WSS_mag": 0.3081609904766083,
+      "pearson_spatial_vs_Cp_abs": 0.43498897552490234,
+      "weights_min": 1.0505849123001099,
+      "weights_max": 8.518842697143555,
+      "weights_mean": 4.7707743644714355,
+      "bin_occupancy": {
+        "d1_top10pct": 0.1634000986814499,
+        "d2_top20pct": 0.30397722125053406,
+        "d3_top30pct": 0.43722301721572876,
+        "d4_top40pct": 0.5611451268196106,
+        "d5_top50pct": 0.6745737791061401,
+        "d6_top60pct": 0.7678734064102173,
+        "d7_top70pct": 0.8378473520278931,
+        "d8_top80pct": 0.9024285674095154,
+        "d9_top90pct": 0.9576188921928406,
+        "d10_top100pct": 1.0000009536743164,
+        "bottom_50pct_share": 0.3254271447658539
+      }
+    },
+    {
+      "case_id": "run_50",
+      "n_surface": 8194077,
+      "pearson_spatial_vs_WSS_mag": 0.28457504510879517,
+      "pearson_spatial_vs_Cp_abs": 0.41925686597824097,
+      "weights_min": 1.207540512084961,
+      "weights_max": 8.42239761352539,
+      "weights_mean": 4.846506118774414,
+      "bin_occupancy": {
+        "d1_top10pct": 0.15506143867969513,
+        "d2_top20pct": 0.29171979427337646,
+        "d3_top30pct": 0.42318665981292725,
+        "d4_top40pct": 0.5452228784561157,
+        "d5_top50pct": 0.6574316024780273,
+        "d6_top60pct": 0.7565080523490906,
+        "d7_top70pct": 0.8310607075691223,
+        "d8_top80pct": 0.8992504477500916,
+        "d9_top90pct": 0.9565355181694031,
+        "d10_top100pct": 1.0000016689300537,
+        "bottom_50pct_share": 0.34257054328918457
+      }
+    },
+    {
+      "case_id": "run_100",
+      "n_surface": 8254434,
+      "pearson_spatial_vs_WSS_mag": 0.35072749853134155,
+      "pearson_spatial_vs_Cp_abs": 0.4730038642883301,
+      "weights_min": 1.0203193426132202,
+      "weights_max": 8.403230667114258,
+      "weights_mean": 4.862100601196289,
+      "bin_occupancy": {
+        "d1_top10pct": 0.15486574172973633,
+        "d2_top20pct": 0.29345041513442993,
+        "d3_top30pct": 0.42683279514312744,
+        "d4_top40pct": 0.5501274466514587,
+        "d5_top50pct": 0.6629016399383545,
+        "d6_top60pct": 0.7607512474060059,
+        "d7_top70pct": 0.83487468957901,
+        "d8_top80pct": 0.9025729894638062,
+        "d9_top90pct": 0.9582880735397339,
+        "d10_top100pct": 1.0000005960464478,
+        "bottom_50pct_share": 0.337098628282547
+      }
+    },
+    {
+      "case_id": "run_200",
+      "n_surface": 8377308,
+      "pearson_spatial_vs_WSS_mag": 0.32821017503738403,
+      "pearson_spatial_vs_Cp_abs": 0.482928603887558,
+      "weights_min": 1.0411573648452759,
+      "weights_max": 8.504644393920898,
+      "weights_mean": 4.762572288513184,
+      "bin_occupancy": {
+        "d1_top10pct": 0.16066226363182068,
+        "d2_top20pct": 0.29871705174446106,
+        "d3_top30pct": 0.4301219880580902,
+        "d4_top40pct": 0.5529547333717346,
+        "d5_top50pct": 0.6663236021995544,
+        "d6_top60pct": 0.7663798332214355,
+        "d7_top70pct": 0.8384377956390381,
+        "d8_top80pct": 0.90346360206604,
+        "d9_top90pct": 0.9583846926689148,
+        "d10_top100pct": 0.9999994039535522,
+        "bottom_50pct_share": 0.3336765170097351
+      }
+    },
+    {
+      "case_id": "run_300",
+      "n_surface": 8185956,
+      "pearson_spatial_vs_WSS_mag": 0.3421241044998169,
+      "pearson_spatial_vs_Cp_abs": 0.47566697001457214,
+      "weights_min": 1.0380109548568726,
+      "weights_max": 8.440301895141602,
+      "weights_mean": 4.942562580108643,
+      "bin_occupancy": {
+        "d1_top10pct": 0.15382665395736694,
+        "d2_top20pct": 0.2919105887413025,
+        "d3_top30pct": 0.42476069927215576,
+        "d4_top40pct": 0.5477506518363953,
+        "d5_top50pct": 0.6602912545204163,
+        "d6_top60pct": 0.7573500871658325,
+        "d7_top70pct": 0.8320685625076294,
+        "d8_top80pct": 0.9005357623100281,
+        "d9_top90pct": 0.9573285579681396,
+        "d10_top100pct": 1.0000005960464478,
+        "bottom_50pct_share": 0.33970922231674194
+      }
+    },
+    {
+      "case_id": "run_400",
+      "n_surface": 8701452,
+      "pearson_spatial_vs_WSS_mag": 0.2993924915790558,
+      "pearson_spatial_vs_Cp_abs": 0.4502580761909485,
+      "weights_min": 1.2804529666900635,
+      "weights_max": 8.53276252746582,
+      "weights_mean": 4.81514835357666,
+      "bin_occupancy": {
+        "d1_top10pct": 0.16074039041996002,
+        "d2_top20pct": 0.29897141456604004,
+        "d3_top30pct": 0.430115669965744,
+        "d4_top40pct": 0.5524517893791199,
+        "d5_top50pct": 0.6652396321296692,
+        "d6_top60pct": 0.7633570432662964,
+        "d7_top70pct": 0.834701418876648,
+        "d8_top80pct": 0.9004825949668884,
+        "d9_top90pct": 0.9565962553024292,
+        "d10_top100pct": 0.9999998807907104,
+        "bottom_50pct_share": 0.33476030826568604
+      }
+    },
+    {
+      "case_id": "run_485",
+      "n_surface": 9242495,
+      "pearson_spatial_vs_WSS_mag": 0.29093581438064575,
+      "pearson_spatial_vs_Cp_abs": 0.43428727984428406,
+      "weights_min": 1.0345592498779297,
+      "weights_max": 8.5166015625,
+      "weights_mean": 4.912765026092529,
+      "bin_occupancy": {
+        "d1_top10pct": 0.15720543265342712,
+        "d2_top20pct": 0.2949286103248596,
+        "d3_top30pct": 0.4271007478237152,
+        "d4_top40pct": 0.550049364566803,
+        "d5_top50pct": 0.6630569100379944,
+        "d6_top60pct": 0.7598910927772522,
+        "d7_top70pct": 0.8329720497131348,
+        "d8_top80pct": 0.9000934958457947,
+        "d9_top90pct": 0.9568663835525513,
+        "d10_top100pct": 1.000001072883606,
+        "bottom_50pct_share": 0.33694422245025635
+      }
+    }
+  ]
+}

--- a/student_logs/spatial_prior_diagnostic_alpha10.md
+++ b/student_logs/spatial_prior_diagnostic_alpha10.md
@@ -1,0 +1,31 @@
+# Spatial-prior diagnostic (alpha=10.0)
+
+Cases: run_1, run_50, run_100, run_200, run_300, run_400, run_485
+
+## Pearson correlation (mean across cases)
+
+| Quantity | Mean |
+|---|---:|
+| pearson(spatial_score, \|WSS\|) | +0.3149 |
+| pearson(spatial_score, \|Cp\|)  | +0.4529 |
+
+Green light (ρ ≥ +0.20): **PASS**
+
+## Bin-occupancy (mean across cases)
+
+| Bin | Uniform | Weighted | Oversample |
+|---|---:|---:|---:|
+| Top 10% | 10.00% | 15.80% | x1.58 |
+| Bottom 50% | 50.00% | 33.57% | x0.67 |
+
+## Per-case
+
+| Case | N | rho(spatial,\|WSS\|) | rho(spatial,\|Cp\|) | top10%_mass | bot50%_mass |
+|---|---:|---:|---:|---:|---:|
+| run_1 | 8828095 | +0.3082 | +0.4350 | 16.34% | 32.54% |
+| run_50 | 8194077 | +0.2846 | +0.4193 | 15.51% | 34.26% |
+| run_100 | 8254434 | +0.3507 | +0.4730 | 15.49% | 33.71% |
+| run_200 | 8377308 | +0.3282 | +0.4829 | 16.07% | 33.37% |
+| run_300 | 8185956 | +0.3421 | +0.4757 | 15.38% | 33.97% |
+| run_400 | 8701452 | +0.2994 | +0.4503 | 16.07% | 33.48% |
+| run_485 | 9242495 | +0.2909 | +0.4343 | 15.72% | 33.69% |

--- a/train.py
+++ b/train.py
@@ -33,6 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
+from data.spatial_prior_sampler import SpatialPriorSurfaceDataset
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -138,6 +139,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    surface_importance_mode: str = "off"
+    surface_importance_alpha: float = 0.0
     debug: bool = False
 
 
@@ -219,6 +222,25 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "surface_importance_mode": (
+            "Surface point-sampling importance source for the training "
+            "loader. 'off' (default) draws uniformly with replacement; "
+            "'spatial' biases samples toward the front of the car (-x) "
+            "and far-from-ground regions (|z|), the two strongest "
+            "Pearson predictors of |WSS| on DrivAerML (rho~+0.236 and "
+            "+0.176 on the 7-case sample). Per-point weight "
+            "w = 1 + alpha * (front_bias + ground_bias) / 2, drawn via "
+            "torch.multinomial with replacement=True (PR #1113 throughput "
+            "infrastructure). Alpha controlled by "
+            "--surface-importance-alpha."
+        ),
+        "surface_importance_alpha": (
+            "Scalar strength of the surface-importance reweighting. "
+            "alpha=0 falls through to the baseline uniform sampler. "
+            "alpha>0 with --surface-importance-mode=spatial produces "
+            "weights w = 1 + alpha * (front_bias + ground_bias) / 2 "
+            "in [1, 1+alpha]. Default 0.0."
         ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
@@ -677,13 +699,25 @@ def rebuild_train_loader_with_vol_points(
     sampling_mode = (
         "train_random" if (config.train_surface_points > 0 or n_points > 0) else "full"
     )
-    train_ds = DrivAerMLSurfaceDataset(
-        old_ds.case_ids,
-        store=old_ds.store,
-        max_surface_points=config.train_surface_points,
-        max_volume_points=n_points,
-        sampling_mode=sampling_mode,
-    )
+    mode = str(getattr(config, "surface_importance_mode", "off") or "off").lower()
+    alpha = float(getattr(config, "surface_importance_alpha", 0.0))
+    if mode == "spatial" and alpha > 0.0:
+        train_ds = SpatialPriorSurfaceDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+            spatial_alpha=alpha,
+        )
+    else:
+        train_ds = DrivAerMLSurfaceDataset(
+            old_ds.case_ids,
+            store=old_ds.store,
+            max_surface_points=config.train_surface_points,
+            max_volume_points=n_points,
+            sampling_mode=sampling_mode,
+        )
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -31,6 +31,7 @@ from data import (
     load_data,
     pad_collate,
 )
+from data.spatial_prior_sampler import SpatialPriorSurfaceDataset
 
 
 class EMA:
@@ -287,6 +288,22 @@ def make_loaders(
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
     )
+    mode = str(getattr(config, "surface_importance_mode", "off") or "off").lower()
+    alpha = float(getattr(config, "surface_importance_alpha", 0.0))
+    if mode == "spatial" and alpha > 0.0:
+        train_ds = SpatialPriorSurfaceDataset(
+            train_ds.case_ids,
+            store=train_ds.store,
+            max_surface_points=train_ds.max_surface_points,
+            max_volume_points=train_ds.max_volume_points,
+            sampling_mode=train_ds.sampling_mode,
+            spatial_alpha=alpha,
+        )
+    elif mode not in ("off", "spatial"):
+        raise ValueError(
+            f"--surface-importance-mode={mode!r} not supported on this branch; "
+            "use 'off' or 'spatial'."
+        )
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:


### PR DESCRIPTION
## Hypothesis

Your α=3 spatial-prior experiment (PR #1120) validated the mechanism cleanly: ρ=+0.31 prevents catastrophe, ×1.39 top-decile oversample matched diagnostic prediction, throughput parity, strongest 3-EP val_WSS in the recipe family (7.94% vs matched-baseline 8.61%). The EP3 short-cycle budget was the binding constraint, not the mechanism.

**This experiment tests two things in one run:**
1. **Stronger spatial-prior at α=10 with 18h budget** (your suggested follow-up #2) — gives more aggressive top-region oversample (predicted ×~2.2 vs current ×1.39 at α=3) without catastrophe risk since ρ is positive.
2. **Full 13-EP convergence at 18h budget** — answers whether spatial-prior closes the gap to no-SDF tay ceiling (test_WSS ~6.99%) when given enough budget.

Mechanism intuition: at α=3, the top-decile (high-spatial-weight) regions get ×1.39 the sampling probability of uniform — modest. Increasing α to 10 should yield ~×2.2 top-decile oversample (linear `1 + α·norm_weight` scaling). The pre-train diagnostic confirms there's no catastrophe risk at this ρ.

Important: at higher α, the **bottom-decile** undersampling becomes more aggressive (×0.4 at α=10 vs ×0.78 at α=3). The bottom-decile is the low-spatial-weight tail (rear underbody, distant body sections); we may lose coverage there. Watch test_SP carefully — that's where rear-region undersample would manifest first.

## Instructions

**Single CLI flag change from your α=3 run**: `--surface-importance-alpha 10.0` (was 3.0). All other recipe parameters identical. Add `SENPAI_TIMEOUT_MINUTES=1100` for full 13-EP convergence. No code changes.

**Pre-train diagnostic check (5 min)**:
- Re-run the bin-occupancy diagnostic with α=10. Confirm:
  - Top-decile oversample ratio in [2.0, 2.5] range (predicted ~2.2)
  - Bottom-decile undersample ratio ≥ 0.35 (if below 0.30, the rear-region coverage drops to a level worth flagging)
- If bottom-decile drops below 0.30, **PAUSE and post** — we may need α=7 instead.

**Smoke test (1 EP)**: Confirm EP1 val_abupt ≤ 35% (gentle catastrophe gate; your α=3 hit 23.6% EP1). If EP1 > 35%, flag and pause — could mean the higher α has tipped past the safety floor.

**Full 13-EP run** with the same recipe as your α=3 run plus the α change and budget extension:

```bash
export SENPAI_TIMEOUT_MINUTES=1100
torchrun --standalone --nproc-per-node=8 train.py \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --no-compile-model \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --surface-importance-mode spatial --surface-importance-alpha 10.0 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group spatial-prior-alpha10-18h \
  --wandb-name "nezuko/spatial-prior-alpha10-18h-$(date -u +%Y%m%dT%H%M%SZ)"
```

## Gates

**EP3 gate** (recipe-standard):
- PASS: val_abupt ≤ 7.2% AND val_vol_p ≤ 4.5%
- MARGINAL: val_abupt ≤ 7.6% AND val_vol_p ≤ 5.0%
- KILL: otherwise

**EP6 mid-flight check**:
- val_abupt ≤ 6.5% expected
- val_SP must NOT regress vs α=3 EP3 (4.71%) — if SP rises, the bottom-decile undersample is hurting rear-region SP prediction

**EP13 terminal** (merge criteria):
- test_WSS < 6.99% (beat no-SDF tay ceiling) AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%
- Strong win: test_WSS in [6.5%, 6.7%] range = approaching PR #972 SOTA (6.727%) without SDF
- Paper-relevant: test_τ_z < 9.0% standalone

## Diagnostics to report at terminal SENPAI-RESULT

1. Full per-epoch val table (val_abupt, val_WSS, val_WSSx/y/z, val_vol_p, val_SP)
2. Best-EMA-checkpoint test eval on all 50 cases (all 4 surface metrics + test_τ_x/y/z)
3. **Bin-occupancy diagnostic at α=10**: top-decile / bottom-decile sampling ratios from training-time samples
4. **τ_z/τ_x test ratio**: compare vs α=3 baseline (1.44 in your EP3 run) — if α=10 reduces this ratio, spatial-prior is τ_z-specific; if it stays the same, the mechanism is axis-neutral
5. Throughput (it/s) per epoch — should match α=3 1.90 it/s within noise
6. Peak GPU memory — should match α=3 45.2 GB within noise

## Baseline

Current best metrics (BASELINE.md and CURRENT_RESEARCH_STATE.md):

**Project SOTA (PR #1102 K=8 Caruana ensemble — ensembles BANNED for new work):**
- val_abupt = 5.7452% | test_WSS = **6.3263%** | test_vol_p = 3.5397% | test_SP = 3.3529%

**Single-model SOTA (PR #972 SDF-stratified vol sampling — NOT on tay):**
- val_abupt = 6.126% | test_WSS = **6.727%** | test_vol_p = 3.643% | test_SP = 3.577%

**No-SDF tay structural ceiling (alphonse #1078 / thorfinn #1100):**
- test_WSS = 6.989-6.996%, test_vol_p = 3.644-3.680%, test_SP = 3.832-3.855%

**Your α=3 EP3 baseline (#1120, just closed):**
- test_WSS = 7.757%, test_vol_p = 4.068%, test_SP = 4.383%, test_τ_z = 9.851%
- Val EP3 best: val_abupt=7.028%, val_WSS=7.940%, val_vol_p=4.109%, val_SP=4.708%

**Win criteria for merge**:
- test_WSS < 6.989% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%

## Why this experiment over the SDF + spatial-prior combination

Per your suggested follow-up ranking, the SDF + spatial-prior combination is held until alphonse #1122 lands a working SDF port on tay (currently in revision with FAR-field α=2.0 corrected plan, smoke pending). Once that lands, the SDF + spatial-prior combination is the obvious Wave 30 follow-up — but right now α=10 standalone is the highest-EV test we can run on tay without dependencies.
