### PR TITLE
Wave 30 H11: multi-scale kNN-pooled local context features (9 channels at k=4/16/64)

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -7,6 +7,7 @@ from .loader import (
     EXPECTED_SURFACE_SPLIT_COUNTS,
     SURFACE_TARGET_NAMES,
     SURFACE_X_DIM,
+    SURFACE_X_DIM_BASE,
     SURFACE_Y_DIM,
     VOLUME_TARGET_NAMES,
     VOLUME_X_DIM,
@@ -16,7 +17,9 @@ from .loader import (
     DrivAerMLSurfaceDataset,
     SurfaceBatch,
     load_data,
+    multiscale_surface_dim,
     pad_collate,
+    parse_multiscale_k_values,
 )
 
 __all__ = [
@@ -24,6 +27,7 @@ __all__ = [
     "EXPECTED_SURFACE_SPLIT_COUNTS",
     "SURFACE_TARGET_NAMES",
     "SURFACE_X_DIM",
+    "SURFACE_X_DIM_BASE",
     "SURFACE_Y_DIM",
     "VOLUME_TARGET_NAMES",
     "VOLUME_X_DIM",
@@ -33,5 +37,7 @@ __all__ = [
     "DrivAerMLSurfaceDataset",
     "SurfaceBatch",
     "load_data",
+    "multiscale_surface_dim",
     "pad_collate",
+    "parse_multiscale_k_values",
 ]

--- a/data/loader.py
+++ b/data/loader.py
@@ -35,10 +35,15 @@ from torch.utils.data import Dataset
 from .split_utils import expand_pvc_candidates, first_existing
 
 DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest.json")
-SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM_BASE = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM = SURFACE_X_DIM_BASE  # default surface input dim; overridden when multi-scale features are enabled
 SURFACE_Y_DIM = 4  # cp(1) + wall shear stress(3)
 VOLUME_X_DIM = 4  # xyz(3) + sdf(1)
 VOLUME_Y_DIM = 1  # volume pressure
+MULTISCALE_FEATURES_PER_K = 3  # (cos_align, log1p(area), log1p(dist)) per scale
+MULTISCALE_AREA_SCALE = 1.0e6  # scales panel area (m^2) to ~unit range before log1p
+MULTISCALE_DIST_SCALE = 1.0e3  # scales kNN distance (m) to ~unit range before log1p
+MULTISCALE_CACHE_VERSION = "v1"
 SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")
 VOLUME_TARGET_NAMES = ("volume_pressure",)
 EXPECTED_SURFACE_SPLIT_COUNTS = {"train": 400, "val": 34, "test": 50}
@@ -269,12 +274,154 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+def parse_multiscale_k_values(spec: str | tuple[int, ...] | list[int] | None) -> tuple[int, ...]:
+    """Parse a multi-scale kNN spec like ``"4,16,64"`` to a tuple of ints.
+
+    Returns an empty tuple when ``spec`` is falsy. Validates that each k is a
+    positive integer. Order is preserved so the cache key (``k4_16_64``)
+    matches the channel layout in the cached array.
+    """
+
+    if spec is None:
+        return ()
+    if isinstance(spec, str):
+        if not spec.strip():
+            return ()
+        parts = [token.strip() for token in spec.split(",") if token.strip()]
+    else:
+        parts = list(spec)
+    out: list[int] = []
+    for token in parts:
+        k = int(token)
+        if k < 1:
+            raise ValueError(f"multiscale_k_values entries must be positive, got {k}")
+        out.append(k)
+    return tuple(out)
+
+
+def multiscale_surface_dim(k_values: tuple[int, ...] | None) -> int:
+    """Return the surface_x dim contributed by multi-scale features."""
+
+    if not k_values:
+        return 0
+    return MULTISCALE_FEATURES_PER_K * len(k_values)
+
+
+def _multiscale_cache_path(case_dir: Path, k_values: tuple[int, ...]) -> Path:
+    k_key = "_".join(str(k) for k in k_values)
+    return case_dir / f"surface_multiscale_k{k_key}_{MULTISCALE_CACHE_VERSION}.npy"
+
+
+def _compute_multiscale_features(
+    xyz_full: np.ndarray,
+    normals_full: np.ndarray,
+    area_full: np.ndarray,
+    k_values: tuple[int, ...],
+) -> np.ndarray:
+    """Compute multi-scale per-vertex kNN context features.
+
+    For each scale ``k`` in ``k_values`` we emit 3 channels:
+        * mean cosine alignment of neighbor unit normals to self normal
+        * log1p of mean panel area in the k-neighborhood (after scaling)
+        * log1p of mean L2 distance to the k nearest neighbors (after scaling)
+
+    The query excludes the self point. Returns ``[N, 3 * len(k_values)]``
+    float32. Requires SciPy (``cKDTree``); raises ``RuntimeError`` if missing.
+    """
+
+    try:
+        from scipy.spatial import cKDTree
+    except ImportError as exc:  # pragma: no cover - dependency required for this feature path
+        raise RuntimeError(
+            "Multi-scale kNN features require scipy.spatial.cKDTree. "
+            "Install scipy (>=1.10) to enable --use-multiscale-context."
+        ) from exc
+
+    if not k_values:
+        raise ValueError("k_values must be non-empty for multi-scale feature compute")
+
+    n_points = xyz_full.shape[0]
+    k_max = max(k_values)
+    if n_points <= k_max:
+        raise ValueError(
+            f"case has only {n_points} surface points; need > max(k_values)={k_max}"
+        )
+
+    xyz_64 = xyz_full.astype(np.float64, copy=False)
+    tree = cKDTree(xyz_64)
+    distances, indices = tree.query(xyz_64, k=k_max + 1, workers=-1)
+    distances = distances.astype(np.float32, copy=False)
+    indices = indices.astype(np.int64, copy=False)
+
+    normals_unit = normals_full.astype(np.float32, copy=False)
+    normals_unit = normals_unit / (
+        np.linalg.norm(normals_unit, axis=1, keepdims=True) + 1.0e-8
+    )
+    area_flat = area_full.astype(np.float32, copy=False).reshape(-1)
+
+    out_channels: list[np.ndarray] = []
+    for k in k_values:
+        nbr_idx = indices[:, 1 : k + 1]
+        nbr_normals = normals_unit[nbr_idx]
+        cos_align = np.einsum("nd,nkd->nk", normals_unit, nbr_normals).mean(axis=1)
+        cos_align = np.clip(cos_align, -1.0, 1.0).astype(np.float32)
+
+        mean_area = area_flat[nbr_idx].mean(axis=1)
+        mean_dist = distances[:, 1 : k + 1].mean(axis=1)
+        log_area = np.log1p(np.maximum(mean_area * MULTISCALE_AREA_SCALE, 0.0)).astype(np.float32)
+        log_dist = np.log1p(np.maximum(mean_dist * MULTISCALE_DIST_SCALE, 0.0)).astype(np.float32)
+
+        out_channels.extend([cos_align, log_area, log_dist])
+
+    return np.stack(out_channels, axis=1).astype(np.float32, copy=False)
+
+
+def _load_or_compute_multiscale_features(
+    case_dir: Path,
+    k_values: tuple[int, ...],
+    *,
+    full_rows: int | None = None,
+) -> np.ndarray:
+    """Return ``[N_full, 3 * len(k_values)]`` features, computing once and caching.
+
+    The cache filename encodes the exact ``k_values`` so different combinations
+    coexist. Writes through a ``.tmp.npy`` rename to be safe under parallel
+    worker access. If the file exists and its first-axis length matches
+    ``full_rows`` (when provided) it is returned via mmap; otherwise it is
+    re-computed and overwritten.
+    """
+
+    cache = _multiscale_cache_path(case_dir, k_values)
+    if cache.exists():
+        try:
+            arr = np.load(cache, mmap_mode="r")
+            expected_cols = MULTISCALE_FEATURES_PER_K * len(k_values)
+            shape_ok = arr.ndim == 2 and arr.shape[1] == expected_cols
+            len_ok = full_rows is None or arr.shape[0] == full_rows
+            if shape_ok and len_ok:
+                return arr
+        except (ValueError, OSError):
+            # Corrupt or partial write — fall through and rebuild.
+            pass
+
+    xyz_full = np.load(_resolve_artifact_path(case_dir / "surface_xyz.npy"))
+    normals_full = np.load(_resolve_artifact_path(case_dir / "surface_normals.npy"))
+    area_full = np.load(_resolve_artifact_path(case_dir / "surface_area.npy"))
+    features = _compute_multiscale_features(xyz_full, normals_full, area_full, k_values)
+
+    tmp = cache.with_suffix(".tmp.npy")
+    np.save(tmp, features)
+    os.replace(tmp, cache)
+    return features
+
+
 def load_case(
     root: str | Path,
     case_id: str,
     *,
     surface_rows: np.ndarray | None = None,
     volume_rows: np.ndarray | None = None,
+    multiscale_k_values: tuple[int, ...] | None = None,
 ) -> DrivAerMLCase:
     case_dir = _case_dir(Path(root), case_id)
     xyz = _load_npy_rows(case_dir / "surface_xyz.npy", surface_rows)
@@ -285,7 +432,18 @@ def load_case(
         _load_npy_rows(case_dir / "surface_wallshearstress.npy", surface_rows),
         "surface_wallshearstress.npy",
     )
-    surface_x = np.concatenate([xyz, normals, area], axis=1)
+    surface_parts = [xyz, normals, area]
+    if multiscale_k_values:
+        full_rows = _npy_row_count(case_dir / "surface_xyz.npy")
+        features_full = _load_or_compute_multiscale_features(
+            case_dir, multiscale_k_values, full_rows=full_rows
+        )
+        if surface_rows is None:
+            features = np.asarray(features_full, dtype=np.float32)
+        else:
+            features = np.asarray(features_full[surface_rows], dtype=np.float32)
+        surface_parts.append(features)
+    surface_x = np.concatenate(surface_parts, axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [
@@ -338,8 +496,15 @@ class DrivAerMLCaseStore:
         *,
         surface_rows: np.ndarray | None = None,
         volume_rows: np.ndarray | None = None,
+        multiscale_k_values: tuple[int, ...] | None = None,
     ) -> DrivAerMLCase:
-        return load_case(self.root, case_id, surface_rows=surface_rows, volume_rows=volume_rows)
+        return load_case(
+            self.root,
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+            multiscale_k_values=multiscale_k_values,
+        )
 
     def case_point_counts(self, case_id: str) -> dict[str, int]:
         cached = self._point_count_cache.get(case_id)
@@ -367,6 +532,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        multiscale_k_values: tuple[int, ...] | None = None,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +542,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.multiscale_k_values = tuple(multiscale_k_values) if multiscale_k_values else ()
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -444,6 +611,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             view.case_id,
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
+            multiscale_k_values=self.multiscale_k_values or None,
         )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
@@ -473,10 +641,12 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
     max_surface_n = max(sample.surface_x.shape[0] for sample in samples)
     max_volume_n = max(sample.volume_x.shape[0] for sample in samples)
     batch_size = len(samples)
-    surface_x = torch.zeros(batch_size, max_surface_n, SURFACE_X_DIM, dtype=samples[0].surface_x.dtype)
+    surface_x_dim = int(samples[0].surface_x.shape[1])
+    volume_x_dim = int(samples[0].volume_x.shape[1])
+    surface_x = torch.zeros(batch_size, max_surface_n, surface_x_dim, dtype=samples[0].surface_x.dtype)
     surface_y = torch.zeros(batch_size, max_surface_n, SURFACE_Y_DIM, dtype=samples[0].surface_y.dtype)
     surface_mask = torch.zeros(batch_size, max_surface_n, dtype=torch.bool)
-    volume_x = torch.zeros(batch_size, max_volume_n, VOLUME_X_DIM, dtype=samples[0].volume_x.dtype)
+    volume_x = torch.zeros(batch_size, max_volume_n, volume_x_dim, dtype=samples[0].volume_x.dtype)
     volume_y = torch.zeros(batch_size, max_volume_n, VOLUME_Y_DIM, dtype=samples[0].volume_y.dtype)
     volume_mask = torch.zeros(batch_size, max_volume_n, dtype=torch.bool)
     for i, sample in enumerate(samples):
@@ -544,6 +714,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    multiscale_k_values: tuple[int, ...] | None = None,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +739,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        multiscale_k_values=multiscale_k_values,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +748,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            multiscale_k_values=multiscale_k_values,
         )
     }
     test_splits = {
@@ -585,6 +758,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            multiscale_k_values=multiscale_k_values,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/prewarm_multiscale.py
+++ b/prewarm_multiscale.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Pre-warm the multi-scale kNN feature cache for all train+val+test cases.
+
+Computing per-case features lazily inside DataLoader workers (32 concurrent
+processes on an 8-rank DDP run) over-subscribes the CPUs because both
+``cKDTree(..., workers=-1)`` and BLAS-backed numpy operations grab every
+available core inside each worker. This script runs the same feature compute
+sequentially within each subprocess and parallelises across cases via
+``concurrent.futures.ProcessPoolExecutor``, with strict per-worker thread
+caps so the wall-clock cost is bounded.
+
+Usage::
+
+    uv run python prewarm_multiscale.py \
+        --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+        --multiscale-k-values 4,16,64 \
+        --processes 16
+
+The cache is co-located in each case directory and shared across all training
+runs, so this script is a one-time cost per ``k_values`` tuple.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+
+def _limit_threads(n: int) -> None:
+    """Cap per-process numpy/BLAS/MKL threads to avoid CPU over-subscription."""
+
+    n = max(1, int(n))
+    for var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    ):
+        os.environ[var] = str(n)
+
+
+def _worker(args: tuple[str, str, tuple[int, ...], int]) -> tuple[str, float, str]:
+    case_id, root, k_values, threads = args
+    _limit_threads(threads)
+    # Imports happen inside the subprocess so the thread caps above take effect
+    # before BLAS is initialised.
+    from data.loader import (  # noqa: E402  (intentional late import)
+        _load_or_compute_multiscale_features,
+        _npy_row_count,
+        _case_dir,
+    )
+
+    case_dir = _case_dir(Path(root), case_id)
+    full_rows = _npy_row_count(case_dir / "surface_xyz.npy")
+    t0 = time.time()
+    arr = _load_or_compute_multiscale_features(case_dir, k_values, full_rows=full_rows)
+    elapsed = time.time() - t0
+    return case_id, elapsed, f"shape={arr.shape}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-root",
+        required=True,
+        help="DrivAerML processed root, e.g. /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="data/split_manifest.json",
+        help="Path to split manifest JSON",
+    )
+    parser.add_argument(
+        "--multiscale-k-values",
+        default="4,16,64",
+        help="Comma-separated kNN scales (default: 4,16,64)",
+    )
+    parser.add_argument(
+        "--processes",
+        type=int,
+        default=8,
+        help="Number of subprocesses to use for feature compute (default: 8)",
+    )
+    parser.add_argument(
+        "--threads-per-process",
+        type=int,
+        default=0,
+        help="Per-process thread cap for numpy/cKDTree. 0 -> auto-pick (cpu_count // processes).",
+    )
+    parser.add_argument(
+        "--splits",
+        default="train,val,test",
+        help="Splits to pre-warm (default: all three)",
+    )
+    args = parser.parse_args()
+
+    from data.loader import (  # noqa: E402  (relies on data module being importable)
+        DrivAerMLCaseStore,
+        parse_multiscale_k_values,
+    )
+
+    k_values = parse_multiscale_k_values(args.multiscale_k_values)
+    if not k_values:
+        raise SystemExit("--multiscale-k-values must be non-empty (e.g. '4,16,64')")
+
+    store = DrivAerMLCaseStore(manifest_path=args.manifest, root=args.data_root)
+    splits = [s.strip() for s in args.splits.split(",") if s.strip()]
+    case_ids: list[str] = []
+    seen: set[str] = set()
+    for split in splits:
+        for cid in store.case_ids(split):
+            if cid not in seen:
+                seen.add(cid)
+                case_ids.append(cid)
+
+    n_cpus = os.cpu_count() or 8
+    threads = args.threads_per_process or max(1, n_cpus // max(1, args.processes))
+    print(
+        f"Pre-warming multi-scale cache for {len(case_ids)} cases | "
+        f"k_values={list(k_values)} | processes={args.processes} | "
+        f"threads/process={threads} | data_root={store.root}"
+    )
+
+    futures_args = [(cid, str(store.root), tuple(k_values), threads) for cid in case_ids]
+    successes: list[tuple[str, float, str]] = []
+    failures: list[tuple[str, str]] = []
+    t_start = time.time()
+    with ProcessPoolExecutor(max_workers=args.processes) as pool:
+        future_map = {pool.submit(_worker, fa): fa[0] for fa in futures_args}
+        for i, fut in enumerate(as_completed(future_map), start=1):
+            case_id = future_map[fut]
+            try:
+                result = fut.result()
+                successes.append(result)
+                elapsed = result[1]
+                wall = time.time() - t_start
+                print(
+                    f"  [{i}/{len(case_ids)}] {case_id}: {elapsed:.1f}s ({result[2]}) "
+                    f"wall={wall/60:.1f}min"
+                )
+            except Exception as exc:  # pragma: no cover - prewarm diagnostic
+                failures.append((case_id, repr(exc)))
+                print(f"  [{i}/{len(case_ids)}] {case_id}: FAILED -> {exc!r}")
+
+    total = time.time() - t_start
+    print(
+        f"\nDone in {total/60:.1f}min. "
+        f"{len(successes)} succeeded, {len(failures)} failed."
+    )
+    if failures:
+        for cid, err in failures:
+            print(f"  FAIL {cid}: {err}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "wandb",
     "pyyaml",
     "lion-pytorch>=0.2.4",
+    "scipy>=1.17.1",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -32,7 +32,12 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import (
+    DrivAerMLSurfaceDataset,
+    SURFACE_X_DIM_BASE,
+    multiscale_surface_dim,
+    parse_multiscale_k_values,
+)
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -103,6 +108,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_multiscale_context: bool = False
+    multiscale_k_values: str = "4,16,64"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +236,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_multiscale_context": (
+            "Enable PR #1150 multi-scale kNN-pooled local context features. "
+            "Adds 3 statistics x len(--multiscale-k-values) channels to the "
+            "7-channel surface input: per-vertex mean cosine alignment of "
+            "neighbor normals, log1p(mean panel area) and log1p(mean kNN "
+            "distance) at each scale. Computed once per case on the full "
+            "mesh via scipy cKDTree and cached as "
+            "surface_multiscale_k{ks}_v1.npy in each case directory."
+        ),
+        "multiscale_k_values": (
+            "Comma-separated kNN scales for --use-multiscale-context "
+            "(e.g. '4,16,64'). Each k produces 3 input channels."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +314,74 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def resolve_surface_input_dim(config: Config) -> int:
+    """Compute the surface_x feature dimension implied by ``config``.
+
+    Returns the base SURFACE_X_DIM (xyz + normals + area = 7) plus 3 channels
+    per kNN scale when --use-multiscale-context is enabled.
+    """
+
+    if not config.use_multiscale_context:
+        return SURFACE_X_DIM_BASE
+    k_values = parse_multiscale_k_values(config.multiscale_k_values)
+    if not k_values:
+        raise ValueError(
+            "--use-multiscale-context requires --multiscale-k-values to be a "
+            "non-empty comma-separated list of positive ints (e.g. '4,16,64')."
+        )
+    return SURFACE_X_DIM_BASE + multiscale_surface_dim(k_values)
+
+
+def log_multiscale_input_stats(config: Config, train_loader: DataLoader) -> None:
+    """Log per-channel statistics of the multi-scale kNN features for one case.
+
+    Only logs when --use-multiscale-context is enabled. Pulls one full sample
+    from ``train_loader.dataset`` (no shuffling needed; we just need a real
+    case) and writes mean/std/p95 of each of the ``3 * len(k_values)`` extra
+    channels to ``wandb.summary`` under ``multiscale/*``. Triggers feature
+    compute for that case if not yet cached, which is harmless (the same
+    compute will run again on the first training batch otherwise).
+    """
+
+    import numpy as np  # local import keeps train.py module import light
+
+    k_values = parse_multiscale_k_values(config.multiscale_k_values)
+    if not k_values:
+        return
+    try:
+        sample = train_loader.dataset[0]
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        print(f"multiscale stats: could not load sample: {exc}")
+        return
+    ms = sample.surface_x[:, SURFACE_X_DIM_BASE:].numpy()
+    expected_dim = multiscale_surface_dim(k_values)
+    if ms.shape[-1] != expected_dim:
+        print(
+            f"multiscale stats: expected {expected_dim} extra channels, "
+            f"got {ms.shape[-1]} (cache shape mismatch?)"
+        )
+        return
+    stat_names = ("cos_align", "log_area", "log_dist")
+    summary: dict[str, float] = {}
+    for ki, k in enumerate(k_values):
+        for si, stat_name in enumerate(stat_names):
+            col = ms[:, ki * len(stat_names) + si]
+            summary[f"multiscale/k{k}/{stat_name}_mean"] = float(col.mean())
+            summary[f"multiscale/k{k}/{stat_name}_std"] = float(col.std())
+            summary[f"multiscale/k{k}/{stat_name}_p05"] = float(np.percentile(col, 5))
+            summary[f"multiscale/k{k}/{stat_name}_p50"] = float(np.percentile(col, 50))
+            summary[f"multiscale/k{k}/{stat_name}_p95"] = float(np.percentile(col, 95))
+    summary["multiscale/k_values"] = ",".join(str(k) for k in k_values)
+    summary["multiscale/surface_input_dim"] = int(sample.surface_x.shape[-1])
+    summary["multiscale/sample_case_id"] = str(sample.case_id)
+    wandb.summary.update(summary)
+    print(
+        f"Multi-scale context enabled: k_values={list(k_values)}, "
+        f"surface_input_dim={sample.surface_x.shape[-1]}, "
+        f"sample={sample.case_id}, extra channels={ms.shape[-1]}"
+    )
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +396,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        surface_input_dim=resolve_surface_input_dim(config),
     )
 
 
@@ -683,6 +772,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        multiscale_k_values=getattr(old_ds, "multiscale_k_values", ()) or None,
     )
     train_sampler = None
     train_shuffle = True
@@ -883,6 +973,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.use_multiscale_context:
+                log_multiscale_input_stats(config, train_loader)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -30,6 +30,7 @@ from data import (
     VOLUME_Y_DIM,
     load_data,
     pad_collate,
+    parse_multiscale_k_values,
 )
 
 
@@ -278,6 +279,16 @@ def make_loaders(
     config,
     distributed_state: DistributedState | None = None,
 ) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
+    multiscale_k_values: tuple[int, ...] | None = None
+    if getattr(config, "use_multiscale_context", False):
+        spec = getattr(config, "multiscale_k_values", "") or ""
+        parsed = parse_multiscale_k_values(spec)
+        if not parsed:
+            raise ValueError(
+                "--use-multiscale-context requires --multiscale-k-values to be a "
+                "non-empty comma-separated list of positive ints (e.g. '4,16,64')."
+            )
+        multiscale_k_values = parsed
     train_ds, val_splits, test_splits, stats = load_data(
         manifest_path=config.manifest,
         root=config.data_root or None,
@@ -286,6 +297,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        multiscale_k_values=multiscale_k_values,
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**Multi-scale kNN-pooled local context features (H11).** For each surface point, precompute pooled geometric statistics within k=4, k=16, k=64 nearest-neighbor balls in 3D space: mean normal alignment `<n_i, n_j>`, mean panel area, mean curvature κ_i = `mean(1 - <n_i, n_j>)`. Concatenate as **9 additional surface channels** (3 statistics × 3 scales). Provides the model with **explicit multi-scale geometric context** that pure attention currently captures only implicitly through long-range interactions.

**Why this attacks the τ_z bottleneck:**

The **6-of-6 Wave 30 model-side widening pattern** (your own H7 #1140 closed) decisively confirms the bottleneck is NOT at the model architecture layer. The unexplored attack surface is data-level signal injection. Three independent output-head attacks are now in flight (H6'/H10/H7). Two single-feature data attacks are in flight (H8 mirror-aug #1143, H9' single-scale curvature #1146). H11 escalates the data-level attack by providing **richer, multi-resolution geometric structure** as input — going beyond single-scale curvature to a full multi-scale local descriptor.

**Mechanism intuition:**

1. **Long-tail of τ_z error concentrates at scale-discontinuity regions.** Vehicle geometry has features at multiple scales — body panels (large k), door edges (medium k), mirror housings and sharp creases (small k). The model currently has to learn the right pooling scale for each surface region via attention — which is hard with only 128 slice tokens covering 65,536 points.
2. **Multi-scale pooling provides explicit geometric receptive field.** Like the multi-scale convolutional bag in PointNet++ / FPN-based 3D detection, kNN-pooled features at multiple scales give each token a pre-built multi-resolution context vector. The model can then learn *which* scale matters per region.
3. **Strong Kaggle pedigree.** Multi-scale kNN-pooled context features were the winning ingredient in recent Kaggle 3D-fluid benchmarks (e.g., Volkswagen-AI-Driven-Aerodynamics 2024 — top 3 solutions all used multi-scale neighborhood pooling).

**Orthogonal to all 11 in-flight axes:**

| Wave 30 axis | What it touches | H11 touches |
|---|---|---|
| H1 (#1139) | Input coord frame | Per-token statistics |
| H3 (#1138) | Soft slice routing | Token-level context |
| H4 (#1141) | Hard MoE routing | Token-level context |
| H6' (#1147) | Loss term | Input layer |
| H8 (#1143) | Input distribution (aug) | Per-token features (concat) |
| H9' (#1146) | Input: single-scale curvature | Input: 9-channel multi-scale context |
| H10 (#1148) | Output reparametrization | Input layer |
| **H11 (this PR)** | **Multi-scale input context** | — |

H11 is the only experiment that provides **multi-resolution pooled features** at the per-vertex level. Stacks cleanly with any winning output-head attack (H6', H10) or input attack (H8 mirror, H9' single-scale).

**Theoretical basis:**
- Qi et al., NeurIPS 2017 (PointNet++): multi-scale neighborhood grouping is the key to handling non-uniform point cloud density.
- Wang et al., TOG 2019 (DGCNN, EdgeConv): explicit local geometric features as input dramatically improve downstream prediction in 3D.
- Lin et al., CVPR 2017 (FPN): multi-scale feature pyramids handle scale-imbalance in long-tailed regression — exactly the τ_z bottleneck signature.

**This is NOT an ensemble.** Single model, single forward pass at test time. Just 9 additional input channels precomputed at data load time.

## Instructions

**Files to modify:**
- `target/data/loader.py` — change `SURFACE_X_DIM` from 7 to 16 (or thread via Config); precompute multi-scale kNN pooled features in `load_case`, cache to disk
- `target/train.py` — add `use_multiscale_context: bool = False` to Config; thread `surface_input_dim` through model construction

**Total LOC:** ~80 across 2 files. The bulk of LOC is in the kNN computation; the rest is just config plumbing.

### Step 1 — Add `--use-multiscale-context` flag in `target/train.py`

In `class Config` around line 86, add:

```python
use_multiscale_context: bool = False
multiscale_k_values: str = "4,16,64"  # comma-separated; produces 3×3=9 channels
```

The k_values are tunable; default produces channels at k=4 (fine), k=16 (medium), k=64 (coarse).

### Step 2 — Precompute multi-scale kNN features in `target/data/loader.py`

At line 38, modify `SURFACE_X_DIM`:

```python
SURFACE_X_DIM_BASE = 7  # xyz(3) + normals(3) + area(1)
SURFACE_X_DIM = SURFACE_X_DIM_BASE  # default; overridden if multi-scale enabled
# When use_multiscale_context=True, the loader pads to BASE + 3*len(k_values) channels.
```

The cleaner approach: make `SURFACE_X_DIM` truly dynamic — set it once at config-resolution time based on `--use-multiscale-context` and `--multiscale_k_values`. Pass `surface_input_dim` explicitly to model constructor.

In `load_case` after line 288 (where `surface_x = np.concatenate([xyz, normals, area], axis=1)`):

```python
# H11 multi-scale kNN context features (precomputed, cached per-case)
multiscale_features = _load_or_compute_multiscale_features(
    case_dir, xyz, normals, area, k_values=[4, 16, 64]
)  # [N, 9]: 3 stats × 3 scales
if multiscale_features is not None:
    surface_x = np.concatenate([surface_x, multiscale_features], axis=1)  # [N, 16]
```

Add `_load_or_compute_multiscale_features` helper:

```python
def _load_or_compute_multiscale_features(
    case_dir: Path, xyz: np.ndarray, normals: np.ndarray, area: np.ndarray,
    k_values: list[int],
) -> np.ndarray | None:
    """Compute (or load cached) multi-scale kNN pooled features.

    For each k in k_values, computes 3 per-vertex statistics:
      - mean cosine alignment of neighborhood normals to self normal (=1 - curvature_k)
      - mean panel area in k-NN
      - mean L2 distance to k-NN points

    Returns [N, 3 * len(k_values)] float32, or None if N is too small.
    Cached per-case per-(k_values tuple) to disk for fast reload.
    """
    if xyz.shape[0] < max(k_values) + 1:
        return None
    k_key = "_".join(str(k) for k in k_values)
    cache_path = case_dir / f"surface_multiscale_k{k_key}.npy"
    if cache_path.exists():
        return np.load(cache_path).astype(np.float32)

    from sklearn.neighbors import NearestNeighbors
    nbrs = NearestNeighbors(n_neighbors=max(k_values) + 1, algorithm="auto").fit(xyz)
    distances, indices = nbrs.kneighbors(xyz)  # [N, K_max+1], including self at index 0

    n_norm = normals / (np.linalg.norm(normals, axis=1, keepdims=True) + 1e-8)
    features = []
    for k in k_values:
        idx_k = indices[:, 1:k+1]  # exclude self
        # Stat 1: mean cosine alignment of neighbor normals to own normal
        cos_align = (n_norm[:, None, :] * n_norm[idx_k, :]).sum(axis=2).mean(axis=1)  # [N]
        # Stat 2: mean panel area in neighborhood
        mean_area = area[idx_k].mean(axis=1).flatten()  # [N]
        # Stat 3: mean L2 distance to k-NN (locality scale)
        mean_dist = distances[:, 1:k+1].mean(axis=1)  # [N]
        features.extend([cos_align, mean_area, mean_dist])

    out = np.stack(features, axis=1).astype(np.float32)  # [N, 9]
    np.save(cache_path, out)
    return out
```

**Implementation notes for the student:**
- `sklearn.neighbors.NearestNeighbors` is already used elsewhere in the codebase — safe import.
- First-time computation per case: ~200ms at 65k points; subsequent loads ~5ms. The cache pays for itself on epoch 2.
- Normalize each feature column to z-score across the training set before model ingestion. Add a `normalizers.json` entry or compute mean/std from a single pass.
- If `use_multiscale_context` is False, the loader behaves exactly as before (SURFACE_X_DIM=7).

### Step 3 — Thread surface_input_dim to model constructor

In `target/train.py`'s `build_model` factory, compute:

```python
surface_input_dim = SURFACE_X_DIM_BASE
if config.use_multiscale_context:
    k_values = [int(k) for k in config.multiscale_k_values.split(",")]
    surface_input_dim += 3 * len(k_values)  # 3 stats per scale
```

Pass to `SurfaceTransolver(surface_input_dim=surface_input_dim, ...)`.

### Step 4 — Sanity smoke before full launch

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1 --use-multiscale-context`) and confirm:
- First case takes ~200ms longer (kNN compute); subsequent loads ~5ms (cache hit)
- No NaN in `train/nonfinite_loss`
- `surface_x.shape[-1] == 16` (verify the input dim was threaded correctly)
- Per-channel statistics look reasonable (mean cos_align ∈ [0.8, 1.0], mean_dist correlates with k)

### Step 5 — Full training recipe (18h, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-multiscale-context --multiscale-k-values 4,16,64 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h11_multiscale_context \
  --wandb-name askeladd/multiscale-k4-16-64-18h --agent askeladd
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~28–33% (warmup) — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS
- EP13 terminal: full SENPAI-RESULT with **val AND test** scores (per #1056 directive)

### Step 6 — Reporting

Terminal `SENPAI-RESULT` must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← KEY structural metric
- best epoch + EMA vs raw
- per-channel statistics of the 9 multi-scale features (mean/std/p95 — 1 W&B log row at init is enough)

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | < 1.40 = mechanism PASS, < 1.30 = breakthrough |
| dl24-tanjiro #1132 reference | test_WSS=6.609% | curvature attention bias on parallel branch |

## What success looks like

- **BIG WIN**: test_WSS < 6.609% (beats dl24 reference) with all floors held AND test τz/τx ≤ 1.40. Multi-scale context unlocks the τ_z bottleneck via input signal — confirms the data-level attack thesis decisively.
- **MERGE**: test_WSS < 6.727% with both vol_p/SP floors held — single-model winner.
- **PARTIAL**: test_WSS within 0.1pp baseline but test_τ_z materially down — try `--multiscale-k-values 8,32,128` (coarser ranges) or stack with H8 mirror-aug.
- **FLAT NULL**: test_WSS unchanged AND test_τ_z unchanged — the implicit attention context was sufficient; explicit multi-scale features don't add information. Move to alternative data-level attacks (geodesic distance to feature, learned anisotropic basis).

**Why this is the right next experiment:** The 6-of-6 widening pattern says architecture is exhausted. H9' single-scale curvature is testing one data signal; H11 multi-scale context tests the *richer* version of the same axis. If single-scale wins big, H11 will compound; if single-scale fails, multi-scale could still succeed by capturing context that single-scale misses.

**Source:** Researcher-agent dispatch 2026-05-16. Wave 30 H11. Direct follow-up to your own H7 closure (mechanism-clean falsification motivates moving from architecture to data-level signal).

**Wave 30 fleet at launch:** 12 orthogonal attacks running in parallel (7 prior in-flight + H9' + H6' + H10 + this H11).
