### PR TITLE
[dl24-fern] WSS H4: per-axis loss weights [1.0, 1.5, 2.5] targeting τ_z dominant error axis

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    wss_axis_loss_weights: str = "1.0,1.0,1.0"
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -189,6 +190,24 @@ def parse_pe_init_sigmas(spec: str) -> list[float] | None:
         return None
     sigmas = [float(s) for s in spec.split(",") if s.strip()]
     return sigmas or None
+
+
+def parse_wss_axis_loss_weights(spec: str) -> tuple[float, float, float]:
+    """Parse per-axis WSS loss weights spec ``"w_x,w_y,w_z"`` to a 3-tuple."""
+    spec = (spec or "").strip()
+    if not spec:
+        return (1.0, 1.0, 1.0)
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if len(parts) != 3:
+        raise ValueError(
+            f"--wss-axis-loss-weights expects 3 comma-separated floats (w_x,w_y,w_z); got {spec!r}"
+        )
+    weights = tuple(float(p) for p in parts)
+    if any(w < 0.0 or not math.isfinite(w) for w in weights):
+        raise ValueError(
+            f"--wss-axis-loss-weights must be non-negative finite floats; got {weights}"
+        )
+    return weights  # type: ignore[return-value]
 
 
 class GradNormWeights(nn.Module):
@@ -301,6 +320,7 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    wss_axis_loss_weights: tuple[float, float, float] = (1.0, 1.0, 1.0),
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
@@ -310,6 +330,7 @@ def train_loss(
             aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    use_per_axis_wss = any(abs(w - 1.0) > 0.0 for w in wss_axis_loss_weights)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -317,12 +338,23 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        surface_per_ch = per_channel_masked_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )  # [4]: cp, tau_x, tau_y, tau_z
+        # surface_per_ch sums to 4 * masked_mse, so mean over the 4 channels
+        # reproduces the original uniform masked_mse exactly.
+        surface_loss = surface_per_ch.mean()
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        if use_per_axis_wss:
+            wss_w = torch.tensor(
+                [1.0, *wss_axis_loss_weights],
+                dtype=surface_per_ch.dtype,
+                device=surface_per_ch.device,
+            )  # [4]: cp, tau_x, tau_y, tau_z weights
+            surface_loss_for_loss = (wss_w * surface_per_ch).mean()
+        else:
+            surface_loss_for_loss = surface_loss
         if gradnorm_weights is not None:
-            surface_per_ch = per_channel_masked_mse(
-                out["surface_preds"], surface_target, batch.surface_mask
-            )  # [4]: cp, tau_x, tau_y, tau_z
             volume_per_ch = per_channel_masked_mse(
                 out["volume_preds"], volume_target, batch.volume_mask
             )  # [1]: vol_p
@@ -333,17 +365,22 @@ def train_loss(
             weighted_volume_loss = w_detached[4] * volume_per_ch[0]
         else:
             task_losses = None
-            weighted_surface_loss = surface_loss_weight * surface_loss
+            weighted_surface_loss = surface_loss_weight * surface_loss_for_loss
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    loss_log = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }, task_losses
+        "surface_loss_cp": float(surface_per_ch[0].detach().cpu().item()),
+        "surface_loss_tau_x": float(surface_per_ch[1].detach().cpu().item()),
+        "surface_loss_tau_y": float(surface_per_ch[2].detach().cpu().item()),
+        "surface_loss_tau_z": float(surface_per_ch[3].detach().cpu().item()),
+    }
+    return loss, loss_log, task_losses
 
 
 def run_eval_only(config: Config, state) -> None:
@@ -440,6 +477,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         if config.seed >= 0:
             seed_everything(config.seed)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
+        wss_axis_loss_weights_tuple = parse_wss_axis_loss_weights(config.wss_axis_loss_weights)
+        if state.is_main and any(abs(w - 1.0) > 0.0 for w in wss_axis_loss_weights_tuple):
+            print(
+                "Per-axis WSS loss weights enabled: "
+                f"tau_x={wss_axis_loss_weights_tuple[0]}, "
+                f"tau_y={wss_axis_loss_weights_tuple[1]}, "
+                f"tau_z={wss_axis_loss_weights_tuple[2]} "
+                "(cp weight fixed at 1.0)"
+            )
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
             requested_epochs = min(requested_epochs, int(os.environ["SENPAI_MAX_EPOCHS"]))
@@ -524,6 +570,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "pe_source_run_ki2q9ko9": (
                         config.model_pe == "string_multisigma"
                     ),
+                    "wss_axis_loss_weight_x": wss_axis_loss_weights_tuple[0],
+                    "wss_axis_loss_weight_y": wss_axis_loss_weights_tuple[1],
+                    "wss_axis_loss_weight_z": wss_axis_loss_weights_tuple[2],
+                    "wss_axis_loss_weights_enabled": any(
+                        abs(w - 1.0) > 0.0 for w in wss_axis_loss_weights_tuple
+                    ),
                 },
                 allow_val_change=True,
             )
@@ -583,6 +635,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    wss_axis_loss_weights=wss_axis_loss_weights_tuple,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -632,6 +685,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/surface_loss_cp": batch_loss_metrics["surface_loss_cp"],
+                            "train/surface_loss_tau_x": batch_loss_metrics["surface_loss_tau_x"],
+                            "train/surface_loss_tau_y": batch_loss_metrics["surface_loss_tau_y"],
+                            "train/surface_loss_tau_z": batch_loss_metrics["surface_loss_tau_z"],
                         }
                     )
                 if config.use_y_symmetry_aug and aug_log:


### PR DESCRIPTION
## Hypothesis

The current SOTA (PR #972, `56bcqp3m`) treats wall shear stress as a 3-channel regression with **uniform per-axis loss weight**. The corrected-split test evaluation shows the per-axis error budget is highly unequal:

| Axis | SOTA test (corrected split) | Gap vs τ_x |
|---|---:|---:|
| τ_x (streamwise) | 5.971% | — (best) |
| τ_y (vertical shear) | 7.362% | +1.39pp |
| τ_z (spanwise/cross-flow) | **8.747%** | **+2.78pp (dominant error)** |

The τ_z (spanwise) axis is the hardest to predict — driven by 3D wake recirculation, wheel-arch separation/reattachment, and underbody cross-flow that the shared uniform loss treats equally with the easier τ_x axis. **By upweighting τ_z (×2.5) and τ_y (×1.5) in the WSS loss, we redirect model capacity toward the dominant error axes without changing architecture or hyperparameters.**

Expected outcome: test_wss improves by 0.3–0.5pp (target <6.40%) while test_abupt stays within 0.1pp of SOTA. This is a single-variable, one-line change to the loss computation.

## Distinction from related in-flight work

| PR | Axis target | Mechanism | Status |
|---|---|---|---|
| tay-thorfinn #1128 (different fleet) | τ_z only | Raw loss weight 3.0 | WIP |
| **This PR (H4)** | **τ_y AND τ_z** | **Per-axis [1.0, 1.5, 2.5]** | **NEW** |
| tay-edward #1116 (different fleet) | per-channel | Separate output heads | WIP |

## Instructions

**Base:** SOTA PR #972 stack (`56bcqp3m`) on corrected dataset. **Single change: per-axis WSS loss weights.**

### Step 1: Discover the flag (1 min)

```bash
cd target/
python train.py --help | grep -iE "wss|wall.shear|loss.weight|axis.weight"
```

**If a per-axis WSS weight flag exists** (e.g. `--wss-axis-loss-weights`, `--wall-shear-loss-weights`, `--loss-weight-wss-x/y/z`): use it with values `"1.0,1.5,2.5"`.

**If no such flag exists:** apply a minimal code change to the loss computation (likely in `train.py` or `losses.py`):

```python
# Before (in WSS loss computation):
wss_loss = ((pred_wss - true_wss) ** 2).mean()

# After (per-axis weighted):
# pred_wss and true_wss have shape (..., 3) for (x, y, z) axes
wss_axis_weights = torch.tensor([1.0, 1.5, 2.5], dtype=pred_wss.dtype, device=pred_wss.device)
per_axis_se = (pred_wss - true_wss) ** 2  # (..., 3)
wss_loss = (per_axis_se * wss_axis_weights).mean()
```

If the code computes WSS loss per-axis separately and sums/averages, apply weights before the sum. Document in your PR comment exactly which lines you changed and what they looked like before.

### Step 2: Reproduce command

Use the SOTA PR #972 command as the base. The only changes vs SOTA are:
1. `--weight-decay 0.005` (SOTA, NOT 0.01 — fern's last run used WD=0.01 which regressed WSS by 0.327pp)
2. WSS per-axis loss weights [1.0, 1.5, 2.5] as implemented in Step 1
3. Updated `--output-dir`, `--wandb-name`, `--wandb-group`

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h4_wss_per_axis_loss_weights \
  --epochs 30 \
  --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion \
  --lr 1e-4 \
  --weight-decay 0.005 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --no-use-gradnorm \
  [--wss-axis-loss-weights "1.0,1.5,2.5" OR code-level change] \
  --wandb-group wss_h4_per_axis_weights \
  --wandb-name dl24-fern/h4-wss-per-axis-loss-weights \
  --agent dl24-fern
```

Add any other SOTA flags from PR #972 that are not listed here (match SOTA exactly, only vary the WSS weight axis).

### Step 3: Gate reporting

Post a gate comment at each checkpoint with ALL of: val_abupt, val_vol_p, val_surf_p, val_wss, AND per-axis val_wss (τ_x / τ_y / τ_z). The per-axis breakdown is critical for this hypothesis — we need to see τ_z dropping specifically.

## Gate schedule

| Epoch | val_abupt gate | val_wss gate | Action if missed |
|---|---|---|---|
| EP1 | ≤30% | — | KILL |
| EP3 | ≤7.5% | report | KILL if >7.5% |
| EP5 | ≤7.2% | ≤7.5% | KILL if abupt>7.2% |
| EP10 | ≤6.60% | ≤7.1% | KILL if either missed |
| EP15 | ≤6.40% | ≤6.95% | KILL if either missed |
| EP20 | ≤6.35% | ≤6.85% | KILL if either missed |
| EP30 | terminal | terminal | Submit SENPAI-RESULT |

**Hard floors at terminal (Issue #1056):** test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%.

## Baseline (corrected split SOTA)

PR #972, run `56bcqp3m`, eval `zxnhtagj`:

| Metric | SOTA value |
|---|---:|
| test_abupt | **5.844%** |
| test_vol_p | 3.643% |
| test_surf_p | 3.577% |
| test_wss | 6.727% |
| τ_x | 5.971% |
| τ_y | 7.362% |
| τ_z | 8.747% |

**Target to beat for merge:** test_abupt < 5.844% with test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%.
