### PR TITLE
Wave 30 H10b: bounded-exp magnitude head fix (softplus→clamp.exp)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        vector_decoupled_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,11 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.vector_decoupled_head = vector_decoupled_head
+        # When True, surface head outputs 5 channels (cp, dir_x, dir_y, dir_z, log_mag).
+        # The 3-vector τ part is reconstructed as `log_mag.clamp(-3, 3).exp() * unit(dir)`
+        # in normalized space (H10b, PR #1164). Public surface_preds remain 4-channel.
+        self._surface_head_out_dim = self.surface_output_dim + (1 if vector_decoupled_head else 0)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -484,7 +490,7 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(n_hidden, self._surface_head_out_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -496,7 +502,7 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_out = LinearProjection(n_hidden, self._surface_head_out_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
@@ -518,6 +524,31 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+    def _reconstruct_surface(
+        self, raw: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Map raw 5-channel head output to (cp, τ_x, τ_y, τ_z) + decoupled diagnostics.
+
+        raw: [..., 5] = (cp, dir_x, dir_y, dir_z, log_mag)
+        Returns:
+            preds: [..., 4] = (cp, τ_x, τ_y, τ_z) in normalized space
+            dir_unit: [..., 3] L2-normalized direction
+            log_mag: [..., 1] raw log-magnitude channel (pre-clamp)
+
+        H10b: magnitude reconstructed as `clamp(log_mag, -3, 3).exp()` —
+        bounded log-normal in [e^-3, e^+3] ≈ [0.050, 20.09] without the
+        softplus floor (~0.693) that bottlenecked H10. Covers ±3σ of the
+        normalized τ-magnitude distribution.
+        """
+        cp = raw[..., 0:1]
+        dir_raw = raw[..., 1:4]
+        log_mag = raw[..., 4:5]
+        dir_unit = F.normalize(dir_raw, dim=-1, eps=1e-6)
+        mag = log_mag.clamp(min=-3.0, max=3.0).exp()
+        tau = mag * dir_unit
+        preds = torch.cat([cp, tau], dim=-1)
+        return preds, dir_unit, log_mag
 
     def _encode_group(
         self,
@@ -621,8 +652,20 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        surface_dir_unit: torch.Tensor | None = None
+        surface_log_mag: torch.Tensor | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_raw = self.surface_out(surface_hidden)
+            if self.vector_decoupled_head:
+                surface_preds_raw, surface_dir_unit, surface_log_mag = self._reconstruct_surface(
+                    surface_raw
+                )
+                mask_unsq = surface_mask.unsqueeze(-1)
+                surface_preds = surface_preds_raw * mask_unsq
+                surface_dir_unit = surface_dir_unit * mask_unsq
+                surface_log_mag = surface_log_mag * mask_unsq
+            else:
+                surface_preds = surface_raw * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -633,10 +676,14 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if self.vector_decoupled_head and surface_dir_unit is not None:
+            out["surface_pred_direction"] = surface_dir_unit
+            out["surface_pred_log_mag"] = surface_log_mag
+        return out

--- a/train.py
+++ b/train.py
@@ -105,6 +105,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    vector_decoupled_head: bool = False
+    direction_cos_loss_weight: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -308,6 +310,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        vector_decoupled_head=config.vector_decoupled_head,
     )
 
 
@@ -321,6 +324,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    direction_cos_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -344,7 +348,26 @@ def train_loss(
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
+        # H10/H10b vector-decoupled head: cosine-similarity aux loss on the
+        # unit direction of the wall shear vector in normalized space.
+        # Predicted direction is L2-normalized at the model layer (see
+        # SurfaceTransolver._reconstruct_surface); GT direction is normalized
+        # here from surface_target[..., 1:4]. Only active when the model
+        # populated "surface_pred_direction" AND weight > 0.
+        direction_cos_loss = surface_loss.new_zeros(())
+        active = (
+            "surface_pred_direction" in out and direction_cos_loss_weight > 0.0
+        )
+        if active:
+            pred_dir = out["surface_pred_direction"]  # [B, N, 3] unit (model-side)
+            tau_target = surface_target[..., 1:4]
+            tgt_dir = torch.nn.functional.normalize(tau_target, dim=-1, eps=1e-6)
+            cos_sim = (pred_dir * tgt_dir).sum(dim=-1)
+            direction_cos_loss_pv = 1.0 - cos_sim
+            mask_f = batch.surface_mask.to(direction_cos_loss_pv.dtype)
+            direction_cos_loss = (direction_cos_loss_pv * mask_f).sum() / mask_f.sum().clamp(min=1)
+        weighted_direction_cos_loss = direction_cos_loss_weight * direction_cos_loss
+        loss = weighted_surface_loss + weighted_volume_loss + weighted_direction_cos_loss
         base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
@@ -352,6 +375,8 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "direction_cos_loss": float(direction_cos_loss.detach().cpu().item()),
+        "direction_cos_loss_weighted": float(weighted_direction_cos_loss.detach().cpu().item()),
     }
 
 
@@ -883,6 +908,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/vector_decoupled_head"] = bool(config.vector_decoupled_head)
+            wandb.summary["loss/direction_cos_loss_weight"] = float(config.direction_cos_loss_weight)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1057,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        direction_cos_loss_weight=config.direction_cos_loss_weight,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1098,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "direction_cos_loss" in batch_loss_metrics:
+                        train_log["train/direction_cos_loss"] = batch_loss_metrics["direction_cos_loss"]
+                        train_log["train/direction_cos_loss_weighted"] = batch_loss_metrics[
+                            "direction_cos_loss_weighted"
+                        ]
+                        train_log["train/direction_cos_loss_weight"] = config.direction_cos_loss_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**H10b: Bounded-exp magnitude head fix.** Your H10 run (PR #1148, closed) produced the most important diagnostic in Wave 30: **73% of WSS squared error is in MAGNITUDE, only 27% in direction.** The direction head worked perfectly (val direction_cos_loss saturated at 0.00355 ≈ 99.65% cos-sim with GT, physical angle error ~8.3°). **The softplus magnitude head is the bottleneck.**

Your own suggestion #3 from the H10 close comment is exactly right and is being implemented here: replace `softplus(log_mag) * mag_scale=10.0` with `log_mag.clamp(min=-3, max=3).exp()`.

**Why softplus failed for magnitude:**

`softplus(x) = ln(1 + e^x)` has two pathological behaviors at the extremes of the log-magnitude range:
1. **Near-zero saturation**: softplus(x) ≈ ln(2) ≈ 0.693 as x→−∞ (it never goes below 0.693). For low-τ vertices (τ≈0 in normalized space), the model cannot predict magnitudes below 0.693 × 10.0 = 6.93. But in normalized space, τ_x/τ_y/τ_z have σ=1 — so low-τ vertices SHOULD be predicted near 0, not 6.93. This floor is catastrophic for flat automotive panels.
2. **Coupled scale**: multiplying by mag_scale=10.0 shifts the entire predicted distribution up by 10×. Even after training to compensate for this, the gradient landscape is distorted by the scale mismatch between the softplus floor and the GT distribution.

`log_mag.clamp(min=-3, max=3).exp()` instead:
- At x=−3: magnitude = e^{−3} ≈ 0.050 (near-zero for τ≈0 vertices ✓)
- At x=+3: magnitude = e^{+3} ≈ 20.09 (covers 5σ tails with room ✓)
- No floor saturation — log-normal predicted distribution is centered at e^0 = 1.0 (σ=1 normalized space) ✓
- Clean gradient signal through the clamp: only the top/bottom 5% of the normalized distribution is clipped

**Connection to 73%/27% diagnostic:**
The direction head proved it can learn direction to 99.65% cos-sim. The softplus floor of 6.93 in normalized space forced the model to compensate by pushing direction weights to correct for magnitude errors — but this is an inferior signal path compared to an accurate magnitude head. H10b removes the floor and tests whether the magnitude bottleneck was purely the softplus saturation artifact.

This is fern's own diagnosis. H10b is the minimal targeted fix to test it.

## Instructions

**Important**: Your H10 implementation from branch `fern/vector-decoupled-wss-head` (the closed PR #1148 branch) is your reference — the full vector-decoupled architecture is correct. H10b keeps all H10 architecture (5-channel output head, direction head, cosine aux loss at weight=0.1) and changes **only the magnitude reconstruction formula** in `model.py`.

### Step 1 — Start from your H10 branch

Your H10 implementation has all the infrastructure. You can start from that branch or implement the changes fresh on this branch. The delta from H10 is a single-line change in `model.py`.

### Step 2 — The only code change: replace softplus with bounded-exp in `_reconstruct_surface`

In `target/model.py`, in the `_reconstruct_surface` method (around where you wrote `mag = F.softplus(log_mag) * self.vector_decoupled_mag_scale`), change:

```python
# H10 (OLD — softplus floor causes near-zero saturation)
mag = F.softplus(log_mag) * self.vector_decoupled_mag_scale
```

to:

```python
# H10b (NEW — bounded-exp: covers [e^-3, e^+3] = [0.05, 20.09] without floor)
mag = log_mag.clamp(min=-3.0, max=3.0).exp()
```

Also remove `vector_decoupled_mag_scale` from the constructor and `__init__` signature since it is no longer used.

That is the ONLY change from H10. Everything else stays identical:
- 5-channel surface head (cp, dir_x, dir_y, dir_z, log_mag)
- Direction normalization: `F.normalize(dir_raw, dim=-1, eps=1e-6)`
- Cosine aux loss: `--direction-cos-loss-weight 0.1` (unchanged)
- All other hyperparameters: same as H10 baseline recipe

### Step 3 — Smoke run (verify before full launch)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=30 torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vector-decoupled-head --direction-cos-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 1 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 \
  --train-surface-points 16384 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --wandb-group wave30_h10b_bounded_exp --wandb-name fern/h10b-smoke --agent fern
```

Smoke PASS criteria:
- `train/direction_cos_loss` starts in [0.5, 2.0] at init, descends — same as H10 ✓
- `train/surface_loss` comparable to H10 baseline at same step ✓
- No NaN: `nonfinite_loss=0`, `nonfinite_grad=0` ✓
- **Key check:** `train/surface_loss` should drop FASTER than H10 (magnitude gradients cleaner) — if it does, that confirms the fix

### Step 4 — Full training run (18h budget)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vector-decoupled-head --direction-cos-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h10b_bounded_exp \
  --wandb-name fern/h10b-bounded-exp-18h --agent fern
```

### EP gates (warmup=1 recipe, same as H10)

- EP1 floor: val_abupt ~28–33% — DO NOT KILL (warmup epoch)
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS
- EP13 terminal: full SENPAI-RESULT with val AND test (per #1056 directive)

### Step 5 — Key diagnostics to report at terminal

Compare H10b vs H10 (#1148, closed) directly. Report:

1. **Magnitude error fraction** (most important): what % of WSS squared error is magnitude vs direction at terminal? Compare to H10's 73%/27% split.
2. `direction_cos_loss` final value — expect same ~0.003–0.005 as H10 since direction head is unchanged
3. `val_wall_shear_rel_l2_pct` and `test_wall_shear_rel_l2_pct` — key absolute metrics
4. `test_tau_z / test_tau_x` ratio — key structural metric (target < 1.40)
5. Per-epoch table: `val_abupt | val_WSS | val_SP | val_vol_p | direction_cos_loss | epoch`

Terminal SENPAI-RESULT must include:
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, test_τ_z
- **test τz/τx ratio**
- `direction_cos_loss` final value
- magnitude % share of WSS squared error

## Baseline (single-model SOTA: PR #972)

| Metric | Baseline (PR #972) | Gate/Floor | H10 result (PR #1148, closed) |
|---|---:|---|---:|
| val_abupt | 6.126% | < 6.126% to merge | 6.325% (−0.199pp worse) |
| test_WSS | 6.727% | < 6.727% to merge | 6.885% (+0.158pp worse) |
| test_vol_p | 3.643% | ≤ 3.643% floor (HARD) | 3.619% (floor PASSED) |
| test_SP | 3.577% | ≤ 3.577% floor (HARD) | 3.776% (floor FAILED +0.199pp) |
| test τz/τx | ~1.46 | < 1.40 structural target | 1.463 (flat — dir learning did not reduce τ_z) |

**H10 key finding**: direction head learned perfectly (direction_cos_loss=0.00355, 99.65% cos-sim), but magnitude error dominated (~73% of WSS squared error). Softplus floor at 6.93 in normalized space prevented accurate near-zero magnitude predictions. **H10b tests whether replacing softplus with bounded-exp unblocks the 73% magnitude bottleneck.**

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`
**Reproduce baseline run #972:** `56bcqp3m`

## What success looks like

- **BIG WIN**: test_WSS < 6.600% AND floors held → magnitude bottleneck was the softplus artifact; single-model breakthrough
- **MERGE**: test_WSS < 6.727% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% → improvement, stack with other winners
- **PARTIAL**: magnitude error fraction < 50% (down from 73%) but WSS still above baseline → magnitude head improved but floor violations persist; try with `direction_cos_loss_weight=0.25` to push direction harder
- **NULL**: magnitude fraction still ~73% → the saturation artifact was not the bottleneck; try `direction_cos_loss_weight=0.5` or separate magnitude normalization

**Source**: Wave 30 H10b. fern's own suggestion #3 from H10 close diagnostic. The 73%/27% magnitude-bottleneck finding is the primary scientific result from H10; H10b is the targeted follow-up.
