### PR TITLE
Wave 30 H5: Y-Architecture Dual-Backbone (pressure vs WSS branches)

### DIFF
--- a/model.py
+++ b/model.py
@@ -327,6 +327,16 @@ class TransformerBlock(nn.Module):
 
 
 class Transformer(nn.Module):
+    """Transolver backbone with optional Y-architecture dual-branch split (PR #1137).
+
+    When ``y_arch_split_layer == 0`` (default), this is a single stack of ``depth``
+    blocks (legacy behavior). When ``y_arch_split_layer > 0``, the first
+    ``y_arch_split_layer`` blocks are shared, then two parallel stacks of
+    ``depth - y_arch_split_layer`` blocks process the same shared output
+    independently: a "pressure" branch and a "WSS" branch. The split returns a
+    tuple ``(x_pressure, x_wss)`` to signal split mode to the caller.
+    """
+
     def __init__(
         self,
         depth: int,
@@ -336,26 +346,50 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        y_arch_split_layer: int = 0,
     ):
         super().__init__()
-        self.blocks = nn.ModuleList(
-            [
-                TransformerBlock(
-                    hidden_dim=hidden_dim,
-                    num_heads=num_heads,
-                    mlp_expansion_factor=mlp_expansion_factor,
-                    num_slices=num_slices,
-                    dropout=dropout,
-                    use_qk_norm=use_qk_norm,
-                )
-                for _ in range(depth)
-            ]
-        )
+        self.y_arch_split_layer = y_arch_split_layer
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        def _make_block() -> TransformerBlock:
+            return TransformerBlock(
+                hidden_dim=hidden_dim,
+                num_heads=num_heads,
+                mlp_expansion_factor=mlp_expansion_factor,
+                num_slices=num_slices,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+
+        if y_arch_split_layer <= 0:
+            self.blocks = nn.ModuleList([_make_block() for _ in range(depth)])
+            self.pressure_blocks = None
+            self.wss_blocks = None
+        else:
+            if y_arch_split_layer >= depth:
+                raise ValueError(
+                    f"y_arch_split_layer={y_arch_split_layer} must be < depth={depth}"
+                )
+            n_shared = y_arch_split_layer
+            n_branch = depth - y_arch_split_layer
+            self.blocks = nn.ModuleList([_make_block() for _ in range(n_shared)])
+            self.pressure_blocks = nn.ModuleList([_make_block() for _ in range(n_branch)])
+            self.wss_blocks = nn.ModuleList([_make_block() for _ in range(n_branch)])
+
+    def forward(
+        self, x: torch.Tensor, attn_mask: torch.Tensor | None = None
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         for block in self.blocks:
             x = block(x, attn_mask=attn_mask)
-        return x
+        if self.pressure_blocks is None:
+            return x
+        x_pressure = x
+        x_wss = x
+        for block in self.pressure_blocks:
+            x_pressure = block(x_pressure, attn_mask=attn_mask)
+        for block in self.wss_blocks:
+            x_wss = block(x_wss, attn_mask=attn_mask)
+        return x_pressure, x_wss
 
 
 class SurfaceTransolver(nn.Module):
@@ -382,6 +416,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        y_arch_split_layer: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +431,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.y_arch_split_layer = y_arch_split_layer
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,9 +508,37 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            y_arch_split_layer=y_arch_split_layer,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        if use_aux_decoder_heads:
+        if y_arch_split_layer > 0:
+            # Y-arch: separate cp head (1 channel) and WSS head (3 channels).
+            # cp head consumes the pressure branch; WSS head consumes the WSS
+            # branch. surface_out is left as None — outputs are stitched into
+            # surface_preds in forward(). volume_out consumes the pressure
+            # branch since volume_pressure is also a pressure quantity.
+            self.surface_out_cp = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, 1),
+            )
+            self.surface_out_cp.apply(_init_linear)
+            self.surface_out_wss = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, 3),
+            )
+            self.surface_out_wss.apply(_init_linear)
+            self.surface_out = None
+            self.volume_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 2, n_hidden // 4),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 4, self.volume_output_dim),
+            )
+            self.volume_out.apply(_init_linear)
+        elif use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
             # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
             # Volume head is a deeper 3-layer MLP for the harder vol_p task —
@@ -595,8 +659,70 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
-        hidden = _apply_token_mask(hidden, attn_mask)
+        backbone_out = self.backbone(hidden, attn_mask=attn_mask)
+
+        if self.y_arch_split_layer > 0:
+            # Y-arch: backbone returns (pressure_branch, wss_branch).
+            # Volume tokens use the pressure branch (vol_p is a pressure
+            # prediction); surface tokens are split between the cp head
+            # (pressure branch) and the WSS head (WSS branch).
+            hidden_pressure, hidden_wss = backbone_out
+            hidden_pressure = _apply_token_mask(hidden_pressure, attn_mask)
+            hidden_wss = _apply_token_mask(hidden_wss, attn_mask)
+            hidden_pressure_norm = _apply_token_mask(self.norm(hidden_pressure), attn_mask)
+            hidden_wss_norm = _apply_token_mask(self.norm(hidden_wss), attn_mask)
+
+            surface_hidden_pressure = hidden_pressure_norm[:, :surface_tokens]
+            surface_hidden_wss = hidden_wss_norm[:, :surface_tokens]
+            volume_hidden = hidden_pressure_norm[:, surface_tokens : surface_tokens + volume_tokens]
+
+            if (
+                self.surf_to_vol_xattn is not None
+                and surface_x is not None
+                and volume_x is not None
+                and surface_tokens > 0
+                and volume_tokens > 0
+            ):
+                # surf-to-vol xattn uses pressure-branch surface tokens as K/V.
+                # (Volume is a pressure prediction; vol_p attending to
+                # WSS-branch features would defeat the purpose of the split.)
+                xattn_out, _ = self.surf_to_vol_xattn(
+                    query=volume_hidden,
+                    key=surface_hidden_pressure,
+                    value=surface_hidden_pressure,
+                    need_weights=False,
+                )
+                xattn_out = _apply_token_mask(xattn_out, volume_mask)
+                volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+                volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+            if surface_x is not None:
+                cp_pred = self.surface_out_cp(surface_hidden_pressure)
+                wss_pred = self.surface_out_wss(surface_hidden_wss)
+                surface_preds = torch.cat([cp_pred, wss_pred], dim=-1) * surface_mask.unsqueeze(-1)
+            else:
+                batch_size = volume_hidden.shape[0]
+                surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+
+            if volume_x is not None:
+                volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
+            else:
+                batch_size = surface_hidden_pressure.shape[0]
+                volume_preds = surface_hidden_pressure.new_zeros(
+                    batch_size, 0, self.volume_output_dim
+                )
+
+            return {
+                "surface_preds": surface_preds,
+                "volume_preds": volume_preds,
+                "hidden": hidden_pressure,
+                "surface_hidden": surface_hidden_pressure,
+                "volume_hidden": volume_hidden,
+                "surface_hidden_pressure": surface_hidden_pressure,
+                "surface_hidden_wss": surface_hidden_wss,
+            }
+
+        hidden = _apply_token_mask(backbone_out, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
         cursor = 0

--- a/train.py
+++ b/train.py
@@ -1103,6 +1103,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for _k, _v in batch_loss_metrics.items():
+                        if _k.startswith("y_arch/"):
+                            train_log[_k] = _v
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/train.py
+++ b/train.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
@@ -103,6 +104,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    y_arch_split_layer: int = 0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "y_arch_split_layer": (
+            "PR #1137 — Y-architecture dual-backbone split. After "
+            "N shared layers (the first N TransformerBlocks), the backbone "
+            "splits into two parallel stacks of (depth - N) layers: a "
+            "pressure branch (drives cp + vol_p heads) and a WSS branch "
+            "(drives the tau_x/tau_y/tau_z head). 0 disables the split "
+            "(legacy single-stack backbone, default). Recommended: 1 = share "
+            "first layer, split the remaining --model-layers - 1. Must be "
+            "strictly less than --model-layers when enabled. Total backbone "
+            "params scale by ~1 + 2 * (depth - N) / depth (e.g. depth=5, "
+            "N=1 -> 1.8x backbone params)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        y_arch_split_layer=config.y_arch_split_layer,
     )
 
 
@@ -346,13 +361,26 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    log = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    # Y-arch branch separation diagnostic (PR #1137).
+    # cos_sim ~ 1.0 = branches collapse (split adds nothing);
+    # cos_sim < 0.7 = branches diverge as intended.
+    if "surface_hidden_pressure" in out and "surface_hidden_wss" in out:
+        hp = out["surface_hidden_pressure"].detach().float()
+        hw = out["surface_hidden_wss"].detach().float()
+        if hp.shape[1] > 0:
+            mask = batch.surface_mask.to(dtype=hp.dtype)
+            cos_per_token = F.cosine_similarity(hp, hw, dim=-1)
+            num = (cos_per_token * mask).sum()
+            den = mask.sum().clamp(min=1.0)
+            log["y_arch/branch_cos_sim_surface"] = float((num / den).item())
+    return loss, log
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -773,7 +801,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.y_arch_split_layer > 0:
+                # Y-arch (PR #1137): surface-only / volume-only views activate
+                # different output heads (cp+wss vs volume_out) and different
+                # branch paths, so ranks can see different sub-graphs in the
+                # same DDP step. find_unused_parameters=True synchronizes
+                # unused params across ranks.
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

Split the backbone after the first encoder layer into **two parallel transformer stacks**: one branch specializes on **pressure** (cp, vol_p), one branch specializes on **WSS** (τ_x, τ_y, τ_z). Shared first layer → independent intermediate layers (2–4) → optional final merge.

**The mechanism we are testing:** Pressure and WSS are physically distinct quantities:
- **Pressure** is a scalar potential field governed by Bernoulli-type equations (irrotational contribution to flow)
- **WSS** is a vector gradient of velocity at the wall (rotational/viscous contribution)

These correspond to fundamentally different physical modes. The current shared-backbone model has to encode BOTH in the same hidden representation across all 5 layers. The hypothesis is that this **task interference** causes the shared backbone to optimize primarily for the easier signal (pressure / streamwise τ_x) and leaves vertical shear (τ_z) as a secondary optimization target.

**Why this experiment NOW:** Your PR #1126 closed with a profound mechanistic finding — TWO independent capacity uplifts (slices=256 backbone width AND surface_out depth=4 decoder depth) both converged to **exactly** the same no-SDF ceiling (test_WSS 6.989%, test_vol_p 3.645%, test_SP 3.833%) to within 0.001pp. This is the strongest possible evidence that the bottleneck is a **representation-axis bottleneck, not a capacity bottleneck**. The Y-architecture directly tests whether splitting the representation axis along the pressure-vs-WSS task boundary breaks this ceiling.

Your own follow-up note from #1126 was correct: *"Re-introducing SDF or finding the right SDF-equivalent input feature is the larger architectural lever, not more parameters in the existing computation graph."* This is a different attack on the same insight — instead of changing inputs, we change the backbone topology.

**Wave 30 orthogonality:**
- H6 (tanjiro #1134): output-side fix (local-frame WSS head, τ·n=0 by construction)
- H2 (nezuko #1136): input-side fix (Fourier basis on surface normals)
- **H5 (this PR): backbone-side fix (split task representations)**

If τ_z bottleneck is at the output, H6 wins. If it's at the input, H2 wins. If it's in shared backbone optimization pressure, **H5 wins**.

**Theoretical basis:** Multi-task learning literature (Misra et al. *Cross-Stitch Networks* CVPR 2016; Vandenhende et al. *Multi-Task Learning Survey* 2021) shows Y-networks consistently outperform single-backbone multi-task models when tasks have structurally distinct optimal representations. Applied to CFD: pressure (potential) and WSS (vortical) optimize for different spectral content of the backbone representation.

## Instructions

**File to modify:** `target/model.py` (only)
**Auxiliary:** `target/train.py` (one CLI flag + plumbing)
**Total LOC:** ~80 in model.py, ~10 in train.py

### Step 1 — Add CLI flag in `train.py`

Add `--y-arch-split-layer N` (default: 0 = disabled, sentinel for "share all layers"; recommended: 1 = share first layer, split rest). Use the same wiring pattern as `--use-qk-norm` or `--surface-out-depth`.

### Step 2 — Modify `Transformer` class in `model.py` (around line 329)

Replace the single `ModuleList` with three module lists when split is enabled. Keep the original behavior when `split_layer=0`. Sketch:

```python
class Transformer(nn.Module):
    def __init__(
        self, depth, hidden_dim, num_heads, mlp_expansion_factor,
        num_slices, dropout=0.0, use_qk_norm=False,
        y_arch_split_layer: int = 0,  # 0 = no split (legacy single stack)
    ):
        super().__init__()
        self.y_arch_split_layer = y_arch_split_layer

        def _make_block():
            return TransformerBlock(
                hidden_dim=hidden_dim, num_heads=num_heads,
                mlp_expansion_factor=mlp_expansion_factor, num_slices=num_slices,
                dropout=dropout, use_qk_norm=use_qk_norm,
            )

        if y_arch_split_layer <= 0:
            self.blocks = nn.ModuleList([_make_block() for _ in range(depth)])
            self.pressure_blocks = None
            self.wss_blocks = None
        else:
            assert y_arch_split_layer < depth, "split_layer must be < depth"
            n_shared = y_arch_split_layer
            n_branch = depth - y_arch_split_layer
            self.blocks = nn.ModuleList([_make_block() for _ in range(n_shared)])
            self.pressure_blocks = nn.ModuleList([_make_block() for _ in range(n_branch)])
            self.wss_blocks = nn.ModuleList([_make_block() for _ in range(n_branch)])

    def forward(self, x, attn_mask=None):
        for blk in self.blocks:
            x = blk(x, attn_mask=attn_mask)
        if self.pressure_blocks is None:
            return x  # legacy single stack
        x_pressure = x
        x_wss = x
        for blk in self.pressure_blocks:
            x_pressure = blk(x_pressure, attn_mask=attn_mask)
        for blk in self.wss_blocks:
            x_wss = blk(x_wss, attn_mask=attn_mask)
        return x_pressure, x_wss  # tuple signals split mode to caller
```

### Step 3 — Modify `SurfaceTransolver` to handle the tuple return

In `__init__` (around line 467), pass the flag through:

```python
self.y_arch_split_layer = y_arch_split_layer  # store for forward
self.backbone = Transformer(
    depth=n_layers, hidden_dim=n_hidden, num_heads=n_head,
    mlp_expansion_factor=mlp_ratio, num_slices=slice_num,
    dropout=dropout, use_qk_norm=use_qk_norm,
    y_arch_split_layer=y_arch_split_layer,
)
```

**Surface head split** (in `__init__`, replacing the current shared `self.surface_out`):

```python
if y_arch_split_layer > 0:
    # Y-arch: separate cp head (from pressure branch) and WSS head (from WSS branch)
    self.surface_out_cp = nn.Sequential(
        nn.Linear(n_hidden, n_hidden), nn.SiLU(),
        nn.Linear(n_hidden, 1),
    )
    self.surface_out_wss = nn.Sequential(
        nn.Linear(n_hidden, n_hidden), nn.SiLU(),
        nn.Linear(n_hidden, 3),  # τ_x, τ_y, τ_z
    )
    self.surface_out_cp.apply(_init_linear)
    self.surface_out_wss.apply(_init_linear)
    self.surface_out = None  # disable shared head
else:
    # legacy shared head (unchanged from current code)
    ... existing code ...
```

In `forward` (around line 548), after the backbone call, dispatch based on whether the backbone returned a tuple:

```python
hidden = self.backbone(hidden, attn_mask=attn_mask)

if self.y_arch_split_layer > 0:
    hidden_pressure, hidden_wss = hidden
    hidden_pressure = _apply_token_mask(hidden_pressure, attn_mask)
    hidden_wss = _apply_token_mask(hidden_wss, attn_mask)
    hidden_pressure_norm = _apply_token_mask(self.norm(hidden_pressure), attn_mask)
    hidden_wss_norm = _apply_token_mask(self.norm(hidden_wss), attn_mask)
    # split tokens
    surf_pressure = hidden_pressure_norm[:, :surface_tokens]
    surf_wss = hidden_wss_norm[:, :surface_tokens]
    vol_pressure = hidden_pressure_norm[:, surface_tokens:]  # vol uses pressure branch
    # Apply surf-to-vol xattn if enabled (use pressure branch for vol context too)
    if self.use_surf_to_vol_xattn:
        ... # adapt the xattn to use surf_pressure as K/V for vol_pressure as Q
    cp_pred = self.surface_out_cp(surf_pressure)
    wss_pred = self.surface_out_wss(surf_wss)
    surface_pred = torch.cat([cp_pred, wss_pred], dim=-1)
    volume_pred = self.volume_out(vol_pressure)
else:
    # legacy single-stack path (unchanged)
    ... existing code ...
```

**Important implementation notes:**

1. **`LayerNorm` reuse**: The current `self.norm` is one layernorm. Reuse it for both branches (it's a normalization, not learned per-branch). This avoids parameter count surprises.

2. **`surf_to_vol_xattn` path**: Currently this xattn projects volume tokens (Q) attending to surface tokens (K/V). In Y-arch, volume comes from pressure branch — keep the xattn using pressure-branch surface tokens as K/V. (Volume is a pressure prediction, so it should attend to pressure-branch surface features.) Do NOT use the WSS-branch surface tokens for volume; that would defeat the purpose of the split.

3. **Layer-norm before split**: Apply the existing `self.norm` to each branch independently. This keeps the head input distribution stable.

4. **Parameter count check**: With `--model-layers 5 --y-arch-split-layer 1`, you have:
   - 1 shared layer (`self.blocks`)
   - 4 pressure-branch layers (`self.pressure_blocks`)
   - 4 WSS-branch layers (`self.wss_blocks`)
   - Total: 9 backbone layers' worth of params instead of 5 — **roughly 1.8× backbone params**
   - At hidden_dim=512, each layer ~4M params → ~16M extra backbone params total
   - **Expected total params: ~34M** (vs depth=2 baseline ~17.4M). Confirm before launching.

5. **Memory budget**: Forward pass runs 4 extra layers + 4 extra layers in parallel → roughly +30% wall-clock per step at the same vol_points. Expect throughput drop from 1.88 it/s → ~1.45 it/s at vol_points=16384. Calibrate epoch ETA accordingly.

### Step 4 — Sanity check before full launch

Run a 200-step smoke (5 minutes, `SENPAI_TIMEOUT_MINUTES=5`) with `--y-arch-split-layer 1 --epochs 1` and the recipe below at low vol_points. Confirm:
- No NaN in `train/nonfinite_loss`
- Peak VRAM < 90 GB (with 1.8× backbone params + 16384 vol_points)
- Forward pass works for surface-only batch AND surface+volume batch
- Total param count matches the +16M estimate

If smoke OOMs, drop to `--model-hidden-dim 384` for the smoke only and report — we may need to tune hidden_dim down to fit.

### Step 5 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --y-arch-split-layer 1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_y_arch_dual_backbone \
  --wandb-name fern/y-arch-split1-18h --agent fern
```

### EP gates (recipe-adjusted for warmup=1, expected +30% wall-clock)

- EP1 floor: val_abupt ~33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL  
  (Adjusted from 6.5% standard because the Y-arch may need an extra epoch to coordinate the two branches' representations.)
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS (the regime where the split should pay off)
- EP13 terminal: full SENPAI-RESULT

### Step 6 — Reporting

Terminal `SENPAI-RESULT` comment must include:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_WSS","value":<number>}}
```

Plus full breakdown:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H5 falsification
- best epoch + EMA vs raw
- **Branch separation diagnostic** (recommended): at EP3/EP10/EP13, log the cosine similarity between the WSS-branch and pressure-branch surface features (e.g. mean over batch of cos_sim(pressure_norm_surf, wss_norm_surf)). If this drops below ~0.7, the branches are diverging as intended; if it stays at 0.99, the branches collapse and the split adds no value.

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H5 confirms task interference**, < 1.40 = breakthrough |

**Source idea:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H5 (taste score 9/12, rank 3 of 8). Companion to tanjiro #1134 H6 and nezuko #1136 H2 — these three test orthogonal Wave 30 attack axes (output / input / backbone).

**Stretch goal context (Issue #1056):** test_WSS < 5.85% (Transolver-3 SOTA). Current best single-model on tay: PR #972 at 6.727%. Gap = 0.877pp. Multiple architectural breakthroughs likely needed.

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.40 (first mechanism to break the structural band) AND test_WSS < 6.727%. This would directly support the task-interference mechanism.
- **MERGE**: test_WSS < 6.727% with both floors held (vol_p ≤ 3.643%, SP ≤ 3.577%). Single-model winner.
- **INTERESTING NULL**: branches diverge (cos_sim < 0.7) but metrics don't move — tells us task interference is real but isn't the τ_z bottleneck mechanism. Would point next experiments at H3/H4 (slice-routing).
- **FLAT NULL**: branches stay correlated (cos_sim ~0.99) — split-layer=1 too early, may need to retry with split_layer=2 or 3.

Train hard. The mechanistic finding from your #1126 (capacity-uplift ceiling) makes this the highest-EV backbone-level experiment we have. Looking forward to the result.
