### PR TITLE
Wave 30 H4: Hard Normal-Routing Slice Partition (MoE-style attention)

### DIFF
--- a/model.py
+++ b/model.py
@@ -253,16 +253,11 @@ class TransolverAttention(nn.Module):
             self.num_slices_xy = num_slices - self.num_slices_z
             if self.num_slices_xy <= 0:
                 raise ValueError(
-                    f"z_slice_fraction={z_slice_fraction} leaves no xy-slices "
-                    f"(num_slices={num_slices})"
+                    "z_slice_fraction too high: would leave zero slices for xy-surfaces"
                 )
         else:
             self.num_slices_z = 0
             self.num_slices_xy = num_slices
-        # Diagnostic stash (populated only when hard routing engages).
-        self.last_z_fraction: float | None = None
-        self.last_util_z: float | None = None
-        self.last_util_xy: float | None = None
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -278,37 +273,45 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
+        # Hard-routing diagnostic buffers, refreshed per forward pass when routing is on.
+        # Stored on-device as 0-dim tensors so DDP/AMP do not complicate the read path.
+        self._last_z_surface_fraction: torch.Tensor | None = None
+        self._last_util_z: torch.Tensor | None = None
+        self._last_util_xy: torch.Tensor | None = None
+
     def build_routing_mask(
         self,
         normals: torch.Tensor,
         num_tokens: int,
-        device: torch.device,
-    ) -> torch.Tensor | None:
-        """Per-token boolean slice mask [B, N, S] enforcing hard normal-routing.
+    ) -> torch.Tensor:
+        """Returns [B, N, S] boolean mask for hard normal-routing.
 
-        Surface tokens with |n_z| >= threshold may attend only to the last
-        ``num_slices_z`` slices; surface tokens with |n_z| < threshold may
-        attend only to the first ``num_slices_xy`` slices. Volume tokens
-        (passed in with all-zero normals) keep the full slice budget so the
-        baseline behaviour is preserved.
+        True = token may attend to slice; False = token forbidden from slice.
+        Volume tokens (all-zero normals) are permitted everywhere.
         """
-        if self.z_slice_fraction <= 0.0 or normals is None:
-            return None
-        abs_nz = normals[..., 2].abs()
-        is_z_surface = abs_nz >= self.nz_routing_threshold
-        is_volume = normals.abs().sum(dim=-1) < 1e-6
+        batch_size = normals.shape[0]
+        device = normals.device
+        abs_nz = normals[..., 2].abs()  # [B, N]
+        is_z_surface = abs_nz >= self.nz_routing_threshold  # [B, N]
         mask = torch.zeros(
-            normals.shape[0], num_tokens, self.num_slices,
-            device=device, dtype=torch.bool,
+            batch_size,
+            num_tokens,
+            self.num_slices,
+            device=device,
+            dtype=torch.bool,
         )
-        mask[:, :, -self.num_slices_z:] = is_z_surface.unsqueeze(-1)
-        mask[:, :, : self.num_slices_xy] = (~is_z_surface).unsqueeze(-1)
+        if self.num_slices_z > 0:
+            mask[:, :, -self.num_slices_z:] = is_z_surface.unsqueeze(-1)
+        if self.num_slices_xy > 0:
+            mask[:, :, : self.num_slices_xy] = (~is_z_surface).unsqueeze(-1)
+        # Volume tokens carry zero normals; allow all slices for them.
+        is_volume = normals.abs().sum(dim=-1) < 1e-6  # [B, N]
         mask = mask | is_volume.unsqueeze(-1)
-        if not mask.any(dim=-1).all():
-            # Fallback: any pathological token with no allowed slice falls back
-            # to the full mask. Prevents softmax NaN from an all-false row.
-            bad_tokens = ~mask.any(dim=-1)
-            mask = mask | bad_tokens.unsqueeze(-1)
+        # Safety: any token with zero allowed slices (e.g. degenerate normal)
+        # falls back to all-True to avoid softmax(-inf, ..., -inf) = NaN.
+        no_allowed = ~mask.any(dim=-1)  # [B, N]
+        if no_allowed.any():
+            mask = mask | no_allowed.unsqueeze(-1)
         return mask
 
     def create_slices(
@@ -321,16 +324,17 @@ class TransolverAttention(nn.Module):
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
-        routing_mask = None
+
         if self.z_slice_fraction > 0.0 and normals is not None:
-            routing_mask = self.build_routing_mask(normals, num_tokens, x.device)
-            if routing_mask is not None:
-                # Broadcast across heads: [B, 1, N, S]. Use a large finite
-                # negative (Switch Transformer §6) rather than -inf so a row
-                # that ends up all-suppressed in bf16 can never become NaN.
-                routing_mask_h = routing_mask.unsqueeze(1)
-                neg_inf = torch.finfo(slice_logits.dtype).min / 2
-                slice_logits = slice_logits.masked_fill(~routing_mask_h, neg_inf)
+            routing_mask = self.build_routing_mask(normals, num_tokens)  # [B, N, S]
+            # Broadcast across heads: [B, 1, N, S]; cast to logits dtype for the masked_fill.
+            routing_mask_h = routing_mask.unsqueeze(1)
+            slice_logits = slice_logits.masked_fill(
+                ~routing_mask_h, torch.finfo(slice_logits.dtype).min
+            )
+            if self.training:
+                self._record_routing_diagnostics(slice_logits, normals, attn_mask)
+
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
@@ -339,44 +343,37 @@ class TransolverAttention(nn.Module):
             )
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
-        if routing_mask is not None:
-            self._stash_routing_diag(slice_weights, normals, attn_mask)
         return slice_tokens, slice_weights
 
-    def _stash_routing_diag(
+    def _record_routing_diagnostics(
         self,
-        slice_weights: torch.Tensor,
+        slice_logits: torch.Tensor,
         normals: torch.Tensor,
         attn_mask: torch.Tensor | None,
     ) -> None:
-        """Record cheap mean diagnostics so the trainer can log them."""
+        """Record per-batch hard-routing utilization (head-averaged, surface-only)."""
+        # slice_logits: [B, H, N, S]
         with torch.no_grad():
-            abs_nz = normals[..., 2].abs()
-            is_z = abs_nz >= self.nz_routing_threshold
-            is_volume = normals.abs().sum(dim=-1) < 1e-6
-            is_surface = ~is_volume
+            sw = F.softmax(slice_logits.detach().float(), dim=-1)  # [B, H, N, S]
+            # Only surface tokens carry real normals; volume tokens are all-zero.
+            is_surface = normals.abs().sum(dim=-1) > 1e-6  # [B, N]
             if attn_mask is not None:
-                surface_valid = is_surface & attn_mask.bool()
-            else:
-                surface_valid = is_surface
-            is_z_surface = is_z & surface_valid
-            is_xy_surface = (~is_z) & surface_valid
-            n_surface = surface_valid.float().sum().clamp_min(1.0)
-            self.last_z_fraction = float(
-                (is_z_surface.float().sum() / n_surface).item()
-            )
-            # Average over heads -> [B, N, S]
-            sw_mean = slice_weights.mean(dim=1).float()
-            z_util_per_token = sw_mean[..., -self.num_slices_z:].sum(dim=-1)
-            xy_util_per_token = sw_mean[..., : self.num_slices_xy].sum(dim=-1)
-            n_z = is_z_surface.float().sum().clamp_min(1.0)
-            n_xy = is_xy_surface.float().sum().clamp_min(1.0)
-            self.last_util_z = float(
-                ((z_util_per_token * is_z_surface.float()).sum() / n_z).item()
-            )
-            self.last_util_xy = float(
-                ((xy_util_per_token * is_xy_surface.float()).sum() / n_xy).item()
-            )
+                is_surface = is_surface & attn_mask.to(dtype=torch.bool)
+            abs_nz = normals[..., 2].abs()
+            is_z_surface = (abs_nz >= self.nz_routing_threshold) & is_surface
+            is_xy_surface = (abs_nz < self.nz_routing_threshold) & is_surface
+            # Head-averaged softmax weights: [B, N, S]
+            sw_mean_heads = sw.mean(dim=1)
+            util_z = sw_mean_heads[..., -self.num_slices_z:].sum(dim=-1)  # [B, N]
+            util_xy = sw_mean_heads[..., : self.num_slices_xy].sum(dim=-1)  # [B, N]
+
+            z_count = is_z_surface.sum().clamp(min=1).float()
+            xy_count = is_xy_surface.sum().clamp(min=1).float()
+            surf_count = is_surface.sum().clamp(min=1).float()
+
+            self._last_util_z = (util_z * is_z_surface.float()).sum() / z_count
+            self._last_util_xy = (util_xy * is_xy_surface.float()).sum() / xy_count
+            self._last_z_surface_fraction = is_z_surface.sum().float() / surf_count
 
     def forward(
         self,
@@ -384,9 +381,7 @@ class TransolverAttention(nn.Module):
         attn_mask: torch.Tensor | None = None,
         normals: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(
-            x, attn_mask=attn_mask, normals=normals,
-        )
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, normals=normals)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -732,17 +727,16 @@ class SurfaceTransolver(nn.Module):
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
 
         combined_normals: torch.Tensor | None = None
-        if self.z_slice_fraction > 0.0 and surface_x is not None:
-            # Surface features are [x, y, z, nx, ny, nz, area]; re-normalise the
-            # raw mesh normals so the |n_z| >= threshold cut is well-defined
-            # regardless of any upstream rescaling.
-            surf_normals = F.normalize(
-                surface_x[:, :, 3:6].to(hidden.dtype), dim=-1, eps=1e-6
-            )
-            if volume_x is not None:
+        if self.z_slice_fraction > 0.0 and surface_x is not None and surface_x.shape[-1] >= 6:
+            # Channels 3:6 of surface_x are the per-point surface normal (nx, ny, nz).
+            surf_normals = F.normalize(surface_x[..., 3:6], dim=-1, eps=1e-6)
+            if volume_x is not None and volume_tokens > 0:
                 vol_zeros = torch.zeros(
-                    volume_x.shape[0], volume_x.shape[1], 3,
-                    device=surf_normals.device, dtype=surf_normals.dtype,
+                    volume_x.shape[0],
+                    volume_tokens,
+                    3,
+                    device=surf_normals.device,
+                    dtype=surf_normals.dtype,
                 )
                 combined_normals = torch.cat([surf_normals, vol_zeros], dim=1)
             else:

--- a/model.py
+++ b/model.py
@@ -234,6 +234,8 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        z_slice_fraction: float = 0.0,
+        nz_routing_threshold: float = 0.5,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +246,23 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.z_slice_fraction = z_slice_fraction
+        self.nz_routing_threshold = nz_routing_threshold
+        if z_slice_fraction > 0.0:
+            self.num_slices_z = max(1, int(num_slices * z_slice_fraction))
+            self.num_slices_xy = num_slices - self.num_slices_z
+            if self.num_slices_xy <= 0:
+                raise ValueError(
+                    f"z_slice_fraction={z_slice_fraction} leaves no xy-slices "
+                    f"(num_slices={num_slices})"
+                )
+        else:
+            self.num_slices_z = 0
+            self.num_slices_xy = num_slices
+        # Diagnostic stash (populated only when hard routing engages).
+        self.last_z_fraction: float | None = None
+        self.last_util_z: float | None = None
+        self.last_util_xy: float | None = None
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -259,11 +278,59 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def build_routing_mask(
+        self,
+        normals: torch.Tensor,
+        num_tokens: int,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        """Per-token boolean slice mask [B, N, S] enforcing hard normal-routing.
+
+        Surface tokens with |n_z| >= threshold may attend only to the last
+        ``num_slices_z`` slices; surface tokens with |n_z| < threshold may
+        attend only to the first ``num_slices_xy`` slices. Volume tokens
+        (passed in with all-zero normals) keep the full slice budget so the
+        baseline behaviour is preserved.
+        """
+        if self.z_slice_fraction <= 0.0 or normals is None:
+            return None
+        abs_nz = normals[..., 2].abs()
+        is_z_surface = abs_nz >= self.nz_routing_threshold
+        is_volume = normals.abs().sum(dim=-1) < 1e-6
+        mask = torch.zeros(
+            normals.shape[0], num_tokens, self.num_slices,
+            device=device, dtype=torch.bool,
+        )
+        mask[:, :, -self.num_slices_z:] = is_z_surface.unsqueeze(-1)
+        mask[:, :, : self.num_slices_xy] = (~is_z_surface).unsqueeze(-1)
+        mask = mask | is_volume.unsqueeze(-1)
+        if not mask.any(dim=-1).all():
+            # Fallback: any pathological token with no allowed slice falls back
+            # to the full mask. Prevents softmax NaN from an all-false row.
+            bad_tokens = ~mask.any(dim=-1)
+            mask = mask | bad_tokens.unsqueeze(-1)
+        return mask
+
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        routing_mask = None
+        if self.z_slice_fraction > 0.0 and normals is not None:
+            routing_mask = self.build_routing_mask(normals, num_tokens, x.device)
+            if routing_mask is not None:
+                # Broadcast across heads: [B, 1, N, S]. Use a large finite
+                # negative (Switch Transformer §6) rather than -inf so a row
+                # that ends up all-suppressed in bf16 can never become NaN.
+                routing_mask_h = routing_mask.unsqueeze(1)
+                neg_inf = torch.finfo(slice_logits.dtype).min / 2
+                slice_logits = slice_logits.masked_fill(~routing_mask_h, neg_inf)
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
@@ -272,10 +339,54 @@ class TransolverAttention(nn.Module):
             )
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
+        if routing_mask is not None:
+            self._stash_routing_diag(slice_weights, normals, attn_mask)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def _stash_routing_diag(
+        self,
+        slice_weights: torch.Tensor,
+        normals: torch.Tensor,
+        attn_mask: torch.Tensor | None,
+    ) -> None:
+        """Record cheap mean diagnostics so the trainer can log them."""
+        with torch.no_grad():
+            abs_nz = normals[..., 2].abs()
+            is_z = abs_nz >= self.nz_routing_threshold
+            is_volume = normals.abs().sum(dim=-1) < 1e-6
+            is_surface = ~is_volume
+            if attn_mask is not None:
+                surface_valid = is_surface & attn_mask.bool()
+            else:
+                surface_valid = is_surface
+            is_z_surface = is_z & surface_valid
+            is_xy_surface = (~is_z) & surface_valid
+            n_surface = surface_valid.float().sum().clamp_min(1.0)
+            self.last_z_fraction = float(
+                (is_z_surface.float().sum() / n_surface).item()
+            )
+            # Average over heads -> [B, N, S]
+            sw_mean = slice_weights.mean(dim=1).float()
+            z_util_per_token = sw_mean[..., -self.num_slices_z:].sum(dim=-1)
+            xy_util_per_token = sw_mean[..., : self.num_slices_xy].sum(dim=-1)
+            n_z = is_z_surface.float().sum().clamp_min(1.0)
+            n_xy = is_xy_surface.float().sum().clamp_min(1.0)
+            self.last_util_z = float(
+                ((z_util_per_token * is_z_surface.float()).sum() / n_z).item()
+            )
+            self.last_util_xy = float(
+                ((xy_util_per_token * is_xy_surface.float()).sum() / n_xy).item()
+            )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(
+            x, attn_mask=attn_mask, normals=normals,
+        )
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +414,8 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        z_slice_fraction: float = 0.0,
+        nz_routing_threshold: float = 0.5,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +426,20 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            z_slice_fraction=z_slice_fraction,
+            nz_routing_threshold=nz_routing_threshold,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, normals=normals)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +456,8 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        z_slice_fraction: float = 0.0,
+        nz_routing_threshold: float = 0.5,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +469,21 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    z_slice_fraction=z_slice_fraction,
+                    nz_routing_threshold=nz_routing_threshold,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, normals=normals)
         return x
 
 
@@ -382,6 +511,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        z_slice_fraction: float = 0.0,
+        nz_routing_threshold: float = 0.5,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +527,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.z_slice_fraction = z_slice_fraction
+        self.nz_routing_threshold = nz_routing_threshold
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +605,8 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            z_slice_fraction=z_slice_fraction,
+            nz_routing_threshold=nz_routing_threshold,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -595,7 +730,25 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        combined_normals: torch.Tensor | None = None
+        if self.z_slice_fraction > 0.0 and surface_x is not None:
+            # Surface features are [x, y, z, nx, ny, nz, area]; re-normalise the
+            # raw mesh normals so the |n_z| >= threshold cut is well-defined
+            # regardless of any upstream rescaling.
+            surf_normals = F.normalize(
+                surface_x[:, :, 3:6].to(hidden.dtype), dim=-1, eps=1e-6
+            )
+            if volume_x is not None:
+                vol_zeros = torch.zeros(
+                    volume_x.shape[0], volume_x.shape[1], 3,
+                    device=surf_normals.device, dtype=surf_normals.dtype,
+                )
+                combined_normals = torch.cat([surf_normals, vol_zeros], dim=1)
+            else:
+                combined_normals = surf_normals
+
+        hidden = self.backbone(hidden, attn_mask=attn_mask, normals=combined_normals)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -232,18 +232,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
         "z_slice_fraction": (
-            "PR #1141 Wave 30 H4: fraction of --model-slices reserved for "
-            "z-normal surface tokens. When > 0, surface tokens with "
-            "|n_z| >= --nz-routing-threshold are hard-routed to the last "
-            "int(z_slice_fraction * num_slices) slices via pre-softmax "
-            "masking; other surface tokens are routed to the remaining "
-            "xy-slices. Volume tokens keep full slice access. At 0.0 the "
-            "model is bit-exact baseline."
+            "Hard normal-routing fraction for slice attention (PR #1141, "
+            "Wave 30 H4). When >0, partitions --model-slices into two "
+            "disjoint groups: int(model_slices * z_slice_fraction) z-slices "
+            "(last) and the rest as xy-slices (first). Surface tokens with "
+            "|n_z| >= --nz-routing-threshold are hard-routed (via pre-softmax "
+            "-inf masking) to z-slices ONLY; tokens with |n_z| below the "
+            "threshold are hard-routed to xy-slices ONLY. Volume tokens "
+            "(no normals) retain soft routing across all slices. At 0.0 "
+            "the model is bit-exact baseline. Recommended 0.25."
         ),
         "nz_routing_threshold": (
-            "PR #1141 Wave 30 H4: absolute z-normal threshold separating "
-            "z-surface tokens (|n_z| >= threshold) from xy-surface tokens. "
-            "Only active when --z-slice-fraction > 0."
+            "Threshold on |n_z| for the hard normal-routing classifier "
+            "(see --z-slice-fraction). Surface tokens with |n_z| >= this "
+            "threshold are routed to z-slices; tokens below it are routed "
+            "to xy-slices. Default 0.5. Ignored when --z-slice-fraction=0."
         ),
     }
     for field in fields(Config):
@@ -292,6 +295,43 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_hard_routing_metrics(model: nn.Module) -> dict[str, float]:
+    """Read per-block hard-routing diagnostics stashed by TransolverAttention.
+
+    Returns mean-over-layers utilization and z-surface fraction, plus per-layer
+    keys for debugging. Empty dict if hard routing is not engaged.
+    """
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return metrics
+    util_z_vals: list[float] = []
+    util_xy_vals: list[float] = []
+    z_frac_vals: list[float] = []
+    for block_idx, block in enumerate(getattr(backbone, "blocks", [])):
+        attn = getattr(block, "attention", None)
+        if attn is None or getattr(attn, "z_slice_fraction", 0.0) <= 0.0:
+            continue
+        uz = getattr(attn, "_last_util_z", None)
+        ux = getattr(attn, "_last_util_xy", None)
+        zf = getattr(attn, "_last_z_surface_fraction", None)
+        if uz is None or ux is None or zf is None:
+            continue
+        uz_v = float(uz.detach().cpu().item())
+        ux_v = float(ux.detach().cpu().item())
+        zf_v = float(zf.detach().cpu().item())
+        util_z_vals.append(uz_v)
+        util_xy_vals.append(ux_v)
+        z_frac_vals.append(zf_v)
+        metrics[f"train/slice_capacity_utilization_z/block_{block_idx}"] = uz_v
+        metrics[f"train/slice_capacity_utilization_xy/block_{block_idx}"] = ux_v
+    if util_z_vals:
+        metrics["train/slice_capacity_utilization_z"] = sum(util_z_vals) / len(util_z_vals)
+        metrics["train/slice_capacity_utilization_xy"] = sum(util_xy_vals) / len(util_xy_vals)
+        metrics["train/z_surface_fraction"] = sum(z_frac_vals) / len(z_frac_vals)
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -307,40 +347,6 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
         for axis in range(log_freq.shape[0]):
             metrics[f"{prefix}/freq_axis_{axis}_mean"] = float(log_freq[axis].mean().item())
             metrics[f"{prefix}/freq_axis_{axis}_std"] = float(log_freq[axis].std().item())
-    return metrics
-
-
-def collect_slice_routing_metrics(model: nn.Module) -> dict[str, float]:
-    """PR #1141: per-layer z-routing diagnostics for hard-normal slice routing.
-
-    Logs the most recent training-batch slice-utilisation stats that each
-    TransolverAttention stashed during forward. Returns nothing when
-    z_slice_fraction is disabled.
-    """
-    from model import TransolverAttention
-
-    metrics: dict[str, float] = {}
-    z_fracs: list[float] = []
-    util_zs: list[float] = []
-    util_xys: list[float] = []
-    for name, module in model.named_modules():
-        if not isinstance(module, TransolverAttention):
-            continue
-        if module.z_slice_fraction <= 0.0:
-            continue
-        if module.last_z_fraction is None:
-            continue
-        path = name.replace(".", "/")
-        metrics[f"slice_routing/{path}/z_surface_fraction"] = module.last_z_fraction
-        metrics[f"slice_routing/{path}/util_z"] = module.last_util_z
-        metrics[f"slice_routing/{path}/util_xy"] = module.last_util_xy
-        z_fracs.append(module.last_z_fraction)
-        util_zs.append(module.last_util_z)
-        util_xys.append(module.last_util_xy)
-    if z_fracs:
-        metrics["slice_routing/mean/z_surface_fraction"] = sum(z_fracs) / len(z_fracs)
-        metrics["slice_routing/mean/util_z"] = sum(util_zs) / len(util_zs)
-        metrics["slice_routing/mean/util_xy"] = sum(util_xys) / len(util_xys)
     return metrics
 
 
@@ -1178,6 +1184,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        if (
+                            state.is_main
+                            and config.z_slice_fraction > 0.0
+                            and config.gradient_log_every > 0
+                            and global_step % config.gradient_log_every == 0
+                        ):
+                            train_log.update(collect_hard_routing_metrics(base_model))
 
                 train_log.update(
                     train_slope_tracker.update(
@@ -1314,7 +1327,6 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
-                log_metrics.update(collect_slice_routing_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    z_slice_fraction: float = 0.0
+    nz_routing_threshold: float = 0.5
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "z_slice_fraction": (
+            "PR #1141 Wave 30 H4: fraction of --model-slices reserved for "
+            "z-normal surface tokens. When > 0, surface tokens with "
+            "|n_z| >= --nz-routing-threshold are hard-routed to the last "
+            "int(z_slice_fraction * num_slices) slices via pre-softmax "
+            "masking; other surface tokens are routed to the remaining "
+            "xy-slices. Volume tokens keep full slice access. At 0.0 the "
+            "model is bit-exact baseline."
+        ),
+        "nz_routing_threshold": (
+            "PR #1141 Wave 30 H4: absolute z-normal threshold separating "
+            "z-surface tokens (|n_z| >= threshold) from xy-surface tokens. "
+            "Only active when --z-slice-fraction > 0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +310,40 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_slice_routing_metrics(model: nn.Module) -> dict[str, float]:
+    """PR #1141: per-layer z-routing diagnostics for hard-normal slice routing.
+
+    Logs the most recent training-batch slice-utilisation stats that each
+    TransolverAttention stashed during forward. Returns nothing when
+    z_slice_fraction is disabled.
+    """
+    from model import TransolverAttention
+
+    metrics: dict[str, float] = {}
+    z_fracs: list[float] = []
+    util_zs: list[float] = []
+    util_xys: list[float] = []
+    for name, module in model.named_modules():
+        if not isinstance(module, TransolverAttention):
+            continue
+        if module.z_slice_fraction <= 0.0:
+            continue
+        if module.last_z_fraction is None:
+            continue
+        path = name.replace(".", "/")
+        metrics[f"slice_routing/{path}/z_surface_fraction"] = module.last_z_fraction
+        metrics[f"slice_routing/{path}/util_z"] = module.last_util_z
+        metrics[f"slice_routing/{path}/util_xy"] = module.last_util_xy
+        z_fracs.append(module.last_z_fraction)
+        util_zs.append(module.last_util_z)
+        util_xys.append(module.last_util_xy)
+    if z_fracs:
+        metrics["slice_routing/mean/z_surface_fraction"] = sum(z_fracs) / len(z_fracs)
+        metrics["slice_routing/mean/util_z"] = sum(util_zs) / len(util_zs)
+        metrics["slice_routing/mean/util_xy"] = sum(util_xys) / len(util_xys)
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +358,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        z_slice_fraction=config.z_slice_fraction,
+        nz_routing_threshold=config.nz_routing_threshold,
     )
 
 
@@ -1262,6 +1314,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_slice_routing_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Partition the `num_slices=128` budget into TWO disjoint groups based on surface-normal orientation, and route each surface token **hardly** to one group:
- `num_slices_xy` slices for predominantly horizontal/lateral-normal surfaces (|n_z| < threshold)
- `num_slices_z` slices for predominantly vertical-normal surfaces (|n_z| ≥ threshold) — i.e. roof and underbody patches

Each surface token's slice-weight distribution is **masked** so it can only mix into one group, enforcing **dedicated attention capacity for z-normal surfaces**. This is the hard-routing counterpart to thorfinn's H3 (PR #1138, soft routing). Together they sweep the soft↔hard axis.

The mechanism is **mixture-of-experts over surface orientation**. The Transolver paper itself frames slice attention as "physics-informed slicing" — extending this principle to orientation regimes (rather than spatial regimes) is the most direct architectural test of the orientation-capacity-sharing hypothesis. If hard partitioning helps, slice-attention was indeed mixing orientation modes and that mixing was the bottleneck. If hard partitioning DOESN'T help (and H3 soft routing also fails), the bottleneck is orthogonal to attention routing entirely — points to backbone-level (H5) or output-level (H6) attacks as the remaining frontier.

**This is the SEVENTH and most invasive Wave 30 attack** on the τ_z bottleneck:
- H6 (tanjiro #1134): output decomposition
- H2 (nezuko #1136): input features
- H5 (fern #1137): backbone split
- H3 (thorfinn #1138): attention routing — **soft**
- H1 (edward #1139): input coord frame
- H7 (askeladd #1140): gradient signal
- **H4 (this PR): attention routing — HARD** ← complements H3

The fleet now covers all 6 layers of the architecture stack at varying severity. H4 is the diagnostic counterpart: if H3 wins, H4 confirms via structural redundancy. If H3 fails, H4 is the harder test of the same axis.

**Theoretical basis:** Switch Transformer (Fedus et al. 2022) and Expert Choice routing (Zhou et al. 2022) consistently show hard routing outperforms soft routing when the problem has **discrete structural modes**. In aerodynamics, surface normals DO have discrete structure: the vehicle has a roof (n_z ≈ +1), underbody (n_z ≈ −1), and sides (n_z ≈ 0). WSS profiles on these regions are qualitatively different — z-normal surfaces have separation lines and stagnation regions that differ from side surfaces. This is closer to a "routing problem" than a "mixing problem."

**Eighthfold τ_z structural confirmation** (alphonse #1122 close, this morning) showed sampling-side interventions cannot break the ratio band. The attention-mechanism level (this PR + #1138) is the cleanest remaining structural test. After this, only output (#1134) and backbone (#1137) layers remain.

## Instructions

**Files to modify:** `target/model.py` (only)
**Auxiliary:** `target/train.py` (two CLI flags)
**Total LOC:** ~70 in model.py, ~5 in train.py

### Step 1 — Add CLI flags in `train.py`

Add `--z-slice-fraction FLOAT` (default 0.0 = disabled; recommended 0.25) and `--nz-routing-threshold FLOAT` (default 0.5). Thread both into `SurfaceTransolver` construction. Document: when `z_slice_fraction > 0`, surface tokens with |n_z| ≥ threshold are hard-routed to the last `int(z_slice_fraction × num_slices)` slices, and tokens with |n_z| < threshold are hard-routed to the first `num_slices − num_slices_z` slices. Volume tokens (no normals) keep their existing soft routing over ALL slices (unchanged behavior). At `z_slice_fraction = 0.0` the model is bit-exact baseline.

### Step 2 — Modify `TransolverAttention.__init__` (around line 229)

Add hard-routing parameters:

```python
class TransolverAttention(nn.Module):
    def __init__(
        self, hidden_dim, num_heads, num_slices,
        dropout=0.0, use_qk_norm=False,
        z_slice_fraction: float = 0.0,
        nz_routing_threshold: float = 0.5,
    ):
        super().__init__()
        # ... existing code ...
        self.z_slice_fraction = z_slice_fraction
        self.nz_routing_threshold = nz_routing_threshold
        if z_slice_fraction > 0.0:
            self.num_slices_z = max(1, int(num_slices * z_slice_fraction))
            self.num_slices_xy = num_slices - self.num_slices_z
            # Sanity: with num_slices=128 and frac=0.25 → 32 z-slices, 96 xy-slices.
        else:
            self.num_slices_z = 0
            self.num_slices_xy = num_slices
```

### Step 3 — Add a routing-mask helper

Build a per-token mask `slice_routing_mask` of shape `[B, N, S]` where:
- For surface tokens with |n_z| ≥ threshold: mask is True for the LAST `num_slices_z` slices, False elsewhere
- For surface tokens with |n_z| < threshold: mask is True for the FIRST `num_slices_xy` slices, False elsewhere
- For volume tokens (no normals provided): mask is True everywhere (preserves baseline behavior)

```python
def build_routing_mask(
    self,
    normals: torch.Tensor | None,  # [B, N, 3] or None
    num_tokens: int,
    device: torch.device,
) -> torch.Tensor | None:
    """Returns [B, N, S] boolean mask or None if hard routing is disabled.

    True = token may attend to slice; False = token forbidden from slice.
    """
    if self.z_slice_fraction <= 0.0 or normals is None:
        return None
    abs_nz = normals[..., 2].abs()  # [B, N]
    is_z_surface = abs_nz >= self.nz_routing_threshold  # [B, N]
    # Build slice masks
    mask = torch.zeros(
        normals.shape[0], num_tokens, self.num_slices,
        device=device, dtype=torch.bool,
    )
    # z-surfaces: route to last num_slices_z slices
    mask[:, :, -self.num_slices_z:] = is_z_surface.unsqueeze(-1)
    # xy-surfaces: route to first num_slices_xy slices
    mask[:, :, :self.num_slices_xy] = (~is_z_surface).unsqueeze(-1)
    # Volume tokens (those with normals = 0): allow all (preserves baseline)
    is_volume = (normals.abs().sum(dim=-1) < 1e-6).unsqueeze(-1)  # [B, N, 1]
    mask = mask | is_volume  # OR-in the all-True row for volume tokens
    return mask
```

### Step 4 — Modify `create_slices` to apply the routing mask

```python
def create_slices(self, x, attn_mask=None, normals=None):
    batch_size, num_tokens, _ = x.shape
    fx_mid = self.in_project_fx(x).view(...).permute(0, 2, 1, 3)
    x_mid = self.in_project_x(x).view(...).permute(0, 2, 1, 3)
    slice_logits = self.in_project_slice(x_mid) / self.temperature  # [B, H, N, S]

    if self.z_slice_fraction > 0.0 and normals is not None:
        routing_mask = self.build_routing_mask(normals, num_tokens, x.device)  # [B, N, S]
        if routing_mask is not None:
            # Broadcast across heads: [B, 1, N, S]
            routing_mask_h = routing_mask.unsqueeze(1)
            # Mask out forbidden slices with -inf BEFORE softmax
            slice_logits = slice_logits.masked_fill(~routing_mask_h, float("-inf"))

    slice_weights = F.softmax(slice_logits, dim=-1)
    # ... rest unchanged ...
```

The `-inf` masking is critical — adding a large negative bias after softmax doesn't fully zero the forbidden slices, but pre-softmax `-inf` does.

### Step 5 — Thread normals through TransformerBlock → Transformer → TransolverAttention

Same threading pattern as H3 (PR #1138). Add `normals` kwarg to `TransformerBlock.forward`, `Transformer.forward`, and `TransolverAttention.forward`. In `SurfaceTransolver.forward`, build the combined normals tensor (surface normals from `surface_x[..., 3:6]`, zeros for volume tokens) and pass through to backbone.

```python
# In SurfaceTransolver.forward, before self.backbone(hidden, ...):
if self.z_slice_fraction > 0.0 and surface_x is not None:
    surf_normals = F.normalize(surface_x[..., 3:6], dim=-1, eps=1e-6)
    if volume_x is not None:
        vol_zeros = torch.zeros(
            volume_x.shape[0], volume_x.shape[1], 3,
            device=surf_normals.device, dtype=surf_normals.dtype,
        )
        combined_normals = torch.cat([surf_normals, vol_zeros], dim=1)
    else:
        combined_normals = surf_normals
else:
    combined_normals = None

hidden = self.backbone(hidden, attn_mask=attn_mask, normals=combined_normals)
```

**NOTE on coordination with #1138:** thorfinn's H3 also threads `normals` through the same backbone chain. The thorfinn branch is on `thorfinn/normal-aligned-slice-groups`. **Your branch (`alphonse/hard-normal-slice-routing`) is independent from tay** — implement the `normals` kwarg threading yourself; do not branch from thorfinn's branch. The two will be merge-compatible because both follow the same kwarg name (`normals`).

### Step 6 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1`) with `--z-slice-fraction 0.25 --nz-routing-threshold 0.5` and confirm:
- No NaN in `train/nonfinite_loss`
- No `inf` propagation from `-inf` masking — verify by checking that `train/loss` is finite at step 1
- Throughput within 5% of baseline (the masked_fill + bool mask costs are negligible)
- Memory unchanged

If smoke shows NaN at step 1, the issue is likely `softmax(-inf, -inf, ..., -inf) = nan`. To prevent: ensure the all-False mask case (no z-surface tokens in a batch) does NOT occur. With `nz_routing_threshold = 0.5` and any realistic car surface sample (~30-40% of surface points have |n_z| ≥ 0.5), this won't happen in practice — but add a safety guard:

```python
# Inside build_routing_mask, before returning:
if not mask.any(dim=-1).all():
    # Pathological case: token has no allowed slice. Fall back to all-True for those tokens.
    bad_tokens = ~mask.any(dim=-1)  # [B, N]
    mask = mask | bad_tokens.unsqueeze(-1)
```

### Step 7 — Diagnostic logging

Log to W&B at each epoch:
- `train/z_surface_fraction` — mean of `(|n_z| >= threshold).float().mean()` across batches. Expect ~0.3-0.4 for car geometry.
- `train/slice_capacity_utilization_z` — mean of softmax(slice_logits) summed over the z-slice indices, averaged across z-surface tokens. Should approach 1.0 once routing engages.
- `train/slice_capacity_utilization_xy` — same for xy-slices and xy-surface tokens. Should approach 1.0.

If utilization stays < 0.95 by EP3, the routing isn't enforcing — debug the mask construction.

### Step 8 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --z-slice-fraction 0.25 --nz-routing-threshold 0.5 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_hard_normal_routing \
  --wandb-name alphonse/z-slice-frac0.25-nz0.5-18h --agent alphonse
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where hard routing should compound with dense supervision (vol_points=65536)
- EP13 terminal: full SENPAI-RESULT

### Step 9 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H4 falsification
- **`train/slice_capacity_utilization_z`** and **`train/slice_capacity_utilization_xy`** at EP3, EP10, EP13 (mechanism-engagement diagnostic)
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.45 = H4 confirms hard orientation routing**, < 1.40 = breakthrough |

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.40 AND test_WSS < 6.727% with both floors. Mechanism confirmed; hard orientation routing is the structural lever.
- **MERGE**: test_WSS < 6.727% with both floors held. Single-model winner.
- **INTERESTING NULL**: utilization metrics confirm hard routing is engaging (>0.95 both) but τz/τx unchanged — rules out orientation-capacity-sharing as the bottleneck. Strong evidence the bottleneck is NOT attention-routing-level, narrows the search to backbone or output layers. Pairs cleanly with H3 (thorfinn #1138) result.
- **FLAT NULL**: utilization stays < 0.95 (routing didn't engage) or training diverges — debug mask construction, try `--z-slice-fraction 0.5` for more z-capacity.

**Source:** `research/RESEARCH_IDEAS_2026-05-15_18:00.md` H4 (taste score 8/12, rank 5 of 8). Seventh Wave 30 attack axis — completes the soft↔hard sweep on the attention layer.

**Wave 30 fleet at launch:** 7 of 8 ideas active in parallel after this assignment (H6 tanjiro #1134, H2 nezuko #1136, H5 fern #1137, H3 thorfinn #1138, H1 edward #1139, H7 askeladd #1140, **H4 alphonse this PR**). Only H8 (contrastive orientation regularization) remains in reserve. Each tests a different layer of the architecture stack.
