### PR TITLE
H19: VICReg batch-variance regularization on predicted τ_z

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,12 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    # H19: VICReg batch-variance hinge on per-sample mean |τ_z| (PR #1168).
+    # Penalty fires only when std(per-sample-mean|τ_z|) < gamma; zero otherwise.
+    # Defaults 0.05/0.10 per PR; advisor contingency: re-run at gamma=0.10 if penalty never activates.
+    vicreg_tau_z_enable: bool = False
+    vicreg_tau_z_gamma: float = 0.05
+    vicreg_tau_z_lambda: float = 0.10
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,10 +327,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vicreg_tau_z_enable: bool = False,
+    vicreg_tau_z_gamma: float = 0.05,
+    vicreg_tau_z_lambda: float = 0.10,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    vicreg_diag: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,27 +342,55 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_preds = out["surface_preds"]
         if surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_preds,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_preds, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+
+        if vicreg_tau_z_enable:
+            # H19: VICReg variance hinge on per-sample mean |τ_z| in normalized space.
+            # Penalizes batch collapse of τ_z magnitudes; zero when std ≥ gamma.
+            mask_f = batch.surface_mask.to(dtype=surface_preds.dtype)
+            tau_z_abs = surface_preds[..., 3].abs()
+            n_valid = mask_f.sum(dim=1).clamp_min(1.0)
+            tau_z_mean = (tau_z_abs * mask_f).sum(dim=1) / n_valid
+            if tau_z_mean.shape[0] > 1:
+                std_tau_z = tau_z_mean.std(unbiased=False)
+                vicreg_var_loss = torch.relu(vicreg_tau_z_gamma - std_tau_z).pow(2)
+            else:
+                zero = surface_preds.sum() * 0.0
+                std_tau_z = zero
+                vicreg_var_loss = zero
+            vicreg_var_loss_weighted = vicreg_tau_z_lambda * vicreg_var_loss
+            loss = loss + vicreg_var_loss_weighted
+            std_tau_z_f = float(std_tau_z.detach().cpu().item())
+            vicreg_diag = {
+                "vicreg_std_tau_z": std_tau_z_f,
+                "vicreg_var_loss": float(vicreg_var_loss.detach().cpu().item()),
+                "vicreg_var_loss_weighted": float(vicreg_var_loss_weighted.detach().cpu().item()),
+                "vicreg_penalty_active": 1.0 if std_tau_z_f < vicreg_tau_z_gamma else 0.0,
+                "vicreg_tau_z_batch_mean": float(tau_z_mean.detach().mean().cpu().item()),
+            }
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(vicreg_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +890,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.vicreg_tau_z_enable:
+                print(
+                    f"H19 VICReg τ_z variance hinge: gamma={config.vicreg_tau_z_gamma} "
+                    f"lambda={config.vicreg_tau_z_lambda} (PR #1168). Penalty fires only when "
+                    f"std(per-sample-mean|τ_z|) < gamma; zero otherwise."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +927,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/vicreg_tau_z_enable"] = config.vicreg_tau_z_enable
+            wandb.summary["loss/vicreg_tau_z_gamma"] = config.vicreg_tau_z_gamma
+            wandb.summary["loss/vicreg_tau_z_lambda"] = config.vicreg_tau_z_lambda
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1077,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vicreg_tau_z_enable=config.vicreg_tau_z_enable,
+                        vicreg_tau_z_gamma=config.vicreg_tau_z_gamma,
+                        vicreg_tau_z_lambda=config.vicreg_tau_z_lambda,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1120,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if config.vicreg_tau_z_enable and "vicreg_std_tau_z" in batch_loss_metrics:
+                        train_log.update(
+                            {
+                                "vicreg/std_tau_z": batch_loss_metrics["vicreg_std_tau_z"],
+                                "vicreg/var_loss": batch_loss_metrics["vicreg_var_loss"],
+                                "vicreg/var_loss_weighted": batch_loss_metrics["vicreg_var_loss_weighted"],
+                                "vicreg/penalty_active": batch_loss_metrics["vicreg_penalty_active"],
+                                "vicreg/tau_z_batch_mean": batch_loss_metrics["vicreg_tau_z_batch_mean"],
+                                "vicreg/gamma": config.vicreg_tau_z_gamma,
+                                "vicreg/lambda": config.vicreg_tau_z_lambda,
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

The τ_z/τ_x collapse band [1.44, 1.55] persists across 8+ independent attacks (loss reweighting, architecture width, multi-scale aggregation, curvature input, soft-constraint penalty, tangent-frame output reparameterization, EMA). Fern H10 confirmed the 73%/27% magnitude/direction split: direction is 99.65% solved; ALL residual WSS error is in magnitude. The τ_z collapse is a batch-level distributional failure: the model produces nearly identical mean |τ_z| across all car geometries, collapsing a physically meaningful variance (different car shapes produce different |τ_z| distributions) into a near-constant value.

VICReg (Bardes, Ponce, LeCun; ICLR 2022) includes a variance hinge loss: `max(0, γ − std(z))²` that penalizes collapse of a feature dimension to a constant. Applied to the per-sample mean |τ_z| across the batch, this loss directly penalizes the model for predicting the same τ_z level for every car geometry — breaking the collapse by imposing a distributional pressure.

This is a loss-level intervention operating on the batch-level statistics of predicted |τ_z|, not on individual vertex predictions. It is orthogonal to all 7 in-flight Wave 30 attacks:
- **H10b/fern** (bounded-exp magnitude decoder): output activation change — H19 is a loss term on batch statistics
- **H12/edward** (architecture/attention variant): model topology — H19 is a train.py-only change
- **H15b/alphonse** (EMA decay=0.999): parameter averaging — H19 is a gradient-level loss term
- **H16/frieren** (Huber-δ=1.0 loss): per-vertex loss shape — H19 is a batch-level variance term
- **H17/nezuko** (tangent-frame output reparameterization): output coordinate system — H19 is a loss penalty on global-frame τ_z stats
- **H18/tanjiro** (per-vertex area-weighted surface MSE): vertex-level loss weighting — H19 is a batch-level distributional term
- **H11b/askeladd** (gated multi-scale input): input aggregation — H19 is a train.py loss addition

Reference: Bardes et al. "VICReg: Variance-Invariance-Covariance Regularization for Self-Supervised Learning" (ICLR 2022), https://openreview.net/forum?id=xm6YD62D1Zs. Physics-domain analogue: Hanna et al. "VICReg for Physics-Informed Neural Networks" (arXiv:2412.13993, 2024) — applies the same variance hinge to Navier-Stokes PINN residuals to prevent distributional collapse in physically constrained outputs.

## Instructions

**Change `target/train.py` only. Do NOT modify `model.py`, `data/loader.py`, `trainer_runtime.py`, or any eval code.**

The change is approximately 12 lines added to the training loss computation. Here is the exact implementation:

**Step 1 — Locate the training loss block in `train.py`.**

Find the line where `loss = train_loss(out, batch, ...)` (or equivalent) produces the base loss scalar. The exact function name may be `train_loss`, `compute_loss`, or inline — search for where `loss.backward()` is called and work backward one step.

**Step 2 — Add the VICReg variance term immediately after the base loss is computed:**

```python
# --- H19: VICReg batch-variance regularization on predicted |τ_z| ---
# Hyperparameters
VICREG_GAMMA  = 0.05   # target std of per-sample mean |τ_z| (normalized units)
VICREG_LAMBDA = 0.10   # loss weight

# surface_preds is out["surface_preds"], shape [B, N_surf, 4]; channel 3 = τ_z
# surface_mask is batch.surface_mask or equivalent, shape [B, N_surf], bool/float
surface_preds = out["surface_preds"]           # [B, N_surf, 4]
surface_mask  = batch.surface_mask.float()     # [B, N_surf]

tau_z_pred  = surface_preds[..., 3]            # [B, N_surf]
tau_z_abs   = tau_z_pred.abs()                 # [B, N_surf]
n_valid     = surface_mask.sum(dim=1).clamp(min=1.0)            # [B]
tau_z_mean  = (tau_z_abs * surface_mask).sum(dim=1) / n_valid   # [B] per-sample mean |τ_z|

if tau_z_mean.shape[0] > 1:
    std_tau_z = tau_z_mean.std(unbiased=False)   # scalar: batch std of per-sample means
else:
    std_tau_z = torch.zeros(1, device=tau_z_pred.device).squeeze()

vicreg_var_loss = torch.nn.functional.relu(VICREG_GAMMA - std_tau_z).pow(2)
loss = loss + VICREG_LAMBDA * vicreg_var_loss

# --- Logging (add to whatever log_dict or wandb.log call is used) ---
# log_dict["vicreg/std_tau_z"]      = std_tau_z.item()
# log_dict["vicreg/var_loss"]        = vicreg_var_loss.item()
# log_dict["vicreg/penalty_active"]  = float(std_tau_z.item() < VICREG_GAMMA)
```

**Step 3 — Add the three vicreg/ keys to the wandb logging dict** that is already being logged in the training loop (wherever `wandb.log(...)` or `log_dict` is populated).

**Step 4 — Verify:**
- No changes to model.py
- No changes to eval code
- The `surface_mask` name: check whether the codebase uses `batch.surface_mask`, `surface_mask`, or `mask` — use whatever the existing code uses
- Import: `torch.nn.functional` is almost certainly already imported; if not, add `import torch.nn.functional as F` and use `F.relu`

**Critical implementation notes:**

1. The variance term is applied to the **normalized** τ_z predictions (post-`TargetTransform`). VICREG_GAMMA=0.05 is calibrated for normalized units. If the loss is computed in un-normalized space, scale GAMMA accordingly (multiply by the τ_z normalization std, typically ~1.0 for z-score normalized targets).

2. The penalty is **zero** when std_tau_z ≥ 0.05 — it only activates when the model is collapsing. It does NOT push the model to over-disperse; it only enforces a minimum diversity floor.

3. On a single-GPU debug run (batch_size=1), `tau_z_mean.shape[0] == 1` and the variance is undefined — the `if` guard handles this by zeroing the loss. On DDP-8 with batch_size=4, there are 32 samples per global step, giving a meaningful batch std estimate.

4. VICREG_LAMBDA=0.10 was chosen so that the variance loss contributes ~10% of the base loss when the penalty is active. If training shows instability (loss spikes, val_abupt > 48% at EP1), reduce to LAMBDA=0.05 and re-run.

## Baseline

Current single-model SOTA (PR #972, W&B run `56bcqp3m`):
- val_abupt = 6.126%
- test_abupt = 5.844%
- test_SP = 3.577% (FLOOR — must not exceed)
- test_vol_p = 3.643% (FLOOR — must not exceed)
- test_WSS = 6.727%
- test_WSS_direction_cos = 0.9965 (reference level — do not regress)

Current ensemble SOTA (PR #1102, K=8 Caruana):
- val_abupt = 5.7452% (single-model merge gate: beat this)
- test_abupt = 5.5196%
- test_WSS = 6.3263%

**Single-model merge gate**: val_abupt < 5.7452% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%

**Floors (hard)**: test_vol_p ≤ 3.643% and test_SP ≤ 3.577% (breach = cannot merge regardless of other metrics)

Reproduce baseline:
```bash
cd target/ && python train.py \
  --dataset_path /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --lion_beta1 0.9 --lion_beta2 0.99 \
  --batch_size 4 --epochs 13 --n_hidden 512 --n_heads 4 --n_layers 5 \
  --n_slice 128 --amp_mode bf16 --grad_clip_norm 1.0 \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_group baseline-wave30 \
  --use_ema --ema_decay 0.999
```

## Run Command

```bash
cd target/ && python train.py \
  --dataset_path /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --lion_beta1 0.9 --lion_beta2 0.99 \
  --batch_size 4 --epochs 13 --n_hidden 512 --n_heads 4 --n_layers 5 \
  --n_slice 128 --amp_mode bf16 --grad_clip_norm 1.0 \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_group H19-vicreg-tau-z-variance \
  --use_ema --ema_decay 0.999
```

**CRITICAL**: lr=9e-5 (NOT 5e-4 — this caused 4 Wave 30 divergences). Do not change lr.

## EP Gates (kill criteria)

Check val_abupt at these checkpoints:

- **EP3**: Kill if val_abupt > 9.5%
- **EP6**: Kill if val_abupt > 7.5%
- **EP10**: Kill if val_abupt > 6.2%

Healthy baseline trajectory lands val_abupt ~30–35% at EP1 (after warmup), ~10% at EP3, ~7% at EP5. The VICReg term should not materially change this trajectory.

## Watch Items at Terminal

Report all five of these alongside standard val_abupt / test metrics:

1. **vicreg/std_tau_z** (W&B log): should show an increasing trend from near-zero early in training toward ≥ 0.05 if the penalty is working. Flat or oscillating means the loss is ineffective.
2. **vicreg/penalty_active** fraction over training: what fraction of steps had the penalty firing? If < 20% after EP6, the model solved the variance constraint early and the penalty may be too weak.
3. **τ_z/τ_x ratio at test time**: compute `mean(|τ_z_pred|) / mean(|τ_x_pred|)` over the test set. Baseline collapse band = [1.44, 1.55]; ground truth ≈ 0.08. Report this ratio — any movement below 1.4 confirms the mechanism is alive.
4. **test_WSS_direction_cos**: should remain ≥ 0.9965. Regression here would indicate the variance term is distorting the direction encoding.
5. **test_vol_p and test_SP**: monitor these floors throughout. If either breaches at any checkpoint, flag immediately — do not continue to final eval if floor is breached at EP10.
