### PR TITLE
Wave 30 H13b: anisotropic tangent/normal loss at β=2 (follow-up to β=5 divergence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_anisotropic_loss_enable: bool = False
+    tau_anisotropic_alpha_tangent: float = 1.0
+    tau_anisotropic_beta_normal: float = 5.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -311,6 +314,91 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def tau_anisotropic_mse(
+    pred_surface: torch.Tensor,
+    target_surface: torch.Tensor,
+    mask: torch.Tensor,
+    surface_x: torch.Tensor,
+    alpha_tangent: float,
+    beta_normal: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Anisotropic surface MSE that decomposes the tau error along the
+    per-vertex normal/tangent frame.
+
+    Math identity: with unit normal n, the error ``e = pred - gt`` splits as
+    ``e = (e·n) n + (e - (e·n) n) = e_n + e_t`` with ``e_n ⟂ e_t``, so
+    ``‖e‖² = ‖e_t‖² + (e·n)²``. With ``alpha=beta=1``, the loss reduces to
+    ``masked_mse`` on the 4-channel surface output (averaging cp_err² + ‖tau_err‖²
+    over valid_points × 4).
+    """
+    if pred_surface.numel() == 0:
+        return pred_surface.sum() * 0.0, {
+            "tau_loss_tangent": 0.0,
+            "tau_loss_normal": 0.0,
+            "tau_normal_to_tangent_ratio": 0.0,
+            "tau_gt_tangent_magnitude": 0.0,
+            "tau_gt_normal_magnitude": 0.0,
+            "tau_gt_normal_to_tangent_ratio": 0.0,
+        }
+
+    work_dtype = torch.float32
+    pred = pred_surface.to(work_dtype)
+    tgt = target_surface.to(work_dtype)
+
+    cp_err_sq = (pred[..., 0:1] - tgt[..., 0:1]).square()  # [B, N, 1]
+
+    tau_pred = pred[..., 1:4]  # [B, N, 3]
+    tau_gt = tgt[..., 1:4]      # [B, N, 3]
+    err = tau_pred - tau_gt     # [B, N, 3]
+
+    # Per-vertex unit normal from surface_x channels 3,4,5; re-normalise to
+    # guard against bf16 / aug-pipeline drift away from unit length.
+    n = surface_x[..., 3:6].to(work_dtype)
+    n = n / n.norm(dim=-1, keepdim=True).clamp_min(1e-8)
+
+    err_n_scalar = (err * n).sum(dim=-1, keepdim=True)  # [B, N, 1]
+    err_t_vec = err - err_n_scalar * n                  # [B, N, 3]
+
+    tangent_sq = err_t_vec.square().sum(dim=-1, keepdim=True)  # [B, N, 1]
+    normal_sq = err_n_scalar.square()                           # [B, N, 1]
+
+    mask_dev = mask.to(device=pred.device, dtype=work_dtype).unsqueeze(-1)
+    valid_points = mask_dev.sum().clamp_min(1.0)
+
+    cp_term = cp_err_sq * mask_dev
+    tan_term = tangent_sq * mask_dev
+    nor_term = normal_sq * mask_dev
+
+    # 4-channel averaging budget so (alpha=1, beta=1) reproduces baseline
+    # masked_mse on [cp, tau_x, tau_y, tau_z] exactly.
+    denom = valid_points * 4.0
+    loss = (cp_term.sum() + alpha_tangent * tan_term.sum() + beta_normal * nor_term.sum()) / denom
+
+    # Diagnostics: per-channel error magnitudes (unweighted) plus GT decomposition
+    # magnitudes so we can read off the actual scale of the GT normal component.
+    with torch.no_grad():
+        tan_mean = tan_term.sum() / valid_points
+        nor_mean = nor_term.sum() / valid_points
+        gt_n_scalar = (tau_gt * n).sum(dim=-1, keepdim=True)
+        gt_n_sq = gt_n_scalar.square() * mask_dev
+        gt_t_vec = tau_gt - gt_n_scalar * n
+        gt_t_sq = gt_t_vec.square().sum(dim=-1, keepdim=True) * mask_dev
+        gt_tan_mean = gt_t_sq.sum() / valid_points
+        gt_nor_mean = gt_n_sq.sum() / valid_points
+        ratio = float(nor_mean / tan_mean.clamp_min(1e-12))
+        gt_ratio = float(gt_nor_mean / gt_tan_mean.clamp_min(1e-12))
+
+    diag = {
+        "tau_loss_tangent": float(tan_mean.cpu().item()),
+        "tau_loss_normal": float(nor_mean.cpu().item()),
+        "tau_normal_to_tangent_ratio": ratio,
+        "tau_gt_tangent_magnitude": float(gt_tan_mean.cpu().item()),
+        "tau_gt_normal_magnitude": float(gt_nor_mean.cpu().item()),
+        "tau_gt_normal_to_tangent_ratio": gt_ratio,
+    }
+    return loss, diag
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,10 +409,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_anisotropic_loss_enable: bool = False,
+    tau_anisotropic_alpha_tangent: float = 1.0,
+    tau_anisotropic_beta_normal: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    aniso_diag: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,7 +424,16 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if tau_anisotropic_loss_enable:
+            surface_loss, aniso_diag = tau_anisotropic_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                batch.surface_x,
+                tau_anisotropic_alpha_tangent,
+                tau_anisotropic_beta_normal,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +447,16 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if aniso_diag:
+        metrics.update(aniso_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +956,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.tau_anisotropic_loss_enable:
+                bypass_note = (
+                    " (channel weights bypassed — anisotropic loss runs in "
+                    "tangent/normal basis)"
+                    if use_channel_weights
+                    else ""
+                )
+                print(
+                    f"H13 anisotropic loss ENABLED: alpha_tangent="
+                    f"{config.tau_anisotropic_alpha_tangent} beta_normal="
+                    f"{config.tau_anisotropic_beta_normal}{bypass_note}"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +999,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_anisotropic_loss_enable"] = (
+                config.tau_anisotropic_loss_enable
+            )
+            wandb.summary["loss/tau_anisotropic_alpha_tangent"] = (
+                config.tau_anisotropic_alpha_tangent
+            )
+            wandb.summary["loss/tau_anisotropic_beta_normal"] = (
+                config.tau_anisotropic_beta_normal
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1155,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_anisotropic_loss_enable=config.tau_anisotropic_loss_enable,
+                        tau_anisotropic_alpha_tangent=config.tau_anisotropic_alpha_tangent,
+                        tau_anisotropic_beta_normal=config.tau_anisotropic_beta_normal,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1198,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for aniso_key in (
+                        "tau_loss_tangent",
+                        "tau_loss_normal",
+                        "tau_normal_to_tangent_ratio",
+                        "tau_gt_tangent_magnitude",
+                        "tau_gt_normal_magnitude",
+                        "tau_gt_normal_to_tangent_ratio",
+                    ):
+                        if aniso_key in batch_loss_metrics:
+                            train_log[f"train/{aniso_key}"] = batch_loss_metrics[aniso_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis (H13b — Tangent/Normal Anisotropic Loss at β=2.0, follow-up to H13 β=5 divergence)

H13 β=5 (#1152) catastrophically diverged at warmup boundary (step 3793, LR jumping 2.5e-5 → 5e-4). The math was verified identical to baseline at α=β=1.0 (abs diff 0.00) and the GT τ_normal/tangent magnitude ratio = **0.08** was measured — the GT normal component IS real signal (not noise), but small enough that 5× amplification was clearly past the LR×β stability cliff.

**Two consecutive Wave 30 amplification-style attacks diverged at this same warmup boundary**:
- H14 (#1153): Lion + head_lr=2.5e-3 (5× backbone) → diverged at warmup end
- H13 β=5 (#1152): anisotropic loss 5× on normal-grad → diverged at warmup end (~168 steps after LR jump)

This identifies a fleet-wide cliff: at the standing recipe (lr=5e-4, 1-epoch warmup), 5× amplification of any specific gradient direction is unstable.

**H13b moves the amplification factor squarely into the safe band**:
- β_normal = 2.0 (PR-queued follow-up arm)
- 2.5× reduction from divergent β=5
- Same anisotropic decomposition mechanism — math identity verified at α=β=1.0
- GT n/t = 0.08 floor means β=2 amplifies a real 8% signal to 16% of loss contribution — modest, well within the SOTA-tuning regime

### Mechanism if H13b wins (β=2 trains AND beats baseline test_WSS)

- The anisotropic loss formulation correctly emphasizes the small-but-real GT normal-component
- Model fits the normal-direction residuals better than baseline 4-channel MSE
- Test τz/τx should drop slightly below baseline 1.46 (model better-matches GT magnitude split)
- Test_WSS drops below baseline 6.727% (improved overall WSS prediction)

### Mechanism if H13b loses (β=2 trains but no WSS improvement vs baseline)

- The GT normal component IS real signal but the baseline 4-channel MSE already captures it adequately
- Anisotropic decomposition is redundant — no extra signal extracted by per-vertex frame rotation
- → Closes the "model under-fits normal component" axis cleanly; H6' (suppress normal) is then the right direction

### Mechanism if H13b also diverges (β=2 crashes)

- Entire amplification axis under the current 1-epoch warmup recipe is broken
- Cliff is between β=1 (baseline) and β=2, much narrower than expected
- → Pivot to **cosine+magnitude decoupling** (Lagemann et al. arxiv 2507.22817, your suggestion #4) as the geometric-reformulation attack that doesn't break gradient flow

## Instructions

**Most of the implementation is already in place from H13 #1152** (your work on `train.py` `tau_anisotropic_mse` + diagnostics is good — re-use it). The only change is the β value.

### Step 1: Re-apply H13 implementation to the new branch

If the H13 commit `af174ac` is on the closed PR #1152 branch, cherry-pick or re-apply the anisotropic loss implementation to this new branch. The implementation should be identical:
- `tau_anisotropic_mse(pred, target, mask, surface_x, alpha, beta)` in `train.py`
- 3 Config fields: `tau_anisotropic_loss_enable`, `tau_anisotropic_alpha_tangent`, `tau_anisotropic_beta_normal`
- W&B diagnostics: `train/tau_loss_tangent`, `train/tau_loss_normal`, `train/tau_normal_to_tangent_ratio`, `train/tau_gt_tangent_magnitude`, `train/tau_gt_normal_magnitude`, `train/tau_gt_normal_to_tangent_ratio`
- Re-run the standalone identity check (α=β=1.0 should give abs diff = 0.00 vs baseline 4-channel MSE)

### Step 2: Launch H13b with β=2.0

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --batch-size 4 \
  --epochs 13 \
  --lr 5e-4 \
  --lr-warmup-epochs 1 \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --train-surface-points 40000 \
  --eval-surface-points 65536 \
  --train-volume-points 49152 \
  --eval-volume-points 65536 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-qk-norm \
  --tau-anisotropic-loss-enable \
  --tau-anisotropic-alpha-tangent 1.0 \
  --tau-anisotropic-beta-normal 2.0 \
  --wandb-group wave30_tau_anisotropic_h13b \
  --wandb-name thorfinn/h13b-anisotropic-beta2-rank{rank}
```

### Critical sanity gate before the full run

Given the H13 β=5 divergence, **run a 1-epoch viability check FIRST**:
- Confirm the math identity (α=β=1.0 abs diff = 0.00) still holds
- Run with β=2.0 for 1 epoch (warmup-only, lr peaks at 5e-4 by end)
- Watch for grad_norm explosion at the warmup boundary (step ~3625)
- If grad_norm stays below 100 through the warmup boundary, launch the full 13-epoch arm
- If grad_norm spikes above 1000 within 200 steps of warmup end → divergence cliff is even tighter than expected; abort and post falsification (β=2 is also unstable)

### Watch-items in main run

1. `train/tau_normal_to_tangent_ratio` trajectory at EP1/EP6/EP13 — should track the GT ratio (~0.08) if model learns correctly
2. `train/tau_loss_normal` and `train/tau_loss_tangent` raw magnitudes — confirm normal-loss is contributing modestly to total (~16% with β=2)
3. Grad norm pre-clip at warmup boundary (~step 3625) — if it spikes above 100, divergence is imminent
4. val_abupt at EP3 (≤6.5% PASS), EP6 (≤6.3%), EP10 (≤6.15%), EP13 terminal
5. val τz/τx trajectory — does β=2 bend the ratio below 1.46 baseline?

### Falsification panel at terminal

Report:
1. val + test on all 7 metrics (abupt, WSS, SP, vol_p, τ_x, τ_y, τ_z)
2. val τz/τx and test τz/τx at EP3/EP6/EP10/EP13
3. `train/tau_normal_to_tangent_ratio` at EP1/EP6/EP13 vs GT ratio 0.08
4. Comparison vs the 6 closed model-side attacks (test τz/τx band 1.44-1.47) — does H13b break this band?
5. Grad norm trajectory across the warmup boundary (no divergence event expected, but record it for cross-check)

## Baseline (PR #972 single-model SOTA, corrected dataset)

- **val_abupt: 6.126%** · val_vol_p: 3.798%
- **test_abupt: 5.844%** · **test_WSS: 6.727%** · **test_vol_p: 3.643%** · **test_SP: 3.577%**
- W&B seed run: `56bcqp3m`; eval run: `zxnhtagj`
- Single-model gate: val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%
- WSS target (Issue #1056): test_WSS < 5.85% (gap = 0.877pp)
- Hard floors (must hold): test_vol_p ≤ 3.643%, test_SP ≤ 3.577%

## Notes

- Use DDP with 8 GPUs (the standing fleet constraint).
- 18h budget — set `SENPAI_TIMEOUT_MINUTES=1100` and `SENPAI_MAX_EPOCHS=13`. (Your H13 throughput was ~23min/epoch so the full run should fit comfortably in ~5h.)
- No ensembles — single-model only.
- Post per-epoch val readout from EP3 onward including the new τ_n/τ_t ratio diagnostics.
- Single arm β_normal=2.0; if β=2 trains stably but shows no/marginal WSS improvement, follow-up at β=3 is queued (probes the cliff position). If β=2 trains AND improves WSS, follow-up at β=1.5 to test the lower side. If β=2 also diverges, pivot to cosine+magnitude decoupling (Lagemann arxiv 2507.22817) as the next attack.
