### PR TITLE
Wave 30 H14: asymmetric LR for surface output head (5× backbone)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    surface_out_lr_multiplier: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -245,18 +246,48 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
-    if optimizer_name == "adamw":
-        return torch.optim.AdamW(
-            model.parameters(),
-            lr=config.lr,
-            weight_decay=config.weight_decay,
+
+    head_params: list[nn.Parameter] = []
+    backbone_params: list[nn.Parameter] = []
+    head_param_names: list[str] = []
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        if "surface_out" in name.split("."):
+            head_params.append(p)
+            head_param_names.append(name)
+        else:
+            backbone_params.append(p)
+
+    base_lr = float(config.lr)
+    multiplier = float(config.surface_out_lr_multiplier)
+    head_lr = base_lr * multiplier
+
+    backbone_count = sum(p.numel() for p in backbone_params)
+    head_count = sum(p.numel() for p in head_params)
+    print(
+        f"[build_optimizer] backbone params: {backbone_count:,} @ lr={base_lr:.2e}; "
+        f"head (surface_out): {head_count:,} @ lr={head_lr:.2e} "
+        f"(multiplier={multiplier:.4f}); head tensors: {head_param_names}"
+    )
+    if head_count == 0:
+        raise ValueError(
+            "[build_optimizer] surface_out head group has 0 params; check naming "
+            "(expected to match 'surface_out' as a dot-separated component)."
         )
+
+    param_groups = [
+        {"params": backbone_params, "lr": base_lr, "name": "backbone"},
+        {"params": head_params, "lr": head_lr, "name": "surface_out_head"},
+    ]
+
+    if optimizer_name == "adamw":
+        return torch.optim.AdamW(param_groups, weight_decay=config.weight_decay)
     if optimizer_name == "lion":
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
-            lr=config.lr,
+            param_groups,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
             use_triton=False,
@@ -1049,10 +1080,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                last_lrs = scheduler.get_last_lr()
+                backbone_lr = float(last_lrs[0])
+                head_lr_value = float(last_lrs[1]) if len(last_lrs) > 1 else backbone_lr
+                head_to_backbone_ratio = (
+                    head_lr_value / backbone_lr if backbone_lr > 1e-12 else 0.0
+                )
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "lr/backbone": backbone_lr,
+                    "lr/surface_out_head": head_lr_value,
+                    "lr/head_to_backbone_ratio": head_to_backbone_ratio,
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1175,10 +1215,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                 or (timeout_hit and n_batches > 0)
             )
 
+            epoch_last_lrs = scheduler.get_last_lr()
+            epoch_backbone_lr = float(epoch_last_lrs[0])
+            epoch_head_lr = (
+                float(epoch_last_lrs[1]) if len(epoch_last_lrs) > 1 else epoch_backbone_lr
+            )
+            epoch_head_to_backbone_ratio = (
+                epoch_head_lr / epoch_backbone_lr if epoch_backbone_lr > 1e-12 else 0.0
+            )
             log_metrics: dict[str, object] = {
                 "train/epoch_loss": epoch_train_loss,
-                "train/lr": scheduler.get_last_lr()[0],
-                "lr": scheduler.get_last_lr()[0],
+                "train/lr": epoch_backbone_lr,
+                "lr": epoch_backbone_lr,
+                "lr/backbone": epoch_backbone_lr,
+                "lr/surface_out_head": epoch_head_lr,
+                "lr/head_to_backbone_ratio": epoch_head_to_backbone_ratio,
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }


### PR DESCRIPTION
## Hypothesis (H14 — Asymmetric Learning Rate for Surface Output Head)

The Wave 30 fleet has now closed **6 model-side / architecture-layer attacks** (H1 cylindrical, H2 spectral, H3 soft-routing, H4 hard-routing, H5 Y-arch, H7 normal-aux). The architecture-layer attack surface is **DEFINITIVELY exhausted** for the τ_z structural bottleneck — all 6 closures show the same engaged-but-neutral signature (val widening 1.50–1.55 → test collapse to 1.44–1.47 baseline band).

H6 (tanjiro #1134) broke that pattern via hard τ·n=0 projection → test τz/τx=1.281 (mechanism PASS, absolute FAIL): definitive proof that **the bottleneck is at the output-head layer**, but hard projection throws away ~5-8% of real GT normal-component signal.

The current Wave 30 in-flight fleet covers:
- **Loss layer (3-strong)**: H6' soft τ·n penalty (#1147), H12 magnitude-weighted MSE (#1151), H13 tangent/normal anisotropic (#1152)
- **Data-input layer (3-strong)**: H8 mirror-symmetry aug (#1143), H9' curvature input feature (#1146), H11 multi-scale kNN context (#1150)
- **Output-head layer (1-strong)**: H10 vector-decoupled head (#1148)
- **Optimization layer (0-strong)**: ← THIS IS THE COMPLETELY UNDER-ATTACKED SURFACE

**H14 fills the optimization-layer gap**: split optimizer parameter groups so the `surface_out.*` MLP receives a **5× higher learning rate** than the backbone. Two motivations:

1. **The H6 mechanism PASS confirmed the output head IS the bottleneck location**. Pushing more gradient signal into those specific parameters is the most direct attack consistent with that diagnostic.
2. **Standard Kaggle / ImageNet precedent**: classifier heads consistently benefit from higher LR than feature backbones during fine-tuning (e.g., DeiT/timm `head_init_scale`, MAE linear probing protocol, ULMFit slanted triangular). The intuition: the output projection sees a fixed feature distribution and needs to rapidly adapt to the task, while the backbone needs gentler updates to preserve geometry-aware structure.

**Mechanism if H14 wins**:
- `surface_out` parameters update with effective LR ~2.5e-3 (5× the 5e-4 base) under cosine schedule
- The 2-layer surface MLP (n_hidden=512 → 512 → 4) has ~263k params, ~0.5% of total
- Heightened LR on these 263k params drives faster adaptation of the τ-direction-and-magnitude projection without disturbing the slice-attention representation
- If test τz/τx drops below baseline 1.45 (without floor breach), it confirms output-head capacity-budget was the real constraint

**Mechanism if H14 loses (likely outcomes)**:
- Same engaged-but-neutral signature → output-head LR budget is NOT the issue; problem is upstream (the backbone representation doesn't encode τ_z well enough at any output projection)
- Training instability (NaN, divergence) → asymmetric LR ratio too aggressive; falsifies the simple "more LR on head" hypothesis but motivates a follow-up sweep at 2-3x

## Instructions

**File to modify:** `target/train.py`, specifically `build_optimizer` at line 246 onward.

### Implementation outline

Add a new Config field near `lr`:

```python
@dataclass
class Config:
    ...
    lr: float = 5e-4
    weight_decay: float = 5e-4
    # H14 asymmetric LR for surface output head
    surface_out_lr_multiplier: float = 1.0  # 1.0 = baseline; 5.0 = H14 active arm
```

Modify `build_optimizer` to split parameters into two groups:

```python
def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
    optimizer_name = config.optimizer.lower()

    # Split named_parameters into surface_out head vs. everything else.
    head_params = []
    backbone_params = []
    for name, p in model.named_parameters():
        if not p.requires_grad:
            continue
        # Match `surface_out.*` regardless of DDP wrapping (module.surface_out.* or surface_out.*)
        if "surface_out" in name.split("."):
            head_params.append(p)
        else:
            backbone_params.append(p)

    base_lr = config.lr
    head_lr = base_lr * float(config.surface_out_lr_multiplier)

    # Log split for sanity
    backbone_count = sum(p.numel() for p in backbone_params)
    head_count = sum(p.numel() for p in head_params)
    print(
        f"[build_optimizer] backbone params: {backbone_count:,} @ lr={base_lr:.2e}; "
        f"head (surface_out): {head_count:,} @ lr={head_lr:.2e} "
        f"(multiplier={config.surface_out_lr_multiplier:.2f})"
    )

    param_groups = [
        {"params": backbone_params, "lr": base_lr, "name": "backbone"},
        {"params": head_params,     "lr": head_lr,  "name": "surface_out_head"},
    ]

    if optimizer_name == "adamw":
        return torch.optim.AdamW(param_groups, weight_decay=config.weight_decay)
    if optimizer_name == "lion":
        from lion_pytorch import Lion
        return Lion(
            param_groups,
            weight_decay=config.weight_decay,
            betas=(config.lion_beta1, config.lion_beta2),
            use_triton=False,
        )
    raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
```

### LR scheduler compatibility check

The cosine LR scheduler (`get_lr_scheduler` or similar — find it in `trainer_runtime.py` or the main training loop near `scheduler = ...`) typically scales each param_group's LR by the same cosine factor. PyTorch's `CosineAnnealingLR` and friends preserve per-group ratios automatically: at any step, `group['lr'] = group['initial_lr'] * cosine_factor`. **Verify** that the scheduler in use does this. If a custom scheduler is hard-coded to a single `lr` value, modify it to iterate per-group.

Specifically check `target/trainer_runtime.py` for the LR schedule implementation and confirm both param groups will be scaled. If they're not, you'll need to add per-group scaling.

### Log per-group LR to W&B every epoch

Add to the W&B `log_metrics` dict in the train loop:
```python
metrics["lr/backbone"] = optimizer.param_groups[0]["lr"]
metrics["lr/surface_out_head"] = optimizer.param_groups[1]["lr"]
metrics["lr/head_to_backbone_ratio"] = (
    optimizer.param_groups[1]["lr"] / max(optimizer.param_groups[0]["lr"], 1e-12)
)
```

Should hold steady at 5.0 throughout training (modulo cosine scaling).

### Sanity-check: matching baseline at multiplier=1.0

Before launching the H14 arm at 5×, **run a 1-epoch viability check at multiplier=1.0** to confirm:
- The split optimizer produces bit-identical (or near-identical, within numerical noise) results vs the original `model.parameters()` path
- Both param groups have nonzero param counts
- The W&B `lr/head_to_backbone_ratio` logs as exactly 1.0
- No NaN in either group's gradients

This protects against subtle bugs (e.g., missing some params via the `"surface_out" in name.split(".")` rule).

### Reproduce command (H14 active arm, multiplier=5.0)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --batch-size 4 \
  --epochs 13 \
  --lr 5e-4 \
  --lr-warmup-epochs 1 \
  --optimizer lion \
  --weight-decay 5e-4 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --train-surface-points 40000 \
  --eval-surface-points 65536 \
  --train-volume-points 49152 \
  --eval-volume-points 65536 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --model-layers 5 \
  --model-hidden-dim 512 \
  --model-heads 4 \
  --model-slices 128 \
  --use-qk-norm \
  --surface-out-lr-multiplier 5.0 \
  --wandb-group wave30_asymmetric_lr_h14 \
  --wandb-name alphonse/h14-headlr5x-rank{rank}
```

(If your CLI parser auto-generates `--surface-out-lr-multiplier` from the dataclass via reflection — and it does at line ~233-241 of `train.py` — no extra parse_args change is needed.)

### Expected EP gate guidance

- **EP1 sanity**: val_abupt ≤ 33% (warmup floor); `lr/head_to_backbone_ratio = 5.0` confirmed in W&B logs
- **EP3 PASS**: val_abupt ≤ 6.5%
- **EP6 PASS**: val_abupt ≤ 6.3%
- **EP10 PASS**: val_abupt ≤ 6.15%
- **EP13 terminal**: full SENPAI-RESULT with val + test on abupt, WSS, SP, vol_p, τ_x, τ_y, τ_z, plus the per-group LR traces

### Falsification panel

Report at terminal:
1. val + test on all 7 metrics
2. val τz/τx and test τz/τx trajectory (EP3 / EP6 / EP10 / EP13)
3. Per-group LR traces (should be smooth cosine for both, ratio fixed at 5.0)
4. Surface_out grad norm vs backbone grad norm trajectory if logged
5. Comparison vs the 6 closed model-side attacks (test τz/τx 1.44–1.47 band): does H14 break this band?

## Baseline (PR #972 single-model SOTA, corrected dataset)

- **val_abupt: 6.126%** · val_vol_p: 3.798%
- **test_abupt: 5.844%** · **test_WSS: 6.727%** · **test_vol_p: 3.643%** · **test_SP: 3.577%**
- W&B seed run: `56bcqp3m`; eval run: `zxnhtagj`
- Single-model gate: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
- WSS target (Issue #1056): test_WSS < 5.85% (gap = 0.877pp)
- Hard floors (must hold): test_vol_p ≤ 3.643%, test_SP ≤ 3.577%

## Notes

- Use DDP with 8 GPUs (the standing fleet constraint).
- 18h budget — set `SENPAI_TIMEOUT_MINUTES=1100` and `SENPAI_MAX_EPOCHS=13`.
- No ensembles — single-model only.
- Post per-epoch val readout from EP3 onward including the new LR diagnostics.
- Single arm `surface_out_lr_multiplier=5.0`; if mechanism engages but doesn't beat baseline, follow-up sweep over {2.0, 3.0, 10.0} is queued.
- Sanity-check at multiplier=1.0 for a single epoch BEFORE the full 18h run, to catch any param-split bugs.
