### PR TITLE
Wave 30 H17: Local tangent-frame output reparameterization for WSS (enforce τ·n=0 by construction)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,11 +382,14 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_tangent_frame_output: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
         self.surface_input_dim = surface_input_dim
         self.surface_output_dim = surface_output_dim
+        self.use_tangent_frame_output = use_tangent_frame_output
+        surface_head_channels = 3 if use_tangent_frame_output else surface_output_dim
         self.volume_input_dim = volume_input_dim
         self.volume_output_dim = volume_output_dim
         self.rff_num_features = rff_num_features
@@ -484,7 +487,7 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(n_hidden, surface_head_channels),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -496,7 +499,7 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_out = LinearProjection(n_hidden, surface_head_channels)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
@@ -621,8 +624,57 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        tangent_diagnostics: dict[str, torch.Tensor] | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            raw = self.surface_out(surface_hidden)
+            if self.use_tangent_frame_output:
+                # Per-vertex normals from input features (channels 3:6 of surface_x).
+                n = F.normalize(surface_x[..., 3:6].float(), dim=-1)
+                # Degeneracy-safe reference: e_x if |n·e_x| < 0.9 else e_y.
+                e_x = torch.zeros_like(n)
+                e_x[..., 0] = 1.0
+                e_y = torch.zeros_like(n)
+                e_y[..., 1] = 1.0
+                dot_x = (n * e_x).sum(dim=-1, keepdim=True).abs()
+                degeneracy = (dot_x >= 0.9).float()
+                ref = torch.where(dot_x < 0.9, e_x, e_y)
+                # Gram-Schmidt tangent basis in fp32 for numerical stability.
+                t1 = F.normalize(ref - (ref * n).sum(dim=-1, keepdim=True) * n, dim=-1)
+                t2 = torch.linalg.cross(n, t1, dim=-1)
+                # Cast tangent basis back to raw dtype for combination with predicted coefficients.
+                t1_cast = t1.to(raw.dtype)
+                t2_cast = t2.to(raw.dtype)
+                alpha_t1 = raw[..., 1:2]
+                alpha_t2 = raw[..., 2:3]
+                # Reconstruct global-frame WSS in the (normalized) target space.
+                tau_wss = alpha_t1 * t1_cast + alpha_t2 * t2_cast  # [B, N, 3]
+                surface_preds = torch.cat([raw[..., 0:1], tau_wss], dim=-1)  # [B, N, 4]
+                # Diagnostics: only meaningful with at least one surface vertex
+                # in the batch. Surface-empty batches (e.g. volume-only views in
+                # the curriculum) produce 0-element tensors that crash .amax().
+                if surface_hidden.shape[1] > 0:
+                    mask_float = surface_mask.unsqueeze(-1).to(t1.dtype)
+                    mask_valid = mask_float.sum().clamp(min=1.0)
+                    t1_t2_orth = (t1 * t2).sum(dim=-1, keepdim=True).abs() * mask_float
+                    n_t1_orth = (n * t1).sum(dim=-1, keepdim=True).abs() * mask_float
+                    degeneracy_masked = degeneracy * mask_float
+                    alpha_t1_masked = alpha_t1.abs() * mask_float
+                    alpha_t2_masked = alpha_t2.abs() * mask_float
+                    tau_dot_n = (tau_wss.float() * n).sum(dim=-1, keepdim=True).abs() * mask_float
+                    tangent_diagnostics = {
+                        "t1_t2_orthogonality_residual": (t1_t2_orth.sum() / mask_valid).detach(),
+                        "n_t1_orthogonality_residual": (n_t1_orth.sum() / mask_valid).detach(),
+                        "degeneracy_frac": (degeneracy_masked.sum() / mask_valid).detach(),
+                        "alpha_t1_absmean": (alpha_t1_masked.sum() / mask_valid).detach(),
+                        "alpha_t2_absmean": (alpha_t2_masked.sum() / mask_valid).detach(),
+                        "alpha_t1_absmax": alpha_t1_masked.amax().detach(),
+                        "alpha_t2_absmax": alpha_t2_masked.amax().detach(),
+                        "tau_dot_n_max": tau_dot_n.amax().detach(),
+                        "tau_dot_n_mean": (tau_dot_n.sum() / mask_valid).detach(),
+                    }
+            else:
+                surface_preds = raw
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -633,10 +685,14 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if tangent_diagnostics is not None:
+            for key, value in tangent_diagnostics.items():
+                out[f"tangent_frame/{key}"] = value
+        return out

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_tangent_frame_output: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_tangent_frame_output": (
+            "PR #1162 H17: local tangent-frame output reparameterization "
+            "for wall-shear-stress. Predict (alpha_t1, alpha_t2) in the "
+            "per-vertex tangent plane built by Gram-Schmidt from the "
+            "input surface normal, then reconstruct global-frame "
+            "tau = alpha_t1 * t1 + alpha_t2 * t2 inside model.forward(). "
+            "Surface head outputs 3 channels (cp + 2 tangent scalars) "
+            "instead of 4. Enforces tau . n = 0 in the predicted "
+            "(normalized) space by construction. Eval/loss code is "
+            "unchanged: predictions are still compared against the "
+            "normalized 4-channel surface target."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_tangent_frame_output=config.use_tangent_frame_output,
     )
 
 
@@ -346,13 +360,17 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    for key, value in out.items():
+        if key.startswith("tangent_frame/") and torch.is_tensor(value):
+            metrics[key] = float(value.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1070,6 +1088,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for key, value in batch_loss_metrics.items():
+                        if key.startswith("tangent_frame/"):
+                            train_log[f"train/{key}"] = value
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**H17 — Local Tangent-Frame Output Reparameterization for WSS.**

Predict WSS as two scalar tangent-plane coefficients `(α_t1, α_t2)` in the local surface tangent basis, then reconstruct global-frame `τ_WSS = α_t1·t1 + α_t2·t2` inside `model.py:forward()` — enforcing `τ·n=0` by construction.

This is a **representational** attack on the τ_z bottleneck, distinct from all in-flight loss-formulation attacks and from #1148 fern H10 (which keeps global-frame). Inspired by Gao et al. ICML 2024 (arxiv:2406.09648 "Intrinsic Vector Heat Network") and Hendriks et al. 2020 (arxiv:2002.01600 "Linearly Constrained Neural Networks").

### Why it might work

Every closed Wave 30 model-side attack lands in the same collapse band: `τ_z/τ_x ∈ [1.44, 1.55]` versus the **GT vertex-level ratio of 0.08**. #1148 fern H10 EP8 showed WSS direction is already learned to 99.65% cosine similarity — **all residual error is in magnitude reconstruction**.

The likely mechanism: a spurious geometric correlation in the **global frame**. On horizontal automotive surfaces (hood, roof, trunk — highest area, highest importance), the surface normal `n` points approximately `+z`. This means `τ_z` in global frame partially collapses onto the normal direction — which has **zero physical content for WSS** (τ·n ≡ 0 by definition). The model must learn to suppress `τ_z` on these panels, an implicit constraint the global-frame output space does NOT express naturally. In the tangent basis `(t1, t2 perpendicular to n)`, this constraint is eliminated by construction: the model only predicts tangential components, and `τ_z` emerges from basis rotation rather than being predicted directly.

**Difference from #1147 H6' (tanjiro)**: H6' adds a soft τ·n=0 PENALTY after global-frame prediction. H17 changes the OUTPUT REPRESENTATION so the constraint cannot be violated — analogous to the difference between penalizing a network to output positive values versus using a softplus activation.

**Difference from #1148 H10 (fern)**: H10 separates direction from magnitude prediction in the GLOBAL xyz frame. H17 changes the frame entirely — only 2 tangent-plane scalars predicted; global xyz emerges by deterministic reconstruction.

## Instructions

All implementation lives in `model.py`. **No changes to loss code, eval, metrics, or `TargetTransform`** — reconstruction to global xyz happens inside `forward()` before returning `out["surface_preds"]` of shape `[B, N, 4]`. Eval/loss code keeps comparing `surface_preds` against `TargetTransform.apply_surface(batch.surface_y)` in normalized global-xyz space.

### Add a config flag

To preserve baseline + enable controlled comparison, add a config option `use_tangent_frame_output: bool = False`:

1. **`model.py:__init__`** — accept `use_tangent_frame_output: bool = False` arg; store as `self.use_tangent_frame_output = use_tangent_frame_output`.

2. **`model.py:__init__`** — when `use_tangent_frame_output=True`, change the final `nn.Linear` in `surface_out` (currently at `model.py:484-488`) to output **3 channels** instead of `self.surface_output_dim` (which is 4): `Linear(n_hidden, 3)`. **Keep `self.surface_output_dim = 4`** for downstream code compatibility. The 3 channels represent `[cp_pred, alpha_t1, alpha_t2]`.

3. **`model.py:forward()`** — modify the surface output path at line 624-625. Replace:

   ```python
   if surface_x is not None:
       surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
   ```

   with:

   ```python
   if surface_x is not None:
       raw = self.surface_out(surface_hidden)  # [B, N, 3] if tangent-frame, else [B, N, 4]
       if self.use_tangent_frame_output:
           # Extract per-vertex normals from input features (channels 3:6)
           n = F.normalize(surface_x[..., 3:6].float(), dim=-1)
           # Degeneracy-safe reference vector (use e_x if |n·e_x| < 0.9 else e_y)
           e_x = torch.zeros_like(n); e_x[..., 0] = 1.0
           e_y = torch.zeros_like(n); e_y[..., 1] = 1.0
           dot_x = (n * e_x).sum(dim=-1, keepdim=True).abs()
           ref = torch.where(dot_x < 0.9, e_x, e_y)
           # Gram-Schmidt tangent basis (in fp32 for numerical stability)
           t1 = F.normalize(ref - (ref * n).sum(dim=-1, keepdim=True) * n, dim=-1)
           t2 = torch.linalg.cross(n, t1, dim=-1)
           # Cast back to raw dtype for combination with predicted coefficients
           t1 = t1.to(raw.dtype); t2 = t2.to(raw.dtype)
           # Reconstruct global-frame WSS
           tau_wss = raw[..., 1:2] * t1 + raw[..., 2:3] * t2  # [B, N, 3]
           surface_preds = torch.cat([raw[..., 0:1], tau_wss], dim=-1)  # [B, N, 4]
       else:
           surface_preds = raw
       surface_preds = surface_preds * surface_mask.unsqueeze(-1)
   ```

   Critical gotchas:
   - `torch.linalg.cross(a, b, dim=-1)` — the `dim` keyword is REQUIRED for batched tensors.
   - Compute the basis in fp32 to avoid bf16 numerical drift in Gram-Schmidt (then cast back).
   - The tangent basis is computed from input features (not learned parameters), so gradients flow only through `(α_t1, α_t2)`. This is correct — basis is a fixed geometric frame.

4. **CLI flag in `train.py`**: add `--use-tangent-frame-output` (store_true). Plumb through to model constructor.

5. **Diagnostics (recommended)**: log a couple of telemetry metrics every step or every eval batch for debugging:
   - `train/tangent_frame/t1_t2_orthogonality_residual` = `|t1 · t2|.mean()` — should be near 0 (orthogonal basis)
   - `train/tangent_frame/n_t1_orthogonality_residual` = `|n · t1|.mean()` — should be near 0
   - `train/tangent_frame/alpha_t1_p95`, `train/tangent_frame/alpha_t2_p95` — magnitudes of predicted coefficients
   - `train/tangent_frame/degeneracy_frac` = fraction of vertices where `|n·e_x| ≥ 0.9` (using fallback `e_y`)

### Smoke run (2-rank, 2 epochs, 16k surf points)

Before launching the full DDP-8 18h run, please do a smoke run to verify:
- Forward pass produces finite `surface_preds`
- `t1·t2` and `n·t1` orthogonality residuals are <1e-3
- EP1 val_abupt ≤ 50% (warmup; lr=9e-5 with 1-ep warmup typically lands ~33% but tangent-frame may take longer to initialize)
- No NaN/nonfinite_grad spikes

If smoke is clean, proceed to main run with the recipe below.

### Main run — DDP 8 GPU, 18h budget, lr=9e-5

```bash
DRIVAERML_USE_CURVATURE=0 torchrun --standalone --nproc-per-node=8 \
  train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-tangent-frame-output \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h17_tangent_frame --wandb-name nezuko/tangent-frame-wss-18h --agent nezuko
```

**CRITICAL**: `--lr 9e-5` — NOT 5e-4. The lr=5e-4 setting caused 4 Wave 30 divergences (#1153, #1152, #1156, #1155).

`SENPAI_TIMEOUT_MINUTES=1100` for the 18h budget.

### What success looks like

- **WIN (top priority)**: `test_WSS < 6.727%` AND `test_SP ≤ 3.577%` AND `test_vol_p ≤ 3.643%` → MERGE
- **STRONG SIGNAL**: `test_τ_z/τ_x < 1.40` (breaks out of the [1.44, 1.55] collapse band) regardless of WSS — this would be the FIRST mechanism to break the band and would be merged even on a marginal WSS result
- **PARTIAL**: `test_WSS` within 0.05pp of baseline + `τ_z/τ_x` materially below 1.45 → request follow-up (e.g. combine with H10 vector-decouple or H16 Huber)
- **FLAT NULL**: `test_WSS` flat, `τ_z/τ_x` stays in band → architecture-side τ_z bottleneck story is dead; redirect to optimization/output-projection variants
- **KILL EP1** if val_abupt > 50% (tangent-frame may need different init, but >50% post-warmup signals broken implementation)
- **KILL EP5** if val_abupt > 12% (won't reach baseline at EP13)

### Required terminal report

Please report both **val** AND **test** metrics in the terminal SENPAI-RESULT, including:
- val/test full panel (abupt, WSS, SP, vol_p, per-component τ_x/τ_y/τ_z)
- val/test τ_z/τ_x ratio (critical mechanism diagnostic)
- Best-checkpoint test eval (not just terminal-epoch eval)
- Tangent-basis diagnostics summary (orthogonality residuals across epochs, α_t1/α_t2 magnitude distribution)
- Per-epoch val_abupt trajectory + τ_z/τ_x trajectory

## Baseline

From BASELINE.md (PR #972, "L=5 + surf→vol xattn ... Lion lr=9e-5, 13ep", best single-model):

| Metric | val (n=34) | test (n=50) |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.126%** | **5.844%** |
| `val_primary/surface_pressure_rel_l2_pct` | 3.962% | 3.456% |
| `val_primary/wall_shear_rel_l2_pct` | 6.917% | **6.727%** (paper-facing) |
| `val_primary/volume_pressure_rel_l2_pct` | 3.798% | 3.563% |
| `val/wall_shear_x_rel_l2_pct` | — | 6.04% |
| `val/wall_shear_y_rel_l2_pct` | — | 7.42% |
| `val/wall_shear_z_rel_l2_pct` | — | 8.26% |
| `val/τ_z/τ_x` | — | ~1.46 (collapse band) |

Floors: `test_vol_p ≤ 3.643%`, `test_SP ≤ 3.577%`. Goal: `test_WSS < 5.85%` (Transolver-3 SOTA — per Issue #1056).

**Baseline W&B run**: `1mky7rni` (group `pr972`, branch `tay`)
