### PR TITLE
Local-frame WSS head — enforce τ·n=0 by construction (Wave 30 H6)

### DIFF
--- a/model.py
+++ b/model.py
@@ -358,6 +358,32 @@ class Transformer(nn.Module):
         return x
 
 
+def build_orthonormal_frame(n: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build a per-point orthonormal tangent basis (t1, t2) from surface normals n.
+
+    Uses Gram-Schmidt with axis-fallback to avoid degeneracy:
+        pick e = (1, 0, 0) if |n_x| < 0.9 else (0, 1, 0)
+        t1 = normalize(e - (e . n) n)
+        t2 = n x t1
+
+    The frame is mathematically arbitrary (any rotation about n is valid) but
+    smooth except at the fallback boundary; since predictions are scalar
+    coefficients in this frame and the frame itself is a fixed function of
+    input normals (no learnable params), frame discontinuity does not affect
+    optimization. See PR #1134.
+    """
+    e_x = torch.zeros_like(n)
+    e_x[..., 0] = 1.0
+    e_y = torch.zeros_like(n)
+    e_y[..., 1] = 1.0
+    use_y = (n[..., 0].abs() > 0.9).unsqueeze(-1)
+    e = torch.where(use_y, e_y, e_x)
+    t1 = e - (e * n).sum(-1, keepdim=True) * n
+    t1 = F.normalize(t1, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+    return t1, t2
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -382,6 +408,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        local_frame_wss_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +423,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.local_frame_wss_head = local_frame_wss_head
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,12 +509,33 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if self.local_frame_wss_head:
+                # PR #1134: split surface output head into (cp) + (tau in 2D
+                # local frame), then reconstruct tau_global = t1*tau_t1 +
+                # t2*tau_t2 in the forward pass. The 4-channel
+                # surface_output_dim contract is preserved so callers see
+                # [cp, tau_x, tau_y, tau_z] as before.
+                if self.surface_output_dim != 4:
+                    raise ValueError(
+                        "local_frame_wss_head requires surface_output_dim=4 "
+                        f"(got {self.surface_output_dim})."
+                    )
+                self.surface_out_cp = nn.Linear(n_hidden, 1)
+                self.surface_out_wss_local = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, 2),
+                )
+                self.surface_out_cp.apply(_init_linear)
+                self.surface_out_wss_local.apply(_init_linear)
+                self.surface_out = None
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),
@@ -496,6 +545,10 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
+            if self.local_frame_wss_head:
+                raise ValueError(
+                    "local_frame_wss_head requires use_aux_decoder_heads=True."
+                )
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
@@ -621,8 +674,28 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        surface_normal_unit: torch.Tensor | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.local_frame_wss_head:
+                # Surface features are [x, y, z, nx, ny, nz, area]. Renormalize
+                # to guard against any preprocessing drift; the frame must be
+                # built from unit vectors. Detach so the frame is treated as a
+                # fixed input — gradients flow only through the predicted
+                # scalar coefficients tau_t1, tau_t2.
+                normals_raw = surface_x[..., self.space_dim : self.space_dim + 3]
+                n = F.normalize(normals_raw.float(), dim=-1, eps=1e-6).detach()
+                t1, t2 = build_orthonormal_frame(n)
+                t1 = t1.detach().to(dtype=surface_hidden.dtype)
+                t2 = t2.detach().to(dtype=surface_hidden.dtype)
+                surface_normal_unit = n.to(dtype=surface_hidden.dtype)
+
+                cp = self.surface_out_cp(surface_hidden)
+                wss_local = self.surface_out_wss_local(surface_hidden)
+                wss_global = wss_local[..., 0:1] * t1 + wss_local[..., 1:2] * t2
+                surface_preds = torch.cat([cp, wss_global], dim=-1)
+                surface_preds = surface_preds * surface_mask.unsqueeze(-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -633,10 +706,13 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        result = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if surface_normal_unit is not None:
+            result["surface_normal_unit"] = surface_normal_unit
+        return result

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    local_frame_wss_head: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "local_frame_wss_head": (
+            "Replace the global Cartesian (tau_x, tau_y, tau_z) WSS output "
+            "head with a local-frame head predicting WSS in a 2D tangent "
+            "basis (tau_t1, tau_t2). A per-point orthonormal frame is built "
+            "from surface normals via Gram-Schmidt with axis-fallback, and "
+            "the global 3-vector is reconstructed by tau_global = "
+            "tau_t1*t1 + tau_t2*t2. This enforces tau.n=0 (WSS tangent to "
+            "the surface) by construction. The cp channel keeps its own "
+            "linear head; surface_preds remains [cp, tau_x, tau_y, tau_z]. "
+            "See PR #1134."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,7 +320,32 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        local_frame_wss_head=config.local_frame_wss_head,
     )
+
+
+def compute_wss_penetration_frac(
+    surface_preds: torch.Tensor,
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    space_dim: int = 3,
+) -> float:
+    """Mean |tau . n| / (|tau| + eps) over unmasked surface points.
+
+    A diagnostic for PR #1134: in the global Cartesian head this should be
+    strictly positive (the model can violate the tangent constraint); in the
+    local-frame head it should be at the numerical precision floor (<1e-5).
+    """
+    with torch.no_grad():
+        wss = surface_preds[..., 1:4].float()
+        normals = surface_x[..., space_dim : space_dim + 3].float()
+        n_unit = torch.nn.functional.normalize(normals, dim=-1, eps=1e-6)
+        penetration = (wss * n_unit).sum(-1).abs()
+        wss_norm = wss.norm(dim=-1).clamp(min=1e-8)
+        frac = penetration / wss_norm
+        mask = surface_mask.float()
+        denom = mask.sum().clamp(min=1.0)
+        return float(((frac * mask).sum() / denom).cpu().item())
 
 
 def train_loss(
@@ -321,6 +358,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    log_wss_penetration: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,13 +384,20 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if log_wss_penetration:
+        metrics["wss_penetration_frac"] = compute_wss_penetration_frac(
+            out["surface_preds"],
+            batch.surface_x,
+            batch.surface_mask,
+        )
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1030,6 +1075,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        log_wss_penetration=True,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1116,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "wss_penetration_frac" in batch_loss_metrics:
+                        train_log["train/wss_penetration_frac"] = batch_loss_metrics[
+                            "wss_penetration_frac"
+                        ]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Replace the global Cartesian (τ_x, τ_y, τ_z) WSS output head with a local-frame (τ_t1, τ_t2) head using an orthonormal surface basis derived from the surface normals.**

### Why this hypothesis specifically

Wall-shear-stress is by physical definition the tangential component of the stress tensor at the wall:

```
τ · n = 0   (always, by definition — WSS is tangent to the surface)
```

The current architecture predicts τ in the global Cartesian frame as a 3-vector with NO constraint that τ · n = 0. So the model must implicitly learn the constraint from data. The eight-fold structural τ_z bottleneck finding (see below) is consistent with the hypothesis that this constraint cannot be reliably learned without enforcing it architecturally.

**Mechanism**: Build a per-point orthonormal frame (t1, t2) from the surface normal n via Gram-Schmidt, predict WSS in this 2D local frame, then reconstruct the global 3-vector via `τ_global = τ_t1 · t1 + τ_t2 · t2`. The reconstructed τ_global automatically satisfies τ · n = 0 by construction.

Critically, the τ_z component is the most affected by surface orientation (vertical features like the windshield, roof, and rear bumper have high τ_z magnitude precisely because they are not horizontal). A local-frame head naturally rotates the prediction problem so the model learns the same flow-tangential physics regardless of surface orientation.

### Pre-flight diagnostic (zero training cost, run before the full training)

Before launching training, run this on a small batch of baseline predictions to confirm the constraint violation is real:

```python
# Load baseline predictions from a recent run (e.g. PR #972 best-EMA ckpt)
tau = predictions[:, [1,2,3]]   # [τx, τy, τz]
n = surface_normals             # [nx, ny, nz] from loader
penetration = (tau * n).sum(-1).abs() / (tau.norm(dim=-1) + 1e-8)
print(f"Mean |τ·n|/|τ| = {penetration.mean():.4f}")
print(f"Max |τ·n|/|τ| = {penetration.max():.4f}")
```

Expected: penetration > 0.01 means the global head is structurally violating τ·n=0. If <0.01, the constraint is being learned cleanly and this hypothesis is wrong (close immediately, no training cost).

## Eightfold structural-bottleneck context

The τ_z bottleneck is the dominant residual error channel across the fleet. Eight mechanistically distinct interventions have failed to suppress τz/τx ratio below the 1.50–1.57 band by EP5-10:

1. **Loss reweighting** — tanjiro #1114 learnable WSS weights (null), thorfinn #1128 τ_z×3 (active, ratio asymptoted at 1.539)
2. **Sampling rebalancing** — nezuko #1125 spatial-prior α=10 (active, 1.548), alphonse #1122 SDF FAR-field α=2.0 (active, 1.526 at EP4)
3. **Output capacity** — edward #1116 per-channel heads (active, 1.551)
4. **Decoder depth** — fern #1126 surface_out d=4 (active, 1.543)
5. **Temporal averaging** — tanjiro #1124 EMA 0.9995 (just CLOSED, 1.469 test ratio)
6. **Magnitude calibration** — frieren #1121 mag-only decomp (CLOSED, 1.457 test ratio)
7. **Magnitude per-axis decomp** — frieren #1133 active

**Conclusion**: τ_z bottleneck is backbone-representation-side. The cleanest test of this is an inductive-bias change at the output head — exactly what H6 (local-frame WSS) does.

## Instructions

### 1. Pre-flight diagnostic (5 min, no GPU)

Run the diagnostic on PR #972 reference predictions to confirm penetration >0.01:

```bash
# In the target/ directory
python -c "
import numpy as np
from pathlib import Path

# Find a recent baseline checkpoint - e.g. from BASELINE.md run 56bcqp3m
# If you don't have the prediction cache, use a synthetic test
# (the constraint should still hold)
# At minimum, log surface_normals stats and confirm normalization
"
```

**Goal**: Confirm via either a real baseline checkpoint or a quick synthetic test that τ·n ≠ 0 in the current architecture. If you can't easily access cached predictions, just verify the math via the README of `data/loader.py` (which says surface input features include normals already) and the model's output (4 channels: cp, τ_x, τ_y, τ_z with no τ·n constraint).

### 2. Implement local-frame WSS head in `model.py` (~65 LOC)

In `model.py`, find the `surface_out` head (it's a `nn.Sequential(Linear → SiLU → Linear)` predicting 4 channels). Add a new mode controlled by a CLI flag:

```python
# In train.py add CLI flag:
parser.add_argument("--local-frame-wss-head", action="store_true",
                    help="Use orthonormal local-frame WSS head (enforces τ·n=0)")

# In model.py, replace the surface_out head when this flag is True:
if local_frame_wss_head:
    # Predict cp (1 ch) + WSS in local 2D frame (2 ch) = 3 ch total
    self.surface_out_cp = nn.Linear(hidden_dim, 1)
    self.surface_out_wss_local = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.SiLU(),
        nn.Linear(hidden_dim, 2),  # τ_t1, τ_t2
    )
else:
    # Original 4-channel head
    self.surface_out = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim), nn.SiLU(),
        nn.Linear(hidden_dim, 4),
    )

# In the forward pass, when local_frame_wss_head=True:
def build_orthonormal_frame(n):
    """Build (t1, t2) orthonormal to n via Gram-Schmidt with axis-fallback."""
    # n: [B, N, 3], assumed unit-norm
    # Pick e = (1,0,0) if |n_x| < 0.9 else (0,1,0) to avoid degeneracy
    e_x = torch.zeros_like(n); e_x[..., 0] = 1.0
    e_y = torch.zeros_like(n); e_y[..., 1] = 1.0
    use_y = (n[..., 0].abs() > 0.9).unsqueeze(-1)
    e = torch.where(use_y, e_y, e_x)  # [B, N, 3]
    t1 = e - (e * n).sum(-1, keepdim=True) * n
    t1 = F.normalize(t1, dim=-1, eps=1e-6)
    t2 = torch.cross(n, t1, dim=-1)
    return t1, t2

# Extract surface normals from surface_x: [..., 3:6] are nx, ny, nz
n = F.normalize(surface_x[..., 3:6], dim=-1, eps=1e-6)
t1, t2 = build_orthonormal_frame(n)

cp = self.surface_out_cp(surface_features)              # [B, N, 1]
wss_local = self.surface_out_wss_local(surface_features)  # [B, N, 2]
wss_global = wss_local[..., 0:1] * t1 + wss_local[..., 1:2] * t2  # [B, N, 3]
surface_pred_norm = torch.cat([cp, wss_global], dim=-1)  # [B, N, 4]
```

**Key invariant**: `(wss_global * n).sum(-1).abs().max()` should be < 1e-5 at every step (assert this in the model forward when in dev mode, or log it as a diagnostic).

### 3. Add a diagnostic metric

Log `train/wss_penetration_frac = mean(|τ·n|/|τ|)` per training step so we can confirm the constraint is being enforced. For the baseline (without the flag), this is the "free-running" violation; with the flag, it should be ~0 (numerical precision floor).

### 4. Training command

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --epochs 13 \
  --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 \
  --local-frame-wss-head \
  --wandb_group tanjiro/local-frame-wss-head
```

Set `SENPAI_TIMEOUT_MINUTES=1100` for the 18h budget. Use DDP with 8 GPUs.

### 5. Smoke run first (200 steps, 8 GPUs)

Before the full 13EP run, run a 200-step smoke to confirm:
- `train/wss_penetration_frac` drops to ~0 from step 1 (or stays at ~0 if init is good)
- Training is stable (no NaN, no explosion)
- Loss decreases normally

```bash
# Same command but with --kill-thresholds "200:train/loss>0.5" and smaller epoch budget
torchrun --nproc_per_node=8 train.py ... --epochs 1 --kill-thresholds "200:train/loss>0.5"
```

### 6. Report at each epoch

Per-EP val readout: include `wss_penetration_frac`, val_abupt, val_WSS, per-axis (τ_x, τ_y, τ_z), val_SP, val_vol_p, and **τz/τx ratio** at every epoch gate. This is the headline mechanism signal.

## Falsifiability — explicit win/lose criteria

### MAJOR WIN (paper-worthy)

- **test_τz/τx ratio ≤ 1.40** at terminal — local-frame is the FIRST mechanism to break the structural pattern (sevenfold→broken)
- test_τ_z ≤ 8.50% absolute
- test_WSS < 6.85% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%

### MINOR WIN (merge)

- test_WSS < 6.727% (beats PR #972 SOTA) AND both floors held
- τz/τx ratio anywhere

### MARGINAL (review for follow-up)

- test_WSS in [6.727%, 6.85%] AND both floors held — direction is right, may stack with other Wave 30 mechanisms

### FAIL (close — backbone-side bottleneck even deeper)

- val_τz/τx > 1.45 at EP13 — the bottleneck is NOT at the output head level. Points to backbone slice-attention mechanism (H3 candidates) or full backbone replacement (H5 Y-architecture).

## Baseline (PR #972 single-model SOTA)

- W&B run: `56bcqp3m`
- val_abupt = 6.126%
- test_abupt = 5.844%, test_vol_p = 3.643%, test_SP = 3.577%, test_WSS = 6.727%
- test_τ_x = (not broken out in baseline metadata)

**Single-model training gate** (corrected split): val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5% at EP3.

## Implementation notes

- **No data/loader changes** — surface normals are already in `surface_x[..., 3:6]` per the program contract.
- **No volume changes** — this is a surface head modification only.
- **No loss function changes initially** — loss is still MSE on (cp, τ_x, τ_y, τ_z) after reconstruction. The architectural enforcement of τ·n=0 means the gradient flow through the loss is the same; the model just can't violate the constraint.
- **Optional follow-up if H6 works**: switch the loss to predict directly on (τ_t1, τ_t2) instead of reconstructing then MSE on global — this would be a stronger version of the same idea.

## Reproduce baseline command

```bash
cd /workspace/senpai/target
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --epochs 13 \
  --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 \
  --use-sdf-stratified-vol-sampling --sdf-stratified-alpha 2.0
```

(This is the SDF FAR-field SOTA recipe `56bcqp3m`. Don't use this for tanjiro #1124's replacement — instead use the H6 command above, which is the no-SDF tay base recipe + local-frame head.)
