### PR TITLE
[dl24-frieren] WSS H6: wind-exposure additive attention bias (surface_input_channels=7)

### DIFF
--- a/model.py
+++ b/model.py
@@ -172,6 +172,49 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+def compute_wind_exposure_features(normals: torch.Tensor) -> torch.Tensor:
+    """Per-token wind-exposure geometry from surface unit normals.
+
+    normals: [..., 3] unit normal (nx, ny, nz). Returns [..., 3]:
+        wind_exposure    = max(0, -nx)   one-sided frontal cross-flow attack
+        abs_cross_normal = |ny|          lateral cross-flow attack
+        wind_mag         = sqrt(we^2 + acn^2)  combined magnitude
+
+    All three channels are y-reflection invariant by construction (|-ny|=|ny|;
+    nx unaffected). For unit normals each channel lies in [0, sqrt(2)].
+    """
+    nx = normals[..., 0:1]
+    ny = normals[..., 1:2]
+    wind_exposure = torch.clamp(-nx, min=0.0)
+    abs_cross_normal = torch.abs(ny)
+    wind_mag = torch.sqrt(wind_exposure * wind_exposure + abs_cross_normal * abs_cross_normal)
+    return torch.cat([wind_exposure, abs_cross_normal, wind_mag], dim=-1)
+
+
+class WindExposureAttentionBias(nn.Module):
+    """Zero-init projection of 3-channel wind-exposure → hidden_dim token bias (H6).
+
+    Added after the 7-channel surface input projection so ``surface_input_channels``
+    stays at 7 and the per-token feature/GradNorm budget is preserved. The final
+    Linear is zero-initialised so the module contributes exactly 0 at step 0,
+    matching the SOTA baseline forward pass identically.
+    """
+
+    def __init__(self, hidden_dim: int, wind_exposure_dim: int = 3):
+        super().__init__()
+        mid = max(hidden_dim // 8, 16)
+        self.net = nn.Sequential(
+            nn.Linear(wind_exposure_dim, mid),
+            nn.SiLU(),
+            nn.Linear(mid, hidden_dim),
+        )
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, wind_exposure: torch.Tensor) -> torch.Tensor:
+        return self.net(wind_exposure)
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -315,6 +358,7 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        use_wind_exposure_attention_bias: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -325,6 +369,12 @@ class SurfaceTransolver(nn.Module):
         self.pe_kind = pe_kind
         self.pe_num_features = pe_num_features
         self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        self.use_wind_exposure_attention_bias = use_wind_exposure_attention_bias
+        if use_wind_exposure_attention_bias and surface_input_dim < space_dim + 3:
+            raise ValueError(
+                "use_wind_exposure_attention_bias requires surface_input_dim >= "
+                f"{space_dim + 3} to include unit normals (got {surface_input_dim})"
+            )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -364,6 +414,11 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+        self.wind_exposure_attn_bias: WindExposureAttentionBias | None = (
+            WindExposureAttentionBias(hidden_dim=n_hidden)
+            if use_wind_exposure_attention_bias
+            else None
+        )
 
     def _encode_group(
         self,
@@ -401,14 +456,24 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    surface_x,
-                    project_features=self.project_surface_features,
-                    bias=self.surface_bias,
-                    placeholder=self.surface_placeholder,
-                )
+            surface_token_emb = self._encode_group(
+                surface_x,
+                project_features=self.project_surface_features,
+                bias=self.surface_bias,
+                placeholder=self.surface_placeholder,
             )
+            if self.wind_exposure_attn_bias is not None:
+                normals = surface_x[..., self.space_dim : self.space_dim + 3]
+                wind_exposure = compute_wind_exposure_features(normals).to(
+                    dtype=surface_token_emb.dtype
+                )
+                wind_bias = self.wind_exposure_attn_bias(wind_exposure)
+                if surface_mask is not None:
+                    wind_bias = wind_bias * surface_mask.unsqueeze(-1).to(
+                        dtype=wind_bias.dtype
+                    )
+                surface_token_emb = surface_token_emb + wind_bias
+            tokens.append(surface_token_emb)
             masks.append(surface_mask)
 
         if volume_x is not None:

--- a/train.py
+++ b/train.py
@@ -132,6 +132,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_wind_exposure_attention_bias: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -235,6 +236,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_wind_exposure_attention_bias=config.use_wind_exposure_attention_bias,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H6: Wind-exposure as zero-init additive attention bias — parallel to H5 for the wind-exposure signal**

**Evidence from H1 (PR #1115 — just closed):**
- The wind-exposure features `max(0,-nx)` and `|ny|` are geometrically valid (EP0 audit confirmed well-distributed `wind_exposure∈[0,1]`, mean≈0.16)
- BUT injecting them as raw surface input channels (7→9) produced the **same gradnorm-imbalance failure as H2 #1117**:
  - test_wss +0.040pp (slight regression on target)
  - test_vol_p +0.437pp **FLOOR BREACH** (severe)
  - test_surf_p +0.128pp **FLOOR BREACH**
  - test_abupt +0.150pp regression
- Root cause: adding 2 surface input channels diluted the per-token feature budget → gradnorm task-share imbalance → volume head under-trained

**Strong corroborating signal from H5 (PR #1132 — in flight, EP9 current):**
- Same idea but with curvature signal — injected via zero-init additive attention bias AFTER 7-channel projection
- At EP9 (live W&B `lbi210l2`): H5 leads H2 across all metrics. val_abupt 6.232 vs H2's 6.288, val_wss 6.938 vs 6.991, val_vol_p 4.051 vs 4.136.
- The zero-init bias mechanism preserves vol_p discipline AND delivers the WSS signal

**H6 mechanistic claim:** The wind-exposure signal is real (per the H1 test of the feature distribution and the WSS-axis improvement in val), but the *injection point* was wrong. Apply the H5 mechanism — zero-init additive token bias after the 7-channel surface projection — to the wind-exposure signal instead. This:
1. Keeps `surface_input_channels=7` → GradNorm sees the same task-share budget
2. **Zero-initialises** the wind-exposure projection → identical to SOTA at step 0
3. Wind-exposure modulates slice-attention via its contribution to Q/K — same physics, different injection point

**Connection:** ALiBi / T5 relative-position-bias literature applies positional biases to attention scores. Here we apply the same principle to wind-exposure geometry: the per-token cross-flow attack signal as a learned attention bias term.

---

## Instructions

### 1. Compute wind-exposure features (same as H1)

Use exactly the formulas from PR #1115 (which the EP0 audit confirmed):

```python
def compute_wind_exposure_features(normals: np.ndarray) -> np.ndarray:
    """
    Returns (V, 3): [wind_exposure, abs_cross_normal, wind_mag] per surface point.
    wind_exposure = max(0, -nx)   # frontal cross-flow attack
    abs_cross_normal = |ny|        # lateral cross-flow attack  
    wind_mag = sqrt(wind_exposure^2 + abs_cross_normal^2)  # magnitude (new — for symmetry with H5)
    """
    wind_exposure = np.maximum(0.0, -normals[:, 0])  # nx is x-component of unit normal
    abs_cross_normal = np.abs(normals[:, 1])
    wind_mag = np.sqrt(wind_exposure**2 + abs_cross_normal**2)
    return np.stack([wind_exposure, abs_cross_normal, wind_mag], axis=1)  # (V, 3)
```

Normalize each of the 3 channels independently (subtract train-split mean, divide by train-split std). Compute at data-load time per case — no heavy computation needed (just basic arithmetic on normals).

### 2. Add CLI flag to train.py

```python
parser.add_argument("--use-wind-exposure-attention-bias", action="store_true",
                    help="Inject wind-exposure as additive token bias after surface input projection (H6)")
```

In batch construction: add `surface_wind_exposure: Optional[torch.Tensor]` shape `[B, N_surf, 3]` to the batch object (None if flag not set).

**Note on naming:** `--use-wind-exposure-features` (used by H1 #1115) sets input_dim 7→9 — do NOT use that flag. Use the NEW flag `--use-wind-exposure-attention-bias` which keeps input_dim=7.

### 3. Add WindExposureAttentionBias module to model.py

```python
class WindExposureAttentionBias(nn.Module):
    """Zero-init projection of wind-exposure → hidden_dim additive token bias.
    
    Does NOT change surface_input_channels. Added after the 7-channel
    surface_input_proj to decouple wind-exposure from the GradNorm feature budget.
    """
    def __init__(self, hidden_dim: int, wind_exposure_dim: int = 3):
        super().__init__()
        mid = max(hidden_dim // 8, 16)
        self.net = nn.Sequential(
            nn.Linear(wind_exposure_dim, mid),
            nn.SiLU(),
            nn.Linear(mid, hidden_dim),
        )
        # Zero-init final layer: at step 0 this contributes exactly 0 → SOTA baseline
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)

    def forward(self, wind_exposure: torch.Tensor) -> torch.Tensor:
        return self.net(wind_exposure)  # [B, N_surf, hidden_dim]
```

In the model `__init__`:
```python
self.wind_exposure_attn_bias: Optional[WindExposureAttentionBias] = None
if use_wind_exposure_attention_bias:
    self.wind_exposure_attn_bias = WindExposureAttentionBias(hidden_dim=model_hidden_dim)
```

In the model `forward()`, immediately after the 7-channel surface input projection and **before** the Transolver backbone:
```python
# surface_tokens: [B, N_surf, hidden_dim]  ← from 7-channel surface_input_proj
if self.wind_exposure_attn_bias is not None and surface_wind_exposure is not None:
    bias = self.wind_exposure_attn_bias(surface_wind_exposure)  # [B, N_surf, hidden_dim]
    if surface_mask is not None:
        bias = bias * surface_mask.unsqueeze(-1).float()
    surface_tokens = surface_tokens + bias
# → surface_tokens now carries wind-exposure context; Transolver backbone unchanged
```

**Critical:** `surface_input_channels` stays at 7. Do NOT pass `--surface-input-channels 9` (and the flag wouldn't be relevant anyway — the input projection is unchanged).

**Gradient telemetry:** After launch confirm `train/grad_module/WindExposureAttentionBias/*` appears in W&B — confirms the module is visible through `named_modules()`.

### 4. Gate schedule (same as H5)

| Gate | val_abupt | val_wss | val_vol_p | Action |
|------|----------:|--------:|----------:|--------|
| EP3  | ≤ 7.5%   | ≤ 7.5% | ≤ 5.5%   | Kill if over |
| EP6  | ≤ 7.0%   | ≤ 7.2% | ≤ 4.8%   | Kill if over |
| EP10 | ≤ 6.6%   | ≤ 7.0% | ≤ 4.5%   | Kill if over |
| EP15 | ≤ 6.4%   | ≤ 6.9% | ≤ 4.3%   | Kill if over |
| EP20 | ≤ 6.3%   | ≤ 6.75%| ≤ 4.2%   | Kill if over |
| EP25 | ≤ 6.25%  | ≤ 6.65%| ≤ 4.1%   | Kill if over |
| EP30 | —        | target < 6.5% | **≤ 3.75%** | Terminal eval |

**vol_p floor is hard:** If val_vol_p > 4.5% at EP10 OR val_vol_p > 4.3% at EP15, halt and report. Do NOT push to EP30 with a floor breach trajectory.

Post at each gate: `EP<N> gate: val_abupt=X%, val_wss=X%, val_vol_p=X%, val_surf_p=X% [PASS/FAIL]`

### 5. Run command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 1e-4 --weight-decay 0.005 --batch-size 1 --epochs 30 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --use-gradnorm --gradnorm-alpha 0.5 \
  --ema-decay 0.999 --ema-start-step 5000 \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --lr-cosine-t-max 30 --lr-min 1e-6 --lr-warmup-epochs 1 \
  --amp-mode bf16 --seed 42 \
  --use-wind-exposure-attention-bias \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h6-wind-exposure-attention-bias \
  --wandb-name "dl24-frieren/wss-wind-exposure-attn-bias" \
  --agent dl24-frieren
```

> **Key difference from H1 (#1115):** NO `--use-wind-exposure-features` (that's the failed input-channel approach). Use NEW flag `--use-wind-exposure-attention-bias`.

### 6. EP0 sanity checks

After first W&B step appears:
- `train/weight_module/WindExposureAttentionBias/net.2/*` should be ~0.0 (zero-init confirmed)
- `train/base_mse_loss` first 200 steps should be nearly identical to a SOTA-no-wind-exposure baseline (zero-init means identical forward pass)
- Confirm `surface_input_channels=7` in W&B run config

### 7. Terminal evaluation

At EP30 (or best-val checkpoint), run test eval with `eval_surface_points=65536`, `eval_volume_points=65536`. Report:
- test_abupt, test_wss, test_vol_p, test_surf_p
- Per-axis: test_tau_x, test_tau_y, test_tau_z

Post SENPAI-RESULT before flipping label to review:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val-number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<test-number>}}
```

---

## Baseline (corrected-split SOTA, rawcanon_20260511, PR #972 `56bcqp3m` eval `zxnhtagj`)

| Metric | Value | Note |
|--------|------:|------|
| test_abupt | **5.844%** | primary target |
| test_surf_p | 3.577% | **floor: must not exceed** |
| test_vol_p | **3.643%** | **floor: must not exceed** |
| test_wss | 6.727% | **WSS target: beat → < 5.85%** |
| test_tau_x | 5.971% | reference |
| test_tau_y | 7.362% | **highest priority** |
| test_tau_z | 8.747% | **highest priority** |

**H1 comparison (PR #1115 — your closed run `3rja7gw6` / EP9 best-val):**
- test_wss=6.767% (worse than SOTA by 0.040pp — wind-exposure didn't even help WSS via input channels)
- test_vol_p=4.080% (floor breach +0.437pp → closed)
- **H6 must: extract whatever signal wind-exposure carries AND keep vol_p ≤ 3.643%**

**H5 comparison (PR #1132 — currently running, EP9):** val_wss=6.938, val_vol_p=4.051, val_abupt=6.232. If H5 ends winning at terminal AND H6 wins, the natural next wave is compositional (both biases active).

**Issue #1056 (Morgan) hard floors:** test_vol_p ≤ 3.643% AND test_surf_p ≤ 3.577%. Relentlessly target test_wss < 5.85%.
