### PR TITLE
Wave 30 H1: Cylindrical Coordinates (r, theta, z) Input Frame

### DIFF
--- a/model.py
+++ b/model.py
@@ -27,6 +27,28 @@ def _init_linear(module: nn.Module, std: float = 0.02) -> None:
             nn.init.zeros_(module.bias)
 
 
+def _cartesian_to_cylindrical(pos: torch.Tensor) -> torch.Tensor:
+    """(..., 3): (x, y, z) -> (r, theta, z).
+
+    r = sqrt(x^2 + y^2 + 1e-8) >= ~1e-4 to keep r positive and gradients
+    finite. theta = atan2(y, x) in [-pi, pi]. atan2 backward is NaN at
+    (0, 0) (PyTorch issue #98276); padding tokens have x = y = 0, so we
+    swap in (safe_x=1, safe_y=0) near the z-axis via torch.where on constant
+    tensors to avoid poisoning autograd while preserving the angle for
+    real points (r^2 >= 1e-12).
+    """
+    x = pos[..., 0]
+    y = pos[..., 1]
+    z = pos[..., 2]
+    r2 = x * x + y * y
+    r = torch.sqrt(r2 + 1e-8)
+    near_axis = r2 < 1e-12
+    safe_x = torch.where(near_axis, torch.ones_like(x), x)
+    safe_y = torch.where(near_axis, torch.zeros_like(y), y)
+    theta = torch.atan2(safe_y, safe_x)
+    return torch.stack([r, theta, z], dim=-1)
+
+
 def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tensor:
     if mask is None:
         return x
@@ -382,6 +404,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_cylindrical_coords: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_cylindrical_coords = use_cylindrical_coords
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -530,6 +554,8 @@ class SurfaceTransolver(nn.Module):
         placeholder: torch.Tensor,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
+        if self.use_cylindrical_coords:
+            pos = _cartesian_to_cylindrical(pos)
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_cylindrical_coords: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_cylindrical_coords": (
+            "Replace the Cartesian (x, y, z) position passed to pos_embed, "
+            "string_sep, and rff with cylindrical (r, theta, z) where "
+            "r = sqrt(x^2 + y^2 + 1e-8), theta = atan2(y, x). Surface "
+            "normals, area, and sdf are left in their Cartesian frame. "
+            "Targets attacking the tau_z bottleneck by giving the backbone "
+            "a direct height axis."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +317,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_cylindrical_coords=config.use_cylindrical_coords,
     )
 
 


### PR DESCRIPTION
## Hypothesis

Replace the Cartesian `(x, y, z)` input frame with **cylindrical `(r, θ, z)`** before `pos_embed` / `string_sep` encoding. The car has near-mirror symmetry across the x-z plane (left/right symmetry) and is fundamentally a "tubular" object aligned around the longitudinal axis. Cartesian inputs force the backbone to learn this symmetry from data — wasting capacity. **Cylindrical inputs encode the geometry's natural symmetry axis explicitly**: `z` becomes the dedicated "vertical" channel that directly corresponds to τ_z's response direction.

Currently `pos_embed(pos)` and `string_sep(pos)` both consume `(x, y, z)` and fold all three axes through the same sincos transform. The model has no reason to treat `z` differently from `x` or `y` — every position-derived feature is rotationally entangled. Switching to `(r, θ, z)` gives the backbone a **direct height axis** (the one that matters most for vertical shear stress) and explicitly separates "horizontal layout" `(r, θ)` from "altitude" `(z)`.

**This is the FIFTH orthogonal Wave 30 attack axis** on the τ_z bottleneck:
- H6 (tanjiro #1134): output-side decomposition (local-frame WSS head)
- H2 (nezuko #1136): input-side **normal** Fourier features
- H5 (fern #1137): backbone task-split (Y-architecture)
- H3 (thorfinn): backbone slice-attention routing (normal-aligned soft slices)
- **H1 (this PR): input-side coordinate frame (cylindrical position)** ← simplest attack

Five mechanisms, five layers of the stack, all aimed at the same structural ratio. This one is the **cheapest test**: ~35 LOC, one CLI flag, no new parameters.

**Theoretical basis:** Equivariant networks (e.g., SE(3)-Transformer, EGNN, Tensor Field Networks) consistently show that aligning the input coordinate system with the geometry's symmetry axis improves sample efficiency and reduces capacity waste. For car aerodynamics specifically, the natural symmetry is around the vertical axis (yaw symmetry under symmetric flow conditions) — cylindrical coordinates around `z` make this explicit. The DrivAerML dataset is generated with zero yaw and zero pitch, so the geometry's principal symmetry is mirror across x-z, but cylindrical around z still gives the cleanest single-axis decomposition of "horizontal-vs-vertical" surface character.

The Wave 29 closure of #1116 (per-channel WSS heads) showed per-channel gradient decoupling is real but absorbed by the no-SDF ceiling — meaning **the bottleneck is upstream of the output head**. H1 attacks the most upstream point: the raw input frame.

## Instructions

**Files to modify:** `target/model.py` (only)
**Auxiliary:** `target/train.py` (one CLI flag)
**Total LOC:** ~35 in model.py, ~5 in train.py

### Step 1 — Add CLI flag in `train.py`

Add `--use-cylindrical-coords` (bool, default False). Thread it into `SurfaceTransolver(...)` construction. Use the same wiring pattern as `--use-qk-norm`. Document: when enabled, the backbone receives position as `(r, θ, z)` instead of `(x, y, z)`; surface normals and area remain Cartesian; sdf remains unchanged.

### Step 2 — Add helper in `model.py`

Add a free function (or static method on `SurfaceTransolver`) near the top of model.py, just after the imports:

```python
def _cartesian_to_cylindrical(pos: torch.Tensor) -> torch.Tensor:
    """(B, N, 3): (x, y, z) -> (r, theta, z). r >= 0, theta in [-pi, pi]."""
    x = pos[..., 0]
    y = pos[..., 1]
    z = pos[..., 2]
    r = torch.sqrt(x * x + y * y + 1e-8)
    theta = torch.atan2(y, x)
    return torch.stack([r, theta, z], dim=-1)
```

The `1e-8` floor inside the sqrt prevents NaN gradients at `r=0` (which doesn't occur on the car surface but could on volume tokens at exactly the central axis).

### Step 3 — Modify `SurfaceTransolver.__init__`

Accept `use_cylindrical_coords: bool = False` and store on `self`:

```python
def __init__(
    self,
    # ... existing args ...
    use_cylindrical_coords: bool = False,
):
    super().__init__()
    # ... existing code ...
    self.use_cylindrical_coords = use_cylindrical_coords
```

### Step 4 — Modify `_encode_group` (around line 522)

Apply the cylindrical transform on `pos` before `pos_embed`, `string_sep`, or `rff`. The non-position features (normals, area, sdf) pass through unchanged.

```python
def _encode_group(
    self,
    x: torch.Tensor,
    *,
    rff: nn.Module | None,
    string_sep: nn.Module | None,
    project_features: LinearProjection | None,
    bias: MLP,
    placeholder: torch.Tensor,
) -> torch.Tensor:
    pos = x[:, :, : self.space_dim]
    if self.use_cylindrical_coords:
        pos = _cartesian_to_cylindrical(pos)
    hidden = self.pos_embed(pos)
    feature_parts: list[torch.Tensor] = []
    if x.shape[-1] > self.space_dim:
        feature_parts.append(x[:, :, self.space_dim :])
    if string_sep is not None:
        feature_parts.append(string_sep(pos))
    elif rff is not None:
        feature_parts.append(rff(pos))
    if project_features is not None and feature_parts:
        features = (
            feature_parts[0] if len(feature_parts) == 1 else torch.cat(feature_parts, dim=-1)
        )
        hidden = hidden + project_features(features)
    return bias(hidden) + placeholder
```

That's the entire core change — the cylindrical `pos` flows naturally to all three position-consuming submodules (`pos_embed`, `string_sep`, `rff`). All embedding modules accept 3D vectors and produce sincos/RFF features over them; the change of basis only affects what they encode.

### Step 5 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1`) with `--use-cylindrical-coords` and confirm:
- No NaN in `train/nonfinite_loss`
- No NaN in `train/loss` (the `1e-8` sqrt floor handles the singularity)
- Throughput unchanged (cylindrical transform is ~3 FLOPs per token — negligible)
- Memory unchanged

If smoke shows NaN, increase the sqrt floor to `1e-6`.

### Step 6 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-cylindrical-coords \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_cylindrical_coords \
  --wandb-name edward/cylindrical-r-theta-z-18h --agent edward
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where coord frame should compound with dense supervision (vol_points=65536)
- EP13 terminal: full SENPAI-RESULT

### Step 7 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H1 falsification
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H1 confirms input frame matters**, < 1.40 = breakthrough |

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.40 AND test_WSS < 6.727% with both floors. Mechanism confirmed; the input frame *is* the τ_z bottleneck.
- **MERGE**: test_WSS < 6.727% with both floors held. Single-model winner.
- **INTERESTING NULL**: test_WSS within 0.1pp of baseline but τz/τx materially down — coord-frame helps balance but mass capacity still capped. Combine with H2 (normal features) in next wave.
- **FLAT NULL**: test_WSS within 0.05pp baseline AND τz/τx unchanged — coord frame is invariant under sincos pos_embed (a real possibility, since sincos already covers the unit circle). Move on to H4 (hard slice routing) or H7 (gradient signal).

**A note on why this might be a flat null:** `ContinuousSincosEmbed` over `(x, y, z)` already produces features like `sin(ω x)`, `cos(ω y)`, etc., which span a full Fourier basis. Cylindrical `(r, θ, z)` produces `sin(ω r)`, `sin(ω θ)`, `sin(ω z)` — different basis but possibly equivalent under the downstream MLP. The hypothesis is that the **direct height channel `z`** is what helps — even if the rest is Fourier-equivalent, having an axis-aligned channel for the response direction should improve τ_z. This is also why this is the *cheapest* H1 to test: 35 LOC, one flag, definitive answer in 18h.

**Source:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H1 (taste score 11/12, rank 1 of 8). Fifth Wave 30 attack axis (simplest implementation).

**Wave 30 fleet at launch:** 6 of 8 ideas active in parallel after this assignment (H6 tanjiro #1134, H2 nezuko #1136, H5 fern #1137, H3 thorfinn, **H1 edward this PR**, H7 askeladd). Each tests a different layer of the architecture stack.
