### PR TITLE
Wave 30 H3: Normal-Aligned Slice Groups (soft orientation routing)

### DIFF
--- a/model.py
+++ b/model.py
@@ -234,6 +234,7 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        normal_slice_alpha: float = 0.0,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +245,7 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.normal_slice_alpha = float(normal_slice_alpha)
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -258,24 +260,60 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+        if self.normal_slice_alpha > 0.0:
+            # Project 3-D unit normal into per-head slice-logit space.
+            # Zero-init so the bias is identity at EP0 (preserves baseline behavior).
+            self.normal_slice_bias = nn.Linear(3, num_heads * num_slices, bias=False)
+            nn.init.zeros_(self.normal_slice_bias.weight)
+        else:
+            self.normal_slice_bias = None
+        # Diagnostic: last batch's slice-weight entropy (scalar, normalized by log(num_slices)).
+        self._last_slice_entropy: torch.Tensor | None = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        if self.normal_slice_bias is not None and normals is not None:
+            # normals: [B, N, 3]; zero rows for volume tokens pass through to zero bias.
+            nb = self.normal_slice_bias(normals.to(dtype=slice_logits.dtype))
+            nb = nb.view(batch_size, num_tokens, self.num_heads, self.num_slices)
+            nb = nb.permute(0, 2, 1, 3)  # [B, H, N, S]
+            slice_logits = slice_logits + self.normal_slice_alpha * nb
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,
                 dtype=slice_weights.dtype,
             )
+        with torch.no_grad():
+            log_p = torch.log(slice_weights.detach().clamp_min(1e-12))
+            per_token_entropy = -(slice_weights.detach() * log_p).sum(dim=-1)  # [B, H, N]
+            if attn_mask is not None:
+                mask_b1n = attn_mask[:, None, :].to(dtype=per_token_entropy.dtype)
+                ent_sum = (per_token_entropy * mask_b1n).sum()
+                n_valid = mask_b1n.sum().clamp_min(1.0) * float(self.num_heads)
+                ent_mean = ent_sum / n_valid
+            else:
+                ent_mean = per_token_entropy.mean()
+            self._last_slice_entropy = ent_mean
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, normals=normals)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +341,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        normal_slice_alpha: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +352,19 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            normal_slice_alpha=normal_slice_alpha,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, normals=normals)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +381,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        normal_slice_alpha: float = 0.0,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +393,20 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    normal_slice_alpha=normal_slice_alpha,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, normals=normals)
         return x
 
 
@@ -382,6 +434,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        normal_slice_alpha: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +449,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.normal_slice_alpha = float(normal_slice_alpha)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +526,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            normal_slice_alpha=normal_slice_alpha,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -595,7 +650,23 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        combined_normals: torch.Tensor | None = None
+        if self.normal_slice_alpha > 0.0:
+            parts: list[torch.Tensor] = []
+            if surface_x is not None:
+                surf_normals = surface_x[..., 3:6].to(dtype=hidden.dtype)
+                surf_normals = F.normalize(surf_normals, dim=-1, eps=1e-6)
+                # Mask invalid (padded) surface tokens so they contribute zero bias.
+                if surface_mask is not None:
+                    surf_normals = surf_normals * surface_mask.unsqueeze(-1).to(
+                        device=surf_normals.device, dtype=surf_normals.dtype
+                    )
+                parts.append(surf_normals)
+            if volume_x is not None:
+                vol_zeros = hidden.new_zeros(volume_x.shape[0], volume_x.shape[1], 3)
+                parts.append(vol_zeros)
+            combined_normals = torch.cat(parts, dim=1)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, normals=combined_normals)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -640,3 +711,32 @@ class SurfaceTransolver(nn.Module):
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+
+    def collect_slice_entropy_metrics(self) -> dict[str, float]:
+        """Return slice-weight entropy diagnostics from the last forward pass.
+
+        H3 mechanism gauge: lower entropy = more concentrated slice assignment.
+        The normalized score in [0, 1] is the raw entropy divided by log(num_slices),
+        so a uniform softmax score is 1.0 and a degenerate one-slice score is 0.0.
+        """
+        metrics: dict[str, float] = {}
+        block_norm: list[float] = []
+        num_slices_ref: int | None = None
+        for i, block in enumerate(self.backbone.blocks):
+            attn = block.attention
+            num_slices_ref = num_slices_ref or attn.num_slices
+            ent = attn._last_slice_entropy
+            if ent is None:
+                continue
+            raw = float(ent.item())
+            denom = math.log(max(attn.num_slices, 2))
+            norm = raw / denom if denom > 0 else 0.0
+            metrics[f"train/slice_entropy/block_{i}_raw"] = raw
+            metrics[f"train/slice_entropy/block_{i}_norm"] = norm
+            block_norm.append(norm)
+        if block_norm:
+            avg_norm = sum(block_norm) / len(block_norm)
+            metrics["train/slice_entropy/mean_norm"] = avg_norm
+            # Higher score = more orientation-coherent (lower entropy) grouping.
+            metrics["train/slice_normal_alignment_score"] = 1.0 - avg_norm
+        return metrics

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    normal_slice_alpha: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "normal_slice_alpha": (
+            "Wave 30 H3: orientation-aware slice routing. When > 0, each "
+            "TransolverAttention block adds a learnable Linear(3, "
+            "num_heads*num_slices) bias to the slice-assignment logits, "
+            "scaled by this alpha. Volume tokens pass zero normals so their "
+            "routing is unchanged. Zero-init so identity at EP0. Default "
+            "0.0 disables the mechanism; recommended 0.5."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +317,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        normal_slice_alpha=config.normal_slice_alpha,
     )
 
 
@@ -1126,6 +1136,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        if should_log_gradients and config.normal_slice_alpha > 0.0:
+                            try:
+                                slice_entropy_metrics = (
+                                    unwrap_model(model).collect_slice_entropy_metrics()
+                                )
+                            except AttributeError:
+                                slice_entropy_metrics = {}
+                            train_log.update(slice_entropy_metrics)
 
                 train_log.update(
                     train_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis

Bias the slice-attention assignment in `TransolverAttention` so that each slice token attracts surface tokens with similar normal orientation. Currently slice assignment is based purely on the learned projection `in_project_slice(x_mid)`, which has no explicit orientation prior — in practice it groups by spatial proximity and feature similarity, mixing upward-facing (τ_z-relevant) and sideways-facing (τ_x-relevant) surfaces in the same slice token. This **averages out the directional signal** at the slice level — exactly the kind of representation-axis bottleneck identified across the 12 prior null experiments.

The fix: add a learnable `normal_align_bias` term to the slice logits, scaled by a tunable `alpha`. Slices then form orientation-coherent groups: a slice token specialized in "upward-facing surfaces" attracts roof patches → concentrates τ_z-relevant flow context in that slice → QKV attention can compute vertical-shear interactions more cleanly.

**This is the FOURTH orthogonal Wave 30 attack axis** on the τ_z bottleneck:
- H6 (tanjiro #1134): output-side decomposition (local-frame WSS head)
- H2 (nezuko #1136): input-side normal Fourier features
- H5 (fern #1137): backbone task-split (Y-architecture)
- **H3 (this PR): backbone slice-attention routing** ← attention-layer fix

The Wave 29 closure of #1128 confirms loss-weight escalation can't break the structural ratio. The Wave 29 closure of #1116 (per-channel heads) showed per-channel decoupling is real but absorbed by the no-SDF ceiling. **The bottleneck is in the slice attention's failure to form orientation-coherent token groups** — exactly what H3 fixes.

**Theoretical basis:** Point cloud transformers with geometric attention (PointBERT 2022, Point-MAE 2022, DGCNN 2019) consistently show that grouping/sampling strategies based on local geometry outperform purely feature-based grouping for shape-dependent outputs. The original Transolver paper (Wu et al. 2024) showed "physics-informed slicing" outperforms random token grouping — H3 extends this principle to orientation rather than spatial position.

## Instructions

**Files to modify:** `target/model.py` (only)
**Auxiliary:** `target/train.py` (one CLI flag)
**Total LOC:** ~50 in model.py, ~5 in train.py

### Step 1 — Add CLI flag in `train.py`

Add `--normal-slice-alpha FLOAT` (default: 0.0 = disabled; recommended: 0.5). Thread it into `SurfaceTransolver` construction. Use the same wiring pattern as `--use-qk-norm`. Document: alpha=0 disables H3, alpha>0 enables soft orientation-aware routing.

### Step 2 — Modify `TransolverAttention.__init__` in `model.py` (around line 229)

Add an optional normal-bias projection. Sketch:

```python
class TransolverAttention(nn.Module):
    def __init__(
        self, hidden_dim, num_heads, num_slices,
        dropout=0.0, use_qk_norm=False,
        normal_slice_alpha: float = 0.0,
    ):
        super().__init__()
        # ... existing code ...
        self.normal_slice_alpha = normal_slice_alpha
        if normal_slice_alpha > 0.0:
            # Project 3-d normals into per-head slice space
            self.normal_slice_bias = nn.Linear(3, num_heads * num_slices, bias=False)
            # Zero-init so the bias is identity at training start (preserves baseline behavior at EP0)
            nn.init.zeros_(self.normal_slice_bias.weight)
        else:
            self.normal_slice_bias = None
```

### Step 3 — Modify `create_slices` to accept normals

```python
def create_slices(self, x, attn_mask=None, normals=None):
    batch_size, num_tokens, _ = x.shape
    fx_mid = self.in_project_fx(x).view(...).permute(0, 2, 1, 3)
    x_mid = self.in_project_x(x).view(...).permute(0, 2, 1, 3)
    slice_logits = self.in_project_slice(x_mid) / self.temperature  # [B, H, N, S]

    if self.normal_slice_bias is not None and normals is not None:
        # normals: [B, N, 3], may have zero rows for volume tokens
        nb = self.normal_slice_bias(normals)  # [B, N, H*S]
        nb = nb.view(batch_size, num_tokens, self.num_heads, self.num_slices)
        nb = nb.permute(0, 2, 1, 3)  # [B, H, N, S]
        slice_logits = slice_logits + self.normal_slice_alpha * nb

    slice_weights = F.softmax(slice_logits, dim=-1)
    # ... rest unchanged ...
```

### Step 4 — Thread normals through TransformerBlock and Transformer

In `TransformerBlock.forward` (around line 320), accept and pass `normals` kwarg:

```python
def forward(self, x, attn_mask=None, normals=None):
    x = _apply_token_mask(x, attn_mask)
    x = x + self.attention(self.norm1(x), attn_mask=attn_mask, normals=normals)
    x = _apply_token_mask(x, attn_mask)
    x = x + self.mlp(self.norm2(x))
    x = _apply_token_mask(x, attn_mask)
    return x
```

In `Transformer.forward` (around line 355):

```python
def forward(self, x, attn_mask=None, normals=None):
    for block in self.blocks:
        x = block(x, attn_mask=attn_mask, normals=normals)
    return x
```

In `TransolverAttention.forward` (around line 277), pass `normals` through to `create_slices`:

```python
def forward(self, x, attn_mask=None, normals=None):
    slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, normals=normals)
    # ... rest unchanged ...
```

### Step 5 — Build the combined normal tensor in `SurfaceTransolver.forward`

The backbone runs on concatenated [surface_tokens, volume_tokens]. Surface tokens have normals in `surface_x[..., 3:6]`; volume tokens don't have normals (use zeros). Build a combined normals tensor that matches the token order:

```python
# In SurfaceTransolver.forward, before self.backbone(hidden, ...):
if self.normal_slice_alpha > 0.0 and surface_x is not None:
    surf_normals = F.normalize(surface_x[..., 3:6], dim=-1, eps=1e-6)  # [B, N_surf, 3]
    if volume_x is not None:
        vol_zeros = torch.zeros(
            volume_x.shape[0], volume_x.shape[1], 3,
            device=surf_normals.device, dtype=surf_normals.dtype,
        )
        combined_normals = torch.cat([surf_normals, vol_zeros], dim=1)  # [B, N_surf+N_vol, 3]
    else:
        combined_normals = surf_normals
else:
    combined_normals = None

hidden = self.backbone(hidden, attn_mask=attn_mask, normals=combined_normals)
```

Volume tokens contribute zero normal bias (zeros pass through Linear → 0), so they're routed purely by `in_project_slice` (legacy behavior). Surface tokens get the orientation bias added.

### Step 6 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1`) with `--normal-slice-alpha 0.5` and confirm:
- No NaN in `train/nonfinite_loss`
- Slice-weight entropy logged in W&B: at `alpha=0.5` slice-weight entropy should be slightly lower than baseline (more concentrated assignment) by ~5-10%. If entropy collapses to near-zero, alpha is too high.
- Throughput unchanged (the `Linear(3, H*S)` adds ~13k params per layer, negligible)
- Memory unchanged

If smoke OOMs or hangs, drop to `--normal-slice-alpha 0.25` for the full run.

### Step 7 — Diagnostic logging (recommended)

Add a single scalar to W&B at each epoch: `train/slice_normal_alignment_score`. Compute as the average per-head entropy of `slice_weights` over surface tokens, normalized by log(num_slices). Lower = more orientation-coherent grouping. If this drops by ~10-20% vs alpha=0 baseline, the mechanism is engaging. If it's identical, the projection isn't learning a useful bias.

### Step 8 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --normal-slice-alpha 0.5 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_normal_aligned_slices \
  --wandb-name thorfinn/normal-slice-alpha0.5-18h --agent thorfinn
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where slice-attention routing should compound with dense supervision (vol_points=65536)
- EP13 terminal: full SENPAI-RESULT

### Step 9 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H3 falsification
- **slice-weight entropy** at EP3, EP10, EP13 (the diagnostic for whether the mechanism engaged)
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H3 confirms attention routing**, < 1.40 = breakthrough |

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.40 AND test_WSS < 6.727% with both floors. Mechanism confirmed; attention slice routing is the τ_z bottleneck.
- **MERGE**: test_WSS < 6.727% with both floors held. Single-model winner.
- **INTERESTING NULL**: slice_entropy drops materially (mechanism engages) but τz/τx unchanged — rules out attention routing as the τ_z bottleneck. Points to H4 (hard routing) or H7 (aux gradient) as next attack.
- **FLAT NULL**: slice_entropy ≈ baseline (mechanism didn't engage) — retry with higher alpha (1.0) or different normal projection topology.

**Source:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H3 (taste score 9/12, rank 4 of 8). Fourth Wave 30 attack axis.

**Wave 30 fleet at launch:** 6 of 8 ideas active in parallel after this assignment (H6 tanjiro #1134, H2 nezuko #1136, H5 fern #1137, H3 thorfinn this PR, plus H1 edward and H7 askeladd assigned in same wave). Each tests a different layer of the architecture stack.
