### PR TITLE
Wave 30 H21: Per-component independent output heads — separate MLPs per surface channel

### DIFF
--- a/model.py
+++ b/model.py
@@ -358,6 +358,62 @@ class Transformer(nn.Module):
         return x
 
 
+class PerComponentOutputHead(nn.Module):
+    """Per-component independent output heads for surface predictions (H21).
+
+    Replaces the shared 4-channel MLP with four independent decoder MLPs to
+    decouple gradient flow between surface targets (Sener & Koltun, NeurIPS 2018;
+    Standley et al., ICML 2020).
+
+    - cp head:    n_hidden -> n_hidden -> 1
+    - tau_x head: n_hidden -> n_hidden -> 1
+    - tau_y head: n_hidden -> n_hidden -> 1
+    - tau_z head: n_hidden -> n_hidden -> n_hidden -> 1  (extra layer for the
+      worst-performing channel; magnitude bottleneck per H10 diagnostic)
+
+    Hidden layers use trunc-normal _init_linear (same as baseline shared head);
+    final linear layers are zero-initialised so surface predictions start at
+    zero and warm up gradually, matching the spirit of zero-init residual
+    branches in the rest of the model.
+    """
+
+    def __init__(self, n_hidden: int):
+        super().__init__()
+        self.head_cp = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, 1),
+        )
+        self.head_tau_x = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, 1),
+        )
+        self.head_tau_y = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, 1),
+        )
+        self.head_tau_z = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, n_hidden),
+            nn.SiLU(),
+            nn.Linear(n_hidden, 1),
+        )
+        for head in (self.head_cp, self.head_tau_x, self.head_tau_y, self.head_tau_z):
+            head.apply(_init_linear)
+            nn.init.zeros_(head[-1].weight)
+            nn.init.zeros_(head[-1].bias)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        cp = self.head_cp(z)
+        tau_x = self.head_tau_x(z)
+        tau_y = self.head_tau_y(z)
+        tau_z = self.head_tau_z(z)
+        return torch.cat([cp, tau_x, tau_y, tau_z], dim=-1)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -476,17 +532,10 @@ class SurfaceTransolver(nn.Module):
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
-            # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
-            # Volume head is a deeper 3-layer MLP for the harder vol_p task —
-            # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
-            # Default for current training; older checkpoints (PR #823 era,
-            # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            # H21 (PR #1171): surface decoder is four independent MLPs, one per
+            # surface channel, to decouple gradient flow between targets whose
+            # error magnitudes differ >2x (tau_z dominates). Returns [B, N, 4].
+            self.surface_out = PerComponentOutputHead(n_hidden=n_hidden)
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),

--- a/train.py
+++ b/train.py
@@ -1108,6 +1108,24 @@ def main(argv: Iterable[str] | None = None) -> None:
                         if should_log_gradients and not skip_step
                         else {}
                     )
+                    # H21 (PR #1171) diagnostic: per-component head gradient
+                    # norms. Verifies the mechanism is active — tau_z head
+                    # should receive more gradient signal than tau_y/cp heads.
+                    if should_log_gradients and not skip_step and hasattr(
+                        base_model, "surface_out"
+                    ) and hasattr(base_model.surface_out, "head_tau_z"):
+                        for head_name in (
+                            "head_cp",
+                            "head_tau_x",
+                            "head_tau_y",
+                            "head_tau_z",
+                        ):
+                            head = getattr(base_model.surface_out, head_name)
+                            grad_sq_sum = 0.0
+                            for p in head.parameters():
+                                if p.grad is not None:
+                                    grad_sq_sum += float(p.grad.detach().pow(2).sum().item())
+                            gradient_metrics[f"train/grad/h21_{head_name}_norm"] = grad_sq_sum ** 0.5
                     if skip_step:
                         optimizer.zero_grad(set_to_none=True)
                     else:


### PR DESCRIPTION
## Hypothesis

**H21 — Per-component independent output heads.** Replace the shared 4-channel surface output MLP at `model.py:484-489` with four independent MLPs — one per surface output channel (cp, τ_x, τ_y, τ_z). Each head receives the same shared encoder output but has its own weights and decoder pathway. The τ_z head gets one extra hidden layer to test whether the worst-performing channel needs more decoder capacity.

The current Transolver surface head (model.py:484):
```python
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),  # 4 channels: [cp, τ_x, τ_y, τ_z]
)
```

This shared 2-layer MLP forces gradient interference between the 4 surface tasks. When per-channel error magnitudes differ by 2× or more (currently true: τ_z error is ~9% vs τ_y error ~4% in best Wave 30 results), the shared trunk is forced to interpolate conflicting gradient signals — classic multi-task learning interference.

**Mechanism**: gradient isolation. Each channel's training signal propagates through its own MLP weights without interference from other channels. This is what multi-task learning research calls "task-specific decoder heads" — consistently recommended when per-task loss magnitudes differ by more than 2× (Sener and Koltun, NeurIPS 2018; Standley et al., ICML 2020).

The current per-channel SOTA targets and gap:
- cp: SOTA 3.82%, current ~3.7% (close to floor — gradient signal mostly already correct)
- τ_x: SOTA 5.35%, current ~5.8%+ (moderate gap)
- τ_y: SOTA 3.65%, current ~4.0% (close)
- τ_z: SOTA 3.63%, current ~9%+ (huge gap — magnitude bottleneck per H10)

With a shared head, the dominant (easy) τ_y/cp gradients partially overwrite the τ_z gradient at every update step. **Per-component heads decouple this**: the τ_z head receives full gradient bandwidth from the τ_z loss alone.

**Representation-layer character**: this is a nezuko-suitable mechanism, similar in spirit to your H17 hard-constraint output reparameterization — both change the decoder architecture to attack the τ_z bottleneck. H17 changed the OUTPUT BASIS; H21 changes the DECODER TOPOLOGY. H21 has no cold-start representational gap (zero-init final layers reproduce baseline behavior at EP0).

## Instructions

All implementation in `model.py`. **No changes to `train.py`, `trainer_runtime.py`, eval code, or loss code.** No new CLI flag needed — this is a model architecture change.

### Step 1 — Add the new PerComponentOutputHead class

Add a new module class to `model.py` (place near the other output head definitions, around line 484):

```python
class PerComponentOutputHead(nn.Module):
    """Per-component independent output heads for surface predictions.

    Replaces shared 4-channel MLP with 4 independent heads:
    - cp head:    n_hidden -> n_hidden -> 1
    - τ_x head:   n_hidden -> n_hidden -> 1
    - τ_y head:   n_hidden -> n_hidden -> 1
    - τ_z head:   n_hidden -> n_hidden -> n_hidden -> 1  (extra layer for hardest channel)

    Final linear layers zero-initialized for training stability — at EP0,
    outputs match the original zero-init shared head exactly.
    """
    def __init__(self, n_hidden: int):
        super().__init__()
        self.head_cp = nn.Sequential(
            nn.Linear(n_hidden, n_hidden), nn.SiLU(),
            nn.Linear(n_hidden, 1),
        )
        self.head_tau_x = nn.Sequential(
            nn.Linear(n_hidden, n_hidden), nn.SiLU(),
            nn.Linear(n_hidden, 1),
        )
        self.head_tau_y = nn.Sequential(
            nn.Linear(n_hidden, n_hidden), nn.SiLU(),
            nn.Linear(n_hidden, 1),
        )
        # τ_z head: extra hidden layer (3-layer MLP) for the worst-performing channel
        self.head_tau_z = nn.Sequential(
            nn.Linear(n_hidden, n_hidden), nn.SiLU(),
            nn.Linear(n_hidden, n_hidden), nn.SiLU(),
            nn.Linear(n_hidden, 1),
        )
        # Zero-init final layers for stability
        for head in [self.head_cp, self.head_tau_x, self.head_tau_y, self.head_tau_z]:
            nn.init.zeros_(head[-1].weight)
            nn.init.zeros_(head[-1].bias)

    def forward(self, z: torch.Tensor) -> torch.Tensor:
        """z: [B, N, n_hidden] -> [B, N, 4] in order [cp, τ_x, τ_y, τ_z]."""
        cp    = self.head_cp(z)
        tau_x = self.head_tau_x(z)
        tau_y = self.head_tau_y(z)
        tau_z = self.head_tau_z(z)
        return torch.cat([cp, tau_x, tau_y, tau_z], dim=-1)
```

### Step 2 — Replace the surface_out construction

In the existing `__init__` of the model (around line 484), replace:

```python
# BEFORE (current shared 2-layer MLP):
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),
)
self.surface_out.apply(_init_linear)
```

With:

```python
# AFTER (per-component independent heads):
self.surface_out = PerComponentOutputHead(n_hidden=n_hidden)
# Note: zero-init for final layers already inside PerComponentOutputHead.
# All hidden layers get default initialization (matches _init_linear behavior
# closely enough; if not, apply _init_linear to the intermediate Linear layers
# inside PerComponentOutputHead instead of zero-init globally).
```

**Important**: the assertion `self.surface_output_dim = SURFACE_Y_DIM = 4` is used elsewhere — do NOT change this attribute. The PerComponentOutputHead returns shape `[B, N, 4]` to match the downstream contract.

The forward call at `model.py:625` is unchanged:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```
Works as-is because PerComponentOutputHead.forward returns the correct shape.

### Step 3 — Diagnostic logging in train.py (small addition)

Add per-head gradient norm logging to verify the gradient-decoupling mechanism is active. Place inside the training loop after `loss.backward()` (or after grad clipping):

```python
# H21 diagnostic: per-component head gradient norms
if hasattr(model.module if hasattr(model, "module") else model, "surface_out"):
    surface_out = model.module.surface_out if hasattr(model, "module") else model.surface_out
    if hasattr(surface_out, "head_tau_z"):  # only logs for PerComponentOutputHead
        head_grad_norms = {}
        for name in ["head_cp", "head_tau_x", "head_tau_y", "head_tau_z"]:
            head = getattr(surface_out, name)
            grad_sq_sum = 0.0
            for p in head.parameters():
                if p.grad is not None:
                    grad_sq_sum += p.grad.detach().pow(2).sum().item()
            head_grad_norms[f"grad_norm/{name}"] = grad_sq_sum ** 0.5
        wandb.log(head_grad_norms, step=global_step)
```

**Expected pattern**: `grad_norm/head_tau_z > grad_norm/head_tau_y > grad_norm/head_cp` (because τ_z has the largest residuals during training, larger gradient signal flows through its dedicated head).

### Step 4 — Smoke run (2-rank, 2 epochs, recommended)

Before launching the full DDP-8 18h run, smoke-test:
- Forward pass produces finite `surface_preds`
- All 4 heads produce different outputs (not collapsed to identical predictions)
- EP1 val_abupt ≤ 35% post-warmup (matches baseline trajectory — H17 KILL signal was EP1 33% which was BORDERLINE, but H21 zero-init should match baseline at EP0 exactly)
- Per-head gradient norms log correctly and show heterogeneity

If smoke is clean, proceed to main run.

### Step 5 — Full training run (18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h21_per_component_heads \
  --wandb-name nezuko/h21-per-component-heads-18h --agent nezuko
```

**CRITICAL**: `--lr 9e-5` — NOT 5e-4 (5e-4 caused 4 Wave 30 divergences).

No new CLI flag needed — the architecture change is in `model.py` directly (uncoditional). If you want a config flag for A/B testing, add `--use-per-component-heads` but the simpler approach is unconditional replacement.

### EP gates and kill criteria

| Gate | Criterion | Action |
|---|---|---|
| EP1 | val_abupt > 35% post-warmup | Zero-init failed or architecture broken — KILL |
| EP1 | Per-head gradient norms logged AND `grad_norm/head_tau_z > grad_norm/head_tau_y` | Mechanism active (τ_z receiving more gradient signal due to larger residuals) — continue |
| EP1 | Per-head gradient norms uniform across heads (within 20%) | Gradient decoupling not happening — investigate at EP3, kill if val_abupt > 7.4% |
| EP3 | val_abupt > 6.70% | No improvement over H10b EP3 6.697% — KILL |
| EP3 | val_abupt ≤ 6.50% | Strong progress — continue to terminal |
| EP6 | val_abupt > baseline 6.126% + 0.5pp | KILL unless gradient decoupling diagnostic shows late pickup |
| EP13 | val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643% | TERMINAL MERGE-ELIGIBLE |

### Step 6 — Terminal SENPAI-RESULT

Must include (per #1056 directive — report val AND test):
- val per-epoch table: val_abupt, val_vol_p, val_SP, val_WSS
- test from best checkpoint: test_abupt, test_vol_p, test_SP, test_WSS, **test_τ_x, test_τ_y, test_τ_z, test τz/τx ratio**
- **Per-head gradient norm trajectory**: `grad_norm/head_{cp, tau_x, tau_y, tau_z}` across all 13 epochs — the decisive mechanism diagnostic
- **Test vs val gap on τ_z**: a wider gap than baseline would signal the deeper τ_z head is overfitting (key risk)
- 8-rank DDP run IDs + best-checkpoint epoch + source (raw/ema)

## Baseline (single-model SOTA: PR #972)

| Metric | Baseline (PR #972) | Gate/Floor |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_abupt | 5.844% | < 5.844% to merge |
| test_WSS | 6.727% | < 6.727% to merge |
| test_vol_p | 3.643% | ≤ 3.643% floor (HARD) |
| test_SP | 3.577% | ≤ 3.577% floor (HARD) |
| test τz/τx | ~1.46 | < 1.40 structural target |

**Best in-flight result**: fern H10b #1164 at val_abupt 6.697% at EP3 (closest to baseline of all in-flight). If H21 EP3 lands ≤ 6.50%, you've beat H10b and become the top-priority watch.

**Fern H10 diagnostic (PR #1148, closed)**: 73% of WSS squared error is in MAGNITUDE, 27% in direction. Direction saturated at 99.65% cos_sim. Magnitude is the bottleneck. H21 attacks magnitude via decoder gradient decoupling — the τ_z head can specialize without τ_y/cp gradients overwriting its weights.

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Why orthogonal to all 6 in-flight Wave 30 attacks

| In-flight PR | Student | Axis | Why H21 is orthogonal |
|---|---|---|---|
| H10b #1164 | fern | Output head activation: bounded-exp magnitude (softplus→clamp.exp) | H10b changes the ACTIVATION FUNCTION inside the (shared) output head. H21 changes the HEAD TOPOLOGY — independent MLPs per channel. Could stack: H21 independent heads + H10b bounded-exp activation inside the τ_z head. |
| H11b #1167 | askeladd | Gated multi-scale input aggregation | H11b changes input features. H21 changes output decoder. Opposite ends of model. |
| H12 #1151 | edward | Per-vertex τ-magnitude-weighted MSE | H12 changes loss weights. H21 changes model architecture. Zero overlap. |
| H16b #1169 | frieren | Huber loss δ=0.3 | H16b changes loss shape. H21 changes architecture. Both attack τ magnitude bottleneck from different angles. Could stack. |
| H18 #1163 | tanjiro | Per-vertex area-weighted MSE | H18 changes loss weights (by mesh area). H21 changes architecture. Zero overlap. |
| H19 #1168 | thorfinn | VICReg batch-variance regularization on \|τ_z\| | H19 is regularization on batch statistics. H21 is decoder architecture. Could stack: per-component heads + VICReg variance on the τ_z head's outputs. |

## What success looks like

- **BIG WIN**: val_abupt < 6.126% AND test_WSS < 6.727% AND floors held → MERGE (per-component heads is the right axis; resolves gradient interference in shared decoder)
- **MERGE**: test_abupt < 5.844% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643% AND test_WSS < 6.727% → MERGE
- **STRONG SIGNAL**: test τz/τx < 1.44 (band-break) + grad_norm/head_tau_z > 1.3 × grad_norm/head_tau_y → request follow-up (stack with H10b bounded-exp activation inside τ_z head)
- **PARTIAL**: val_abupt within 0.2pp of baseline, mechanism active but not enough → suggest depth-equalization variant (all 4 heads same depth) or per-channel LR scaling
- **NULL**: val_abupt > baseline + 0.5pp AND grad_norm/head_tau_z ≈ grad_norm/head_tau_y → gradient interference is not the bottleneck → CLOSE H21 series
- **REGRESSION RISK**: τ_z head overfits if val→test gap on τ_z widens vs baseline — would indicate the deeper head is the culprit; follow-up at single-depth (head_tau_z same depth as others)

## Reference papers

- **Multi-Task Learning as Multi-Objective Optimization** (Sener and Koltun, NeurIPS 2018) — arXiv:1810.04650. Establishes per-task decoder heads as the standard separation mechanism when gradient magnitudes are heterogeneous.
- **Which Tasks Should Be Learned Together in Multi-Task Learning?** (Standley et al., ICML 2020) — arXiv:1905.07553. Task grouping study; aerodynamic fields of different difficulty benefit from independent decoders.
- **NeurIPS 2024 ML4CFD Competition: Results and Retrospective** (arXiv:2506.08516) — top methods used target-specific MLP decoders following a shared backbone in CFD surrogate prediction.
- **GradNorm: Gradient Normalization for Adaptive Loss Balancing** (Chen et al., ICML 2018) — arXiv:1711.02257. If H21 shows per-head gradient magnitudes differ, GradNorm-style weighting is the follow-on experiment.

**Source**: Wave 30 H21. Researcher-agent synthesis on the magnitude bottleneck (H10 73%/27% diagnostic) targeting gradient interference in shared decoder as a distinct cause from H10b (activation function) or H19 (batch statistics).
