### PR TITLE
Deeper surface_out MLP (depth 2→4) — test τ_z magnitude decoder bottleneck

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        surface_out_depth: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -476,16 +477,20 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
-            # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
+            # Surface head is a parameterized depth MLP (cp, tau_x, tau_y, tau_z).
+            # surface_out_depth=2 (default) reproduces baseline: [Linear, SiLU, Linear].
+            # PR #1126 tests depth=4 to probe τ_z magnitude decoder bottleneck.
             # Volume head is a deeper 3-layer MLP for the harder vol_p task —
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
+            self.surface_out_depth = surface_out_depth
+            surface_layers: list[nn.Module] = []
+            for _ in range(max(1, surface_out_depth - 1)):
+                surface_layers.append(nn.Linear(n_hidden, n_hidden))
+                surface_layers.append(nn.SiLU())
+            surface_layers.append(nn.Linear(n_hidden, self.surface_output_dim))
+            self.surface_out = nn.Sequential(*surface_layers)
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    surface_out_depth: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -220,6 +221,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "surface_out_depth": (
+            "Number of Linear layers in the surface output head MLP (PR #1126). "
+            "Default 2 reproduces the baseline [Linear, SiLU, Linear]. "
+            "Increasing to 4 inserts two additional [Linear, SiLU] blocks, "
+            "giving the surface head more representational capacity for τ_z "
+            "magnitude regression. At depth=N the head is (N-1) [Linear, SiLU] "
+            "blocks followed by a final Linear(n_hidden, surface_output_dim). "
+            "Only applies when --use-aux-decoder-heads (default True)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        surface_out_depth=config.surface_out_depth,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Deeper surface_out MLP head (depth 2 → 4) bottlenecks τ_z magnitude prediction at convergence.**

The current `surface_out` is a 2-layer MLP (Linear(n_hidden, n_hidden) → SiLU → Linear(n_hidden, surface_output_dim)) at `model.py:484-488`. It predicts 4 surface channels: cp, tau_x, tau_y, tau_z. Meanwhile `volume_out` is 3-layer with narrowing widths (n_hidden → n_hidden//2 → n_hidden//4 → output) for the harder vol_p task (PR #958).

**Wave 27 finding (frieren analysis):** 91–96% of WSS residual is magnitude error — direction is solved (cos_sim=0.996). And τ_z is the worst axis on no-SDF tay (~9.05% across runs). Magnitude regression is a near-pointwise scalar regression problem — exactly where decoder depth pays off, since the backbone hidden representations encode rich relational structure but the final magnitude readout requires nonlinear scalar fitting.

**Mechanism:** doubling the depth of `surface_out` from 2 → 4 nonlinear layers gives the surface head more representational capacity specifically for the τ_z magnitude readout. This is structurally **orthogonal** to:
- thorfinn #1123 τ_z dedicated subnet (separate branch, not deeper shared head)
- edward #1116 per-channel WSS heads (decouple channels, not deepen)
- alphonse #1122 SDF importance sampling (data-side, not architecture)

If τ_z magnitude is decoder-depth-limited (rather than backbone-limited), this single-flag change should produce a measurable test_WSS improvement, especially on test_τ_z. If the bottleneck is elsewhere (backbone capacity, data sampling, optimizer), this experiment cleanly falsifies the decoder-depth hypothesis.

**Cross-check with prior:** slices=256 capacity uplift (thorfinn #1100, val_abupt=6.353%) showed that adding capacity to the **Transformer backbone** plateaus at test_WSS ≈ 6.99% on no-SDF tay. That doesn't preclude decoder-side capacity from giving fresh gains — the slices=256 result narrowed the bottleneck to "training-time sampling is load-bearing", but decoder MLP depth is a different axis.

## Instructions

### Step 1 — parameterize `surface_out_depth` in `model.py`

Add a `surface_out_depth: int = 2` argument to the model constructor (around line 350-380 area where other arch hyperparams are declared), and replace the hard-coded 2-layer surface_out with a parameterized builder. Target signature inside the `use_aux_decoder_heads:` branch (~line 478-489):

```python
# Surface head — parameterized depth (default 2 for backward compat with prior checkpoints).
# At depth=2: Linear(n_hidden, n_hidden) → SiLU → Linear(n_hidden, surface_output_dim)
# At depth>2: (depth-1) blocks of [Linear(n_hidden, n_hidden), SiLU] + final Linear(n_hidden, surface_output_dim)
surface_layers = []
for _ in range(max(1, surface_out_depth - 1)):
    surface_layers.append(nn.Linear(n_hidden, n_hidden))
    surface_layers.append(nn.SiLU())
surface_layers.append(nn.Linear(n_hidden, self.surface_output_dim))
self.surface_out = nn.Sequential(*surface_layers)
self.surface_out.apply(_init_linear)
```

Keep `volume_out` exactly as-is.

**Verify depth=2 reproduces baseline init**: with `surface_out_depth=2`, the loop runs once → `[Linear, SiLU, Linear]`, matching the existing structure byte-for-byte. Run a 50-step smoke at depth=2 first and confirm loss trajectory matches baseline within numerical noise.

### Step 2 — wire CLI flag in `train.py`

Add `--surface-out-depth` arg (default=2) and thread it through to the model constructor where `n_hidden`, `n_layers`, etc. are passed.

### Step 3 — smoke test (200 steps, depth=4)

Run a 200-step smoke at depth=4 to verify:
- No NaN / no OOM (depth=4 adds ~2 × n_hidden² = ~524K params; total model param count grows ~3-5%; well within 96GB VRAM)
- `train/surface_loss` trajectory parallels baseline at depth=2 (not catastrophically worse — would indicate init issue)
- `it/s` is within ±5% of baseline (decoder MLP adds negligible compute vs backbone)

Post smoke results in a PR comment.

### Step 4 — full 13-EP run with 18h budget (`SENPAI_TIMEOUT_MINUTES=1100`)

```bash
cd "target/" && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --surface-out-depth 4 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group fern-surface-out-depth-4-18h \
  --wandb-name fern/surface-out-depth-4-18h
```

### Step 5 — terminal eval

At terminal, evaluate the best-val EMA checkpoint on test set and post a `SENPAI-RESULT` marker with terminal=true, primary_metric=val_abupt, test_metric=test_WSS, plus a full breakdown of test_τ_x / test_τ_y / **test_τ_z** (most relevant — was the magnitude bottleneck moved?).

## Baseline (tay, no-SDF, single-model)

| Metric | thorfinn #1100 (no-SDF, slices=256, EP15) | PR #972 SOTA (SDF, slices=128) |
|---|---:|---:|
| val_abupt | 6.353% | 6.126% |
| test_abupt | — | 5.844% |
| test_WSS | **6.989%** (no-SDF ceiling) | **6.727%** |
| test_vol_p | 3.6442% | 3.643% (floor) |
| test_SP | 3.8324% | 3.577% (floor) |
| test_τ_z | ~9.05% (no-SDF ceiling axis) | 8.96% (PR #972 era) |

**Win criteria:**
- **PASS EP3 gate**: `val_abupt ≤ 7.0%` AND `val_vol_p ≤ 4.5%`
- **MARGINAL EP3 gate**: `val_abupt ≤ 7.3%` AND `val_vol_p ≤ 5.0%`
- **Terminal target (paper-facing)**: `test_WSS < 6.989%` AND `test_vol_p ≤ 3.643%` AND `test_SP ≤ 3.577%`
- **Reach goal (Issue #1056)**: `test_WSS < 6.727%` (true SOTA on no-SDF stack — would be a major result)
- **τ_z-specific signal**: `test_τ_z` improvement vs baseline (the load-bearing magnitude axis)

