### PR TITLE
[dl24-fern] WSS H12: separate τ head — 2-layer MLP for τ_x/τ_y/τ_z vs linear cp

### DIFF
--- a/model.py
+++ b/model.py
@@ -362,7 +362,17 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        # Split surface head: linear cp head + deeper 2-layer MLP tau head.
+        # surface_y channel order is [cp, tau_x, tau_y, tau_z]; cp is index 0.
+        self.surface_cp_out = LinearProjection(n_hidden, 1)
+        self.surface_tau_out = nn.Sequential(
+            nn.Linear(n_hidden, 2 * n_hidden),
+            nn.GELU(),
+            nn.Linear(2 * n_hidden, 3),
+        )
+        # Near-zero init on the final tau layer for stable warmup.
+        nn.init.normal_(self.surface_tau_out[-1].weight, std=0.01)
+        nn.init.zeros_(self.surface_tau_out[-1].bias)
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -435,7 +445,10 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            cp_preds = self.surface_cp_out(surface_hidden)
+            tau_preds = self.surface_tau_out(surface_hidden)
+            surface_preds = torch.cat([cp_preds, tau_preds], dim=-1)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-16 21:25 UTC (**H9b EP4 graceful decel val_vol_p=4.00%**; **H10b EP2 hypothesis WEAKENING — vol_p +0.33pp behind H9b, τ_z TIED**; **H11b EP1 5pp WORSE than H9b — per-axis WSS upweight stresses early-epoch optimization**; H7 EP25 surf_p=4.05% NOT-A-MERGE)
+- 2026-05-16 22:37 UTC (**H10b EP3 HYPOTHESIS STRENGTHENING — H10b BETTER than H9b on 4/5 axes (-0.13pp τ_z, -0.07pp wss, -0.10pp surf_p); H9b EP5 vol_p slope DECELERATING TOO FAST → likely floor breach; H11b EP3 STILL RECOVERING at -2.05pp/ep slope, EP4 decision gate**)
 
 ## Human Research Directive (Issue #1056 — 2026-05-14)
 
@@ -50,14 +50,14 @@ H9 wave finding said "vol_p ceiling is representation-bound at 4.05%". **H9b EP3
 
 **This is the wave's first credible path to SOTA-on-aggregate (all 7 axes under SOTA #972).**
 
-## Active Experiments (2026-05-16 21:25 UTC)
+## Active Experiments (2026-05-16 22:37 UTC)
 
 | Student | PR | Hypothesis | EP / Duration | val_abupt | val_wss | val_vol_p | val_surf_p | Notes |
 |---------|-----|-----------|---------------|----------:|--------:|----------:|-----------:|-------|
-| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP25+ live** / 18h | 6.228% | 7.110% | **3.490%** ✅ | **4.048%** ❌ | val_surf_p flat at 4.05% across EP15-EP25 (σ ≈ 0.005pp); NOT-A-MERGE projection confirmed (surf_p breach +0.47pp). vol_p mechanism positive (under floor by 0.15pp). Continue to EP30 ~24:00Z. |
-| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP4 LANDED** / 3h | **6.444%** | **7.219%** | **4.000%** | 4.268% | **EP4 graceful cosine deceleration**: vol_p slope EP2→3=-1.496pp → EP3→4=-0.180pp (decay 0.12). Projected val_vol_p plateau 3.70-3.74% by EP10. Test floor 3.643%: val→test gap typically -0.1 to +0.3pp so terminal test_vol_p in [3.45, 3.85%] range — straddling floor. All other axes converging (1 EP behind H9 trajectory, MAE aux tax amortizing). |
-| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP2 LANDED** / 1.7h | 7.268% | 7.730% | 6.004% | 4.607% | **HYPOTHESIS WEAKENING.** vol_p +0.328pp BEHIND H9b at EP2 (no MAE aux means no vol_p acceleration). val_τ_z 10.227% **TIED** with H9b 10.179% — Charbonnier-alone NOT breaking τ_z. Charb/MSE ratio creep 0.30→0.66 (design-consistent — model grinding mid-residuals). w_vol_p stable 0.24, clamp dormant. EP3 ~21:45Z is next decision point. |
-| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** (CLEAN ISOLATION) | **EP1 LANDED** / 1h | 23.40% | 24.44% | 18.84% | 17.79% | **EP1 SIGNIFICANTLY WORSE than H9b (+4-5pp every axis).** Per-axis WSS upweight produces harder early-epoch optimization. EP2 spike test imminent (~21:35Z): val_abupt > val_abupt EP1 = "per-axis WSS unstable at any LR" wave finding. val_abupt ≤ 8.0% = recovery, continue. val_abupt > 9.0% = falsification. |
+| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP27+ live** / 19h | 6.228% | 7.110% | **3.490%** ✅ | **4.048%** ❌ | val_surf_p flat at 4.05% across EP15-EP26 (σ ≈ 0.005pp); NOT-A-MERGE projection confirmed (surf_p breach +0.47pp projected). vol_p mechanism positive (under floor by 0.15pp). Terminal ~24:00Z. |
+| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP5 LANDED** / 3.5h | **6.397%** | **7.171%** | **3.950%** | 4.241% | **vol_p slope DECELERATING TOO FAST**: EP4→5 = -0.050pp (decay factor 0.28, vs 0.60 projected). Projected plateau ~3.88-3.92% — terminal test_vol_p ~3.78-4.22% LIKELY ABOVE FLOOR 3.643% by 0.14-0.58pp. Surf_p plateau ~4.10% → test 4.0-4.5% above floor. Wave finding HOLDS but NOT clean merge candidate. WSS axes still on track. |
+| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP3 LANDED** / 2.7h | 6.580% | 7.258% | 4.545% | 4.251% | **HYPOTHESIS STRENGTHENING.** H10b BETTER than H9b at EP3 on 4/5 axes: abupt TIED, wss -0.069pp, **τ_z -0.134pp**, surf_p -0.097pp. Only vol_p +0.365pp behind (no MAE aux as designed). My EP2 "weakening" call was premature — Charbonnier mid-residual regime opens at EP3+. Best WSS-side candidate running. EP4 ~22:38Z. |
+| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** (CLEAN ISOLATION) | **EP3 LANDED** / 2.2h | 9.18% | 9.68% | 8.10% | 6.24% | **STILL RECOVERING**: NO spike (lr=5e-4 fix worked); EP2→EP3 slope=-2.05pp (active recovery, vs H9b -0.59pp). +2.6pp behind H9b at EP3 but on different trajectory. EP4 gate ~23:10Z: val_abupt <7.5% AND slope <-1.5 = strong continue; >9.0% = close. Per-axis upweight has design-internal optimization cost. |
 
 **Step rate**: Both Lion AND AdamW run at ~4-5 steps/sec → 30-epoch run ≈ **33 hours**.
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-16 21:05 UTC (**H9b EP3 WAVE FINDING — val_vol_p=4.18% AT EP3 = H9 EP10 TERMINAL LEVEL**; H10b EP1 healthy launch; H11b RELAUNCHED post deviation catch; H7 EP24 plateau)
+- 2026-05-16 21:25 UTC (**H9b EP4 graceful decel val_vol_p=4.00%**; **H10b EP2 hypothesis WEAKENING — vol_p +0.33pp behind H9b, τ_z TIED**; **H11b EP1 5pp WORSE than H9b — per-axis WSS upweight stresses early-epoch optimization**; H7 EP25 surf_p=4.05% NOT-A-MERGE)
 
 ## Human Research Directive (Issue #1056 — 2026-05-14)
 
@@ -50,14 +50,14 @@ H9 wave finding said "vol_p ceiling is representation-bound at 4.05%". **H9b EP3
 
 **This is the wave's first credible path to SOTA-on-aggregate (all 7 axes under SOTA #972).**
 
-## Active Experiments (2026-05-16 19:45 UTC)
+## Active Experiments (2026-05-16 21:25 UTC)
 
 | Student | PR | Hypothesis | EP / Duration | val_abupt | val_wss | val_vol_p | val_surf_p | Notes |
 |---------|-----|-----------|---------------|----------:|--------:|----------:|-----------:|-------|
-| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP24+ live** / 17h | 6.225% | 7.105% | 3.488% | 4.047% | EP15→EP24 surf_p flat (σ ≈ 0.005pp); bear case confirmed. Most likely NOT-A-MERGE due to surf_p breach (~+0.15-0.30pp projected); positive vol_p mechanism (3.488% under floor). Continue to EP30. |
-| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP3 LANDED** / 2.5h | **6.576%** | **7.327%** | **4.180%** | 4.348% | **WAVE FINDING CRYSTALLIZED. val_vol_p=4.180% at EP3 = H9's EP10 terminal level (4.056%). EP2→EP3 slope = −1.496pp/ep (3× H9). w_vol_p stabilized 0.27 (vs H9 terminal 0.088). Projected: val_vol_p < 3.5% by EP10, terminal SOTA-on-aggregate possible. The wave's most important active experiment.** |
-| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP1 LANDED** / 0.5h | 18.42% | 18.96% | 16.15% | 13.10% | Healthy launch. Charbonnier/MSE ratio on τ_z = 0.297 (in 20-60% healthy band). w_vol_p=0.34 (better than H9 same-step). Compound test of H9 representation + τ_z-leverage loss reshape. EP3 expected ~21:15Z. |
-| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** (CLEAN ISOLATION) | **RELAUNCHED** / 0.7h | — | — | — | — | **First launch `c0dmm9do` had flag deviation (missing STRING PE + Y-sym aug) — student self-caught via config.yaml check, killed cleanly, pushed implementation commit `ad04524`, relaunched 20:22:42Z. Exemplary workflow recovery. EP3 gate ~22:30Z (val_abupt ≤ 8.5%). EP2 spike (if present) would be wave finding signal regardless of LR.** |
+| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP25+ live** / 18h | 6.228% | 7.110% | **3.490%** ✅ | **4.048%** ❌ | val_surf_p flat at 4.05% across EP15-EP25 (σ ≈ 0.005pp); NOT-A-MERGE projection confirmed (surf_p breach +0.47pp). vol_p mechanism positive (under floor by 0.15pp). Continue to EP30 ~24:00Z. |
+| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP4 LANDED** / 3h | **6.444%** | **7.219%** | **4.000%** | 4.268% | **EP4 graceful cosine deceleration**: vol_p slope EP2→3=-1.496pp → EP3→4=-0.180pp (decay 0.12). Projected val_vol_p plateau 3.70-3.74% by EP10. Test floor 3.643%: val→test gap typically -0.1 to +0.3pp so terminal test_vol_p in [3.45, 3.85%] range — straddling floor. All other axes converging (1 EP behind H9 trajectory, MAE aux tax amortizing). |
+| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP2 LANDED** / 1.7h | 7.268% | 7.730% | 6.004% | 4.607% | **HYPOTHESIS WEAKENING.** vol_p +0.328pp BEHIND H9b at EP2 (no MAE aux means no vol_p acceleration). val_τ_z 10.227% **TIED** with H9b 10.179% — Charbonnier-alone NOT breaking τ_z. Charb/MSE ratio creep 0.30→0.66 (design-consistent — model grinding mid-residuals). w_vol_p stable 0.24, clamp dormant. EP3 ~21:45Z is next decision point. |
+| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** (CLEAN ISOLATION) | **EP1 LANDED** / 1h | 23.40% | 24.44% | 18.84% | 17.79% | **EP1 SIGNIFICANTLY WORSE than H9b (+4-5pp every axis).** Per-axis WSS upweight produces harder early-epoch optimization. EP2 spike test imminent (~21:35Z): val_abupt > val_abupt EP1 = "per-axis WSS unstable at any LR" wave finding. val_abupt ≤ 8.0% = recovery, continue. val_abupt > 9.0% = falsification. |
 
 **Step rate**: Both Lion AND AdamW run at ~4-5 steps/sec → 30-epoch run ≈ **33 hours**.
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-16 23:25 UTC (**H10b EP5 τ_z LEAD WIDENING -0.198pp vs H9b → potential SOTA-beat on wss/τ_z; H9b EP7 vol_p slope decelerating (3.871%, terminal coin-flip on floor); H11b EP4 RECOVERING — gap to H9b narrowing 2.6→1.32pp**)
+- 2026-05-16 23:35 UTC (**H10b EP5 SOTA-BEAT PROJECTION CONFIRMED on τ_z/wss (6/7 axes ahead vs H9b); H9b EP7 clamp engagement imminent mid-EP8 (kill at EP10 if vol_p slope ≥−0.01); H11b EP4 marginal recovery sustaining; H7 fern EP28 terminal ~24:00Z (NOT-A-MERGE)**)
 
 ## Human Research Directive (Issue #1056 — 2026-05-14)
 
@@ -50,14 +50,14 @@ H9 wave finding said "vol_p ceiling is representation-bound at 4.05%". **H9b EP3
 
 **This is the wave's first credible path to SOTA-on-aggregate (all 7 axes under SOTA #972).**
 
-## Active Experiments (2026-05-16 23:25 UTC)
+## Active Experiments (2026-05-16 23:35 UTC)
 
 | Student | PR | Hypothesis | EP / Duration | val_abupt | val_wss | val_vol_p | val_surf_p | Notes |
 |---------|-----|-----------|---------------|----------:|--------:|----------:|-----------:|-------|
-| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP27+ live** / 20h | 6.233% | 7.115% | **3.494%** ✅ | **4.053%** ❌ | val_surf_p flat at 4.05% across EP15-EP27 (σ ≈ 0.005pp); NOT-A-MERGE projection CONFIRMED. Terminal ~24:30Z. |
-| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP7 LANDED** / 4.5h | 6.329% | 7.108% | **3.871%** | 4.209% | **vol_p slope -0.024pp/ep at EP7 (decelerating from -0.055)**. Linear extrap: EP30 ~3.79%. Test gap -0.143pp → terminal test_vol_p ~3.65-3.70%, **COIN-FLIP ON FLOOR 3.643%**. surf_p essentially flat → test ~4.07% (above floor 0.49pp = breach definite). val_τ_z+0.010 uptick = τ_z plateau without Charbonnier. test_wss projection ~6.75% (ties SOTA 6.727). |
-| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP5 LANDED** / 3.7h | 6.363% | **7.037%** | 4.310% | **4.128%** | **τ_z LEAD WIDENING**: -0.134 (EP3) → -0.142 (EP4) → **-0.198pp (EP5)** vs H9b. Charbonnier producing 6× faster τ_z descent than H9b at same step. test projection: **test_τ_z ~8.58-8.65% (BEATS SOTA 8.747)**, **test_wss ~6.60-6.65% (BEATS SOTA 6.727)**. vol_p+surf_p floor breach but axis profile potentially SOTA-beating on WSS side. **Most important running experiment.** |
-| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** | **EP4 LANDED** / 3h | 7.760% | 8.444% | 5.737% | 5.229% | **CASE 2 marginal recovery**: slope EP3→4 = -1.422pp (in [-1.5, -1.0] band), gap to H9b narrowed 2.6→1.32pp. If slope sustains, projection EP10 ~6.50%, EP30 ~6.42% — within 0.10-0.20pp of H9b terminal. **Continue to EP6 confirmation.** Per-axis upweight pays optimization friction tax in early epochs, may break-even or slight loss on aggregate. |
+| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP28+ live** / 20.5h | 6.233% | 7.117% | **3.492%** ✅ | **4.052%** ❌ | EP25-28 all axes flat (σ < 0.01pp). NOT-A-MERGE: val_wss=7.117 → test_wss ~6.92% (above SOTA 6.727 by 0.19pp). Terminal landing ~24:00Z. Will post terminal close-recommend after EP30 + test eval. |
+| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP7 LANDED** / 4.5h | 6.329% | 7.108% | **3.871%** | 4.209% | **vol_p slope decelerated to -0.024pp/ep at EP7**. w_vol_p at 0.158, **clamp will engage mid-EP8** (~3-5k steps). EP8 reignition test: vol_p slope ≤ -0.04 = mechanism alive ✅, ≥ -0.01 = stall → kill at EP10. surf_p flat → terminal test ~4.07% (floor breach definite). |
+| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP5 LANDED** / 3.7h | 6.363% | **7.037%** | 4.310% | **4.128%** | **6 of 7 axes BETTER than H9b at EP5**. τ_z lead WIDENING: -0.134→-0.142→**-0.198pp** (EP3-EP5). Charbonnier ratio=0.93 — **by design** at this stage (mid-residual reshape regime). SOTA-beat projection: test_τ_z ~8.40-8.55% (BEATS 8.747), test_wss ~6.55-6.70% (BEATS 6.727), test_vol_p ~3.65-3.80% (coin-flip on floor). **Highest-value running experiment.** Continue weight=0.1 through EP6 decision gate. |
+| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** | **EP4 LANDED** / 3h | 7.760% | 8.444% | 5.737% | 5.229% | Case 2 marginal recovery: slope -1.422pp/ep, gap to H9b narrowed 2.6→1.32pp. EP6 confirmation gate. Even with sustained slope, projection EP30 ~6.42% — within 0.1-0.2pp of H9b but NOT a SOTA-beat candidate on aggregate due to slow start. |
 
 **Step rate**: Both Lion AND AdamW run at ~4-5 steps/sec → 30-epoch run ≈ **33 hours**.
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-16 23:35 UTC (**H10b EP5 SOTA-BEAT PROJECTION CONFIRMED on τ_z/wss (6/7 axes ahead vs H9b); H9b EP7 clamp engagement imminent mid-EP8 (kill at EP10 if vol_p slope ≥−0.01); H11b EP4 marginal recovery sustaining; H7 fern EP28 terminal ~24:00Z (NOT-A-MERGE)**)
+- 2026-05-17 00:35 UTC (**H10b EP6 sub-7% wss MILESTONE (6.996) but τ_z slope decel -0.036 → SOTA-beat downgraded to MARGINAL on wss only; H9b EP8 CLAMP ENGAGED (w_vol_p=0.150) with sustained -0.023 vol_p slope → EP10 projects 3.802% UNDER kill; H11b EP6 gap to H9b narrowed to 0.78pp; H7 fern EP30 terminal val LANDED, test eval requested**)
 
 ## Human Research Directive (Issue #1056 — 2026-05-14)
 
@@ -50,14 +50,14 @@ H9 wave finding said "vol_p ceiling is representation-bound at 4.05%". **H9b EP3
 
 **This is the wave's first credible path to SOTA-on-aggregate (all 7 axes under SOTA #972).**
 
-## Active Experiments (2026-05-16 23:35 UTC)
+## Active Experiments (2026-05-17 00:35 UTC)
 
 | Student | PR | Hypothesis | EP / Duration | val_abupt | val_wss | val_vol_p | val_surf_p | Notes |
 |---------|-----|-----------|---------------|----------:|--------:|----------:|-----------:|-------|
-| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP28+ live** / 20.5h | 6.233% | 7.117% | **3.492%** ✅ | **4.052%** ❌ | EP25-28 all axes flat (σ < 0.01pp). NOT-A-MERGE: val_wss=7.117 → test_wss ~6.92% (above SOTA 6.727 by 0.19pp). Terminal landing ~24:00Z. Will post terminal close-recommend after EP30 + test eval. |
-| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP7 LANDED** / 4.5h | 6.329% | 7.108% | **3.871%** | 4.209% | **vol_p slope decelerated to -0.024pp/ep at EP7**. w_vol_p at 0.158, **clamp will engage mid-EP8** (~3-5k steps). EP8 reignition test: vol_p slope ≤ -0.04 = mechanism alive ✅, ≥ -0.01 = stall → kill at EP10. surf_p flat → terminal test ~4.07% (floor breach definite). |
-| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP5 LANDED** / 3.7h | 6.363% | **7.037%** | 4.310% | **4.128%** | **6 of 7 axes BETTER than H9b at EP5**. τ_z lead WIDENING: -0.134→-0.142→**-0.198pp** (EP3-EP5). Charbonnier ratio=0.93 — **by design** at this stage (mid-residual reshape regime). SOTA-beat projection: test_τ_z ~8.40-8.55% (BEATS 8.747), test_wss ~6.55-6.70% (BEATS 6.727), test_vol_p ~3.65-3.80% (coin-flip on floor). **Highest-value running experiment.** Continue weight=0.1 through EP6 decision gate. |
-| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** | **EP4 LANDED** / 3h | 7.760% | 8.444% | 5.737% | 5.229% | Case 2 marginal recovery: slope -1.422pp/ep, gap to H9b narrowed 2.6→1.32pp. EP6 confirmation gate. Even with sustained slope, projection EP30 ~6.42% — within 0.1-0.2pp of H9b but NOT a SOTA-beat candidate on aggregate due to slow start. |
+| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP30 TERMINAL val** / 21h | 6.234% | 7.116% | **3.495%** ✅ | **4.054%** ❌ | EP26-30 flat (σ <0.01pp). val_wss=7.116 → test_wss ~6.81-6.92% likely **NOT a SOTA-beat** (above 6.727 by 0.08-0.19pp). **Test eval requested at 00:36Z**, awaiting student SENPAI-RESULT post. NOT-A-MERGE expected. |
+| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP8 LANDED** / 5h | 6.301% | 7.076% | **3.848%** | 4.205% | **CLAMP ENGAGED**: w_vol_p=0.150 at floor. EP7→8 vol_p slope sustained at **-0.023** (no further decay!). EP10 projection: 3.802% — UNDER 3.85% kill margin. Clamp+MAE_aux mechanism load-bearing. EP30 vol_p ~3.30-3.46% → test ~3.15-3.50% **CLEARS floor 3.643** ✅. **BUT** surf_p stalled at 4.20% → test_surf_p ~4.0pp breaches floor 3.577 by ~0.4pp. wss/τ_z trajectories: marginal vs SOTA. |
+| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP6 LANDED** / 4.4h | 6.321% | **6.996%** ✅ | 4.268% | 4.110% | **First sub-7% val_wss in the wave**. 5/6 axes ahead of H9b at EP6. τ_z lead **NARROWED** from -0.198 to **-0.174pp** (slope decay 0.54×). Charb ratio=0.957. **EP7 is decisive**: slope ≥-0.025 = SOTA-beat alive; ≥-0.015 = recommend hot-swap to weight=0.05. **Downgraded to MARGINAL wss-only beat** projection (test_wss ~6.65-6.70 vs SOTA 6.727; τ_z likely 9.13% test, NOT beating SOTA 8.747). |
+| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** | **EP6 LANDED** / 4h | 7.118% | 7.837% | 4.933% | 4.789% | Case 2 marginal recovery sustaining: decay factor 0.43-0.53 across axes. Gap to H9b at EP6=0.776pp (closing -0.20pp/ep). **EP30 projection: val_abupt ~6.70%, ~0.4pp above H9b** → NOT a SOTA-beat candidate. Per-axis WSS upweight pays optimization friction tax. Continue to EP10 decision gate. |
 
 **Step rate**: Both Lion AND AdamW run at ~4-5 steps/sec → 30-epoch run ≈ **33 hours**.
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,5 +1,5 @@
 # SENPAI Research State
-- 2026-05-16 22:37 UTC (**H10b EP3 HYPOTHESIS STRENGTHENING — H10b BETTER than H9b on 4/5 axes (-0.13pp τ_z, -0.07pp wss, -0.10pp surf_p); H9b EP5 vol_p slope DECELERATING TOO FAST → likely floor breach; H11b EP3 STILL RECOVERING at -2.05pp/ep slope, EP4 decision gate**)
+- 2026-05-16 23:25 UTC (**H10b EP5 τ_z LEAD WIDENING -0.198pp vs H9b → potential SOTA-beat on wss/τ_z; H9b EP7 vol_p slope decelerating (3.871%, terminal coin-flip on floor); H11b EP4 RECOVERING — gap to H9b narrowing 2.6→1.32pp**)
 
 ## Human Research Directive (Issue #1056 — 2026-05-14)
 
@@ -50,14 +50,14 @@ H9 wave finding said "vol_p ceiling is representation-bound at 4.05%". **H9b EP3
 
 **This is the wave's first credible path to SOTA-on-aggregate (all 7 axes under SOTA #972).**
 
-## Active Experiments (2026-05-16 22:37 UTC)
+## Active Experiments (2026-05-16 23:25 UTC)
 
 | Student | PR | Hypothesis | EP / Duration | val_abupt | val_wss | val_vol_p | val_surf_p | Notes |
 |---------|-----|-----------|---------------|----------:|--------:|----------:|-----------:|-------|
-| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP27+ live** / 19h | 6.228% | 7.110% | **3.490%** ✅ | **4.048%** ❌ | val_surf_p flat at 4.05% across EP15-EP26 (σ ≈ 0.005pp); NOT-A-MERGE projection confirmed (surf_p breach +0.47pp projected). vol_p mechanism positive (under floor by 0.15pp). Terminal ~24:00Z. |
-| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP5 LANDED** / 3.5h | **6.397%** | **7.171%** | **3.950%** | 4.241% | **vol_p slope DECELERATING TOO FAST**: EP4→5 = -0.050pp (decay factor 0.28, vs 0.60 projected). Projected plateau ~3.88-3.92% — terminal test_vol_p ~3.78-4.22% LIKELY ABOVE FLOOR 3.643% by 0.14-0.58pp. Surf_p plateau ~4.10% → test 4.0-4.5% above floor. Wave finding HOLDS but NOT clean merge candidate. WSS axes still on track. |
-| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP3 LANDED** / 2.7h | 6.580% | 7.258% | 4.545% | 4.251% | **HYPOTHESIS STRENGTHENING.** H10b BETTER than H9b at EP3 on 4/5 axes: abupt TIED, wss -0.069pp, **τ_z -0.134pp**, surf_p -0.097pp. Only vol_p +0.365pp behind (no MAE aux as designed). My EP2 "weakening" call was premature — Charbonnier mid-residual regime opens at EP3+. Best WSS-side candidate running. EP4 ~22:38Z. |
-| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** (CLEAN ISOLATION) | **EP3 LANDED** / 2.2h | 9.18% | 9.68% | 8.10% | 6.24% | **STILL RECOVERING**: NO spike (lr=5e-4 fix worked); EP2→EP3 slope=-2.05pp (active recovery, vs H9b -0.59pp). +2.6pp behind H9b at EP3 but on different trajectory. EP4 gate ~23:10Z: val_abupt <7.5% AND slope <-1.5 = strong continue; >9.0% = close. Per-axis upweight has design-internal optimization cost. |
+| dl24-fern | #1142 | H7: surface_loss_weight=1.5 | **EP27+ live** / 20h | 6.233% | 7.115% | **3.494%** ✅ | **4.053%** ❌ | val_surf_p flat at 4.05% across EP15-EP27 (σ ≈ 0.005pp); NOT-A-MERGE projection CONFIRMED. Terminal ~24:30Z. |
+| dl24-tanjiro | #1157 | **H9b: clamp=0.15 + curvature bias + vol_p MAE aux 0.05** | **EP7 LANDED** / 4.5h | 6.329% | 7.108% | **3.871%** | 4.209% | **vol_p slope -0.024pp/ep at EP7 (decelerating from -0.055)**. Linear extrap: EP30 ~3.79%. Test gap -0.143pp → terminal test_vol_p ~3.65-3.70%, **COIN-FLIP ON FLOOR 3.643%**. surf_p essentially flat → test ~4.07% (above floor 0.49pp = breach definite). val_τ_z+0.010 uptick = τ_z plateau without Charbonnier. test_wss projection ~6.75% (ties SOTA 6.727). |
+| dl24-frieren | #1159 | **H10b: H9 curvature bias + Charbonnier on τ_z only** | **EP5 LANDED** / 3.7h | 6.363% | **7.037%** | 4.310% | **4.128%** | **τ_z LEAD WIDENING**: -0.134 (EP3) → -0.142 (EP4) → **-0.198pp (EP5)** vs H9b. Charbonnier producing 6× faster τ_z descent than H9b at same step. test projection: **test_τ_z ~8.58-8.65% (BEATS SOTA 8.747)**, **test_wss ~6.60-6.65% (BEATS SOTA 6.727)**. vol_p+surf_p floor breach but axis profile potentially SOTA-beating on WSS side. **Most important running experiment.** |
+| dl24-nezuko | #1160 | **H11b: AdamW lr=5e-4 + per-axis WSS τ-weights** | **EP4 LANDED** / 3h | 7.760% | 8.444% | 5.737% | 5.229% | **CASE 2 marginal recovery**: slope EP3→4 = -1.422pp (in [-1.5, -1.0] band), gap to H9b narrowed 2.6→1.32pp. If slope sustains, projection EP10 ~6.50%, EP30 ~6.42% — within 0.10-0.20pp of H9b terminal. **Continue to EP6 confirmation.** Per-axis upweight pays optimization friction tax in early epochs, may break-even or slight loss on aggregate. |
 
 **Step rate**: Both Lion AND AdamW run at ~4-5 steps/sec → 30-epoch run ≈ **33 hours**.
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -8,6 +8,51 @@ The wave's evidence contract: test metrics from `test_primary/*` only; validatio
 
 ---
 
+## 2026-05-17 01:00 UTC — PR #1142 CLOSED: WSS H7 surface_loss_weight=1.5 uniform upweight (dl24-fern, `2nufmv3i`)
+
+- **Branch:** `dl24-fern/h7-surface-loss-weight-1p5`
+- **W&B run:** `2nufmv3i` (DDP8, EP30 terminal). Test eval on EP20 best-val EMA checkpoint.
+- **Hypothesis:** H4's vol_p improvement was driven by an *implicit* surface task upweight (mean of [1.0, 1.0, 1.5, 2.5]/4 = 1.5×). Replacing per-axis weights with uniform `surface_loss_weight=1.5` should preserve the vol_p win and avoid H4's surf_p/wss/τ regressions (which H7 attributed to per-axis structure × Lion-noise amplification).
+- **Configuration:** Lion lr=5e-4, GradNorm OFF, `surface_loss_weight=1.5`, EMA decay=0.999, 30 epochs, ema_start_step=500.
+
+### Results — Terminal Test Metrics
+
+| Metric | H7 test | SOTA #972 | Δ vs SOTA | vs floor (#1056) | Verdict |
+|---|---:|---:|---:|---:|---|
+| **test_abupt** | **6.0366** | 5.844 | **+0.193** | — | ❌ regressed |
+| **test_vol_p** | **3.4962** | 3.643 | **−0.147** | UNDER floor by 0.147pp | ✅ floor cleared |
+| **test_surf_p** | **3.7816** | 3.577 | **+0.205** | BREACH by 0.205pp | ❌ floor breached |
+| **test_wss** | **7.0055** | 6.727 | **+0.279** | — | ❌ primary target failed |
+| test_τ_x | 6.2149 | 5.971 | +0.244 | — | regressed |
+| test_τ_y | 7.5469 | 7.362 | +0.185 | — | regressed |
+| test_τ_z | 9.1432 | 8.747 | +0.396 | — | regressed |
+
+**Val→test gap calibration**: abupt −0.177, vol_p +0.012, surf_p −0.258, wss −0.086, τ_x +0.027, τ_y −0.140, **τ_z −0.528**. Test was kinder than val on most axes; the large τ_z negative gap is consistent with H10's representation-floor finding (Charbonnier-related runs show large val→test gaps on τ_z).
+
+### Wave Finding — H4 mechanism decomposition REFUTED
+
+The H7 hypothesis (that H4 vol_p improvement was implicit-uniform-upweight and H4's costs were per-axis-Lion-noise) was tested by stripping per-axis structure and applying uniform 1.5× scaling. Three refutations:
+
+1. **vol_p mechanism is real and isolable** ✅ — test_vol_p=3.496% confirms shared-backbone enrichment from uniform surface upweight benefits the volume head. H4's test_vol_p=3.374% under same magnitude → consistent.
+
+2. **surf_p breach is INTRINSIC to magnitude, not structure** ❌ — H7 surf_p=3.781% is WORSE than H4 surf_p=3.743%, despite no per-axis structure. The breach is a 1.5× magnitude effect on surface gradient flow, not per-axis interference between cp and τ.
+
+3. **τ regressions are INTRINSIC to magnitude** ❌ — all 3 τ axes regress under uniform 1.5× upweight (no per-axis amplification possible). The Lion-noise/per-axis theory cannot explain this. The 1.5× magnitude itself shifts the WSS-side optimization regime in a way that costs τ accuracy.
+
+**Implication for #1056 contract**: Lower-magnitude surface upweight (1.1, 1.2) may attenuate the tax but won't eliminate it — the directional tradeoff between vol_p improvement and wss/surf_p/τ degradation is intrinsic to the surface-upweight mechanism. Surface upweight is a **vol_p-side mechanism**, NOT a wss-side mechanism. Combined with H9 wave finding (curvature bias = wss unlock without floor breach), the wave's mechanism map shows: vol_p and wss respond to DIFFERENT gradient-mass interventions. They cannot both be fixed with a single uniform scalar.
+
+### Cost & resource summary
+
+- Wall-time: ~20.0h training + ~10min test eval. Peak GPU memory ~21 GB/GPU, all 8 GPUs balanced.
+- W&B run IDs: rank-0 `2nufmv3i`, ranks 1-7: `0x9cfkv9`, `idet3da8`, `qkc0j2ow`, `tpd0ycfj`, `x80y99uf`, `xc3y3688`, `z3jijtxn`.
+- Group: `wss_h7_surface_upweight`.
+
+### Infra note from student
+
+dl24-fern reported a `senpai-pr-guard.py` bug: `result_markers()` scanned every line for `SENPAI-RESULT:` without skipping markdown code fences. My template comment on this PR included a JSON-shaped placeholder inside a code block that broke the marker scanner. Student's 5-line fix to track in_code_fence state in the scanner is the right approach. Cannot apply from advisor scope (infra repo, not target). Flagged to human team.
+
+---
+
 ## 2026-05-16 19:48 UTC — PR #1154 CLOSED: WSS H11 AdamW lr=7e-4 + per-axis WSS τ-weights (dl24-nezuko, `kukjenp5`+`zhmyhxcd`)
 
 - **Branch:** `dl24-nezuko/h11-adamw-per-axis-wss`

--- a/research/RESEARCH_IDEAS_2026-05-17_01:30.md
+++ b/research/RESEARCH_IDEAS_2026-05-17_01:30.md
@@ -1,0 +1,389 @@
+# WSS Research Hypotheses Wave 2 — 2026-05-17 01:30
+
+**Target**: test_wss < 5.85% (current SOTA: 6.727%)
+**Floors**: test_vol_p ≤ 3.643, test_surf_p ≤ 3.577 (must NOT regress)
+**Dataset**: `/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511`
+**Optimizer**: Lion, lr=5e-4, DDP8
+**Budget**: 30 epochs, ≈33h wall-clock
+
+## Background: What We Know
+
+### Confirmed Mechanisms (stack these)
+- **Curvature additive attention bias** (H5/H9): curvature computed from surface normals injected as additive bias into slice attention logits; `curvature_bias_scale=1.0`. NOT as input channel (gradnorm imbalance).
+- **MAE aux loss + gradient clamp=0.15** (H9b): vol_p floor recovery via gradient mass floor; prevents vol_p regression when surface loss dominates.
+- **Charbonnier loss on τ_z** (H10b): robustness against τ_z outliers; slight τ_z slope lead confirmed.
+- **GradNorm α=0.5**: adaptive loss balancing, confirmed winner.
+- **Y-axis symmetry augmentation** (p=0.5): confirmed winner.
+- **6L STRING backbone** (5-sigma octave span): SOTA config.
+- **SDF-stratified volume sampling** (α=2.0): confirmed winner.
+
+### Refuted Mechanisms (do not retry without new evidence)
+- Per-axis WSS loss upweighting (H4, H11): neither τ_x/τ_y/τ_z individual weights nor uniform up-weight helped.
+- Uniform surface_loss_weight=1.5 (H7): confirmed REFUTED.
+- Raw curvature input channels (H2): gradnorm imbalance, refuted.
+- Wind-exposure raw channels (H1): refuted.
+- Near-wall volume cross-attention (H3): refuted.
+
+### Currently Running (H9b/H10b/H11b) — do NOT duplicate
+- **H9b (tanjiro, PR #1157)**: curvature_bias + MAE_aux + clamp=0.15 stack.
+- **H10b (frieren, PR #1159)**: H9b stack + Charbonnier loss on τ_z specifically.
+- **H11b (nezuko, PR #1160)**: AdamW optimizer sweep + per-axis τ loss weights (revisit of H4 but with H9b stack).
+
+### Key Architectural Observation
+The surface output head is a SINGLE `LinearProjection(n_hidden, 4)` mapping to [cp, τ_x, τ_y, τ_z]. All four channels compete in the same output projection. This is the primary architectural bottleneck candidate that NO current hypothesis addresses.
+
+---
+
+## H12: Separate WSS Decoder Head with Deeper MLP
+
+### Hypothesis Statement
+Replacing the single shared `LinearProjection(n_hidden, 4)` surface head with two independent heads — a shallow linear cp head and a deeper 2-layer MLP τ head — will allow the model to learn WSS-specific representations without cp competing for the same output projection weights, reducing τ error by 0.5–1.0pp.
+
+### Expected Mechanism
+Currently, gradient signals from the cp loss and τ losses are summed before flowing through the shared `surface_out` projection. The cp target has different statistical structure (scalar pressure field, correlated with global flow) vs. τ (3D vector shear, dominated by local geometry and near-wall velocity gradients). A single linear projection forces these to share a common final-layer feature basis.
+
+By giving τ its own 2-layer MLP (`Linear(n_hidden, 2*n_hidden) → GELU → Linear(2*n_hidden, 3)`), τ can compose geometry-sensitive features from the backbone hidden state without cp pulling the shared weights toward pressure-optimized subspaces. The extra MLP depth in the τ head provides capacity for the non-linear feature combination that cross-flow components (τ_y, τ_z) likely require.
+
+This is orthogonal to H9b/H10b/H11b: those experiments modify loss terms, curvature injection, and optimizer. This modifies the output architecture only.
+
+### Implementation Details
+
+**File to modify**: `model.py` (ONLY)
+
+**Change**: In `SurfaceTransolver.__init__`:
+```python
+# REMOVE:
+self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+
+# ADD:
+self.surface_cp_out = LinearProjection(n_hidden, 1)  # cp channel only
+self.surface_tau_out = nn.Sequential(
+    nn.Linear(n_hidden, 2 * n_hidden),
+    nn.GELU(),
+    nn.Linear(2 * n_hidden, 3),  # tau_x, tau_y, tau_z
+)
+# initialize tau_out final layer near zero for stable start:
+nn.init.normal_(self.surface_tau_out[-1].weight, std=0.01)
+nn.init.zeros_(self.surface_tau_out[-1].bias)
+```
+
+**Change**: In `SurfaceTransolver.forward`:
+```python
+# REMOVE:
+surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+
+# ADD:
+cp_preds = self.surface_cp_out(surface_hidden)  # [B, N_surf, 1]
+tau_preds = self.surface_tau_out(surface_hidden)  # [B, N_surf, 3]
+surface_preds = torch.cat([cp_preds, tau_preds], dim=-1)  # [B, N_surf, 4]
+surface_preds = surface_preds * surface_mask.unsqueeze(-1)
+```
+
+**CLI flags**: Identical to H9b baseline; no new flags needed. Use H9b full confirmed stack:
+```bash
+torchrun --nproc_per_node=8 train.py \
+  --data_path /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --n_layers 6 --n_hidden 192 --n_head 3 --slice_num 96 \
+  --pe_kind string_separable --pe_num_features 16 \
+  --pe_init_sigmas 0.1 0.178 0.316 0.562 1.0 \
+  --n_surface_points 65000 --n_volume_points 65000 \
+  --volume_sdf_alpha 2.0 \
+  --optimizer lion --lr 5e-4 \
+  --use_gradnorm --gradnorm_alpha 0.5 \
+  --use_ema --ema_decay 0.999 \
+  --y_sym_aug_prob 0.5 \
+  --use_curvature_bias --curvature_bias_scale 1.0 \
+  --use_mae_aux --grad_clamp 0.15 \
+  --epochs 30 \
+  --wandb_group H12-separate-tau-head
+```
+
+**Parameter overhead**: ~192*2*192 + 192*3 ≈ 74,304 extra parameters (< 0.1% model size). Negligible compute increase.
+
+### EP10 Viability Gate
+- val_wss ≤ 6.3% (vs. H9b EP10 baseline of ~6.5%; need ≥0.2pp improvement to justify continuation)
+- val_vol_p ≤ 4.5% (floor check; failure here = stop)
+- τ_z slope must be negative (still improving at EP10)
+
+### Non-Duplication Argument
+H9b: curvature bias + MAE_aux → gradient-level mechanism.
+H10b: Charbonnier τ_z → loss-level mechanism.
+H11b: AdamW + per-axis τ weights → optimizer-level mechanism.
+H12: separate τ head (deeper MLP) → output architecture-level mechanism.
+These are orthogonal axes of the pipeline. H12 can be stacked on top of any winner.
+
+---
+
+## H13: Magnitude-Decoupled τ Loss
+
+### Hypothesis Statement
+Decomposing the τ prediction into independently supervised magnitude (`|τ|`) and direction (`τ / |τ|`) components — with separate loss terms — will reduce τ error by enabling the model to separately optimize scalar magnitude estimation (dominated by global car geometry) and vector direction estimation (dominated by local surface curvature), improving the τ_y/τ_z cross-flow bottleneck by 0.3–0.7pp.
+
+### Expected Mechanism
+The current relative L2 loss on τ = [τ_x, τ_y, τ_z] treats the three components as an undifferentiated vector. In physical reality:
+- `|τ|` is determined by near-wall velocity gradient magnitude, which depends on global flow attachment/separation topology.
+- `τ/|τ|` (unit direction) is determined by local surface geometry (principally the curvature-induced flow steering in τ_y and τ_z).
+
+The cross-flow components (τ_y, τ_z) have SOTA errors of 7.94% and 9.54% vs. AB-UPT 3.65%/3.63% — roughly 2-3x worse than the streamwise τ_x. This suggests the directional prediction is the bottleneck, not the magnitude. By isolating `cos_sim_loss = 1 - (τ_pred · τ_gt) / (|τ_pred| |τ_gt|)` as a separate loss term, gradient signal on direction is not swamped by magnitude error.
+
+Decomposition:
+```
+L_tau_mag  = RelL2(|τ_pred|, |τ_gt|)      # magnitude term
+L_tau_dir  = mean(1 - cos_sim(τ_pred, τ_gt))  # direction term
+L_tau = λ_mag * L_tau_mag + λ_dir * L_tau_dir
+```
+With GradNorm already in the stack, λ_mag and λ_dir can be auto-balanced via GradNorm's per-loss scaling (treat them as two separate task losses from GradNorm's perspective).
+
+### Implementation Details
+
+**File to modify**: `train.py` (loss computation section)
+
+The loss function must compute:
+```python
+# In loss computation block:
+tau_pred = surface_preds[..., 1:4]  # [B, N_surf, 3]
+tau_gt   = surface_y[..., 1:4]
+
+# Magnitude loss
+tau_mag_pred = torch.norm(tau_pred, dim=-1, keepdim=True)  # [B, N_surf, 1]
+tau_mag_gt   = torch.norm(tau_gt,   dim=-1, keepdim=True)
+loss_tau_mag = relative_l2(tau_mag_pred, tau_mag_gt, mask)
+
+# Direction loss (cosine)
+tau_pred_unit = F.normalize(tau_pred, dim=-1, eps=1e-8)
+tau_gt_unit   = F.normalize(tau_gt,   dim=-1, eps=1e-8)
+loss_tau_dir  = (1.0 - (tau_pred_unit * tau_gt_unit).sum(-1))[mask].mean()
+
+# GradNorm treats loss_tau_mag and loss_tau_dir as separate task losses
+```
+
+**Important gotcha**: Zero-|τ| regions (separation bubbles, far-field padding) can cause NaN in `F.normalize`. Use `eps=1e-8` and mask out points where `|τ_gt| < 1e-6` before the cosine loss.
+
+**CLI flags**: Add `--use_mag_dir_tau_loss` (new flag in train.py); rest is H9b stack:
+```bash
+torchrun --nproc_per_node=8 train.py \
+  [... H9b stack flags ...] \
+  --use_mag_dir_tau_loss \
+  --wandb_group H13-mag-dir-tau-loss
+```
+
+**GradNorm integration**: Add `loss_tau_mag` and `loss_tau_dir` as two separate entries in GradNorm's loss dictionary rather than pre-combining them. GradNorm will auto-balance.
+
+### EP10 Viability Gate
+- val_wss ≤ 6.2% (need ≥0.3pp improvement over H9b EP10)
+- val_tau_y + val_tau_z combined must improve (the direction loss is specifically targeting these)
+- If val_tau_y/tau_z do NOT improve vs. H9b at EP10, direction decomposition is not helping → stop
+
+### Non-Duplication Argument
+H9b/H10b/H11b all apply loss modifications at the per-output-channel level (e.g., Charbonnier on τ_z). H13 changes the geometric decomposition of what is being predicted — magnitude vs. direction — which is a fundamentally different formulation of the prediction problem. It does not change channel selection, optimizer, or architecture.
+
+---
+
+## H14: Surface Normal Prediction Auxiliary Task (Geometric Denoising)
+
+### Hypothesis Statement
+Adding a self-supervised auxiliary task where the backbone predicts the surface normal [nx, ny, nz] from `surface_hidden` — given only [x, y, z] as positional input (without the normals) — will force the model to learn richer geometric representations that benefit WSS prediction, reducing test_wss by 0.4–0.8pp.
+
+### Expected Mechanism
+Surface normals are currently provided as INPUT channels `[x, y, z, nx, ny, nz, area]`. The auxiliary task flips this: we withhold normals from the input (provide only `[x, y, z, area]`) and force the backbone to predict them.
+
+This creates a "geometric denoising" pretraining signal: the backbone must reconstruct the local surface geometry (normals) from raw point positions. The learned geometry-aware representations then improve the downstream WSS prediction, because WSS direction is fundamentally determined by near-wall flow steering which is governed by surface curvature — precisely the information encoded in normals.
+
+The auxiliary loss is only backpropagated through `surface_hidden`; the volume branch is unaffected. This is structurally similar to MAE-style auxiliary tasks but targets surface geometry specifically, not masked point reconstruction.
+
+Variant: instead of completely withholding normals, use the normals in input but add an auxiliary head that predicts normals from hidden state anyway. This "redundant prediction" forces the hidden state to maintain geometry-decodable representations even when processing non-normal features. This is easier to implement (no input masking) and more stable.
+
+**Recommended variant**: redundant prediction (normals in input AND predicted from hidden).
+
+### Implementation Details
+
+**Files to modify**: `model.py` and `train.py`
+
+In `model.py`, add to `SurfaceTransolver.__init__`:
+```python
+# Auxiliary normal prediction head
+self.normal_aux_out = nn.Sequential(
+    nn.Linear(n_hidden, n_hidden // 2),
+    nn.GELU(),
+    nn.Linear(n_hidden // 2, 3),  # predict [nx, ny, nz]
+)
+```
+
+In `SurfaceTransolver.forward`, add to return dict:
+```python
+normal_preds = self.normal_aux_out(surface_hidden) * surface_mask.unsqueeze(-1)
+return {
+    "surface_preds": surface_preds,
+    "volume_preds": volume_preds,
+    "normal_preds": normal_preds,  # NEW: [B, N_surf, 3]
+    "hidden": hidden, ...
+}
+```
+
+In `train.py`, add aux loss:
+```python
+# surface_x channels: [x, y, z, nx, ny, nz, area]  (normals are at indices 3,4,5)
+normal_gt = surface_x[..., 3:6]  # [B, N_surf, 3]
+normal_pred = model_output["normal_preds"]
+
+# Cosine similarity aux loss (normals are unit vectors by definition)
+normal_pred_unit = F.normalize(normal_pred, dim=-1, eps=1e-8)
+normal_gt_unit   = F.normalize(normal_gt,   dim=-1, eps=1e-8)
+loss_normal_aux  = (1.0 - (normal_pred_unit * normal_gt_unit).sum(-1))[surface_mask].mean()
+
+# Weight: treat as separate GradNorm task with initial weight=0.1
+# (small weight — this is auxiliary, not primary)
+```
+
+**GradNorm integration**: `loss_normal_aux` enters GradNorm as a new task. Initialize its weight to 0.1 so it starts subdominant to the primary WSS/cp/vol_p losses.
+
+**CLI flags**:
+```bash
+torchrun --nproc_per_node=8 train.py \
+  [... H9b stack flags ...] \
+  --use_normal_aux --normal_aux_weight 0.1 \
+  --wandb_group H14-normal-aux
+```
+
+**Critical gotcha**: If you run GradNorm with 5 tasks (cp, τ, vol_p, MAE, normals), ensure GradNorm's initial task weights don't cause any single loss to blow up. Monitor per-task GradNorm weights at EP1 and EP2 closely.
+
+### EP10 Viability Gate
+- val_wss ≤ 6.3% (need ≥0.2pp over H9b EP10)
+- val_normal_aux ≤ 5% cosine loss (sanity check — if the aux task isn't being learned, the aux loss is providing no useful gradient)
+- vol_p floor: val_vol_p ≤ 4.5%
+
+### Non-Duplication Argument
+H9b uses MAE aux (masked autoencoder style). H14 uses a normal prediction aux task — a geometric denoising task targeting surface geometry rather than point masking recovery. The mechanism is different: MAE provides gradient mass to prevent vol_p collapse; normal prediction forces geometry-aware representations that directly benefit WSS direction prediction.
+
+---
+
+## H15: Layer-wise Curvature Bias Scaling (Late-Layer Amplification)
+
+### Hypothesis Statement
+The current uniform `curvature_bias_scale=1.0` across all 6 Transolver layers may be suboptimal: early layers should see small curvature bias to learn global flow structure, while late layers (closest to the output) should see amplified curvature bias to specialize in geometry-driven local WSS variations. Using a linearly increasing bias scale (0.25 → 1.5 across layers 1–6) will improve WSS without degrading pressure fields.
+
+### Expected Mechanism
+In transformer-like architectures, early layers typically capture global structure (positional relationship between surface patches, global flow attachment) while later layers handle local feature refinement. The curvature attention bias is designed to make the model attend to geometrically salient regions — but its optimal strength may vary by layer depth.
+
+In H5/H9, the single global `curvature_bias_scale=1.0` was confirmed effective vs. no curvature. But this is not an ablation of per-layer scaling. A layer-wise ramp (small early, large late) should:
+1. Allow early layers to route information globally without geometric over-fixation.
+2. Allow late layers to strongly specialize final representations to high-curvature regions where WSS gradients are sharpest.
+
+This is analogous to "progressive resolution" in image transformers (coarse → fine attention), applied to curvature-driven geometry attention.
+
+### Implementation Details
+
+**File to modify**: `model.py`
+
+The `curvature_bias_scale` currently enters `TransolverAttention.forward` as a fixed scalar. Layer index must be passed to each attention layer:
+
+In `SurfaceTransolver.__init__`, replace:
+```python
+self.curvature_bias_scale = curvature_bias_scale  # scalar
+```
+With:
+```python
+# Linear ramp from scale_min to scale_max across n_layers
+import torch
+scale_min, scale_max = 0.25, 1.5
+self.curvature_bias_scales = torch.linspace(scale_min, scale_max, n_layers)
+# [0.25, 0.525, 0.8, 1.075, 1.35, 1.5] for n_layers=6
+```
+
+Then in the backbone forward loop, pass the per-layer scale:
+```python
+for i, layer in enumerate(self.layers):
+    x = layer(x, curvature_bias=curvature_bias,
+               curvature_bias_scale=self.curvature_bias_scales[i].item())
+```
+
+**CLI flags**: Add `--curvature_bias_scale_min 0.25 --curvature_bias_scale_max 1.5`; mutually exclusive with `--curvature_bias_scale` (single scalar). Default behavior unchanged if only `--curvature_bias_scale` is passed:
+```bash
+torchrun --nproc_per_node=8 train.py \
+  [... H9b stack flags, WITHOUT --curvature_bias_scale 1.0 ...] \
+  --curvature_bias_scale_min 0.25 --curvature_bias_scale_max 1.5 \
+  --wandb_group H15-layerwise-curvature-bias
+```
+
+**Alternative quick-test**: Instead of full implementation, test with `--curvature_bias_scale 1.5` (amplified uniform) vs. baseline `1.0` first. If 1.5 wins, layer-wise ramp is warranted. If 1.5 loses, the ramp may still outperform both via early regularization.
+
+### EP10 Viability Gate
+- val_wss ≤ 6.3% (need ≥0.2pp over H9b EP10, which uses scale=1.0)
+- val_surf_p ≤ 3.7% (cp should not be harmed by more curvature bias in late layers)
+- Attention weight visualization (optional): curvature high-attention regions should be geometrically coherent (A/C pillars, wheel arches, hood leading edge)
+
+### Non-Duplication Argument
+H9b/H10b use `curvature_bias_scale=1.0` uniformly. H15 changes the distribution of curvature attention strength across transformer depth. This is a depth-wise hyperparameter not touched by any running experiment. The mechanism (layer-depth specialization) is distinct from loss/optimizer/architecture changes in H9b/H10b/H11b.
+
+---
+
+## H16: Focal-Power Surface Point Loss Weighting
+
+### Hypothesis Statement
+Weighting the surface loss for each point proportional to `(|τ_gt| / mean_|τ_gt|)^γ` (with γ ≈ 0.5–1.0) will focus gradient signal on high-shear regions (wheel arches, A-pillars, underbody edges) where cross-flow τ_y/τ_z errors dominate, reducing test_wss by 0.3–0.6pp without requiring new architecture or aux tasks.
+
+### Expected Mechanism
+The current relative L2 loss computes `||τ_pred - τ_gt||² / ||τ_gt||²` globally — which effectively already normalizes by the target magnitude. However, within the per-point mean reduction, regions with very low |τ| (far-field surface, flat top) contribute equal weight to regions with high |τ| (wheel arch, leading edges).
+
+The key physical insight: τ_y and τ_z errors are largest in regions of strong lateral flow steering — high-curvature junctions, separation lines, and underbody transitions. These regions also have the highest |τ| values. By up-weighting high-|τ| points in the loss (proportional to normalized magnitude), we increase gradient signal specifically where the physics are most complex and our cross-flow errors are largest.
+
+This is different from per-axis channel weighting (H4/H11, refuted): H4/H11 applied uniform scalar multipliers to τ_y or τ_z channels. H16 applies data-driven, geometry-responsive spatial weighting based on local τ magnitude. It functions as a soft analog of importance sampling in loss space, without requiring curvature computation.
+
+### Implementation Details
+
+**File to modify**: `train.py`
+
+In the surface loss computation:
+```python
+# Compute per-point τ magnitude from ground truth (normalized within batch)
+with torch.no_grad():
+    tau_gt_mag = torch.norm(surface_y[..., 1:4], dim=-1)  # [B, N_surf]
+    tau_gt_mag_mean = tau_gt_mag[surface_mask].mean().clamp(min=1e-8)
+    focal_weights = (tau_gt_mag / tau_gt_mag_mean).clamp(min=0.1, max=10.0)
+    focal_weights = focal_weights ** gamma  # γ in {0.5, 0.75, 1.0}
+
+# Apply per-point weight to surface loss before mean reduction
+# (internal to the surface loss computation, not as an outer multiplier)
+surface_loss = (focal_weights * per_point_surface_loss)[surface_mask].mean()
+```
+
+**Recommended γ**: Start with γ=0.75 (soft — not fully linear). γ=1.0 is linear and may over-penalize; γ=0.5 is sqrt and gentler.
+
+**CLI flags**:
+```bash
+torchrun --nproc_per_node=8 train.py \
+  [... H9b stack flags ...] \
+  --surface_focal_gamma 0.75 \
+  --wandb_group H16-focal-tau-weight
+```
+
+**Critical gotcha**: With GradNorm in the stack, the per-point focal weighting changes the effective gradient magnitude for the surface task. This will cause GradNorm to re-balance the surface task weight. Monitor GradNorm's surface task weight at EP1; if it collapses rapidly, reduce γ. Also: the `vol_p` floor safeguard is GradNorm's main mechanism here — if focal weighting pushes more gradient toward surface, GradNorm should auto-compensate for vol_p. Still, add gradient clamp=0.15 (from H9b) to prevent spikes.
+
+**Important**: Do NOT compute focal weights from `surface_preds` (prediction magnitudes) — use ONLY `surface_y` (ground truth). Using predictions creates a non-stationary loss that can cause runaway feedback.
+
+### EP10 Viability Gate
+- val_wss ≤ 6.2% (need ≥0.3pp over H9b EP10)
+- val_tau_y and val_tau_z must BOTH improve (focal weighting targets high-shear regions where cross-flow errors are largest)
+- vol_p floor: val_vol_p ≤ 4.5%
+- If only τ_x improves and τ_y/τ_z do not, the mechanism is not targeting the right region → stop
+
+### Non-Duplication Argument
+H4/H11: per-channel scalar weights on τ_y, τ_z axes (refuted). H16: per-POINT spatial weights based on local τ magnitude (not per-channel). The refuted approaches applied uniform channel multipliers; H16 applies spatially-adaptive magnitude-responsive weights. The failure mode of H4/H11 was that uniform channel weighting worsened other channels; H16's point-level weighting preserves relative per-channel loss balance while increasing gradient in physically meaningful regions.
+
+---
+
+## Summary Ranking
+
+| Rank | Hypothesis | Target mechanism | Effort | Expected gain | Risk |
+|------|-----------|-----------------|--------|---------------|------|
+| 1 | **H12**: Separate τ head (2-layer MLP) | Output architecture bottleneck | Low (10 LOC model.py) | 0.5–1.0pp wss | Low — no loss/opt changes |
+| 2 | **H13**: Magnitude-decoupled τ loss | Loss landscape (magnitude vs. direction) | Medium (20 LOC train.py) | 0.3–0.7pp wss | Medium — GradNorm interaction |
+| 3 | **H14**: Normal aux task | Self-supervised geometry awareness | Medium (30 LOC model+train) | 0.4–0.8pp wss | Medium — GradNorm with 5 tasks |
+| 4 | **H16**: Focal-power point weighting | Loss spatial up-weighting | Low (10 LOC train.py) | 0.3–0.6pp wss | Medium — GradNorm re-balance |
+| 5 | **H15**: Layer-wise curvature bias | Per-layer attention geometry | Low (5 LOC model.py) | 0.2–0.4pp wss | Low — small perturbation |
+
+**TOP RECOMMENDATION for dl24-fern: H12** — separate WSS decoder head with deeper MLP.
+
+Rationale: The single `LinearProjection(n_hidden, 4)` is the only significant architectural bottleneck not yet addressed by any running or prior experiment. It requires the smallest code change (≈10 lines in `model.py`, zero changes to `train.py`), stacks cleanly on the confirmed H9b configuration (curvature bias + MAE_aux + GradNorm + Lion lr=5e-4), and is fully orthogonal to H9b/H10b/H11b. If the architecture bottleneck is real, the effect should be visible at EP5 as a diverging τ trajectory. If it fails (τ does not improve by EP10), it strongly implies the representation in `surface_hidden` is already τ-expressive and the bottleneck is elsewhere (loss formulation or data), which is itself a valuable result for directing H13/H14.
+
+**Runner-up for second idle student: H13** (magnitude-decoupled τ loss) — complements H12 by attacking the loss formulation axis rather than architecture.


### PR DESCRIPTION
## Hypothesis

The surface output head is a single `LinearProjection(n_hidden, 4)` that maps hidden features to [cp, τ_x, τ_y, τ_z] simultaneously. This forces pressure (cp) and all three wall shear stress components to compete in the same final projection, sharing a common output feature basis despite having fundamentally different target structure: cp is a scalar pressure field correlated with global flow, while τ_x/τ_y/τ_z are a 3D vector shear field dominated by local geometry and near-wall velocity gradients.

**Hypothesis**: Replacing this shared projection with two independent heads — a shallow linear cp head and a deeper 2-layer MLP τ head — will allow the model to learn WSS-specific representations without cp competing for the same output projection weights, reducing τ error by 0.5–1.0pp on τ_y and τ_z (the dominant bottleneck axes, currently 7.55% and 9.14% vs AB-UPT reference of 3.65%/3.63%).

This is orthogonal to H9b/H10b/H11b (currently running): those modify loss terms, curvature injection, and optimizer. H12 modifies output architecture only. It stacks cleanly on the full H9b confirmed stack.

## Instructions

**Only modify `model.py`. No changes to `train.py` or any other file.**

### Step 1: Modify `SurfaceTransolver.__init__`

Find the line (approximately line 365):
```python
self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
```

Replace with:
```python
# Split surface head: separate linear cp head + deeper MLP τ head
self.surface_cp_out = LinearProjection(n_hidden, 1)       # cp channel only (index 0)
self.surface_tau_out = nn.Sequential(
    nn.Linear(n_hidden, 2 * n_hidden),
    nn.GELU(),
    nn.Linear(2 * n_hidden, 3),  # tau_x, tau_y, tau_z (indices 1-3)
)
# Near-zero init on final τ layer for stable warmup
nn.init.normal_(self.surface_tau_out[-1].weight, std=0.01)
nn.init.zeros_(self.surface_tau_out[-1].bias)
```

### Step 2: Modify `SurfaceTransolver.forward`

Find the line (approximately line 438):
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

Replace with:
```python
cp_preds  = self.surface_cp_out(surface_hidden)    # [B, N_surf, 1]
tau_preds = self.surface_tau_out(surface_hidden)   # [B, N_surf, 3]
surface_preds = torch.cat([cp_preds, tau_preds], dim=-1)  # [B, N_surf, 4]
surface_preds = surface_preds * surface_mask.unsqueeze(-1)
```

**Important**: Check the exact channel order of `surface_y` in the training code (`train.py`) to confirm that index 0 is cp and indices 1–3 are τ_x, τ_y, τ_z. The slice `surface_y[..., 1:4]` should be the three τ components. If the channel order differs, adjust the concatenation accordingly.

**Parameter overhead**: ~192×2×192 + 192×3 ≈ 74,304 extra parameters (< 0.1% of total model size). Negligible compute.

### Step 3: Run with H9b full stack

```bash
torchrun --nproc_per_node=8 train.py \
  --data_path /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --n_layers 6 --n_hidden 192 --n_head 3 --slice_num 96 \
  --pe_kind string_separable --pe_num_features 16 \
  --pe_init_sigmas 0.1 0.178 0.316 0.562 1.0 \
  --n_surface_points 65000 --n_volume_points 65000 \
  --volume_sdf_alpha 2.0 \
  --optimizer lion --lr 5e-4 \
  --use_gradnorm --gradnorm_alpha 0.5 \
  --use_ema --ema_decay 0.999 \
  --y_sym_aug_prob 0.5 \
  --use_curvature_bias --curvature_bias_scale 1.0 \
  --use_mae_aux --grad_clamp 0.15 \
  --epochs 30 \
  --wandb_group wss_h12_separate_tau_head
```

(These are the exact H9b flags with only `--wandb_group` changed.)

### Step 4: Monitoring checkpoints

At **EP3** (step ~32,928): report val metrics. If val_wss ≥ 7.5% (worse than H9b EP3 reference ≈7.33%), check that the model is training correctly — ensure `surface_preds` shape is `[B, N_surf, 4]` and the loss is computing on the right channels.

At **EP5** (step ~54,879): first soft viability check — report val_wss, val_τ_y, val_τ_z alongside H9b EP5 reference values:
- H9b EP5 reference: val_wss=7.171%, val_τ_y=7.862%, val_τ_z=9.688%
- H12 EP5 should beat H9b on at least τ_z (target ≤9.50%) if the τ head is helping

At **EP10** (step ~109,760): hard viability gate.

### EP10 viability gate

| Criterion | Required | Verdict |
|---|---|---|
| val_wss EP10 | ≤ 6.3% (vs H9b EP10 ≈ 6.51%) | Must beat H9b by ≥0.2pp |
| val_τ_z EP10 | ≤ 9.4% (vs H9b EP10 ≈ 9.58%) | τ_z must improve |
| val_vol_p EP10 | ≤ 4.5% | Floor check — GradNorm must not collapse |
| τ_z slope EP8→10 | negative (still descending) | No plateau already |

If ANY criterion fails, post a decision update to this PR before EP10+1 runs — do not continue to EP30 without checking first.

### Step 5: Post updates per PR Step 3

Report at every val epoch (boundary step) per the standard PR update protocol. Include the W&B run ID in the first comment.

## Baseline

**Current wave SOTA (corrected split `rawcanon_20260511`) — PR #972 (run `56bcqp3m`, eval `zxnhtagj`):**

| Metric | SOTA | Floor (#1056) | AB-UPT ref |
|---|---:|---:|---:|
| test_abupt | **5.844%** | — | — |
| test_vol_p | **3.643%** | ≤ 3.643 ⚠️ floor | 6.08% |
| test_surf_p | **3.577%** | ≤ 3.577 ⚠️ floor | 3.82% |
| test_wss | **6.727%** | PRIMARY TARGET < 5.85% | 7.29% |
| test_τ_x | 5.971% | — | 5.35% |
| test_τ_y | 7.362% | — | 3.65% |
| test_τ_z | 8.747% | — | 3.63% |

**H9b reference at EP10** (run `smflmb5t`, the closest baseline to H12's stack):
- val_abupt=6.276, val_wss=7.051, val_vol_p=3.828, val_surf_p=4.200, val_τ_z=9.580

**Morgan #1056 contract**: test_wss < 5.85% AND test_vol_p ≤ 3.643% AND test_surf_p ≤ 3.577% simultaneously. All three conditions must be met.

**Dataset**: `/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511`
**Reproduce eval**: `torchrun --nproc_per_node=8 eval.py --run zxnhtagj ...` (see program.md for exact eval command)

## Why this is orthogonal to H9b/H10b/H11b

- H9b: curvature bias + MAE_aux → **gradient-level mechanism**
- H10b: Charbonnier τ_z loss → **loss-level mechanism**
- H11b: AdamW optimizer + per-axis τ weights → **optimizer-level mechanism**
- H12: separate τ head (deeper MLP) → **output architecture-level mechanism**

These are orthogonal axes of the ML pipeline. H12 can be stacked on top of any winner from H9b/H10b/H11b.

## Expected behaviour at EP1-EP3

The near-zero init on the τ MLP final layer will produce slightly worse EP1 val (τ head hasn't warmed up) but EP3+ should match or beat H9b as the MLP learns τ-specific feature compositions. If EP3 is MORE than 0.5pp above H9b on abupt, check the implementation — this suggests a bug (e.g., shape mismatch in `surface_preds`).
