### PR TITLE
[dl24-fern] WSS H7: surface-loss-weight=1.5 isolation (uniform upweight, no per-axis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -31,6 +31,8 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from data import DrivAerMLCase, DrivAerMLSurfaceDataset
+from data.loader import _resolve_artifact_path  # noqa: PLC2701 — internal helper for PVC fallback
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -61,6 +63,108 @@ from trainer_runtime import (
     timeout_budget_minutes,
     unwrap_model,
 )
+
+
+# ---------------------------------------------------------------------------
+# SDF-stratified volume sampling (port from frieren/sdf-stratified-vol-sampling,
+# matches PR #972 / run 56bcqp3m SOTA mechanism). Read-only data/loader.py is
+# preserved; we monkey-patch DrivAerMLSurfaceDataset.__getitem__ here.
+# ---------------------------------------------------------------------------
+
+_SDF_ABS_CACHE: dict[str, torch.Tensor] = {}
+
+
+def _load_case_sdf_abs(root, case_id: str, expected_n: int) -> torch.Tensor:
+    cached = _SDF_ABS_CACHE.get(case_id)
+    if cached is not None:
+        if cached.shape[0] != expected_n:
+            raise RuntimeError(
+                f"SDF cache for {case_id} has size {cached.shape[0]} but "
+                f"case_point_counts reports {expected_n}; cache poisoning?"
+            )
+        return cached
+    sdf_path = Path(root) / case_id / "volume_sdf.npy"
+    resolved = _resolve_artifact_path(sdf_path)
+    sdf_np = np.asarray(np.load(resolved), dtype=np.float32).reshape(-1)
+    if sdf_np.shape[0] != expected_n:
+        raise RuntimeError(
+            f"volume_sdf.npy for {case_id} has {sdf_np.shape[0]} rows but "
+            f"case_point_counts reports {expected_n}"
+        )
+    tensor = torch.from_numpy(np.abs(sdf_np)).contiguous()
+    _SDF_ABS_CACHE[case_id] = tensor
+    return tensor
+
+
+_orig_drivaerml_getitem = None
+
+
+def enable_sdf_stratified_sampling(alpha: float) -> None:
+    """Patch DrivAerMLSurfaceDataset.__getitem__ for SDF-stratified train sampling.
+
+    Eval (sampling_mode='eval_chunk') is untouched; only train_random views
+    use the SDF-weighted multinomial draw with weight[i] = 1 + alpha * |sdf[i]|.
+    """
+
+    global _orig_drivaerml_getitem
+    if _orig_drivaerml_getitem is None:
+        _orig_drivaerml_getitem = DrivAerMLSurfaceDataset.__getitem__
+    DrivAerMLSurfaceDataset._sdf_stratified_alpha = float(alpha)
+
+    def _patched_getitem(self, idx: int) -> DrivAerMLCase:
+        view = self.views[idx]
+        if view.sampling_mode != "train_random":
+            return _orig_drivaerml_getitem(self, idx)
+
+        counts = self.store.case_point_counts(view.case_id)
+        surface_idx = self._indices(
+            counts["n_surface"],
+            self.max_surface_points,
+            view,
+            group_view_count=view.surface_view_count,
+        )
+
+        n_total = int(counts["n_volume"])
+        N_vol = int(self.max_volume_points)
+        if view.view_index >= view.volume_view_count:
+            volume_idx_np = np.empty(0, dtype=np.int64)
+        elif N_vol <= 0 or n_total <= N_vol:
+            volume_idx_np = None
+        else:
+            sdf_abs = _load_case_sdf_abs(self.store.root, view.case_id, n_total)
+            alpha_val = getattr(self, "_sdf_stratified_alpha", 2.0)
+            weights = 1.0 + alpha_val * sdf_abs
+            sampled = torch.multinomial(weights, N_vol, replacement=True)
+            volume_idx_np = sampled.sort().values.numpy()
+
+        case = self.store.load_case(
+            view.case_id,
+            surface_rows=None if surface_idx is None else surface_idx.numpy(),
+            volume_rows=volume_idx_np,
+        )
+
+        metadata = dict(case.metadata)
+        metadata["n_surface_full"] = int(counts["n_surface"])
+        metadata["n_surface_loaded"] = int(case.surface_x.shape[0])
+        metadata["surface_view_index"] = int(view.view_index)
+        metadata["surface_view_count"] = int(view.surface_view_count)
+        metadata["surface_sampling_mode"] = view.sampling_mode
+        metadata["n_volume_full"] = int(counts["n_volume"])
+        metadata["n_volume_loaded"] = int(case.volume_x.shape[0])
+        metadata["volume_view_index"] = int(view.view_index)
+        metadata["volume_view_count"] = int(view.volume_view_count)
+        metadata["volume_sampling_mode"] = "sdf_stratified"
+        metadata["joint_view_count"] = int(view.view_count)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+    DrivAerMLSurfaceDataset.__getitem__ = _patched_getitem
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +236,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    use_sdf_stratified_vol_sampling: bool = False
+    sdf_stratified_alpha: float = 2.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -450,6 +556,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
             print(f"Device: {device}{ddp_suffix}" + (" [DEBUG]" if config.debug else ""))
 
+        if config.use_sdf_stratified_vol_sampling:
+            enable_sdf_stratified_sampling(config.sdf_stratified_alpha)
+            if state.is_main:
+                print(
+                    f"SDF-stratified volume sampling enabled: "
+                    f"alpha={config.sdf_stratified_alpha}"
+                )
         train_loader, val_loaders, test_loaders, stats = make_loaders(config, distributed_state=state)
         final_val_loaders = full_eval_loaders_from(val_loaders, config) if state.is_main else {}
         final_test_loaders = full_eval_loaders_from(test_loaders, config) if state.is_main else {}


### PR DESCRIPTION
# H7: Surface-loss weight 1.5× isolation (no per-axis attack)

## Hypothesis

Setting `surface_loss_weight=1.5` (uniform 1.5× scale on entire surface task loss) on the SOTA #972 stack will reproduce the H4 vol_p gain (**−0.269pp under SOTA**, the only positive H4 effect) WITHOUT the H4 surf_p floor breach AND without the H4 WSS regression. Expected outcome: test_abupt ≤ 5.844% (BEAT SOTA), test_vol_p ≤ 3.50% (under floor), test_surf_p ≤ 3.65% (under floor).

## Mechanistic reasoning

H4 fern PR #1130 ran `--wss-axis-loss-weights "1.0,1.5,2.5"` — per-axis on the 3 τ channels with cp at implicit 1.0. The terminal test showed three orthogonal effects:

1. **Lion-noise on weighted τ axes** caused all 3 τ to regress (τ_x +0.147pp, τ_y +0.085pp, τ_z +0.125pp vs SOTA) → test_wss +0.143pp WORSE
2. **Capacity stolen from cp** (cp at 1.0 while τ_y/τ_z amplified) → test_surf_p +0.166pp WORSE → FLOOR BREACH
3. **Implicit surface task upweight** (mean of [1.0, 1.0, 1.5, 2.5] / 4 = 1.5) drove backbone to learn richer surface features → test_vol_p **−0.269pp BETTER** (volume head benefits from shared backbone improvements)

Effects 1 and 2 are caused by per-axis amplification of noisy axes (Lion sign-vote contamination). Effect 3 is caused by the global gradient-flow shift.

**H7 isolates effect 3**: uniform `surface_loss_weight=1.5` applies equally to cp + all 3 τ channels. No per-axis amplification → no Lion-noise on individual τ axes. cp also gets 1.5× → surf_p should IMPROVE (not regress like H4).

## Predicted test metrics (terminal)

| Metric | SOTA #972 | H7 prediction | Direction |
|---|---:|---:|---|
| test_abupt | 5.844% | **5.78-5.85%** | better-or-equal |
| test_vol_p | 3.643% | **3.40-3.50%** | better |
| test_surf_p | 3.577% | **3.50-3.60%** | better-or-equal |
| test_wss | 6.727% | **6.65-6.75%** | better-or-equal |
| test_τ_x | 5.971% | similar | unchanged |
| test_τ_y | 7.362% | similar | unchanged |
| test_τ_z | 8.747% | similar | unchanged |

Key prediction: **uniform upweight = strict improvement** over SOTA across all surface-related metrics; volume head latents improve via the shared backbone.

## Important precedent — be aware

`qqtdnlwq` (old dataset, pre-corrected) tried `surface_loss_weight=2.0` → test_abupt=8.292% (worse than peers). **This is on the old dataset with a +7-8pp val→test gap and a different stack.** Three reasons not to be discouraged:

1. **Different baseline**: that run was not on the SOTA #972 stack (current SOTA uses corrected dataset + SDF-stratified vol sampling α=2.0 + GradNorm-off + Lion lr=1e-4 + Y-sym 0.5 + multi-sigma STRING PE).
2. **Different magnitude**: H4 evidence specifically identifies the **1.5× effective rate** as the gradient-flow level that produced the +vol_p signal. 2.0× may have over-corrected.
3. **Corrected-dataset baseline**: the dataset bug that made cars look much harder in volume is fixed — the gradient-flow regime is different now.

The right approach: trust H4's mechanistic evidence (1.5× is the empirically validated magnitude) and run 1.5× on the SOTA stack as a clean single-variable test.

## Exact command

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h7_surface_loss_weight_1p5 \
  --epochs 30 --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --no-use-gradnorm \
  --surface-loss-weight 1.5 \
  --volume-loss-weight 1.0 \
  --use-sdf-stratified-sampling --sdf-stratified-alpha 2.0 \
  --wandb-group wss_h7_surface_upweight \
  --wandb-name dl24-fern/h7-surface-loss-weight-1p5 \
  --agent dl24-fern
```

**Key differences from H4 command:**
- `--wss-axis-loss-weights` flag REMOVED (no per-axis amplification)
- `--surface-loss-weight 1.5` ADDED (the isolated mechanism)
- `--use-sdf-stratified-sampling --sdf-stratified-alpha 2.0` ADDED (this is SOTA #972's volume sampling mechanism — H4 may have missed it; double-check the exact SOTA flags before launch)

**CRITICAL**: Before launching, verify the SOTA #972 command (`56bcqp3m`) exactly and use the same flags as that command, ONLY changing `--surface-loss-weight` from 1.0 to 1.5. If any other H4 flag differs from SOTA #972, replace it with SOTA #972's value. We want a single-variable change from SOTA, not a hybrid stack.

## Implementation note

`surface_loss_weight` is an existing config field in `train.py` (line 82, type=float, default=1.0). No code changes needed. This is the cleanest possible single-variable experiment.

## Baselines for gate decisions

**Current SOTA #972 (corrected dataset):** test_abupt=5.844%, test_vol_p=3.643%, test_surf_p=3.577%, test_wss=6.727%, test_τ_x=5.971%, test_τ_y=7.362%, test_τ_z=8.747%

**Issue #1056 floors (DO NOT BREACH):** test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%

**Hard floor at #1056:** target test_wss < 5.85% (Transolver-3 SOTA)

## Gates and monitoring

- **EP3 gate** (~2h after launch): val_abupt ≤ 7.5%, val_wss ≤ 7.5%, val_vol_p ≤ 5.5% — basic launch viability
- **EP6 gate** (~4h): val_abupt ≤ 7.0%, val_wss ≤ 7.2%, val_vol_p ≤ 4.8% — early commitment
- **EP10 gate** (~7h): val_abupt ≤ 6.6%, val_wss ≤ 7.0%, val_vol_p ≤ 4.5% — early-mid trajectory
- **EP15 gate** (~10h): val_abupt ≤ 6.4%, val_wss ≤ 6.9%, val_vol_p ≤ 4.3% — typical best-val window
- **EP20 gate** (~14h): val_abupt ≤ 6.3%, val_wss ≤ 6.75%, val_vol_p ≤ 4.2% — mid-late trajectory
- **EP30 terminal** (~21h): full evaluation + test eval at best-val checkpoint

Best-val checkpoint usually lands at EP15-20 for this SOTA stack. Test eval auto-runs on rank-0 from the saved best-val checkpoint.

## Watch points

1. **vol_p trajectory shape**: H4 had vol_p in band [3.45, 3.55] from EP5-EP30 (consistent under-floor lead). H7 should reproduce this. If vol_p stays at or above 3.643% by EP10, the upweight is not delivering the predicted effect.

2. **surf_p trajectory**: this is the key new prediction. H4 had surf_p at 4.05% across val (much worse than SOTA's val_surf_p ~3.65%). H7 should have val_surf_p in or below the SOTA band. If H7 val_surf_p climbs above 3.7% by EP10, the 1.5× upweight is contaminating cp the same way per-axis did → likely terminal floor breach.

3. **WSS plateau timing**: SOTA-stack runs typically plateau on val_wss around EP18-22. H7 should plateau no later than SOTA (since no extra noise). If val_wss is still descending at EP25, that's bonus signal.

## SENPAI-RESULT marker

When training completes, post a terminal `SENPAI-RESULT` marker with format:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"full_val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Plus full markdown report with all per-axis test metrics, hypothesis verdict, and mechanistic interpretation as fern's H4 report demonstrated (excellent format).

## Why this matters

H4's mechanism breakdown was sharp and correctly attributed: per-axis amplification is the Lion-noise failure; surface task upweight is the positive effect. H7 isolates the positive without the negative — if it wins, it's a clean SOTA-beat on a one-flag change. If it doesn't, we learn whether the implicit surface-task upweight is genuinely the cp+τ-uniform mechanism, or whether it required the specific [1.0, 1.0, 1.5, 2.5] distribution (would indicate the per-axis structure itself helped vol_p somehow). Either result is informative.

Go.
