### PR TITLE
Wave 30 H18: Per-vertex area-weighted surface MSE (physical force-integral matching)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,7 +54,9 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    compute_area_vertex_weights,
     masked_mse,
+    masked_weighted_mse,
     metric_namespace,
     weighted_channel_mse,
     parse_kill_thresholds,
@@ -105,6 +107,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    use_area_weighted_loss: bool = False
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,10 +324,16 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_area_weighted_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    vertex_weights: torch.Tensor | None = None
+    area_metrics: dict[str, float] = {}
+    if use_area_weighted_loss:
+        vertex_weights = compute_area_vertex_weights(batch.surface_x, batch.surface_mask)
+        area_metrics = _area_weight_diagnostics(vertex_weights, batch.surface_mask)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -338,6 +347,11 @@ def train_loss(
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
+                vertex_weights=vertex_weights,
+            )
+        elif vertex_weights is not None:
+            surface_loss = masked_weighted_mse(
+                out["surface_preds"], surface_target, batch.surface_mask, vertex_weights
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
@@ -346,12 +360,36 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+    }
+    metrics.update(area_metrics)
+    return loss, metrics
+
+
+def _area_weight_diagnostics(
+    vertex_weights: torch.Tensor,
+    surface_mask: torch.Tensor,
+) -> dict[str, float]:
+    """Summary stats for the per-vertex area weights (masked vertices only)."""
+    with torch.no_grad():
+        mask_bool = surface_mask.bool()
+        valid_weights = vertex_weights[mask_bool]
+        if valid_weights.numel() == 0:
+            return {}
+        w_max = float(valid_weights.max().item())
+        w_min = float(valid_weights.min().item())
+        w_p95 = float(torch.quantile(valid_weights.float(), 0.95).item())
+        dyn_range = w_max / max(w_min, 1e-8)
+    return {
+        "area_weighted/vertex_weight_max": w_max,
+        "area_weighted/vertex_weight_min": w_min,
+        "area_weighted/vertex_weight_p95": w_p95,
+        "area_weighted/effective_dynamic_range": dyn_range,
     }
 
 
@@ -364,6 +402,8 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_area_weighted_loss: bool = False,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -371,11 +411,18 @@ def per_task_train_losses(
     All five share the same forward graph so the GradNorm balancer can
     extract per-task gradient norms via ``torch.autograd.grad`` with
     ``retain_graph=True``.
+
+    When ``use_area_weighted_loss`` is True the four surface losses are
+    computed with per-vertex area weights (volume pressure stays unweighted
+    since it lives on a different mesh).
     """
 
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    vertex_weights: torch.Tensor | None = None
+    if use_area_weighted_loss:
+        vertex_weights = compute_area_vertex_weights(batch.surface_x, batch.surface_mask)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -384,10 +431,24 @@ def per_task_train_losses(
             volume_mask=batch.volume_mask,
         )
         surface_pred = out["surface_preds"]
-        sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
-        taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
-        tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
-        tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+        if vertex_weights is not None:
+            sp_loss = masked_weighted_mse(
+                surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask, vertex_weights
+            )
+            taux_loss = masked_weighted_mse(
+                surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask, vertex_weights
+            )
+            tauy_loss = masked_weighted_mse(
+                surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask, vertex_weights
+            )
+            tauz_loss = masked_weighted_mse(
+                surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask, vertex_weights
+            )
+        else:
+            sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
+            taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+            tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+            tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
     return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
 
@@ -883,6 +944,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_area_weighted_loss"] = config.use_area_weighted_loss
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -937,10 +999,24 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                area_diag_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        use_area_weighted_loss=config.use_area_weighted_loss,
                     )
+                    if config.use_area_weighted_loss:
+                        with torch.no_grad():
+                            _vw = compute_area_vertex_weights(
+                                batch.surface_x.to(device), batch.surface_mask.to(device)
+                            )
+                            area_diag_metrics = _area_weight_diagnostics(
+                                _vw, batch.surface_mask.to(device)
+                            )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
                     )
@@ -1030,7 +1106,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_area_weighted_loss=config.use_area_weighted_loss,
                     )
+                    if config.use_area_weighted_loss:
+                        for diag_key in (
+                            "area_weighted/vertex_weight_max",
+                            "area_weighted/vertex_weight_min",
+                            "area_weighted/vertex_weight_p95",
+                            "area_weighted/effective_dynamic_range",
+                        ):
+                            if diag_key in batch_loss_metrics:
+                                area_diag_metrics[diag_key] = batch_loss_metrics.pop(diag_key)
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1072,6 +1158,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if area_diag_metrics:
+                    train_log.update({f"train/{k}": v for k, v in area_diag_metrics.items()})
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,11 +837,35 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_weighted_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    vertex_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Per-vertex-weighted masked MSE.
+
+    pred / target: [B, N, C]; mask: [B, N]; vertex_weights: [B, N].
+    ``vertex_weights`` should be pre-normalized so the mean over masked
+    vertices in each sample equals 1.0; this preserves the loss magnitude
+    relative to ``masked_mse`` and keeps existing learning rates / channel
+    weights calibrated. Weights are broadcast over the channel axis so the
+    same vertex weighting applies to every output channel.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    weights_dev = vertex_weights.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    sq_err = (pred - target).square()
+    weighted_sq_err = sq_err * weights_dev
+    return masked_mean(weighted_sq_err, mask)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
     mask: torch.Tensor,
     weights: torch.Tensor,
+    vertex_weights: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Per-channel weighted masked MSE with a single mean over all entries.
 
@@ -852,6 +876,12 @@ def weighted_channel_mse(
     and only changes the relative gradient budget across channels — it does NOT
     decompose into per-channel means (which would double-weight the smaller
     channels and was the failure mode of PR #353).
+
+    When ``vertex_weights`` is supplied ([B, N], normalized so mean over masked
+    vertices = 1), each vertex's squared error is also multiplied by its own
+    weight. Channel and vertex weights compose multiplicatively; the
+    pre-normalization keeps the overall scale equal to ``weighted_channel_mse``
+    with uniform vertex weights.
     """
     if pred.numel() == 0:
         return pred.sum() * 0.0
@@ -863,11 +893,40 @@ def weighted_channel_mse(
     sq_err = (pred - target).square()
     mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     weighted = sq_err * weights_dev * mask_dev
+    if vertex_weights is not None:
+        weighted = weighted * vertex_weights.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):
         return weighted.sum() / denominator
     return pred.sum() * 0.0
+
+
+def compute_area_vertex_weights(
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    area_channel_idx: int = 6,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Per-sample area-normalized vertex weights for surface losses.
+
+    surface_x: [B, N, C_in] with raw per-vertex panel area at channel
+    ``area_channel_idx`` (default 6, matches ``data.loader.SURFACE_X_DIM``).
+    surface_mask: [B, N] with 1.0 on valid vertices.
+
+    Returns: [B, N] weights normalized per-sample so the mean over masked
+    vertices equals 1.0. This is a numerically-safe Voronoi-style discrete
+    approximation of ``∫ |τ-τ̂|^2 dA`` (DoMINO, arXiv 2501.13350); per-sample
+    (not per-batch) normalization keeps it consistent under DDP since each
+    rank sees full samples.
+    """
+    raw_area = surface_x[..., area_channel_idx].to(dtype=torch.float32)
+    raw_area = torch.clamp(raw_area, min=eps)
+    mask_float = surface_mask.to(dtype=raw_area.dtype, device=raw_area.device)
+    area_sum = (raw_area * mask_float).sum(dim=1, keepdim=True)
+    n_valid = mask_float.sum(dim=1, keepdim=True).clamp_min(1.0)
+    area_mean = (area_sum / n_valid).clamp_min(eps)
+    return raw_area / area_mean
 
 
 def squared_relative_l2_loss(


### PR DESCRIPTION
## Hypothesis

**H18 — Per-vertex area-weighted surface MSE.**

Currently the surface loss is uniform per vertex (`masked_mse` averages over all valid vertices). But the discretized mesh has highly non-uniform vertex distribution: hood/roof/trunk panels are large and sparse (high area per vertex), small detail panels (mirrors, wheel wells, bumpers) are dense (low area per vertex). The physical force integral is `∫ τ dA` — i.e., **area-weighted**, not vertex-count-weighted. Re-weighting each vertex's MSE by its panel area makes the loss match the physical integral.

### Why this might attack the τ_z bottleneck

Per the H6' (tanjiro #1147, closed) and H17 (nezuko #1162, in-flight) analyses, τ_z over-prediction is concentrated on **horizontal panels** (hood/roof/trunk) where `n ≈ +z` — exactly the **high-area panels**. Uniform vertex weighting under-weights these high-area regions relative to their physical importance, letting the model accept a higher τ_z error there in exchange for marginal improvement on dense detail panels (low τ_z error). Area-weighting flips this trade-off: the model is pushed harder to fit the high-area horizontal panels, exactly where the τ_z bias lives.

H6' showed that loss-side mechanism attacks on τ_z DO move the collapse band (test τ_z/τ_x went from in-band 1.50 to below-band 1.420), even when the soft-penalty formulation overall lost on primary metrics. H18 is a **different loss-side mechanism** — vertex-importance reweighting via physical area, not direction constraint — and is orthogonal to all 7 in-flight Wave 30 attacks.

### Difference from in-flight loss-formulation attacks

- **edward H12 (tau-magnitude weighted)**: reweights at the CHANNEL level (τ_y_weight, τ_z_weight scalars). H18 reweights at the VERTEX level (per-vertex area).
- **frieren H16 (Huber τ)**: clips outlier vertices via gradient cap. H18 emphasizes high-area vertices via loss multiplier. Orthogonal — could compose later.
- **thorfinn H13c (cos+mag decoupling)**: separates direction error from magnitude error. H18 reweights all errors uniformly per vertex but by area. Orthogonal.

### Theoretical basis

The numerical PDE / finite-element view: when discretizing a continuous loss `L = ∫ |τ(x) − τ̂(x)|² dA`, the discrete approximation is `L ≈ Σ_i w_i |τ_i − τ̂_i|²` where `w_i = A_i` is the vertex area weight. Uniform weighting (`w_i = 1/N`) is only correct for uniform meshes. References:

- **Cheng et al. 2018 "Surface networks via general covers"** — area-weighting in surface CNN losses
- **Ranjan et al. 2018 "CoMA: Convolutional Mesh Autoencoders"** — explicitly area-weighted vertex losses on irregular meshes
- **Karras et al. 2024 "Analyzing and Improving the Training Dynamics of Diffusion Models"** — vertex-area-weighting as natural physical prior (analogous to log-snr weighting)

## Instructions

All implementation in `trainer_runtime.py` and `train.py`. **No model changes**, no architecture changes.

### Step 1: Add `masked_weighted_mse` helper to `trainer_runtime.py`

After the existing `masked_mse` definition (around `trainer_runtime.py:836`):

```python
def masked_weighted_mse(
    pred: torch.Tensor,        # [B, N, C]
    target: torch.Tensor,      # [B, N, C]
    mask: torch.Tensor,        # [B, N]
    vertex_weights: torch.Tensor,  # [B, N] — normalized so mean over masked vertices = 1
) -> torch.Tensor:
    """Per-vertex-weighted masked MSE.
    
    vertex_weights are pre-normalized so that the SUM over valid vertices
    divided by the COUNT of valid vertices equals 1.0 (preserves loss scale).
    """
    sq_err = (pred - target).square()  # [B, N, C]
    # weight applies per-vertex, broadcast over channels
    weighted_sq_err = sq_err * vertex_weights.unsqueeze(-1)
    return masked_mean(weighted_sq_err, mask)
```

### Step 2: Compute area weights from surface_x

In both `train_loss()` (around `train.py:314-345`) and `per_task_train_losses()` (around `train.py:361-391`), after computing `surface_target`:

```python
# Per-vertex panel area is surface_x[..., 6] (channel 6 per data/loader.py:38)
# CRITICAL: This is the RAW area — may be normalized depending on data pipeline.
# Check data/normalizers.json or data/loader.py to confirm units before using.
# Normalize so mean over masked vertices = 1.0 to preserve loss magnitude.
if args.use_area_weighted_loss:
    raw_area = batch.surface_x[..., 6]  # [B, N]
    # Avoid div-by-zero by clamping (some preprocessed samples may have tiny areas)
    raw_area = torch.clamp(raw_area, min=1e-8)
    # Compute per-batch normalizer: mean area over MASKED vertices
    area_sum = (raw_area * batch.surface_mask).sum(dim=1, keepdim=True)
    n_valid = batch.surface_mask.sum(dim=1, keepdim=True).clamp(min=1)
    area_mean = area_sum / n_valid  # [B, 1]
    vertex_weights = raw_area / area_mean  # [B, N], mean = 1 over masked vertices
    # Use weighted MSE for surface
    surface_loss = masked_weighted_mse(
        out["surface_preds"], surface_target, batch.surface_mask, vertex_weights
    )
else:
    surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

For `per_task_train_losses()`, replace each `masked_mse(...)` call for surface channels (sp, tau_x, tau_y, tau_z) with the weighted version (volume_pressure stays unchanged — that's a different mesh).

### Step 3: Add CLI flag in `train.py`

```python
parser.add_argument("--use-area-weighted-loss", action="store_true",
                    help="Weight per-vertex surface MSE by panel area for physical integral matching")
```

### Step 4: Telemetry — log area-weight distribution

In the training loop, log every step or every N steps:

```python
# Diagnostics for area-weighting health
if args.use_area_weighted_loss:
    masked_weights = vertex_weights * batch.surface_mask
    log_metrics["train/area_weighted/vertex_weight_max"] = masked_weights.max().item()
    log_metrics["train/area_weighted/vertex_weight_min"] = (
        masked_weights[batch.surface_mask.bool()].min().item()
    )
    log_metrics["train/area_weighted/vertex_weight_p95"] = (
        torch.quantile(masked_weights[batch.surface_mask.bool()], 0.95).item()
    )
    log_metrics["train/area_weighted/effective_dynamic_range"] = (
        log_metrics["train/area_weighted/vertex_weight_max"] /
        max(log_metrics["train/area_weighted/vertex_weight_min"], 1e-8)
    )
```

If `effective_dynamic_range` is > 1000, that's a warning sign that the loss may be dominated by a tiny number of mega-area vertices. If it's < 10, area-weighting is doing almost nothing and the hypothesis can't fire — flag in your terminal report.

### Smoke run (2-rank, 2 epochs, 16k surf points)

Before launching the full DDP-8 18h run, smoke-test:
- Verify `train/area_weighted/effective_dynamic_range` is in a reasonable range (10–500 expected; report what you see)
- Verify train loss trajectory is smooth (no instability from large weights)
- Verify EP1 val_abupt is in the typical range (~33% with lr=9e-5, 1ep warmup)
- Verify GradNorm weights still converge to similar values as baseline (sp≈0.4, τ_x≈0.8, τ_y≈1.8, τ_z≈1.6, vp≈0.4)

### Main run — DDP 8 GPU, 18h budget, lr=9e-5

```bash
torchrun --standalone --nproc-per-node=8 \
  train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-area-weighted-loss \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h18_area_weighted --wandb-name tanjiro/area-weighted-mse-18h --agent tanjiro
```

**CRITICAL**: `--lr 9e-5` — NOT 5e-4. The lr=5e-4 setting caused 4 Wave 30 divergences (#1153, #1152, #1156, #1155).

`SENPAI_TIMEOUT_MINUTES=1100` for the 18h budget.

### What success looks like

- **WIN (top priority)**: `test_WSS < 6.727%` AND `test_SP ≤ 3.577%` AND `test_vol_p ≤ 3.643%` → MERGE
- **STRONG SIGNAL**: `test_τ_z/τ_x < 1.40` (cleanly breaks below the collapse band) — H6' got 1.420, H18 with stronger mechanism should test if we can go lower
- **PARTIAL**: WSS within 0.05pp of baseline + τ_z/τ_x below 1.42 → request follow-up (e.g. combine with H17 reparam if it lands)
- **FLAT NULL**: No movement on WSS or τ_z/τ_x → area-weighting is not the lever
- **KILL EP1** if val_abupt > 50% (instability from dynamic-range issue)
- **KILL EP5** if val_abupt > 12% (won't reach baseline at EP13)

### Required terminal report

Please post a terminal SENPAI-RESULT comment with:
- Full val + test panel (abupt, WSS, SP, vol_p, per-component τ_x/τ_y/τ_z)
- val + test τ_z/τ_x ratio
- Best-checkpoint test eval (not just terminal-epoch)
- Per-epoch val trajectory (abupt + WSS + τ_z/τ_x)
- Area-weighting diagnostics summary: effective_dynamic_range trajectory, max area weight observed
- Comparison vs H6' #1147 closure (same mechanism family — soft τ·n=0 lost on WSS but moved test τz/τx to 1.420)

## Baseline

From BASELINE.md (PR #972, "L=5 + surf→vol xattn ... Lion lr=9e-5, 13ep"):

| Metric | val (n=34) | test (n=50) |
|---|---:|---:|
| `val_primary/abupt_axis_mean_rel_l2_pct` | **6.126%** | **5.844%** |
| `val_primary/surface_pressure_rel_l2_pct` | 3.962% | 3.456% (floor 3.577%) |
| `val_primary/wall_shear_rel_l2_pct` | 6.917% | **6.727%** (paper-facing) |
| `val_primary/volume_pressure_rel_l2_pct` | 3.798% | 3.563% (floor 3.643%) |
| `val/wall_shear_x_rel_l2_pct` | — | 6.04% |
| `val/wall_shear_z_rel_l2_pct` | — | 8.26% |
| `test_τ_z/τ_x` | — | ~1.46 |

**H6' #1147 reference (just closed, same mechanism family — soft τ·n=0 penalty)**:
- test_abupt 6.037% (+0.193pp WORSE)
- test_SP 3.814% (FAIL floor +0.237pp)
- test_WSS 7.002% (+0.275pp WORSE)
- test_vol_p 3.603% PASS floor
- **test τ_z/τ_x = 1.420** (first attack to break below collapse band lower edge 1.44)

**Baseline W&B run**: `1mky7rni` (group `pr972`, branch `tay`)
