### PR TITLE
Wave 30 H9': curvature-aware surface feature (port of dl24 #1132)

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -35,7 +35,7 @@ from torch.utils.data import Dataset
 from .split_utils import expand_pvc_candidates, first_existing
 
 DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest.json")
-SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM = 8  # xyz(3) + normals(3) + panel area(1) + curvature(1)
 SURFACE_Y_DIM = 4  # cp(1) + wall shear stress(3)
 VOLUME_X_DIM = 4  # xyz(3) + sdf(1)
 VOLUME_Y_DIM = 1  # volume pressure
@@ -269,6 +269,97 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+def _curvature_enabled() -> bool:
+    return os.environ.get("DRIVAERML_USE_CURVATURE", "0") in ("1", "true", "True", "TRUE")
+
+
+def _curvature_knn() -> int:
+    return int(os.environ.get("DRIVAERML_CURVATURE_KNN", "16"))
+
+
+def _compute_curvature_array(xyz: np.ndarray, normals: np.ndarray, knn: int) -> np.ndarray:
+    """Per-vertex curvature κ_i = mean_{j in kNN(i)} (1 - cos(n_i, n_j)) ∈ [0, 2].
+
+    Rotation- and translation-invariant. Concentrated at sharp edges (A-pillar,
+    mirror housings, wing tips). Computed via scipy.spatial.cKDTree on the FULL
+    case xyz and FULL case normals; sampling/indexing happens after this call
+    against the cached per-case array.
+    """
+
+    from scipy.spatial import cKDTree
+
+    n = int(xyz.shape[0])
+    if n <= knn + 1:
+        return np.zeros((n,), dtype=np.float32)
+    tree = cKDTree(xyz)
+    _, idx = tree.query(xyz, k=knn + 1, workers=-1)
+    n_norm = normals / (np.linalg.norm(normals, axis=1, keepdims=True) + 1e-8)
+    kappa = np.zeros(n, dtype=np.float32)
+    chunk = 200_000
+    for i in range(0, n, chunk):
+        j = min(i + chunk, n)
+        ns = n_norm[i:j][:, None, :]  # [c, 1, 3]
+        nbrs = n_norm[idx[i:j, 1:], :]  # [c, K, 3] (exclude self at idx[:, 0])
+        dots = (ns * nbrs).sum(axis=2)  # [c, K]
+        kappa[i:j] = (1.0 - dots).mean(axis=1).astype(np.float32)
+    return kappa
+
+
+def _load_or_compute_curvature(case_dir: Path, knn: int) -> Path:
+    """Resolve the cached curvature .npy path, computing it on first miss.
+
+    Cache filename includes `k` so different KNN values do not collide.
+    Atomic write via `os.replace` so concurrent workers do not corrupt
+    the file. Computation runs on the FULL case xyz/normals; per-view
+    sampling indexes the cached result downstream.
+    """
+
+    cache = case_dir / f"surface_curvature_k{knn}.npy"
+    if cache.exists():
+        return cache
+    try:
+        resolved = _resolve_artifact_path(cache)
+        if resolved.exists():
+            return resolved
+    except FileNotFoundError:
+        pass
+
+    xyz_path = _resolve_artifact_path(case_dir / "surface_xyz.npy")
+    normals_path = _resolve_artifact_path(case_dir / "surface_normals.npy")
+    xyz_full = np.asarray(np.load(xyz_path), dtype=np.float32)
+    normals_full = np.asarray(np.load(normals_path), dtype=np.float32)
+    kappa_full = _compute_curvature_array(xyz_full, normals_full, knn)
+    # `np.save` always appends `.npy`, so make the temp file already end
+    # in `.npy` and atomically rename onto the canonical cache path.
+    tmp = case_dir / f".{cache.stem}.pid{os.getpid()}.tmp.npy"
+    np.save(tmp, kappa_full)
+    os.replace(tmp, cache)
+    return cache
+
+
+def _curvature_column(
+    case_dir: Path,
+    n_rows: int,
+    surface_rows: np.ndarray | None,
+) -> np.ndarray:
+    """Return the per-vertex curvature as an [N, 1] float32 column.
+
+    Zero column when ``DRIVAERML_USE_CURVATURE`` is unset/0 (so SURFACE_X_DIM=8
+    is preserved regardless of flag state, keeping eval-on-trained-checkpoint
+    clean). Otherwise loads the cached per-case array and indexes by
+    ``surface_rows``.
+    """
+
+    if not _curvature_enabled():
+        return np.zeros((n_rows, 1), dtype=np.float32)
+    knn = _curvature_knn()
+    cache = _load_or_compute_curvature(case_dir, knn)
+    kappa = _load_npy_rows(cache, surface_rows)
+    if kappa.ndim == 1:
+        kappa = kappa[:, None]
+    return kappa.astype(np.float32, copy=False)
+
+
 def load_case(
     root: str | Path,
     case_id: str,
@@ -285,7 +376,8 @@ def load_case(
         _load_npy_rows(case_dir / "surface_wallshearstress.npy", surface_rows),
         "surface_wallshearstress.npy",
     )
-    surface_x = np.concatenate([xyz, normals, area], axis=1)
+    kappa = _curvature_column(case_dir, int(xyz.shape[0]), surface_rows)
+    surface_x = np.concatenate([xyz, normals, area, kappa], axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [

--- a/data/precompute_curvature.py
+++ b/data/precompute_curvature.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Pre-build the per-case curvature cache for the curvature feature (PR #1146).
+
+Run once before launching the training job to amortise the kNN compute
+outside the DataLoader hot path. Safe to re-run: cases that already have
+the cache file are skipped.
+
+Usage:
+    uv run python -m data.precompute_curvature \
+        --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+        --knn 16 --workers 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+from . import DEFAULT_MANIFEST
+from .loader import (
+    DrivAerMLCaseStore,
+    _case_dir,
+    _load_or_compute_curvature,
+)
+
+
+def _build_one(case_root: str, case_id: str, knn: int) -> tuple[str, float, bool]:
+    case_dir = _case_dir(Path(case_root), case_id)
+    cache = case_dir / f"surface_curvature_k{knn}.npy"
+    if cache.exists():
+        return case_id, 0.0, False
+    t0 = time.time()
+    _load_or_compute_curvature(case_dir, knn)
+    return case_id, time.time() - t0, True
+
+
+def _worker(args: tuple[str, str, int]) -> tuple[str, float, bool]:
+    return _build_one(*args)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pre-build curvature cache.")
+    parser.add_argument(
+        "--data-root",
+        type=str,
+        required=True,
+        help="DrivAerML processed root (PVC path).",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=str(DEFAULT_MANIFEST),
+        help="Split manifest JSON path.",
+    )
+    parser.add_argument("--knn", type=int, default=16)
+    parser.add_argument("--workers", type=int, default=8)
+    args = parser.parse_args()
+
+    store = DrivAerMLCaseStore(manifest_path=args.manifest, root=args.data_root)
+    all_cases = []
+    for split in ("train", "val", "test"):
+        all_cases.extend(store.case_ids(split))
+    print(f"Pre-building curvature cache for {len(all_cases)} cases (K={args.knn})")
+    case_root = str(store.root)
+    work = [(case_root, cid, args.knn) for cid in all_cases]
+
+    t0 = time.time()
+    built = 0
+    skipped = 0
+    with mp.get_context("spawn").Pool(processes=args.workers) as pool:
+        for i, (case_id, dt, did_build) in enumerate(pool.imap_unordered(_worker, work), 1):
+            if did_build:
+                built += 1
+            else:
+                skipped += 1
+            if i % 20 == 0 or i == len(work):
+                elapsed = time.time() - t0
+                eta = elapsed / i * (len(work) - i)
+                print(
+                    f"  [{i:4d}/{len(work):4d}] {case_id}: "
+                    f"{'BUILT' if did_build else 'skip'} ({dt:.2f}s) | "
+                    f"elapsed={elapsed:.0f}s eta={eta:.0f}s"
+                )
+    total = time.time() - t0
+    print(f"Done: built={built} skipped={skipped} in {total:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -85,6 +86,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    use_curvature_feature: bool = False
+    curvature_knn: int = 16
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -228,6 +231,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_curvature_feature": (
+            "Enable the per-vertex local surface curvature κ as the 8th "
+            "surface input channel (Wave 30 H9', PR #1146). κ_i = "
+            "mean_{j in kNN(i)} (1 - cos(n_i, n_j)) ∈ [0, 2] computed from "
+            "the existing surface normals over a kNN ball. Provides a "
+            "rotation/translation-invariant geometric prior concentrated "
+            "at A-pillar, mirror housings, wing tips — the same regions "
+            "where τ_z prediction is worst. When disabled the κ column "
+            "is set to zero so SURFACE_X_DIM=8 and model dim are constant. "
+            "Loader caches the per-case κ in surface_curvature_k{KNN}.npy."
+        ),
+        "curvature_knn": (
+            "Number of nearest neighbours (excluding self) used to compute "
+            "the curvature κ. Default 16. Larger values smooth κ; smaller "
+            "values give sharper edge detection. Cache filename includes "
+            "this value so different settings do not collide. Only "
+            "applies when --use-curvature-feature is on."
         ),
     }
     for field in fields(Config):
@@ -710,6 +731,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        # Wire curvature feature flags into the loader before any data
+        # access. The loader reads these env vars at every load_case call,
+        # so setting them here propagates to all DataLoader workers.
+        os.environ["DRIVAERML_USE_CURVATURE"] = "1" if config.use_curvature_feature else "0"
+        os.environ["DRIVAERML_CURVATURE_KNN"] = str(int(config.curvature_knn))
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -883,6 +909,38 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["features/use_curvature_feature"] = bool(config.use_curvature_feature)
+            wandb.summary["features/curvature_knn"] = int(config.curvature_knn)
+            if config.use_curvature_feature:
+                # κ distribution smoke check: pull a single training case directly
+                # and report stats on the curvature channel (last surface_x column).
+                try:
+                    sample_case = train_loader.dataset[0]
+                    kappa_col = sample_case.surface_x[:, -1].detach().cpu().numpy()
+                    k_stats = {
+                        "features/kappa_min": float(kappa_col.min()),
+                        "features/kappa_max": float(kappa_col.max()),
+                        "features/kappa_mean": float(kappa_col.mean()),
+                        "features/kappa_std": float(kappa_col.std()),
+                        "features/kappa_p50": float(np.quantile(kappa_col, 0.50)),
+                        "features/kappa_p95": float(np.quantile(kappa_col, 0.95)),
+                        "features/kappa_p99": float(np.quantile(kappa_col, 0.99)),
+                        "features/kappa_nonzero_frac": float((kappa_col > 1e-6).mean()),
+                        "features/kappa_sample_case": str(sample_case.case_id),
+                    }
+                    for k, v in k_stats.items():
+                        wandb.summary[k] = v
+                    print(
+                        f"κ distribution ({sample_case.case_id}, K={config.curvature_knn}): "
+                        f"min={k_stats['features/kappa_min']:.4f} "
+                        f"max={k_stats['features/kappa_max']:.4f} "
+                        f"mean={k_stats['features/kappa_mean']:.4f} "
+                        f"std={k_stats['features/kappa_std']:.4f} "
+                        f"p95={k_stats['features/kappa_p95']:.4f} "
+                        f"p99={k_stats['features/kappa_p99']:.4f}"
+                    )
+                except Exception as exc:
+                    print(f"κ distribution probe failed: {exc!r}")
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

**Curvature-aware surface feature (H9').** Compute per-vertex local surface curvature κ from the existing surface normals via a k-NN-of-normals statistic, append it as an 8th surface channel, and let the model learn to use it. Provides geometric prior signal in regions where the τ_z gradient is largest (A-pillar, side mirror, wing tips, rocker panel transitions) — exactly where the τ_z bottleneck is sharpest.

**Why this attacks the τ_z bottleneck:**

The τ_z structural ratio is now confirmed across **NINE distinct mechanisms** all landing in the [1.44, 1.57] band. The 4-of-4 Wave 30 model-side widening pattern (H1/H2/H4/H7 — closed) tells us the bottleneck is **not at the model architecture layer**. Tanjiro's H6 (just closed, paper-worthy) confirms the τ_z bottleneck IS at the output head level but cannot be solved by hard architectural enforcement (throws away 5–8% real GT normal-component signal).

This leaves **data-level signal injection** as the remaining attack surface. We have ONE strong external signal: an advisor working on the parallel `drivaerml-long-20260504` branch (cross-pollination thread on Issue #1056) tested *curvature attention bias* and reported `test_WSS=6.609%` (−0.118pp under SOTA) and `test_τ_z=8.592%` (−0.155pp on dominant axis). That's a real WSS gain AND a real τ_z gain, on the same underlying dataset. We have not tested any curvature-aware signal on tay.

**Mechanism intuition:**
1. **Curvature correlates with τ_z magnitude.** Vehicle geometry has sharp curvature concentrated on the A-pillar, mirror housings, wing tips, and rocker panel transitions — these are the same regions where τ_z is large (separation, vortex shedding) and where the model's τ_z prediction is worst.
2. **Existing normals don't encode curvature directly.** The model sees `(nx, ny, nz)` per vertex but has to infer curvature from the spatial variation of normals across attention windows. A scalar curvature channel hands this for free.
3. **Orthogonal to all 8 in-flight Wave 30 axes.** Operates at the input feature layer, not architecture, loss, sampling, output, or input distribution. Stacks cleanly with H8 mirror-aug (frieren #1143) if both win.

**Theoretical basis:**
- Stokes-friction WSS scales with the wall-normal velocity gradient, which in turbulent boundary layers couples to local surface curvature via the favorable/adverse pressure gradient.
- Cross-pollination evidence: dl24-tanjiro #1132 (curvature attention bias on `drivaerml-long-20260504`) — `test_WSS=6.609%`, `test_τ_z=8.592%`. We are testing whether the input-feature variant lands a similar gain on tay.

**This is NOT an ensemble.** Single model, single forward pass at test time. Just one additional input channel.

## Instructions

**Files to modify:**
- `target/data/loader.py` — add curvature computation in `load_case` (line 280-289); bump `SURFACE_X_DIM` from 7 to 8 (line 38)
- `target/train.py` — add `use_curvature_feature: bool = False` to Config (line 76 area)

**Total LOC:** ~50 across 2 files.

### Step 1 — Add `--use-curvature-feature` flag in `target/train.py`

In `class Config` around line 86 (next to `surface_loss_weight`), add:

```python
use_curvature_feature: bool = False
curvature_knn: int = 16
```

Defaults preserve baseline exactly (no behavior change unless explicitly enabled). The `parse_args` reflection auto-generates `--use-curvature-feature` / `--no-use-curvature-feature` and `--curvature-knn`.

### Step 2 — Compute κ in `target/data/loader.py`

At line 38, change `SURFACE_X_DIM = 7` to be either a constant (always 8) OR module-level mutable based on env. **Simplest approach:** make it a constant `SURFACE_X_DIM = 8` and ALWAYS compute curvature (set to zero when flag is off, so existing checkpoints still load — but actually for fresh training this doesn't matter).

After the existing `surface_x = np.concatenate(...)` in `load_case` (line 288), insert:

```python
# Per-vertex local curvature from normals' angular spread over k-NN.
# κ_i = mean_{j in kNN(i)} (1 - cos(n_i, n_j))   ∈ [0, 2]
# Rotation- and translation-invariant. Concentrated at sharp edges.
from sklearn.neighbors import NearestNeighbors
import os
KNN = int(os.environ.get("DRIVAERML_CURVATURE_KNN", "16"))
if surface_x.shape[0] > KNN + 1:
    nbrs = NearestNeighbors(n_neighbors=KNN + 1, algorithm="auto").fit(xyz)
    _, idx = nbrs.kneighbors(xyz)
    n_norm = normals / (np.linalg.norm(normals, axis=1, keepdims=True) + 1e-8)
    # idx[:, 0] is self; skip it
    neigh_dots = (n_norm[:, None, :] * n_norm[idx[:, 1:], :]).sum(axis=2)  # [N, K]
    kappa = (1.0 - neigh_dots).mean(axis=1, keepdims=True).astype(np.float32)  # [N, 1]
else:
    kappa = np.zeros((surface_x.shape[0], 1), dtype=np.float32)
surface_x = np.concatenate([surface_x, kappa], axis=1)  # now [N, 8]
```

**Implementation notes for the student:**
- `sklearn.neighbors.NearestNeighbors` is already in the environment (used elsewhere). If preferred, `scipy.spatial.KDTree` works too.
- The kNN cost is non-trivial — ~100ms per case at 65k points. To avoid blowing up data loading, **CACHE κ per-case on first computation** (write to `case_dir / f"surface_curvature_k{KNN}.npy"`, reuse on subsequent loads). 
- Cache invalidation: include `k` in the cache filename so different KNN values don't collide.
- Normalize κ before model ingestion: `(κ - mean) / std` over the training set; this can be added to the existing TargetTransform machinery or hardcoded constants computed from a single pass.
- If `--use-curvature-feature` is False, set the κ column to zeros (so SURFACE_X_DIM is still 8 and model dim doesn't change at runtime — keeps eval-on-trained-checkpoint clean).

### Step 3 — Validate κ distribution before launch

Add a quick smoke validation: print or `wandb.log` the κ distribution on the first batch (min/max/mean/std/p95/p99). Healthy distribution:
- κ on a flat panel ≈ 0
- κ on a sharp edge ≈ 0.1–0.3
- κ on a corner / mirror housing ≈ 0.3–1.0
- p99 < 1.5 (otherwise the kNN ball is too small)

If p99 > 1.5, increase `--curvature-knn` to 24 or 32.

### Step 4 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1 --use-curvature-feature`) and confirm:
- No NaN in `train/nonfinite_loss`
- Throughput within 5% of baseline (first epoch slow due to κ caching, subsequent epochs ~baseline)
- κ distribution looks healthy (no all-zeros, no all-NaN)
- `wandb` records `use_curvature_feature=True`

### Step 5 — Full training recipe (18h, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-curvature-feature --curvature-knn 16 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h9_curvature \
  --wandb-name nezuko/curvature-knn16-18h --agent nezuko
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~28–33% (warmup epoch) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS — checkpoint where curvature should compound with dense supervision
- EP13 terminal: full SENPAI-RESULT with **val AND test** scores (per #1056 directive)

### Step 6 — Reporting

Terminal `SENPAI-RESULT` comment must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← KEY structural metric (already at 1.281 from tanjiro H6 confirming bottleneck location)
- best epoch + EMA vs raw
- κ distribution histogram (1 log line is fine)

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | < 1.40 = data-level bias fix, < 1.30 = breakthrough |
| dl24-tanjiro #1132 reference | test_WSS=6.609% | curvature variant on parallel branch |

## What success looks like

- **BIG WIN**: test_WSS < 6.609% (beats dl24 reference) with all floors held AND test τz/τx ≤ 1.40. Confirms curvature is a genuine data-level inductive bias that unlocks the τ_z bottleneck.
- **MERGE**: test_WSS < 6.727% with both vol_p/SP floors held — single-model winner.
- **PARTIAL**: test_WSS within 0.1pp of baseline but test_τ_z materially down — try `--curvature-knn 32` (smoother κ) or stack with mirror-aug H8.
- **FLAT NULL**: test_WSS unchanged AND test_τ_z unchanged — curvature signal is already implicit in normals + position. Move to other data-level attacks (kNN-pooled local context, learned anisotropic basis).

**Why this is the right next experiment:** Of the 8 in-flight Wave 30 axes, none touches the input feature layer. The 4-of-4 widening pattern says we cannot fix τ_z at the architecture level. dl24 cross-pollination gives us strong evidence (test_WSS=6.609%) that curvature CAN unlock additional WSS gain. This is the cleanest, lowest-risk port of that mechanism.

**Source:** dl24 advisor cross-pollination on Issue #1056 (PR #1132 reference). Wave 30 H9' assignment. Researcher-agent dispatch 2026-05-16, taste 4/4/4.

**Wave 30 fleet at launch:** 8 in-flight axes + this H9' input-feature axis = 9 orthogonal attacks running in parallel.
