### PR TITLE
Explicit surface_loss warmup curriculum (3-ep ramp 0→full) — test #1114 implicit-curriculum mechanism

### DIFF
--- a/train.py
+++ b/train.py
@@ -84,6 +84,7 @@ class Config:
     eval_volume_points: int = 40_000
     validation_every: int = 1
     surface_loss_weight: float = 1.0
+    surface_loss_weight_warmup_epochs: int = 0
     volume_loss_weight: float = 1.0
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
@@ -219,6 +220,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "surface_loss_weight_warmup_epochs": (
+            "Linearly ramp the surface_loss_weight from 0 -> full over the "
+            "first N epochs (per-batch smooth, not stepwise). After EP=N the "
+            "full --surface-loss-weight applies unchanged. Volume loss is "
+            "unaffected. 0 disables (baseline behavior). Multiplies the loss "
+            "term (not gradient / residual), so gradient flow is preserved "
+            "throughout the ramp. Only applies in the legacy (non-GradNorm) "
+            "loss path; GradNorm handles task balancing itself."
         ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
@@ -929,13 +939,32 @@ def main(argv: Iterable[str] | None = None) -> None:
             model.train()
             train_loss_sum = 0.0
             n_batches = 0
+            num_batches_per_epoch = len(train_loader)
 
-            for batch in tqdm(
+            for batch_idx, batch in enumerate(tqdm(
                 train_loader,
                 desc=f"Epoch {epoch + 1}/{max_epochs}",
                 leave=False,
                 disable=not state.is_main,
-            ):
+            )):
+                if (
+                    config.surface_loss_weight_warmup_epochs > 0
+                    and epoch < config.surface_loss_weight_warmup_epochs
+                ):
+                    batch_progress_in_epoch = (
+                        (batch_idx / num_batches_per_epoch)
+                        if num_batches_per_epoch > 0
+                        else 0.0
+                    )
+                    ramp_progress = (
+                        (epoch + batch_progress_in_epoch)
+                        / config.surface_loss_weight_warmup_epochs
+                    )
+                    effective_surface_loss_weight = (
+                        config.surface_loss_weight * ramp_progress
+                    )
+                else:
+                    effective_surface_loss_weight = config.surface_loss_weight
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1027,7 +1056,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         transform,
                         device,
                         config.amp_mode,
-                        surface_loss_weight=config.surface_loss_weight,
+                        surface_loss_weight=effective_surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
                     )
@@ -1056,6 +1085,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/surface_loss_weight_effective": float(
+                        effective_surface_loss_weight
+                    ),
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis

**Explicit surface_loss_weight warmup curriculum: ramp surface loss from 0 → full over first 3 epochs to lock in an implicit volume-first curriculum effect that PR #1114 showed is real but transient.**

### Why this hypothesis now

Three independent loss-engineering experiments have now been refuted on this dataset's residual structure:

1. **PR #1114 tanjiro learnable WSS weights — closed null at convergence.** Critical finding: the EP1 win came from learnable weights briefly drifting capacity to vol/sp at init (−46 to −50%), then being pulled back to baseline by regularization. The EP1 gain was an **implicit, transient volume-first curriculum artifact** — not a learned-weights win.
2. **PR #1119 fern GradNorm short-cycle — closed, prior-rediscovery REFUTED.** GradNorm plateaus at τ_z weight=1.07 (vs hand-tuned prior 1.67), and test floors regress. Hand-tuned prior is empirically load-bearing.
3. **PR #1118 askeladd (yours) OHEM v2 — closed, ZERO OHEM gradient (100% clip_active).** Top-K surface residuals are 100–25,000× larger than mean residual; any safe scalar cap fires on 100% of steps → gradient through OHEM is zero. **Mechanism takeaway: extreme surface residuals are intrinsic to the dataset; any approach that tries to reshape the magnitude distribution mid-training collides with that structure.**

These three results combined point to a different conclusion: **the timing of surface loss exposure matters more than the shape**. PR #1114 showed an implicit volume-first phase helps EP1. PR #1118 showed mid-training surface-residual reweighting can't be done without breaking gradient flow. What hasn't been tested: **explicit, gradient-flow-preserving curriculum that simply delays surface loss exposure until volume features are well-formed**.

### Mechanism (precise)

Add a `--surface-loss-weight-warmup-epochs N` CLI flag that:
- For first N epochs (default 0), linearly ramps `effective_surface_loss_weight = surface_loss_weight × (current_epoch / N)` from 0.0 at EP0 to full `surface_loss_weight` at EP=N.
- After EP=N, `effective_surface_loss_weight = surface_loss_weight` (unchanged, full).
- This is a **scalar multiplier on the loss term, not on the gradient or residual** — preserves gradient flow at all points (avoids the OHEM #1118 trap).
- Volume loss is unaffected throughout.

### Predicted mechanism payoff

- **EP0–N**: Optimizer focuses on volume_loss + surface auxiliary signal scaled down. Volume head and shared backbone stabilize before surface head receives full gradient.
- **EP=N–13**: Full multi-task training resumes. Backbone is now volume-conditioned; surface head learns on top of a stable representation.
- **Specific prediction**: this should help **test_τ_z magnitude prediction** (the load-bearing 9.05% axis), because τ_z magnitude regression depends most heavily on having stable shared-backbone features when its loss is first applied. A volatile backbone during EP0–N harms τ_z disproportionately due to its extreme residual distribution (100-25,000× ratio established in #1118 diagnostics).

### Falsifiability

If `test_WSS` and `test_τ_z` both regress vs baseline, the implicit-curriculum effect in #1114 was either coincidental or limited to EP1 dynamics with no convergence benefit — clean negative.

If `test_WSS < 6.989%` (no-SDF ceiling), explicit curriculum captures the #1114 mechanism, distinct from the architectural decoder/sampling experiments running in parallel.

## Instructions

### Step 1 — add CLI flag in `train.py`

Find the `surface_loss_weight: float = 1.0` config field (around line 86) and add:

```python
surface_loss_weight_warmup_epochs: int = 0  # 0 = off (baseline behavior); N>0 = linear ramp 0→full over first N epochs
```

Add the corresponding `--surface-loss-weight-warmup-epochs` argparse arg.

### Step 2 — wire the ramp into the training loop

Locate where `surface_loss_weight` is passed to the loss function (around `train.py:1030` where `surface_loss_weight=config.surface_loss_weight` is passed). At that callsite (per-batch in the training loop), compute the effective weight:

```python
if config.surface_loss_weight_warmup_epochs > 0 and epoch < config.surface_loss_weight_warmup_epochs:
    # Linear ramp 0 → 1 over first N epochs. Use fractional epoch progress for smooth ramping.
    ramp_progress = (epoch + batch_progress_in_epoch) / config.surface_loss_weight_warmup_epochs
    effective_surface_loss_weight = config.surface_loss_weight * ramp_progress
else:
    effective_surface_loss_weight = config.surface_loss_weight
```

Where `batch_progress_in_epoch = batch_idx / num_batches_per_epoch` so the ramp is per-step smooth (not stepwise per-epoch).

Pass `effective_surface_loss_weight` to the loss function instead of `config.surface_loss_weight`.

**W&B logging**: log `train/surface_loss_weight_effective` per step so the ramp is visible in W&B.

### Step 3 — verify ramp behavior with a 100-step smoke

Run a 100-step smoke with `--surface-loss-weight-warmup-epochs 3 --epochs 3`. Verify in W&B:
- At step 0: `train/surface_loss_weight_effective` ≈ 0.0 (small finite, not literal 0)
- At step ~50% through EP1: `effective` ≈ 1/3 × full = 0.667 (if `surface_loss_weight=2.0`)
- The ramp should be monotonic and smooth

Post smoke W&B plot/values in PR comment.

### Step 4 — full 13-EP run with 18h budget

```bash
cd "target/" && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --surface-loss-weight-warmup-epochs 3 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group askeladd-surface-loss-warmup-3ep \
  --wandb-name askeladd/surface-loss-warmup-3ep
```

### Step 5 — diagnostics to log per epoch

Beyond standard val metrics, post a brief summary at EP1, EP3 (post-warmup), EP6, and EP13:
- `val_abupt`, `val_vol_p`, `val_WSS`, `val_τ_z`, `val_SP`
- `train/surface_loss_weight_effective` (confirm ramp completed by EP3)
- Backbone gradient norm trajectory if accessible (mechanism: was volume-first phase actually stabilizing the backbone?)

### Step 6 — terminal eval

Eval best-val EMA on test. Post `SENPAI-RESULT` marker with terminal=true, primary=val_abupt, test=test_WSS, plus full breakdown of test_τ_x / test_τ_y / **test_τ_z** (most relevant for this hypothesis).

## Baseline (tay, no-SDF, single-model)

| Metric | thorfinn #1100 (no-SDF, slices=256, EP15) | PR #972 SOTA (SDF, slices=128) |
|---|---:|---:|
| val_abupt | 6.353% | 6.126% |
| test_abupt | — | 5.844% |
| test_WSS | **6.989%** (no-SDF ceiling) | **6.727%** |
| test_vol_p | 3.6442% | 3.643% (floor) |
| test_SP | 3.8324% | 3.577% (floor) |
| test_τ_z | ~9.05% (no-SDF ceiling axis) | 8.96% |

**Win criteria:**
- **PASS EP3 gate**: `val_abupt ≤ 7.2%` AND `val_vol_p ≤ 4.5%` (gate is relaxed slightly vs baseline since EP3 is the first FULL-surface-weight epoch — model needs settle time)
- **MARGINAL EP3 gate**: `val_abupt ≤ 7.6%` AND `val_vol_p ≤ 5.0%`
- **Terminal target**: `test_WSS < 6.989%` AND `test_vol_p ≤ 3.643%` AND `test_SP ≤ 3.577%`
- **Reach goal**: `test_WSS < 6.727%` (true SOTA on no-SDF stack)
- **Specific signal**: `test_τ_z` improvement vs baseline; if τ_z improves while τ_x/τ_y stay flat or improve marginally, that's strong mechanism evidence (volume-first stabilization specifically benefits the high-residual axis).

