### PR TITLE
Wave 30 H13: tangent/normal anisotropic surface-loss decomposition (β_n=5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_anisotropic_loss_enable: bool = False
+    tau_anisotropic_alpha_tangent: float = 1.0
+    tau_anisotropic_beta_normal: float = 5.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -311,6 +314,91 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def tau_anisotropic_mse(
+    pred_surface: torch.Tensor,
+    target_surface: torch.Tensor,
+    mask: torch.Tensor,
+    surface_x: torch.Tensor,
+    alpha_tangent: float,
+    beta_normal: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Anisotropic surface MSE that decomposes the tau error along the
+    per-vertex normal/tangent frame.
+
+    Math identity: with unit normal n, the error ``e = pred - gt`` splits as
+    ``e = (e·n) n + (e - (e·n) n) = e_n + e_t`` with ``e_n ⟂ e_t``, so
+    ``‖e‖² = ‖e_t‖² + (e·n)²``. With ``alpha=beta=1``, the loss reduces to
+    ``masked_mse`` on the 4-channel surface output (averaging cp_err² + ‖tau_err‖²
+    over valid_points × 4).
+    """
+    if pred_surface.numel() == 0:
+        return pred_surface.sum() * 0.0, {
+            "tau_loss_tangent": 0.0,
+            "tau_loss_normal": 0.0,
+            "tau_normal_to_tangent_ratio": 0.0,
+            "tau_gt_tangent_magnitude": 0.0,
+            "tau_gt_normal_magnitude": 0.0,
+            "tau_gt_normal_to_tangent_ratio": 0.0,
+        }
+
+    work_dtype = torch.float32
+    pred = pred_surface.to(work_dtype)
+    tgt = target_surface.to(work_dtype)
+
+    cp_err_sq = (pred[..., 0:1] - tgt[..., 0:1]).square()  # [B, N, 1]
+
+    tau_pred = pred[..., 1:4]  # [B, N, 3]
+    tau_gt = tgt[..., 1:4]      # [B, N, 3]
+    err = tau_pred - tau_gt     # [B, N, 3]
+
+    # Per-vertex unit normal from surface_x channels 3,4,5; re-normalise to
+    # guard against bf16 / aug-pipeline drift away from unit length.
+    n = surface_x[..., 3:6].to(work_dtype)
+    n = n / n.norm(dim=-1, keepdim=True).clamp_min(1e-8)
+
+    err_n_scalar = (err * n).sum(dim=-1, keepdim=True)  # [B, N, 1]
+    err_t_vec = err - err_n_scalar * n                  # [B, N, 3]
+
+    tangent_sq = err_t_vec.square().sum(dim=-1, keepdim=True)  # [B, N, 1]
+    normal_sq = err_n_scalar.square()                           # [B, N, 1]
+
+    mask_dev = mask.to(device=pred.device, dtype=work_dtype).unsqueeze(-1)
+    valid_points = mask_dev.sum().clamp_min(1.0)
+
+    cp_term = cp_err_sq * mask_dev
+    tan_term = tangent_sq * mask_dev
+    nor_term = normal_sq * mask_dev
+
+    # 4-channel averaging budget so (alpha=1, beta=1) reproduces baseline
+    # masked_mse on [cp, tau_x, tau_y, tau_z] exactly.
+    denom = valid_points * 4.0
+    loss = (cp_term.sum() + alpha_tangent * tan_term.sum() + beta_normal * nor_term.sum()) / denom
+
+    # Diagnostics: per-channel error magnitudes (unweighted) plus GT decomposition
+    # magnitudes so we can read off the actual scale of the GT normal component.
+    with torch.no_grad():
+        tan_mean = tan_term.sum() / valid_points
+        nor_mean = nor_term.sum() / valid_points
+        gt_n_scalar = (tau_gt * n).sum(dim=-1, keepdim=True)
+        gt_n_sq = gt_n_scalar.square() * mask_dev
+        gt_t_vec = tau_gt - gt_n_scalar * n
+        gt_t_sq = gt_t_vec.square().sum(dim=-1, keepdim=True) * mask_dev
+        gt_tan_mean = gt_t_sq.sum() / valid_points
+        gt_nor_mean = gt_n_sq.sum() / valid_points
+        ratio = float(nor_mean / tan_mean.clamp_min(1e-12))
+        gt_ratio = float(gt_nor_mean / gt_tan_mean.clamp_min(1e-12))
+
+    diag = {
+        "tau_loss_tangent": float(tan_mean.cpu().item()),
+        "tau_loss_normal": float(nor_mean.cpu().item()),
+        "tau_normal_to_tangent_ratio": ratio,
+        "tau_gt_tangent_magnitude": float(gt_tan_mean.cpu().item()),
+        "tau_gt_normal_magnitude": float(gt_nor_mean.cpu().item()),
+        "tau_gt_normal_to_tangent_ratio": gt_ratio,
+    }
+    return loss, diag
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,10 +409,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_anisotropic_loss_enable: bool = False,
+    tau_anisotropic_alpha_tangent: float = 1.0,
+    tau_anisotropic_beta_normal: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    aniso_diag: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,7 +424,16 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if tau_anisotropic_loss_enable:
+            surface_loss, aniso_diag = tau_anisotropic_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                batch.surface_x,
+                tau_anisotropic_alpha_tangent,
+                tau_anisotropic_beta_normal,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +447,16 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if aniso_diag:
+        metrics.update(aniso_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +956,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.tau_anisotropic_loss_enable:
+                bypass_note = (
+                    " (channel weights bypassed — anisotropic loss runs in "
+                    "tangent/normal basis)"
+                    if use_channel_weights
+                    else ""
+                )
+                print(
+                    f"H13 anisotropic loss ENABLED: alpha_tangent="
+                    f"{config.tau_anisotropic_alpha_tangent} beta_normal="
+                    f"{config.tau_anisotropic_beta_normal}{bypass_note}"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +999,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_anisotropic_loss_enable"] = (
+                config.tau_anisotropic_loss_enable
+            )
+            wandb.summary["loss/tau_anisotropic_alpha_tangent"] = (
+                config.tau_anisotropic_alpha_tangent
+            )
+            wandb.summary["loss/tau_anisotropic_beta_normal"] = (
+                config.tau_anisotropic_beta_normal
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1155,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_anisotropic_loss_enable=config.tau_anisotropic_loss_enable,
+                        tau_anisotropic_alpha_tangent=config.tau_anisotropic_alpha_tangent,
+                        tau_anisotropic_beta_normal=config.tau_anisotropic_beta_normal,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1198,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for aniso_key in (
+                        "tau_loss_tangent",
+                        "tau_loss_normal",
+                        "tau_normal_to_tangent_ratio",
+                        "tau_gt_tangent_magnitude",
+                        "tau_gt_normal_magnitude",
+                        "tau_gt_normal_to_tangent_ratio",
+                    ):
+                        if aniso_key in batch_loss_metrics:
+                            train_log[f"train/{aniso_key}"] = batch_loss_metrics[aniso_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis (H13 — Tangent/Normal Anisotropic Loss Decomposition)

The Wave 30 fleet has now CLOSED **5 model-side architecture attacks** (#1136 H2, #1137 H5, #1138 H3, #1139 H1, #1140 H7) with a uniform terminal signature: clean val_abupt descent AND val τz/τx widening (1.50→1.55 band) AND test τz/τx collapsing back to ~baseline (1.44–1.47). The model-side / architecture-layer attack surface for the τ_z structural bottleneck is **definitively exhausted**.

The remaining attack surfaces are:
1. **Loss layer** — H6' soft τ·n=0 penalty (#1147 tanjiro, in-flight); H12 magnitude-weighted MSE (#1151 edward, in-flight)
2. **Output-head layer** — H10 vector-length-decoupled head (#1148 fern, in-flight)
3. **Data-input layer** — H8 mirror-symmetry aug (#1143 frieren), H9' curvature feature (#1146 nezuko), H11 multi-scale kNN context (#1150 askeladd) — all in-flight

**H13 fills a key gap on the loss layer**: a *geometric* loss reformulation that decomposes the surface τ prediction error along the **per-vertex normal direction** rather than in the Cartesian basis. The current MSE treats τ_x/τ_y/τ_z as 3 independent channels, but a wall shear stress vector is geometrically a vector that should be predominantly *tangent* to the surface (with a small noisy normal component from turbulence + FEM artifacts). Rotating into a per-vertex (tangent, normal) frame lets us apply **different relative weights to the tangent and normal components**, directly testing whether the τ_z bottleneck is caused by under-learning the GT normal-component or under-learning the tangent component.

**H13 is the symmetric opposite of H6'**:
- H6' (tanjiro #1147) penalizes `τ_pred · n` → pushes model toward tangent-only predictions
- H13 with β_normal > 1 explicitly upweights matching the GT normal component
- These hypotheses probe OPPOSITE causal directions; only one can be right at the τ_z bottleneck

If H13 with β_normal=5 helps absolute WSS: the model is currently under-predicting the noisy normal component and the loss needs to force it to match.
If H13 with β_normal=5 widens τz/τx + fails WSS: confirms that the long-tail normal component contains noise the model shouldn't fit AND that the bottleneck is at a higher level than the loss.
If H13 results parallel #1138 (clean abupt descent + τz/τx widening + test collapse): the τ_z bottleneck is downstream of point-wise loss weighting and likely structural (curvature features, multi-scale context, vector decoupling are the surviving probes).

## Instructions

**File to modify:** `target/train.py` (in `train_loss` function around line 320–355). Per-vertex surface normals are available at `batch.surface_x[..., 3:6]` (channels 3/4/5 of surface_x in the canonical [xyz, normals, area] layout — already L2-normalized to unit vectors by the dataset loader at `data/loader.py:288`).

### Implementation outline

Add two new Config dataclass fields near `surface_loss_weight`:
```python
@dataclass
class Config:
    ...
    surface_loss_weight: float = 1.0
    volume_loss_weight: float = 1.0
    # H13 anisotropic tangent/normal loss decomposition
    tau_anisotropic_loss_enable: bool = False
    tau_anisotropic_alpha_tangent: float = 1.0
    tau_anisotropic_beta_normal: float = 5.0
```

In `train_loss` (line ~326 onward), when `tau_anisotropic_loss_enable=True`, REPLACE the τ-channel portion of `surface_loss` with the decomposed version:

```python
def tau_anisotropic_mse(
    pred_surface: torch.Tensor,       # [B, N, 4]   normalized (cp, tau_x, tau_y, tau_z)
    target_surface: torch.Tensor,     # [B, N, 4]
    mask: torch.Tensor,               # [B, N]
    surface_x: torch.Tensor,          # [B, N, 7]
    alpha_tangent: float,
    beta_normal: float,
) -> tuple[torch.Tensor, dict[str, float]]:
    # cp loss unchanged
    cp_err_sq = (pred_surface[..., 0:1] - target_surface[..., 0:1]).square()  # [B,N,1]

    # tau vectors in normalized output space
    tau_pred = pred_surface[..., 1:4]     # [B, N, 3]
    tau_gt   = target_surface[..., 1:4]   # [B, N, 3]
    err = tau_pred - tau_gt               # [B, N, 3]

    # per-vertex unit normal from surface_x channels 3,4,5
    n = surface_x[..., 3:6]               # [B, N, 3]  unit (dataset loader normalizes)
    # safety re-norm (avoid drift from float16/aug pipeline)
    n = n / (n.norm(dim=-1, keepdim=True).clamp_min(1e-8))

    # decompose err into normal + tangent components
    err_n_scalar = (err * n).sum(dim=-1, keepdim=True)        # [B, N, 1]
    err_n_vec    = err_n_scalar * n                            # [B, N, 3]
    err_t_vec    = err - err_n_vec                             # [B, N, 3]

    tangent_sq = err_t_vec.square().sum(dim=-1, keepdim=True)  # [B, N, 1]
    normal_sq  = err_n_scalar.square()                          # [B, N, 1]

    # masked mean over valid points; concat cp + alpha*tan + beta*norm and average so the
    # gradient budget across the 4 surface channels is preserved relative to baseline (cp + 3 tau channels)
    weighted = torch.cat([cp_err_sq, alpha_tangent * tangent_sq, beta_normal * normal_sq], dim=-1)  # [B,N,3]
    mask_3 = mask.unsqueeze(-1).to(weighted.dtype)
    weighted = weighted * mask_3
    # divide by valid_points * (1 + 1 + 1) so unit-weight (1,1,1) gives baseline-equivalent MSE on 3 channels
    valid_points = mask_3.sum().clamp_min(1.0)
    loss = weighted.sum() / (valid_points * 3.0)
    diag = {
        "tau_loss_tangent": float((tangent_sq * mask_3[..., :1]).sum().detach().cpu() / valid_points.detach().cpu()),
        "tau_loss_normal":  float((normal_sq  * mask_3[..., :1]).sum().detach().cpu() / valid_points.detach().cpu()),
        "tau_normal_to_tangent_ratio": float((normal_sq.sum() / tangent_sq.sum().clamp_min(1e-8)).detach().cpu()),
    }
    return loss, diag
```

Then in `train_loss`:

```python
if surface_channel_weights is not None:
    surface_loss = weighted_channel_mse(...)  # unchanged path
elif tau_anisotropic_loss_enable:
    surface_loss, aniso_diag = tau_anisotropic_mse(
        out["surface_preds"], surface_target, batch.surface_mask, batch.surface_x,
        tau_anisotropic_alpha_tangent, tau_anisotropic_beta_normal,
    )
else:
    surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

Pass the new fields through to `train_loss` (similar to how `surface_loss_weight` is plumbed in the main training loop ~line 1030). Log `aniso_diag` keys to W&B under `train/tau_loss_tangent`, `train/tau_loss_normal`, `train/tau_normal_to_tangent_ratio` so we can see the decomposition magnitudes during training.

### Validate the math

The total un-weighted (`α=β=1.0`) version should give the **same scalar value** as `masked_mse(out["surface_preds"], surface_target, mask)` (mathematical identity: `‖err‖² = ‖err_t‖² + ‖err_n‖²` for orthogonal tangent/normal decomposition with unit normal). Add a small sanity-check assertion at the start of the first training step:

```python
if step == 0 and rank == 0 and tau_anisotropic_loss_enable:
    # sanity-check: alpha=beta=1.0 should match baseline MSE on tau channels
    with torch.no_grad():
        baseline_tau = masked_mse(out["surface_preds"][..., 1:4], surface_target[..., 1:4], batch.surface_mask)
        ours_tau, _ = tau_anisotropic_mse(out["surface_preds"], surface_target, batch.surface_mask, batch.surface_x, 1.0, 1.0)
        # ours_tau includes cp (channel 0); subtract that and renormalize
        # ... or run with alpha=beta=1.0 and verify identity another way
```

Or simpler: run the decomposed version with α=1.0, β=1.0 first locally and check it matches baseline; then flip the flag and run with α=1.0, β=5.0 for the real experiment.

### Reproduce command

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --batch-size 4 \
  --epochs 13 \
  --lr 5e-4 \
  --lr-warmup-epochs 1 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --train-surface-points 40000 \
  --eval-surface-points 65536 \
  --train-volume-points 49152 \
  --eval-volume-points 65536 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --use-qk-norm \
  --tau-anisotropic-loss-enable \
  --tau-anisotropic-alpha-tangent 1.0 \
  --tau-anisotropic-beta-normal 5.0 \
  --wandb-group wave30_tau_anisotropic_h13 \
  --wandb-name thorfinn/h13-anisotropic-beta5-rank{rank}
```

### Expected EP gate guidance

- **EP3 PASS**: val_abupt ≤ 6.5% (warmup=1 recipe)
- **EP10 PASS**: val_abupt ≤ 6.3% AND τ_normal/τ_tangent diagnostic ratio < EP3 ratio (i.e., model IS shrinking normal-error relative to tangent-error)
- **EP13 terminal**: full SENPAI-RESULT with val + test for abupt, WSS, SP, vol_p, τ_x, τ_y, τ_z, plus the diagnostic `train/tau_loss_tangent`, `train/tau_loss_normal`, `train/tau_normal_to_tangent_ratio` traces across EP1/EP6/EP13

If `tau_normal_to_tangent_ratio` rises (>1.5 at EP13) while WSS gets WORSE → confirms model is overfitting normal-component noise (H13 falsified, H6' direction validated)
If `tau_normal_to_tangent_ratio` drops AND WSS improves → confirms GT normal-component is real signal the model was missing (H13 PASS, H6' direction falsified)

### Falsification panel

Report at terminal:
1. val + test on all 7 metrics (abupt, WSS, SP, vol_p, τ_x, τ_y, τ_z)
2. val τz/τx and test τz/τx trajectory (EP3, EP6, EP10, EP13)
3. `tau_normal_to_tangent_ratio` at EP1, EP6, EP13
4. Comparison vs the H3/H1/H5/H7/H2 fleet leader test τz/τx of 1.44–1.47 — does H13 break this band on test?

## Baseline (PR #972 single-model SOTA, corrected dataset)

- **val_abupt: 6.126%** · val_vol_p: 3.798%
- **test_abupt: 5.844%** · **test_WSS: 6.727%** · **test_vol_p: 3.643%** · **test_SP: 3.577%**
- W&B seed run: `56bcqp3m`; eval run: `zxnhtagj`
- Single-model gate: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
- WSS target (Issue #1056): test_WSS < 5.85% (gap = 0.877pp)
- Hard floors (must hold): test_vol_p ≤ 3.643%, test_SP ≤ 3.577%

## Notes

- Use DDP with 8 GPUs (the standing fleet constraint).
- 18h budget — set `SENPAI_TIMEOUT_MINUTES=1100` and `SENPAI_MAX_EPOCHS=13`.
- No ensembles — single-model only.
- Post per-epoch val readout from EP3 onward including the new diagnostics.
- Single arm β_normal=5.0; if the mechanism engages but doesn't beat baseline, follow-ups with β_normal ∈ {2, 10} will be queued.
