### PR TITLE
Wave 30 H26: Normal-Projected Coordinate Augmentation (NPCA) — local-frame input features to break τz/τx band attractor

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,42 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
+    """Project global position onto a per-vertex local surface frame.
+
+    Computes ``[p·n, p·t1, p·t2]`` per vertex, where ``t1, t2`` are a
+    Gram-Schmidt tangent basis derived from the surface normal.
+
+    Computed in fp32 with an explicit eps=1e-6 in ``F.normalize`` so that
+    zero-padded tokens (normal == ``[0,0,0]``) produce zero projections
+    instead of NaN, even when called inside a bf16/fp16 autocast region.
+
+    Args:
+        surface_x: ``[B, N, >=6]`` with columns ``[x, y, z, nx, ny, nz, ...]``.
+
+    Returns:
+        ``[B, N, 3]`` with ``[p·n, p·t1, p·t2]`` per vertex, cast back to
+        the input dtype.
+    """
+    input_dtype = surface_x.dtype
+    sx = surface_x.float()
+    pos = sx[:, :, :3]
+    n = F.normalize(sx[:, :, 3:6], dim=-1, eps=1e-6)
+
+    ref_a = torch.tensor([0.0, 0.0, 1.0], device=n.device, dtype=n.dtype).expand_as(n)
+    ref_b = torch.tensor([0.0, 1.0, 0.0], device=n.device, dtype=n.dtype).expand_as(n)
+    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
+    ref = torch.where(parallel_mask, ref_b, ref_a)
+
+    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+
+    local_n = (pos * n).sum(-1, keepdim=True)
+    local_t1 = (pos * t1).sum(-1, keepdim=True)
+    local_t2 = (pos * t2).sum(-1, keepdim=True)
+    return torch.cat([local_n, local_t1, local_t2], dim=-1).to(dtype=input_dtype)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_local_frame_proj: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,7 +433,10 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_local_frame_proj = use_local_frame_proj
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        if use_local_frame_proj:
+            surface_extra_dim += 3
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_multisigma":
@@ -462,6 +502,14 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if use_local_frame_proj and self.project_surface_features is not None:
+            # Identity-init: zero the 3 NEW input columns of project_surface_features
+            # so the model starts from the current baseline at step 0. The 3 new
+            # columns sit at indices [4, 5, 6] of the surface feature vector
+            # (after [nx, ny, nz, area] at [0, 1, 2, 3]). The bias is already
+            # zero-init via _init_linear, so no extra step is needed.
+            with torch.no_grad():
+                self.project_surface_features.project.weight[:, 4:7].zero_()
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -528,12 +576,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        local_proj: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if local_proj is not None:
+            feature_parts.append(local_proj)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -567,6 +618,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            local_proj = (
+                compute_local_frame_proj(surface_x) if self.use_local_frame_proj else None
+            )
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -575,6 +629,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    local_proj=local_proj,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_local_frame_proj: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_local_frame_proj": (
+            "Enable normal-projected coordinate augmentation (H26, PR "
+            "#1177). For each surface vertex, append 3 scalar features "
+            "[p.n, p.t1, p.t2] -- the global position projected onto the "
+            "vertex's local normal/tangent frame -- to the surface input "
+            "features before the projection linear. t1, t2 are a "
+            "Gram-Schmidt tangent basis from the surface normal. Goal: "
+            "give the encoder explicit local-frame position so it can "
+            "break the structural tau_z/tau_x band attractor at [1.44, "
+            "1.55]. The 3 new input columns of project_surface_features "
+            "are zero-init so step 0 is identical to the baseline. Volume "
+            "branch is unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_local_frame_proj=config.use_local_frame_proj,
     )
 
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,52 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Compute per-car tau_z_rel_l2 / tau_x_rel_l2 statistics for H26 diagnostics.
+
+    Iterates over case_ids common to both stores, builds per-case rel_l2 from
+    sqrt(error_sq / target_sq), and reports mean/std/min/max plus an
+    out-of-band counter for the [1.40, 1.60] band attractor probe.
+
+    Returns an empty dict if fewer than 2 common cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1113,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1164,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**H26 — Normal-Projected Coordinate Augmentation (NPCA): augment each surface token's input features with three scalar projections of its global position onto the local surface tangent/normal frame — `[p·n, p·t1, p·t2]` — to break the τ_z/τ_x band attractor at the encoder's input level.**

### Why it might work here

The band attractor `[1.44, 1.55]` for τ_z/τ_x is **structural in the encoder**. Eight Wave 30 attacks on output heads, loss functions, and training dynamics have all failed to break it. H10b's decisive negative result confirmed the 73%/27% mag/dir split is unchanged even when the output activation matches the GT distribution exactly — the bottleneck is upstream.

**Root cause hypothesis**: The encoder's positional encoding receives ONLY global xyz coordinates. Surface normals are injected additively but are NOT used to define the coordinate system in which position is encoded. The model therefore reasons about "where is this vertex?" in global (x,y,z) space — where z (streamwise) dominates automotive bodies, leading to over-assignment of τ_z weight in all slice groupings.

**Mechanism**: By appending `[p·n, p·t1, p·t2]` to features fed through `project_surface_features`, the encoder receives explicit local-frame positional information: how far "into" the surface (normal projection) and how far "along" the surface (tangent projections) each vertex sits. On flat hood/roof panels `p·n ≈ const` and `p·t1, p·t2 ≈ global x, z` — on A-pillar, door-sill, and underbody, the local frame rotates relative to global, so the projections carry geometry-relative information that global xyz cannot.

This explicitly breaks the model's global-z privilege without touching the output head, loss, or training dynamics.

### Why orthogonal to all 7 in-flight + 4 closed Wave 30 attacks

| PR | Student | Attack | Why H26 is orthogonal |
|---|---|---|---|
| H10b (closed) | fern | bounded-exp output activation | H26: encoder input only, no output change |
| H11b | askeladd | gated multi-scale input channels | H26: adds derived coordinate features, different mechanism |
| H12 | edward | per-token τ-magnitude weighted loss | H26: loss-free, encoder side only |
| H17 (closed) | nezuko | OUTPUT tangent-frame reparameterization | H26: INPUT augmentation — output basis remains global, NO convergence gap |
| H18 | tanjiro | per-vertex area-weighted MSE | H26: loss-free |
| H20 (closed) | alphonse | per-vertex focal reweighting | H26: no loss change |
| H21 | nezuko | per-component output heads | H26: encoder-side only, output heads unchanged |
| H22 (closed) | thorfinn | Charbonnier-cp + MAE-aux | H26: no loss change |
| H23 | frieren | Mean Teacher EMA consistency | H26: architectural, no training dynamics |
| H24 | fern | encoder slice-temperature MLP | H24 attacks HOW slices are formed (temperature); H26 attacks WHAT the encoder SEES (input content). Independent. |
| H25 | alphonse | Auxiliary Local-Gradient Prediction | H25: auxiliary loss on backbone; H26: encoder input — different pathways |

**Critical: NOT the same failure mode as H17**. H17 changed what the model PREDICTS (global τ → local-frame τ), requiring 13ep to learn a new output basis. H26 changes what the model SEES as position — the output head remains unchanged, so there is no convergence gap to overcome.

### References

1. **Intrinsic Vector Heat Network** — Gao et al., ICML 2024 (arXiv:2406.09648). Shows treating surface vectors as scalar channels fails to preserve intrinsic surface properties; surface-frame-aware propagation matters.
2. **Beyond Canonicalization** — Lippmann et al., ICLR 2025 (arXiv:2405.15389). Local reference frame canonicalization for geometric deep learning; local frame injection improves normal-vector regression to SOTA.
3. **SE(3)-Transformers** — Fuchs et al., NeurIPS 2020 (arXiv:2006.10503). Anchor for local-frame attention in 3D; global-coordinate attention fails to exploit local geometry.

---

## Instructions

**Code change is ~50-60 lines: ~45-55 in `model.py`, ~5-10 in `train.py`. Do NOT touch loss or output head.**

### Step 1 — Add `compute_local_frame_proj` helper in `model.py`

Add a static helper function near the top of `model.py` (before `SurfaceTransolver` class):

```python
def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
    """
    Compute local surface frame projections of global position.

    Args:
        surface_x: [B, N, >=6] where columns are [x, y, z, nx, ny, nz, ...]

    Returns:
        local_proj: [B, N, 3] with [p·n, p·t1, p·t2] per vertex
    """
    pos = surface_x[:, :, :3]                    # [B, N, 3]
    n = surface_x[:, :, 3:6]                     # [B, N, 3]
    n = F.normalize(n, dim=-1)                   # ensure unit normals

    # Gram-Schmidt tangent basis (deterministic, no learnable params)
    ref_a = torch.tensor([0., 0., 1.], device=n.device, dtype=n.dtype).expand_as(n)
    ref_b = torch.tensor([0., 1., 0.], device=n.device, dtype=n.dtype).expand_as(n)
    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
    ref = torch.where(parallel_mask, ref_b, ref_a)

    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1)
    t2 = torch.cross(n, t1, dim=-1)

    local_n  = (pos * n).sum(-1, keepdim=True)    # [B, N, 1] — p·n
    local_t1 = (pos * t1).sum(-1, keepdim=True)   # [B, N, 1] — p·t1
    local_t2 = (pos * t2).sum(-1, keepdim=True)   # [B, N, 1] — p·t2

    return torch.cat([local_n, local_t1, local_t2], dim=-1)  # [B, N, 3]
```

### Step 2 — Wire it into `SurfaceTransolver`

In `SurfaceTransolver.__init__()`:

```python
# Add parameter
self.use_local_frame_proj = use_local_frame_proj

# When constructing project_surface_features, bump input dim by 3 if enabled
# Find the line that constructs project_surface_features and adjust:
extra_dim = 4  # existing: normals(3) + area(1)
if use_local_frame_proj:
    extra_dim += 3
self.project_surface_features = LinearProjection(extra_dim + rff_out_dim, n_hidden)

# RECOMMENDED: zero-init the 3 NEW input columns so the model starts
# from current baseline behavior (then learns to use them)
if use_local_frame_proj:
    with torch.no_grad():
        # Zero-init the last 3 input columns of project_surface_features.weight
        # The weight shape is [n_hidden, extra_dim + rff_out_dim]
        # The 3 new columns are at positions [4:7] of the extra_dim section
        # (immediately after normals+area, before RFF features)
        self.project_surface_features.weight[:, 4:7].zero_()
```

In `SurfaceTransolver.forward()`:

```python
# Before calling _encode_group for surface tokens:
local_proj = None
if self.use_local_frame_proj:
    local_proj = compute_local_frame_proj(surface_x)

# Pass local_proj into _encode_group as a kwarg
```

In `_encode_group()`:

```python
def _encode_group(self, x, ..., local_proj=None):
    feature_parts = []
    feature_parts.append(x[:, :, self.space_dim:])   # existing: normals + area
    if local_proj is not None:
        feature_parts.append(local_proj)              # NEW: 3 local-frame projections
    # ... existing RFF features ...
    features = torch.cat(feature_parts, dim=-1)
    return self.project_features(features)
```

**Critical: do NOT apply to volume branch.** Volume tokens have no normals; only surface should receive `local_proj`.

### Step 3 — Add `--use_local_frame_proj` flag to `train.py`

```python
parser.add_argument("--use_local_frame_proj", action="store_true",
                    help="Augment surface features with local-frame position projections [p·n, p·t1, p·t2]")
```

Thread this through to model instantiation.

### Step 4 — Diagnostic logging (per-epoch)

Add per-val-car diagnostics to W&B logging (val loop):

```python
# After computing per-channel val metrics per car, compute τz/τx per car:
tau_z_per_car = ...  # [num_val_cars] tensor of val_tau_z_rel_l2_pct per car
tau_x_per_car = ...
ratio_per_car = tau_z_per_car / tau_x_per_car

wandb.log({
    "val/tau_zx_ratio_mean": ratio_per_car.mean().item(),
    "val/tau_zx_ratio_std": ratio_per_car.std().item(),
    "val/tau_zx_ratio_min": ratio_per_car.min().item(),
    "val/tau_zx_ratio_max": ratio_per_car.max().item(),
    "val/tau_zx_ratio_n_outside_band": ((ratio_per_car < 1.40) | (ratio_per_car > 1.60)).sum().item(),
}, commit=False)
```

This is the EP3 mechanism signal.

### Step 5 — Pre-launch budget verification

**CRITICAL**: Before launching the 18h main run:
```bash
printenv SENPAI_TIMEOUT_MINUTES
```
If it shows `360`, post a comment here with the value and consider Path B (6h budget, EP3 gate read). If `1100`, proceed with full 13ep.

### Step 6 — Smoke test (2 GPU, 2 epoch)

```bash
torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --epochs 2 --batch-size 2 \
  --train-surface-points 16384 --eval-surface-points 16384 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model \
  --use_local_frame_proj \
  --wandb-group wave30_h26_npca_smoke \
  --wandb-name thorfinn/h26-npca-smoke \
  --agent thorfinn
```

Smoke PASS criteria:
- `train/loss` descends from EP1 cold-start
- `val/tau_zx_ratio_std` > 0 at val time
- `local_proj` values: report `local_n` range, `local_t1` range, `local_t2` range at first step (expect ~[-2, 2] m)
- No NaN / nonfinite, no OOM
- Identity-init check: at step 0, model output should equal baseline within numerical noise (because new 3 columns are zero-init)

### Step 7 — Full 18h DDP-8 run

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 \
  --use_local_frame_proj \
  --wandb-group wave30_h26_npca \
  --wandb-name thorfinn/h26-npca-18h \
  --agent thorfinn
```

---

## EP Gates (mechanism-decisive)

| EP | Primary gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | val_abupt ≤ ~33% (warmup, not a kill epoch) | `local_proj` values finite, in expected range | sanity only |
| **EP3** | val_abupt ≤ 9.5% | **`std(τz/τx | per-val-car) ≥ 0.04` AND ≥ 1/34 val cars outside [1.40, 1.60]** | **KILL if both gates FAIL or val_abupt > 11%** |
| EP5 | val_abupt ≤ 7.0% | `std(τz/τx) ≥ 0.05`, mean drifting toward ≤ 1.45 | warn if both gates regress |
| EP8 | val_abupt ≤ 6.3% (approaching baseline 6.126%) | `mean(τz/τx) ≤ 1.45` (band lower edge breached) | confirm trajectory |
| EP13 (terminal) | **val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%** | `std(τz/τx) ≥ 0.05` at terminal | MERGE gate |

**EP3 binary gate**: If `std(τz/τx)` stays at ≤ 0.02 (the baseline band-locked variance) AND no val cars are outside [1.40, 1.60] AT EP3, the mechanism is dead — KILL immediately. Do not wait for EP10.

---

## Baseline (PR #972, single-model SOTA — corrected split 2026-05-11)

| Metric | Value | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to MERGE |
| test_abupt | 5.844% | < 5.844% to MERGE |
| test_vol_p | 3.643% | ≤ 3.643% **floor — hard breach blocker** |
| test_SP | 3.577% | ≤ 3.577% **floor — hard breach blocker** |
| test_WSS | 6.727% | < 6.727% to MERGE |

**W&B run:** `56bcqp3m` (source) · `zxnhtagj` (eval)

---

## Terminal SENPAI-RESULT format

```markdown
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0>","<rank1>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Must include:
- **Per-epoch val table** (val_abupt, val_SP, val_vol_p, val_WSS, val_τx, val_τy, val_τz, val_τz/τx mean, val_τz/τx std)
- **Per-epoch `std(τz/τx | per-val-car)` table** — mechanism signal
- **Per-epoch `n_outside_band` count** — vertices outside [1.40, 1.60]
- **Test best-checkpoint reload**: test_abupt, test_vol_p, test_SP, test_WSS, test_τx, test_τy, test_τz, test τz/τx ratio (mean and std across test cars)
- **`local_proj` value-range diagnostic at terminal** (local_n, local_t1, local_t2 min/max/std)
- **8-rank run IDs** + best-checkpoint epoch + source (raw/ema)
- **Comparison vs baseline #972 matched-epoch trajectory** if possible

---

## Context — why this is the bold orthogonal direction now

After H22 closure, the floor-preservation lane via cp-side loss reformulation is closed. The Wave 30 fleet has now ruled out:
- Per-vertex error reweighting (H18, H20)
- Static-Huber on τ (H16, H16b)
- Bounded-exp output activation (H10, H10b)
- Charbonnier on cp (H22)
- Output tangent-frame reparameterization (H17 — convergence gap)

The remaining axes are encoder-level: H24 (slice temperature), H25 (backbone auxiliary loss), H26 (input feature augmentation). H26 attacks the input feature content directly — the most upstream lever that has not yet been pulled. The Gram-Schmidt local frame is parameter-free, deterministic, and produces three new scalar features with **zero added inference cost** beyond the projection-feature linear's slightly larger input dim.

**NO ENSEMBLES.** Single-model gates only.

If H26's EP3 gate passes (band perturbed), the next experiment is the **stack**: H26 + H24 (encoder input + encoder slice temperature, both attacking the band attractor from independent levels). If H26 EP3 fails, the band attractor's source is NOT input feature content, and the diagnosis sharpens for future Wave 31 attacks.
