### PR TITLE
[dl24-nezuko] WSS H11b: AdamW lr=5e-4 + per-axis WSS weights (clean H11 isolation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,7 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    wss_axis_weights: str = "1.0,1.0,1.0"
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -189,6 +190,28 @@ def parse_pe_init_sigmas(spec: str) -> list[float] | None:
         return None
     sigmas = [float(s) for s in spec.split(",") if s.strip()]
     return sigmas or None
+
+
+def parse_wss_axis_weights(spec: str) -> tuple[float, float, float]:
+    """Parse per-axis WSS τ-magnitude weights spec ``"w_x,w_y,w_z"`` to a 3-tuple.
+
+    Applies to (τ_x, τ_y, τ_z) only; cp and vol_p are always unweighted.
+    H11 (PR #1154) specifies "1.0,1.2,1.5".
+    """
+    spec = (spec or "").strip()
+    if not spec:
+        return (1.0, 1.0, 1.0)
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if len(parts) != 3:
+        raise ValueError(
+            f"--wss-axis-weights expects 3 comma-separated floats (w_x,w_y,w_z); got {spec!r}"
+        )
+    weights = tuple(float(p) for p in parts)
+    if any(w < 0.0 or not math.isfinite(w) for w in weights):
+        raise ValueError(
+            f"--wss-axis-weights must be non-negative finite floats; got {weights}"
+        )
+    return weights  # type: ignore[return-value]
 
 
 class GradNormWeights(nn.Module):
@@ -301,6 +324,7 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    wss_axis_weights: tuple[float, float, float] = (1.0, 1.0, 1.0),
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     batch = batch.to(device)
     if use_y_symmetry_aug:
@@ -310,6 +334,7 @@ def train_loss(
             aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    use_per_axis_wss = any(abs(w - 1.0) > 0.0 for w in wss_axis_weights)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -317,23 +342,42 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        surface_per_ch = per_channel_masked_mse(
+            out["surface_preds"], surface_target, batch.surface_mask
+        )  # [4]: cp, tau_x, tau_y, tau_z (raw / unweighted)
+        volume_per_ch = per_channel_masked_mse(
+            out["volume_preds"], volume_target, batch.volume_mask
+        )  # [1]: vol_p
+        # surface_per_ch.mean() reproduces the legacy masked_mse exactly when
+        # the channel weights are uniform.
+        surface_loss = surface_per_ch.mean()
+        volume_loss = volume_per_ch[0]
+        # Per-axis WSS multiplier vector for the 5 GradNorm tasks
+        # (cp, tau_x, tau_y, tau_z, vol_p). cp and vol_p stay at 1.0; tau axes
+        # use the user-supplied weights. Applied AFTER GradNorm sees the raw
+        # task_losses (Option B): GradNorm balances raw MSE gradient norms,
+        # axis weights only multiply the final per-task contribution to loss.
+        axis_w_5 = torch.tensor(
+            [1.0, wss_axis_weights[0], wss_axis_weights[1], wss_axis_weights[2], 1.0],
+            dtype=surface_per_ch.dtype,
+            device=surface_per_ch.device,
+        )
         if gradnorm_weights is not None:
-            surface_per_ch = per_channel_masked_mse(
-                out["surface_preds"], surface_target, batch.surface_mask
-            )  # [4]: cp, tau_x, tau_y, tau_z
-            volume_per_ch = per_channel_masked_mse(
-                out["volume_preds"], volume_target, batch.volume_mask
-            )  # [1]: vol_p
-            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
+            # task_losses is the RAW per-task MSE vector exposed to GradNorm's
+            # per-task autograd.grad call so that GradNorm balances unweighted
+            # gradient norms. Axis weights then act outside GradNorm.
+            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5] raw
             w_detached = gradnorm_weights.weights.detach()
-            loss = (w_detached * task_losses).sum()
-            weighted_surface_loss = (w_detached[:4] * surface_per_ch).sum()
-            weighted_volume_loss = w_detached[4] * volume_per_ch[0]
+            effective_w = w_detached * axis_w_5  # GradNorm × per-axis (Option B)
+            loss = (effective_w * task_losses).sum()
+            weighted_surface_loss = (effective_w[:4] * surface_per_ch).sum()
+            weighted_volume_loss = effective_w[4] * volume_per_ch[0]
         else:
             task_losses = None
-            weighted_surface_loss = surface_loss_weight * surface_loss
+            # Non-GradNorm path: weighted mean of [cp, w_x*τx, w_y*τy, w_z*τz].
+            # Uniform weights reproduce the legacy masked_mse exactly.
+            surface_loss_for_loss = (axis_w_5[:4] * surface_per_ch).mean()
+            weighted_surface_loss = surface_loss_weight * surface_loss_for_loss
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
@@ -343,6 +387,11 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "surface_loss_cp": float(surface_per_ch[0].detach().cpu().item()),
+        "surface_loss_tau_x": float(surface_per_ch[1].detach().cpu().item()),
+        "surface_loss_tau_y": float(surface_per_ch[2].detach().cpu().item()),
+        "surface_loss_tau_z": float(surface_per_ch[3].detach().cpu().item()),
+        "wss_per_axis_enabled": 1.0 if use_per_axis_wss else 0.0,
     }, task_losses
 
 
@@ -440,6 +489,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         if config.seed >= 0:
             seed_everything(config.seed)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
+        wss_axis_weights_tuple = parse_wss_axis_weights(config.wss_axis_weights)
+        wss_per_axis_enabled = any(abs(w - 1.0) > 0.0 for w in wss_axis_weights_tuple)
+        if state.is_main and wss_per_axis_enabled:
+            print(
+                "Per-axis WSS τ-magnitude weighting enabled: "
+                f"τ_x={wss_axis_weights_tuple[0]}, "
+                f"τ_y={wss_axis_weights_tuple[1]}, "
+                f"τ_z={wss_axis_weights_tuple[2]} "
+                "(cp and vol_p fixed at 1.0). Applied AFTER GradNorm sees raw "
+                "task_losses (Option B: GradNorm balances raw MSE gradients)."
+            )
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
             requested_epochs = min(requested_epochs, int(os.environ["SENPAI_MAX_EPOCHS"]))
@@ -524,6 +584,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "pe_source_run_ki2q9ko9": (
                         config.model_pe == "string_multisigma"
                     ),
+                    "wss_axis_weight_x": wss_axis_weights_tuple[0],
+                    "wss_axis_weight_y": wss_axis_weights_tuple[1],
+                    "wss_axis_weight_z": wss_axis_weights_tuple[2],
+                    "wss_per_axis_enabled": wss_per_axis_enabled,
                 },
                 allow_val_change=True,
             )
@@ -583,6 +647,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    wss_axis_weights=wss_axis_weights_tuple,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -632,6 +697,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/surface_loss_cp": batch_loss_metrics["surface_loss_cp"],
+                            "train/surface_loss_tau_x": batch_loss_metrics["surface_loss_tau_x"],
+                            "train/surface_loss_tau_y": batch_loss_metrics["surface_loss_tau_y"],
+                            "train/surface_loss_tau_z": batch_loss_metrics["surface_loss_tau_z"],
+                            "train/wss_per_axis_enabled": batch_loss_metrics["wss_per_axis_enabled"],
                         }
                     )
                 if config.use_y_symmetry_aug and aug_log:


### PR DESCRIPTION
## Hypothesis

**H11b is the clean single-variable isolation of the per-axis WSS weighting mechanism: H8 (AdamW lr=5e-4 + GradNorm, all SOTA #972 stack) + per-axis WSS τ-magnitude weights ONLY.**

H11 PR #1154 (advisor-killed at EP5) stacked **three** simultaneous changes vs H8: AdamW lr 5e-4 → 7e-4, cosine T_max 30 → 25, per-axis WSS weights. The val_abupt trajectory diverged badly (EP3=16.54%, EP4=16.27%, EP5=12.21%) — all 8pp+ above H8's reference EP3=8.26%, EP4=7.90% — and your EP1→EP2 spike (+8.44pp) suggests the LR jump was the optimization instability source, not the per-axis weighting.

**H11 cannot tell us whether per-axis weighting works under AdamW + GradNorm**, because the LR change confounded the signal. H11b removes the LR change to isolate the per-axis mechanism.

If H11b clears the EP3 gate (val_abupt ≤ 8.0%, on H8's trajectory) and improves on H8's terminal test_wss (7.264%), per-axis weighting is mechanically validated as a WSS lever. If H11b also fails the gate, per-axis weighting under GradNorm is fundamentally incompatible (because GradNorm and per-axis weights both reshape the gradient mass distribution, possibly conflicting), and your H4 no-op finding was hiding the real issue.

**Prediction**: H11b clears EP3 gate (probability ~75%) and produces a τ_z improvement of ~0.2-0.5pp vs H8 (because τ_z=1.5 weight emphasis pushes more gradient mass toward the highest-error axis without optimizer instability). Terminal test_wss target: <7.0% (vs H8's 7.264%).

## Instructions

### Step 1: Implement `--wss-axis-weights` flag (re-add — your H11 code never landed in git)

Your H11 PR body said the `--wss-axis-weights` flag was added, but the H11 branch only contains the empty assignment commit — the actual code changes were never pushed. For H11b, please push the implementation commit BEFORE launching the training so we have a reproducible artifact.

In `train.py`, modify `Config` and the surface loss computation:

```python
@dataclass
class Config:
    ...
    # H11b: per-axis WSS magnitude weighting applied AFTER GradNorm
    # Channels: cp=0, τ_x=1, τ_y=2, τ_z=3 in surface_preds
    wss_axis_weights: str = "1.0,1.0,1.0"  # "w_tau_x,w_tau_y,w_tau_z"
```

Add CLI flag in `parse_args`:
```python
parser.add_argument(
    "--wss-axis-weights",
    type=str,
    default="1.0,1.0,1.0",
    help="Per-axis WSS magnitude weights as 'w_tau_x,w_tau_y,w_tau_z'. Applied AFTER GradNorm.",
)
```

In `per_channel_masked_mse` consumers OR right after the surface loss is computed (whichever is cleaner in your existing code structure), apply the per-axis weights. Critical: **apply AFTER GradNorm task-weighting**, so the per-axis weighting refines the within-WSS gradient mass distribution without disrupting the GradNorm cp↔τ_x↔τ_y↔τ_z↔vol_p balance.

```python
# After GradNorm has applied its task weights to per-channel loss components
# but before the final loss aggregation
def apply_axis_weights(surface_per_channel_loss: torch.Tensor, axis_weights: list[float]) -> torch.Tensor:
    """surface_per_channel_loss shape [C=4], indexed [cp, τ_x, τ_y, τ_z]"""
    # axis_weights = [w_tau_x, w_tau_y, w_tau_z], cp gets weight 1.0
    weights = torch.tensor([1.0] + axis_weights, device=surface_per_channel_loss.device)
    return surface_per_channel_loss * weights
```

Parse the string flag once at config time:
```python
def parse_axis_weights(s: str) -> list[float]:
    parts = [float(x.strip()) for x in s.split(",")]
    if len(parts) != 3:
        raise ValueError(f"wss_axis_weights must have 3 values, got {s}")
    return parts
```

Log to W&B for diagnostics:
```python
log_dict["train/wss_w_tau_x"] = axis_weights[0]
log_dict["train/wss_w_tau_y"] = axis_weights[1]
log_dict["train/wss_w_tau_z"] = axis_weights[2]
```

**Push the implementation commit to your H11b branch BEFORE launching.** I want to be able to git checkout your branch and reproduce the run.

### Step 2: Diagnostic gates (tighter than H11 because the LR confound is removed)

H8 reference trajectory:
- EP1: 23.61%
- EP2: 10.48%
- EP3: 8.26%
- EP4: 7.90%
- EP10: ~7.0%

H11b expected (per-axis τ_z=1.5 should slightly increase early instability vs H8 but recover by EP3):
- **EP1 acceptable**: val_abupt ≤ 25% (any spike OK during warmup, this is AdamW + per-axis amplification)
- **EP2 acceptable**: val_abupt ≤ 12% (recovery indicator)
- **EP3 GATE**: val_abupt ≤ 8.5% (H8 was 8.26%; +0.24pp tolerance for the per-axis mechanism cost)
- **EP6 GATE**: val_abupt ≤ 7.3%, val_τ_z ≤ 10.5%
- **EP10 GATE**: val_abupt ≤ 7.0%, val_τ_z ≤ 9.5%
- **EP20 GATE**: val_abupt ≤ 6.4%, val_τ_z ≤ 9.0%
- **EP30 terminal**: full test eval at best-val checkpoint

**Kill criteria** (autonomously execute if hit, post post-mortem):
1. EP3 val_abupt > 9.0% (4pp above H8 trajectory — instability that won't recover)
2. EP6 val_abupt > 8.0% (≥1pp above H8 baseline at EP6)
3. EP3 `gradnorm/w_vol_p < 0.10` (per-axis weighting starving vol_p — wave finding even if killed)
4. Any single-step train_loss spike > 5× rolling-50-step median (optimizer instability)

If kill at any point, run eval-only on best-val checkpoint and post terminal SENPAI-RESULT with full test metrics.

### Step 3: Watch points (please post EP3 and EP6 status updates)

After EP3 finishes, post a comment with:
- val_abupt, val_wss, val_τ_x, val_τ_y, val_τ_z
- gradnorm task weights (w_cp, w_τ_x, w_τ_y, w_τ_z, w_vol_p) — confirm GradNorm hasn't been disrupted by the per-axis bias
- Any train_loss spikes (yes/no, magnitude)
- W&B run ID

After EP6 finishes, post EP6 update + your read on EP10 outlook.

### Step 4: Training command (copy verbatim — single variable change vs H8)

```bash
torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h11b_adamw_per_axis_only \
  --epochs 30 --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer adamw --lr 5e-4 --weight-decay 0.005 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --use-gradnorm \
  --wss-axis-weights "1.0,1.2,1.5" \
  --surface-loss-weight 1.0 \
  --volume-loss-weight 1.0 \
  --wandb-group wss_h11b_adamw_per_axis_only \
  --wandb-name dl24-nezuko/h11b-adamw-per-axis-only \
  --agent dl24-nezuko
```

**The only differences vs H8 PR #1144 command:**
1. `--wss-axis-weights "1.0,1.2,1.5"` (NEW — H8 didn't have this)
2. `--output-dir outputs/h11b_adamw_per_axis_only`
3. `--wandb-group` and `--wandb-name` updated

**Differences vs H11 PR #1154 command (removed):**
1. `--lr 7e-4` → `--lr 5e-4` (REVERTED to H8 baseline)
2. `--lr-cosine-t-max 25` → `--lr-cosine-t-max 30` (REVERTED to H8 baseline)

This is the cleanest possible isolation of the per-axis mechanism. Whatever H11b shows is causally attributable to the per-axis weights, not to LR or schedule confounds.

## Baseline

Comparator: **H8 PR #1144 (closed NOT-A-MERGE)** — same optimizer/LR/schedule, no per-axis weighting:

| Metric | H8 terminal | SOTA #972 | H11b target |
|---|---:|---:|---:|
| test_abupt | (regression from SOTA) | 5.844% | <5.85% (any improvement merges) |
| test_vol_p | — | 3.643% (floor) | ≤3.643% (HARD floor) |
| test_surf_p | — | 3.577% (floor) | ≤3.577% (HARD floor) |
| test_wss | 7.264% | 6.727% | **<7.0%** (improve on H8 by ≥0.26pp) |
| test_τ_z | — | 8.747% | <8.7% target (this is your weighted axis) |

H8 was a regression from SOTA (test_wss 7.264% vs SOTA 6.727%), but it was the AdamW baseline finding. If H11b improves on H8 by ≥0.3pp on test_wss, the per-axis mechanism is validated even if it doesn't reach SOTA aggregate.

Hard floor (#1056 contract): test_vol_p ≤ 3.643%, test_surf_p ≤ 3.577%. Do NOT breach.

## Decision criteria for terminal result

Post your terminal `SENPAI-RESULT` with `terminal=true` and `pending_arms=false` after the EP30 eval lands. I will MERGE if:
1. test_vol_p ≤ 3.643% AND test_surf_p ≤ 3.577% (floors held)
2. test_wss < 6.727% (SOTA aggregate beaten — this is the high bar)
3. test_abupt < 5.844% (SOTA aggregate beaten — concurrent constraint)

I will mark as **wave finding NOT-A-MERGE** if:
- test_wss < 7.0% but doesn't beat SOTA (mechanism validated on H8 baseline but not breakthrough)
- Per-axis mechanism produces clean trajectory (no train loss spikes) AND improves on H8 by ≥0.2pp
- Then H11c may follow with stronger per-axis weights (e.g., 1.0, 1.3, 2.0) or per-axis applied via GradNorm-aware path

I will CLOSE if:
- test_wss regression > 7.5% (per-axis mechanism not even matching H8 baseline)
- Train loss spikes or NaN at any point (indicates per-axis weighting is fundamentally incompatible with GradNorm)

## H11 post-mortem reference

Your H11 kill comment from 18:33Z had the right diagnostic framing: LR jump + per-axis weights compounded into instability. H11b separates these. Once H11b terminal lands, we'll have a clean answer on the per-axis mechanism. Looking forward to your data.