### PR TITLE
[dl24-frieren] WSS H10: Charbonnier supplementary loss on WSS channels

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    wss_charbonnier_weight: float = 0.0
+    wss_charbonnier_eps: float = 1e-3
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -224,6 +226,27 @@ def per_channel_masked_mse(
     return weighted.sum(dim=(0, 1)) / denom  # [C]
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Masked Charbonnier (pseudo-Huber) loss: ``sqrt(eps^2 + (pred-target)^2) - eps``.
+
+    Averaged over masked spatial points and channels, matching the convention
+    used by :func:`masked_mse`. Differentiable everywhere, gradient bounded by 1
+    in magnitude — robust to outliers compared with squared error.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    delta = pred - target
+    values = torch.sqrt(eps * eps + delta * delta) - eps  # [B, N, C]
+    weighted = values * mask_f
+    n_pts = mask_f.sum().clamp_min(1.0)
+    n_ch = float(pred.shape[-1])
+    return weighted.sum() / (n_pts * n_ch)
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -301,6 +324,8 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    wss_charbonnier_weight: float = 0.0,
+    wss_charbonnier_eps: float = 1e-3,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
@@ -337,13 +362,36 @@ def train_loss(
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        # H10: Supplementary Charbonnier (pseudo-Huber) on WSS channels only.
+        # Channels 1-3 of surface_preds/target are tau_x, tau_y, tau_z (idx 0 is cp).
+        if wss_charbonnier_weight > 0.0:
+            pred_wss = out["surface_preds"][..., 1:4]
+            target_wss = surface_target[..., 1:4]
+            loss_wss_charb = masked_charbonnier(
+                pred_wss, target_wss, batch.surface_mask, eps=wss_charbonnier_eps
+            )
+            loss_wss_mse_diag = masked_mse(pred_wss, target_wss, batch.surface_mask)
+            loss = loss + wss_charbonnier_weight * loss_wss_charb
+            charb_metrics = {
+                "loss_wss_charb_unweighted": float(
+                    loss_wss_charb.detach().cpu().item()
+                ),
+                "loss_wss_charb_weighted": float(
+                    (wss_charbonnier_weight * loss_wss_charb).detach().cpu().item()
+                ),
+                "loss_wss_mse": float(loss_wss_mse_diag.detach().cpu().item()),
+            }
+        else:
+            charb_metrics = {}
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }, task_losses
+    }
+    metrics.update(charb_metrics)
+    return loss, metrics, task_losses
 
 
 def run_eval_only(config: Config, state) -> None:
@@ -583,6 +631,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    wss_charbonnier_weight=config.wss_charbonnier_weight,
+                    wss_charbonnier_eps=config.wss_charbonnier_eps,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -634,6 +684,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if "loss_wss_charb_unweighted" in batch_loss_metrics:
+                        wss_mse_diag = batch_loss_metrics["loss_wss_mse"]
+                        charb_unw = batch_loss_metrics["loss_wss_charb_unweighted"]
+                        ratio = charb_unw / wss_mse_diag if wss_mse_diag > 1e-12 else float("nan")
+                        train_log.update(
+                            {
+                                "train/loss_wss_mse": wss_mse_diag,
+                                "train/loss_wss_charb_unweighted": charb_unw,
+                                "train/loss_wss_charb_weighted": batch_loss_metrics[
+                                    "loss_wss_charb_weighted"
+                                ],
+                                "train/loss_wss_charb_to_mse_ratio": ratio,
+                            }
+                        )
                 if config.use_y_symmetry_aug and aug_log:
                     bs = max(1, aug_log.get("batch_size", 0))
                     train_log["train/aug/y_symmetry_flip_rate"] = (


### PR DESCRIPTION
## Hypothesis

Add a **Charbonnier loss** (pseudo-Huber, smooth L1 generalization) as a **supplementary** term alongside the existing per-channel MSE on the **WSS channels only**:

```
L_charb(δ) = sqrt(ε² + δ²) − ε   where δ = pred − gt
```

This is differentiable everywhere, robust to outliers, and **reweights gradient signal toward the mid-range of the WSS dynamic range** — exactly where the rel-L2 error metric accumulates the most. The WSS field spans ~3 orders of magnitude across the car surface (stagnation ~0, attached BL ~5-20 Pa·m⁻¹, rear separation ~50-150 Pa·m⁻¹). MSE squares this range so gradients are dominated by high-WSS peaks; Charbonnier flattens it.

τ_z (test 8.747%, highest error axis) is the primary target — it has the widest dynamic range and worst SNR, so MSE over-penalizes the separation peaks at the cost of mid-range accuracy. This is a **loss-functional axis** attack, orthogonal to the architecture (H5/H6/H9), optimizer (H8), and loss-weighting (H7) axes in the wave.

**Wave 27 constraint compliance**: additive to MSE (never replaces), applied only to WSS channels. Cannot break vol_p or surf_p floors by construction.

## Instructions

### 1. Add the Charbonnier helper and CLI flags

In `train.py`, add a `charbonnier_loss` function (anywhere near the loss utilities):

```python
def charbonnier_loss(pred, target, eps=1e-3, reduction='mean'):
    """Charbonnier (pseudo-Huber): sqrt(eps^2 + (pred-target)^2) - eps."""
    delta = pred - target
    loss = torch.sqrt(eps * eps + delta * delta) - eps
    if reduction == 'mean':
        return loss.mean()
    return loss.sum()
```

In the `Config` dataclass (or equivalent), add:
```python
wss_charbonnier_weight: float = 0.0  # 0 = disabled (backward compat)
wss_charbonnier_eps: float = 1e-3
```

In argparse:
```python
parser.add_argument("--wss-charbonnier-weight", type=float, default=0.0,
    help="Weight of Charbonnier supplementary term on WSS loss (0 disables)")
parser.add_argument("--wss-charbonnier-eps", type=float, default=1e-3,
    help="Charbonnier eps; smaller=more L1-like, larger=more MSE-like")
```

### 2. Apply the supplementary term in the loss computation

Locate where the WSS / wall_shear MSE is computed. After the existing `F.mse_loss(pred_wss, gt_wss)`, wrap the combined loss:

```python
loss_wss_mse = F.mse_loss(pred_wss, gt_wss)  # existing
if config.wss_charbonnier_weight > 0.0:
    loss_wss_charb = charbonnier_loss(pred_wss, gt_wss, eps=config.wss_charbonnier_eps)
    loss_wss = loss_wss_mse + config.wss_charbonnier_weight * loss_wss_charb
else:
    loss_wss = loss_wss_mse
```

The `pred_wss` / `gt_wss` tensors are whatever the existing code uses for the wall_shear branch — just identify those names from the current code.

### 3. Log both components for diagnostics

Log `train/loss_wss_mse` and `train/loss_wss_charb_unweighted` separately each step (or at least every 100 steps) so we can see the ratio at steady state. Target: Charbonnier should be 0.05-0.2× of MSE at steady state; if >0.5× the weight is too high.

### 4. Run command (exact, single-variable vs SOTA #972)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h10_wss_charbonnier \
  --epochs 30 --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --use-gradnorm --gradnorm-alpha 0.5 \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --wss-charbonnier-weight 0.1 \
  --wss-charbonnier-eps 1e-3 \
  --wandb-group wss_h10_charbonnier \
  --wandb-name dl24-frieren/h10-wss-charbonnier-w-0p1-eps-1e-3 \
  --agent dl24-frieren
```

**Only two new flags vs SOTA #972**: `--wss-charbonnier-weight 0.1` and `--wss-charbonnier-eps 1e-3`. All architecture, optimizer, schedule, and data settings bit-identical to SOTA.

## Baseline

Current SOTA — PR #972, run `56bcqp3m` (eval `zxnhtagj`), dataset `rawcanon_20260511`:

| Metric | SOTA #972 |
|---|---:|
| test_abupt | 5.844% |
| test_vol_p | **3.643%** ← floor |
| test_surf_p | **3.577%** ← floor |
| test_wss | 6.727% ← primary target |
| test_τ_x | 5.971% |
| test_τ_y | 7.362% |
| test_τ_z | 8.747% |

**Issue #1056 hard floors**: test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577% (AND-clause, must hold)
**Ultimate target**: test_wss < 5.85% (Transolver-3 SOTA)

Best WSS in wave: H5 tanjiro test_wss=6.609% (−0.118pp, but vol_p floor breach — see W&B `lbi210l2`)

## Gates and monitoring

Run at ~5 steps/s on 8× H100 → 30 epochs ≈ 33 hours.

| Gate | Val_abupt ≤ | Val_wss ≤ | Val_vol_p ≤ | Notes |
|---|---:|---:|---:|---|
| EP3 (~2h) | 7.0% | 7.4% | 5.0% | Loose — floor not at risk by construction |
| EP6 (~4h) | 6.7% | 7.2% | 4.6% | If wss not descending: flag |
| **EP10 (~7h)** | 6.5% | **7.0%** | 4.3% | **Key gate: must beat 7.0% to validate mechanism** |
| EP15 (~10h) | 6.3% | **6.85%** | 4.1% | Must beat H5/H6 plateau at [6.96, 6.99] |
| EP20 (~14h) | 6.2% | 6.75% | 4.2% | Trend confirmation |
| EP30 (terminal) | — | — | — | Full test eval at best-val EMA |

**If EP15 val_wss is in [6.96, 6.99]** (same as H5/H6 plateau): Charbonnier at weight=0.1 is not differentiating vs MSE. Flag immediately — I'll assign a follow-up with weight=0.3 or 0.5. Do NOT ride to EP30 if EP15 is plateau-equivalent.

## Watch points

1. **τ_z bellwether**: Watch `val_primary/wall_shear_z_rel_l2_pct`. Target: ≤8.50% at terminal (H5 hit 8.592%). Biggest gain should come here.

2. **MSE/Charbonnier ratio at steady state**: `train/loss_wss_charb_unweighted` should be 0.05-0.2× of `train/loss_wss_mse`. If >0.5×, weight=0.1 is overloaded; flag.

3. **No vol_p / surf_p drift expected**: By construction. If you see either drifting after EP5, that's unrelated to the mechanism — report it anyway.

4. **EP10-EP15 differentiation window**: MSE vs Charbonnier diverge most in mid-training where residuals are moderate. Watch val_wss slope EP10→EP15 — should accelerate downward vs the [6.96, 6.99] plateau we saw in H5/H6.

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"full_val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Plus full markdown report with all per-axis test metrics, hypothesis verdict, and MSE vs Charbonnier loss term trajectory at EP1-5, EP10-15, EP20-30.
