### PR TITLE
Wave 30 H12: τ-magnitude-weighted surface MSE (per-token loss attack)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_magnitude_loss_alpha: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,6 +322,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_magnitude_loss_alpha: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,7 +334,31 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        diag: dict[str, float] = {}
+        if tau_magnitude_loss_alpha > 0.0:
+            # H12: per-vertex weighting of surface MSE by physical |tau|^alpha.
+            # Replaces surface_channel_weights when active.
+            surface_pred = out["surface_preds"]
+            tau_target_phys = transform.invert_surface(surface_target)[..., 1:4]
+            tau_mag = tau_target_phys.float().norm(dim=-1)  # [B, N]
+            mask_f = batch.surface_mask.to(tau_mag.dtype)
+            valid_count = mask_f.sum().clamp(min=1.0)
+            mean_mag = (tau_mag * mask_f).sum() / valid_count
+            weights = (tau_mag / mean_mag.clamp(min=1e-8)) ** tau_magnitude_loss_alpha  # [B, N]
+            weights = weights * mask_f  # zero out padding so it never contributes
+            diff_sq = (surface_pred.float() - surface_target.float()).square()  # [B, N, 4]
+            diff_sq_mean_chan = diff_sq.mean(dim=-1)  # [B, N]
+            weight_sum = weights.sum().clamp(min=1.0)
+            surface_loss = (diff_sq_mean_chan * weights).sum() / weight_sum
+            with torch.no_grad():
+                w_valid = weights[mask_f > 0]
+                if w_valid.numel() > 0:
+                    diag["tau_mag_weight_max"] = float(w_valid.max().item())
+                    diag["tau_mag_weight_p95"] = float(w_valid.quantile(0.95).item())
+                    diag["tau_mag_weight_p50"] = float(w_valid.quantile(0.50).item())
+                    diag["tau_mag_weight_min"] = float(w_valid.min().item())
+                    diag["tau_mag_weight_mean"] = float(w_valid.mean().item())
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +372,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +880,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.tau_magnitude_loss_alpha > 0.0:
+                print(
+                    f"H12 tau-magnitude surface MSE weighting: "
+                    f"alpha={config.tau_magnitude_loss_alpha} "
+                    f"(per-vertex w_i = (|tau_i| / batch_mean|tau|)^alpha)"
+                )
+                if use_channel_weights:
+                    print(
+                        "WARNING: --tau-magnitude-loss-alpha > 0 overrides "
+                        "--tau-y-loss-weight / --tau-z-loss-weight; channel weights are ignored."
+                    )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +922,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_magnitude_loss_alpha"] = config.tau_magnitude_loss_alpha
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1070,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_magnitude_loss_alpha=config.tau_magnitude_loss_alpha,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1068,8 +1109,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/tau_magnitude_loss_alpha": config.tau_magnitude_loss_alpha,
                         }
                     )
+                    for diag_key in (
+                        "tau_mag_weight_max",
+                        "tau_mag_weight_p95",
+                        "tau_mag_weight_p50",
+                        "tau_mag_weight_min",
+                        "tau_mag_weight_mean",
+                    ):
+                        if diag_key in batch_loss_metrics:
+                            train_log[f"train/{diag_key}"] = batch_loss_metrics[diag_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**τ-Magnitude-weighted Surface MSE Loss (H12).** Multiply per-vertex surface MSE by `w_i = (|τ_target_i| / batch_mean(|τ_target|))^α` so high-WSS regions (where τ_z is also largest) contribute proportionally more to the gradient. Sweep α ∈ {0.3, 0.5, 0.7}. Directly attacks the long-tail τ_z error distribution at the loss layer — a layer that is essentially **untouched** by the 11 in-flight Wave 30 axes (H6' is the only loss attack and is a *tangency* penalty, not a per-token weighting).

**Why this attacks the τ_z bottleneck:**

The **7-of-7 Wave 30 model-side widening pattern** (your own H1 #1139 just closed) decisively exhausts the architecture-layer attack surface. The bottleneck is at the data layer, output-head layer, or loss layer. We have 5 data-level + 3 output-head + 1 loss attacks in flight — the loss layer is the most under-explored remaining axis.

**Mechanism intuition:**

1. **τ_z error concentrates on high-magnitude tokens.** Vehicle WSS has a long-tailed magnitude distribution: small |τ| on flat body panels, large |τ| at separation cliffs (A-pillar, mirror housings, wing tips). The dominant axis error (τ_z) is *largest* where |τ| is largest — high-magnitude regions are where the model's poor τ_z fit hurts most.
2. **Standard MSE weights all tokens equally.** The current loss is `(1/N) Σ MSE_i`, treating a low-|τ| token (where the error is intrinsically small in absolute terms) and a high-|τ| token (where the error is large) as equal contributors. This is a **mismatch** between training signal and evaluation signal — the rel_l2 metric on test naturally weights high-magnitude regions more.
3. **τ-magnitude weighting aligns training with evaluation.** Multiplying by `(|τ_target_i| / mean)^α` makes high-WSS regions matter more in the gradient. At α=0 → equal weighting (baseline); at α=1 → fully magnitude-proportional weighting. α=0.3-0.7 is a sweep over the moderate regime.
4. **Empirically equivalent to importance sampling at the loss layer.** Same expected gradient as oversampling high-|τ| tokens during training, but cheaper (no resampling needed).

**Orthogonal to all 11 in-flight axes:**

| Wave 30 axis | What it touches | H12 touches |
|---|---|---|
| H3/H4 routing | Attention | Loss weighting |
| H6' (#1147) | Tangency penalty | Per-token weighting |
| H7 normal-aux | Aux head | Surface loss term |
| H8 mirror-aug | Data distribution | Loss layer |
| H9'/H11 | Input features | Loss layer |
| H10 vector-decoupled | Output reparametrization | Loss weighting |
| **H12 (this PR)** | **Per-token MSE weighting** | — |

H12 is the only experiment that introduces *per-token loss weighting based on target magnitude*. It stacks multiplicatively with any in-flight winner.

**Theoretical basis:**
- Lin et al., ICCV 2017 (Focal Loss): per-token weighted loss is the standard remedy for long-tailed classification — same principle applies to long-tailed regression.
- Karniadakis et al., Nature 2021 (PINN review): magnitude-aware loss weighting consistently improves regression of physical fields with multi-scale magnitude distributions.
- Kaggle empirical: importance-weighted MSE / weighted MAE consistently outperforms vanilla MSE on long-tailed regression problems (e.g., LANL Earthquake Prediction 2019 top solutions).

**Conservative α=0.3 default protects against the dl24 failure mode**: GradNorm crushed w_vol_p to 0.0064 by over-weighting the τ_z task. Our magnitude weighting is per-token within a task, not per-task, so it does NOT remove gradient budget from vol_p or cp. The α sweep keeps the maximum upweight bounded.

**This is NOT an ensemble.** Single model, single forward pass at test time. Just a per-vertex multiplier in the surface MSE term.

## Instructions

**Files to modify:**
- `target/train.py` — add `tau_magnitude_loss_alpha: float = 0.0` to Config (line 76 area); modify `train_loss` (line 314) to compute the magnitude weights and apply

**Total LOC:** ~25 in 1 file.

### Step 1 — Add `--tau-magnitude-loss-alpha` flag in `target/train.py`

In `class Config` around line 107 (next to `tau_z_loss_weight`), add:

```python
tau_magnitude_loss_alpha: float = 0.0
```

Default 0.0 preserves baseline behavior exactly. `parse_args` reflection auto-generates `--tau-magnitude-loss-alpha`.

### Step 2 — Compute the per-vertex magnitude weight in `train_loss`

In `target/train.py` around line 343, replace the existing surface_loss computation with:

```python
# H12 τ-magnitude weighted surface MSE
if tau_magnitude_loss_alpha > 0.0:
    # surface_target = [cp, τ_x, τ_y, τ_z] in normalized space.
    # Compute weights from the physical-space WSS magnitude.
    tau_target_phys = transform.invert_surface(surface_target)[..., 1:4]  # [B, N, 3]
    tau_mag = tau_target_phys.norm(dim=-1)  # [B, N]
    # Per-batch normalization: divide by the batch-mean magnitude
    if batch.surface_mask is not None:
        mask_f = batch.surface_mask.to(tau_mag.dtype)
        mean_mag = (tau_mag * mask_f).sum() / mask_f.sum().clamp(min=1)
    else:
        mean_mag = tau_mag.mean()
    weights = (tau_mag / (mean_mag + 1e-8)) ** tau_magnitude_loss_alpha  # [B, N]
    # Apply per-vertex weighting in the MSE
    diff_sq = (out["surface_preds"] - surface_target) ** 2  # [B, N, 4]
    diff_sq_mean_chan = diff_sq.mean(dim=-1)  # [B, N] — channel-mean MSE
    if batch.surface_mask is not None:
        weighted_mse = (diff_sq_mean_chan * weights * mask_f).sum() / (weights * mask_f).sum().clamp(min=1)
    else:
        weighted_mse = (diff_sq_mean_chan * weights).mean()
    # Log the actual weighting statistics for diagnostic
    surface_loss = weighted_mse
else:
    if surface_channel_weights is not None:
        surface_loss = weighted_channel_mse(...)  # existing path unchanged
    else:
        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

**Implementation notes:**
- The `transform.invert_surface(...)` call converts normalized targets back to physical space so the magnitude weights are computed on physically meaningful values (not normalized residuals).
- The batch-mean normalization ensures `mean(weights) ≈ 1.0`, so the overall loss scale stays comparable to baseline.
- The `surface_channel_weights` path (which handles `tau_y_loss_weight` / `tau_z_loss_weight`) is preserved when `tau_magnitude_loss_alpha == 0.0`. When alpha > 0, the magnitude weighting **replaces** the channel weighting — the channel weights cancel out under the per-vertex multiplier. **Important: when running H12, do NOT also set `--tau-y-loss-weight` or `--tau-z-loss-weight` above 1.0** (or the test will be confounded; remove those flags from the recipe).

### Step 3 — Log diagnostic statistics

Add to the returned metrics dict (line 349):

```python
"tau_mag_weight_max": float(weights.max().detach().cpu().item()) if tau_magnitude_loss_alpha > 0 else 1.0,
"tau_mag_weight_p95": float(weights.flatten().quantile(0.95).detach().cpu().item()) if tau_magnitude_loss_alpha > 0 else 1.0,
"tau_mag_weight_p50": float(weights.flatten().quantile(0.50).detach().cpu().item()) if tau_magnitude_loss_alpha > 0 else 1.0,
```

The diagnostic lets us see how heavy the upweighting actually is. For α=0.5, expect p50 ≈ 0.7-0.9 and p95 ≈ 2.5-4.0.

### Step 4 — Sanity smoke before launches

Run a 200-step smoke (`SENPAI_TIMEOUT_MINUTES=5`, `--epochs 1 --tau-magnitude-loss-alpha 0.5`) and confirm:
- No NaN in `train/nonfinite_loss`
- `train/tau_mag_weight_p95` is in [1.5, 5.0] range
- `train/surface_loss` is comparable to baseline at step 200 (within 2×)
- Throughput within 1% of baseline

### Step 5 — α sweep recipe (3 parallel arms, 18h each)

Run 3 arms with `--wandb-group wave30_h12_tau_magnitude_sweep` so they're grouped:

**Arm A: α=0.3** — conservative, protects floors
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-magnitude-loss-alpha 0.3 \
  --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h12_tau_magnitude_sweep \
  --wandb-name edward/tau-mag-a0p3-18h --agent edward
```

**Note:** When using `--tau-magnitude-loss-alpha > 0`, **DO NOT** also pass `--tau-y-loss-weight` or `--tau-z-loss-weight > 1.0` (confounded test; the magnitude weighting subsumes those). The recipe above is correct.

**Arm B: α=0.5** — moderate (favorite first arm to run)
Same command, `--tau-magnitude-loss-alpha 0.5`, `--wandb-name edward/tau-mag-a0p5-18h`.

**Arm C: α=0.7** — aggressive
Same command, `--tau-magnitude-loss-alpha 0.7`, `--wandb-name edward/tau-mag-a0p7-18h`.

**Run Arm B first** (moderate, highest expected value). If Arm B wins, ship terminal and run A/C as confirmations. If Arm B partial-wins or null, sweep based on direction.

### EP gates (warmup=1 recipe, each arm)

- EP1 floor: val_abupt ~28–33% — DO NOT KILL
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS
- EP13 terminal: full SENPAI-RESULT with **val AND test** scores (per #1056 directive)

### Step 6 — Reporting

Terminal `SENPAI-RESULT` per arm must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, **test_τ_z**
- **test τz/τx ratio** ← KEY structural metric
- `train/tau_mag_weight_p95` final value (the diagnostic — confirms weighting was applied)
- best epoch + EMA vs raw

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor |
| test_SP | 3.577% | ≤ 3.577% floor |
| test τz/τx | ~1.46 | < 1.40 = mechanism PASS, < 1.30 = breakthrough |

## What success looks like

- **BIG WIN**: Any arm with test_WSS < 6.609% AND all floors held AND test τz/τx ≤ 1.40 — magnitude weighting + structural break = the lab's strongest single-model.
- **MERGE**: test_WSS < 6.727% with both vol_p/SP floors held — single-model winner.
- **PARTIAL**: test_WSS within 0.1pp baseline AND test τz/τx ≤ 1.45 — magnitude weighting helps but doesn't fully crack the bottleneck; try stacking with H9' curvature or H10 vector-decoupled.
- **FLAT NULL**: all 3 arms within 0.05pp baseline — magnitude weighting is too weak a signal. Suggest moving to focal-style loss (per-token error^γ weighting).
- **FLOOR-BREACH REGRESSION**: α=0.7 arm shows vol_p or SP breach — over-aggressive weighting starves the small-magnitude regions. α=0.3 should be the safe sweet spot.

**Why this is the right next experiment:** The 7-of-7 widening pattern says architecture is dead. The H6 mechanism PASS (test τz/τx=1.281) confirmed the bottleneck is at the output head. H6' attacks via tangency penalty, H10 via reparametrization, H11/H9' via input features. H12 is the only experiment that attacks the **training-objective alignment with evaluation metric** — directly addresses the long-tail mismatch.

**Source:** Researcher-agent dispatch 2026-05-16. Wave 30 H12. Direct follow-up to your own H1 closure (architecture-attack falsification motivates loss-layer attack).

**Wave 30 fleet at launch:** 8 active in-flight (+ H12) = 9 orthogonal attacks running. Wave 30 closed: H1, H2, H5, H6, H7. Wave 30 active: H3, H4, H6', H8, H9', H10, H11, H12.
