### PR TITLE
Wave 30 H11b: gated multi-scale input (zero-init learned channel scaling)

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -7,6 +7,7 @@ from .loader import (
     EXPECTED_SURFACE_SPLIT_COUNTS,
     SURFACE_TARGET_NAMES,
     SURFACE_X_DIM,
+    SURFACE_X_DIM_BASE,
     SURFACE_Y_DIM,
     VOLUME_TARGET_NAMES,
     VOLUME_X_DIM,
@@ -16,7 +17,9 @@ from .loader import (
     DrivAerMLSurfaceDataset,
     SurfaceBatch,
     load_data,
+    multiscale_surface_dim,
     pad_collate,
+    parse_multiscale_k_values,
 )
 
 __all__ = [
@@ -24,6 +27,7 @@ __all__ = [
     "EXPECTED_SURFACE_SPLIT_COUNTS",
     "SURFACE_TARGET_NAMES",
     "SURFACE_X_DIM",
+    "SURFACE_X_DIM_BASE",
     "SURFACE_Y_DIM",
     "VOLUME_TARGET_NAMES",
     "VOLUME_X_DIM",
@@ -33,5 +37,7 @@ __all__ = [
     "DrivAerMLSurfaceDataset",
     "SurfaceBatch",
     "load_data",
+    "multiscale_surface_dim",
     "pad_collate",
+    "parse_multiscale_k_values",
 ]

--- a/data/loader.py
+++ b/data/loader.py
@@ -35,10 +35,15 @@ from torch.utils.data import Dataset
 from .split_utils import expand_pvc_candidates, first_existing
 
 DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest.json")
-SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM_BASE = 7  # xyz(3) + normals(3) + panel area(1)
+SURFACE_X_DIM = SURFACE_X_DIM_BASE  # default surface input dim; overridden when multi-scale features are enabled
 SURFACE_Y_DIM = 4  # cp(1) + wall shear stress(3)
 VOLUME_X_DIM = 4  # xyz(3) + sdf(1)
 VOLUME_Y_DIM = 1  # volume pressure
+MULTISCALE_FEATURES_PER_K = 3  # (cos_align, log1p(area), log1p(dist)) per scale
+MULTISCALE_AREA_SCALE = 1.0e6  # scales panel area (m^2) to ~unit range before log1p
+MULTISCALE_DIST_SCALE = 1.0e3  # scales kNN distance (m) to ~unit range before log1p
+MULTISCALE_CACHE_VERSION = "v1"
 SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")
 VOLUME_TARGET_NAMES = ("volume_pressure",)
 EXPECTED_SURFACE_SPLIT_COUNTS = {"train": 400, "val": 34, "test": 50}
@@ -269,12 +274,154 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+def parse_multiscale_k_values(spec: str | tuple[int, ...] | list[int] | None) -> tuple[int, ...]:
+    """Parse a multi-scale kNN spec like ``"4,16,64"`` to a tuple of ints.
+
+    Returns an empty tuple when ``spec`` is falsy. Validates that each k is a
+    positive integer. Order is preserved so the cache key (``k4_16_64``)
+    matches the channel layout in the cached array.
+    """
+
+    if spec is None:
+        return ()
+    if isinstance(spec, str):
+        if not spec.strip():
+            return ()
+        parts = [token.strip() for token in spec.split(",") if token.strip()]
+    else:
+        parts = list(spec)
+    out: list[int] = []
+    for token in parts:
+        k = int(token)
+        if k < 1:
+            raise ValueError(f"multiscale_k_values entries must be positive, got {k}")
+        out.append(k)
+    return tuple(out)
+
+
+def multiscale_surface_dim(k_values: tuple[int, ...] | None) -> int:
+    """Return the surface_x dim contributed by multi-scale features."""
+
+    if not k_values:
+        return 0
+    return MULTISCALE_FEATURES_PER_K * len(k_values)
+
+
+def _multiscale_cache_path(case_dir: Path, k_values: tuple[int, ...]) -> Path:
+    k_key = "_".join(str(k) for k in k_values)
+    return case_dir / f"surface_multiscale_k{k_key}_{MULTISCALE_CACHE_VERSION}.npy"
+
+
+def _compute_multiscale_features(
+    xyz_full: np.ndarray,
+    normals_full: np.ndarray,
+    area_full: np.ndarray,
+    k_values: tuple[int, ...],
+) -> np.ndarray:
+    """Compute multi-scale per-vertex kNN context features.
+
+    For each scale ``k`` in ``k_values`` we emit 3 channels:
+        * mean cosine alignment of neighbor unit normals to self normal
+        * log1p of mean panel area in the k-neighborhood (after scaling)
+        * log1p of mean L2 distance to the k nearest neighbors (after scaling)
+
+    The query excludes the self point. Returns ``[N, 3 * len(k_values)]``
+    float32. Requires SciPy (``cKDTree``); raises ``RuntimeError`` if missing.
+    """
+
+    try:
+        from scipy.spatial import cKDTree
+    except ImportError as exc:  # pragma: no cover - dependency required for this feature path
+        raise RuntimeError(
+            "Multi-scale kNN features require scipy.spatial.cKDTree. "
+            "Install scipy (>=1.10) to enable --use-multiscale-context."
+        ) from exc
+
+    if not k_values:
+        raise ValueError("k_values must be non-empty for multi-scale feature compute")
+
+    n_points = xyz_full.shape[0]
+    k_max = max(k_values)
+    if n_points <= k_max:
+        raise ValueError(
+            f"case has only {n_points} surface points; need > max(k_values)={k_max}"
+        )
+
+    xyz_64 = xyz_full.astype(np.float64, copy=False)
+    tree = cKDTree(xyz_64)
+    distances, indices = tree.query(xyz_64, k=k_max + 1, workers=-1)
+    distances = distances.astype(np.float32, copy=False)
+    indices = indices.astype(np.int64, copy=False)
+
+    normals_unit = normals_full.astype(np.float32, copy=False)
+    normals_unit = normals_unit / (
+        np.linalg.norm(normals_unit, axis=1, keepdims=True) + 1.0e-8
+    )
+    area_flat = area_full.astype(np.float32, copy=False).reshape(-1)
+
+    out_channels: list[np.ndarray] = []
+    for k in k_values:
+        nbr_idx = indices[:, 1 : k + 1]
+        nbr_normals = normals_unit[nbr_idx]
+        cos_align = np.einsum("nd,nkd->nk", normals_unit, nbr_normals).mean(axis=1)
+        cos_align = np.clip(cos_align, -1.0, 1.0).astype(np.float32)
+
+        mean_area = area_flat[nbr_idx].mean(axis=1)
+        mean_dist = distances[:, 1 : k + 1].mean(axis=1)
+        log_area = np.log1p(np.maximum(mean_area * MULTISCALE_AREA_SCALE, 0.0)).astype(np.float32)
+        log_dist = np.log1p(np.maximum(mean_dist * MULTISCALE_DIST_SCALE, 0.0)).astype(np.float32)
+
+        out_channels.extend([cos_align, log_area, log_dist])
+
+    return np.stack(out_channels, axis=1).astype(np.float32, copy=False)
+
+
+def _load_or_compute_multiscale_features(
+    case_dir: Path,
+    k_values: tuple[int, ...],
+    *,
+    full_rows: int | None = None,
+) -> np.ndarray:
+    """Return ``[N_full, 3 * len(k_values)]`` features, computing once and caching.
+
+    The cache filename encodes the exact ``k_values`` so different combinations
+    coexist. Writes through a ``.tmp.npy`` rename to be safe under parallel
+    worker access. If the file exists and its first-axis length matches
+    ``full_rows`` (when provided) it is returned via mmap; otherwise it is
+    re-computed and overwritten.
+    """
+
+    cache = _multiscale_cache_path(case_dir, k_values)
+    if cache.exists():
+        try:
+            arr = np.load(cache, mmap_mode="r")
+            expected_cols = MULTISCALE_FEATURES_PER_K * len(k_values)
+            shape_ok = arr.ndim == 2 and arr.shape[1] == expected_cols
+            len_ok = full_rows is None or arr.shape[0] == full_rows
+            if shape_ok and len_ok:
+                return arr
+        except (ValueError, OSError):
+            # Corrupt or partial write — fall through and rebuild.
+            pass
+
+    xyz_full = np.load(_resolve_artifact_path(case_dir / "surface_xyz.npy"))
+    normals_full = np.load(_resolve_artifact_path(case_dir / "surface_normals.npy"))
+    area_full = np.load(_resolve_artifact_path(case_dir / "surface_area.npy"))
+    features = _compute_multiscale_features(xyz_full, normals_full, area_full, k_values)
+
+    tmp = cache.with_suffix(".tmp.npy")
+    np.save(tmp, features)
+    os.replace(tmp, cache)
+    return features
+
+
 def load_case(
     root: str | Path,
     case_id: str,
     *,
     surface_rows: np.ndarray | None = None,
     volume_rows: np.ndarray | None = None,
+    multiscale_k_values: tuple[int, ...] | None = None,
 ) -> DrivAerMLCase:
     case_dir = _case_dir(Path(root), case_id)
     xyz = _load_npy_rows(case_dir / "surface_xyz.npy", surface_rows)
@@ -285,7 +432,18 @@ def load_case(
         _load_npy_rows(case_dir / "surface_wallshearstress.npy", surface_rows),
         "surface_wallshearstress.npy",
     )
-    surface_x = np.concatenate([xyz, normals, area], axis=1)
+    surface_parts = [xyz, normals, area]
+    if multiscale_k_values:
+        full_rows = _npy_row_count(case_dir / "surface_xyz.npy")
+        features_full = _load_or_compute_multiscale_features(
+            case_dir, multiscale_k_values, full_rows=full_rows
+        )
+        if surface_rows is None:
+            features = np.asarray(features_full, dtype=np.float32)
+        else:
+            features = np.asarray(features_full[surface_rows], dtype=np.float32)
+        surface_parts.append(features)
+    surface_x = np.concatenate(surface_parts, axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [
@@ -338,8 +496,15 @@ class DrivAerMLCaseStore:
         *,
         surface_rows: np.ndarray | None = None,
         volume_rows: np.ndarray | None = None,
+        multiscale_k_values: tuple[int, ...] | None = None,
     ) -> DrivAerMLCase:
-        return load_case(self.root, case_id, surface_rows=surface_rows, volume_rows=volume_rows)
+        return load_case(
+            self.root,
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+            multiscale_k_values=multiscale_k_values,
+        )
 
     def case_point_counts(self, case_id: str) -> dict[str, int]:
         cached = self._point_count_cache.get(case_id)
@@ -367,6 +532,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        multiscale_k_values: tuple[int, ...] | None = None,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +542,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.multiscale_k_values = tuple(multiscale_k_values) if multiscale_k_values else ()
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -444,6 +611,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             view.case_id,
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
+            multiscale_k_values=self.multiscale_k_values or None,
         )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
@@ -473,10 +641,12 @@ def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
     max_surface_n = max(sample.surface_x.shape[0] for sample in samples)
     max_volume_n = max(sample.volume_x.shape[0] for sample in samples)
     batch_size = len(samples)
-    surface_x = torch.zeros(batch_size, max_surface_n, SURFACE_X_DIM, dtype=samples[0].surface_x.dtype)
+    surface_x_dim = int(samples[0].surface_x.shape[1])
+    volume_x_dim = int(samples[0].volume_x.shape[1])
+    surface_x = torch.zeros(batch_size, max_surface_n, surface_x_dim, dtype=samples[0].surface_x.dtype)
     surface_y = torch.zeros(batch_size, max_surface_n, SURFACE_Y_DIM, dtype=samples[0].surface_y.dtype)
     surface_mask = torch.zeros(batch_size, max_surface_n, dtype=torch.bool)
-    volume_x = torch.zeros(batch_size, max_volume_n, VOLUME_X_DIM, dtype=samples[0].volume_x.dtype)
+    volume_x = torch.zeros(batch_size, max_volume_n, volume_x_dim, dtype=samples[0].volume_x.dtype)
     volume_y = torch.zeros(batch_size, max_volume_n, VOLUME_Y_DIM, dtype=samples[0].volume_y.dtype)
     volume_mask = torch.zeros(batch_size, max_volume_n, dtype=torch.bool)
     for i, sample in enumerate(samples):
@@ -544,6 +714,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    multiscale_k_values: tuple[int, ...] | None = None,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +739,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        multiscale_k_values=multiscale_k_values,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +748,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            multiscale_k_values=multiscale_k_values,
         )
     }
     test_splits = {
@@ -585,6 +758,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            multiscale_k_values=multiscale_k_values,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/model.py
+++ b/model.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
+from data import SURFACE_X_DIM, SURFACE_X_DIM_BASE, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        num_multiscale_channels: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,8 +397,22 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.num_multiscale_channels = int(num_multiscale_channels)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
+
+        if self.num_multiscale_channels > 0:
+            expected = SURFACE_X_DIM_BASE + self.num_multiscale_channels
+            if self.surface_input_dim != expected:
+                raise ValueError(
+                    f"num_multiscale_channels={self.num_multiscale_channels} "
+                    f"requires surface_input_dim={expected} (base {SURFACE_X_DIM_BASE} + "
+                    f"multiscale {self.num_multiscale_channels}); got surface_input_dim="
+                    f"{self.surface_input_dim}"
+                )
+            self.multiscale_gate = nn.Parameter(torch.zeros(self.num_multiscale_channels))
+        else:
+            self.multiscale_gate = None
 
         if pos_encoding_mode == "string_multisigma":
             string_sep_features = rff_num_features if rff_num_features > 0 else 16
@@ -559,6 +574,11 @@ class SurfaceTransolver(nn.Module):
             raise ValueError("SurfaceTransolver requires surface_mask when surface_x is provided")
         if volume_x is not None and volume_mask is None:
             raise ValueError("SurfaceTransolver requires volume_mask when volume_x is provided")
+
+        if surface_x is not None and self.multiscale_gate is not None:
+            base = SURFACE_X_DIM_BASE
+            gated = surface_x[..., base:] * self.multiscale_gate
+            surface_x = torch.cat([surface_x[..., :base], gated], dim=-1)
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []

--- a/prewarm_multiscale.py
+++ b/prewarm_multiscale.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Pre-warm the multi-scale kNN feature cache for all train+val+test cases.
+
+Computing per-case features lazily inside DataLoader workers (32 concurrent
+processes on an 8-rank DDP run) over-subscribes the CPUs because both
+``cKDTree(..., workers=-1)`` and BLAS-backed numpy operations grab every
+available core inside each worker. This script runs the same feature compute
+sequentially within each subprocess and parallelises across cases via
+``concurrent.futures.ProcessPoolExecutor``, with strict per-worker thread
+caps so the wall-clock cost is bounded.
+
+Usage::
+
+    uv run python prewarm_multiscale.py \
+        --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+        --multiscale-k-values 4,16,64 \
+        --processes 16
+
+The cache is co-located in each case directory and shared across all training
+runs, so this script is a one-time cost per ``k_values`` tuple.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+
+def _limit_threads(n: int) -> None:
+    """Cap per-process numpy/BLAS/MKL threads to avoid CPU over-subscription."""
+
+    n = max(1, int(n))
+    for var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    ):
+        os.environ[var] = str(n)
+
+
+def _worker(args: tuple[str, str, tuple[int, ...], int]) -> tuple[str, float, str]:
+    case_id, root, k_values, threads = args
+    _limit_threads(threads)
+    # Imports happen inside the subprocess so the thread caps above take effect
+    # before BLAS is initialised.
+    from data.loader import (  # noqa: E402  (intentional late import)
+        _load_or_compute_multiscale_features,
+        _npy_row_count,
+        _case_dir,
+    )
+
+    case_dir = _case_dir(Path(root), case_id)
+    full_rows = _npy_row_count(case_dir / "surface_xyz.npy")
+    t0 = time.time()
+    arr = _load_or_compute_multiscale_features(case_dir, k_values, full_rows=full_rows)
+    elapsed = time.time() - t0
+    return case_id, elapsed, f"shape={arr.shape}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-root",
+        required=True,
+        help="DrivAerML processed root, e.g. /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="data/split_manifest.json",
+        help="Path to split manifest JSON",
+    )
+    parser.add_argument(
+        "--multiscale-k-values",
+        default="4,16,64",
+        help="Comma-separated kNN scales (default: 4,16,64)",
+    )
+    parser.add_argument(
+        "--processes",
+        type=int,
+        default=8,
+        help="Number of subprocesses to use for feature compute (default: 8)",
+    )
+    parser.add_argument(
+        "--threads-per-process",
+        type=int,
+        default=0,
+        help="Per-process thread cap for numpy/cKDTree. 0 -> auto-pick (cpu_count // processes).",
+    )
+    parser.add_argument(
+        "--splits",
+        default="train,val,test",
+        help="Splits to pre-warm (default: all three)",
+    )
+    args = parser.parse_args()
+
+    from data.loader import (  # noqa: E402  (relies on data module being importable)
+        DrivAerMLCaseStore,
+        parse_multiscale_k_values,
+    )
+
+    k_values = parse_multiscale_k_values(args.multiscale_k_values)
+    if not k_values:
+        raise SystemExit("--multiscale-k-values must be non-empty (e.g. '4,16,64')")
+
+    store = DrivAerMLCaseStore(manifest_path=args.manifest, root=args.data_root)
+    splits = [s.strip() for s in args.splits.split(",") if s.strip()]
+    case_ids: list[str] = []
+    seen: set[str] = set()
+    for split in splits:
+        for cid in store.case_ids(split):
+            if cid not in seen:
+                seen.add(cid)
+                case_ids.append(cid)
+
+    n_cpus = os.cpu_count() or 8
+    threads = args.threads_per_process or max(1, n_cpus // max(1, args.processes))
+    print(
+        f"Pre-warming multi-scale cache for {len(case_ids)} cases | "
+        f"k_values={list(k_values)} | processes={args.processes} | "
+        f"threads/process={threads} | data_root={store.root}"
+    )
+
+    futures_args = [(cid, str(store.root), tuple(k_values), threads) for cid in case_ids]
+    successes: list[tuple[str, float, str]] = []
+    failures: list[tuple[str, str]] = []
+    t_start = time.time()
+    with ProcessPoolExecutor(max_workers=args.processes) as pool:
+        future_map = {pool.submit(_worker, fa): fa[0] for fa in futures_args}
+        for i, fut in enumerate(as_completed(future_map), start=1):
+            case_id = future_map[fut]
+            try:
+                result = fut.result()
+                successes.append(result)
+                elapsed = result[1]
+                wall = time.time() - t_start
+                print(
+                    f"  [{i}/{len(case_ids)}] {case_id}: {elapsed:.1f}s ({result[2]}) "
+                    f"wall={wall/60:.1f}min"
+                )
+            except Exception as exc:  # pragma: no cover - prewarm diagnostic
+                failures.append((case_id, repr(exc)))
+                print(f"  [{i}/{len(case_ids)}] {case_id}: FAILED -> {exc!r}")
+
+    total = time.time() - t_start
+    print(
+        f"\nDone in {total/60:.1f}min. "
+        f"{len(successes)} succeeded, {len(failures)} failed."
+    )
+    if failures:
+        for cid, err in failures:
+            print(f"  FAIL {cid}: {err}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "wandb",
     "pyyaml",
     "lion-pytorch>=0.2.4",
+    "scipy>=1.17.1",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -382,6 +382,15 @@ def log_multiscale_input_stats(config: Config, train_loader: DataLoader) -> None
     )
 
 
+def resolve_num_multiscale_channels(config: Config) -> int:
+    """Return the number of multi-scale channels appended to surface_x."""
+
+    if not config.use_multiscale_context:
+        return 0
+    k_values = parse_multiscale_k_values(config.multiscale_k_values)
+    return multiscale_surface_dim(k_values)
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -397,6 +406,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         surface_input_dim=resolve_surface_input_dim(config),
+        num_multiscale_channels=resolve_num_multiscale_channels(config),
     )
 
 
@@ -975,6 +985,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
             if config.use_multiscale_context:
                 log_multiscale_input_stats(config, train_loader)
+            init_gate = getattr(base_model, "multiscale_gate", None)
+            if init_gate is not None:
+                init_gate_vals = init_gate.detach().float().cpu().tolist()
+                wandb.summary["multiscale_gate/init_values"] = init_gate_vals
+                wandb.summary["multiscale_gate/init_mean_abs"] = float(
+                    sum(abs(v) for v in init_gate_vals) / max(len(init_gate_vals), 1)
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1219,6 +1236,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
 
+                gate = getattr(base_model, "multiscale_gate", None)
+                if gate is not None:
+                    gate_vals = gate.detach().float().cpu()
+                    train_log["train/multiscale_gate/mean_abs"] = float(gate_vals.abs().mean())
+                    train_log["train/multiscale_gate/max_abs"] = float(gate_vals.abs().max())
+                    train_log["train/multiscale_gate/l2"] = float(gate_vals.norm())
+                    train_log["train/multiscale_gate/min"] = float(gate_vals.min())
+                    train_log["train/multiscale_gate/max"] = float(gate_vals.max())
+                    for i, g in enumerate(gate_vals.tolist()):
+                        train_log[f"train/multiscale_gate/channel_{i}"] = float(g)
+
                 train_log.update(
                     train_slope_tracker.update(
                         global_step=global_step,
@@ -1427,10 +1455,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             return
 
         distributed_barrier(state)
+        final_gate = getattr(base_model, "multiscale_gate", None)
         if not state.is_main:
             wandb.summary.update({"total_train_minutes": total_minutes})
             wandb.finish()
             return
+        if final_gate is not None:
+            final_vals = final_gate.detach().float().cpu().tolist()
+            abs_vals = [abs(v) for v in final_vals]
+            wandb.summary["multiscale_gate/final_values"] = final_vals
+            wandb.summary["multiscale_gate/final_mean_abs"] = float(
+                sum(abs_vals) / max(len(abs_vals), 1)
+            )
+            wandb.summary["multiscale_gate/final_max_abs"] = float(max(abs_vals) if abs_vals else 0.0)
 
         if not best_metrics:
             wandb.summary.update(

--- a/train.py
+++ b/train.py
@@ -32,7 +32,12 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import (
+    DrivAerMLSurfaceDataset,
+    SURFACE_X_DIM_BASE,
+    multiscale_surface_dim,
+    parse_multiscale_k_values,
+)
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -103,6 +108,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_multiscale_context: bool = False
+    multiscale_k_values: str = "4,16,64"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +236,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_multiscale_context": (
+            "Enable PR #1150 multi-scale kNN-pooled local context features. "
+            "Adds 3 statistics x len(--multiscale-k-values) channels to the "
+            "7-channel surface input: per-vertex mean cosine alignment of "
+            "neighbor normals, log1p(mean panel area) and log1p(mean kNN "
+            "distance) at each scale. Computed once per case on the full "
+            "mesh via scipy cKDTree and cached as "
+            "surface_multiscale_k{ks}_v1.npy in each case directory."
+        ),
+        "multiscale_k_values": (
+            "Comma-separated kNN scales for --use-multiscale-context "
+            "(e.g. '4,16,64'). Each k produces 3 input channels."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +314,74 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def resolve_surface_input_dim(config: Config) -> int:
+    """Compute the surface_x feature dimension implied by ``config``.
+
+    Returns the base SURFACE_X_DIM (xyz + normals + area = 7) plus 3 channels
+    per kNN scale when --use-multiscale-context is enabled.
+    """
+
+    if not config.use_multiscale_context:
+        return SURFACE_X_DIM_BASE
+    k_values = parse_multiscale_k_values(config.multiscale_k_values)
+    if not k_values:
+        raise ValueError(
+            "--use-multiscale-context requires --multiscale-k-values to be a "
+            "non-empty comma-separated list of positive ints (e.g. '4,16,64')."
+        )
+    return SURFACE_X_DIM_BASE + multiscale_surface_dim(k_values)
+
+
+def log_multiscale_input_stats(config: Config, train_loader: DataLoader) -> None:
+    """Log per-channel statistics of the multi-scale kNN features for one case.
+
+    Only logs when --use-multiscale-context is enabled. Pulls one full sample
+    from ``train_loader.dataset`` (no shuffling needed; we just need a real
+    case) and writes mean/std/p95 of each of the ``3 * len(k_values)`` extra
+    channels to ``wandb.summary`` under ``multiscale/*``. Triggers feature
+    compute for that case if not yet cached, which is harmless (the same
+    compute will run again on the first training batch otherwise).
+    """
+
+    import numpy as np  # local import keeps train.py module import light
+
+    k_values = parse_multiscale_k_values(config.multiscale_k_values)
+    if not k_values:
+        return
+    try:
+        sample = train_loader.dataset[0]
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        print(f"multiscale stats: could not load sample: {exc}")
+        return
+    ms = sample.surface_x[:, SURFACE_X_DIM_BASE:].numpy()
+    expected_dim = multiscale_surface_dim(k_values)
+    if ms.shape[-1] != expected_dim:
+        print(
+            f"multiscale stats: expected {expected_dim} extra channels, "
+            f"got {ms.shape[-1]} (cache shape mismatch?)"
+        )
+        return
+    stat_names = ("cos_align", "log_area", "log_dist")
+    summary: dict[str, float] = {}
+    for ki, k in enumerate(k_values):
+        for si, stat_name in enumerate(stat_names):
+            col = ms[:, ki * len(stat_names) + si]
+            summary[f"multiscale/k{k}/{stat_name}_mean"] = float(col.mean())
+            summary[f"multiscale/k{k}/{stat_name}_std"] = float(col.std())
+            summary[f"multiscale/k{k}/{stat_name}_p05"] = float(np.percentile(col, 5))
+            summary[f"multiscale/k{k}/{stat_name}_p50"] = float(np.percentile(col, 50))
+            summary[f"multiscale/k{k}/{stat_name}_p95"] = float(np.percentile(col, 95))
+    summary["multiscale/k_values"] = ",".join(str(k) for k in k_values)
+    summary["multiscale/surface_input_dim"] = int(sample.surface_x.shape[-1])
+    summary["multiscale/sample_case_id"] = str(sample.case_id)
+    wandb.summary.update(summary)
+    print(
+        f"Multi-scale context enabled: k_values={list(k_values)}, "
+        f"surface_input_dim={sample.surface_x.shape[-1]}, "
+        f"sample={sample.case_id}, extra channels={ms.shape[-1]}"
+    )
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +396,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        surface_input_dim=resolve_surface_input_dim(config),
     )
 
 
@@ -683,6 +772,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        multiscale_k_values=getattr(old_ds, "multiscale_k_values", ()) or None,
     )
     train_sampler = None
     train_shuffle = True
@@ -883,6 +973,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.use_multiscale_context:
+                log_multiscale_input_stats(config, train_loader)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -30,6 +30,7 @@ from data import (
     VOLUME_Y_DIM,
     load_data,
     pad_collate,
+    parse_multiscale_k_values,
 )
 
 
@@ -278,6 +279,16 @@ def make_loaders(
     config,
     distributed_state: DistributedState | None = None,
 ) -> tuple[DataLoader, dict[str, DataLoader], dict[str, DataLoader], dict[str, torch.Tensor]]:
+    multiscale_k_values: tuple[int, ...] | None = None
+    if getattr(config, "use_multiscale_context", False):
+        spec = getattr(config, "multiscale_k_values", "") or ""
+        parsed = parse_multiscale_k_values(spec)
+        if not parsed:
+            raise ValueError(
+                "--use-multiscale-context requires --multiscale-k-values to be a "
+                "non-empty comma-separated list of positive ints (e.g. '4,16,64')."
+            )
+        multiscale_k_values = parsed
     train_ds, val_splits, test_splits, stats = load_data(
         manifest_path=config.manifest,
         root=config.data_root or None,
@@ -286,6 +297,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        multiscale_k_values=multiscale_k_values,
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**H11b: Gated multi-scale input — zero-initialised learned diagonal scaling on the 9 multi-scale kNN channels.** Your H11 run (PR #1150, closed NOT-A-MERGE) produced the **best single-model test_abupt on `tay`** (5.809% vs baseline 5.844%) and the **best single-model test_WSS** (6.633% vs baseline 6.727%) — but both floor metrics regressed (SP +0.120pp, vol_p +0.022pp), blocking merge.

Your own analysis identified the mechanism: the 9 unscaled multi-scale channels concatenated at the input **steal representational capacity from the SP/vol_p heads** because the model has no way to selectively admit them. At EP0 they are random projections relative to baseline; the model wastes early training adapting its SP head to account for them.

**H11b fixes this with a single 9-element learned gate:**

```python
# In SurfaceTransolver.__init__, when use_multiscale_context is True:
self.multiscale_gate = nn.Parameter(torch.zeros(9))  # init = 0

# In forward(), before _encode_group:
if self.multiscale_gate is not None:
    gated_multiscale = surface_x[..., 7:16] * self.multiscale_gate
    surface_x = torch.cat([surface_x[..., :7], gated_multiscale], dim=-1)
```

With `torch.zeros(9)`:
- **EP0**: gate = 0 → `surface_x[..., 7:16] = 0` → model behaves **exactly like baseline** (no multi-scale info). SP/vol_p heads start from a clean baseline capacity allocation.
- **EP1+**: the gate learns from gradient → channels with genuine predictive signal grow non-zero; channels that are dead or harmful stay near zero. The model decides what to admit, not the architecture.

This is the same principle as residual / skip-connection zero-initialisation (He et al., CVPR 2016) and gating in highway networks (Srivastava et al., 2015): a zero-init gate preserves the base path while giving the model an opt-in pathway to additional signal. It is also analogous to `LoRA` low-rank gating at adapter layers — start at zero, let gradient decide the magnitude.

**Why this should fix the SP/vol_p regression while keeping the WSS gain:**
1. SP capacity is no longer stolen at EP0 — the baseline SP signal path is clean through the first epoch before the gate warms up
2. WSS gain comes from multi-scale context (which is genuine geometric signal); the gate will learn to keep those channels non-zero because they reduce WSS loss
3. SP-neutral channels (e.g. log-distance channels that don't correlate with surface pressure) may be gated near-zero, freeing capacity

**This is NOT an ensemble.** Single model, single forward pass. One 9-element parameter vector added to the existing H11 implementation.

**References:**
- He et al. (CVPR 2016) — zero-init residual connections; the gate-to-zero principle is the same
- Srivastava et al. (NeurIPS 2015) — highway network transform gates, initialized to carry (but the negative carry = 0 case applies here)
- Ross et al. (2018) ICML — input gating in multi-task learning to decouple feature groups

## Instructions

**Start from your H11 implementation** (`askeladd/multi-scale-knn-context`, commit `90db377`). All the prewarm cache infrastructure, the k=4/16/64 compute, the `--use-multiscale-context` flag, the channel statistics logging — keep all of that. The diff from H11 to H11b is **small**: one new `nn.Parameter` in `__init__` and one gate application in `forward`.

### Step 1 — Add `multiscale_gate` parameter to `SurfaceTransolver.__init__`

In `target/model.py`, in `SurfaceTransolver.__init__`, find where `use_multiscale_context` or `multiscale_dim` is handled (you added it in H11). Add the gate parameter:

```python
# Only when multi-scale context is active
if use_multiscale_context:
    self.multiscale_gate = nn.Parameter(torch.zeros(num_multiscale_channels))
    # num_multiscale_channels = 9 for k_values=(4, 16, 64)
else:
    self.multiscale_gate = None
```

Where `num_multiscale_channels` is already computed from `multiscale_surface_dim(k_values) - SURFACE_X_DIM` or just hardcoded to `3 * len(k_values)`. In your H11 implementation `data/loader.py:79-85` computes `multiscale_surface_dim` as `3 * len(k_values)` = 9 for k=(4,16,64). Thread this value through the constructor (it's already in `surface_input_dim`).

**Important:** Initialize with `torch.zeros`, NOT `torch.ones`. `torch.ones` would give H11 behavior at init; `torch.zeros` gives baseline behavior at init. That is the entire mechanism difference.

### Step 2 — Apply gate in `forward()` before `_encode_group`

In `target/model.py`, in `forward()`, before the call to `self._encode_group(surface_x, ...)` (around line 571 in the H11 version):

```python
if surface_x is not None and self.multiscale_gate is not None:
    # surface_x shape: [B, N, surface_input_dim]
    # Layout: [xyz(3), normals(3), area(1), multiscale(9)] = 16 total
    base_dim = 7  # xyz=3 + normals=3 + area=1
    gated = surface_x[..., base_dim:] * self.multiscale_gate
    surface_x = torch.cat([surface_x[..., :base_dim], gated], dim=-1)
```

**Do not use in-place operations** (e.g. `surface_x[..., 7:] *= self.multiscale_gate`) — this breaks autograd. Always create a new tensor with `torch.cat`.

### Step 3 — Add gate magnitude diagnostic to W&B logging

In `train.py` or `trainer_runtime.py`, log the gate vector at each epoch end (or every N steps):

```python
if hasattr(model, 'multiscale_gate') and model.multiscale_gate is not None:
    gate_vals = model.multiscale_gate.detach().cpu()
    for i, g in enumerate(gate_vals):
        wandb.log({"train/multiscale_gate/channel_{i}": float(g)}, step=global_step)
    wandb.log({
        "train/multiscale_gate/mean_abs": float(gate_vals.abs().mean()),
        "train/multiscale_gate/max_abs": float(gate_vals.abs().max()),
    }, step=global_step)
```

This lets us directly verify that the gate is warming up (|gate| growing from 0) and not collapsing to zero (which would mean multi-scale context is unhelpful).

### Step 4 — Smoke run (verify gate dynamics before main launch)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=30 torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-multiscale-context --multiscale-k-values 4,16,64 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 1 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 \
  --train-surface-points 16384 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --wandb-group wave30_h11b_gated_multiscale \
  --wandb-name askeladd/h11b-gated-smoke --agent askeladd
```

**Smoke PASS criteria:**
1. `train/multiscale_gate/max_abs` starts at 0, grows non-zero within 200 steps — gate is receiving gradient ✓
2. `train/surface_loss` at step 200 is comparable to H11 baseline (within 5%) — gated model not handicapped ✓
3. No NaN: `nonfinite_loss=0`, `nonfinite_grad=0` ✓
4. **Key gate warming check**: by step 500, `train/multiscale_gate/mean_abs > 0.01` — if gate stays exactly 0, check gradient flow (common issue: missing `.requires_grad_(True)` or gate registered as buffer not parameter)

### Step 5 — Full training run (18h budget, same recipe as H11)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-multiscale-context --multiscale-k-values 4,16,64 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h11b_gated_multiscale \
  --wandb-name askeladd/h11b-gated-k4-16-64-18h --agent askeladd
```

**prewarm cache is already built** from your H11 run (`surface_multiscale_k4_16_64_v1.npy` per case) — no need to rerun prewarm_multiscale.py.

### EP gates (warmup=1 recipe — same as H11)

- EP1: val_abupt ~28–33% — DO NOT KILL (warmup floor; with gate near zero, EP1 behavior should closely track baseline #972's val_abupt = 6.126% descent curve)
- EP3 gate: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- **Critical EP3 check**: compare `train/multiscale_gate/mean_abs` — if still < 0.001 at EP3, gate is dead (likely gradient path broken); report and advisor will diagnose
- EP6 gate: val_abupt ≤ 6.5% PASS / ≤ 6.8% MARGINAL / > 6.8% KILL
- EP10 gate: val_abupt ≤ 6.3% PASS
- EP13 terminal: full SENPAI-RESULT with val + test per #1056 directive

### Step 6 — Terminal SENPAI-RESULT reporting requirements

Terminal must include (per #1056 directive — always report val AND test):
- val_abupt, val_vol_p, val_SP, val_WSS
- test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, test_τ_z
- **test τz/τx ratio** — compare to H11's 1.470 (engaged-but-neutral band)
- **Gate diagnostic at terminal**: `multiscale_gate` values per channel (which channels were admitted?), `mean_abs`, `max_abs`
- H11 vs H11b direct comparison table for SP, vol_p, WSS
- Per-epoch table of val_abupt + val_SP + val_vol_p (so advisor can verify floors were protected from EP1 onward)

**The primary question H11b answers**: does gating the multi-scale channels at zero-init restore the SP/vol_p baselines while preserving the WSS gain?

## Baseline (single-model SOTA: PR #972)

| Metric | Baseline #972 | H11 result (#1150, closed) | H11b target |
|---|---:|---:|---|
| val_abupt | 6.126% | **6.0953% (WIN)** | < 6.0953% to beat H11 |
| test_abupt | 5.844% | **5.809% (WIN — best on tay)** | < 5.844% to merge |
| test_WSS | 6.727% | **6.633% (WIN)** | < 6.727% to merge |
| test_vol_p | 3.643% (FLOOR) | 3.665% (FAIL +0.022pp) | ≤ 3.643% — must hold |
| test_SP | 3.577% (FLOOR) | 3.697% (FAIL +0.120pp) | ≤ 3.577% — must hold |
| test τz/τx | ~1.46 collapse band | 1.470 (neutral) | < 1.40 structural breakthrough |

**H11 W&B rank-0 reference:** `vgfkotop` (group `wave30_h11_multiscale_context`)

## What success looks like

- **MERGE**: test_WSS < 6.727% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577% → gate fixed the floor regression while keeping WSS gain. New candidate for ensemble pool refresh.
- **BIG WIN**: test_WSS < 6.609% (beats dl24-tanjiro #1132 on tay stack) AND floors held → headline single-model result.
- **PARTIAL**: test_SP returns to ≤ 3.577% but test_WSS regresses above 6.727% → gate over-constrained the multi-scale channels; try gate init near 0.1 instead of 0.0 for next iteration.
- **NULL (gate dead)**: `multiscale_gate` stays near 0 throughout AND val_abupt matches H11 → implementation issue (gradient path broken); check gate is `nn.Parameter`, not `nn.Buffer`.
- **NULL (gate active but SP still fails)**: gate warms up (mean_abs > 0.1 by EP6) but SP still above 3.577% → the capacity-stealing mechanism operates at a level deeper than the input gate (e.g. the multi-scale channels destabilise the SP head's gradient path even when scaled down); consider adding a separate surface-pressure output head normalization.

**Source**: Wave 30 H11b. Directly motivated by your own H11 closure self-diagnosis (your suggestion #1 in the H11 terminal comment). Your H11 run produced the highest single-model WSS and abupt on `tay` — H11b is the targeted surgical fix for the floor regression that blocked merge.
