### PR TITLE
Wave 30 H16b: Huber loss on τ channels (δ=0.3, calibrated bulk-reshape)

### DIFF
--- a/train.py
+++ b/train.py
@@ -52,10 +52,13 @@ from trainer_runtime import (
     init_distributed,
     init_wandb_run,
     is_valid_primary_metric,
+    huber_diagnostics,
     loader_kwargs,
     make_loaders,
+    masked_huber,
     masked_mse,
     metric_namespace,
+    weighted_channel_huber_mse,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -138,6 +141,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    tau_loss_fn: str = "mse"
+    tau_huber_delta: float = 1.0
     debug: bool = False
 
 
@@ -228,6 +233,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "tau_loss_fn": (
+            "Loss function applied to the wall-shear tau channels "
+            "(tau_x, tau_y, tau_z) in z-scored space. 'mse' (default) "
+            "matches the historical behaviour. 'huber' caps the gradient "
+            "magnitude in the tail at --tau-huber-delta, redirecting "
+            "capacity to bulk vertices instead of outlier separation/"
+            "wake regions. The cp channel always uses MSE. Volume "
+            "pressure (vp) always uses MSE."
+        ),
+        "tau_huber_delta": (
+            "Huber transition threshold in z-scored space when "
+            "--tau-loss-fn=huber. delta=1.0 transitions at 1 standard "
+            "deviation of the per-channel signal (e.g. tau_z sigma ~1.11 Pa "
+            "in raw units => delta=1.11 Pa). Loss is 0.5*err^2 for "
+            "|err|<delta and delta*(|err|-0.5*delta) for |err|>=delta. "
+            "Unused when --tau-loss-fn=mse."
         ),
     }
     for field in fields(Config):
@@ -321,7 +343,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, dict[str, float]]:
+    tau_loss_fn: str = "mse",
+    tau_huber_delta: float = 1.0,
+) -> tuple[torch.Tensor, dict[str, object]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -332,27 +356,73 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        surface_pred = out["surface_preds"]
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
-            )
+            if tau_loss_fn == "huber":
+                surface_loss = weighted_channel_huber_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                    tau_huber_delta=tau_huber_delta,
+                )
+            else:
+                surface_loss = weighted_channel_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            if tau_loss_fn == "huber":
+                surface_loss = weighted_channel_huber_mse(
+                    surface_pred,
+                    surface_target,
+                    batch.surface_mask,
+                    torch.ones(4, device=surface_pred.device, dtype=surface_pred.dtype),
+                    tau_huber_delta=tau_huber_delta,
+                )
+            else:
+                surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        # Per-channel detached diagnostics (cp MSE + per-tau Huber/MSE).
+        with torch.no_grad():
+            cp_mse = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
+            if tau_loss_fn == "huber":
+                tau_x_loss = masked_huber(
+                    surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask, tau_huber_delta
+                )
+                tau_y_loss = masked_huber(
+                    surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask, tau_huber_delta
+                )
+                tau_z_loss = masked_huber(
+                    surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask, tau_huber_delta
+                )
+            else:
+                tau_x_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+                tau_y_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+                tau_z_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+            huber_diag = huber_diagnostics(
+                surface_pred, surface_target, batch.surface_mask, tau_huber_delta
+            )
+    tau_suffix = "huber" if tau_loss_fn == "huber" else "mse"
+    metrics: dict[str, object] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "train/loss_per_channel/cp_mse": float(cp_mse.detach().cpu().item()),
+        f"train/loss_per_channel/tau_x_{tau_suffix}": float(tau_x_loss.detach().cpu().item()),
+        f"train/loss_per_channel/tau_y_{tau_suffix}": float(tau_y_loss.detach().cpu().item()),
+        f"train/loss_per_channel/tau_z_{tau_suffix}": float(tau_z_loss.detach().cpu().item()),
     }
+    metrics.update(huber_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -364,13 +434,23 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
-) -> list[torch.Tensor]:
+    *,
+    tau_loss_fn: str = "mse",
+    tau_huber_delta: float = 1.0,
+) -> tuple[list[torch.Tensor], dict[str, float]]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
-    Returns scalar tensors in order: [sp, tau_x, tau_y, tau_z, vp].
-    All five share the same forward graph so the GradNorm balancer can
-    extract per-task gradient norms via ``torch.autograd.grad`` with
-    ``retain_graph=True``.
+    Returns ``(losses, diagnostics)`` where ``losses`` is a list of scalar
+    tensors in order: ``[sp, tau_x, tau_y, tau_z, vp]``. All five share
+    the same forward graph so the GradNorm balancer can extract per-task
+    gradient norms via ``torch.autograd.grad`` with ``retain_graph=True``.
+
+    sp (cp) and vp always use MSE. tau channels use MSE or Huber
+    (``0.5*err^2`` for ``|err|<delta``; ``delta*(|err|-0.5*delta)``
+    otherwise) depending on ``tau_loss_fn``.
+
+    The ``diagnostics`` dict includes per-channel Huber/L1 fractions and
+    the tau_z max-abs-error (all in z-scored space).
     """
 
     batch = batch.to(device)
@@ -385,11 +465,25 @@ def per_task_train_losses(
         )
         surface_pred = out["surface_preds"]
         sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
-        taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
-        tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
-        tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+        if tau_loss_fn == "huber":
+            taux_loss = masked_huber(
+                surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask, tau_huber_delta
+            )
+            tauy_loss = masked_huber(
+                surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask, tau_huber_delta
+            )
+            tauz_loss = masked_huber(
+                surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask, tau_huber_delta
+            )
+        else:
+            taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+            tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+            tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
+        diagnostics = huber_diagnostics(
+            surface_pred, surface_target, batch.surface_mask, tau_huber_delta
+        )
+    return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss], diagnostics
 
 
 GRADNORM_MODES = ("full", "ema_proxy")
@@ -937,9 +1031,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                huber_diag_metrics: dict[str, float] = {}
                 if balancer is not None:
-                    per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                    per_task_losses, huber_diag_metrics = per_task_train_losses(
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        tau_loss_fn=config.tau_loss_fn,
+                        tau_huber_delta=config.tau_huber_delta,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -994,6 +1095,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     for i, name in enumerate(GRADNORM_TASK_NAMES):
                         gradnorm_metrics[f"gradnorm/weight_{name}"] = weights_cpu[i]
                         gradnorm_metrics[f"train/loss_{name}"] = losses_cpu[i]
+                    tau_suffix = "huber" if config.tau_loss_fn == "huber" else "mse"
+                    gradnorm_metrics["train/loss_per_channel/cp_mse"] = losses_cpu[0]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_x_{tau_suffix}"] = losses_cpu[1]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_y_{tau_suffix}"] = losses_cpu[2]
+                    gradnorm_metrics[f"train/loss_per_channel/tau_z_{tau_suffix}"] = losses_cpu[3]
+                    gradnorm_metrics["train/loss_per_channel/vp_mse"] = losses_cpu[4]
                     if synced_norms is not None:
                         norms_cpu = synced_norms.detach().cpu().tolist()
                         for i, name in enumerate(GRADNORM_TASK_NAMES):
@@ -1030,6 +1137,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_loss_fn=config.tau_loss_fn,
+                        tau_huber_delta=config.tau_huber_delta,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,8 +1179,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    # Pass through any train/* keys carried by batch_loss_metrics
+                    # (the no-GradNorm path emits per-channel loss + huber diags
+                    # under such keys; GradNorm path produces them separately).
+                    for key, val in batch_loss_metrics.items():
+                        if key.startswith("train/"):
+                            train_log[key] = val
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if huber_diag_metrics:
+                    train_log.update(huber_diag_metrics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,58 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_huber(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float,
+) -> torch.Tensor:
+    """Masked Huber (smooth-L1) loss.
+
+    For |err| < delta: 0.5 * err^2 (matches PyTorch nn.HuberLoss with default reduction).
+    For |err| >= delta: delta * (|err| - 0.5 * delta).
+    """
+    err = pred - target
+    abs_err = err.abs()
+    quadratic = 0.5 * err.square()
+    linear = delta * (abs_err - 0.5 * delta)
+    huber_elem = torch.where(abs_err < delta, quadratic, linear)
+    return masked_mean(huber_elem, mask)
+
+
+def huber_diagnostics(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float,
+) -> dict[str, float]:
+    """Per-channel Huber telemetry for the surface tau channels.
+
+    Computes the fraction of valid vertices whose normalized abs-error
+    falls in the L2 region (|err| < delta) vs the L1 region for tau_x,
+    tau_y, tau_z, plus the max abs error on tau_z. All values are floats
+    on CPU. Inputs are expected to be in z-scored (normalized) space.
+    """
+    out: dict[str, float] = {}
+    if pred.numel() == 0:
+        return out
+    with torch.no_grad():
+        err = (pred.detach() - target.detach()).float()
+        abs_err = err.abs()
+        mask_float = mask.to(device=err.device, dtype=torch.float32)
+        valid_total = mask_float.sum().clamp_min(1.0)
+        tau_names = ("tau_x", "tau_y", "tau_z")
+        for c_idx, name in zip((1, 2, 3), tau_names):
+            abs_err_c = abs_err[..., c_idx]
+            in_L2 = ((abs_err_c < delta).float() * mask_float).sum() / valid_total
+            in_L1 = ((abs_err_c >= delta).float() * mask_float).sum() / valid_total
+            out[f"train/huber/frac_in_L2_region/{name}"] = float(in_L2.item())
+            out[f"train/huber/frac_in_L1_region/{name}"] = float(in_L1.item())
+            abs_err_c_masked = abs_err_c * mask_float
+            out[f"train/max_abs_error_normed/{name}"] = float(abs_err_c_masked.max().item())
+    return out
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -863,6 +915,46 @@ def weighted_channel_mse(
     sq_err = (pred - target).square()
     mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     weighted = sq_err * weights_dev * mask_dev
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
+def weighted_channel_huber_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    tau_huber_delta: float,
+) -> torch.Tensor:
+    """Per-channel weighted masked loss with MSE on channel 0 (cp) and Huber on channels 1: (tau_x, tau_y, tau_z).
+
+    pred / target: [B, N, 4]; mask: [B, N]; weights: [4]. Returns a single
+    scalar averaged over (valid points x channels), with each channel's
+    per-element loss multiplied by its weight before averaging. Matches
+    ``weighted_channel_mse`` semantics: the channel weights only rescale
+    the relative gradient budget; it does NOT decompose into per-channel
+    means.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    weights_dev = weights.to(device=pred.device, dtype=pred.dtype)
+    if weights_dev.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"weights last-dim {weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    err = pred - target
+    sq = err.square()
+    abs_err = err.abs()
+    quadratic = 0.5 * sq
+    linear = tau_huber_delta * (abs_err - 0.5 * tau_huber_delta)
+    huber_elem = torch.where(abs_err < tau_huber_delta, quadratic, linear)
+    per_elem = torch.cat([sq[..., 0:1], huber_elem[..., 1:]], dim=-1)
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighted = per_elem * weights_dev * mask_dev
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):


### PR DESCRIPTION
## Hypothesis

H16 (δ=1.0) proved that the Huber threshold at 1.0σ was too coarse for the actual training residual distribution: `frac_in_L1_region/tau_z` never exceeded 0.018% (expected ~2.5%), confirming δ=1.0 was functionally MSE-on-τ. The residual tail collapsed fast: `max_abs_error_normed/tau_z` dropped from 9.8σ at EP0.5 → 1.8σ at EP4. **δ=0.3σ targets the bulk of the post-EP1 residual distribution**, where the majority of gradient mass sits.

H16b tests whether Huber-on-τ with a properly-calibrated δ acts as an effective outlier-robust regression overlay on the three τ channels. At δ=0.3:

- Residuals beyond ±0.3σ (which includes the bulk of the EP4+ distribution at max_abs ~1.8σ) receive **linear/constant gradient** (capped at 1.0) instead of growing gradient
- This caps the gradient contribution of the worst vertices (the "τ_z over-prediction" cluster identified by fern H10 #1148 73%/27% mag/dir analysis)
- The per-channel GradNorm + Huber combination should jointly normalize both task scales and within-task outlier vertices

Reference: Huber (1964), "Robust Estimation of a Location Parameter." For CFD WSS surrogates, the heavy-tailed per-vertex error distribution (especially τ_z over-predictions on near-horizontal panels) is the canonical use case for robust regression.

The H16 infrastructure is complete — this is a one-flag change from `--tau-huber-delta 1.0` to `--tau-huber-delta 0.3`. Bring forward all H16 diagnostic logging:
- `train/huber/frac_in_L1_region/{tau_x, tau_y, tau_z}`
- `train/huber/max_abs_error_normed/{tau_x, tau_y, tau_z}`

## Instructions

**Change `target/train.py` only. No changes to `model.py` or eval code.**

The only required change from H16 is the Huber delta flag:

**From** (H16): `--tau-huber-delta 1.0`
**To** (H16b): `--tau-huber-delta 0.3`

Verify the flag is wired correctly in train.py — it should configure the Huber loss function on τ channels (τ_x, τ_y, τ_z) with `delta=0.3`. The GradNorm, tau-y/z loss weights, and all other recipe flags remain identical.

### Required: Mechanism verification at EP1

After EP1 completes, post a brief comment confirming `frac_in_L1_region/tau_z` is in the range **(0.4, 0.8)** — the canonical Huber-active range. If it's < 0.1%, δ is still too large for the current distribution; if it's > 2%, δ is fine. This is the decisive mechanism-active gate.

The target range (0.4, 0.8) means approximately half the residuals are in the L1 region — the transition is properly active, not too aggressive, not dormant.

### Run commands

**Smoke run** (2 GPUs, 1 ep, 16k pts) — quick sanity before 18h main:
```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=15 torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 1 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-gradnorm --tau-loss-fn huber --tau-huber-delta 0.3 \
  --wandb-group wave30_h16b_huber_delta03 --wandb-name frieren/h16b-smoke \
  --agent frieren
```

Smoke PASS criteria: train/loss descending, no NaN, `frac_in_L1_region/tau_z` logging (sanity-check it's a non-zero fraction — even at EP0.5 with δ=0.3 it should be higher than 0.018%).

**Main 18h run** (8 GPUs, 13 epochs):
```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-gradnorm --tau-loss-fn huber --tau-huber-delta 0.3 \
  --wandb-group wave30_h16b_huber_delta03 --wandb-name frieren/h16b-huber-tau-d0.3-13ep \
  --agent frieren
```

**CRITICAL**: `--lr 9e-5` (NOT 5e-4 — this caused 4 Wave 30 divergences). Do not change lr.

## Baseline

Current single-model SOTA (PR #972, W&B run `56bcqp3m`):
- val_abupt = **6.126%** (training gate ≤ 6.2%)
- test_abupt = **5.844%**
- test_SP = **3.577%** (**FLOOR — hard breach blocker**)
- test_vol_p = **3.643%** (**FLOOR — hard breach blocker**)
- test_WSS = **6.727%**

H16 (#1161, δ=1.0) EP3 partial (terminal-null, pod killed):
- val_abupt = 6.894% (MARGINAL-PASS gate) — baseline for comparison
- val τz/τx = 1.516 (in collapse band — H16b should not change this if mechanism is loss-only)

## EP Gates

- **EP1 mechanism gate** (post immediately): `frac_in_L1_region/tau_z` ∈ (0.4, 0.8) → mechanism active. If < 0.1%, δ still too large; if > 2%, δ too small.
- **EP3 gate**: val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL / > 7.4% KILL
- **EP6 gate**: val_abupt ≤ 6.5% PASS
- **EP10 gate**: val_abupt ≤ 6.3% PASS

Comparison baseline at EP3 from H16 (δ=1.0, effectively MSE): val_abupt = 6.894%. If H16b δ=0.3 shows val_abupt at EP3 ≤ 6.4%, that's a meaningful mechanism signal vs the MSE-equivalent arm.

## Terminal SENPAI-RESULT required format (per #1056)

- val_abupt, val_vol_p, val_SP, val_WSS per-epoch table
- test metrics (best-checkpoint reload): test_abupt, test_vol_p, test_SP, test_WSS, test_τ_x, test_τ_y, test_τ_z
- **test τz/τx ratio** (collapse band diagnostic)
- **`frac_in_L1_region/{tau_x, tau_y, tau_z}` at final epoch** — mechanism-was-active proof
- **`max_abs_error_normed/{tau_x, tau_y, tau_z}` at final epoch** — residual scale evidence
- **Comparison table: H16 (δ=1.0) vs H16b (δ=0.3)** at matched epochs — decisive for reporting
- 8-rank run IDs + best-checkpoint epoch + source (raw/ema)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```
