### PR TITLE
Wave 30 H24: Geometric-Saliency Slice-Temperature Sharpening

### DIFF
--- a/model.py
+++ b/model.py
@@ -226,6 +226,32 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class GeomSaliencyTempMLP(nn.Module):
+    """Per-vertex slice-temperature multiplier from geometry saliency features (H24).
+
+    Maps [nx, ny, nz, area] -> t_v = exp(clamp(MLP(.), -3, 3)).
+    Zero-init final layer guarantees t_v = 1.0 at init (exact Transolver identity).
+    Applied multiplicatively to slice_logits BEFORE softmax, so t_v acts as 1/T:
+    high t_v -> sharper slice assignment, low t_v -> softer assignment.
+    """
+
+    def __init__(self, hidden: int = 16):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(4, hidden),
+            nn.GELU(),
+            nn.Linear(hidden, 1),
+        )
+        nn.init.zeros_(self.mlp[2].weight)
+        nn.init.zeros_(self.mlp[2].bias)
+
+    def forward(self, geom_feats: torch.Tensor) -> torch.Tensor:
+        # geom_feats: [B, N, 4]  (nx, ny, nz, area from surface_x[:, :, 3:7])
+        raw = self.mlp(geom_feats).clamp(-3.0, 3.0)        # [B, N, 1]
+        t_v = torch.exp(raw)                                # [B, N, 1]
+        return t_v.permute(0, 2, 1).unsqueeze(-1)           # [B, 1, N, 1] broadcasts over [B, H, N, S]
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -259,11 +285,20 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        vertex_temps: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        if vertex_temps is not None:
+            slice_logits = slice_logits * vertex_temps.to(
+                device=slice_logits.device, dtype=slice_logits.dtype
+            )
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
@@ -274,8 +309,13 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        vertex_temps: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, vertex_temps=vertex_temps)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -317,9 +357,14 @@ class TransformerBlock(nn.Module):
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        vertex_temps: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, vertex_temps=vertex_temps)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -352,9 +397,14 @@ class Transformer(nn.Module):
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        vertex_temps: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, vertex_temps=vertex_temps)
         return x
 
 
@@ -473,6 +523,10 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
         )
+        # H24 (PR #1174): geometry-saliency slice-temperature MLP. Conditions
+        # per-vertex slice-assignment temperature on [nx, ny, nz, area]; zero-init
+        # final layer preserves Transolver identity at step 0.
+        self.geom_temp_mlp = GeomSaliencyTempMLP(hidden=16)
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
@@ -595,7 +649,25 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+
+        # H24 per-vertex slice-temperature from geometry saliency features.
+        # surface tokens precede volume tokens in the concat order above; the
+        # vertex_temps cat order must match. Volume tokens get a constant 1.0
+        # multiplier so their slice assignments are unchanged from baseline.
+        vertex_temps: torch.Tensor | None = None
+        if surface_x is not None:
+            geom_feats = surface_x[:, :, 3:7]  # [B, N_surf, 4]: nx, ny, nz, area
+            surf_temps = self.geom_temp_mlp(geom_feats)  # [B, 1, N_surf, 1]
+            if volume_x is not None and volume_tokens > 0:
+                vol_ones = torch.ones(
+                    surf_temps.shape[0], 1, volume_tokens, 1,
+                    device=surf_temps.device, dtype=surf_temps.dtype,
+                )
+                vertex_temps = torch.cat([surf_temps, vol_ones], dim=2)
+            else:
+                vertex_temps = surf_temps
+
+        hidden = self.backbone(hidden, attn_mask=attn_mask, vertex_temps=vertex_temps)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -1146,6 +1146,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                     early_stop_reason = "distributed peer requested early stop"
                 if early_stop_reason is not None:
                     train_log["early_stop/triggered"] = 1.0
+                # H24 mechanism-alive diagnostic: log per-vertex temperature
+                # statistics. At init t_v=1.0 for all vertices => std=0. As the
+                # MLP trains, std must rise (or mechanism is inert).
+                if (
+                    hasattr(base_model, "geom_temp_mlp")
+                    and batch.surface_x is not None
+                    and batch.surface_x.numel() > 0
+                    and batch.surface_x.shape[1] > 1
+                ):
+                    with torch.no_grad():
+                        _geom_feats = batch.surface_x[:, :, 3:7].to(device)
+                        _t_v = base_model.geom_temp_mlp(_geom_feats)
+                        train_log["train/geom_temp_std"] = float(_t_v.std().item())
+                        train_log["train/geom_temp_mean"] = float(_t_v.mean().item())
+                        train_log["train/geom_temp_min"] = float(_t_v.min().item())
+                        train_log["train/geom_temp_max"] = float(_t_v.max().item())
                 wandb.log(train_log)
                 if early_stop_reason is not None:
                     if state.is_main:


### PR DESCRIPTION
## Hypothesis

**H24 — Geometric-Saliency Slice-Temperature Sharpening (GSTS)**

Eight consecutive Wave 30 attacks on the output head (H10b bounded-exp activation), decoder topology (H21 independent heads), input gating (H12, H11b), loss form (H16/H16b Huber, H18 area-weighted, H20 focal-vertex, H22 Charbonnier), and training dynamics (H23 Mean Teacher) have all left the τ_z/τ_x collapse band [1.44, 1.55] intact by EP3-5. The H10b terminal result (EP12, 14.31h run) delivered the decisive diagnostic: bounded-exp matched GT pred distribution exactly (median 0.697 vs GT 0.700, frac<6.93 = 0.993 matching GT exactly), yet the 73%/27% magnitude/direction error split was UNCHANGED. **The 73%/27% split is structural in the encoder, not the output activation.**

**Hypothesis**: the band attractor lives in the Transolver slice-assignment mechanism — specifically in the single global softmax temperature `self.temperature` (model.py:248) that is shared identically across all N surface vertices. High-curvature A-pillar/mirror vertices and low-curvature hood/trunk vertices compete for the same `num_slices=128` slice budget with identical sharpness, even though their τ_z flow regimes are categorically different. H24 fixes this by conditioning the slice-assignment temperature on geometry-saliency features already present in the input.

**Mechanism**: a lightweight 3-layer MLP (4→16→1, zero-init final layer) maps `[nx, ny, nz, area]` from `surface_x[:, :, 3:7]` (confirmed 7-dim per data/loader.py:38: `xyz(3) + normals(3) + panel_area(1)`) to a per-vertex multiplicative temperature modifier `t_v = exp(clamp(MLP(nx,ny,nz,area), -3, 3))`. Zero-init guarantees `t_v = 1.0` at init — exact Transolver baseline identity with zero disruption. During training, high-curvature vertices learn `t_v > 1` (sharper assignments → dedicated slice representations), low-curvature vertices learn `t_v < 1` (softer, pooled representations).

**Literature anchors**:
- *GeoTransolver* (arXiv 2512.20399): Encoder-level geometric conditioning yields test_WSS **4.90%** on DrivAerML vs our baseline 6.727% — the only sub-baseline result in the published literature. Their GALE mechanism (dual-stream slice-attention + cross-attention to ball-query geometry context) proves that encoder geometry conditioning, not output-head changes, is the decisive lever on this benchmark.
- *Transolver++*: locally adaptive per-point softmax temperature yields consistent improvements over fixed-temperature Transolver on CFD benchmarks. H24 extends this with geometry-conditioned (rather than hidden-state-conditioned) temperature — strictly more informative at init and avoids cold-start instability.

**Why orthogonal to all 8 in-flight attacks**: H24 modifies the slice-assignment logits BEFORE softmax in `create_slices()` (model.py:262-278). All 8 other active attacks (H11b, H12, H18, H20, H21, H22, H23 — plus H10b just closed) operate downstream of this step (loss reweighting, output head topology, input embedding, training dynamics). No mechanism overlap.

---

## Instructions

Make the following changes to `target/model.py` and `target/train.py` only. **Do not touch any other file.**

### model.py changes (~60 lines)

**Step 1**: Add `GeomSaliencyTempMLP` class just before `TransolverAttention` (find class `TransolverAttention` around line 240 and insert this above it):

```python
class GeomSaliencyTempMLP(nn.Module):
    """Per-vertex temperature multiplier from geometry saliency features.

    Maps [nx, ny, nz, area] → t_v = exp(clamp(MLP(.), -3, 3)).
    Zero-init final layer guarantees t_v = 1.0 at init (exact Transolver identity).
    """
    def __init__(self, hidden: int = 16):
        super().__init__()
        self.mlp = nn.Sequential(
            nn.Linear(4, hidden),
            nn.GELU(),
            nn.Linear(hidden, 1),
        )
        nn.init.zeros_(self.mlp[2].weight)
        nn.init.zeros_(self.mlp[2].bias)

    def forward(self, geom_feats: torch.Tensor) -> torch.Tensor:
        # geom_feats: [B, N, 4]  (nx, ny, nz, area from surface_x[:, :, 3:7])
        raw = self.mlp(geom_feats).clamp(-3.0, 3.0)        # [B, N, 1]
        t_v = torch.exp(raw)                                # [B, N, 1]
        return t_v.permute(0, 2, 1).unsqueeze(-1)           # [B, 1, N, 1] — broadcasts over [B, H, N, S]
```

**Step 2**: Add `vertex_temps=None` parameter to `TransolverAttention.create_slices()` and apply it before softmax. The existing slice_logits line is around line 266:

```python
# Existing code (find these lines):
def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
    ...
    slice_logits = self.in_project_slice(x_mid) / self.temperature
    slice_weights = F.softmax(slice_logits, dim=-1)

# Replace with:
def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None, vertex_temps: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
    ...
    slice_logits = self.in_project_slice(x_mid) / self.temperature
    if vertex_temps is not None:
        slice_logits = slice_logits * vertex_temps   # [B, H, N, S] × [B, 1, N, 1]
    slice_weights = F.softmax(slice_logits, dim=-1)
```

**Step 3**: Thread `vertex_temps=None` through `TransolverAttention.forward()` → `TransformerBlock.forward()` → `Transformer.forward()`. Each just adds `vertex_temps=None` to the signature and passes it through to the inner call. Find each `.forward(self, x, attn_mask=None)` in these three classes and extend it to `forward(self, x, attn_mask=None, vertex_temps=None)`, passing `vertex_temps=vertex_temps` to the inner call (create_slices / attention / block).

**Step 4**: In `SurfaceTransolver.__init__()`, add the MLP:
```python
self.geom_temp_mlp = GeomSaliencyTempMLP(hidden=16)
```

**Step 5**: In `SurfaceTransolver.forward()`, compute per-vertex temperatures and pass to backbone. Find the line where tokens are concatenated and `self.backbone(...)` is called. Insert before that call:

```python
# Compute per-vertex temperature from geometry saliency features
if surface_x is not None:
    geom_feats = surface_x[:, :, 3:7]  # [B, N_surf, 4]: nx, ny, nz, area
    surf_temps = self.geom_temp_mlp(geom_feats)  # [B, 1, N_surf, 1]
    if volume_x is not None:
        N_vol = volume_x.shape[1]
        vol_ones = torch.ones(surf_temps.shape[0], 1, N_vol, 1,
                              device=surf_temps.device, dtype=surf_temps.dtype)
        # Surface tokens are appended to tokens[] BEFORE volume tokens (per loader)
        vertex_temps = torch.cat([surf_temps, vol_ones], dim=2)  # [B, 1, N_surf+N_vol, 1]
    else:
        vertex_temps = surf_temps
else:
    vertex_temps = None

# Modify the backbone call to pass vertex_temps:
hidden = self.backbone(hidden, attn_mask=attn_mask, vertex_temps=vertex_temps)
```

**CRITICAL gotcha**: The `vertex_temps` multiplication happens **before** softmax (on `slice_logits`), not after. Do not move it to post-softmax — that is a different, weaker mechanism.

**CRITICAL gotcha**: `surface_x` tokens are prepended to the token sequence before `volume_x` tokens (check the order tokens are appended to `tokens[]` in `SurfaceTransolver.forward()`). The cat order `[surf_temps, vol_ones]` along `dim=2` must match that token order exactly.

### train.py changes (~8 lines)

Add W&B diagnostic logging for the mechanism-alive monitor. After the forward pass in the training step (immediately after computing loss, before optimizer step), add:

```python
if hasattr(model, 'module'):
    _gts_model = model.module
else:
    _gts_model = model
if hasattr(_gts_model, 'geom_temp_mlp') and batch.surface_x is not None:
    with torch.no_grad():
        _geom_feats = batch.surface_x[:, :, 3:7]
        _t_v = _gts_model.geom_temp_mlp(_geom_feats)
        wandb.log({
            "train/geom_temp_std": _t_v.std().item(),
            "train/geom_temp_mean": _t_v.mean().item(),
        }, commit=False)
```

**Note**: DDP wraps model in `DistributedDataParallel`, so access `model.module.geom_temp_mlp`. Use `commit=False` to keep step counter aligned with the training loss.

### Smoke test (before full run)

Run 1 epoch on 1 GPU to confirm:
1. No crash / NaN
2. `train/geom_temp_std` > 0 at some point (MLP receiving gradient)
3. Loss shape similar to baseline

Kill after EP1 and start the 8-GPU 13-epoch run.

### Full training command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vector-decoupled-head --direction-cos-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h24_gsts \
  --wandb-name fern/h24-gsts-h16 --agent fern
```

### EP gates

| EP | val_abupt gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | ≤ ~33% (warmup, not kill) | `geom_temp_std` > 0 (MLP receiving gradient) | Sanity only — continue unless NaN |
| EP3 | ≤ 8.0% | τ_z/τ_x exits [1.40, 1.60] **AND** `geom_temp_std` > 0.05 | **Both gates must pass** — if either fails, KILL |
| EP5 | ≤ 6.5% | `geom_temp_std` > 0.10 | If stagnant at EP3 or regressing: kill |
| EP8 | ≤ 6.3% | τ_z/τ_x outside [1.40, 1.60] | Confirm on track for baseline beat |
| EP13 | < 6.126% **AND** test_SP ≤ 3.577% **AND** test_vol_p ≤ 3.643% | `geom_temp_std` > 0.10 | Merge gate |

**Critical floor constraint**: val_abupt < 6.126% is necessary but NOT sufficient. test_SP ≤ 3.577% and test_vol_p ≤ 3.643% are hard merge blockers (floor-breach is the dominant failure mode in Wave 30 — report both at every checkpoint from EP8 onward).

### Terminal SENPAI-RESULT must include

1. **val + test per-epoch table**: val_abupt, val_WSS, val_SP, val_vol_p, τ_x/τ_y/τ_z, τz/τx ratio at each epoch
2. **Test metrics from best val checkpoint**: test_abupt, test_WSS, test_SP, test_vol_p, test_τ_x/τ_y/τ_z, test τz/τx
3. **8 W&B rank run IDs**, best checkpoint epoch + source (raw/ema)
4. **`geom_temp_std` trajectory** (primary mechanism monitor): values at EP1, EP2, EP3, EP5, EP8, EP13 — must rise from ~0 at init to >0.05 at EP3 for mechanism to be alive
5. **Per-region temperature split**: at terminal, report `mean(t_v)` for high-curvature vertices (area < median area) vs low-curvature vertices — confirms the MLP is using geometry, not ignoring it
6. **τ_z/τ_x trajectory**: confirm whether band exited [1.40, 1.60] at EP3 and if so, when

---

## Baseline

Single-model baseline PR #972 (run `56bcqp3m`):
- **val_abupt**: 6.126%
- **test_abupt**: 5.844%
- **test_WSS**: 6.727% (goal: <5.85%)
- **test_vol_p**: 3.643% (hard floor — must not exceed)
- **test_SP**: 3.577% (hard floor — must not exceed)

Reproduce command:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vector-decoupled-head --direction-cos-loss-weight 0.1 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_baseline_56bcqp3m --agent fern
```

**Most recent closed result for comparison — fern H10b (#1164, just closed):**
- test_abupt: 5.998%, test_WSS: 6.980% (FAIL), test_SP: 3.755% (FLOOR FAIL), test_vol_p: **3.481% (FLOOR PASS)**, test τz/τx: 1.441
- Key negative result: bounded-exp fixed pred magnitude distribution exactly (median 0.697 = GT, frac<6.93 = 0.993 = GT), yet 73%/27% mag/dir split UNCHANGED. **Mechanism worked, hypothesis FALSIFIED.** The 73%/27% split is structural in the encoder, not the output activation. This is the direct motivation for H24 targeting the slice-assignment temperature upstream.
