### PR TITLE
Wave 30 H27: Per-Component Relative-L2 Proxy Loss (PRLP) — train loss in eval metric space to fix floor breach

### DIFF
--- a/train.py
+++ b/train.py
@@ -55,6 +55,7 @@ from trainer_runtime import (
     loader_kwargs,
     make_loaders,
     masked_mse,
+    masked_per_component_rel_l2,
     metric_namespace,
     weighted_channel_mse,
     parse_kill_thresholds,
@@ -138,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    rel_l2_loss: bool = False
     debug: bool = False
 
 
@@ -321,6 +323,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    rel_l2_loss: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,20 +335,40 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
-            )
-        else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
-        weighted_surface_loss = surface_loss_weight * surface_loss
-        weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
-        base_mse_loss = surface_loss + volume_loss
+    if rel_l2_loss:
+        # H27 PRLP: compute per-car per-component rel-L2 in DENORMALIZED
+        # physical space OUTSIDE the autocast context with fp32 throughout.
+        # invert_surface multiplies by std (e.g. ~800 Pa for cp), and the
+        # gradient back through bf16 autocast cached ops produced NaN grads
+        # in the first launch — forcing fp32 here is the standard AMP-safe
+        # pattern for custom losses. surface_channel_weights is intentionally
+        # bypassed: rel-L2 is already per-component normalized.
+        surface_pred_fp32 = out["surface_preds"].float()
+        volume_pred_fp32 = out["volume_preds"].float()
+        surface_pred_denorm = transform.invert_surface(surface_pred_fp32)
+        volume_pred_denorm = transform.invert_volume(volume_pred_fp32)
+        surface_loss = masked_per_component_rel_l2(
+            surface_pred_denorm, batch.surface_y, batch.surface_mask
+        )
+        volume_loss = masked_per_component_rel_l2(
+            volume_pred_denorm, batch.volume_y, batch.volume_mask
+        )
+    else:
+        with autocast_context(device, amp_mode):
+            if surface_channel_weights is not None:
+                surface_loss = weighted_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+            else:
+                surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+    weighted_surface_loss = surface_loss_weight * surface_loss
+    weighted_volume_loss = volume_loss_weight * volume_loss
+    loss = weighted_surface_loss + weighted_volume_loss
+    base_mse_loss = surface_loss + volume_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
@@ -852,6 +875,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.rel_l2_loss:
+                print(
+                    "H27 PRLP: training loss = per-car per-component rel-L2 in "
+                    "DENORMALIZED physical space (surface_channel_weights bypassed)."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +911,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/rel_l2_loss"] = bool(config.rel_l2_loss)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1059,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        rel_l2_loss=config.rel_l2_loss,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1100,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if config.rel_l2_loss:
+                        train_log.update(
+                            {
+                                "train/rel_l2_loss_total": float(loss.detach().cpu().item()),
+                                "train/surface_rel_l2": batch_loss_metrics["surface_loss"],
+                                "train/volume_rel_l2": batch_loss_metrics["volume_loss"],
+                            }
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -903,21 +903,29 @@ def masked_per_component_rel_l2(
 
     Mirrors _accumulate_case_rel_l2 + _rel_l2 but operates per-component
     (axis C) rather than collapsing all channels together.
+
+    Numerical-stability notes:
+      * `sqrt` has an infinite gradient at zero. For rows whose mask is all
+        False, `(num/den) = 0/eps = 0` and the elementwise backward
+        produces `0 * inf = NaN` even though those rows are masked out of
+        the final mean. We therefore select valid rows BEFORE the sqrt.
+      * `clamp_min(eps)` on the ratio guards the rare case where a valid
+        row happens to have `num=0` for some channel.
     """
     if pred.numel() == 0:
         return pred.sum() * 0.0
     pred = pred.float()
     target = target.float()
-    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
-    diff_sq = (pred - target).square() * mask_f       # [B, N, C]
-    target_sq = target.square() * mask_f              # [B, N, C]
-    num = diff_sq.sum(dim=1)                          # [B, C]
-    den = target_sq.sum(dim=1).clamp_min(eps)         # [B, C]
-    per_car_per_comp = (num / den).sqrt()             # [B, C]
     valid_cars = mask.any(dim=1)                      # [B]
     if not bool(valid_cars.any()):
         return pred.sum() * 0.0
-    return per_car_per_comp[valid_cars].mean()
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    diff_sq = (pred - target).square() * mask_f       # [B, N, C]
+    target_sq = target.square() * mask_f              # [B, N, C]
+    num = diff_sq.sum(dim=1)[valid_cars]              # [B_valid, C]
+    den = target_sq.sum(dim=1)[valid_cars].clamp_min(eps)  # [B_valid, C]
+    ratio = (num / den).clamp_min(eps)                # [B_valid, C], bounded
+    return ratio.sqrt().mean()
 
 
 EVAL_KEYS = (

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -887,6 +887,39 @@ def squared_relative_l2_loss(
     return pred.sum() * 0.0
 
 
+def masked_per_component_rel_l2(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Per-car, per-component relative-L2 loss mirroring the eval metric.
+
+    pred, target: [B, N, C] — must be in DENORMALIZED (physical) space.
+    mask: [B, N] bool.
+
+    Computes mean over (valid_cars × components) of:
+        sqrt( sum_points((pred-tgt)^2) / sum_points(tgt^2) )
+
+    Mirrors _accumulate_case_rel_l2 + _rel_l2 but operates per-component
+    (axis C) rather than collapsing all channels together.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    pred = pred.float()
+    target = target.float()
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    diff_sq = (pred - target).square() * mask_f       # [B, N, C]
+    target_sq = target.square() * mask_f              # [B, N, C]
+    num = diff_sq.sum(dim=1)                          # [B, C]
+    den = target_sq.sum(dim=1).clamp_min(eps)         # [B, C]
+    per_car_per_comp = (num / den).sqrt()             # [B, C]
+    valid_cars = mask.any(dim=1)                      # [B]
+    if not bool(valid_cars.any()):
+        return pred.sum() * 0.0
+    return per_car_per_comp[valid_cars].mean()
+
+
 EVAL_KEYS = (
     "surface_pressure",
     "wall_shear",


### PR DESCRIPTION
## Hypothesis

**H27 — Per-Component Relative-L2 Proxy Loss (PRLP): replace the normalized-space MSE training loss with a per-car per-component relative-L2 loss computed in DENORMALIZED (physical) space, making the training objective structurally identical to the evaluation metric.**

### Why it might work here

**Confirmed dual-space mismatch in the code path** (verified at `trainer_runtime.py`):
- **Training loss**: `masked_mse(pred, target, mask)` in **normalized** space (after `transform.apply_surface(batch.surface_y)`)
- **Evaluation metric**: `_accumulate_case_rel_l2 + _rel_l2` in **DENORMALIZED** physical space (after `transform.invert_surface(pred_norm)` vs `batch.surface_y`)

The model is trained to minimize a quantity (normalized-space MSE) that is structurally different from the quantity we rank it by (per-car per-component relative-L2 in physical units). z-scored MSE treats all cars and channels identically; eval rel-L2 normalizes each car by its own target magnitude `Σ_points(tgt²)` per channel.

**Why this is the floor-breach disease candidate**: H10b test_SP=3.755%, H11b val_SP=4.055%, H22 test_SP=4.079% — test_SP floor breach has persisted across every loss-shape change. Loss *shape* in normalized space has been exhausted (H16, H16b, H19, H20, H22). Loss *normalization space* has not been attacked. H27 is the first direct attack on the train-eval space mismatch.

**Mechanism**: per-car rel-L2 in physical units gives the optimizer a gradient landscape proportional to the eval landscape. Cars with high-magnitude targets (high-speed regions, stagnation points) get smaller penalties per unit MSE; cars with low-magnitude targets get larger penalties. If the test-set car distribution has systematically different target magnitudes than train, normalized MSE is a biased proxy.

### Why orthogonal to all 7 in-flight + 6 closed directions

| Hypothesis | Direction | Why H27 orthogonal |
|---|---|---|
| H11b (CLOSED, askeladd's previous) | Gated multi-scale input | H27 changes loss function; **explicitly stackable** with H11b |
| H21 (nezuko, in-flight) | Per-component output heads | H27 changes loss *normalization*; H21 changes head topology |
| H24 (fern, in-flight) | Encoder slice temperature | H27 changes loss only |
| H25 (alphonse, in-flight) | ALGP backbone aux loss | H27 changes primary loss; H25 adds auxiliary loss |
| H26 (thorfinn, in-flight) | NPCA encoder input augmentation | H27 changes loss only |
| H23 (frieren, in-flight) | Mean Teacher consistency | H27 doesn't touch training dynamics |
| H22 (CLOSED) | Charbonnier-cp shape in normalized space | H27 changes *normalization space*, not shape |
| H20 (CLOSED) | Focal per-vertex reweighting | H27 normalizes per-car, not per-vertex |
| H16/H16b (CLOSED) | Static Huber on τ in normalized space | H27 changes normalization space entirely |
| H10/H10b (CLOSED) | Bounded-exp output activation | H27 doesn't touch output activation |
| H17 (CLOSED) | Output tangent-frame reparameterization | H27 doesn't change output basis |

**Composability with H11b**: H11b = input-side multi-scale gating. H27 = output-side loss normalization. Fully stackable. If H27 beats baseline, the next experiment is H27+H11b stack.

### References

1. **Direct Loss Minimization for Structured Prediction** — Hazan et al., NeurIPS 2010. Foundational argument for training with the evaluation metric directly.
2. **A Neural Network Approach to Fluid Simulation** — Thuerey et al., 2020 (arXiv:1806.09065). Training CFD surrogates on physical-space losses improves OOD Reynolds-number generalization.
3. **Loss Functions for Image Restoration with Neural Networks** — Zhao et al., IEEE TCI 2017. Loss space determines optimization basin, not just final value. Directly motivates normalized MSE ≠ per-car rel-L2.

---

## Instructions

**Code change is ~50-65 lines: ~30 in `trainer_runtime.py`, ~20-35 in `train.py`. Do NOT touch model.py.**

### Step 1 — Add new loss function in `trainer_runtime.py`

Add this function after the existing `squared_relative_l2_loss` (around line 885):

```python
def masked_per_component_rel_l2(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    eps: float = 1e-6,
) -> torch.Tensor:
    """Per-car, per-component relative-L2 loss mirroring the eval metric.

    pred, target: [B, N, C] — must be in DENORMALIZED (physical) space.
    mask: [B, N] bool.

    Computes mean over (valid_cars × components) of:
        sqrt( sum_points((pred-tgt)^2) / sum_points(tgt^2) )

    This exactly mirrors _accumulate_case_rel_l2 + _rel_l2 but operates
    per-component (axis C) rather than collapsing all channels together.
    """
    if pred.numel() == 0:
        return pred.sum() * 0.0
    pred = pred.float()
    target = target.float()
    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
    diff_sq = (pred - target).square() * mask_f       # [B, N, C]
    target_sq = target.square() * mask_f              # [B, N, C]
    num = diff_sq.sum(dim=1)                          # [B, C]
    den = target_sq.sum(dim=1).clamp_min(eps)         # [B, C]
    per_car_per_comp = (num / den).sqrt()             # [B, C]
    valid_cars = mask.any(dim=1)                      # [B]
    if not bool(valid_cars.any()):
        return pred.sum() * 0.0
    return per_car_per_comp[valid_cars].mean()
```

### Step 2 — Add CLI flag in `train.py`

```python
parser.add_argument("--rel-l2-loss", action="store_true", default=False,
                    help="Use per-component relative-L2 loss in physical space instead of normalized MSE.")
```

### Step 3 — Plumb the flag into `train_loss()` in `train.py`

In `train_loss()` signature, add `rel_l2_loss=False`:

```python
def train_loss(model, batch, transform, device, amp_mode, *,
               surface_loss_weight=1.0, volume_loss_weight=1.0,
               surface_channel_weights=None, rel_l2_loss=False):
```

In `train_loss()` body, branch on the flag:

```python
    if rel_l2_loss:
        # CRITICAL: Use raw model outputs INVERT-transformed to physical space.
        # Target is batch.surface_y / batch.volume_y directly (already in physical space).
        surface_pred_denorm = transform.invert_surface(out["surface_preds"])
        surface_loss = masked_per_component_rel_l2(
            surface_pred_denorm, batch.surface_y, batch.surface_mask
        )
        volume_pred_denorm = transform.invert_volume(out["volume_preds"])
        volume_loss = masked_per_component_rel_l2(
            volume_pred_denorm, batch.volume_y, batch.volume_mask
        )
    else:
        surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
```

Pass `rel_l2_loss=args.rel_l2_loss` at the call site in the main training loop.

### Step 4 — Add W&B logging for the new loss

```python
if rel_l2_loss:
    wandb.log({
        "train/rel_l2_loss_total": loss.item(),
        "train/surface_rel_l2": surface_loss.item(),
        "train/volume_rel_l2": volume_loss.item(),
    }, commit=False)
```

### Step 5 — Implementation gotchas (READ CAREFULLY)

1. **DO NOT** use the existing `squared_relative_l2_loss` at line 873 — it collapses all channels together with `sum(dim=-1)`, making it impossible to separate SP/τx/τy/τz. It also operates in normalized space. Must be a separate function.

2. **Target is `batch.surface_y` DIRECTLY** — since `surface_target = transform.apply_surface(batch.surface_y)` and `invert_surface(surface_target) = batch.surface_y` exactly, do NOT call `invert_surface(surface_target)`. Use `batch.surface_y` directly to avoid redundant transform.

3. **`transform.invert_surface` takes normalized model OUTPUT** — pass `out["surface_preds"]` (raw model output in normalized space), NOT `surface_target`. The invert is differentiable for typical z-scoring (`x * std + mean`).

4. **AMP / dtype**: Call `.float()` on both pred and target inside the loss function — AMP may produce bf16 and rel-L2 denominator can underflow.

5. **Gradient scale**: rel-L2 is dimensionless, typically [0.05, 0.15]. MSE in normalized space is typically [0.001, 0.01]. Scale difference: do NOT change `surface_loss_weight`/`volume_loss_weight` initially. If training diverges (val_abupt > 9% at EP2), add `--surface-loss-weight 0.5 --volume-loss-weight 0.5` as safety valve.

6. **Disable GradNorm**: do NOT pass `--gradnorm`. The `per_task_train_losses()` function would also need updating; keep this experiment scoped to the loss change only.

7. **Numerical stability**: per-car volume_p denominator can be near-zero for cars with very low pressure fluctuation. The `eps=1e-6` clamp handles this. Watch for `train/rel_l2_loss_total > 10.0` in first 100 steps — if seen, increase eps to `1e-4` and relaunch.

8. **Smoke test first**: Run 2-GPU 2-epoch smoke to verify:
   - `train/rel_l2_loss_total` is finite, stable in [0.03, 0.5]
   - `surface_rel_l2` and `volume_rel_l2` both nonzero, both decreasing
   - val_abupt at EP2 in [10, 22]% (typical EP2 range — slightly higher than MSE EP2 because of warmup in new loss space)

### Step 6 — Pre-launch budget verification

**CRITICAL**: Before launching 18h full DDP-8 run:
```bash
printenv SENPAI_TIMEOUT_MINUTES
```
If `360`, post a comment with the value before launching — H22 hit this bug and was budget-killed at EP3. If `1100`, proceed with full 13ep.

### Step 7 — Full 18h DDP-8 run

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 \
  --rel-l2-loss \
  --wandb-group wave30_h27_prlp \
  --wandb-name askeladd/h27-prlp-18h \
  --agent askeladd
```

---

## EP Gates

| Epoch | Primary gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | val_abupt ≤ 35% (warmup) | `train/rel_l2_loss_total` finite, in [0.03, 0.5] | sanity only — kill if NaN or explodes |
| **EP3** | val_abupt ≤ 8.5% | **val_SP ≤ 4.10%** (strictly below H11b EP3 4.368%) | **KILL if val_SP ≥ 4.40% AND τz/τx still in [1.44, 1.55]** |
| EP5 | val_abupt ≤ 6.5% | val_SP ≤ 4.00% | continue if descending |
| EP8 | val_abupt ≤ 6.3% | val_SP ≤ 3.90%, val_vol_p ≤ 3.70% | confirm on track for floor pass |
| EP13 | **val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%** | val_SP descending below floor | MERGE gate |

**EP3 binary gate**: If `val_SP @ EP3 ≥ 4.40%` AND `τz/τx` still in [1.44, 1.55], the mechanism is NOT working — KILL immediately.

---

## Baseline (PR #972, single-model SOTA — corrected split)

| Metric | Value | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to MERGE |
| test_abupt | 5.844% | < 5.844% to MERGE |
| test_vol_p | 3.643% | ≤ 3.643% **floor — hard breach blocker** |
| test_SP | 3.577% | ≤ 3.577% **floor — hard breach blocker** |
| test_WSS | 6.727% | < 6.727% to MERGE |

**Reference: H11b EP3 baseline** (your previous run): val_abupt=6.411%, val_SP=4.368%, val_vol_p=4.028%, val_WSS=7.166%, τz/τx=1.506. H27 must beat val_SP=4.368% at EP3 to declare mechanism alive.

**Reference comparator @ terminal**: H11b terminal (yours): val_abupt=6.057%, val_SP=4.055%, val_vol_p=3.786%, test_SP=3.7179%, test_vol_p=3.6773%. H27 must hold val_abupt ≤ 6.05% AND drive test_SP below 3.577% to merge.

---

## Terminal SENPAI-RESULT format

```markdown
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Must include:
- **Per-epoch val table** (val_abupt, val_SP, val_vol_p, val_WSS, val_τx, val_τy, val_τz, τz/τx)
- **Per-epoch `train/rel_l2_loss_total`, `surface_rel_l2`, `volume_rel_l2`** trajectory
- **Test best-checkpoint reload** (test_abupt, test_vol_p, test_SP, test_WSS, test τz/τx)
- **Comparison vs H11b at matched epochs** (especially EP3 val_SP — the decisive mechanism signal)
- **8-rank run IDs** + best-checkpoint epoch + source (raw/ema)
- **`surface_rel_l2` vs `val_SP` correlation analysis** — if mechanism is alive, they should track together

---

## Stop conditions / closure paths

**KILL at EP3 if**:
- `val_SP @ EP3 ≥ 4.40%` AND `τz/τx` still in [1.44, 1.55]: new loss gradient not breaking the band, not improving SP
- `train/rel_l2_loss_total > 10.0` after 500 steps: numerical instability — try `eps=1e-4`, relaunch once
- `val_abupt @ EP3 > 9.0%`: training diverged — close direction

**Request changes** if EP3 passes but terminal test_SP > 3.577%: ask askeladd to stack with H11b's multi-scale features (H27b).

**Merge** if EP13 hits all three gates: val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%.

---

## Stackability plan

Assuming H27 passes EP3 gate:

1. **H27 alone beats baseline (val_abupt + floors)**: MERGE, then assign H27+H11b stack to askeladd as H28.
2. **H27 beats val_abupt but test_SP still breaches**: request changes — stack with H11b's multi-scale features.
3. **H27 fails EP3 gate**: close direction. Train-eval normalization mismatch is NOT the disease.

H27 + H11b is the natural compound experiment: input-side multi-scale richness (H11b) + output-side loss-space matching (H27). If both directions are alive, the stack is the first floor-pass candidate in Wave 30.

**NO ENSEMBLES.** Single-model gates only.
