### PR TITLE
Wave 30 H10: vector-length-decoupled WSS output head (direction-aware loss)

### DIFF
--- a/eval_direction_magnitude.py
+++ b/eval_direction_magnitude.py
@@ -1,0 +1,249 @@
+"""H10 direction-vs-magnitude WSS error decomposition (PR #1148).
+
+Loads BEST ckpt from a run-<id> dir, runs DDP inference over val_surface and
+test_surface, and decomposes the wall-shear rel-L2 error orthogonally into a
+magnitude component (along the GT direction) and a tangential component
+(direction component perpendicular to GT direction).
+
+Per-vertex (in physical units):
+    u_gt    = tau_gt / |tau_gt|
+    proj    = tau_pred . u_gt            (signed scalar)
+    mag_err = proj - |tau_gt|            (signed)
+    tan_err = tau_pred - proj * u_gt     (perpendicular to u_gt)
+
+Per case (Pythagoras):
+    total_err^2 = sum_v ||tau_pred - tau_gt||^2 == sum_v (mag_err^2 + ||tan_err||^2)
+    mag_rel_l2  = sqrt(sum_v mag_err^2  / sum_v ||tau_gt||^2)
+    dir_rel_l2  = sqrt(sum_v ||tan_err||^2 / sum_v ||tau_gt||^2)
+    total_rel_l2= sqrt(mag_rel_l2^2 + dir_rel_l2^2)   (== wall_shear case rel L2)
+
+Aggregated as the mean of per-case rel L2 values, matching evaluate_split().
+
+Usage:
+    cd target/
+    torchrun --standalone --nproc-per-node=8 eval_direction_magnitude.py \\
+        --run-dir outputs/drivaerml/run-qncb8ikl --eval-volume-points 65536
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import yaml
+
+from data import load_data
+from train import Config, build_model
+from trainer_runtime import (
+    TargetTransform,
+    autocast_context,
+    cleanup_distributed,
+    eval_loader_for_dataset,
+    init_distributed,
+    unwrap_model,
+)
+
+
+def _per_vertex_errs(tau_pred: torch.Tensor, tau_gt: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return mag_err_sq, tan_err_sq, target_sq, cos_sim per vertex.
+
+    Shapes: all inputs/outputs are [..., 3] for tau and [...] (scalar per vertex) for outputs.
+    """
+    gt_norm = torch.linalg.vector_norm(tau_gt, dim=-1)
+    safe_gt_norm = gt_norm.clamp(min=1e-12)
+    u_gt = tau_gt / safe_gt_norm.unsqueeze(-1)
+    proj = (tau_pred * u_gt).sum(dim=-1)
+    mag_err = proj - gt_norm
+    tan_err_vec = tau_pred - proj.unsqueeze(-1) * u_gt
+    tan_err_sq = (tan_err_vec * tan_err_vec).sum(dim=-1)
+    target_sq = gt_norm * gt_norm
+    pred_norm = torch.linalg.vector_norm(tau_pred, dim=-1).clamp(min=1e-12)
+    cos_sim = proj / pred_norm
+    return mag_err * mag_err, tan_err_sq, target_sq, cos_sim
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--eval-volume-points", type=int, default=None)
+    parser.add_argument("--eval-surface-points", type=int, default=None)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--skip-full-val", action="store_true")
+    args = parser.parse_args()
+
+    state = init_distributed()
+    device = state.device
+    is_main = state.is_main
+
+    run_dir = Path(args.run_dir)
+    with open(run_dir / "config.yaml") as f:
+        cfg_dict = yaml.safe_load(f)
+    config = Config(**cfg_dict)
+    if args.eval_volume_points is not None:
+        config.eval_volume_points = args.eval_volume_points
+    if args.eval_surface_points is not None:
+        config.eval_surface_points = args.eval_surface_points
+    config.batch_size = args.batch_size
+    config.num_workers = 2
+
+    if is_main:
+        print(f"World size: {state.world_size}  Device: {device}", flush=True)
+
+    _train_ds, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=config.debug,
+    )
+    full_val_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=state)
+        for name, ds in val_splits.items()
+    }
+    full_test_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=state)
+        for name, ds in test_splits.items()
+    }
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+    model = build_model(config).to(device)
+    ckpt_path = run_dir / "checkpoint.pt"
+    if is_main:
+        print(f"Loading: {ckpt_path}", flush=True)
+    checkpoint = torch.load(ckpt_path, map_location=device, weights_only=True)
+    model.load_state_dict(checkpoint["model"])
+    if is_main:
+        print(f"  epoch={checkpoint['epoch']} source={checkpoint['checkpoint_source']}", flush=True)
+    model.eval()
+
+    def run_split(name: str, loader) -> dict[str, float]:
+        # case_sums[case_id] = [mag_err_sq, tan_err_sq, target_sq, n_verts, cos_sum]
+        case_sums: dict[str, list[float]] = defaultdict(lambda: [0.0, 0.0, 0.0, 0, 0.0])
+        eval_module = unwrap_model(model)
+        for batch in loader:
+            batch = batch.to(device)
+            with torch.no_grad(), autocast_context(device, config.amp_mode):
+                out = eval_module(
+                    surface_x=batch.surface_x,
+                    surface_mask=batch.surface_mask,
+                    volume_x=batch.volume_x,
+                    volume_mask=batch.volume_mask,
+                )
+            surface_pred_norm = out["surface_preds"].float()
+            surface_pred = transform.invert_surface(surface_pred_norm)
+            mask = batch.surface_mask  # [B, N]
+            tau_pred = surface_pred[..., 1:4]
+            tau_gt = batch.surface_y[..., 1:4]
+            mag_err_sq, tan_err_sq, target_sq, cos_sim = _per_vertex_errs(tau_pred, tau_gt)
+            for b, case_id in enumerate(batch.case_ids):
+                m = mask[b]
+                if not bool(m.any()):
+                    continue
+                state_arr = case_sums[case_id]
+                state_arr[0] += float(mag_err_sq[b][m].sum().detach().cpu().item())
+                state_arr[1] += float(tan_err_sq[b][m].sum().detach().cpu().item())
+                state_arr[2] += float(target_sq[b][m].sum().detach().cpu().item())
+                state_arr[3] += int(m.sum().item())
+                state_arr[4] += float(cos_sim[b][m].sum().detach().cpu().item())
+
+        if state.enabled:
+            payload: dict[str, list[float]] = {k: list(v) for k, v in case_sums.items()}
+            gathered: list[dict | None] = [None for _ in range(state.world_size)]
+            dist.all_gather_object(gathered, payload)
+            if not is_main:
+                return {}
+            merged: dict[str, list[float]] = defaultdict(lambda: [0.0, 0.0, 0.0, 0, 0.0])
+            for shard in gathered:
+                if shard is None:
+                    continue
+                for k, v in shard.items():
+                    m = merged[k]
+                    m[0] += v[0]
+                    m[1] += v[1]
+                    m[2] += v[2]
+                    m[3] += int(v[3])
+                    m[4] += v[4]
+            case_sums = merged
+
+        mag_rel = []
+        dir_rel = []
+        total_rel = []
+        cos_avg = []
+        for case_id, (m_sq, d_sq, t_sq, n_verts, cos_s) in case_sums.items():
+            if t_sq <= 0.0 or n_verts == 0:
+                continue
+            mag_rel.append(math.sqrt(m_sq / t_sq))
+            dir_rel.append(math.sqrt(d_sq / t_sq))
+            total_rel.append(math.sqrt((m_sq + d_sq) / t_sq))
+            cos_avg.append(cos_s / n_verts)
+        if not mag_rel:
+            return {}
+        return {
+            "n_cases": len(mag_rel),
+            "mag_rel_l2_pct": 100.0 * sum(mag_rel) / len(mag_rel),
+            "dir_rel_l2_pct": 100.0 * sum(dir_rel) / len(dir_rel),
+            "total_rel_l2_pct": 100.0 * sum(total_rel) / len(total_rel),
+            "mean_cos_sim": sum(cos_avg) / len(cos_avg),
+            "mag_share_sq": (
+                sum(m * m for m in mag_rel) / sum(t * t for t in total_rel)
+                if total_rel else 0.0
+            ),
+            "dir_share_sq": (
+                sum(d * d for d in dir_rel) / sum(t * t for t in total_rel)
+                if total_rel else 0.0
+            ),
+        }
+
+    results: dict[str, dict[str, float]] = {}
+    if not args.skip_full_val:
+        if is_main:
+            print("\n=== full_val direction/magnitude decomposition ===", flush=True)
+        for name, loader in full_val_loaders.items():
+            metrics = run_split(name, loader)
+            if is_main and metrics:
+                results[f"full_val.{name}"] = metrics
+                print(
+                    f"  {name}: n={metrics['n_cases']} total={metrics['total_rel_l2_pct']:.4f}%"
+                    f" mag={metrics['mag_rel_l2_pct']:.4f}% dir={metrics['dir_rel_l2_pct']:.4f}%"
+                    f" cos={metrics['mean_cos_sim']:.6f}"
+                    f" mag_share_sq={metrics['mag_share_sq']:.3f}"
+                    f" dir_share_sq={metrics['dir_share_sq']:.3f}",
+                    flush=True,
+                )
+
+    if is_main:
+        print("\n=== test direction/magnitude decomposition ===", flush=True)
+    for name, loader in full_test_loaders.items():
+        metrics = run_split(name, loader)
+        if is_main and metrics:
+            results[f"test.{name}"] = metrics
+            print(
+                f"  {name}: n={metrics['n_cases']} total={metrics['total_rel_l2_pct']:.4f}%"
+                f" mag={metrics['mag_rel_l2_pct']:.4f}% dir={metrics['dir_rel_l2_pct']:.4f}%"
+                f" cos={metrics['mean_cos_sim']:.6f}"
+                f" mag_share_sq={metrics['mag_share_sq']:.3f}"
+                f" dir_share_sq={metrics['dir_share_sq']:.3f}",
+                flush=True,
+            )
+
+    if is_main:
+        out_path = run_dir / "direction_magnitude_decomp.json"
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2, default=float)
+        print(f"\nWrote: {out_path}", flush=True)
+
+    cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        vector_decoupled_head: bool = False,
+        vector_decoupled_mag_scale: float = 10.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,12 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.vector_decoupled_head = vector_decoupled_head
+        self.vector_decoupled_mag_scale = float(vector_decoupled_mag_scale)
+        # When True, surface head outputs 5 channels (cp, dir_x, dir_y, dir_z, log_mag).
+        # The 3-vector τ part is reconstructed as `softplus(log_mag) * mag_scale * unit(dir)`
+        # in normalized space (H10, PR #1148). Public surface_preds remain 4-channel.
+        self._surface_head_out_dim = self.surface_output_dim + (1 if vector_decoupled_head else 0)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -484,7 +492,7 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(n_hidden, self._surface_head_out_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -496,7 +504,7 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_out = LinearProjection(n_hidden, self._surface_head_out_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
@@ -518,6 +526,25 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+    def _reconstruct_surface(self, raw: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Map raw 5-channel head output to (cp, τ_x, τ_y, τ_z) + decoupled diagnostics.
+
+        raw: [..., 5] = (cp, dir_x, dir_y, dir_z, log_mag)
+        Returns:
+            preds: [..., 4] = (cp, τ_x, τ_y, τ_z) in normalized space
+            dir_unit: [..., 3] L2-normalized direction (model-layer normalization for
+                gradient stability; loss-side cosine sim reuses this)
+            log_mag: [..., 1] raw log-magnitude channel (pre-softplus)
+        """
+        cp = raw[..., 0:1]
+        dir_raw = raw[..., 1:4]
+        log_mag = raw[..., 4:5]
+        dir_unit = F.normalize(dir_raw, dim=-1, eps=1e-6)
+        mag = F.softplus(log_mag) * self.vector_decoupled_mag_scale
+        tau = mag * dir_unit
+        preds = torch.cat([cp, tau], dim=-1)
+        return preds, dir_unit, log_mag
 
     def _encode_group(
         self,
@@ -621,8 +648,20 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        surface_dir_unit: torch.Tensor | None = None
+        surface_log_mag: torch.Tensor | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_raw = self.surface_out(surface_hidden)
+            if self.vector_decoupled_head:
+                surface_preds_raw, surface_dir_unit, surface_log_mag = self._reconstruct_surface(
+                    surface_raw
+                )
+                mask_unsq = surface_mask.unsqueeze(-1)
+                surface_preds = surface_preds_raw * mask_unsq
+                surface_dir_unit = surface_dir_unit * mask_unsq
+                surface_log_mag = surface_log_mag * mask_unsq
+            else:
+                surface_preds = surface_raw * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -633,10 +672,14 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if self.vector_decoupled_head and surface_dir_unit is not None:
+            out["surface_pred_direction"] = surface_dir_unit
+            out["surface_pred_log_mag"] = surface_log_mag
+        return out

--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    vector_decoupled_head: bool = False
+    vector_decoupled_mag_scale: float = 10.0
+    direction_cos_loss_weight: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -308,6 +311,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        vector_decoupled_head=config.vector_decoupled_head,
+        vector_decoupled_mag_scale=config.vector_decoupled_mag_scale,
     )
 
 
@@ -321,6 +326,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    direction_cos_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -342,17 +348,39 @@ def train_loss(
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # H10 vector-decoupled head: cosine-similarity aux loss on the unit
+        # direction of the wall shear vector in normalized space. Predicted
+        # direction is L2-normalized at the model layer (see
+        # SurfaceTransolver._reconstruct_surface); GT direction is normalized
+        # here from surface_target[..., 1:4]. Only active when the model
+        # populated "surface_pred_direction" AND weight > 0.
+        direction_cos_loss = surface_loss.new_zeros(())
+        active = (
+            "surface_pred_direction" in out and direction_cos_loss_weight > 0.0
+        )
+        if active:
+            pred_dir = out["surface_pred_direction"]  # [B, N, 3] unit (model-side)
+            tau_target = surface_target[..., 1:4]
+            tgt_dir = torch.nn.functional.normalize(tau_target, dim=-1, eps=1e-6)
+            cos_sim = (pred_dir * tgt_dir).sum(dim=-1)  # [B, N]
+            direction_cos_loss_pv = 1.0 - cos_sim
+            mask_f = batch.surface_mask.to(direction_cos_loss_pv.dtype)
+            direction_cos_loss = (direction_cos_loss_pv * mask_f).sum() / mask_f.sum().clamp(min=1)
+        weighted_direction_cos_loss = direction_cos_loss_weight * direction_cos_loss
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        loss = weighted_surface_loss + weighted_volume_loss + weighted_direction_cos_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "direction_cos_loss": float(direction_cos_loss.detach().cpu().item()),
+        "direction_cos_loss_weighted": float(weighted_direction_cos_loss.detach().cpu().item()),
     }
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -883,6 +911,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/vector_decoupled_head"] = bool(config.vector_decoupled_head)
+            wandb.summary["model/vector_decoupled_mag_scale"] = float(config.vector_decoupled_mag_scale)
+            wandb.summary["loss/direction_cos_loss_weight"] = float(config.direction_cos_loss_weight)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1061,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        direction_cos_loss_weight=config.direction_cos_loss_weight,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1102,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "direction_cos_loss" in batch_loss_metrics:
+                        train_log["train/direction_cos_loss"] = batch_loss_metrics["direction_cos_loss"]
+                        train_log["train/direction_cos_loss_weighted"] = batch_loss_metrics[
+                            "direction_cos_loss_weighted"
+                        ]
+                        train_log["train/direction_cos_loss_weight"] = config.direction_cos_loss_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Vector-length-decoupled WSS head (H10).** Replace the 4-channel `(cp, τ_x, τ_y, τ_z)` Cartesian output with a 5-channel `(cp, dir_x, dir_y, dir_z, log_mag)` parametrization that explicitly **decouples direction from magnitude** at the output layer. Reconstruct `τ = softplus(log_mag) * unit(dir)` and add an auxiliary cosine-similarity loss on the unit direction so the model receives a direction-aware gradient signal that the rank-3 Cartesian MSE does not supply.

**Why this attacks the τ_z bottleneck:**

The **5-of-5 Wave 30 model-side widening pattern** (H1/H2/H4/H5/H7 — your own #1137 closed) shows the bottleneck is NOT at the model architecture layer. Tanjiro's H6 (closed, paper-worthy) confirms it IS at the output head level — but hard τ·n=0 enforcement throws away ~5–8% real GT normal-component signal. tanjiro #1147 H6' is testing soft τ·n=0 penalty as one fix. H10 attacks the same output-head bottleneck from a **completely different angle**:

1. **Cartesian MSE confounds direction and magnitude.** The rank-3 MSE on (τx, τy, τz) treats `(0, 0, 0.5)` and `(0, 0, 1.0)` as having the same direction error as `(0.5, 0, 0)` vs `(1.0, 0, 0)` — but they're geometrically identical (just scaled). The model has no explicit direction-prediction signal; it has to infer direction from per-axis MSE which is a noisy proxy.
2. **τ_z is the smallest component and the largest relative error.** The dominant axis. A direction-aware loss gives the model a magnitude-invariant gradient signal that doesn't drown the small τ_z out in the per-axis MSE budget.
3. **Decoupling helps the long tail.** Vehicle WSS has a long-tailed magnitude distribution (low |τ| on flat panels, high |τ| at separation cliffs). Log-magnitude prediction is naturally Gaussian-residual, and unit-direction prediction is bounded — both are easier than raw Cartesian.

**Orthogonal to all 10 in-flight axes:**

| Wave 30 axis | What it touches | H10 touches |
|---|---|---|
| H1 cyl coords (#1139) | Input frame | Output head, untouched |
| H3 soft routing (#1138) | Attention logits | Output head |
| H4 hard MoE (#1141) | Attention mask | Output head |
| H6' soft τ·n (#1147) | Loss term | Output parametrization |
| H7 normal aux (#1140) | Aux head on normals | Aux head on direction |
| H8 mirror aug (#1143) | Input distribution | Output head |
| H9' curvature (#1146) | Input features | Output head |
| **H10 (this PR)** | **Output reparametrization** | — |

H10 is the only experiment that reparametrizes the WSS output as polar (magnitude + direction). It stacks cleanly with any winning axis from H6' (loss attack), H8 (data attack), or H9' (input attack).

**Theoretical basis:**
- Lin et al., CVPR 2017 — decoupling magnitude from direction in regression heads improves long-tailed prediction (RepPoints, focal regression).
- Yu & Koltun, ICLR 2016 — multi-scale dilated convolutions, but the underlying insight: **scale-invariant losses on direction outperform scale-coupled losses for orientation-sensitive regression.**
- Kaggle empirical: vector regression in 3D fluid mechanics / robotics benchmarks consistently benefits from polar / log-mag reparametrization over Cartesian.
- The H6 mechanism PASS (tanjiro #1134, test τz/τx=1.281) confirmed the bottleneck IS at the output head — H10 is the natural follow-up that *doesn't* throw away GT signal.

**This is NOT an ensemble.** Single model, single forward pass at test time. Just a 1-channel widening of the output head + reconstruction in physical space.

## Instructions

**Files to modify:**
- `target/model.py` — change `surface_out` to output 5 channels; add a `reconstruct_surface_pred` method that maps 5 → 4 (cp, τx, τy, τz)
- `target/train.py` — add `vector_decoupled_head: bool = False` and `direction_cos_loss_weight: float = 0.0` to Config; in `train_loss`, compute the cosine-similarity aux loss on the unit direction
- `target/data/loader.py` — no changes needed (target stays 4-channel; only the model output reparametrization changes)

**Total LOC:** ~50 across 2 files.

### Step 1 — Add `--vector-decoupled-head` and `--direction-cos-loss-weight` in `target/train.py`

In `class Config` near line 107 (next to `tau_z_loss_weight`), add:

```python
vector_decoupled_head: bool = False
direction_cos_loss_weight: float = 0.1
```

Default `False` preserves baseline behavior exactly.

### Step 2 — Modify `surface_out` in `target/model.py`

In `SurfaceTransolver.__init__` around line 484, the surface head outputs `self.surface_output_dim = 4`. When `vector_decoupled_head=True`, change to **5** output channels:

```python
# H10 vector-length-decoupled output head
self.vector_decoupled_head = vector_decoupled_head  # threaded via __init__ kwarg
surface_raw_dim = self.surface_output_dim + 1 if vector_decoupled_head else self.surface_output_dim
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, surface_raw_dim),
)
self.surface_out.apply(_init_linear)
```

Thread `vector_decoupled_head` through the constructor and add it to the `build_model` factory in `target/train.py`.

### Step 3 — Reconstruct (cp, τx, τy, τz) from (cp, dir_x, dir_y, dir_z, log_mag)

Add a helper inside the model (or inline in `forward`):

```python
def _reconstruct_surface(self, raw: torch.Tensor) -> torch.Tensor:
    """
    raw: [..., 5] = (cp, dir_x, dir_y, dir_z, log_mag)
    returns: [..., 4] = (cp, τx, τy, τz)
    """
    cp = raw[..., 0:1]
    dir_raw = raw[..., 1:4]
    log_mag = raw[..., 4:5]
    dir_norm = dir_raw / (dir_raw.norm(dim=-1, keepdim=True) + 1e-6)
    mag = F.softplus(log_mag) * 10.0  # scale factor — tune if needed
    tau = mag * dir_norm  # [..., 3]
    return torch.cat([cp, tau], dim=-1)
```

In `forward` (around line 625), if `vector_decoupled_head=True`:

```python
surface_raw = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
surface_preds = self._reconstruct_surface(surface_raw) * surface_mask.unsqueeze(-1)
# Stash the raw for loss-side cosine-sim computation
out["surface_raw_decoupled"] = surface_raw
```

If `vector_decoupled_head=False`, the existing path is unchanged.

### Step 4 — Cosine-similarity aux loss in `train_loss`

In `target/train.py` around line 343, after the main `surface_loss` is computed, add:

```python
direction_cos_loss = surface_loss.new_zeros(())
if vector_decoupled_head and direction_cos_loss_weight > 0.0:
    raw = out["surface_raw_decoupled"]  # [B, N, 5]
    # Predicted direction from the raw 5-channel head
    pred_dir = raw[..., 1:4] / (raw[..., 1:4].norm(dim=-1, keepdim=True) + 1e-6)
    # Target direction from the normalized GT WSS (in normalized space — direction is invariant to per-channel scale)
    tau_target = surface_target[..., 1:4]  # already normalized
    tgt_dir = tau_target / (tau_target.norm(dim=-1, keepdim=True) + 1e-6)
    cos_sim = (pred_dir * tgt_dir).sum(dim=-1)  # [B, N]
    direction_cos_loss_pv = 1.0 - cos_sim       # per-vertex [0, 2]
    if batch.surface_mask is not None:
        mask_f = batch.surface_mask.to(direction_cos_loss_pv.dtype)
        direction_cos_loss = (direction_cos_loss_pv * mask_f).sum() / mask_f.sum().clamp(min=1)
    else:
        direction_cos_loss = direction_cos_loss_pv.mean()

weighted_direction_cos_loss = direction_cos_loss_weight * direction_cos_loss
loss = weighted_surface_loss + weighted_volume_loss + weighted_direction_cos_loss
```

Add to the returned metrics dict:

```python
"direction_cos_loss": float(direction_cos_loss.detach().cpu().item()),
"direction_cos_loss_weighted": float(weighted_direction_cos_loss.detach().cpu().item()),
```

### Step 5 — Thread the flag through training loop

`train_loss` is called around line 1030. Add `vector_decoupled_head=config.vector_decoupled_head` and `direction_cos_loss_weight=config.direction_cos_loss_weight` to the kwargs. Same for `per_task_train_losses` if GradNorm is enabled — but H10 should be tested with standard fixed weights, so GradNorm is irrelevant here.

### Step 6 — Sanity smoke before launches

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1 --vector-decoupled-head --direction-cos-loss-weight 0.1`) and confirm:
- No NaN in `train/nonfinite_loss`
- `train/direction_cos_loss` is in [0.5, 2.0] at init, descends below 0.3 by step 200
- Reconstructed surface_preds match the magnitude/range of baseline (no exploding softplus)
- `train/surface_loss` is comparable to baseline at step 200

### Step 7 — Full training recipe (18h, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vector-decoupled-head --direction-cos-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h10_vector_decoupled \
  --wandb-name fern/vector-decoupled-cos0p1-18h --agent fern
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~28–33% — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS
- EP13 terminal: full SENPAI-RESULT with **val AND test** scores (per #1056 directive)

### Step 8 — Reporting

Terminal `SENPAI-RESULT` must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← KEY structural metric
- `train/direction_cos_loss` final value (the diagnostic — if it plateaus below ~0.05, the model has learned direction well)
- `train/surface_loss` per-axis breakdown if available
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | < 1.40 = mechanism PASS, < 1.30 = breakthrough |

## What success looks like

- **BIG WIN**: test_WSS < 6.609% (beats dl24-tanjiro #1132 reference) AND test τz/τx ≤ 1.40 AND all floors held. Mechanism + absolute together = the lab's headline result.
- **MERGE**: test_WSS < 6.727% with both vol_p/SP floors held — single-model winner.
- **PARTIAL**: test_WSS within 0.1pp baseline but test τz/τx materially down — try `--direction-cos-loss-weight 0.25` (more direction pressure) or stack with H8 mirror-aug.
- **FLAT NULL**: test_WSS unchanged AND τz/τx unchanged — the rank-3 Cartesian MSE was already sufficient for direction learning, or softplus magnitude is collapsing. Try `--direction-cos-loss-weight 0.5` with no softplus scale (replace with `exp(log_mag).clamp(max=5.0)`).

**Why this is the right next experiment:** The 5-of-5 widening pattern says don't keep attacking architecture. The H6 mechanism PASS says the output head IS the bottleneck. H6' (tanjiro) attacks via soft penalty; H10 attacks via reparametrization. These are complementary: penalty pulls predictions toward tangency; reparametrization gives explicit direction-aware gradient. Two orthogonal attacks on the confirmed bottleneck location.

**Source:** Researcher-agent dispatch 2026-05-16. Wave 30 H10. Direct follow-up to your own H5 closure (mechanism falsification motivates head reparametrization).

**Wave 30 fleet at launch:** 11 orthogonal attacks in parallel (8 prior + H9' + H6' + this H10).
