### PR TITLE
Wave 30 H28: SAM Sharpness-Aware Minimization to escape τz/τx band attractor

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    sam_rho: float = 0.0
     debug: bool = False
 
 
@@ -220,6 +221,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "sam_rho": (
+            "SAM perturbation radius (Foret et al., ICLR 2021). "
+            "Two-pass optimizer wrap: backward at w to get g, perturb "
+            "w' = w + rho * g/||g||, backward at w' to get g_hat, "
+            "restore w and apply base optimizer update with g_hat. "
+            "When 0.0, the wrapper is a no-op and behavior matches the "
+            "base optimizer exactly (baseline recovery). With DDP, the "
+            "first backward is wrapped in model.no_sync() so only the "
+            "second backward all-reduces. Doubles forward/backward "
+            "cost during training; inference unchanged."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -262,6 +274,97 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
             use_triton=False,
         )
     raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+
+
+class SAMLion:
+    """Sharpness-Aware Minimization wrapper around any base optimizer.
+
+    Two-pass update (Foret et al., ICLR 2021):
+        1. Forward+backward at w -> compute g = grad L(w).
+        2. ``first_step`` perturbs w in-place by rho * g / ||g||.
+        3. Forward+backward at w' -> compute g_hat = grad L(w').
+        4. ``second_step`` restores w in-place, then calls base_optimizer.step()
+           using g_hat (the gradients currently in p.grad).
+
+    When ``rho == 0.0``, ``first_step`` is a no-op and ``second_step`` calls
+    base_optimizer.step() directly: baseline behavior is recovered exactly.
+    """
+
+    def __init__(self, optimizer: torch.optim.Optimizer, rho: float = 0.0):
+        if rho < 0.0:
+            raise ValueError(f"SAM rho must be >= 0; got {rho}")
+        self.optimizer = optimizer
+        self.rho = float(rho)
+        self.param_groups = optimizer.param_groups
+        self.defaults = getattr(optimizer, "defaults", {})
+        self.state = getattr(optimizer, "state", {})
+        self._e_w: dict[int, torch.Tensor] = {}
+
+    @torch.no_grad()
+    def first_step(self) -> torch.Tensor | None:
+        """Perturb weights in-place by rho * g / ||g||. Returns grad-norm tensor or None."""
+        if self.rho == 0.0:
+            return None
+        norm_sq = torch.zeros((), dtype=torch.float32)
+        device = None
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if device is None:
+                    device = p.grad.device
+                    norm_sq = norm_sq.to(device)
+                norm_sq = norm_sq + p.grad.detach().float().square().sum()
+        grad_norm = norm_sq.sqrt()
+        scale = self.rho / (grad_norm + 1e-12)
+        self._e_w.clear()
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                e_w = p.grad.detach() * scale.to(p.grad.dtype)
+                p.add_(e_w)
+                self._e_w[id(p)] = e_w
+        return grad_norm
+
+    @torch.no_grad()
+    def restore_weights(self) -> None:
+        """Undo first_step's perturbation in-place. Safe to call when rho=0."""
+        if self.rho == 0.0 or not self._e_w:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                e_w = self._e_w.pop(id(p), None)
+                if e_w is not None:
+                    p.sub_(e_w)
+        self._e_w.clear()
+
+    @torch.no_grad()
+    def second_step(self) -> None:
+        """Restore weights then apply the base optimizer's update."""
+        if self.rho == 0.0:
+            self.optimizer.step()
+            return
+        self.restore_weights()
+        self.optimizer.step()
+
+    def step(self) -> None:
+        """Single-pass fallback (rho=0). Use first_step + second_step otherwise."""
+        if self.rho != 0.0:
+            raise RuntimeError(
+                "SAMLion.step() is single-pass and only valid when rho=0. "
+                "Use first_step/second_step for SAM updates."
+            )
+        self.optimizer.step()
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        self.optimizer.zero_grad(set_to_none=set_to_none)
+
+    def state_dict(self) -> dict:
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, sd: dict) -> None:
+        self.optimizer.load_state_dict(sd)
 
 
 def parse_rff_init_sigmas(spec: str) -> list[float] | None:
@@ -781,7 +884,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
+        # Scheduler must see a real torch Optimizer (LRScheduler does an isinstance
+        # check); SAMLion wraps it but shares param_groups by reference, so LR
+        # updates by the scheduler are visible through the wrapper.
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
+        if config.sam_rho > 0.0:
+            optimizer = SAMLion(optimizer, rho=config.sam_rho)
+            if state.is_main:
+                print(
+                    f"SAM enabled (Foret et al. 2021): rho={config.sam_rho}, "
+                    f"two-pass perturb-recompute-restore wrapping "
+                    f"{config.optimizer}. DDP first backward uses no_sync; "
+                    f"second backward all-reduces."
+                )
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
         balancer: GradNormBalancer | None = None
@@ -1076,42 +1191,125 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
                 else:
-                    loss.backward()
-                    if config.grad_clip_norm > 0.0:
-                        grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
-                            base_model.parameters(),
-                            max_norm=config.grad_clip_norm,
+                    sam_active = config.sam_rho > 0.0
+                    # First backward at w. With DDP+SAM, suppress all-reduce
+                    # so only the second backward synchronises gradients.
+                    if sam_active and state.enabled:
+                        with model.no_sync():
+                            loss.backward()
+                    else:
+                        loss.backward()
+
+                    sam_first_grad_norm = None
+                    if sam_active:
+                        # Perturb w in-place using the first-pass gradients.
+                        sam_first_grad_norm = optimizer.first_step()
+                        optimizer.zero_grad(set_to_none=True)
+                        # Recompute loss at perturbed weights; this backward
+                        # is the one whose gradients are all-reduced and
+                        # applied by the base optimizer.
+                        sam_loss_perturbed, _ = train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        )
+                        perturbed_nonfinite = not bool(
+                            torch.isfinite(sam_loss_perturbed.detach()).item()
+                        )
+                        perturbed_skip = distributed_any(
+                            state, perturbed_nonfinite, device
+                        )
+                        train_log["train/sam/perturbed_loss"] = (
+                            float(sam_loss_perturbed.detach().cpu().item())
+                            if not perturbed_nonfinite
+                            else float("nan")
+                        )
+                        train_log["train/sam/perturbed_nonfinite"] = (
+                            1.0 if perturbed_nonfinite else 0.0
+                        )
+                        if sam_first_grad_norm is not None:
+                            train_log["train/sam/first_grad_norm"] = float(
+                                sam_first_grad_norm.detach().cpu().item()
+                            )
+                        if perturbed_skip:
+                            # Restore w (undo perturbation) and skip the step.
+                            optimizer.restore_weights()
+                            optimizer.zero_grad(set_to_none=True)
+                            skip_step = True
+                            train_log["train/step_skipped"] = 1.0
+                        else:
+                            sam_loss_perturbed.backward()
+                    if not skip_step:
+                        if config.grad_clip_norm > 0.0:
+                            grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
+                                base_model.parameters(),
+                                max_norm=config.grad_clip_norm,
+                            )
+                        else:
+                            grad_norm_tensor = global_grad_norm(base_model.parameters(), device)
+                        grad_norm_pre_clip = float(grad_norm_tensor.detach().cpu().item())
+                        grad_is_nonfinite = not math.isfinite(grad_norm_pre_clip)
+                        skip_step = distributed_any(state, grad_is_nonfinite, device)
+                        clipped = (
+                            config.grad_clip_norm > 0.0
+                            and math.isfinite(grad_norm_pre_clip)
+                            and grad_norm_pre_clip > config.grad_clip_norm
+                        )
+                        train_log.update(
+                            {
+                                "train/grad/global_norm_pre_clip": grad_norm_pre_clip,
+                                "train/grad/clipped": 1.0 if clipped else 0.0,
+                                "train/nonfinite_grad": 1.0 if grad_is_nonfinite else 0.0,
+                                "train/step_skipped": 1.0 if skip_step else 0.0,
+                            }
+                        )
+                        gradient_metrics = (
+                            collect_gradient_metrics(
+                                model,
+                                log_histograms=config.log_gradient_histograms,
+                            )
+                            if should_log_gradients and not skip_step
+                            else {}
                         )
                     else:
-                        grad_norm_tensor = global_grad_norm(base_model.parameters(), device)
-                    grad_norm_pre_clip = float(grad_norm_tensor.detach().cpu().item())
-                    grad_is_nonfinite = not math.isfinite(grad_norm_pre_clip)
-                    skip_step = distributed_any(state, grad_is_nonfinite, device)
-                    clipped = (
-                        config.grad_clip_norm > 0.0
-                        and math.isfinite(grad_norm_pre_clip)
-                        and grad_norm_pre_clip > config.grad_clip_norm
-                    )
-                    train_log.update(
-                        {
-                            "train/grad/global_norm_pre_clip": grad_norm_pre_clip,
-                            "train/grad/clipped": 1.0 if clipped else 0.0,
-                            "train/nonfinite_grad": 1.0 if grad_is_nonfinite else 0.0,
-                            "train/step_skipped": 1.0 if skip_step else 0.0,
-                        }
-                    )
-                    gradient_metrics = (
-                        collect_gradient_metrics(
-                            model,
-                            log_histograms=config.log_gradient_histograms,
-                        )
-                        if should_log_gradients and not skip_step
-                        else {}
-                    )
+                        gradient_metrics = {}
                     if skip_step:
+                        # Ensure weights are restored if SAM perturbed them.
+                        if sam_active:
+                            optimizer.restore_weights()
                         optimizer.zero_grad(set_to_none=True)
                     else:
-                        optimizer.step()
+                        if sam_active and should_log_gradients:
+                            # cos(g, g_hat) = e_w · g_hat / (rho * ||g_hat||)
+                            # (e_w = rho * g / ||g||, so g · g_hat = (||g|| / rho) e_w · g_hat).
+                            ew_dot_ghat = torch.zeros((), device=device, dtype=torch.float32)
+                            ghat_sq = torch.zeros((), device=device, dtype=torch.float32)
+                            for group_ in optimizer.param_groups:
+                                for p_ in group_["params"]:
+                                    if p_.grad is None:
+                                        continue
+                                    e_w = optimizer._e_w.get(id(p_))
+                                    if e_w is None:
+                                        continue
+                                    ew_dot_ghat = ew_dot_ghat + (
+                                        e_w.detach().float() * p_.grad.detach().float()
+                                    ).sum()
+                                    ghat_sq = ghat_sq + p_.grad.detach().float().square().sum()
+                            ghat_norm = ghat_sq.sqrt()
+                            denom = config.sam_rho * ghat_norm + 1e-12
+                            cos_sim = ew_dot_ghat / denom
+                            train_log["train/sam/grad_cos_g_ghat"] = float(
+                                cos_sim.detach().cpu().item()
+                            )
+                            train_log["train/sam/second_grad_norm"] = float(
+                                ghat_norm.detach().cpu().item()
+                            )
+                        optimizer.second_step()
                         if ema is not None:
                             ema.update(base_model)
                         weight_metrics = (


### PR DESCRIPTION
## Hypothesis

**H28: Sharpness-Aware Minimization — `sam-sharpness-escape`.** Wrap the Lion optimizer with SAM's two-pass perturb-recompute-restore update (Foret et al. ICLR 2021) to bias optimization toward flat minima and escape the τz/τx ∈ [1.44, 1.55] band attractor that has held across all 13 Wave 30 experiments regardless of loss formulation.

**Why this is the right next experiment for edward:**

- **7 confirmed Wave 30 dead ends share one failure mode**: per-vertex loss-reweighting against the rel_L2 metric geometry (H10b, H11b, H12, H16, H16b, H20, H22). The rel_L2 denominator absorbs absolute-residual reweighting signal — the loss-shape axis is exhaustively saturated.
- **7 active experiments cover input representation, output heads, EMA distillation, encoder geometry, auxiliary tasks, coordinate frames, and proxy losses** (H18, H21, H23, H24, H25, H26, H27).
- **Zero experiments in Wave 30 have touched the optimizer or training dynamics layer**. H28 is the FIRST optimizer-space attack in the wave.
- **τz/τx band attractor [1.44, 1.55] is the geometric signature of a sharp basin**. Lion's momentum bias makes this WORSE not better. SAM's flat-minima bias should disproportionately help the harder-to-generalize channel (wall_shear_z has the largest rel_L2 error and is ~3× larger than wall_shear_x in most runs).

**Theoretical grounding:**

SAM seeks `w*` minimizing loss in a neighbourhood of radius ρ:

```
min_w  max_{||ε||≤ρ}  L(w + ε)
```

First-order implementation:
1. At current `w`, compute gradient `g = ∇L(w)`
2. Perturb: `ŵ = w + ρ · g / ‖g‖₂`
3. Forward + backward at `ŵ` → compute `ĝ = ∇L(ŵ)`
4. Restore `w`, apply Lion update using `ĝ`

When `ρ=0`: `ŵ = w`, `ĝ = g` → **exact baseline recovery** (zero-init path ✓).

External evidence:
- ASAM (Kwon et al. ICML 2021) and SAM on point-cloud / irregular-mesh tasks show the largest gains on OOD evaluation — DrivAerML's 400-train / 34-val / 50-test heterogeneous-geometry split is exactly this regime
- LookSAM (Liu et al. ICLR 2022) confirms SAM combines stably with Lion-class optimizers at ρ ∈ [0.02, 0.10]
- Flat-minima work in scientific ML (Subramanian et al. NeurIPS 2024 on PDEs) shows SAM narrows the train/test gap specifically on OOD physical configurations

**This is NOT an ensemble.** Single model, single forward pass at test time. SAM doubles compute during training only.

## Orthogonality table (vs all 7 closed dead ends + 7 active runs)

| Closed/Active experiment | Mechanism | Vs SAM |
|---|---|---|
| H10b/H11b area-weighted MSE | per-vertex loss weight | optimizer space — orthogonal |
| H16/H16b/H22 Charbonnier/smooth-L1 | loss shape | optimizer space — orthogonal |
| H20 per-vertex error reweighting | per-vertex loss weight | optimizer space — orthogonal |
| H12 per-vertex τ-magnitude weighting | per-vertex loss weight | optimizer space — orthogonal |
| **H18 tanjiro area-weighted (active)** | per-vertex loss weight | optimizer space — orthogonal |
| **H21 nezuko per-component heads (active)** | architecture | optimizer space — orthogonal |
| **H23 frieren EMA self-distillation (active)** | training regularization | **complementary** — flat-minima goal aligns |
| **H24 fern GSTS slice-temp (active)** | encoder geometry | optimizer space — orthogonal |
| **H25 alphonse ALGP aux loss (active)** | loss augmentation | optimizer space — orthogonal |
| **H26 thorfinn NPCA local-frame (active)** | input representation | optimizer space — orthogonal |
| **H27 askeladd PRLP rel-L2 proxy (active)** | loss proxy | optimizer space — orthogonal |

SAM is provably orthogonal to all 13 prior/concurrent experiments.

## Instructions

**Files to modify:**
- `target/train.py` — add `--sam-rho` flag (~5 LOC), `SAMLion` wrapper class (~38 LOC), optimizer construction patch (~5 LOC), training-loop two-pass patch (~12 LOC). **Total ≤60 LOC in 1 file.**

### Step 1 — Add `--sam-rho` argument

In the argument parser block:

```python
parser.add_argument("--sam-rho", type=float, default=0.0,
    help="SAM perturbation radius. 0 = standard Lion (exact baseline recovery).")
```

Default 0.0 preserves baseline behavior exactly.

### Step 2 — Add `SAMLion` wrapper class near optimizer construction

```python
class SAMLion:
    """Two-pass SAM wrapper compatible with any base optimizer.

    When rho=0, first_step() is a no-op and second_step() calls
    optimizer.step() directly — exact baseline recovery guaranteed.
    """
    def __init__(self, optimizer, rho=0.05):
        self.optimizer = optimizer
        self.rho = rho
        self.param_groups = optimizer.param_groups

    @torch.no_grad()
    def first_step(self):
        """Perturb weights by rho * g/||g||. No-op when rho=0."""
        if self.rho == 0.0:
            return
        grad_norm = torch.sqrt(sum(
            p.grad.norm() ** 2
            for group in self.param_groups
            for p in group["params"]
            if p.grad is not None
        ) + 1e-12)
        scale = self.rho / grad_norm
        for group in self.param_groups:
            for p in group["params"]:
                if p.grad is None:
                    continue
                e_w = p.grad * scale
                p.add_(e_w)
                p._sam_e_w = e_w

    @torch.no_grad()
    def second_step(self):
        """Restore weights then apply base optimizer update."""
        if self.rho == 0.0:
            self.optimizer.step()
            return
        for group in self.param_groups:
            for p in group["params"]:
                if hasattr(p, "_sam_e_w"):
                    p.sub_(p._sam_e_w)
                    del p._sam_e_w
        self.optimizer.step()

    def zero_grad(self):
        self.optimizer.zero_grad()

    def state_dict(self):
        return self.optimizer.state_dict()

    def load_state_dict(self, sd):
        self.optimizer.load_state_dict(sd)
```

### Step 3 — Optimizer construction patch

Replace the existing `optimizer = Lion(...)` with:

```python
base_optimizer = Lion(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
optimizer = SAMLion(base_optimizer, rho=args.sam_rho)
```

### Step 4 — Training loop two-pass patch (DDP-aware)

Replace the existing `loss.backward(); optimizer.step(); optimizer.zero_grad()` block with:

```python
# First pass — DDP no_sync to avoid wasted gradient all-reduce
if args.sam_rho > 0.0:
    with model.no_sync():
        loss.backward()
        optimizer.first_step()
        optimizer.zero_grad()
    # Second pass — gradient all-reduce happens here
    out2 = model(surface_x, surface_mask, volume_x, volume_mask)
    loss2 = train_loss(out2, batch, transform, args, ...)
    loss2.backward()
    optimizer.second_step()
    optimizer.zero_grad()
else:
    # rho=0 path — exact baseline behaviour
    loss.backward()
    optimizer.first_step()  # no-op
    optimizer.second_step()  # calls base optimizer.step()
    optimizer.zero_grad()
```

**IMPORTANT — DDP no_sync**: This is critical for SAM-DDP correctness. The first backward's gradients are used locally only (to compute the perturbation); they should NOT be all-reduced. The second backward (at the perturbed weights) is the one whose gradients are all-reduced and applied. Skipping `no_sync()` will halve effective gradient signal.

### Step 5 — Smoke test before launch (200 steps, ~5 min)

Run a 200-step smoke:

```bash
SENPAI_TIMEOUT_MINUTES=10 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --sam-rho 0.05 \
  --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 1 \
  --vol-points-schedule 0:16384 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 16384 --eval-surface-points 16384 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --wandb-group wave30_h28_sam_smoke \
  --wandb-name edward/sam-smoke --agent edward
```

Confirm:
- No `train/nonfinite_loss` or `train/nonfinite_grad` across 200 steps
- `train/loss` descends comparably to baseline
- Throughput ~50% of baseline (SAM doubles forward passes — expected)
- DDP all-reduce only on second backward pass (verify via `dist.all_reduce` count if available)

### Step 6 — Main run (DDP-8, 13 epochs, 36h budget)

```bash
SENPAI_TIMEOUT_MINUTES=2200 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --sam-rho 0.05 \
  --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --grad-clip-norm 0.5 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h28_sam \
  --wandb-name edward/sam-rho0p05-36h --agent edward
```

**Wall-clock**: ~36h expected (2× forward passes per step). The 2200-min budget gives ~1h of slack.

### Step 7 — EP3 falsifiable gate (~6-8h elapsed)

**KILL early if EITHER:**
- `val_primary/abupt_axis_mean_rel_l2_pct > 6.50%` at EP3 (divergence / instability)
- `val_primary/wall_shear_z_rel_l2_pct / val_primary/wall_shear_x_rel_l2_pct > 1.55` at EP3 (deeper in attractor than baseline — sharpness theory falsified)

**PROCEED to EP13 if BOTH:**
- `val_primary/abupt_axis_mean_rel_l2_pct < 6.00%` at EP3 (vs ~7.0% baseline EP3 pace) — descending faster
- `val_primary/wall_shear_z_rel_l2_pct / val_primary/wall_shear_x_rel_l2_pct < 1.42` (band break — τz/τx below the [1.44, 1.55] attractor)

Gate 2 is the key falsifier: if SAM's flat-minima bias is actually helping τz disproportionately, the ratio should drop below the attractor band within 3 epochs.

**MARGINAL if val_abupt 6.0–6.5% AND τz/τx 1.42–1.55**: continue to EP6 second gate, decide there based on slope.

### Step 8 — Reporting

Terminal `SENPAI-RESULT` must include:
- val + test per-epoch table: val_abupt, val_vol_p, val_SP, val_WSS
- test best-checkpoint reload: test_abupt, test_vol_p, test_SP, test_WSS, **test_τ_x, test_τ_y, test_τ_z, test τz/τx ratio**
- best epoch + EMA vs raw checkpoint source
- 8-rank wandb run IDs
- `train/grad/nonfinite_count` final value (must be 0)
- **NEW**: SAM-specific diagnostics — log gradient cosine similarity between first-pass (g) and second-pass (ĝ) gradients to verify SAM is providing genuinely-different update directions

### Optional follow-up arms (ONLY if ρ=0.05 fails EP3 cleanly)

If ρ=0.05 KILL at EP3, quick-test variants before closing optimizer-space direction entirely:
- **ρ=0.02** — milder sharpness, may preserve baseline + small flatness bias
- **ρ=0.10** — aggressive sharpness, may overshoot

Sequence ρ=0.02 first (more conservative). Skip ρ=0.10 if ρ=0.02 also fails — direction closed.

## Baseline (target/BASELINE.md PR #972 single-model SOTA)

| Metric | Baseline | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to merge |
| test_abupt | 5.844% | informational |
| test_WSS | 6.727% | < 6.727% to merge (primary goal) |
| test_vol_p | 3.643% floor | ≤ 3.643% to merge |
| test_SP | 3.577% floor | ≤ 3.577% to merge (BLOCKER for ALL Wave 30 runs to date) |
| test τz/τx | ~1.46 (band [1.44, 1.55]) | < 1.40 = mechanism PASS, < 1.30 = breakthrough |

## What success looks like

- **BIG WIN**: Any arm with test_WSS < 6.609% AND all floors held AND test τz/τx ≤ 1.40 — flat-minima optimization broke the band attractor → opens optimizer-space direction for the lab.
- **MERGE**: test_WSS < 6.727% with both vol_p/SP floors held — single-model winner.
- **PARTIAL**: val_abupt < 6.126% AND τz/τx < 1.44 but test_SP still breaches floor → mechanism active but blocked by separate issue; stack with H27 PRLP (loss-proxy) for H29.
- **FLAT NULL**: ρ=0.05 fails EP3 gate AND ρ=0.02 fails → optimizer-space direction CLOSED, redirects research toward representation (H24, H26) as the surviving live hypotheses.

**Information value of a failure:** A definitive negative result on SAM rules out the entire optimizer-trajectory class of explanations for the τz/τx attractor — that's a load-bearing observation for steering Wave 31 design.

**Source:** Researcher-agent dispatch 2026-05-17 17:50Z. Wave 30 H28. Direct follow-up to H12 closure (7th confirmed loss-shape dead end motivates tier-shift to optimizer dynamics).

**Wave 30 fleet at launch:** 7 active in-flight + H28 = 8/8 students engaged. Closed dead ends: H10b, H11b, H12, H16, H16b, H20, H22 (7). Active: H18, H21, H23, H24, H25, H26, H27, H28.
