### PR TITLE
Per-axis WSS mag decomp (|τ_z|+||τ_xy||) — attack τ_z bottleneck

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        wss_decomp_method: str = "none",
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,11 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        if wss_decomp_method not in ("none", "per-axis-mag"):
+            raise ValueError(
+                f"wss_decomp_method must be one of 'none' or 'per-axis-mag', got {wss_decomp_method!r}"
+            )
+        self.wss_decomp_method = wss_decomp_method
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +525,24 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # PR #1133: per-axis WSS magnitude decomposition aux heads. Two scalar
+        # heads attached to the post-norm surface hidden states (same tap as
+        # surface_out): one predicts |tau_z| (wall-normal shear magnitude), the
+        # other predicts ||tau_xy||_2 (in-plane shear vector magnitude). Both
+        # targets are computed in NORMALIZED space (i.e. after per-channel
+        # standardisation), so calibration ratios (mean_pred / mean_gt) should
+        # converge to ~1.0. Used only when wss_decomp_method == "per-axis-mag".
+        if self.wss_decomp_method == "per-axis-mag":
+            self.surface_mag_z_aux = nn.Linear(n_hidden, 1)
+            self.surface_mag_xy_aux = nn.Linear(n_hidden, 1)
+            nn.init.trunc_normal_(self.surface_mag_z_aux.weight, std=0.02)
+            nn.init.trunc_normal_(self.surface_mag_xy_aux.weight, std=0.02)
+            nn.init.zeros_(self.surface_mag_z_aux.bias)
+            nn.init.zeros_(self.surface_mag_xy_aux.bias)
+        else:
+            self.surface_mag_z_aux = None
+            self.surface_mag_xy_aux = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -633,10 +657,22 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        outputs: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+
+        if (
+            self.surface_mag_z_aux is not None
+            and self.surface_mag_xy_aux is not None
+            and surface_x is not None
+        ):
+            mag_z_pred = self.surface_mag_z_aux(surface_hidden).squeeze(-1) * surface_mask
+            mag_xy_pred = self.surface_mag_xy_aux(surface_hidden).squeeze(-1) * surface_mask
+            outputs["surface_mag_z_pred"] = mag_z_pred
+            outputs["surface_mag_xy_pred"] = mag_xy_pred
+
+        return outputs

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -4,11 +4,32 @@
 - **Branch:** tay
 - **W&B project:** wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
 
-## Latest invocation actions (2026-05-15 03:36–03:50Z) — PR #1123 closed, thorfinn reassigned to τ_z loss weight escalation
+## Latest invocation actions (2026-05-15 03:48–04:00Z) — Wave 29 full fleet confirmed active, all 8 students running
 
 - **Closed PR #1123 (thorfinn τ_z dedicated subnet)** — zero student activity after 4+ hours, four advisor check-in messages unanswered. Pod confirmed idle (1/1 READY via kubectl). Hypothesis is sound but requires code implementation; reassigned pod to a zero-code-change experiment to eliminate implementation failure mode.
-- **Assigned PR #1128 (thorfinn: τ_z loss weight escalation 2.0→3.0)** — pure CLI flag change `--tau-z-loss-weight 3.0`, no model code changes. Directly attacks dominant error axis (test_τ_z ≈ 9.05–10.1% across all no-SDF runs). Pass signal: τ_z/τ_x ratio at EP13 < 1.5 (down from ~1.6–1.7 baseline). Full 18h budget (SENPAI_TIMEOUT_MINUTES=1100). Zero implementation risk; student can start immediately.
-- **Fleet confirmed all 8 students active after reassignment**: alphonse #1122 (SDF FAR-field α=2.0, launched 03:36Z), nezuko #1125 (spatial-prior α=10 18h), tanjiro #1124 (EMA decay 0.9995, EP1 PASS 31.48%), thorfinn #1128 (τ_z loss-weight 3.0 — NEW), edward #1116 (per-channel heads 18h), frieren #1121 (magnitude-only 18h, EP3 PASS 6.746%), fern #1126 (surface_out depth=4 18h), askeladd #1127 (surface_loss warmup curriculum 18h). **Zero idle.**
+- **Assigned PR #1128 (thorfinn: τ_z loss weight escalation 2.0→3.0)** — pure CLI flag change `--tau-z-loss-weight 3.0`, no model code changes. Directly attacks dominant error axis (test_τ_z ≈ 9.05–10.1% across all no-SDF runs). Pass signal: τ_z/τ_x ratio at EP13 < 1.5 (down from ~1.6–1.7 baseline). Full 18h budget (SENPAI_TIMEOUT_MINUTES=1100). W&B run `uwqybod5` (group `tau-z-loss-weight-3p0`), launched 03:48:42Z.
+- **thorfinn #1128 confirmed launched** — student ACK received 03:49:15Z with PID confirmed and `SENPAI_TIMEOUT_MINUTES=1100` set. W&B run ID `uwqybod5`, W&B name `thorfinn/tau-z-loss-weight-3p0-20260515T034842Z`. Resolves escalation from #1123 closure.
+- **alphonse #1122 pace corrected** — actual pace at vol=16k is ~131 min/epoch (not 80 min). Root cause: vol=16k → 860 views/case (ceil(14M/16k)) → view_count=max(130,860)=860 → 10,864 iters/rank/epoch × 1.38 it/s = 131 min. Gate schedule revised: EP1 ~05:50Z, EP3 ~07:55Z. Smoke confirmed 5.6× sampled/population weight ratio → correct FAR-field SOTA mechanism.
+- **Full Wave 29 fleet all active** (kubectl: all 8 deployments 1/1 READY at 03:52Z). Zero idle.
+
+### Wave 29 fleet — full status and gate schedule (as of 03:52Z, 2026-05-15)
+
+| PR | Student | Hypothesis | W&B Run | EP1 Gate | EP3 Gate | EP13 ETA |
+|----|---------|------------|---------|----------|----------|----------|
+| #1116 | edward | Per-channel WSS output heads (τ_x/τ_y/τ_z) — 18h convergence (relaunched 03:09Z as `3ufrbxl6`) | `3ufrbxl6` | ~05:10Z | **~08:00Z** | ~14:00Z |
+| #1121 | frieren | WSS magnitude-only decomp (λ_dir=0, λ_mag=0.1) — EP3 PASS 6.746% (best in family) | `frieren/mag-only-*` | DONE | **DONE (PASS)** | ~14:30Z |
+| #1122 | alphonse | SDF FAR-field α=2.0 (`weight=1+α|sdf|`) — corrected SOTA mechanism port | alphonse run | ~05:50Z | **~07:55Z** | ~16:30Z |
+| #1124 | tanjiro | EMA decay 0.9995 — EP1 PASS 31.48%, EP2 in flight | `mw6d04kc` | DONE | **~06:15Z** | ~15:00Z |
+| #1125 | nezuko | Spatial-prior surface sampling α=10 — 18h budget | nezuko run | **~05:00Z** | ~06:00Z | ~14:00Z |
+| #1126 | fern | Deeper surface_out MLP (depth 2→4, +525k params) — 18h budget | fern run | ~04:30Z | **~06:00Z** | ~14:00Z |
+| #1127 | askeladd | Surface_loss warmup curriculum (3-ep ramp 0→full) — 18h budget | `dtgfdsgv` | ~04:30Z | **~06:00Z** | ~14:00Z |
+| #1128 | thorfinn | τ_z loss-weight 3.0 (single CLI flag escalation from 2.0) | `uwqybod5` | **~06:00Z** | ~08:30Z | ~15:30Z |
+
+Gate criteria per row:
+- **frieren #1121 EP6** (~06:00Z): val_abupt ≤6.5% PASS / ≤6.8% MARGINAL (half-way convergence sanity)
+- **Standard no-SDF EP3**: val_abupt ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL
+- **alphonse #1122 EP3 (SDF FAR-field)**: val_abupt ≤6.9% PASS / ≤7.2% MARGINAL / >7.2% KILL (tighter — SDF expected uplift)
+- Per-axis WSS signal: τ_z/τ_x ratio direction is primary quality signal for all WSS-targeting experiments
 
 ## Prior invocation actions (2026-05-15 02:35–02:50Z) — Wave 28.5 closures complete, Wave 29 architectural pivot launched
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,3 +1,140 @@
+## 2026-05-15 04:00 — Wave 29 Active Fleet (8 PRs in flight)
+
+All 8 student pods READY (1/1). Full 18h/13ep convergence budget assigned. Gate criteria (no-SDF students): EP1 ≤35%, EP3 ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL. Alphonse (SDF): EP3 ≤6.9% PASS / ≤7.2% MARGINAL / >7.2% KILL.
+
+---
+
+## 2026-05-15 03:50 — PR #1128: τ_z loss-weight 3.0 escalation (thorfinn) — IN FLIGHT
+
+- **Branch**: `thorfinn/tau-z-loss-weight-3p0`
+- **W&B run**: `uwqybod5` (group `tau-z-loss-weight-3p0`, launched 03:48:42Z, ACK 03:49:15Z)
+- **Hypothesis**: Escalate `--tau-z-loss-weight` from 2.0 → 3.0 (single CLI flag change). τ_z is the dominant WSS error axis (8.75% vs τ_x 5.97%, τ_y 7.36%). Prior PR #1123 unresponsive; reassigned as a simpler single-flag experiment to fill the slot. Tests whether further weighting beyond the standard τ_z=2.0 prior continues to drive τ_z improvement without degrading τ_x/τ_y.
+- **Key signal**: τ_z/τ_x ratio (should decrease from baseline 1.47× if mechanism works)
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | ~06:00Z | ≤35% val_abupt | pending |
+| EP3 | ~08:30Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~15:30Z | terminal | pending |
+
+---
+
+## 2026-05-15 03:10 — PR #1127: Surface_loss warmup curriculum (askeladd) — IN FLIGHT
+
+- **Branch**: `askeladd/surface-loss-warmup`
+- **W&B run**: `dtgfdsgv` (launched ~03:00Z)
+- **Hypothesis**: Explicit 3-epoch ramp from `surface_loss_weight=0 → 2.0` (`--surface-loss-weight-warmup-epochs 3`). Directly tests PR #1114 finding that EP1 WSS wins may be curriculum artifacts from implicit warmup. If explicit curriculum > implicit constant-weight, gain may compound at convergence.
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | ~04:30Z | ≤35% val_abupt | pending |
+| EP3 | ~06:00Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~14:00Z | terminal | pending |
+
+---
+
+## 2026-05-15 03:00 — PR #1126: Deeper surface_out MLP depth=4 (fern) — IN FLIGHT
+
+- **Branch**: `fern/surface-out-depth-4`
+- **W&B run**: fern run (group `surface-out-depth-4`, launched ~02:59Z)
+- **Hypothesis**: Increase `surface_out` MLP depth from 2 → 4 layers (+525k params, +3% total, 17.94M params total). Tests whether τ_z prediction benefits from deeper output projection capacity. Orthogonal to main transformer; negligible VRAM impact.
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | ~04:30Z | ≤35% val_abupt | pending |
+| EP3 | ~06:00Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~14:00Z | terminal | pending |
+
+---
+
+## 2026-05-15 02:50 — PR #1125: Spatial-prior surface sampling α=10 (nezuko) — IN FLIGHT
+
+- **Branch**: `nezuko/spatial-prior-alpha-10`
+- **W&B run**: nezuko run (group `spatial-prior-alpha-10`, launched ~02:45Z)
+- **Hypothesis**: Spatial bias `w = 1 + 10.0·(front_bias + |z|_bias)/2` at full 18h/13ep budget. Prior PR #1120 (α=3) showed real mechanism signal (EP3 val_WSS −0.67pp vs baseline, ρ=+0.31 correlation with |WSS|) but was budget-truncated at 47%. α=10 increases front/side oversample to ×3–4× to drive more τ_z-region coverage.
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | ~05:00Z | ≤35% val_abupt | pending |
+| EP3 | ~06:00Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~14:00Z | terminal | pending |
+
+---
+
+## 2026-05-15 02:00 — PR #1124: EMA decay 0.9995 (tanjiro) — IN FLIGHT
+
+- **Branch**: `tanjiro/ema-slow-decay`
+- **W&B run**: `mw6d04kc` (launched ~01:25Z)
+- **Hypothesis**: Slow EMA decay 0.999 → 0.9995 (double the averaging window at EP13). At 13ep standard recipe, current EMA τ ≈ 141 steps; 0.9995 → τ ≈ 2000 steps. Tests whether EMA over-weights recent noisy steps near cosine LR floor. Primary signal: EMA–raw gap inversion (EMA should outperform raw by larger margin).
+- **EP1 result**: val_abupt = 31.48% — **PASS** (≤35%)
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | DONE | ≤35% | **PASS (31.48%)** |
+| EP3 | ~06:15Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~15:00Z | terminal | pending |
+
+---
+
+## 2026-05-15 01:30 — PR #1122: SDF FAR-field α=2.0 (alphonse) — IN FLIGHT
+
+- **Branch**: `alphonse/sdf-far-field-alpha-2`
+- **W&B run**: alphonse run (launched ~01:00Z, smoke PASS: 5.6× sampled/population weight ratio confirmed)
+- **Hypothesis**: Port SOTA SDF weighting mechanism `weight = 1 + α·|sdf|` (FAR-field amplification) with α=2.0. Prior ADVISOR error: assigned wrong mechanism (NEAR-field `1/(1+α|sdf|)` with α=4.0); alphonse self-caught and corrected. FAR-field mechanism up-weights points far from surface where gradients concentrate → complementary to surface_loss term.
+- **Pace note**: At vol=16k → 860 views/case → 10,864 iters/rank/epoch × 1.38 it/s = **131 min/epoch** (not 80 min as initially estimated). Rate-limiting step is view_count=max(130,860).
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| Smoke | DONE | 5.6× weight ratio | **PASS** |
+| EP1 | ~05:50Z | ≤35% val_abupt | pending |
+| EP3 | ~07:55Z | ≤6.9% PASS / ≤7.2% MARGINAL / >7.2% KILL | pending |
+| EP13 | ~16:30Z | terminal | pending |
+
+**Key signals to monitor**: per-axis WSS at EP3 (τ_z should be the primary beneficiary of FAR-field weighting), sampled/population weight ratio stability.
+
+---
+
+## 2026-05-15 01:00 — PR #1121: WSS magnitude-only decomposition (frieren) — IN FLIGHT
+
+- **Branch**: `frieren/wss-mag-only-decomp`
+- **W&B run**: frieren run (group `wss-mag-only-decomp`, launched ~00:30Z)
+- **Hypothesis**: Decompose WSS auxiliary loss as magnitude-only: λ_dir=0, λ_mag=0.1. Suppresses direction-component loss that may add cross-axis interference. Tests whether magnitude supervision alone drives stronger τ_z learning without the directional penalty competing.
+- **EP3 result (PASS — strongest in decomp family)**:
+
+| Metric | EP3 value | Gate |
+|---|---:|---|
+| val_abupt | **6.746%** | ≤7.2% **PASS** |
+| val_τ_x | 6.580% | — |
+| val_τ_y | 8.593% | — |
+| val_τ_z | 10.093% | — |
+
+EP3 val_abupt=6.746% is strongest in any decomp-family run. Continuing to full 18h/13ep convergence.
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP3 | DONE | ≤7.2% | **PASS (6.746%)** |
+| EP6 sanity | ~06:00Z | ≤6.5% PASS / ≤6.8% MARGINAL | pending |
+| EP13 terminal | ~14:30Z | terminal | pending |
+
+---
+
+## 2026-05-15 00:30 — PR #1116: Per-channel WSS output heads (edward) — IN FLIGHT (relaunched)
+
+- **Branch**: `edward/per-channel-surface-heads`
+- **W&B run**: `3ufrbxl6` (relaunched 03:08:59Z after pod restart killed `rfapq0o3` at EP1 ~97min in)
+- **Hypothesis**: `--use-per-channel-surface-heads`: separate linear output heads per WSS axis (τ_x, τ_y, τ_z) instead of shared head. Tests whether per-axis specialization reduces τ_z/τ_x interference. Budget-matched arm (`hqp13ztw`) showed test_WSS −0.66pp vs baseline; τ_z/τ_x ratio went wrong direction (1.36→1.44). This 18h convergence run tests whether the trend reverses at full budget.
+- **Pod restart**: Pod wipe at 03:05:35Z killed `rfapq0o3` during EP1. Python env wiped (lost `lion_pytorch`). Student re-installed, relaunched as `3ufrbxl6` at 03:08:59Z.
+
+| Gate | ETA | Criterion | Status |
+|---|---|---|---|
+| EP1 | ~05:10Z | ≤35% val_abupt | pending |
+| EP3 | ~08:00Z | ≤7.2% PASS / ≤7.6% MARGINAL / >7.6% KILL | pending |
+| EP13 | ~14:00Z | terminal | pending |
+
+**Key signal**: τ_z/τ_x ratio at EP3 — should decrease from 1.44 (budget-matched arm) toward 1.47 (baseline) or better. If ratio increases further → approach is degrading τ_z.
+
+---
+
 ## 2026-05-15 02:35 — PR #1118: OHEM v2 spike-clipped + reduced λ (askeladd) — CLOSED (DEFINITIVE NEGATIVE: ZERO OHEM GRADIENT)
 
 - **Branch**: `askeladd/ohem-v2-spike-clipped` (closed)

--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_decomp_method: str = "none"
+    wss_decomp_lambda_mag_z: float = 0.1
+    wss_decomp_lambda_mag_xy: float = 0.05
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +233,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "wss_decomp_method": (
+            "WSS magnitude decomposition aux supervision (PR #1133). "
+            "'none' (default) disables aux heads. 'per-axis-mag' adds two "
+            "scalar Linear heads on the surface decoder: one predicting "
+            "|tau_z| (wall-normal magnitude) and one predicting "
+            "||tau_xy||_2 (in-plane vector magnitude), both in normalised "
+            "space. Forces the backbone to develop tau_z-specific features "
+            "instead of relying on the aggregate ||WSS|| signal."
+        ),
+        "wss_decomp_lambda_mag_z": (
+            "Loss weight for the |tau_z| aux head when "
+            "--wss-decomp-method=per-axis-mag. Default 0.1 (asymmetric — "
+            "emphasises the structural bottleneck axis). Used only when "
+            "wss_decomp_method == 'per-axis-mag'."
+        ),
+        "wss_decomp_lambda_mag_xy": (
+            "Loss weight for the ||tau_xy||_2 aux head when "
+            "--wss-decomp-method=per-axis-mag. Default 0.05. Used only "
+            "when wss_decomp_method == 'per-axis-mag'."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +332,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        wss_decomp_method=config.wss_decomp_method,
     )
 
 
@@ -321,6 +346,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_decomp_method: str = "none",
+    wss_decomp_lambda_mag_z: float = 0.0,
+    wss_decomp_lambda_mag_xy: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,12 +374,57 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+    extra_metrics: dict[str, float] = {}
+    if wss_decomp_method == "per-axis-mag" and (
+        wss_decomp_lambda_mag_z > 0.0 or wss_decomp_lambda_mag_xy > 0.0
+    ):
+        # PR #1133: per-axis WSS magnitude aux supervision.
+        # surface_target channels: [cp, tau_x, tau_y, tau_z] in NORMALIZED space.
+        # mag_z_gt = |tau_z_norm|; mag_xy_gt = ||(tau_x_norm, tau_y_norm)||_2.
+        # Aux heads predict these scalars directly from surface_hidden — the
+        # dedicated supervision forces the backbone to develop tau_z-specific
+        # features instead of relying on the aggregate ||WSS|| signal.
+        mag_z_pred = out["surface_mag_z_pred"].float()
+        mag_xy_pred = out["surface_mag_xy_pred"].float()
+        surface_target_f = surface_target.float()
+        mag_z_gt = surface_target_f[..., 3].abs()
+        mag_xy_gt = torch.linalg.vector_norm(surface_target_f[..., 1:3], dim=-1)
+        mask = batch.surface_mask
+        mag_z_loss = masked_mse(mag_z_pred, mag_z_gt, mask)
+        mag_xy_loss = masked_mse(mag_xy_pred, mag_xy_gt, mask)
+        weighted_mag_z = wss_decomp_lambda_mag_z * mag_z_loss
+        weighted_mag_xy = wss_decomp_lambda_mag_xy * mag_xy_loss
+        loss = loss + weighted_mag_z.to(loss.dtype) + weighted_mag_xy.to(loss.dtype)
+
+        with torch.no_grad():
+            mask_f = mask.to(device=mag_z_pred.device, dtype=mag_z_pred.dtype)
+            mag_z_pred_mean = masked_mean(mag_z_pred, mask_f)
+            mag_z_gt_mean = masked_mean(mag_z_gt, mask_f)
+            mag_xy_pred_mean = masked_mean(mag_xy_pred, mask_f)
+            mag_xy_gt_mean = masked_mean(mag_xy_gt, mask_f)
+            mag_z_calib = mag_z_pred_mean / mag_z_gt_mean.clamp_min(1e-9)
+            mag_xy_calib = mag_xy_pred_mean / mag_xy_gt_mean.clamp_min(1e-9)
+        extra_metrics.update({
+            "wss_decomp_mag_z_loss": float(mag_z_loss.detach().cpu().item()),
+            "wss_decomp_mag_xy_loss": float(mag_xy_loss.detach().cpu().item()),
+            "wss_decomp_mag_z_loss_weighted": float(weighted_mag_z.detach().cpu().item()),
+            "wss_decomp_mag_xy_loss_weighted": float(weighted_mag_xy.detach().cpu().item()),
+            "wss_decomp_mag_z_pred_mean": float(mag_z_pred_mean.detach().cpu().item()),
+            "wss_decomp_mag_z_gt_mean": float(mag_z_gt_mean.detach().cpu().item()),
+            "wss_decomp_mag_xy_pred_mean": float(mag_xy_pred_mean.detach().cpu().item()),
+            "wss_decomp_mag_xy_gt_mean": float(mag_xy_gt_mean.detach().cpu().item()),
+            "wss_decomp_mag_z_calib_ratio": float(mag_z_calib.detach().cpu().item()),
+            "wss_decomp_mag_xy_calib_ratio": float(mag_xy_calib.detach().cpu().item()),
+        })
+
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        **extra_metrics,
     }
 
 
@@ -852,6 +925,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.wss_decomp_method == "per-axis-mag":
+                print(
+                    f"WSS decomp aux heads (PR #1133, per-axis-mag): "
+                    f"lambda_mag_z={config.wss_decomp_lambda_mag_z}, "
+                    f"lambda_mag_xy={config.wss_decomp_lambda_mag_xy}; "
+                    f"targets computed in normalized space (|tau_z_norm|, ||tau_xy_norm||_2)"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +963,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["wss_decomp/method"] = config.wss_decomp_method
+            wandb.summary["wss_decomp/lambda_mag_z"] = config.wss_decomp_lambda_mag_z
+            wandb.summary["wss_decomp/lambda_mag_xy"] = config.wss_decomp_lambda_mag_xy
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1113,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_decomp_method=config.wss_decomp_method,
+                        wss_decomp_lambda_mag_z=config.wss_decomp_lambda_mag_z,
+                        wss_decomp_lambda_mag_xy=config.wss_decomp_lambda_mag_xy,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1156,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_decomp_mag_z_loss" in batch_loss_metrics:
+                        train_log.update({
+                            "train/wss_decomp/mag_z_loss": batch_loss_metrics["wss_decomp_mag_z_loss"],
+                            "train/wss_decomp/mag_xy_loss": batch_loss_metrics["wss_decomp_mag_xy_loss"],
+                            "train/wss_decomp/mag_z_loss_weighted": batch_loss_metrics["wss_decomp_mag_z_loss_weighted"],
+                            "train/wss_decomp/mag_xy_loss_weighted": batch_loss_metrics["wss_decomp_mag_xy_loss_weighted"],
+                            "train/wss_decomp/mag_z_pred_mean": batch_loss_metrics["wss_decomp_mag_z_pred_mean"],
+                            "train/wss_decomp/mag_z_gt_mean": batch_loss_metrics["wss_decomp_mag_z_gt_mean"],
+                            "train/wss_decomp/mag_xy_pred_mean": batch_loss_metrics["wss_decomp_mag_xy_pred_mean"],
+                            "train/wss_decomp/mag_xy_gt_mean": batch_loss_metrics["wss_decomp_mag_xy_gt_mean"],
+                            "train/wss_decomp/mag_z_calib_ratio": batch_loss_metrics["wss_decomp_mag_z_calib_ratio"],
+                            "train/wss_decomp/mag_xy_calib_ratio": batch_loss_metrics["wss_decomp_mag_xy_calib_ratio"],
+                            "train/wss_decomp/lambda_mag_z": config.wss_decomp_lambda_mag_z,
+                            "train/wss_decomp/lambda_mag_xy": config.wss_decomp_lambda_mag_xy,
+                        })
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Per-axis WSS magnitude decomposition: |τ_z| + ||τ_xy|| as separate aux supervised heads — direct architectural attack on the τ_z structural bottleneck.**

### Why this hypothesis now

Your just-closed PR #1121 (mag-only decomp at 18h) is the strongest no-SDF single-model val_abupt result on tay since the corrected split (val_abupt=6.073% beats PR #972 baseline 6.126%). The mag aux head was **perfectly calibrated at convergence** (ratio=0.9993, mag_loss=0.0011 at EP13 — 4.4× tighter than #1112's truncated EP3=0.0048). But:
- test_WSS=6.859% still doesn't beat PR #972 SOTA 6.727% (+0.132pp gap)
- test_τ_z=8.873% remains the dominant error channel (vs τ_x=6.091%, τ_y=7.452%)
- Your τ_z EP9→EP10 reversal (9.343 → 9.363, +0.020pp) is the cleanest single-run instance of the **fleet-wide τ_z structural finding**: SIXFOLD independent confirmation that τz/τx ratio converges to ~1.50–1.57 across 6 different mechanisms (loss weight, sampling, output capacity, EMA, mag-only decomp, per-channel heads).

**The structural finding tells us**: τ_z bottleneck is NOT addressable by loss weighting, sampling, output capacity, EMA averaging, or **single-head magnitude calibration**. The ||WSS||₂ aux head in mag-only decomp aggregates over all three axes — τ_z magnitude information gets mixed with the (already-easier) τ_x and τ_y magnitudes. **The model can perfectly predict ||WSS||₂ without learning τ_z magnitude well**, because τ_z contributes only ~30-40% of the WSS magnitude on average.

### Mechanism (precise)

Split the single magnitude aux head into **two scalar magnitude heads**:

1. **`|τ_z|` head**: predict the absolute value of wall-normal shear magnitude per surface point (scalar regression target)
2. **`||τ_xy||₂` head**: predict the L2 norm of the in-plane shear vector per surface point (scalar regression target)

These two heads give the model **separate supervised signals** for the two physically distinct shear components:
- τ_xy is in-plane / tangential to the surface — driven by boundary-layer streamwise dynamics, relatively easier
- τ_z is wall-normal / perpendicular to the surface — driven by separation, vortical, and 3D effects, harder
- The fleet-wide finding is that the SHARED backbone features carry enough information for τ_xy but not for τ_z. A dedicated supervised |τ_z| head **forces the backbone to develop τ_z-specific features** during training.

Loss formulation:
```
L_total = L_base + λ_mag_z * MSE(|τ_z_pred|, |τ_z_gt|) + λ_mag_xy * MSE(||τ_xy_pred||₂, ||τ_xy_gt||₂)
```

Default: `λ_mag_z = 0.1`, `λ_mag_xy = 0.05` (asymmetric — emphasize τ_z which is the bottleneck).

### Falsifiability

If `test_τ_z` at EP13 ≤ 8.50% (vs your #1121's 8.873%), that's a ≥0.37pp improvement on the dominant axis = mechanism win. If `test_τ_z` ≥ 8.80%, the per-axis decomp is no better than the single-head version → the τ_z bottleneck is below the decoder level (in the backbone representation itself), narrowing the future research direction to backbone-side interventions.

If `test_WSS < 6.85%` (your #1121 EP10 KILL gate) AND test_SP ≤ 3.577% (test floor — your #1121 failed this) AND test_vol_p ≤ 3.643%, this would be the **first single-model merge on tay since the SDF stack**.

## Instructions

### Step 1 — extend `wss_decomp_*` infrastructure in `target/`

Your existing mag-only decomp PR added `--wss-decomp-method`, `--wss-decomp-lambda-mag`, `--wss-decomp-lambda-dir` flags. Extend this with a new method:

```python
# in target/train.py (config dataclass)
wss_decomp_method: str = "none"  # existing: "none", "mag-only" | new: "per-axis-mag"
wss_decomp_lambda_mag_z: float = 0.1   # new — used only when method=="per-axis-mag"
wss_decomp_lambda_mag_xy: float = 0.05  # new — used only when method=="per-axis-mag"
```

Add corresponding argparse flags: `--wss-decomp-lambda-mag-z`, `--wss-decomp-lambda-mag-xy`.

### Step 2 — implement two aux heads in `target/model.py`

Inside the surface decoder branch (where your existing mag aux head lives), add two new Linear heads when `method == "per-axis-mag"`:

```python
# Two scalar magnitude heads (in addition to the standard surface_out cp/τ_x/τ_y/τ_z prediction).
# Implementation pattern matches your mag-only decomp aux head from PR #1121.
self.surface_mag_z_aux = nn.Linear(n_hidden, 1)   # |τ_z| scalar
self.surface_mag_xy_aux = nn.Linear(n_hidden, 1)  # ||τ_xy||₂ scalar
nn.init.zeros_(self.surface_mag_z_aux.bias)
nn.init.zeros_(self.surface_mag_xy_aux.bias)
```

In forward, predict and return both:
```python
mag_z_pred = self.surface_mag_z_aux(surface_features).squeeze(-1)   # [B, N_surface]
mag_xy_pred = self.surface_mag_xy_aux(surface_features).squeeze(-1) # [B, N_surface]
```

### Step 3 — compute aux losses

In the loss function (where your existing mag aux loss lives), add:

```python
if config.wss_decomp_method == "per-axis-mag":
    tau_z_gt = surface_target[..., 3]  # 4th channel of WSS target (cp, τ_x, τ_y, τ_z layout)
    tau_xy_gt = surface_target[..., 1:3]  # τ_x, τ_y as 2-vector
    mag_z_gt = tau_z_gt.abs()  # |τ_z|
    mag_xy_gt = tau_xy_gt.norm(dim=-1)  # ||τ_xy||₂
    
    mag_z_loss = F.mse_loss(out["surface_mag_z_pred"], mag_z_gt, reduction="mean")
    mag_xy_loss = F.mse_loss(out["surface_mag_xy_pred"], mag_xy_gt, reduction="mean")
    
    aux_loss = config.wss_decomp_lambda_mag_z * mag_z_loss + config.wss_decomp_lambda_mag_xy * mag_xy_loss
    total_loss = base_surface_loss + base_volume_loss + aux_loss
```

### Step 4 — diagnostics to log per step

W&B logging (mirror your mag-only decomp logging style):

```python
"train/wss_decomp/mag_z_loss": mag_z_loss.item(),
"train/wss_decomp/mag_xy_loss": mag_xy_loss.item(),
"train/wss_decomp/mag_z_pred_mean": out["surface_mag_z_pred"].mean().item(),
"train/wss_decomp/mag_z_gt_mean": mag_z_gt.mean().item(),
"train/wss_decomp/mag_z_calib_ratio": (out["surface_mag_z_pred"].mean() / mag_z_gt.mean().clamp_min(1e-9)).item(),
"train/wss_decomp/mag_xy_calib_ratio": (out["surface_mag_xy_pred"].mean() / mag_xy_gt.mean().clamp_min(1e-9)).item(),
```

The two `calib_ratio` fields are the primary mechanism diagnostics — both should converge to ~1.0 ± 0.005 by EP6-8. **Asymmetric calibration (e.g., mag_z_calib_ratio = 0.85 while mag_xy_calib_ratio = 0.99) is the diagnostic that confirms the structural finding** — the backbone genuinely cannot represent τ_z magnitude as well as τ_xy.

### Step 5 — smoke test (200 steps)

Run a 200-step smoke at the assigned config. Verify:
- No NaN / no OOM
- Both aux heads producing finite calib ratios (initial ~0.0–0.5 expected; convergence trajectory in EP1-3)
- `it/s` within ±5% of mag-only #1121 baseline (1.88 it/s) — two scalar heads add negligible compute

Post smoke results + first 50-step calibration ratios.

### Step 6 — full 13-EP run with 18h budget

```bash
cd "target/" && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-surf-to-vol-xattn \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wss-decomp-method per-axis-mag \
  --wss-decomp-lambda-mag-z 0.1 \
  --wss-decomp-lambda-mag-xy 0.05 \
  --wandb-group frieren-per-axis-mag-decomp \
  --wandb-name frieren/per-axis-mag-decomp-lambda-z-0p1
```

### Step 7 — terminal eval

Eval best-val EMA on test. Post `SENPAI-RESULT` marker with terminal=true, primary=val_abupt, test=test_WSS, plus full breakdown including:
- test_τ_x, test_τ_y, **test_τ_z** (the structural bottleneck axis — primary signal)
- mag_z_calib_ratio at EP13 final
- mag_xy_calib_ratio at EP13 final
- τz/τx test ratio

## Baseline (your prior PR #1121 + the no-SDF ceiling)

| Metric | #1121 mag-only (your prior) | PR #972 SDF SOTA | alphonse #1078 (no decomp) |
|---|---:|---:|---:|
| val_abupt | 6.073% | 6.126% | — |
| test_WSS | 6.859% | 6.727% | 6.996% |
| test_vol_p | 3.545% (below floor) | 3.643% (floor) | 3.644% |
| test_SP | 3.734% (above floor) | 3.577% (floor) | 3.832% |
| **test_τ_z** | **8.873%** | — | — |
| test_τ_x | 6.091% | — | — |
| τz/τx (test) | 1.457 | — | — |

**Win criteria:**
- **EP3 gate**: val_abupt ≤ 7.2% PASS / ≤ 7.6% MARGINAL / >7.6% KILL (same as #1121 mag-only baseline)
- **EP6 half-convergence**: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL (mag_z_calib_ratio should be ≥0.95 by this point — if it's <0.85 while mag_xy_calib_ratio is ≥0.95, **post immediately**: the asymmetric calibration is the direct mechanism evidence we want)
- **Terminal target (paper-facing)**: test_τ_z < 8.50% (0.37pp improvement on dominant axis vs #1121) — this is the primary win signal
- **Reach goal**: test_WSS < 6.85% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% AND val_abupt ≤ 6.20% → first single-model merge on tay since SDF stack

