### PR TITLE
Wave 30 H16: Huber loss on τ channels (δ=1.0, outlier-robust regression overlay)

### DIFF
--- a/train.py
+++ b/train.py
@@ -52,10 +52,13 @@ from trainer_runtime import (
     init_distributed,
     init_wandb_run,
     is_valid_primary_metric,
+    huber_diagnostics,
     loader_kwargs,
     make_loaders,
+    masked_huber,
     masked_mse,
     metric_namespace,
+    weighted_channel_huber_mse,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -138,6 +141,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    tau_loss_fn: str = "mse"
+    tau_huber_delta: float = 1.0
     debug: bool = False
 
 
@@ -228,6 +233,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "tau_loss_fn": (
+            "Loss function applied to the wall-shear tau channels "
+            "(tau_x, tau_y, tau_z) in z-scored space. 'mse' (default) "
+            "matches the historical behaviour. 'huber' caps the gradient "
+            "magnitude in the tail at --tau-huber-delta, redirecting "
+            "capacity to bulk vertices instead of outlier separation/"
+            "wake regions. The cp channel always uses MSE. Volume "
+            "pressure (vp) always uses MSE."
+        ),
+        "tau_huber_delta": (
+            "Huber transition threshold in z-scored space when "
+            "--tau-loss-fn=huber. delta=1.0 transitions at 1 standard "
+            "deviation of the per-channel signal (e.g. tau_z sigma ~1.11 Pa "
+            "in raw units => delta=1.11 Pa). Loss is 0.5*err^2 for "
+            "|err|<delta and delta*(|err|-0.5*delta) for |err|>=delta. "
+            "Unused when --tau-loss-fn=mse."
         ),
     }
     for field in fields(Config):
@@ -321,7 +343,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, dict[str, float]]:
+    tau_loss_fn: str = "mse",
+    tau_huber_delta: float = 1.0,
+) -> tuple[torch.Tensor, dict[str, object]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -332,27 +356,73 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred = out["surface_preds"]
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
-            )
+            if tau_loss_fn == "huber":
+                surface_loss = weighted_channel_huber_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                    tau_huber_delta=tau_huber_delta,
+                )
+            else:
+                surface_loss = weighted_channel_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            if tau_loss_fn == "huber":
+                surface_loss = weighted_channel_huber_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    torch.ones(4, device=surface_pred.device, dtype=surface_pred.dtype),
+                    tau_huber_delta=tau_huber_delta,
+                )
+            else:
+                surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        # Per-channel detached diagnostics (cp MSE + per-tau Huber/MSE).
+        with torch.no_grad():
+            cp_mse = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
+            if tau_loss_fn == "huber":
+                tau_x_loss = masked_huber(
+                    surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask, tau_huber_delta
+                )
+                tau_y_loss = masked_huber(
+                    surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask, tau_huber_delta
+                )
+                tau_z_loss = masked_huber(
+                    surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask, tau_huber_delta
+                )
+            else:
+                tau_x_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+                tau_y_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+                tau_z_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+            huber_diag = huber_diagnostics(
+                surface_pred, surface_target, batch.surface_mask, tau_huber_delta
+            )
+    tau_suffix = "huber" if tau_loss_fn == "huber" else "mse"
+    metrics: dict[str, object] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "train/loss_per_channel/cp_mse": float(cp_mse.detach().cpu().item()),
+        f"train/loss_per_channel/tau_x_{tau_suffix}": float(tau_x_loss.detach().cpu().item()),
+        f"train/loss_per_channel/tau_y_{tau_suffix}": float(tau_y_loss.detach().cpu().item()),
+        f"train/loss_per_channel/tau_z_{tau_suffix}": float(tau_z_loss.detach().cpu().item()),
     }
+    metrics.update(huber_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -364,13 +434,23 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
-) -> list[torch.Tensor]:
+    *,
+    tau_loss_fn: str = "mse",
+    tau_huber_delta: float = 1.0,
+) -> tuple[list[torch.Tensor], dict[str, float]]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
-    Returns scalar tensors in order: [sp, tau_x, tau_y, tau_z, vp].
-    All five share the same forward graph so the GradNorm balancer can
-    extract per-task gradient norms via ``torch.autograd.grad`` with
-    ``retain_graph=True``.
+    Returns ``(losses, diagnostics)`` where ``losses`` is a list of scalar
+    tensors in order: ``[sp, tau_x, tau_y, tau_z, vp]``. All five share
+    the same forward graph so the GradNorm balancer can extract per-task
+    gradient norms via ``torch.autograd.grad`` with ``retain_graph=True``.
+
+    sp (cp) and vp always use MSE. tau channels use MSE or Huber
+    (``0.5*err^2`` for ``|err|<delta``; ``delta*(|err|-0.5*delta)``
+    otherwise) depending on ``tau_loss_fn``.
+
+    The ``diagnostics`` dict includes per-channel Huber/L1 fractions and
+    the tau_z max-abs-error (all in z-scored space).
     """
 
     batch = batch.to(device)
@@ -385,11 +465,25 @@ def per_task_train_losses(
         )
         surface_pred = out["surface_preds"]
         sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
-        taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
-        tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
-        tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+        if tau_loss_fn == "huber":
+            taux_loss = masked_huber(
+                surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask, tau_huber_delta
+            )
+            tauy_loss = masked_huber(
+                surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask, tau_huber_delta
+            )
+            tauz_loss = masked_huber(
+                surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask, tau_huber_delta
+            )
+        else:
+            taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+            tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+            tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
+        diagnostics = huber_diagnostics(
+            surface_pred, surface_target, batch.surface_mask, tau_huber_delta
+        )
+    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss], diagnostics
 
 
 GRADNORM_MODES = ("full", "ema_proxy")
@@ -937,9 +1031,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                huber_diag_metrics: dict[str, float] = {}
                 if balancer is not None:
-                    per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                    per_task_losses, huber_diag_metrics = per_task_train_losses(
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        tau_loss_fn=config.tau_loss_fn,
+                        tau_huber_delta=config.tau_huber_delta,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -994,6 +1095,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for i, name in enumerate(GRADNORM_TASK_NAMES):
                         gradnorm_metrics[f"gradnorm/weight_{name}"] = weights_cpu[i]
                         gradnorm_metrics[f"train/loss_{name}"] = losses_cpu[i]
+                    tau_suffix = "huber" if config.tau_loss_fn == "huber" else "mse"
+                    gradnorm_metrics["train/loss_per_channel/cp_mse"] = losses_cpu[0]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_x_{tau_suffix}"] = losses_cpu[1]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_y_{tau_suffix}"] = losses_cpu[2]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_z_{tau_suffix}"] = losses_cpu[3]
+                    gradnorm_metrics["train/loss_per_channel/vp_mse"] = losses_cpu[4]
                     if synced_norms is not None:
                         norms_cpu = synced_norms.detach().cpu().tolist()
                         for i, name in enumerate(GRADNORM_TASK_NAMES):
@@ -1030,6 +1137,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_loss_fn=config.tau_loss_fn,
+                        tau_huber_delta=config.tau_huber_delta,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,8 +1179,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    # Pass through any train/* keys carried by batch_loss_metrics
+                    # (the no-GradNorm path emits per-channel loss + huber diags
+                    # under such keys; GradNorm path produces them separately).
+                    for key, val in batch_loss_metrics.items():
+                        if key.startswith("train/"):
+                            train_log[key] = val
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if huber_diag_metrics:
+                    train_log.update(huber_diag_metrics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,58 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_huber(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float,
+) -> torch.Tensor:
+    """Masked Huber (smooth-L1) loss.
+
+    For |err| < delta: 0.5 * err^2 (matches PyTorch nn.HuberLoss with default reduction).
+    For |err| >= delta: delta * (|err| - 0.5 * delta).
+    """
+    err = pred - target
+    abs_err = err.abs()
+    quadratic = 0.5 * err.square()
+    linear = delta * (abs_err - 0.5 * delta)
+    huber_elem = torch.where(abs_err < delta, quadratic, linear)
+    return masked_mean(huber_elem, mask)
+
+
+def huber_diagnostics(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float,
+) -> dict[str, float]:
+    """Per-channel Huber telemetry for the surface tau channels.
+
+    Computes the fraction of valid vertices whose normalized abs-error
+    falls in the L2 region (|err| < delta) vs the L1 region for tau_x,
+    tau_y, tau_z, plus the max abs error on tau_z. All values are floats
+    on CPU. Inputs are expected to be in z-scored (normalized) space.
+    """
+    out: dict[str, float] = {}
+    if pred.numel() == 0:
+        return out
+    with torch.no_grad():
+        err = (pred.detach() - target.detach()).float()
+        abs_err = err.abs()
+        mask_float = mask.to(device=err.device, dtype=torch.float32)
+        valid_total = mask_float.sum().clamp_min(1.0)
+        tau_names = ("tau_x", "tau_y", "tau_z")
+        for c_idx, name in zip((1, 2, 3), tau_names):
+            abs_err_c = abs_err[..., c_idx]
+            in_L2 = ((abs_err_c < delta).float() * mask_float).sum() / valid_total
+            in_L1 = ((abs_err_c >= delta).float() * mask_float).sum() / valid_total
+            out[f"train/huber/frac_in_L2_region/{name}"] = float(in_L2.item())
+            out[f"train/huber/frac_in_L1_region/{name}"] = float(in_L1.item())
+        tau_z_abs_masked = abs_err[..., 3] * mask_float
+        out["train/max_abs_error_normed/tau_z"] = float(tau_z_abs_masked.max().item())
+    return out
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -863,6 +915,46 @@ def weighted_channel_mse(
     sq_err = (pred - target).square()
     mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     weighted = sq_err * weights_dev * mask_dev
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
+def weighted_channel_huber_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    tau_huber_delta: float,
+) -> torch.Tensor:
+    """Per-channel weighted masked loss with MSE on channel 0 (cp) and Huber on channels 1: (tau_x, tau_y, tau_z).
+
+    pred / target: [B, N, 4]; mask: [B, N]; weights: [4]. Returns a single
+    scalar averaged over (valid points x channels), with each channel's
+    per-element loss multiplied by its weight before averaging. Matches
+    ``weighted_channel_mse`` semantics: the channel weights only rescale
+    the relative gradient budget; it does NOT decompose into per-channel
+    means.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    weights_dev = weights.to(device=pred.device, dtype=pred.dtype)
+    if weights_dev.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"weights last-dim {weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    err = pred - target
+    sq = err.square()
+    abs_err = err.abs()
+    quadratic = 0.5 * sq
+    linear = tau_huber_delta * (abs_err - 0.5 * tau_huber_delta)
+    huber_elem = torch.where(abs_err < tau_huber_delta, quadratic, linear)
+    per_elem = torch.cat([sq[..., 0:1], huber_elem[..., 1:]], dim=-1)
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighted = per_elem * weights_dev * mask_dev
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):


### PR DESCRIPTION
## Hypothesis

H16 — Per-channel **z-score normalization of surface targets** (cp, τ_x, τ_y, τ_z) using train-set per-channel mean/std (computed OFFLINE, frozen at startup). Predict normalized values; denormalize before computing rel-L2 metrics.

### Why this is the right next attack

Per-channel error statistics from baseline #972 reveal the τ_z bottleneck has a **statistical signature distinct from GradNorm's dynamic upweighting**:

| Channel | val MAE (Pa) | val rel-L2 (%) | GradNorm learned weight |
|---|---:|---:|---:|
| cp | 0.01044 | 3.98% | 0.82 |
| τ_x | 0.07458 | 6.11% | ~1.0 |
| τ_y | 0.04844 | 7.47% | 1.34 |
| τ_z | 0.04964 | 9.39% | 1.95 |

GradNorm has already learned to upweight τ_z by 1.95× — yet τ_z's rel-L2 remains 1.46× worse than τ_x. **The bottleneck is upstream of dynamic gradient balancing.**

Z-score normalization addresses a **different mechanism** than GradNorm:
- GradNorm normalizes per-channel LOSS by current GRADIENT NORM (dynamic, batch-level)
- Z-score normalizes per-channel TARGET by GLOBAL train-set σ (static, dataset-level)

After z-scoring, every channel's MSE has scale ~1.0 by construction (unit variance in normalized space). The static per-channel weights then apply on top of an already-equalized base scale, rather than trying to compensate for a 5× absolute-scale imbalance.

**Key claim:** if τ_z's higher rel-L2 reflects an optimization-trajectory effect — the loss landscape is biased toward larger-magnitude channels because their absolute gradient norms dominate per-step updates — then z-scoring targets removes that bias **deterministically** (vs GradNorm's dynamic adaptation which may converge but not fully equalize).

This is the first **output-side per-channel statistical calibration** probe in Wave 30 — directly addressing the H8 closure analysis recommendation: *"shift toward output-side per-channel calibration (which test_τ_z output statistics suggest is unbalanced) or per-channel target normalization."*

Building on:
- **Frieren H8 #1143 (CLOSED FLAT NULL)** explicitly identified per-channel target normalization as the next priority after eliminating data-distribution attacks
- **9 closed model-side attacks** all land in τz/τx [1.44, 1.57] band → the bottleneck is at output-projection/loss-formulation layer
- **Loss-layer attacks H6'/H12/H13c** are testing different loss reformulations; this is the **statistical-rescaling** variant

### Falsification triangle

- **BIG WIN**: test_WSS < 6.727% AND test τz/τx ≤ 1.30 → output-side calibration mechanism is the missing piece
- **MERGE**: test_WSS < 6.727% (any margin) AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% → real result regardless of τz/τx
- **PARTIAL**: test_WSS within 0.1pp baseline + materially compressed test τz/τx (e.g., ≤1.40) → mechanism partially works
- **FLAT NULL**: similar test τz/τx (1.44-1.57) → z-score insufficient; output-side calibration axis exhausted; pivot to per-channel attention heads or τ_z residual prediction

## Instructions

### Step 1 — Compute per-channel target statistics OFFLINE (one-time)

Write a small precompute script `compute_target_stats.py` that:

1. Loads the train split via the existing dataset class (NO changes to dataloader)
2. Iterates ALL train batches with default config (`--train-surface-points 65536`, all 400 train cases)
3. Accumulates per-channel mean and variance using Welford's online algorithm (numerically stable) over all surface vertices across all batches
4. For each surface channel c ∈ {cp, τ_x, τ_y, τ_z}, compute:
   - `μ_c` = global mean over all (case, vertex)
   - `σ_c` = global std (sqrt of variance)
5. Save to `target/data/surface_target_stats.json`:
   ```json
   {
     "cp": {"mean": <float>, "std": <float>},
     "tau_x": {"mean": <float>, "std": <float>},
     "tau_y": {"mean": <float>, "std": <float>},
     "tau_z": {"mean": <float>, "std": <float>},
     "n_vertices_total": <int>,
     "n_cases": <int>,
     "computed_at": "<ISO 8601 timestamp>",
     "manifest_split": "train",
     "data_root": "<path>"
   }
   ```
6. Also compute volume target stats `vol_p` for consistency (single channel), save in same JSON under `vol_p` key
7. Print the stats to stdout. Verify σ_τ_z is in the expected range ~0.05-0.10 Pa (smaller than σ_τ_x).

Run this ONCE before training:
```bash
cd target/ && python compute_target_stats.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --output data/surface_target_stats.json
```

Commit the stats JSON to the PR.

### Step 2 — Wire z-score normalization into the loss

In `train.py` (or `trainer_runtime.py` — wherever surface MSE loss is computed):

1. **Load stats at trainer init**: read `data/surface_target_stats.json` → tensors `target_mean[4]`, `target_std[4]` on device. Move to GPU once. Same for volume_p (single value).

2. **Apply ONLY in the loss computation**:
   ```python
   # In loss step:
   pred_surface_normed = (pred_surface - target_mean) / target_std    # broadcast over (B, N, 4)
   target_surface_normed = (target_surface - target_mean) / target_std
   loss_per_channel = (pred_surface_normed - target_surface_normed).square()
   # then apply per-channel weights (cp=1.0, τ_x=1.0, τ_y=1.5, τ_z=2.0) as before
   ```

3. **DO NOT normalize the model's output OR the eval metrics.** Evaluation metrics (rel-L2) compute on raw-physical-units predictions. Only the loss sees normalized values. Architecture is unchanged.

4. **Important: keep all loss WEIGHTS as in H3/PR #823 reference** (`--tau-y-loss-weight 1.5`, `--tau-z-loss-weight 2.0`, `--surface-loss-weight 2.0`). The z-score change is on top of, not replacing, these.

5. **Volume_p loss**: also z-score using the saved σ_vol_p. Apply same pattern.

6. **GradNorm interaction**: leave GradNorm as configured. It will now adapt on top of the equalized base scale. Document in W&B config that z-score is enabled.

### Step 3 — Add diagnostics to W&B

Log once at startup (in config):
- `data/target_mean_cp`, `data/target_mean_tau_x`, etc.
- `data/target_std_cp`, `data/target_std_tau_x`, etc.

Log every epoch:
- `train/loss_per_channel_normed/cp`, `/tau_x`, `/tau_y`, `/tau_z` — per-channel MSE in NORMED space (should be O(1) for each)
- `train/loss_per_channel_raw/cp`, etc. — per-channel MSE in RAW space (for backwards-compat comparison)
- `train/loss_per_channel_ratio_normed_to_raw/cp`, etc. — should equal 1/σ_c² per channel (sanity check)

### Step 4 — Pre-flight sanity check (mandatory before main run)

Run a 2-epoch SMOKE on 2 ranks first:
```bash
cd target/ && torchrun --standalone --nproc-per-node=2 train.py \
  --epochs 2 --batch-size 4 --validation-every 1 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --vol-points-schedule 0:16384 \
  --no-compile-model \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --normalize-surface-targets --normalize-volume-targets \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --wandb-group wave30_h16_zscore_smoke \
  --wandb-name frieren/h16-zscore-smoke-2ep --agent frieren
```

**Sanity checks (must all PASS before main run):**
1. **`train/loss_per_channel_normed/*` are all O(0.1-1)** — normalized losses should be of similar scale, not 0.01 (overshoot) or 10 (undershoot)
2. **`train/loss_per_channel_ratio_normed_to_raw/c` ≈ 1/σ²_c** for each channel — sanity check that normalization is applied correctly
3. **val_abupt at EP1 ≤ 33%** (the warmup floor) — model is still learning the same task, just in normalized coordinates
4. **No NaN, no nonfinite_grad** — z-score should be numerically stable
5. **Model parameter count unchanged**: ~16.36M (matches H3 reference)

Post sanity check results before launching the 13-epoch main run.

### Step 5 — Full training recipe (18h budget, 13 epochs)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --normalize-surface-targets --normalize-volume-targets \
  --wandb-group wave30_h16_zscore_targets \
  --wandb-name frieren/h16-zscore-13ep-18h --agent frieren
```

### EP gates (warmup=1 recipe)

- EP1 floor: val_abupt ~33% (warmup) — DO NOT KILL
- EP3 PASS: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 PASS: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 PASS: val_abupt ≤ 6.3% PASS
- EP13 terminal: val_abupt + test_WSS + test τz/τx (the headline)

## Baseline

Current best single-model (corrected split):
- val_abupt: **6.126%**
- test_abupt: 5.844%
- test_WSS: **6.727%**
- test_vol_p: **3.643%** (hard floor)
- test_SP: **3.577%** (hard floor)
- test τz/τx: **1.456** (collapse band, target to break)
- W&B baseline run: `56bcqp3m` (PR #972)
- Issue #1056 stretch target: test_WSS < 5.85%

Per-channel test statistics (post-#972 baseline):
- cp val MAE: 0.01044 Pa, σ unknown (compute it!)
- τ_x val MAE: 0.07458 Pa, σ unknown
- τ_y val MAE: 0.04844 Pa, σ unknown
- τ_z val MAE: 0.04964 Pa, σ unknown

**Note: This PR uses the canonical Wave 30 reference recipe `lr=9e-5` (NOT lr=5e-4 — see #1153/#1152/#1156/#1155 cascade closures for context).** Verified clean against H3/PR #823, PR #1138 (H3 closed-clean val_abupt EMA=6.197%), PR #972 (SOTA), and 6 other in-flight PRs.
