### PR TITLE
[dl24-nezuko] WSS H3: near-wall volume cross-attn into surface decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -295,6 +295,130 @@ class Transformer(nn.Module):
         return x
 
 
+class NearWallCrossAttention(nn.Module):
+    """Cross-attention: surface tokens query near-wall volume tokens (|SDF|<thr).
+
+    H3 hypothesis: τ_z (vertical wall-shear) is driven by boundary-layer
+    velocity gradients which are a volume quantity. By letting surface tokens
+    cross-attend to volume tokens with |SDF| < ``sdf_threshold_m`` after the
+    shared backbone, the surface head can incorporate near-wall flow info.
+
+    Inputs are expected to already be normalized (in this codebase that is
+    enforced by ``SurfaceTransolver.norm`` before the surface/volume split).
+    Implementation uses ``F.scaled_dot_product_attention`` (matching the
+    existing ``TransolverAttention`` pattern).
+
+    The output projection uses a small (std=0.01) init rather than exact
+    zero-init: a pure zero-init would zero-out gradients into Q/K/V on the
+    first iter (dL/d(act) = upstream_grad @ W_out.T == 0). A small-but-non-
+    zero init keeps the cross-attention near-identity at start while letting
+    Q/K/V receive non-trivial gradients from step 1.
+
+    Note on DDP: with this module enabled, the data loader produces view-
+    asymmetric batches (empty surface or empty volume tensors on trailing
+    views of cases where the two modalities have different point counts).
+    On those steps, Q/K/V/out projections receive no gradient, so DDP must
+    be constructed with ``find_unused_parameters=True`` to handle the per-
+    step variation in the used-parameter set across ranks.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int = 4,
+        sdf_threshold_m: float = 0.05,
+        max_keys: int = 1024,
+        out_proj_init_std: float = 0.01,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim ({hidden_dim}) must be divisible by num_heads ({num_heads})"
+            )
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.sdf_threshold_m = sdf_threshold_m
+        self.max_keys = max_keys
+
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.k_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.v_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+
+        nn.init.trunc_normal_(self.q_proj.weight, std=0.02)
+        nn.init.zeros_(self.q_proj.bias)
+        nn.init.trunc_normal_(self.k_proj.weight, std=0.02)
+        nn.init.zeros_(self.k_proj.bias)
+        nn.init.trunc_normal_(self.v_proj.weight, std=0.02)
+        nn.init.zeros_(self.v_proj.bias)
+        # Small-init for out_proj keeps the cross-attention near-identity at
+        # init (residual change is O(0.01) * normal_activations) while keeping
+        # gradients to Q/K/V populated for DDP.
+        nn.init.normal_(self.out_proj.weight, std=out_proj_init_std)
+        nn.init.zeros_(self.out_proj.bias)
+
+        self.norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+
+    def forward(
+        self,
+        surface_feats: torch.Tensor,
+        volume_feats: torch.Tensor,
+        volume_sdf: torch.Tensor,
+        surface_mask: torch.Tensor | None = None,
+        volume_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Fixed top-K: pick the K volume tokens with smallest |SDF| per sample.
+        # This gives a fixed key-tensor shape (B, K, D) across all batches and
+        # ranks — no CUDA syncs, no per-sample Python loop, no kernel
+        # recompilation. Tokens beyond ``sdf_threshold_m`` are masked out via
+        # an additive attention mask so they don't influence attention.
+        B, n_surf, D = surface_feats.shape
+        _, n_vol, _ = volume_feats.shape
+        k = min(self.max_keys, n_vol)
+        H = self.num_heads
+        d = self.head_dim
+
+        sdf_abs = volume_sdf.abs()
+        if volume_mask is not None:
+            valid_volume = volume_mask.to(dtype=torch.bool)
+            sdf_abs = torch.where(
+                valid_volume, sdf_abs, torch.full_like(sdf_abs, float("inf"))
+            )
+
+        topk_values, topk_indices = torch.topk(sdf_abs, k, dim=1, largest=False)
+        idx_expand = topk_indices.unsqueeze(-1).expand(-1, -1, D)
+        nw_feats = torch.gather(volume_feats, dim=1, index=idx_expand)
+        # True = mask out; unconditionally allow the closest key per sample to
+        # guard against the (rare) case where every nearest volume point is
+        # still beyond ``sdf_threshold_m`` (would otherwise softmax a fully
+        # -inf row and emit NaN).
+        pad_mask = topk_values >= self.sdf_threshold_m
+        pad_mask[:, 0] = False
+
+        # Build additive attention mask: 0 for valid keys, -inf for masked.
+        # Shape (B, 1, 1, k) broadcasts across (H, N_surf). Construct in fp32 so
+        # the -inf mask value survives bf16 autocast precision; SDPA upcasts the
+        # mask internally as needed.
+        attn_mask = torch.zeros(
+            B, 1, 1, k, device=surface_feats.device, dtype=torch.float32
+        )
+        attn_mask = attn_mask.masked_fill(
+            pad_mask.unsqueeze(1).unsqueeze(1), float("-inf")
+        )
+
+        q = self.q_proj(surface_feats).view(B, n_surf, H, d).transpose(1, 2)
+        k_t = self.k_proj(nw_feats).view(B, k, H, d).transpose(1, 2)
+        v_t = self.v_proj(nw_feats).view(B, k, H, d).transpose(1, 2)
+
+        out = F.scaled_dot_product_attention(q, k_t, v_t, attn_mask=attn_mask)
+        out = out.transpose(1, 2).contiguous().view(B, n_surf, D)
+        out = self.out_proj(out)
+
+        result = self.norm(surface_feats + out)
+        return _apply_token_mask(result, surface_mask)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -315,6 +439,10 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        use_near_wall_cross_attn: bool = False,
+        near_wall_num_heads: int = 4,
+        near_wall_sdf_threshold_m: float = 0.05,
+        near_wall_max_keys: int = 1024,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -362,6 +490,19 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        self.use_near_wall_cross_attn = use_near_wall_cross_attn
+        self.near_wall_num_heads = near_wall_num_heads
+        self.near_wall_sdf_threshold_m = near_wall_sdf_threshold_m
+        self.near_wall_max_keys = near_wall_max_keys
+        if use_near_wall_cross_attn:
+            self.near_wall_cross_attn = NearWallCrossAttention(
+                hidden_dim=n_hidden,
+                num_heads=near_wall_num_heads,
+                sdf_threshold_m=near_wall_sdf_threshold_m,
+                max_keys=near_wall_max_keys,
+            )
+        else:
+            self.near_wall_cross_attn = None
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
@@ -433,6 +574,21 @@ class SurfaceTransolver(nn.Module):
         surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
         cursor += surface_tokens
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
+
+        if (
+            self.near_wall_cross_attn is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            # volume_x channel layout is [x, y, z, sdf]; SDF is channel index 3
+            volume_sdf = volume_x[:, :, 3]
+            surface_hidden = self.near_wall_cross_attn(
+                surface_feats=surface_hidden,
+                volume_feats=volume_hidden,
+                volume_sdf=volume_sdf,
+                surface_mask=surface_mask,
+                volume_mask=volume_mask,
+            )
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -132,6 +132,10 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_near_wall_cross_attn: bool = False
+    near_wall_num_heads: int = 4
+    near_wall_sdf_threshold_m: float = 0.05
+    near_wall_max_keys: int = 1024
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -235,6 +239,10 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_near_wall_cross_attn=config.use_near_wall_cross_attn,
+        near_wall_num_heads=config.near_wall_num_heads,
+        near_wall_sdf_threshold_m=config.near_wall_sdf_threshold_m,
+        near_wall_max_keys=config.near_wall_max_keys,
     )
 
 
@@ -371,9 +379,9 @@ def run_eval_only(config: Config, state) -> None:
     model: nn.Module = build_model(config).to(device)
     n_params = sum(param.numel() for param in model.parameters())
     if state.enabled:
-        ddp_kwargs = {}
+        ddp_kwargs = {"find_unused_parameters": config.use_near_wall_cross_attn}
         if device.type == "cuda":
-            ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+            ddp_kwargs.update({"device_ids": [state.local_rank], "output_device": state.local_rank})
         model = DistributedDataParallel(model, **ddp_kwargs)
     base_model = unwrap_model(model)
 
@@ -465,9 +473,22 @@ def main(argv: Iterable[str] | None = None) -> None:
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
-            ddp_kwargs = {}
+            # find_unused_parameters=True: the data loader emits view-asymmetric
+            # batches (a case with surface_views < volume_views yields empty
+            # surface tensors on the trailing views, and vice versa). When
+            # surface is empty, the near-wall cross-attention produces a
+            # 0-shape output, so q_proj / k_proj / v_proj / out_proj receive no
+            # gradient on that step. Across ranks, different views land on
+            # different ranks each step, so the set of "used" parameters
+            # differs per-rank-per-step. Without find_unused_parameters,
+            # DDP's gradient AllReduce desyncs at first iteration
+            # (manifesting as the SeqNum=6 split-collective hang). Bitmap
+            # AllReduce at forward start adds a small overhead but keeps
+            # everything consistent. Required whenever
+            # use_near_wall_cross_attn is set; harmless otherwise.
+            ddp_kwargs = {"find_unused_parameters": config.use_near_wall_cross_attn}
             if device.type == "cuda":
-                ddp_kwargs = {"device_ids": [state.local_rank], "output_device": state.local_rank}
+                ddp_kwargs.update({"device_ids": [state.local_rank], "output_device": state.local_rank})
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
         if state.is_main:


### PR DESCRIPTION
## Hypothesis

**τ_z is stuck because local surface features can't capture boundary-layer velocity gradients.**

Every experiment on this wave — including H2 (curvature features, PR #1117 in progress) — shows τ_z ≈ 9.5% regardless of what surface features we add. τ_z (vertical shear, σ=8.747% in SOTA `56bcqp3m`) is the dominant residual WSS error. The reason: τ_z is primarily driven by the velocity gradient ∂u/∂z in the boundary layer, which is a _volume_ quantity, not a surface-only quantity. Surface features like curvature, normals, and wind-exposure cannot tell the model about the velocity profile near the wall.

**H3 hypothesis:** If near-wall volume tokens (SDF < 0.05 m) attend to surface tokens during decoding, the model can incorporate boundary-layer velocity-gradient signal into WSS prediction — specifically addressing τ_z.

## Background and supporting evidence

- **H2 EP10 (tanjiro #1117, in progress):** τ_y is closing toward baseline (+0.16pp gap at EP10 vs +0.48pp at EP3). τ_z is STUCK at +0.77pp above baseline despite 10 epochs. Curvature features help lateral shear but cannot reach vertical wake physics.
- **Per-axis insight from #1086 terminal:** τ_x=5.971%, τ_y=7.362%, τ_z=8.747% — τ_z is the dominant component and ~2.4× the AB-UPT target (3.63%).
- **Tay-track finding:** local geometric features have ρ=-0.11 with |WSS| and don't help τ_z in sampling experiments. Architecture (not features) is the right lever now.
- **SDF data is available:** the training dataset `rawcanon_20260511` includes pre-computed SDF values as a volume input channel. The model already has access to SDF for each volume point, making near-wall filtering straightforward.

**Target WSS:** test_wss < 5.85% (Transolver-3 SOTA). Current SOTA test_wss = 6.727%. Gap = 0.877pp = 13% relative reduction.

## Baseline to beat (SOTA on corrected split — all test metrics)

| Metric | SOTA PR #972 `56bcqp3m` / eval `zxnhtagj` |
|---|---:|
| **test_abupt (PRIMARY)** | **5.844%** |
| test_vol_p (FLOOR ≤ 3.643%) | 3.643% |
| test_surf_p (FLOOR ≤ 3.577%) | 3.577% |
| **test_wss (TARGET: < 5.85%)** | 6.727% |
| test_wss_x | ~5.97% |
| test_wss_y | ~7.36% |
| **test_wss_z** | **8.747%** |

Stack: Lion + 6L STRING 5-sigma + GradNorm α=0.5 + EMA(0.999) + Y-sym(0.5) + bs=1 + 65k surf/vol + SDF(α=2.0) + corrected dataset.
Dataset: `/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511`

## Implementation instructions

### Step 1: locate the surface decoder

Find the class/function that produces the final surface predictions (WSS + surface pressure) from surface tokens. In `trainer_runtime.py` (or a model file it imports), this should be the block that:
- Takes surface point features (from the Transolver encoder blocks)
- Outputs per-point predictions for τ_x, τ_y, τ_z, p_s

The typical pattern in Transolver-style code is something like `surface_head = nn.Linear(hidden_dim, n_surface_outputs)` applied to `surface_feats[-1]`.

### Step 2: add a near-wall volume cross-attention module

Add a new module before the surface head. Example implementation:

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class NearWallCrossAttention(nn.Module):
    """
    Cross-attention: surface tokens query near-wall volume tokens.
    Near-wall = |SDF| < sdf_threshold_m.
    """
    def __init__(self, hidden_dim: int, num_heads: int = 4, sdf_threshold_m: float = 0.05):
        super().__init__()
        self.sdf_threshold_m = sdf_threshold_m
        self.attn = nn.MultiheadAttention(
            embed_dim=hidden_dim, num_heads=num_heads,
            batch_first=True, dropout=0.0
        )
        # Zero-init output proj so the module starts as a pass-through
        nn.init.zeros_(self.attn.out_proj.weight)
        nn.init.zeros_(self.attn.out_proj.bias)
        self.norm = nn.LayerNorm(hidden_dim)

    def forward(self,
                surface_feats: torch.Tensor,    # (B, N_surf, D)
                volume_feats: torch.Tensor,     # (B, N_vol, D)
                volume_sdf: torch.Tensor,       # (B, N_vol) — SDF values
               ) -> torch.Tensor:
        # Filter to near-wall volume points
        near_wall_mask = volume_sdf.abs() < self.sdf_threshold_m  # (B, N_vol)
        
        # If no near-wall points (edge case), skip
        if not near_wall_mask.any():
            return surface_feats
        
        # Gather near-wall features — variable count per batch item
        # Simplest approach: apply mask globally (pad with zeros if needed)
        # For DDP-safety, use max near-wall count across batch and pad
        max_nw = near_wall_mask.sum(dim=1).max().item()  # int
        B, D = surface_feats.shape[0], surface_feats.shape[-1]
        
        nw_feats = torch.zeros(B, max_nw, D, device=surface_feats.device,
                               dtype=surface_feats.dtype)
        nw_key_padding_mask = torch.ones(B, max_nw, device=surface_feats.device,
                                         dtype=torch.bool)  # True=ignore
        for b in range(B):
            idx = near_wall_mask[b].nonzero(as_tuple=True)[0]
            n = idx.shape[0]
            nw_feats[b, :n] = volume_feats[b, idx]
            nw_key_padding_mask[b, :n] = False  # valid tokens
        
        # Cross-attention: surface queries near-wall volume
        attn_out, _ = self.attn(
            query=surface_feats,      # (B, N_surf, D)
            key=nw_feats,             # (B, max_nw, D)
            value=nw_feats,
            key_padding_mask=nw_key_padding_mask,  # (B, max_nw) True=ignore
        )
        # Pre-norm residual
        return self.norm(surface_feats + attn_out)
```

### Step 3: wire it into the forward pass

In the model's `forward()` method, after the encoder has produced both `surface_feats` and `volume_feats`, and before the surface output head:

```python
# Instantiate in __init__ (add to the model class):
self.near_wall_cross_attn = NearWallCrossAttention(
    hidden_dim=self.hidden_dim, num_heads=4, sdf_threshold_m=0.05
)

# In forward(), just before the surface head:
# volume_sdf should be the SDF values of volume points — shape (B, N_vol)
# This is typically already available as part of volume_x[:, :, sdf_channel_idx]
surface_feats = self.near_wall_cross_attn(surface_feats, volume_feats, volume_sdf)
surface_out = self.surface_head(surface_feats)
```

You will need to identify:
1. The correct variable names for `surface_feats`, `volume_feats`, and `volume_sdf` in the existing forward pass
2. The SDF channel index in the volume input tensor (check the dataset loader or training config)
3. Where to insert the cross-attention call (just before the WSS/surface prediction head)

### Step 4: add CLI flag

Add `--use-near-wall-cross-attn` boolean flag (default False) to `train.py`. This lets you ablate it cleanly.

## Run command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h3_near_wall_cross_attn \
  --epochs 30 --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --no-use-gradnorm \
  --use-near-wall-cross-attn \
  --wandb-group h3-near-wall-cross-attention \
  --wandb-name dl24-nezuko/h3-near-wall-cross-attn \
  --agent dl24-nezuko
```

Use lr=1e-4 (SOTA LR, not 9e-5 — we learned from #1101 that 9e-5 hurts WSS and surf_p).

## Gates

**Smoke run (before the 30-ep long run):**
Run 3 epochs. Gate: val_abupt ≤ 8.5%, val_wss ≤ 8.0%. If it diverges (>15% abupt at EP1), halt — the zero-init may not be propagating gradients correctly.

**EP3:** val_abupt ≤ 7.5%, val_wss ≤ 7.8%, val_vol_p ≤ 5.5%
**EP6:** val_wss ≤ 7.4% (H3 should start showing τ_z improvement by here)
**EP10:** val_wss ≤ 7.1%, τ_z ≤ 9.3% ← KEY GATE. If τ_z hasn't improved vs SOTA's 8.747%, H3 isn't working.
**EP15:** val_abupt ≤ 6.50%, val_wss ≤ 6.9%
**EP20:** val_abupt ≤ 6.30%, val_wss ≤ 6.85%

Post per-axis val_wss (τ_x, τ_y, τ_z) at EP3, EP6, EP10, EP15. τ_z is the key signal — if τ_z ≤ 9.0% at EP10 we're on track for a genuine WSS win.

## What to watch for

**Healthy signs:** τ_z improving faster than τ_x/τ_y — this would confirm near-wall volume info is specifically helping vertical shear.

**Warning signs:**
- Any NaN/OOM at EP1-3 (zero-init should prevent, but check gradients)
- τ_z stuck at 9.5%+ through EP6 — means the cross-attention isn't firing (check that volume_sdf is correctly wired)
- val_surf_p drift upward — the extra parameters could overfit if the near-wall filter is too broad. Reduce sdf_threshold_m to 0.03m if this happens.

## What this does NOT change

- Loss function: unchanged MSE + GradNorm α=0.5
- Learning rate: 1e-4 (SOTA)
- Training stack: full PR #972 config
- Only architectural addition: one NearWallCrossAttention module in the surface decoder

