### PR TITLE
H25: Auxiliary Local-Gradient Prediction (ALGP) to break τz band attractor

### DIFF
--- a/h25_offline_test_eval.py
+++ b/h25_offline_test_eval.py
@@ -1,0 +1,162 @@
+"""Offline test-eval for the H25 ALGP run.
+
+Loads the local best checkpoint saved by rank-0 of the DDP run (already EMA
+weights), runs full val + test evaluation on a single GPU, and prints metrics
+in the same shape as `run_final_evaluation`. Auxiliary head is loaded into the
+state dict but is discarded at inference (forward bypasses it when not training).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import fields
+from pathlib import Path
+
+import torch
+import yaml
+
+from data import load_data
+from model import SurfaceTransolver
+from train import Config, parse_rff_init_sigmas
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    eval_loader_for_dataset,
+)
+
+
+def _config_from_yaml(path: Path) -> Config:
+    with path.open() as fh:
+        raw = yaml.safe_load(fh)
+    valid = {f.name for f in fields(Config)}
+    kwargs = {k: v for k, v in raw.items() if k in valid}
+    return Config(**kwargs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        required=True,
+        help="outputs/drivaerml/run-<id> dir containing checkpoint.pt + config.yaml",
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--batch-size", type=int, default=None)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    config = _config_from_yaml(args.run_dir / "config.yaml")
+    if args.batch_size is not None:
+        config.batch_size = args.batch_size
+
+    train_ds, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=config.debug,
+    )
+    val_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in val_splits.items()
+    }
+    test_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in test_splits.items()
+    }
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = SurfaceTransolver(
+        n_layers=config.model_layers,
+        n_hidden=config.model_hidden_dim,
+        dropout=config.model_dropout,
+        n_head=config.model_heads,
+        mlp_ratio=config.model_mlp_ratio,
+        slice_num=config.model_slices,
+        rff_num_features=config.rff_num_features,
+        rff_sigma=config.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
+        pos_encoding_mode=config.pos_encoding_mode,
+        use_qk_norm=config.use_qk_norm,
+        use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_aux_grad_head=(config.aux_grad_weight > 0.0),
+        aux_grad_head_bottleneck=config.aux_grad_head_bottleneck,
+    ).to(device)
+
+    ckpt_path = args.run_dir / "checkpoint.pt"
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+    state_dict = ckpt["model"]
+    missing, unexpected = model.load_state_dict(state_dict, strict=True)
+    if missing or unexpected:
+        raise RuntimeError(f"State-dict mismatch: missing={missing}, unexpected={unexpected}")
+    model.eval()
+    print(
+        f"Loaded checkpoint: epoch={ckpt.get('epoch')}, "
+        f"source={ckpt.get('checkpoint_source')}, "
+        f"selection_metric={ckpt.get('selection_metric')}"
+    )
+
+    t0 = time.time()
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in val_loaders.items()
+    }
+    print(f"[val] elapsed={time.time() - t0:.1f}s")
+    for name, m in val_metrics.items():
+        print(f"\n=== full-{name} ===")
+        for k, v in sorted(m.items()):
+            print(f"  {k}: {v}")
+
+    t1 = time.time()
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in test_loaders.items()
+    }
+    print(f"\n[test] elapsed={time.time() - t1:.1f}s")
+    for name, m in test_metrics.items():
+        print(f"\n=== {name} ===")
+        for k, v in sorted(m.items()):
+            print(f"  {k}: {v}")
+
+    val_s = val_metrics["val_surface"]
+    test_s = test_metrics["test_surface"]
+    print("\n=== H25-OFFLINE-SUMMARY ===")
+    print(
+        "VAL:",
+        {
+            "abupt": val_s["abupt_axis_mean_rel_l2_pct"],
+            "SP": val_s["surface_pressure_rel_l2_pct"],
+            "vol_p": val_s["volume_pressure_rel_l2_pct"],
+            "WSS": val_s["wall_shear_rel_l2_pct"],
+            "WSS_x": val_s["wall_shear_x_rel_l2_pct"],
+            "WSS_y": val_s["wall_shear_y_rel_l2_pct"],
+            "WSS_z": val_s["wall_shear_z_rel_l2_pct"],
+            "tauz_over_taux": val_s["wall_shear_z_rel_l2_pct"] / val_s["wall_shear_x_rel_l2_pct"],
+        },
+    )
+    print(
+        "TEST:",
+        {
+            "abupt": test_s["abupt_axis_mean_rel_l2_pct"],
+            "SP": test_s["surface_pressure_rel_l2_pct"],
+            "vol_p": test_s["volume_pressure_rel_l2_pct"],
+            "WSS": test_s["wall_shear_rel_l2_pct"],
+            "WSS_x": test_s["wall_shear_x_rel_l2_pct"],
+            "WSS_y": test_s["wall_shear_y_rel_l2_pct"],
+            "WSS_z": test_s["wall_shear_z_rel_l2_pct"],
+            "tauz_over_taux": test_s["wall_shear_z_rel_l2_pct"] / test_s["wall_shear_x_rel_l2_pct"],
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/model.py
+++ b/model.py
@@ -358,6 +358,31 @@ class Transformer(nn.Module):
         return x
 
 
+class AuxGradHead(nn.Module):
+    """Auxiliary head predicting local tau_z spatial gradient magnitude.
+
+    Attached to surface_hidden [B, N_s, hidden_dim] post-backbone. Zero-init
+    final layer means outputs ~0 at init, no cold-start disruption. Discarded
+    at inference -- only affects backbone representation learning during
+    training via the auxiliary loss term.
+    """
+
+    def __init__(self, hidden_dim: int = 192, bottleneck: int = 64):
+        super().__init__()
+        self.head = nn.Sequential(
+            nn.Linear(hidden_dim, bottleneck),
+            nn.GELU(),
+            nn.Linear(bottleneck, 1),
+        )
+        nn.init.trunc_normal_(self.head[0].weight, std=0.02)
+        nn.init.zeros_(self.head[0].bias)
+        nn.init.zeros_(self.head[2].weight)
+        nn.init.zeros_(self.head[2].bias)
+
+    def forward(self, surface_hidden: torch.Tensor) -> torch.Tensor:
+        return self.head(surface_hidden).squeeze(-1)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -382,6 +407,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_aux_grad_head: bool = False,
+        aux_grad_head_bottleneck: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -519,6 +546,17 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H25 ALGP (PR #1176): auxiliary head on surface_hidden predicting
+        # local tau_z spatial gradient magnitude. Active only during training
+        # (forward returns aux_grad_preds=None at eval) to keep inference free.
+        self.use_aux_grad_head = use_aux_grad_head
+        if use_aux_grad_head:
+            self.aux_grad_head = AuxGradHead(
+                hidden_dim=n_hidden, bottleneck=aux_grad_head_bottleneck
+            )
+        else:
+            self.aux_grad_head = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -633,10 +671,15 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
+        aux_grad_preds = None
+        if self.aux_grad_head is not None and self.training and surface_x is not None:
+            aux_grad_preds = self.aux_grad_head(surface_hidden) * surface_mask
+
         return {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "aux_grad_preds": aux_grad_preds,
         }

--- a/train.py
+++ b/train.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
@@ -138,6 +139,10 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    aux_grad_weight: float = 0.0
+    aux_grad_n_samples: int = 4096
+    aux_grad_k: int = 8
+    aux_grad_head_bottleneck: int = 64
     debug: bool = False
 
 
@@ -219,6 +224,35 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "aux_grad_weight": (
+            "H25 ALGP (PR #1176) auxiliary tau_z spatial-gradient prediction "
+            "loss weight. 0.0 disables (default). When >0, attaches an "
+            "AuxGradHead to surface_hidden that predicts the KNN finite-"
+            "difference local gradient magnitude of tau_z; the loss is added "
+            "to the primary loss as aux_grad_weight * aux_loss. The auxiliary "
+            "head is zero-init on the final layer (no cold-start disruption) "
+            "and discarded at inference (zero inference overhead). Hypothesis: "
+            "force backbone to encode spatially coherent gradient-aware "
+            "representations to break the tau_z/tau_x [1.44,1.55] band "
+            "attractor. Recommended starting weight: 0.1."
+        ),
+        "aux_grad_n_samples": (
+            "Number of surface vertices sampled per forward pass for KNN "
+            "gradient target computation when --aux-grad-weight > 0. Full "
+            "N_surface (~400K) would be O(N^2) infeasible; default 4096 "
+            "is a compute/coverage trade-off."
+        ),
+        "aux_grad_k": (
+            "Number of nearest neighbors used in the KNN finite-difference "
+            "gradient magnitude target (default 8). Active only when "
+            "--aux-grad-weight > 0."
+        ),
+        "aux_grad_head_bottleneck": (
+            "Width of the AuxGradHead bottleneck layer (default 64). The "
+            "head architecture is Linear(hidden_dim -> bottleneck) -> GELU "
+            "-> Linear(bottleneck -> 1) with zero-init final layer. Active "
+            "only when --aux-grad-weight > 0."
         ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
@@ -308,7 +342,97 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_aux_grad_head=(config.aux_grad_weight > 0.0),
+        aux_grad_head_bottleneck=config.aux_grad_head_bottleneck,
     )
+
+
+def compute_knn_grad_targets(
+    coords: torch.Tensor,
+    tau_z: torch.Tensor,
+    k: int = 8,
+) -> torch.Tensor:
+    """KNN finite-difference gradient magnitude of tau_z at each vertex.
+
+    Args:
+        coords: [B, N, 3] xyz positions (float32).
+        tau_z:  [B, N] tau_z values at each vertex (float32, normalized).
+        k:      number of nearest neighbors (excludes self).
+
+    Returns:
+        [B, N] mean absolute FD gradient magnitude per vertex.
+    """
+    B, N, _ = coords.shape
+    # cdist materializes [B, N, N] (~134MB at N=4096, B=2, fp32) -- avoids
+    # the [B, N, N, 3] broadcast subtraction blow-up flagged by H25 research.
+    dist_mat = torch.cdist(coords, coords, p=2)  # [B, N, N]
+    # K+1 smallest: index 0 is the self-distance (=0), keep K real neighbors.
+    _, knn_idx = dist_mat.topk(k + 1, dim=-1, largest=False)
+    knn_idx = knn_idx[:, :, 1:]  # [B, N, K]
+    batch_idx = torch.arange(B, device=coords.device).view(B, 1, 1).expand(B, N, k)
+    knn_coords = coords[batch_idx, knn_idx]  # [B, N, K, 3]
+    knn_tau_z = tau_z[batch_idx, knn_idx]    # [B, N, K]
+    edge_dist = (knn_coords - coords.unsqueeze(2)).norm(dim=-1).clamp(min=1e-6)
+    grad_mag = (knn_tau_z - tau_z.unsqueeze(2)).abs() / edge_dist
+    return grad_mag.mean(dim=-1)  # [B, N]
+
+
+def compute_aux_grad_loss(
+    aux_preds: torch.Tensor,
+    surface_x: torch.Tensor,
+    surface_target: torch.Tensor,
+    surface_mask: torch.Tensor,
+    *,
+    n_samples: int,
+    k: int,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """H25 ALGP auxiliary loss: predict KNN-FD gradient magnitude of tau_z.
+
+    Subsamples ``n_samples`` surface vertices uniformly, computes the FD
+    gradient target on the subsample (under no_grad), and returns the
+    per-batch std-normalized MSE between the aux head outputs and the
+    target. Masked at the sample level so padding tokens are ignored.
+    """
+    B, N_s = aux_preds.shape
+    # Some views in the DrivAerML loader contain empty surface tensors (when
+    # volume views outnumber surface views). KNN needs at least k+1 vertices.
+    if N_s < k + 1:
+        zero = aux_preds.new_zeros(()).requires_grad_(False)
+        aux_loss = aux_preds.sum() * 0.0  # keep graph for DDP
+        return aux_loss, {
+            "aux_loss": 0.0,
+            "aux_grad_scale": 0.0,
+            "aux_grad_target_mean": 0.0,
+            "aux_grad_target_max": 0.0,
+            "aux_pred_mean": 0.0,
+            "aux_pred_std": 0.0,
+            "aux_n_samples": 0.0,
+            "aux_skipped": 1.0,
+        }
+    n_eff = min(n_samples, N_s)
+    aux_idx = torch.randperm(N_s, device=aux_preds.device)[:n_eff]
+    coords_sub = surface_x[:, aux_idx, 0:3].float()           # [B, n_eff, 3]
+    tau_z_sub = surface_target[:, aux_idx, 3].float()         # [B, n_eff]
+    mask_sub = surface_mask[:, aux_idx].float()               # [B, n_eff]
+    aux_preds_sub = aux_preds[:, aux_idx].float()             # [B, n_eff]
+    with torch.no_grad():
+        gt_grad = compute_knn_grad_targets(coords_sub, tau_z_sub, k=k)  # [B, n_eff]
+        gt_grad_scale = gt_grad.std().clamp(min=1e-6)
+        gt_grad_norm = gt_grad / gt_grad_scale
+    aux_preds_norm = aux_preds_sub / gt_grad_scale
+    sq_err = (aux_preds_norm - gt_grad_norm).pow(2) * mask_sub
+    denom = mask_sub.sum().clamp(min=1.0)
+    aux_loss = sq_err.sum() / denom
+    return aux_loss, {
+        "aux_loss": float(aux_loss.detach().cpu().item()),
+        "aux_grad_scale": float(gt_grad_scale.detach().cpu().item()),
+        "aux_grad_target_mean": float(gt_grad.mean().detach().cpu().item()),
+        "aux_grad_target_max": float(gt_grad.max().detach().cpu().item()),
+        "aux_pred_mean": float(aux_preds_sub.mean().detach().cpu().item()),
+        "aux_pred_std": float(aux_preds_sub.std().detach().cpu().item()),
+        "aux_n_samples": float(n_eff),
+        "aux_skipped": 0.0,
+    }
 
 
 def train_loss(
@@ -321,6 +445,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    aux_grad_weight: float = 0.0,
+    aux_grad_n_samples: int = 4096,
+    aux_grad_k: int = 8,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,13 +473,33 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+
+    aux_metrics: dict[str, float] = {}
+    if aux_grad_weight > 0.0 and out.get("aux_grad_preds") is not None:
+        # Compute aux loss outside autocast in fp32 -- gradient magnitudes are
+        # tiny and the per-batch std normalization is fragile under fp16.
+        aux_loss, aux_metrics = compute_aux_grad_loss(
+            out["aux_grad_preds"],
+            batch.surface_x,
+            surface_target,
+            batch.surface_mask,
+            n_samples=aux_grad_n_samples,
+            k=aux_grad_k,
+        )
+        loss = loss + aux_grad_weight * aux_loss
+        aux_metrics["aux_loss_weighted"] = float(
+            (aux_grad_weight * aux_loss).detach().cpu().item()
+        )
+
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(aux_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -773,7 +920,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.aux_grad_weight > 0.0:
+                # H25 ALGP: empty-surface views skip the aux head entirely, so
+                # the aux_grad_head params are unused for that rank's batch.
+                # find_unused_parameters lets DDP synchronise around it.
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1030,6 +1180,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        aux_grad_weight=config.aux_grad_weight,
+                        aux_grad_n_samples=config.aux_grad_n_samples,
+                        aux_grad_k=config.aux_grad_k,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1223,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for aux_key in (
+                        "aux_loss",
+                        "aux_loss_weighted",
+                        "aux_grad_scale",
+                        "aux_grad_target_mean",
+                        "aux_grad_target_max",
+                        "aux_pred_mean",
+                        "aux_pred_std",
+                        "aux_n_samples",
+                        "aux_skipped",
+                    ):
+                        if aux_key in batch_loss_metrics:
+                            train_log[f"train/{aux_key}"] = batch_loss_metrics[aux_key]
+                    train_log["train/aux_grad_weight"] = config.aux_grad_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1261,6 +1428,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 log_metrics.update(primary_metric_log("val_primary", val_metrics["val_surface"]))
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
+                tz_pct = val_metrics["val_surface"].get("wall_shear_z_rel_l2_pct")
+                tx_pct = val_metrics["val_surface"].get("wall_shear_x_rel_l2_pct")
+                if (
+                    tz_pct is not None
+                    and tx_pct is not None
+                    and math.isfinite(tz_pct)
+                    and math.isfinite(tx_pct)
+                    and tx_pct > 0.0
+                ):
+                    log_metrics["val_primary/tau_z_over_tau_x_ratio"] = tz_pct / tx_pct
                 log_metrics.update(collect_string_sep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(


### PR DESCRIPTION
## Hypothesis — H25: Auxiliary Local-Gradient Prediction (ALGP)

The `[1.44, 1.55]` τ_z/τ_x band attractor is structural in the backbone's representations. All 8 prior Wave 30 attacks (output heads, loss functions, input gating, slice temperature) have failed to break it because **none has changed what information the backbone is trained to encode in `surface_hidden`**. This is the one lever that has not been pulled.

**Core idea**: Attach a lightweight auxiliary MLP head to `surface_hidden [B, N_s, 192]` that predicts the KNN finite-difference spatial gradient magnitude ‖∇τ_z‖ per vertex at training time. This forces the backbone to build spatially coherent, gradient-aware representations — the band attractor should collapse because a backbone that can predict where τ_z changes rapidly must encode a richer, spatially structured τ_z representation.

Zero-init on the auxiliary head's final layer means outputs ~0 at EP0 → no cold-start disruption. The auxiliary head is **discarded at test time** → zero inference overhead. The only effect is representational.

**Reference papers:**
- GraphCast (Lam et al., Science 2023): gradient-aware spatial loss terms improve accuracy on sharp CFD boundaries
- PhysGNN (Golriz Khatami et al., NeurIPS 2022): auxiliary deformation-gradient prediction forces spatially coherent backbone representations — identical mechanism
- Multi-task learning as multi-objective optimization (Sener & Koltun, NeurIPS 2018): λ ∈ [0.05, 0.2] is optimal for primary/auxiliary balance

**Orthogonality:** H25 is orthogonal to all 7 in-flight experiments. H24 (fern, GSTS) attacks encoder slice-assignment logits; H25 attaches an auxiliary head to `surface_hidden` — no shared code path. H22 (thorfinn, Charbonnier-cp) targets floor preservation; H25 targets the backbone content.

---

## Instructions

### 1. `model.py` — Add `AuxGradHead` class (~25 lines)

Add this class before `SurfaceTransolver`:

```python
class AuxGradHead(nn.Module):
    """Auxiliary head predicting local tau_z spatial gradient magnitude.

    Attached to surface_hidden [B, N_s, 192] post-backbone.
    Zero-init final layer: outputs ~0 at init, no cold-start disruption.
    Discarded at inference — only affects backbone representation learning.
    """

    def __init__(self, hidden_dim: int = 192, bottleneck: int = 64):
        super().__init__()
        self.head = nn.Sequential(
            nn.Linear(hidden_dim, bottleneck),
            nn.GELU(),
            nn.Linear(bottleneck, 1),
        )
        nn.init.zeros_(self.head[2].weight)
        nn.init.zeros_(self.head[2].bias)

    def forward(self, surface_hidden: torch.Tensor) -> torch.Tensor:
        # surface_hidden: [B, N_s, 192]
        return self.head(surface_hidden).squeeze(-1)  # [B, N_s]
```

### 2. `model.py` — Add flag to `SurfaceTransolver.__init__()`

```python
# After self.surface_out instantiation:
self.use_aux_grad_head = use_aux_grad_head
if use_aux_grad_head:
    self.aux_grad_head = AuxGradHead(hidden_dim=n_hidden, bottleneck=64)
```

Add `use_aux_grad_head: bool = False` as a constructor parameter.

### 3. `model.py` — Return auxiliary predictions in `forward()`

```python
# After: surface_preds = self.surface_out(surface_hidden) * surface_mask
aux_grad_preds = None
if self.use_aux_grad_head and self.training:
    aux_grad_preds = self.aux_grad_head(surface_hidden)  # [B, N_s]

# Add to the returned dict:
return {
    "surface_preds": surface_preds,
    "volume_preds": volume_preds,
    "aux_grad_preds": aux_grad_preds,   # None at inference
}
```

### 4. `train.py` — Add `compute_knn_grad_targets` helper

**CRITICAL: N_s ~400K per sample. NEVER compute full pairwise O(N^2) distance matrix. Use Option C sub-sampling (N_aux=4096) — simplest correct implementation.**

```python
def compute_knn_grad_targets(surface_x: torch.Tensor, surface_labels: torch.Tensor,
                              K: int = 8) -> torch.Tensor:
    """
    KNN finite-difference gradient magnitude targets for tau_z.

    Args:
        surface_x: [B, N_aux, C] where [:, :, 0:3] are surface coords (x, y, z)
        surface_labels: [B, N_aux, 4] where [:, :, 3] is tau_z (channel index 3)
        K: number of nearest neighbors

    Returns:
        grad_targets: [B, N_aux] — mean absolute FD gradient of tau_z
    """
    B, N, _ = surface_x.shape
    coords = surface_x[:, :, 0:3]           # [B, N, 3]
    tau_z = surface_labels[:, :, 3]         # [B, N]   ← confirm channel 3 = tau_z

    # Pairwise squared distances (N_aux=4096 → 4096^2 = 16M ops, feasible on A100)
    diff = coords.unsqueeze(2) - coords.unsqueeze(1)   # [B, N, N, 3]
    sq_dist = (diff ** 2).sum(-1)                       # [B, N, N]

    # KNN: K+1 smallest (index 0 is self)
    _, knn_idx = sq_dist.topk(K + 1, dim=-1, largest=False)  # [B, N, K+1]
    knn_idx = knn_idx[:, :, 1:]                               # [B, N, K] — exclude self

    # Gather neighbor coords and tau_z values
    knn_coords = torch.stack([
        coords[b][knn_idx[b]] for b in range(B)
    ], dim=0)                                                  # [B, N, K, 3]
    knn_tau_z = torch.stack([
        tau_z[b][knn_idx[b]] for b in range(B)
    ], dim=0)                                                  # [B, N, K]

    # Finite-difference gradient magnitude
    edge_dist = (knn_coords - coords.unsqueeze(2)).norm(dim=-1).clamp(min=1e-6)  # [B, N, K]
    grad_mag = (knn_tau_z - tau_z.unsqueeze(2)).abs() / edge_dist                # [B, N, K]
    return grad_mag.mean(dim=-1)                                                  # [B, N]
```

**Before writing this:** Confirm that `surface_labels[:, :, 3]` is τ_z (the 4th channel of [cp, τx, τy, τz]). Check model.py / dataset preprocessing. If the channel order is different, adjust the index.

### 5. `train.py` — Auxiliary loss computation in training loop

```python
# After forward pass (outputs dict contains "aux_grad_preds"):
if model_cfg.use_aux_grad_head and outputs["aux_grad_preds"] is not None:
    # Sub-sample N_aux=4096 vertices (Option C — avoids O(N^2) OOM for full N_s~400K)
    N_aux = 4096
    B, N_s, _ = batch.surface_x.shape
    aux_idx = torch.randperm(N_s, device=batch.surface_x.device)[:N_aux]

    surf_x_sub     = batch.surface_x[:, aux_idx, :]        # [B, N_aux, C]
    surf_labels_sub = batch.surface_labels[:, aux_idx, :]  # [B, N_aux, 4]
    aux_preds_sub   = outputs["aux_grad_preds"][:, aux_idx] # [B, N_aux]

    with torch.no_grad():
        gt_grad = compute_knn_grad_targets(surf_x_sub, surf_labels_sub, K=8)  # [B, N_aux]

    # Per-batch std normalization (essential — raw grad values span orders of magnitude)
    gt_grad_scale = gt_grad.std().clamp(min=1e-6)
    gt_grad_norm  = gt_grad / gt_grad_scale
    aux_preds_norm = aux_preds_sub / gt_grad_scale

    aux_loss = F.mse_loss(aux_preds_norm, gt_grad_norm)
    loss = primary_loss + args.aux_grad_weight * aux_loss

    # Log to W&B (non-committing)
    wandb.log({
        "train/aux_loss": aux_loss.item(),
        "train/aux_grad_scale": gt_grad_scale.item(),
        "train/loss_total": loss.item(),
    }, commit=False)
else:
    loss = primary_loss
```

### 6. `train.py` — Add CLI flag

```python
parser.add_argument("--aux_grad_weight", type=float, default=0.0,
                    help="Weight for auxiliary tau_z gradient prediction loss. "
                         "0.0 disables (default). Recommended: 0.1")
```

Also ensure `use_aux_grad_head=True` is threaded through to the model config when `--aux_grad_weight > 0`.

### 7. EP1 gradient flow check

At EP1, log: `model.aux_grad_head.head[2].weight.grad.norm()`. If this is zero or NaN, the sub-sampling or target computation is broken — report immediately. Do not continue past EP1 with a silent zero-gradient auxiliary head.

---

## Run command

```bash
torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 \
  --lr-warmup-epochs 1 \
  --lr-cosine-t-max 13 \
  --aux_grad_weight 0.1 \
  --wandb_group "wave30_H25_algp" \
  --wandb_run_name "alphonse_H25_algp_lam0p1" \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  [remaining standard flags from program.md]
```

- **`--lr 9e-5` is a hard constraint** — do not change (5e-4 caused 4 divergences)
- **`--aux_grad_weight 0.1`** is the starting point — λ_aux=0.1 keeps auxiliary signal well below primary loss

---

## EP Gates (kill / continue criteria)

| Epoch | Primary gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | val_abupt ≤ ~33% (warmup — not a kill epoch) | `aux_loss` is finite and decreasing (not NaN/diverging); grad norm non-zero | Sanity only; kill if NaN/crash/zero grad |
| EP3 | val_abupt ≤ 8.0% | `aux_loss` decreasing monotonically EP1→EP3 **AND** τ_z/τ_x exits [1.40, 1.60] on ≥2 val cars | **Both gates must pass.** aux_loss flat/NaN → KILL; τ_z/τ_x unmoved but aux_loss OK → post to PR, evaluate at EP5 |
| EP5 | val_abupt ≤ 6.5% | aux_loss < EP1 value by >20%; τ_z/τ_x outside [1.40, 1.60] | τ_z/τ_x rebound into band → kill |
| EP8 | val_abupt ≤ 6.3% | τ_z/τ_x outside [1.40, 1.60]; aux_loss still decreasing | Confirm baseline approach track |
| EP13 | val_abupt < **6.126%** AND test_SP ≤ **3.577%** AND test_vol_p ≤ **3.643%** | aux_loss < 50% of EP1 | **Merge gate** |

---

## 5 Key Watch Items

1. **`train/aux_loss` trajectory**: Must decrease monotonically from EP1 onward. Flat → mechanism not alive at this K/N_aux.
2. **τ_z/τ_x error ratio at EP3**: Must exit [1.40, 1.60]. If aux_loss decreasing but τ_z/τ_x unmoved, the head is absorbing the task without pushing backbone representations.
3. **`train/aux_grad_scale`**: Should be in [0.01, 1.0]. If >10 or <0.001, report — there's a coordinate normalization mismatch.
4. **test_SP and test_vol_p floor preservation**: Report both from EP8 onward. The auxiliary τ_z task should not perturb the volume pathway.
5. **Gradient flow at EP1**: `aux_grad_head.head[2].weight.grad.norm()` must be non-zero — if zero, the sub-sampling is broken.

---

## Baseline

**Single-model SOTA** (PR #972, W&B run `56bcqp3m`, corrected split `rawcanon_20260511`):
- val_abupt = **6.126%** ← primary target to beat
- test_abupt = 5.844%
- test_vol_p = **3.643%** ← hard floor (merge blocker if exceeded)
- test_SP = **3.577%** ← hard floor (merge blocker if exceeded)
- test_WSS = 6.727%

**Single-model training gate (EP3):** val_abupt ≤ 6.2% AND val_vol_p ≤ 4.5%

**W&B project:** `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

---

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}
```

Also report: val_abupt, test_abupt, test_vol_p, test_SP, test_WSS, τ_z/τ_x error ratio trajectory (EP1/EP3/EP5/EP8/EP13), aux_loss trajectory, aux_grad_scale at EP1.
