### PR TITLE
Wave 30 H8: Mirror-Symmetry Data Augmentation (x-z plane y-flip)

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -16,6 +16,7 @@ from .loader import (
     DrivAerMLSurfaceDataset,
     SurfaceBatch,
     load_data,
+    mirror_collate,
     pad_collate,
 )
 
@@ -33,5 +34,6 @@ __all__ = [
     "DrivAerMLSurfaceDataset",
     "SurfaceBatch",
     "load_data",
+    "mirror_collate",
     "pad_collate",
 ]

--- a/data/loader.py
+++ b/data/loader.py
@@ -20,13 +20,15 @@ This repo predicts surface pressure, wall shear / friction, and volume pressure.
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import json
 import math
 import os
+import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 import torch
@@ -498,6 +500,48 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
         volume_mask=volume_mask,
         metadata=[dict(sample.metadata) for sample in samples],
     )
+
+
+def mirror_collate(samples: Sequence[DrivAerMLCase], prob: float = 0.5) -> SurfaceBatch:
+    """Random x-z plane mirror augmentation collate (per-sample prob).
+
+    DrivAerML is generated at zero yaw and zero pitch, so y -> -y is an exact
+    geometric symmetry. Channel layout (confirmed from loader.py load_case):
+      surface_x = [x, y, z, nx, ny, nz, area]  -> flip y(1), ny(4)
+      surface_y = [cp, tau_x, tau_y, tau_z]    -> flip tau_y(2); cp(0) is scalar
+      volume_x  = [x, y, z, sdf]               -> flip y(1); sdf is scalar
+      volume_y  = [vol_p]                       -> scalar pressure, invariant
+
+    Args:
+      samples: list of DrivAerMLCase (frozen dataclass).
+      prob: per-sample mirror probability in [0, 1]; 0.0 disables aug.
+    """
+    if not samples:
+        raise ValueError("mirror_collate received an empty batch")
+    mirrored: list[DrivAerMLCase] = []
+    for case in samples:
+        if prob > 0.0 and random.random() < prob:
+            sx = case.surface_x.clone()
+            sy = case.surface_y.clone()
+            sx[:, 1] = -sx[:, 1]
+            sx[:, 4] = -sx[:, 4]
+            sy[:, 2] = -sy[:, 2]
+            new_fields: dict[str, Any] = {"surface_x": sx, "surface_y": sy}
+            if case.volume_x is not None and case.volume_x.shape[0] > 0:
+                vx = case.volume_x.clone()
+                vx[:, 1] = -vx[:, 1]
+                new_fields["volume_x"] = vx
+            metadata = dict(case.metadata)
+            metadata["mirror_flipped"] = True
+            new_fields["metadata"] = metadata
+            case = dataclasses.replace(case, **new_fields)
+        else:
+            if "mirror_flipped" not in case.metadata:
+                metadata = dict(case.metadata)
+                metadata["mirror_flipped"] = False
+                case = dataclasses.replace(case, metadata=metadata)
+        mirrored.append(case)
+    return pad_collate(mirrored)
 
 
 def _normalizer_tensor(raw: dict, name: str, expected_dim: int) -> tuple[torch.Tensor, torch.Tensor]:

--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     TargetTransform,
     autocast_context,
     build_lr_scheduler,
+    build_train_collate_fn,
     check_kill_thresholds,
     cleanup_distributed,
     collect_gradient_metrics,
@@ -105,6 +106,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    mirror_aug_prob: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -701,7 +703,7 @@ def rebuild_train_loader_with_vol_points(
         shuffle=train_shuffle,
         sampler=train_sampler,
         drop_last=True,
-        **loader_kwargs(config),
+        **loader_kwargs(config, collate_fn=build_train_collate_fn(config)),
     )
 
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 import os
 import re
@@ -13,7 +14,7 @@ import subprocess
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import Callable, Iterable, Mapping
 
 import torch
 import torch.distributed as dist
@@ -29,6 +30,7 @@ from data import (
     VOLUME_TARGET_NAMES,
     VOLUME_Y_DIM,
     load_data,
+    mirror_collate,
     pad_collate,
 )
 
@@ -229,10 +231,10 @@ def resolve_num_workers(config) -> int:
     return min(4, os.cpu_count() or 4)
 
 
-def loader_kwargs(config) -> dict[str, object]:
+def loader_kwargs(config, *, collate_fn: Callable | None = None) -> dict[str, object]:
     num_workers = resolve_num_workers(config)
     kwargs: dict[str, object] = {
-        "collate_fn": pad_collate,
+        "collate_fn": collate_fn if collate_fn is not None else pad_collate,
         "num_workers": num_workers,
         "pin_memory": config.pin_memory and torch.cuda.is_available(),
     }
@@ -240,6 +242,14 @@ def loader_kwargs(config) -> dict[str, object]:
         kwargs["persistent_workers"] = config.persistent_workers
         kwargs["prefetch_factor"] = config.prefetch_factor
     return kwargs
+
+
+def build_train_collate_fn(config) -> Callable:
+    """Return the training-time collate_fn, applying mirror augmentation if enabled."""
+    prob = float(getattr(config, "mirror_aug_prob", 0.0) or 0.0)
+    if prob > 0.0:
+        return functools.partial(mirror_collate, prob=prob)
+    return pad_collate
 
 
 def eval_loader_for_dataset(
@@ -304,7 +314,7 @@ def make_loaders(
         shuffle=train_shuffle,
         sampler=train_sampler,
         drop_last=True,
-        **loader_kwargs(config),
+        **loader_kwargs(config, collate_fn=build_train_collate_fn(config)),
     )
     val_loaders = {
         name: eval_loader_for_dataset(ds, config, distributed_state=distributed_state)


### PR DESCRIPTION
## Hypothesis

**Mirror-Symmetry Data Augmentation (H8).** Apply random left-right (y-axis) mirror reflection to training samples with 50% probability. DrivAerML is generated at **zero yaw and zero pitch**, so every case has *exact* mirror symmetry across the x-z plane. The model has never been told this, and is wasting capacity learning the symmetry from finite data.

**Why this attacks the τ_z bottleneck:**

The τ_z structural ratio is now confirmed across **9 distinct mechanisms** (loss weighting, output decoupling, EMA, sampling, depth, curriculum, mag decomposition, SDF FAR-field, per-channel heads) all landing in the [1.44, 1.57] band. Every mechanism so far has attacked the architecture/loss/sampling at training time. **None has attacked the input distribution.** Mirror augmentation:

1. **Doubles the effective dataset size** (400 → 800 unique-orientation views per epoch) — directly addresses the OOD test-set generalization gap.
2. **Forces τ_y representations to be sign-flip-equivariant** — the model can no longer co-adapt τ_z predictions to τ_y sign patterns, breaking any spurious τ_y/τ_z correlation that biases the τz/τx structural ratio.
3. **Is exactly equivariant** for this dataset — unlike rotation augmentation (which would break the y-vs-z geometry distinction), the mirror is documented in the DrivAerML data paper as an exact geometric symmetry.

**This is the EIGHTH Wave 30 attack axis** — orthogonal to ALL 7 architectural axes in flight:

| Wave 30 axis | What it touches | Mirror-aug touches |
|---|---|---|
| H1 cylindrical coords (#1139) | Input coord frame | Cartesian unchanged |
| H2 normal Fourier (#1136) | Input features | StringSep unchanged |
| H3 soft slice routing (#1138) | Attention logits | Attention unchanged |
| H4 hard MoE routing (#1141) | Attention mask | Attention unchanged |
| H5 Y-architecture (#1137) | Backbone split | Backbone unchanged |
| H6 local-frame WSS (#1134) | Output head | Output head unchanged |
| H7 normal aux head (#1140) | Aux gradient | Aux gradient unchanged |
| **H8 mirror aug (this PR)** | **Input distribution** | — |

Mirror aug operates entirely at the data collation layer, upstream of every model component. It is provably orthogonal to all seven active axes and can be stacked on any future winner.

**This is NOT an ensemble.** Single model, single forward pass at test time. The augmentation is training-time only.

**Theoretical basis:**
- Weiler & Cesa, NeurIPS 2019 — when a physical symmetry is exact, enforcing it via augmentation converges to the equivariant solution.
- Shorten & Khoshgoftaar, J. Big Data 2019 — geometric symmetry augmentation reduces overfitting when the symmetry holds exactly.
- DrivAerML data paper documents zero-yaw / zero-pitch for all 500 cases.

## Instructions

**Files to modify:**
- `target/data/loader.py` — add `mirror_collate` wrapper next to `pad_collate` (line 470)
- `target/trainer_runtime.py` — thread `mirror_aug_prob` into the DataLoader collate_fn (line 235)
- `target/train.py` — add `mirror_aug_prob: float = 0.0` to Config (line 76 area)

**Total LOC:** ~35 across 3 files.

### Step 1 — Add Config flag in `target/train.py`

In `class Config` (line 76), add:

```python
mirror_aug_prob: float = 0.0
```

This auto-generates the CLI flag `--mirror-aug-prob` via the existing reflection-based `parse_args` (line 144 onward). Default `0.0` preserves baseline behavior exactly — no behavior change unless explicitly enabled.

### Step 2 — Add `mirror_collate` in `target/data/loader.py`

Just after `pad_collate` (line 470), add a wrapper:

```python
def mirror_collate(batch: Sequence[DrivAerMLCase], prob: float = 0.5) -> dict[str, torch.Tensor]:
    """Random x-z plane mirror augmentation (50% per sample by default).

    DrivAerML is zero-yaw + zero-pitch, so y → -y is an exact geometric symmetry.

    Channels (confirmed from loader.py line 288-297):
      surface_x = [x, y, z, nx, ny, nz, area]     flip y(1), ny(4)
      surface_y = [cp, tau_x, tau_y, tau_z]        flip tau_y(2)    DO NOT touch cp(0)
      volume_x  = [x, y, z, sdf]                   flip y(1)
      volume_y  = [vol_p]                          DO NOT touch

    Args:
      batch: list of DrivAerMLCase (frozen dataclass)
      prob: per-sample mirror probability in [0, 1]; 0.0 disables aug
    """
    import random
    import dataclasses

    mirrored: list[DrivAerMLCase] = []
    for case in batch:
        if prob > 0.0 and random.random() < prob:
            sx = case.surface_x.clone() if isinstance(case.surface_x, torch.Tensor) else case.surface_x.copy()
            sy = case.surface_y.clone() if isinstance(case.surface_y, torch.Tensor) else case.surface_y.copy()
            sx[:, 1] = -sx[:, 1]   # y coord
            sx[:, 4] = -sx[:, 4]   # ny normal
            sy[:, 2] = -sy[:, 2]   # tau_y
            new_fields: dict = {"surface_x": sx, "surface_y": sy}
            if case.volume_x is not None and case.volume_x.shape[0] > 0:
                vx = case.volume_x.clone() if isinstance(case.volume_x, torch.Tensor) else case.volume_x.copy()
                vx[:, 1] = -vx[:, 1]   # volume y coord
                new_fields["volume_x"] = vx
            # volume_y (scalar pressure) and any other fields are mirror-invariant
            case = dataclasses.replace(case, **new_fields)
        mirrored.append(case)
    return pad_collate(mirrored)
```

**Implementation notes for the student:**
- The `clone()`/`copy()` is REQUIRED — torch sample tensors are likely shared with the underlying memory; mutating in-place would corrupt the cached dataset.
- The `if volume_x is not None and shape[0] > 0` guard handles surface-only validation steps.
- Volume_y is a scalar field (`vol_p` only) and is mirror-invariant (pressure is a scalar). Don't touch.
- If `DrivAerMLCase` has other fields (e.g., `case_id`, `mesh_filename`), they pass through unchanged via `dataclasses.replace` (only listed fields are replaced).

### Step 3 — Thread the flag in `target/trainer_runtime.py`

At line 235 where `pad_collate` is passed to the DataLoader, replace with a conditional:

```python
import functools
# ... existing imports include pad_collate

collate_fn = pad_collate
if cfg.mirror_aug_prob > 0.0:
    from target.data.loader import mirror_collate
    collate_fn = functools.partial(mirror_collate, prob=cfg.mirror_aug_prob)
```

Then pass `collate_fn` (not `pad_collate`) to the train DataLoader. **Validation and test DataLoaders MUST keep `pad_collate` unchanged** — augmentation is training-only.

### Step 4 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1 --mirror-aug-prob 0.5`) and confirm:
- No NaN in `train/nonfinite_loss`
- No crash from `dataclasses.replace`
- Throughput within 1% of baseline (only adds ~1 ms/sample of work)
- `wandb` records the new flag

### Step 5 — Full training recipe (18h, 13 epochs, mirror prob = 0.5)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --mirror-aug-prob 0.5 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h8_mirror_aug \
  --wandb-name frieren/mirror-aug-prob-0p5-18h --agent frieren
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~28–32% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where mirror aug should compound with dense supervision
- EP13 terminal: full SENPAI-RESULT

### Step 6 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← THE KEY METRIC for H8 falsification
- best epoch + EMA vs raw

**Optional diagnostic (worth logging if cheap):** count of mirror-flipped samples seen by EP13 (should be ~50% × 400 samples × 13 epochs = ~2600 flipped views). Useful for sanity-check on the augmentation rate.

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | **< 1.40 = H8 confirms data-level bias**, < 1.30 = breakthrough |

## What success looks like

- **BIG WIN**: test τz/τx ≤ 1.30 AND test_WSS < 6.727% with both floors. **Mechanism confirmed**: the τ_z bottleneck is data-level (correctable by symmetry-equivariant training), not architectural. This would also strongly suggest stacking with Wave 30 H1/H3/H6 winners is the path forward.
- **MERGE**: test_WSS < 6.727% with both floors held. Single-model winner.
- **PARTIAL**: test_WSS within 0.1pp of baseline but τz/τx materially down (e.g., ~1.35) — symmetry helps balance but mass capacity still capped. Consider sweep on prob (0.25, 0.75).
- **FLAT NULL**: test_WSS within 0.05pp baseline AND τz/τx unchanged — symmetry is invariant under sincos pos_embed + existing normalization (theoretical possibility). Move to alternative data-level attack (kNN local context, curvature features).

**Why this is the right next experiment:** The 9 prior mechanisms all attack the *model* (architecture, loss, sampling, output, capacity, EMA, decoder). Mirror aug is the **first attack on the input distribution itself.** Either result sharply updates our causal map of the τ_z bottleneck. If it works, it stacks with every Wave 30 architectural winner with zero conflict.

**Source:** Researcher-agent dispatch 2026-05-16, taste score 4/4/4 (highest priority for idle slot). Eighth Wave 30 attack axis — orthogonal to all 7 in-flight architectural arms.

**Wave 30 fleet at launch:** 7-of-8 architectural axes active + this H8 data-aug axis = 8 orthogonal attacks running in parallel after this assignment.
