### PR TITLE
Wave 30 H22: Charbonnier-cp + MAE-aux for SP/vol_p floor-preservation

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     TargetTransform,
     autocast_context,
     build_lr_scheduler,
+    charbonnier_cp_with_weighted_tau_mse,
     check_kill_thresholds,
     cleanup_distributed,
     collect_gradient_metrics,
@@ -105,6 +106,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    use_charbonnier_cp: bool = False
+    charbonnier_eps: float = 1e-3
+    cp_mae_aux_lambda: float = 0.5
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -321,10 +325,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_charbonnier_cp: bool = False,
+    charbonnier_eps: float = 1e-3,
+    cp_mae_aux_lambda: float = 0.5,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    charb_diag: dict[str, torch.Tensor] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,7 +340,26 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if use_charbonnier_cp:
+            # H22: cp gets Charbonnier+MAE_aux, τ keeps weighted MSE. Provide a
+            # default unit-weight tensor when no per-channel weights are set so
+            # the helper still treats τ as plain MSE.
+            weights = surface_channel_weights
+            if weights is None:
+                weights = torch.ones(
+                    out["surface_preds"].shape[-1],
+                    device=out["surface_preds"].device,
+                    dtype=out["surface_preds"].dtype,
+                )
+            surface_loss, charb_diag = charbonnier_cp_with_weighted_tau_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                weights,
+                charbonnier_eps=charbonnier_eps,
+                cp_mae_aux_lambda=cp_mae_aux_lambda,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +373,16 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    for key, value in charb_diag.items():
+        metrics[f"charb_{key}"] = float(value.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +882,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_charbonnier_cp:
+                print(
+                    f"H22 cp loss: Charbonnier(ε={config.charbonnier_eps}) + "
+                    f"{config.cp_mae_aux_lambda}*|cp_err|; τ keeps weighted MSE."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +918,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_charbonnier_cp"] = config.use_charbonnier_cp
+            wandb.summary["loss/charbonnier_eps"] = config.charbonnier_eps
+            wandb.summary["loss/cp_mae_aux_lambda"] = config.cp_mae_aux_lambda
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1068,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_charbonnier_cp=config.use_charbonnier_cp,
+                        charbonnier_eps=config.charbonnier_eps,
+                        cp_mae_aux_lambda=config.cp_mae_aux_lambda,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1111,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for diag_key in (
+                        "charb_cp_charb_mean",
+                        "charb_cp_mae_mean",
+                        "charb_cp_err_max_abs",
+                        "charb_cp_err_p95",
+                        "charb_cp_err_mean_abs",
+                        "charb_tau_mse_mean",
+                    ):
+                        if diag_key in batch_loss_metrics:
+                            train_log[f"train/{diag_key}"] = batch_loss_metrics[diag_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -870,6 +870,104 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def charbonnier_cp_with_weighted_tau_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    charbonnier_eps: float,
+    cp_mae_aux_lambda: float,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """H22: Charbonnier + MAE-aux on cp channel; weighted MSE on τ channels.
+
+    Replaces the cp channel's MSE contribution with
+    ``sqrt(e^2 + ε^2) - ε + λ * |e|`` (Charbonnier 1994 smooth-L1 plus
+    auxiliary MAE) to prevent gradient saturation on smooth cp panels. The
+    τ_x, τ_y, τ_z channels keep their existing weighted MSE so the
+    advisor's tau_y / tau_z loss weights stay active.
+
+    pred / target: [B, N, 4] (channel 0 = cp, channels 1..3 = τ).
+    mask: [B, N]; weights: [4] (cp/τ_x/τ_y/τ_z channel weights — cp weight
+    multiplies the (Charbonnier + λ·MAE) sum to remain consistent with the
+    weighted_channel_mse contract).
+
+    Returns a scalar loss matching the magnitude of
+    ``weighted_channel_mse`` (averaged over valid points × 4 channels) plus
+    a diagnostics dict with per-element cp tensors for W&B logging.
+    """
+    if pred.numel() == 0:
+        zero = pred.sum() * 0.0
+        return zero, {
+            "cp_charb_mean": zero.detach(),
+            "cp_mae_mean": zero.detach(),
+            "cp_err_max_abs": zero.detach(),
+            "cp_err_p95": zero.detach(),
+            "cp_err_mean_abs": zero.detach(),
+            "tau_mse_mean": zero.detach(),
+        }
+    weights_dev = weights.to(device=pred.device, dtype=pred.dtype)
+    if weights_dev.shape[-1] != pred.shape[-1]:
+        raise ValueError(
+            f"weights last-dim {weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
+        )
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+
+    # cp channel — Charbonnier + auxiliary MAE
+    cp_err = pred[..., 0:1] - target[..., 0:1]
+    cp_charb = torch.sqrt(cp_err.square() + charbonnier_eps * charbonnier_eps) - charbonnier_eps
+    cp_mae = cp_err.abs()
+    cp_term = (cp_charb + cp_mae_aux_lambda * cp_mae) * weights_dev[0:1]
+
+    # τ channels — weighted MSE, unchanged
+    tau_sq_err = (pred[..., 1:] - target[..., 1:]).square()
+    tau_term = tau_sq_err * weights_dev[1:]
+
+    if not bool(valid_points.detach().cpu().item() > 0):
+        zero = pred.sum() * 0.0
+        return zero, {
+            "cp_charb_mean": zero.detach(),
+            "cp_mae_mean": zero.detach(),
+            "cp_err_max_abs": zero.detach(),
+            "cp_err_p95": zero.detach(),
+            "cp_err_mean_abs": zero.detach(),
+            "tau_mse_mean": zero.detach(),
+        }
+
+    loss = (cp_term * mask_dev).sum() / denominator + (tau_term * mask_dev).sum() / denominator
+
+    # Diagnostics — use masked stats so padding rows do not skew percentiles.
+    mask_1d = mask.to(device=pred.device).reshape(-1).bool()
+    cp_err_valid = cp_err.reshape(-1)[mask_1d].detach()
+    if cp_err_valid.numel() > 0:
+        cp_err_abs = cp_err_valid.abs().float()
+        cp_charb_valid = (
+            torch.sqrt(cp_err_valid.float().square() + charbonnier_eps * charbonnier_eps)
+            - charbonnier_eps
+        )
+        diagnostics = {
+            "cp_charb_mean": cp_charb_valid.mean(),
+            "cp_mae_mean": cp_err_abs.mean(),
+            "cp_err_max_abs": cp_err_abs.max(),
+            "cp_err_p95": torch.quantile(cp_err_abs, 0.95),
+            "cp_err_mean_abs": cp_err_abs.mean(),
+            "tau_mse_mean": (tau_sq_err.detach() * mask_dev).sum() / (denominator * 3.0 / pred.shape[-1]).clamp_min(1.0),
+        }
+    else:
+        zero = pred.sum() * 0.0
+        diagnostics = {
+            "cp_charb_mean": zero.detach(),
+            "cp_mae_mean": zero.detach(),
+            "cp_err_max_abs": zero.detach(),
+            "cp_err_p95": zero.detach(),
+            "cp_err_mean_abs": zero.detach(),
+            "tau_mse_mean": zero.detach(),
+        }
+    return loss, diagnostics
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**H22: Charbonnier loss on cp channel + auxiliary MAE on cp — floor-preservation attack against the SP/vol_p ceiling breach pattern.**

All 7 in-flight Wave 30 magnitude attacks (H10b, H11b, H12, H16b, H18, H20, H21) reshape or reweight gradient signal toward τ channels (τ_x, τ_y, τ_z). This implicitly starves the cp channel of gradient updates, causing surface_pressure (val_SP / test_SP) and volume_pressure (val_vol_p / test_vol_p) errors to grow even when val_abupt beats baseline. The same floor-breach pattern is observed across:

- **dl24 H10b** (LOCKED winner): test_wss=6.68 ✅ but test_SP=3.86 (+0.28pp floor breach) and test_vol_p=4.17 (+0.53pp floor breach) — magnitude fix BEATS WSS but loses floors
- **tay fern H10b (#1164, in flight)**: val_SP=4.116% (+0.54pp above 3.577 test floor) at EP4.5
- **tay askeladd H11b (#1167, in flight)**: val_SP=4.161% (+0.58pp above floor) at EP7
- **tay edward H12 a0p3 (#1151)**: test_SP=3.871% (+0.294pp floor breach) at terminal
- **tay thorfinn H19 (#1168, closed)**: test_SP=4.274% (+0.697pp floor breach) at terminal

The root cause: cp is a smooth, well-conditioned field compared to τ. MSE loss saturates on cp smooth panels early (large gradient only where cp has high curvature), allowing the model to reduce overall loss by dedicating capacity to τ channels where errors are larger. Result: cp prediction quality plateaus while τ accuracy improves — exactly the wrong trade-off when test_SP < 3.577% is a hard floor.

**Charbonnier loss** (Charbonnier et al. 1994) replaces MSE on cp with `L_charb(e) = sqrt(e^2 + ε^2) - ε`. This is differentiable-at-zero smooth-L1 that maintains nonzero gradient on small residuals (`grad ≈ e / sqrt(e^2 + ε^2)`) — preventing the gradient-saturation on smooth-region cp panels that causes floor breaches.

**Auxiliary MAE on cp** adds `λ_aux * |pred_cp - target_cp|` as a secondary loss term — directly penalizing magnitude errors in cp prediction without the MSE quadratic diminishing returns on small residuals.

Together: `L_total = L_charb_cp + λ_aux * |pred_cp - target_cp| + L_mse_tau`

**Expected outcome**: val_SP and test_SP compress by 0.3–0.5pp without degrading val_abupt (since τ channels are unchanged). If test_SP clears the 3.577% floor, this mechanism is the missing ingredient for converting fern H10b and askeladd H11b into clean MERGE candidates via stacking.

This hypothesis is **orthogonal to all 7 in-flight Wave 30 magnitude attacks** — it does not touch τ channels at all. Its mechanism is purely at the cp loss level.

**References**:
- Charbonnier et al. 1994 — "Deterministic edge-preserving regularization in computed imaging" — the canonical smooth-L1 loss
- dl24 H9b clamp+MAE_aux mechanism (referenced in issue #1056 composition spec) — same class of floor-preservation approach on vol_p channel

---

## Instructions

**Code change is ~30 lines in `train.py` only. Do NOT modify `model.py`.**

### Step 1: Add Charbonnier + MAE-aux on cp channel in the surface loss

Find the surface loss computation in `train.py` (wherever `surface_loss` or `surface_mse` is computed — search for `surface_mask` or `surface_preds`). Replace the cp channel's MSE contribution with Charbonnier + auxiliary MAE:

```python
# At the top of train.py (or near the loss function block), add:
CHARB_EPS = 1e-3          # Charbonnier epsilon — controls smoothness at zero
CP_AUX_LAMBDA = 0.5       # Weight for auxiliary MAE on cp channel

# In the surface loss computation, split cp vs τ channels:
# surface_preds shape: [B, N, 4] — channels are [cp, τ_x, τ_y, τ_z]
# surface_target shape: [B, N, 4]
# surface_mask shape: [B, N] or [B, N, 1]

surface_mask_expanded = surface_mask.unsqueeze(-1)  # [B, N, 1]

# --- cp channel: Charbonnier + auxiliary MAE ---
cp_pred   = surface_preds[..., 0:1]   # [B, N, 1]
cp_target = surface_target[..., 0:1]  # [B, N, 1]
cp_err    = cp_pred - cp_target         # [B, N, 1]
cp_charb  = torch.sqrt(cp_err.pow(2) + CHARB_EPS**2) - CHARB_EPS   # [B, N, 1]
cp_mae    = cp_err.abs()               # [B, N, 1]
cp_loss   = (((cp_charb + CP_AUX_LAMBDA * cp_mae) * surface_mask_expanded).sum()
             / (surface_mask_expanded.sum() + 1e-8))

# --- τ channels: original MSE (unchanged) ---
tau_err   = surface_preds[..., 1:] - surface_target[..., 1:]  # [B, N, 3]
tau_loss  = ((tau_err.pow(2) * surface_mask_expanded).sum()
             / (surface_mask_expanded.sum() * 3 + 1e-8))

# --- Combined surface loss ---
surface_loss = cp_loss + tau_loss
# (multiply by existing surface_loss_weight if that hyperparameter exists)
```

Adjust for the exact variable names and tensor shapes in your codebase — cp is channel index 0, τ_x is 1, τ_y is 2, τ_z is 3.

### Step 2: Log the mechanism diagnostics to W&B

In the same loss block (or training step), log:

```python
wandb.log({
    "train/charb_cp_loss": cp_charb.mean().item(),
    "train/charb_cp_mae_aux": cp_mae.mean().item(),
    "train/charb_cp_err_max_abs": cp_err.abs().max().item(),
    "train/charb_cp_err_p95": cp_err.abs().quantile(0.95).item(),
    "train/charb_cp_err_mean_abs": cp_err.abs().mean().item(),
})
```

These diagnostics let the advisor verify the mechanism is active and the Charbonnier+MAE contribution is non-trivial.

### Step 3: Run smoke test before launching full 18h run

```bash
# 2-GPU smoke, 2 epochs, small points — verify loss decreases and no NaN
torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --epochs 2 --batch-size 2 \
  --train-surface-points 16384 --eval-surface-points 16384 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model \
  --wandb-group wave30_h22_charbonnier_cp_smoke \
  --wandb-name thorfinn/charb-cp-smoke \
  --agent thorfinn
```

Smoke PASS criteria:
- `train/loss` descends cleanly (not stuck at constant)
- `train/charb_cp_loss` and `train/charb_cp_mae_aux` both log nonzero values (mechanism active)
- `train/grad/nonfinite_count = 0`
- No OOM

### Step 4: Full 18h DDP-8 run

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 \
  --wandb-group wave30_h22_charbonnier_cp \
  --wandb-name thorfinn/charb-cp-mae-aux-18h \
  --agent thorfinn
```

**CRITICAL: verify SENPAI_TIMEOUT_MINUTES before launch.** Your H19 run was killed at 271min because the pod env var was SENPAI_TIMEOUT_MINUTES=360 (6h) instead of the expected 1100 (18h). Before launching the main run:
```bash
printenv SENPAI_TIMEOUT_MINUTES   # or: kubectl exec ... -- printenv SENPAI_TIMEOUT_MINUTES
```
If it shows 360, the 18h run will be killed at EP3. Post a comment to this PR with the env var value before starting the main run.

### EP gates

| Gate | Threshold | Primary mechanism gate |
|---|---:|:--|
| EP1 (~1.6h) | ~28-33% val_abupt | `charb_cp_loss` nonzero and descending |
| EP3 (~4.8h) | val_abupt ≤ 7.0% PASS / ≤ 7.4% MARGINAL | val_SP ≤ 4.5% PASS (vs baseline EP3 ~4.5%) |
| EP6 (~9.6h) | val_abupt ≤ 6.5% PASS | val_SP ≤ 4.0% PASS (vs baseline ~4.0%) |
| EP10 (~16h) | val_abupt ≤ 6.3% PASS | val_SP ≤ 3.8% (approaching floor 3.577%) |
| EP13 terminal | val_abupt < 6.126% (single-model gate) | test_SP ≤ 3.577% and test_vol_p ≤ 3.643% (floors must hold) |

**EP3 mechanism gate**: `train/charb_cp_loss` should be < `train/charb_cp_mae_aux` (i.e. the smooth correction is smaller than the MAE residual — means the mechanism is pushing toward near-zero cp errors). If `charb_cp_loss` >> `charb_cp_mae_aux`, the ε=1e-3 is too small relative to actual cp errors and both terms are just noisy MSE.

---

## Baseline (PR #972, single-model SOTA — corrected split 2026-05-11)

| Metric | Value | Gate |
|---|---:|:--|
| val_abupt | 6.126% | < 6.126% to MERGE |
| test_abupt | 5.844% | < 5.844% to MERGE |
| test_vol_p | 3.643% | ≤ 3.643% **floor — hard breach blocker** |
| test_SP | 3.577% | ≤ 3.577% **floor — hard breach blocker** |
| test_WSS | 6.727% | < 6.727% to MERGE |

**W&B run:** `56bcqp3m` (source) · `zxnhtagj` (eval)

**Reproduce command** (full recipe, corrected dataset):
```bash
cd target/ && torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1
```

---

## Context — why this is the highest-priority orthogonal attack now

All 7 in-flight Wave 30 experiments target the τ_z magnitude bottleneck. None protect cp/SP. The fleet's two leaders (fern H10b and askeladd H11b) are heading toward baseline beats that will be blocked by floor breaches unless a floor-preservation mechanism exists.

H22 is designed to be the **floor-preservation component of a composition stack**. Even if it doesn't improve val_abupt by itself, it fills the cp-gradient gap that's blocking fern H10b and askeladd H11b from clean merges.

**NO ENSEMBLES** — single-model val_abupt < 6.126% is the merge gate.

---

## Terminal SENPAI-RESULT format (per issue #1056)

```markdown
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Must include:
- val + test per-epoch table (val_abupt, val_vol_p, val_SP, val_WSS)
- test best-checkpoint: test_abupt, test_vol_p, test_SP, test_WSS, **test_τ_x, test_τ_y, test_τ_z**, **test τz/τx ratio**
- **Charbonnier mechanism diagnostics**: final `charb_cp_loss`, `charb_cp_mae_aux`, `charb_cp_err_p95` — per-epoch table showing whether the smooth-L1 correction narrowed over training
- **val_SP per-epoch progression** — the decisive floor-preservation diagnostic
- **Comparison of val_SP trajectory vs H10b PR #1164** (the leading candidate that is hitting the floor breach)
- 8-rank run IDs + best-checkpoint epoch + source (raw/ema)
