### PR TITLE
Wave 30 H20: Focal Vertex Loss — dynamic per-vertex error-weighted MSE on τ channels

### DIFF
--- a/h20_offline_test_eval.py
+++ b/h20_offline_test_eval.py
@@ -1,0 +1,161 @@
+"""Offline test-eval for the H20 focal-vertex run.
+
+Loads the local best checkpoint saved by rank-0 of the DDP run (already EMA
+weights), runs full val + test evaluation on a single GPU, and prints metrics
+in the same shape as `run_final_evaluation`. Intentionally does NOT touch the
+W&B SDK to avoid clobbering rank summaries on the active run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import fields
+from pathlib import Path
+
+import torch
+import yaml
+
+from data import load_data
+from model import SurfaceTransolver
+from train import Config, parse_rff_init_sigmas
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    eval_loader_for_dataset,
+)
+
+
+def _config_from_yaml(path: Path) -> Config:
+    with path.open() as fh:
+        raw = yaml.safe_load(fh)
+    valid = {f.name for f in fields(Config)}
+    kwargs = {k: v for k, v in raw.items() if k in valid}
+    return Config(**kwargs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        required=True,
+        help="outputs/drivaerml/run-<id> dir containing checkpoint.pt + config.yaml",
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--batch-size", type=int, default=None)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    config = _config_from_yaml(args.run_dir / "config.yaml")
+    if args.batch_size is not None:
+        config.batch_size = args.batch_size
+
+    # Reload data (same eval-loader path as training)
+    train_ds, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=config.debug,
+    )
+    val_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in val_splits.items()
+    }
+    test_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in test_splits.items()
+    }
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = SurfaceTransolver(
+        n_layers=config.model_layers,
+        n_hidden=config.model_hidden_dim,
+        dropout=config.model_dropout,
+        n_head=config.model_heads,
+        mlp_ratio=config.model_mlp_ratio,
+        slice_num=config.model_slices,
+        rff_num_features=config.rff_num_features,
+        rff_sigma=config.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
+        pos_encoding_mode=config.pos_encoding_mode,
+        use_qk_norm=config.use_qk_norm,
+        use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+    ).to(device)
+
+    ckpt_path = args.run_dir / "checkpoint.pt"
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+    state_dict = ckpt["model"]
+    missing, unexpected = model.load_state_dict(state_dict, strict=True)
+    if missing or unexpected:
+        raise RuntimeError(f"State-dict mismatch: missing={missing}, unexpected={unexpected}")
+    model.eval()
+    print(
+        f"Loaded checkpoint: epoch={ckpt.get('epoch')}, "
+        f"source={ckpt.get('checkpoint_source')}, "
+        f"selection_metric={ckpt.get('selection_metric')}"
+    )
+
+    t0 = time.time()
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in val_loaders.items()
+    }
+    print(f"[val] elapsed={time.time() - t0:.1f}s")
+    for name, m in val_metrics.items():
+        print(f"\n=== full-{name} ===")
+        for k, v in sorted(m.items()):
+            print(f"  {k}: {v}")
+
+    t1 = time.time()
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in test_loaders.items()
+    }
+    print(f"\n[test] elapsed={time.time() - t1:.1f}s")
+    for name, m in test_metrics.items():
+        print(f"\n=== {name} ===")
+        for k, v in sorted(m.items()):
+            print(f"  {k}: {v}")
+
+    # Print compact summary for grep
+    val_s = val_metrics["val_surface"]
+    test_s = test_metrics["test_surface"]
+    print("\n=== H20-OFFLINE-SUMMARY ===")
+    print(
+        "VAL:",
+        {
+            "abupt": val_s["abupt_axis_mean_rel_l2_pct"],
+            "SP": val_s["surface_pressure_rel_l2_pct"],
+            "vol_p": val_s["volume_pressure_rel_l2_pct"],
+            "WSS": val_s["wall_shear_rel_l2_pct"],
+            "WSS_x": val_s["wall_shear_x_rel_l2_pct"],
+            "WSS_y": val_s["wall_shear_y_rel_l2_pct"],
+            "WSS_z": val_s["wall_shear_z_rel_l2_pct"],
+        },
+    )
+    print(
+        "TEST:",
+        {
+            "abupt": test_s["abupt_axis_mean_rel_l2_pct"],
+            "SP": test_s["surface_pressure_rel_l2_pct"],
+            "vol_p": test_s["volume_pressure_rel_l2_pct"],
+            "WSS": test_s["wall_shear_rel_l2_pct"],
+            "WSS_x": test_s["wall_shear_x_rel_l2_pct"],
+            "WSS_y": test_s["wall_shear_y_rel_l2_pct"],
+            "WSS_z": test_s["wall_shear_z_rel_l2_pct"],
+            "tauz_over_taux": test_s["wall_shear_z_rel_l2_pct"] / test_s["wall_shear_x_rel_l2_pct"],
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -105,6 +105,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    focal_gamma: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "focal_gamma": (
+            "Focal exponent for per-vertex error-weighted MSE on tau "
+            "channels (Lin et al., ICCV 2017, arXiv:1708.02002, regression "
+            "adaptation). Weight per vertex: "
+            "w_v = (|err_v|.detach() + 1e-6)^(2*gamma), per-channel "
+            "normalised so masked mean weight = 1 (preserves total loss "
+            "scale). 0=standard MSE on tau (baseline), 0.5=mild focus, "
+            "1.0=strong. tau_z gets 1.5x amplification of this gamma. "
+            "cp (channel 0) always uses standard masked MSE."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -311,6 +322,88 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def focal_vertex_mse(
+    surface_preds: torch.Tensor,
+    surface_target: torch.Tensor,
+    surface_mask: torch.Tensor,
+    focal_gamma: float,
+    eps: float = 1e-6,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Focal-weighted per-vertex masked MSE on the tau channels (1, 2, 3).
+
+    Regression adaptation of Focal Loss (Lin et al., ICCV 2017,
+    arXiv:1708.02002). Per-vertex weight on tau is
+    ``w_v = (|err_v|.detach() + eps)^(2*gamma)``, per-channel normalised so
+    the masked mean weight equals 1 (preserves total loss scale relative to
+    standard ``masked_mse``). cp (channel 0) keeps standard masked MSE.
+
+    Channel-specific gamma: tau_x and tau_y use ``focal_gamma``; tau_z uses
+    ``1.5 * focal_gamma`` (matching the H10 finding that tau_z is the worst
+    WSS channel).
+
+    The returned scalar matches the per-element-averaged scale of
+    ``masked_mse(surface_preds, surface_target, surface_mask)`` so that the
+    surface vs. volume balance does not need retuning when ``focal_gamma=0``.
+    Diagnostics include both pre- and post-normalisation weight statistics.
+    """
+    # cp (channel 0) standard masked MSE.
+    cp_loss = masked_mse(
+        surface_preds[..., 0:1], surface_target[..., 0:1], surface_mask
+    )
+
+    tau_pred = surface_preds[..., 1:]
+    tau_tgt = surface_target[..., 1:]
+    tau_err = tau_pred - tau_tgt  # [B, N, 3]
+
+    # Weights are detached so gradient flows only through the err^2 factor.
+    abs_err = tau_err.detach().abs()
+
+    gamma_per_channel = torch.tensor(
+        [focal_gamma, focal_gamma, focal_gamma * 1.5],
+        device=surface_preds.device,
+        dtype=surface_preds.dtype,
+    )
+    focal_w_raw = (abs_err + eps).pow(2.0 * gamma_per_channel)  # [B, N, 3]
+
+    mask_expanded = surface_mask.to(dtype=surface_preds.dtype).unsqueeze(-1)
+    # Mask-aware per-channel mean so padding does not bias the normalisation.
+    valid_pts_per_channel = mask_expanded.sum(dim=(0, 1), keepdim=True)
+    masked_w_sum = (focal_w_raw * mask_expanded).sum(dim=(0, 1), keepdim=True)
+    focal_w_mean = masked_w_sum / valid_pts_per_channel.clamp_min(1.0)
+    focal_w = focal_w_raw / (focal_w_mean + eps)  # [B, N, 3], masked mean = 1
+
+    tau_sq = tau_err.pow(2)
+    weighted_tau_sq = focal_w * tau_sq * mask_expanded
+    denom = (mask_expanded.sum() * 3.0).clamp_min(1.0)
+    tau_loss = weighted_tau_sq.sum() / denom
+
+    # Combine on the same scale as masked_mse over 4 channels:
+    #   masked_mse(4ch) = (sum_cp_se + sum_tau_se) / (4 * valid_pts)
+    #   cp_loss         = sum_cp_se / valid_pts
+    #   tau_loss        = sum_tau_se / (3 * valid_pts)       (focal_w=1 case)
+    # => surface_loss = (cp_loss + 3*tau_loss) / 4 matches masked_mse(4ch).
+    surface_loss = (cp_loss + 3.0 * tau_loss) / 4.0
+
+    # Diagnostics. Post-normalisation means are ~1 by construction (they
+    # exist so the ratio gates "p95 / mean > 2.0" stay readable). Raw means
+    # expose the pre-normalisation asymmetry between tau_z (gamma*1.5) and
+    # tau_x / tau_y, which the normalised means hide. Percentiles are
+    # computed over valid (unmasked) entries only.
+    valid_mask_bool = surface_mask.bool()
+    diag: dict[str, float] = {}
+    if valid_mask_bool.any():
+        for ch, name in enumerate(("x", "y", "z")):
+            valid_w = focal_w[..., ch][valid_mask_bool]
+            diag[f"focal/w_{name}_mean"] = float(valid_w.mean().detach().cpu().item())
+            raw_w = focal_w_raw[..., ch][valid_mask_bool]
+            diag[f"focal/raw_mean_w_{name}"] = float(raw_w.mean().detach().cpu().item())
+        valid_w_z = focal_w[..., 2][valid_mask_bool].float()
+        diag["focal/w_z_p95"] = float(torch.quantile(valid_w_z, 0.95).detach().cpu().item())
+        diag["focal/w_z_p99"] = float(torch.quantile(valid_w_z, 0.99).detach().cpu().item())
+        diag["focal/w_z_p05"] = float(torch.quantile(valid_w_z, 0.05).detach().cpu().item())
+    return surface_loss, diag
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -321,10 +414,12 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    focal_gamma: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    focal_diag: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,7 +427,14 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if focal_gamma > 0.0:
+            surface_loss, focal_diag = focal_vertex_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                focal_gamma,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +448,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(focal_diag)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1030,6 +1134,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        focal_gamma=config.focal_gamma,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1068,8 +1173,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/focal_gamma": config.focal_gamma,
                         }
                     )
+                    for key, value in batch_loss_metrics.items():
+                        if key.startswith("focal/"):
+                            train_log[key] = value
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**H20 — Focal Vertex Loss for the magnitude bottleneck.** Reweight per-vertex MSE on τ channels by a monotonically increasing function of each vertex's CURRENT prediction error: `w_v = (|e_v|.detach() + ε)^(2γ)`. This is a regression analogue of Focal Loss (Lin et al., ICCV 2017 — arXiv:1708.02002) applied at the mesh-vertex level to directly target the 73% magnitude bottleneck identified by H10.

The key property is **dynamic per-step reweighting**: weights are recomputed every forward pass from the actual residual, so as training improves the hard-vertex distribution, the weighting automatically adapts. This is fundamentally different from H12 (edward, in-flight) which uses STATIC weights based on ground-truth τ magnitude — H12 weight is fixed for all of training; H20 weight changes every step.

The mechanism targets the magnitude bottleneck through two complementary pathways:
1. Vertices where |τ_z| is large (high-flow underbody/door-mirror regions) tend to have larger residuals even at relative convergence — focal weight keeps gradient signal flowing exactly there.
2. Near-zero-magnitude vertices that are "already solved" get down-weighted, freeing capacity for the hard regime.

**Optimization-layer character**: this is an alphonse-suitable mechanism, similar in spirit to your H15b EMA work — both reshape the gradient signal received by the optimizer without changing the model architecture. H20 changes WHICH vertices contribute gradient mass; EMA changes HOW the trajectory is averaged. The 73% magnitude bottleneck is precisely the kind of skewed-error distribution Focal Loss was designed for.

**Channel-asymmetric γ**: τ_z gets `1.5×` higher γ than τ_x/τ_y, because τ_z is the worst-performing WSS channel (per H10 magnitude/direction split) and has the largest val→test gap. cp gets γ=0 (already close to floor) — no focal weighting on pressure.

## Instructions

All implementation in `train.py`. **No changes to `model.py`, `trainer_runtime.py`, or eval code.**

### Step 1 — Add CLI flag

Add a `--focal-gamma` flag (float, default 0.0). When 0, behavior is identical to baseline MSE. When > 0, applies focal weighting to the τ channels only (channels 1, 2, 3 of surface_preds).

```python
parser.add_argument(
    "--focal-gamma", type=float, default=0.0,
    help="Focal exponent for per-vertex error-weighted MSE on tau channels. "
         "0=standard MSE, 0.5=mild focus, 1.0=strong. "
         "Default 0.0 preserves baseline behavior. "
         "Apply tau_z with 1.5x amplification of this gamma (channel-specific).",
)
```

### Step 2 — Implement focal-weighted vertex loss

You need to modify the surface-loss computation path to accept the focal_gamma. The current loss code path goes through `_loss_components_for_batch` (train.py:~320) which calls either `masked_mse()` (default) or `weighted_channel_mse()` (when channel weights are non-1.0).

Add a new code path for focal-weighted surface MSE on τ channels. The cleanest implementation is a new helper function `focal_vertex_mse(surface_preds, surface_target, surface_mask, focal_gamma)` that:

1. Computes per-vertex residual on τ channels only: `tau_err = surface_preds[..., 1:] - surface_target[..., 1:]` (shape `[B, N, 3]`)
2. Computes detached absolute error: `abs_err = tau_err.detach().abs()` (gradient does NOT flow through the weight)
3. Builds channel-specific γ tensor: `gamma_per_channel = tensor([focal_gamma, focal_gamma, focal_gamma * 1.5], device=...)` (τ_z gets 1.5×)
4. Computes focal weight: `focal_w = (abs_err + eps).pow(2 * gamma_per_channel)` with `eps = 1e-6`
5. **Critical normalization step**: `focal_w = focal_w / (focal_w.mean(dim=(0,1), keepdim=True) + eps)` — preserves total loss scale so you don't need to retune downstream hyperparameters (lr, channel weights, grad-clip).
6. Computes weighted MSE: `tau_loss = ((focal_w * tau_err.pow(2)) * surface_mask.unsqueeze(-1)).sum() / max(surface_mask.sum() * 3, 1)`
7. cp loss separately with standard masked_mse on channel 0.
8. Returns combined surface loss = cp_loss + tau_loss (per-channel average).

Then in `_loss_components_for_batch`, dispatch based on `focal_gamma`:
```python
if focal_gamma > 0:
    surface_loss = focal_vertex_mse(out["surface_preds"], surface_target, batch.surface_mask, focal_gamma)
elif surface_channel_weights is not None:
    surface_loss = weighted_channel_mse(...)  # existing path
else:
    surface_loss = masked_mse(...)  # existing path
```

### Step 3 — Diagnostic logging (CRITICAL for verifying mechanism)

Log focal weight statistics every N steps (use existing log cadence). The mechanism is silent unless we see weight heterogeneity:

```python
# Inside focal_vertex_mse or alongside in the train loop
focal_diag = {
    "focal/w_x_mean": focal_w[..., 0].mean().item(),
    "focal/w_y_mean": focal_w[..., 1].mean().item(),
    "focal/w_z_mean": focal_w[..., 2].mean().item(),
    "focal/w_z_p95":  torch.quantile(focal_w[..., 2].view(-1), 0.95).item(),
    "focal/w_z_p99":  torch.quantile(focal_w[..., 2].view(-1), 0.99).item(),
    "focal/w_z_p05":  torch.quantile(focal_w[..., 2].view(-1), 0.05).item(),
}
wandb.log(focal_diag, step=global_step)
```

**Mechanism-active criterion** (EP1 gate):
- `focal/w_z_p95 / focal/w_z_mean > 2.0` → weights heterogeneous, focal mechanism actually active
- `focal/w_z_mean > focal/w_x_mean` → τ_z amplification working (expected because γ_z = 1.5 × γ_x)

### Step 4 — Full training run (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --focal-gamma 0.5 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h20_focal_vertex_loss \
  --wandb-name alphonse/h20-focal-vertex-loss-18h --agent alphonse
```

**CRITICAL**: `--lr 9e-5` — NOT 5e-4 (5e-4 caused 4 Wave 30 divergences).

### EP gates and kill criteria

| Gate | Criterion | Action |
|---|---|---|
| EP1 | `focal/w_z_mean` logged AND `focal/w_z_p95 / focal/w_z_mean > 2.0` | Mechanism active — continue |
| EP1 | val_abupt > 35% post-warmup | Diverging — KILL |
| EP1 | `focal/w_z_p95 / focal/w_z_mean < 1.1` | Weights frozen near uniform (γ may be too low or normalization broken) — investigate and continue or kill if EP3 also flat |
| EP3 | val_abupt > 6.70% | No improvement over H10b EP3 6.697% — KILL |
| EP3 | val_abupt ≤ 6.50% | Strong progress — continue to terminal |
| EP6 | val_abupt > baseline 6.126% + 0.5pp | KILL unless mechanism diagnostics show late-cosine pickup |
| EP13 | val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643% | TERMINAL MERGE-ELIGIBLE |

### Step 5 — Terminal SENPAI-RESULT

Must include (per #1056 directive — report val AND test):
- val per-epoch table: val_abupt, val_vol_p, val_SP, val_WSS
- test from best checkpoint: test_abupt, test_vol_p, test_SP, test_WSS, **test_τ_x, test_τ_y, test_τ_z, test τz/τx ratio**
- **Focal weight statistics at terminal**: `focal/w_z_mean`, `focal/w_z_p95`, `focal/w_z_p99` per-epoch trajectory
- **Per-vertex error percentile shift**: compare EP1 vs EP13 distributions of `|τ_z_residual|` — should narrow on the right tail if focal weighting is reducing worst-vertex error
- 8-rank DDP run IDs + best-checkpoint epoch + source (raw/ema)

## Baseline (single-model SOTA: PR #972)

| Metric | Baseline (PR #972) | Gate/Floor |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_abupt | 5.844% | < 5.844% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor (HARD) |
| test_SP | 3.577% | ≤ 3.577% floor (HARD) |
| test τz/τx | ~1.46 | < 1.40 structural target |

**Best in-flight result**: fern H10b #1164 at val_abupt 6.697% at EP3 (closest to baseline of all in-flight). If H20 EP3 lands ≤ 6.50%, you've beat H10b and become the top-priority watch.

**Fern H10 diagnostic (PR #1148, closed)**: 73% of WSS squared error is in MAGNITUDE, 27% in direction. Direction saturated at 99.65% cos_sim. Magnitude is the bottleneck. H20 attacks the magnitude bottleneck via dynamic per-vertex gradient amplification.

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Why orthogonal to all 6 in-flight Wave 30 attacks

| In-flight PR | Student | Axis | Why H20 is orthogonal |
|---|---|---|---|
| H10b #1164 | fern | Output head: bounded-exp magnitude (softplus→clamp.exp) | Activation function inside output head. H20 changes LOSS WEIGHTS on each vertex based on per-vertex error. Different pipeline stages; could be stacked. |
| H11b #1167 | askeladd | Gated multi-scale input aggregation | Input features. H20 changes loss computation. Zero overlap. |
| H12 #1151 | edward | Per-vertex τ-magnitude-weighted MSE | STATIC weights from τ ground-truth magnitude. H20 uses DYNAMIC weights from current prediction error. H12 weight fixed for all training; H20 weight changes every step. The |τ_gt|↔|error| correlation is loose — H20 captures actual hard vertices, not a-priori expected-hard ones. |
| H16b #1169 | frieren | Huber loss δ=0.3 (outlier CLIPPING) | H16b REDUCES large-error influence (outlier-robustness). H20 INCREASES it (hard-example amplification). Antagonistic but not overlapping mechanisms. |
| H18 #1163 | tanjiro | Per-vertex area-weighted MSE | Static area-based weights. H20 uses dynamic error-based weights. Different signal, different cadence. Could stack. |
| H19 #1168 | thorfinn | VICReg batch-variance regularization on \|τ_z\| | Acts on batch-level distributional statistics. H20 acts on per-vertex residual-proportional weights. Zero overlap. |

## What success looks like

- **BIG WIN**: val_abupt < 6.126% AND test_WSS < 6.727% AND floors held → MERGE (focal vertex loss is the right axis)
- **MERGE**: test_abupt < 5.844% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643% AND test_WSS < 6.727% → MERGE
- **STRONG SIGNAL**: test τz/τx < 1.44 (band-break) + focal diagnostic shows w_z_p95 / w_z_mean > 3 (strong focus) → request follow-up at γ=1.0
- **PARTIAL**: val_abupt within 0.2pp of baseline, mechanism active but not enough → suggest γ=0.7 with longer warmup
- **NULL**: val_abupt > baseline + 0.5pp AND focal/w_z diagnostics show mechanism active → focal weighting is the wrong axis (the model can already see the hard vertices via standard MSE) → CLOSE H20 series

## Reference papers

- **Focal Loss for Dense Object Detection** (Lin et al., ICCV 2017) — arXiv:1708.02002. Canonical reference; introduced (1-p_t)^γ for classification. Regression adaptation here follows the same principle.
- **Training Region-Based Object Detectors with OHEM** (Shrivastava et al., CVPR 2016). Discrete-selection ancestor of focal weighting.
- **Deep Imbalanced Multi-Target Regression on 3D Point Cloud** (arXiv:2511.12740, 2024) — applied focal regression to continuous multi-target regression on voxelized point clouds; confirms FocalR improves generalization on skewed-loss distributions in 3D data.

**Source**: Wave 30 H20. Researcher-agent synthesis after H10 73%/27% magnitude diagnostic + H15b token-level band-break signal (τz/τx=1.439 from EMA averaging suggests per-vertex prediction variance has structural content).
