### PR TITLE
Wave 30 H2: Normal Spectral Encoding (StringSep on nx,ny,nz)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        normal_spectral_encoding: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_normal_spectral_encoding = normal_spectral_encoding
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -456,6 +458,30 @@ class SurfaceTransolver(nn.Module):
 
         surface_proj_in = surface_extra_dim + rff_out_dim
         volume_proj_in = volume_extra_dim + rff_out_dim
+
+        # PR #1136: apply StringSeparableEncoding to surface normals
+        # (nx, ny, nz). When enabled, the surface feature concat replaces the
+        # raw 3-dim normal slice with 2 * 3 * normal_features extra dims
+        # produced by surface_normal_string_sep. Volume has no normals; only
+        # the surface projection grows. Mirrors the position string_sep init
+        # so behaviour is governed by the same --rff-sigma / --rff-init-sigmas
+        # knobs already exercised by SOTA recipes (PR #972, frieren #1133).
+        if normal_spectral_encoding:
+            normal_features = rff_num_features if rff_num_features > 0 else 32
+            self.surface_normal_string_sep = StringSeparableEncoding(
+                in_dim=3,
+                num_features=normal_features,
+                sigma=rff_sigma,
+                init_sigmas=self.rff_init_sigmas,
+            )
+            normal_proj_dim = self.surface_normal_string_sep.output_dim
+            # Surface extras are [normals(3), area(1)]; the normals slice is
+            # replaced by the spectral encoding output, so we subtract 3 then
+            # add the encoder output dim.
+            surface_proj_in = surface_proj_in - 3 + normal_proj_dim
+        else:
+            self.surface_normal_string_sep = None
+
         self.project_surface_features = (
             LinearProjection(surface_proj_in, n_hidden) if surface_proj_in > 0 else None
         )
@@ -528,11 +554,21 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        normal_string_sep: nn.Module | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
-        if x.shape[-1] > self.space_dim:
+        if normal_string_sep is not None and x.shape[-1] >= self.space_dim + 3:
+            # PR #1136: surface extras layout is [nx, ny, nz, area]. Replace
+            # the raw normal slice with the per-axis StringSeparableEncoding;
+            # keep area (and any future trailing scalar feature) untouched.
+            normals = x[:, :, self.space_dim : self.space_dim + 3]
+            rest = x[:, :, self.space_dim + 3 :]
+            feature_parts.append(normal_string_sep(normals))
+            if rest.shape[-1] > 0:
+                feature_parts.append(rest)
+        elif x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
@@ -575,6 +611,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    normal_string_sep=self.surface_normal_string_sep,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    normal_spectral_encoding: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "normal_spectral_encoding": (
+            "Apply StringSeparableEncoding to the surface normal vector "
+            "(nx, ny, nz) using the same per-axis learnable log_freq + "
+            "phase parameterization currently used only for (x, y, z) "
+            "positions. Builds a dedicated surface_normal_string_sep "
+            "encoder (in_dim=3, num_features matches positions, sigma and "
+            "init_sigmas mirror --rff-sigma / --rff-init-sigmas). The "
+            "normal encoding output is concatenated alongside the existing "
+            "position string-sep features into the surface "
+            "project_features Linear; volume input (xyz+sdf) is untouched "
+            "because volume has no normal channel. PR #1136."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -278,7 +291,7 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
-    for attr in ("surface_string_sep", "volume_string_sep"):
+    for attr in ("surface_string_sep", "volume_string_sep", "surface_normal_string_sep"):
         module = getattr(model, attr, None)
         if module is None:
             continue
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        normal_spectral_encoding=config.normal_spectral_encoding,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Apply `StringSeparableEncoding` to the surface **normal vector** (nx, ny, nz) using the same per-axis learnable log_freq + phase parameterization currently used only for (x, y, z) positions. Currently, normals are concatenated raw as features (`x[:, :, space_dim:]` in `_encode_group`) and flow through a single linear projection. Yet normals are the most important orientation prior for predicting WSS, and `τ_z` in particular: a roof patch (n≈[0,0,1]) and a side-wall patch (n≈[0,1,0]) require fundamentally different shear decompositions.

This is the most obvious architectural asymmetry in the model: positions get rich spectral basis functions, normals get a linear map. **Closing this gap is the second Wave 30 experiment** (after tanjiro #1134 H6 local-frame WSS head). Either it improves τ_z (richer normal representations → better orientation-conditional features) or it doesn't (orientation info is already implicit in WSS direction loss and normals don't need spectral encoding). Both are informative for the Wave 30 architectural map.

**Why now:** 9 mechanisms (loss weighting, sampling, output capacity, EMA, mag-only decomp, per-channel heads, SDF FAR-field, decoder depth, spatial-prior α) have converged τz/τx ratio to the 1.40–1.57 band. The bottleneck is **backbone-representation-side**. Wave 30 attacks the architecture.

**Theoretical basis:** Fourier features for directional quantities on the sphere (spherical harmonics) are classical in physics. Recent work — NequIP (Batzner 2022), Equiformer (Liao 2022), Clifford Neural Layers (Brandstetter 2023) — shows that spectral treatment of directional inputs consistently outperforms linear projection on directional output quantities.

## Instructions

**File to modify:** `target/model.py` (only)
**Auxiliary:** `target/train.py` (one CLI flag added)
**Total LOC:** ~35 in model.py, ~5 in train.py

### Step 1 — Add CLI flag in `train.py`

Add `--normal-spectral-encoding` (default: False, store_true) to the argparse / config and thread it into `SurfaceTransolver` construction. Use the same wiring pattern as `--use-qk-norm` or `--use-surf-to-vol-xattn` — find one of those flags and mirror the path.

### Step 2 — Modify `SurfaceTransolver.__init__` in `model.py`

After the existing position-encoding block (around line 415–452 where `surface_string_sep` / `volume_string_sep` are built), add a dedicated normal encoder for the surface path:

```python
self.use_normal_spectral_encoding = normal_spectral_encoding
if normal_spectral_encoding:
    # Only applies to surface (normals = surface_x[:, :, 3:6]).
    # Volume has SDF as its only extra; no normals.
    normal_features = rff_num_features if rff_num_features > 0 else 16
    self.surface_normal_string_sep = StringSeparableEncoding(
        in_dim=3,
        num_features=normal_features,
        sigma=rff_sigma,
        init_sigmas=self.rff_init_sigmas,
    )
    # Update surface_proj_in to account for the new feature width
    surface_proj_in += self.surface_normal_string_sep.output_dim  # 2 * 3 * num_features
else:
    self.surface_normal_string_sep = None
```

You will need to compute `surface_proj_in` AFTER the conditional so the `LinearProjection(surface_proj_in, n_hidden)` builds with the correct in-dim. Keep `volume_proj_in` unchanged — volume has no normals.

### Step 3 — Modify `SurfaceTransolver._encode_group` (around line 522)

The current implementation:

```python
def _encode_group(self, x, *, rff, string_sep, project_features, bias, placeholder):
    pos = x[:, :, : self.space_dim]
    hidden = self.pos_embed(pos)
    feature_parts: list[torch.Tensor] = []
    if x.shape[-1] > self.space_dim:
        feature_parts.append(x[:, :, self.space_dim :])  # ← currently raw extras
    if string_sep is not None:
        feature_parts.append(string_sep(pos))
    ...
```

Add an optional `normal_string_sep` kwarg and an `is_surface` discriminator. Only the surface call site passes the normal encoder; the volume call site passes `None`. When `normal_string_sep` is not None, split the surface extras into normals (indices 3:6 within original x) and area (index 6:7), apply spectral encoding to the normals, and concatenate `[area, string_sep(pos), normal_string_sep(normals)]`. The exact slicing:

```python
def _encode_group(
    self, x, *, rff, string_sep, project_features, bias, placeholder,
    normal_string_sep=None,
):
    pos = x[:, :, : self.space_dim]
    hidden = self.pos_embed(pos)
    feature_parts: list[torch.Tensor] = []

    if normal_string_sep is not None and x.shape[-1] >= 7:
        # Surface path with normal spectral encoding:
        # extras layout = [nx, ny, nz, area]  (space_dim..space_dim+3 = normals, space_dim+3 = area)
        normals = x[:, :, self.space_dim : self.space_dim + 3]
        rest = x[:, :, self.space_dim + 3 :]  # area
        if rest.numel() > 0:
            feature_parts.append(rest)
        feature_parts.append(normal_string_sep(normals))
    elif x.shape[-1] > self.space_dim:
        feature_parts.append(x[:, :, self.space_dim :])

    if string_sep is not None:
        feature_parts.append(string_sep(pos))
    elif rff is not None:
        feature_parts.append(rff(pos))

    if project_features is not None and feature_parts:
        features = feature_parts[0] if len(feature_parts) == 1 else torch.cat(feature_parts, dim=-1)
        hidden = hidden + project_features(features)
    return bias(hidden) + placeholder
```

Then in `forward` (around line 568), at the surface call site, add the kwarg:

```python
self._encode_group(
    surface_x,
    rff=self.surface_rff,
    string_sep=self.surface_string_sep,
    project_features=self.project_surface_features,
    bias=self.surface_bias,
    placeholder=self.surface_placeholder,
    normal_string_sep=self.surface_normal_string_sep,  # ← new
)
```

Volume call site remains unchanged (passes nothing for the kwarg → defaults to None).

### Step 4 — Training recipe

Use the **18-hour 13-epoch recipe** (matches nezuko PR #972 single-model SOTA, recent tanjiro #1124, frieren #1133):

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 \
  --pos-encoding-mode string_separable \
  --use-qk-norm \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --epochs 13 \
  --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 \
  --normal-spectral-encoding \
  --wandb_group wave30_normal_spectral_encoding
```

Set `SENPAI_MAX_EPOCHS=13` and `SENPAI_TIMEOUT_MINUTES=1100` for the 18h budget (use the same env vars tanjiro #1124 used).

**Sanity check before launch:**
1. Confirm a forward pass works on a single batch with `--normal-spectral-encoding` (just run for 5 steps locally) — the `project_features` dim depends on `surface_proj_in` being computed correctly with the additional `2 * 3 * num_features` term.
2. Confirm `surface_proj_in` arithmetic: with default `rff_num_features=32`, the addition is `2 * 3 * 32 = 192` extra dims. Print the value at construction.

### Step 5 — Reporting

When training completes, post a `SENPAI-RESULT` comment with terminal metrics:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_WSS","value":<number>}}
```

Plus full breakdown:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_tau_x, test_tau_y, test_tau_z
- **test τz/τx ratio** ← THIS IS THE KEY METRIC for H2 falsification
- best epoch (best val_abupt checkpoint)
- best_checkpoint trajectory through epochs

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H2 confirmed**, < 1.40 = breakthrough |

**Reproduce command:**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --pos-encoding-mode string_separable --use-qk-norm \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --batch-size 4 --epochs 13 \
  --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --normal-spectral-encoding \
  --wandb_group wave30_normal_spectral_encoding
```

**Source idea:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H2 (taste score 10/12, rank 2 of 8). Companion to tanjiro #1134 H6 local-frame WSS head — these test orthogonal architectural hypotheses (input representation vs output head) and can run in parallel.

## EP gates (recipe-adjusted)

This recipe uses `--lr-warmup-epochs=1` (Lion default). EP1 floor for warmup recipes is ~val_abupt=33% — DO NOT KILL on EP1. EP3 is the first real gate.

- EP3: val_abupt ≤ 6.5%, val_vol_p ≤ 5.0% → continue
- EP6: val_abupt ≤ 6.4% → continue, otherwise hold and post advisor request
- Terminal: report all 4 gate metrics + ratio

Ping with stale_wip if pod silence exceeds 2 hours between epoch gates.
