### PR TITLE
Wave 30 H7: Normal-Prediction Auxiliary Head (gradient signal regularizer)

### DIFF
--- a/launch_normal_aux_full.sh
+++ b/launch_normal_aux_full.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+# PR #1140 H7: Normal-prediction aux head, full 13-epoch run with vol_points curriculum
+export SENPAI_TIMEOUT_MINUTES=1100
+export SENPAI_MAX_EPOCHS=13
+export WANDB_ENTITY="${WANDB_ENTITY:-wandb-applied-ai-team}"
+export WANDB_PROJECT="${WANDB_PROJECT:-senpai-v1-drivaerml-ddp8}"
+export WANDB_MODE="${WANDB_MODE:-online}"
+
+torchrun --standalone --nproc-per-node=8 train.py \
+  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
+  --pos-encoding-mode string_separable --use-qk-norm \
+  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
+  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
+  --normal-aux-loss-weight 0.1 \
+  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
+  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
+  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
+  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
+  --no-compile-model --batch-size 4 --validation-every 1 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 65536 --eval-volume-points 65536 \
+  --wandb-group wave30_normal_aux_head \
+  --wandb-name askeladd/normal-aux-w0.1-18h --agent askeladd

--- a/launch_smoke_aux.sh
+++ b/launch_smoke_aux.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+export SENPAI_TIMEOUT_MINUTES=5
+export SENPAI_MAX_EPOCHS=1
+export WANDB_ENTITY="${WANDB_ENTITY:-wandb-applied-ai-team}"
+export WANDB_PROJECT="${WANDB_PROJECT:-senpai-v1-drivaerml-ddp8}"
+export WANDB_MODE="${WANDB_MODE:-online}"
+
+torchrun --standalone --nproc-per-node=8 train.py \
+  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
+  --pos-encoding-mode string_separable --use-qk-norm \
+  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
+  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
+  --normal-aux-loss-weight 0.1 \
+  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
+  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
+  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 1 \
+  --no-compile-model --batch-size 2 --validation-every 1 \
+  --train-surface-points 4096 --eval-surface-points 4096 \
+  --train-volume-points 4096 --eval-volume-points 4096 \
+  --gradient-log-every 50 --weight-log-every 50 \
+  --wandb-group wave30_normal_aux_head_smoke \
+  --wandb-name askeladd/smoke-aux-w0.1 --agent askeladd

--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        normal_aux_loss_weight: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.normal_aux_loss_weight = float(normal_aux_loss_weight)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,19 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # PR #1140: normal-prediction auxiliary head. Predicts the input surface
+        # normal (nx, ny, nz) from each surface token's post-norm hidden state.
+        # Trained with cosine-distance against `surface_x[..., 3:6]`, weighted
+        # by `normal_aux_loss_weight` in the trainer. Zero-init weight AND bias
+        # so the head outputs 0 at init => aux loss = 1.0 at step 0, preserving
+        # baseline gradient flow until the head learns.
+        if self.normal_aux_loss_weight > 0.0:
+            self.normal_aux_head = nn.Linear(n_hidden, 3)
+            nn.init.zeros_(self.normal_aux_head.weight)
+            nn.init.zeros_(self.normal_aux_head.bias)
+        else:
+            self.normal_aux_head = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -633,10 +648,20 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
+        if (
+            self.normal_aux_head is not None
+            and surface_x is not None
+            and surface_tokens > 0
+        ):
+            normal_pred = self.normal_aux_head(surface_hidden) * surface_mask.unsqueeze(-1)
+        else:
+            normal_pred = None
+
         return {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "normal_pred": normal_pred,
         }

--- a/train.py
+++ b/train.py
@@ -105,6 +105,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    normal_aux_loss_weight: float = 0.0
+    normal_aux_warmup_epochs: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +231,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "normal_aux_loss_weight": (
+            "PR #1140: enable a normal-prediction auxiliary head on the "
+            "surface tokens. When > 0, a small Linear head predicts the "
+            "input surface normal (nx, ny, nz) from each token's post-norm "
+            "hidden state. A masked cosine-distance loss (1 - cos(pred, "
+            "target_unit_normal)) is added to the total loss, scaled by "
+            "this weight. The head's weight and bias are zero-initialised, "
+            "so EP0 gradient flow matches the baseline. Default 0.0 "
+            "(disabled). Recommended 0.1."
+        ),
+        "normal_aux_warmup_epochs": (
+            "Linearly ramp the normal-aux loss weight from 0 -> "
+            "--normal-aux-loss-weight over this many epochs. Default 0 "
+            "applies full weight from EP0; the zero-init of the aux head "
+            "usually makes warmup unnecessary."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +326,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        normal_aux_loss_weight=config.normal_aux_loss_weight,
     )
 
 
@@ -321,6 +340,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    normal_aux_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,12 +366,35 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+        normal_aux_loss_val = 0.0
+        if normal_aux_loss_weight > 0.0 and out.get("normal_pred") is not None:
+            # batch.surface_x is [B, N, 7] = [x, y, z, nx, ny, nz, area].
+            # Compute masked cosine distance against the unit-normalized
+            # input normals, in fp32 to avoid bf16 underflow when the head
+            # is near-zero at init.
+            target_normals = torch.nn.functional.normalize(
+                batch.surface_x[..., 3:6].float(), dim=-1, eps=1e-6
+            )
+            pred_normals = torch.nn.functional.normalize(
+                out["normal_pred"].float(), dim=-1, eps=1e-6
+            )
+            cos = (pred_normals * target_normals).sum(dim=-1)  # [B, N]
+            cos_loss_per_token = 1.0 - cos  # [B, N]
+            mask = batch.surface_mask.float()
+            denom = mask.sum().clamp(min=1.0)
+            normal_aux_loss = (cos_loss_per_token * mask).sum() / denom
+            loss = loss + normal_aux_loss_weight * normal_aux_loss
+            normal_aux_loss_val = float(normal_aux_loss.detach().cpu().item())
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "normal_aux_loss": normal_aux_loss_val,
+        "normal_aux_loss_weighted": normal_aux_loss_weight * normal_aux_loss_val,
+        "normal_aux_loss_weight_effective": float(normal_aux_loss_weight),
     }
 
 
@@ -772,8 +815,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # batch, so DDP's default find_unused_parameters=False deadlocks
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
-            # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # params across ranks, at a small per-step overhead. The
+            # normal-aux head (PR #1140) is gated the same way, so enable it
+            # there too.
+            if config.use_surf_to_vol_xattn or config.normal_aux_loss_weight > 0.0:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -852,6 +897,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.normal_aux_loss_weight > 0.0:
+                aux_head = getattr(base_model, "normal_aux_head", None)
+                aux_params = sum(p.numel() for p in aux_head.parameters()) if aux_head is not None else 0
+                print(
+                    f"Normal-aux head ON: weight={config.normal_aux_loss_weight} "
+                    f"warmup_epochs={config.normal_aux_warmup_epochs} "
+                    f"aux_params={aux_params:,d} "
+                    f"(zero-init Linear({config.model_hidden_dim}, 3))"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +937,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/normal_aux_loss_weight"] = config.normal_aux_loss_weight
+            wandb.summary["loss/normal_aux_warmup_epochs"] = config.normal_aux_warmup_epochs
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1021,6 +1077,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    if (
+                        config.normal_aux_loss_weight > 0.0
+                        and config.normal_aux_warmup_epochs > 0
+                        and epoch < config.normal_aux_warmup_epochs
+                    ):
+                        normal_aux_w_step = (
+                            config.normal_aux_loss_weight
+                            * (epoch / config.normal_aux_warmup_epochs)
+                        )
+                    else:
+                        normal_aux_w_step = config.normal_aux_loss_weight
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1030,6 +1097,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        normal_aux_loss_weight=normal_aux_w_step,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1138,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "normal_aux_loss" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "train/normal_aux_loss": batch_loss_metrics["normal_aux_loss"],
+                                "train/normal_aux_loss_weighted": batch_loss_metrics["normal_aux_loss_weighted"],
+                                "train/normal_aux_loss_weight_effective": batch_loss_metrics[
+                                    "normal_aux_loss_weight_effective"
+                                ],
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

Add a **normal-prediction auxiliary head** to `SurfaceTransolver`: a small linear head that, from each surface token's backbone-emitted feature vector, predicts the surface normal that was *fed into* that token. Train it with a cosine-embedding loss in parallel with the main WSS/SP regression, weighted at ~0.1×.

The mechanism is **a regularizer that forces backbone features to retain orientation information**. The Wave 29 closure of #1116 (per-channel WSS heads) showed per-channel decoupling at the output is real but absorbed by the no-SDF ceiling — meaning the backbone-emitted feature vector at each surface point doesn't carry enough orientation signal for the output to disentangle. An aux head says "from your backbone feature alone, I must be able to recover the input normal" — this **gradient pressure to preserve normal direction in features** is exactly what's missing.

Critically, this is **different from H2 (normal Fourier features)**: H2 puts more normal information *into* the model; H7 forces the model to *retain* normal information through the backbone, via a contrastive-style loss. H2 attacks input-side; H7 attacks the gradient signal directly.

**This is the SIXTH orthogonal Wave 30 attack axis** on the τ_z bottleneck:
- H6 (tanjiro #1134): output-side decomposition (local-frame WSS head)
- H2 (nezuko #1136): input-side normal Fourier features
- H5 (fern #1137): backbone task-split (Y-architecture)
- H3 (thorfinn): attention routing (normal-aligned soft slices)
- H1 (edward): input-frame change (cylindrical r, θ, z)
- **H7 (this PR): gradient signal (normal-prediction aux head)** ← regularization attack

Six mechanisms, six layers of the stack, all aimed at the same structural ratio. H7 is unique because it operates on the **gradient flow itself**: every backward pass through this aux loss forces the backbone to keep orientation legible at every surface token.

**Theoretical basis:** Self-supervised auxiliary tasks consistently improve transfer and representation quality (DINO, DINOv2, MAE, masked normal prediction in Point-MAE 2022). For task-specific use, "predict the input feature from the embedding" is a classic representation-preservation regularizer (BYOL, SimSiam — without negative pairs). For τ_z specifically, the input normal `n_z` component **is** what determines whether a surface contributes to τ_z vs τ_x; making the backbone retain `n` ensures `n_z` is recoverable from the feature, which means the output head's regression on τ_z is computationally easier.

## Instructions

**Files to modify:** `target/model.py` and `target/train.py` (both)
**Total LOC:** ~80 (~40 model.py, ~40 train.py)

### Step 1 — Add CLI flag in `train.py`

Add `--normal-aux-loss-weight FLOAT` (default: 0.0 = disabled; recommended: 0.1). Document: when > 0, adds an auxiliary cosine-embedding loss between predicted and target surface normals, weighted by this scalar. Thread it into `SurfaceTransolver` construction AND into the loss path.

Also add `--normal-aux-warmup-epochs INT` (default: 0). When > 0, the aux loss weight ramps linearly from 0 to `normal_aux_loss_weight` over that many epochs. Use only if needed (probably not — zero-init the head, see below).

### Step 2 — Add aux head in `SurfaceTransolver.__init__` (around line 460-510)

```python
def __init__(
    self,
    # ... existing args ...
    normal_aux_loss_weight: float = 0.0,
):
    super().__init__()
    # ... existing code ...
    self.normal_aux_loss_weight = normal_aux_loss_weight
    if normal_aux_loss_weight > 0.0:
        self.normal_aux_head = nn.Linear(n_hidden, 3)
        # Zero-init the head's weight (but not bias) so EP0 outputs are the bias only —
        # negligible signal, preserves baseline behavior at training start.
        nn.init.zeros_(self.normal_aux_head.weight)
        nn.init.zeros_(self.normal_aux_head.bias)
    else:
        self.normal_aux_head = None
```

### Step 3 — Predict normals in `SurfaceTransolver.forward`

After computing `surface_hidden` (around line 603), add the aux-head pass. Use the pre-norm `surface_hidden` (already-normed). Add the prediction to the output dict so the trainer can consume it.

```python
# Inside SurfaceTransolver.forward, after:
# surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
# (and after the optional surf_to_vol_xattn block, since we want to use the
# representation that goes into the WSS output head)

if self.normal_aux_head is not None and surface_x is not None:
    normal_pred = self.normal_aux_head(surface_hidden) * surface_mask.unsqueeze(-1)
else:
    normal_pred = None
```

Then extend the return dict:

```python
return {
    "surface_preds": surface_preds,
    "volume_preds": volume_preds,
    "hidden": hidden,
    "surface_hidden": surface_hidden,
    "volume_hidden": volume_hidden,
    "normal_pred": normal_pred,
}
```

### Step 4 — Add aux loss in `train.py` `compute_train_loss` (around line 320)

The function signature currently accepts `surface_loss_weight` and `volume_loss_weight`. Add `normal_aux_loss_weight: float = 0.0` and the effective per-step weight (for warmup) computed in the caller — pass it in as `normal_aux_loss_weight`.

```python
def compute_train_loss(
    model: nn.Module,
    batch,
    transform: TargetTransform,
    device: torch.device,
    amp_mode: str,
    *,
    surface_loss_weight: float = 1.0,
    volume_loss_weight: float = 1.0,
    surface_channel_weights: torch.Tensor | None = None,
    normal_aux_loss_weight: float = 0.0,
) -> tuple[torch.Tensor, dict[str, float]]:
    batch = batch.to(device)
    surface_target = transform.apply_surface(batch.surface_y)
    volume_target = transform.apply_volume(batch.volume_y)
    with autocast_context(device, amp_mode):
        out = model(
            surface_x=batch.surface_x,
            surface_mask=batch.surface_mask,
            volume_x=batch.volume_x,
            volume_mask=batch.volume_mask,
        )
        # ... existing surface_loss / volume_loss code unchanged ...

        loss = weighted_surface_loss + weighted_volume_loss
        base_mse_loss = surface_loss + volume_loss

        normal_aux_loss_val = 0.0
        if normal_aux_loss_weight > 0.0 and out.get("normal_pred") is not None:
            # batch.surface_x is shape [B, N, 7] = [x, y, z, nx, ny, nz, area]
            target_normals = F.normalize(batch.surface_x[..., 3:6], dim=-1, eps=1e-6)
            pred_normals = F.normalize(out["normal_pred"].float(), dim=-1, eps=1e-6)
            # Masked cosine distance: 1 - cos(theta) per token, masked-mean
            cos = (pred_normals * target_normals).sum(dim=-1)  # [B, N]
            cos_loss_per_token = (1.0 - cos)  # [B, N]
            mask = batch.surface_mask.float()
            denom = mask.sum().clamp(min=1.0)
            normal_aux_loss = (cos_loss_per_token * mask).sum() / denom
            loss = loss + normal_aux_loss_weight * normal_aux_loss
            normal_aux_loss_val = float(normal_aux_loss.detach().cpu().item())

    return loss, {
        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
        "surface_loss": float(surface_loss.detach().cpu().item()),
        "volume_loss": float(volume_loss.detach().cpu().item()),
        "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
        "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
        "normal_aux_loss": normal_aux_loss_val,
        "normal_aux_loss_weighted": normal_aux_loss_weight * normal_aux_loss_val,
    }
```

### Step 5 — Wire the warmup at the call site

In the main training loop where `compute_train_loss(...)` is called (search for `compute_train_loss(` in `train.py`), compute the effective `normal_aux_loss_weight` per-step:

```python
# Where you have the current epoch index:
if args.normal_aux_warmup_epochs > 0 and current_epoch < args.normal_aux_warmup_epochs:
    aux_w = args.normal_aux_loss_weight * (current_epoch / args.normal_aux_warmup_epochs)
else:
    aux_w = args.normal_aux_loss_weight

# Then in the call:
loss, loss_metrics = compute_train_loss(
    model, batch, transform, device, amp_mode,
    surface_loss_weight=args.surface_loss_weight,
    volume_loss_weight=args.volume_loss_weight,
    surface_channel_weights=channel_weights,
    normal_aux_loss_weight=aux_w,
)
```

Default `--normal-aux-warmup-epochs 0` means full weight from EP0; the zero-init of the head's weight makes warmup unnecessary in practice.

### Step 6 — Log to W&B

Add `normal_aux_loss` and `normal_aux_loss_weighted` to the W&B step metric log dict alongside `surface_loss`, `volume_loss`. They should already flow through because `loss_metrics` is iterated and posted.

### Step 7 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1`) with `--normal-aux-loss-weight 0.1` and confirm:
- No NaN in `train/nonfinite_loss`
- `train/normal_aux_loss` logged in W&B — at step 0 should be ~1.0 (uniform random direction yields cos≈0), should drop to <0.3 within the first 200 steps
- Throughput unchanged (one `Linear(512, 3)` per forward — negligible)
- Memory unchanged (~6kB extra params)

If `train/normal_aux_loss` stays at ~1.0 at step 200, the head isn't learning — check that `normal_pred` is actually in the output dict and that backward reaches the head's weights.

### Step 8 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --normal-aux-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_normal_aux_head \
  --wandb-name askeladd/normal-aux-w0.1-18h --agent askeladd
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where the aux regularizer should compound with dense supervision (vol_points=65536)
- EP13 terminal: full SENPAI-RESULT

### Step 9 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H7 falsification
- **final train/normal_aux_loss** (should be < 0.1 at EP13 if mechanism engaged)
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H7 confirms gradient-signal mechanism**, < 1.40 = breakthrough |

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.40 AND test_WSS < 6.727% with both floors. Mechanism confirmed; gradient pressure to preserve normals is what was missing.
- **MERGE**: test_WSS < 6.727% with both floors held. Single-model winner.
- **INTERESTING NULL**: aux loss drops cleanly to <0.05 (head learns the task perfectly) but τz/τx unchanged — rules out "feature lacks normal info" as the bottleneck. Points to H4 (hard routing) or sampling-side hypotheses as next attack.
- **FLAT NULL**: aux loss stays near 1.0 or training diverges with the aux on — aux loss is fighting the main loss for capacity. Try `--normal-aux-loss-weight 0.05` and `--normal-aux-warmup-epochs 2`.

**Source:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H7 (taste score 7/12, rank 6 of 8). Sixth Wave 30 attack axis.

**Wave 30 fleet at launch:** 6 of 8 ideas active in parallel after this assignment (H6 tanjiro #1134, H2 nezuko #1136, H5 fern #1137, H3 thorfinn, H1 edward, **H7 askeladd this PR**). Each tests a different layer of the architecture stack — output decomposition, input features, backbone capacity split, attention routing, input coordinate frame, and now gradient-signal regularization.
