### PR TITLE
Wave 30 H29: Spectral Surface Loss with Streamwise Frequency Upweighting (SSFL)

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    lambda_spectral: float = 0.0
+    spectral_hf_weight: float = 2.0
+    spectral_channels: str = "all"
     debug: bool = False
 
 
@@ -229,6 +232,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "lambda_spectral": (
+            "Weight for the streamwise spectral surface loss (H29 SSFL). "
+            "Sorts surface tokens by z, applies torch.fft.rfft along the "
+            "sorted-N axis, and computes a frequency-weighted MSE on the "
+            "FFT residuals with a linear bin weight 1.0 -> "
+            "--spectral-hf-weight from DC to Nyquist. At 0.0 the spectral "
+            "term is exactly zero and the baseline is recovered."
+        ),
+        "spectral_hf_weight": (
+            "Linear-ramp upper bound for the spectral surface loss bin "
+            "weight at the Nyquist frequency. 1.0 = flat (uniform across "
+            "bins, no high-frequency emphasis); >1.0 amplifies the "
+            "high-spatial-frequency gradient signal."
+        ),
+        "spectral_channels": (
+            "Which surface output channels receive the spectral loss: "
+            "'all' applies it to cp + 3-channel wall shear, 'wss' only to "
+            "wall shear (channels 1-3), 'cp' only to surface pressure "
+            "(channel 0)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -262,6 +285,102 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
             use_triton=False,
         )
     raise ValueError(f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion.")
+
+
+SPECTRAL_CHANNELS_CHOICES = ("all", "wss", "cp")
+
+
+def parse_spectral_channels(spec: str) -> torch.Tensor | None:
+    """Build the per-channel mask for the spectral surface loss.
+
+    Returns ``None`` for the all-channels case (the spectral loss
+    applies to every surface output channel). Returns a length-4 bool
+    tensor selecting cp (channel 0) or the three wall-shear axes
+    (channels 1, 2, 3) for the other two choices. Surface targets are
+    laid out as [cp, tau_x, tau_y, tau_z].
+    """
+
+    spec = (spec or "all").strip().lower()
+    if spec == "all":
+        return None
+    if spec == "wss":
+        return torch.tensor([False, True, True, True], dtype=torch.bool)
+    if spec == "cp":
+        return torch.tensor([True, False, False, False], dtype=torch.bool)
+    raise ValueError(
+        f"--spectral-channels must be one of {SPECTRAL_CHANNELS_CHOICES}; got {spec!r}"
+    )
+
+
+def spectral_surface_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    surface_z: torch.Tensor,
+    *,
+    lambda_spectral: float,
+    hf_weight: float,
+    channel_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Streamwise spectral surface loss (H29 SSFL).
+
+    Sorts surface tokens along the streamwise (z) coordinate per case,
+    applies ``torch.fft.rfft`` along the sorted-N axis, and computes a
+    frequency-weighted MSE on the FFT residuals. The frequency weight
+    ramps linearly from 1.0 at DC to ``hf_weight`` at Nyquist, so high-
+    spatial-frequency content (separation events in streamwise
+    coordinates) receives amplified gradient.
+
+    Inputs are cast to fp32 before the FFT regardless of the upstream
+    autocast dtype: ``torch.fft.rfft`` does not support bf16 in PyTorch
+    2.x. Masked tokens are zero-padded before the FFT (no windowing) to
+    avoid leakage from the padding boundary while preserving the true
+    fore/aft signal of the car. At ``lambda_spectral == 0.0`` the
+    function returns an exact zero with no gradient contribution, so
+    the baseline is recovered bit-for-bit.
+    """
+
+    if lambda_spectral == 0.0:
+        return pred.new_zeros(())
+
+    # Surface-empty batches occur when the loader repeats a case to cover
+    # the larger volume-view count: the surface branch returns a zero-row
+    # tensor. ``torch.fft.rfft`` errors on N=0 (and the loss is identically
+    # zero anyway), so short-circuit and let the gradient stay connected.
+    if pred.shape[1] == 0:
+        return lambda_spectral * pred.float().sum() * 0.0
+
+    pred_f = pred.float()
+    target_f = target.float()
+    sort_idx = surface_z.argsort(dim=1).long()
+    _, _, C = pred_f.shape
+
+    idx = sort_idx.unsqueeze(-1).expand(-1, -1, C)
+    pred_s = pred_f.gather(1, idx)
+    tgt_s = target_f.gather(1, idx)
+    msk_s = mask.gather(1, sort_idx).to(dtype=pred_f.dtype).unsqueeze(-1)
+    pred_s = pred_s * msk_s
+    tgt_s = tgt_s * msk_s
+
+    # norm="ortho" makes Parseval exact (sum|x|^2 == sum|X|^2), so the spectral
+    # MSE is on the same scale as the time-domain MSE. Without it, the default
+    # "backward" norm scales |X|^2 by N (~65k surface tokens), and the spectral
+    # term would dwarf the base MSE by ~1000x at lambda=0.1. The ortho convention
+    # also matches the advisor's expected magnitude of ~0.001-1.0 for the
+    # mechanism check.
+    pf = torch.fft.rfft(pred_s, dim=1, norm="ortho")
+    tf = torch.fft.rfft(tgt_s, dim=1, norm="ortho")
+
+    n_bins = pf.shape[1]
+    w = torch.linspace(
+        1.0, hf_weight, n_bins, device=pf.device, dtype=pf.real.dtype
+    ).view(1, -1, 1)
+
+    diff = pf - tf
+    sq = diff.real.square() + diff.imag.square()
+    if channel_mask is not None:
+        sq = sq * channel_mask.to(device=sq.device, dtype=sq.dtype).view(1, 1, -1)
+    return lambda_spectral * (sq * w).mean()
 
 
 def parse_rff_init_sigmas(spec: str) -> list[float] | None:
@@ -321,6 +440,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    lambda_spectral: float = 0.0,
+    spectral_hf_weight: float = 2.0,
+    spectral_channel_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -344,14 +466,26 @@ def train_loss(
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+    # Spectral loss runs outside the autocast scope because torch.fft.rfft
+    # does not support bf16 in PyTorch 2.x; spectral_surface_loss casts to fp32.
+    spectral_loss = spectral_surface_loss(
+        out["surface_preds"],
+        surface_target,
+        batch.surface_mask,
+        batch.surface_x[:, :, 2],
+        lambda_spectral=lambda_spectral,
+        hf_weight=spectral_hf_weight,
+        channel_mask=spectral_channel_mask,
+    )
+    loss = weighted_surface_loss + weighted_volume_loss + spectral_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "spectral_loss": float(spectral_loss.detach().cpu().item()),
     }
 
 
@@ -712,6 +846,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         config = parse_args(argv)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
+        # Fail fast if --spectral-channels is invalid; the mask itself is rebuilt
+        # on-device after init_distributed configures the device.
+        parse_spectral_channels(config.spectral_channels)
         requested_epochs = config.epochs
         if os.environ.get("SENPAI_MAX_EPOCHS"):
             requested_epochs = min(requested_epochs, int(os.environ["SENPAI_MAX_EPOCHS"]))
@@ -758,6 +895,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        spectral_channel_mask = parse_spectral_channels(config.spectral_channels)
+        if spectral_channel_mask is not None:
+            spectral_channel_mask = spectral_channel_mask.to(device)
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1030,6 +1170,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        lambda_spectral=config.lambda_spectral,
+                        spectral_hf_weight=config.spectral_hf_weight,
+                        spectral_channel_mask=spectral_channel_mask,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1213,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "spectral_loss" in batch_loss_metrics:
+                        train_log["train/spectral_loss"] = batch_loss_metrics["spectral_loss"]
+                        train_log["train/lambda_spectral"] = config.lambda_spectral
+                        train_log["train/spectral_hf_weight"] = config.spectral_hf_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Spectral Surface Loss with Streamwise Frequency Upweighting (SSFL)** — first frequency-domain loss attack in all of Wave 30 and DrivAerML experiment history.

### Mechanism

The τz/τx band attractor [1.44, 1.55] has now survived **8 confirmed Wave 30 dead ends** spanning loss shape (H10b, H11b, H12, H16, H16b, H20, H22), per-vertex weighting, and training regularization (your H23 closure). One axis has never been tested: **the spectral content of the surface field loss signal**.

**Physical motivation:** Wall shear stress in streamwise direction (τz) is dominated by separation events — boundary-layer detachment behind windshield, A-pillars, mirrors, trailing edge. These are **localized, high-spatial-frequency events** in streamwise coordinates. Surface pressure (cp) is smooth and dominated by low-frequency curvature variation. The MSE loss treats all tokens identically, so the gradient signal for sharp separation features is diluted across smooth-region tokens.

**The intervention:** Sort surface tokens by streamwise coordinate z, apply `torch.fft.rfft` along the sorted-N dimension, compute frequency-weighted MSE that linearly ramps from 1.0× at DC to `hf_weight=2.0×` at Nyquist. The model receives amplified gradient from separation events → τz floor breach closes.

**Why this is orthogonal to all 8 closed Wave 30 attacks:** H29 weights **spatial frequency bins**, not per-vertex residuals, not per-channel scalars, not per-error-magnitude, not loss shape, not training regularization. Fully composable with H27 PRLP (loss-space) and H28 SAM (optimizer-space) for H30 stacking.

**F-principle grounding** (Xu et al. 2020): Gradient descent provably preferentially learns low-frequency components first. High-frequency upweighting in the loss directly counteracts this bias — established theoretical grounding for why spectral upweighting helps sharp features.

### Causal chain

1. Sort surface tokens by streamwise z → consistent spatial ordering across all cars
2. Apply `rfft` along sorted-N axis → decompose into spatial frequency bins k=0,...,N//2
3. Compute `(pred_fft - tgt_fft)^2 * w(k)` where `w(k) = linspace(1.0, hf_weight, N//2+1)` → high-k bins receive `hf_weight×` more gradient
4. Add `λ_spectral * spectral_loss` to standard normalized-space MSE
5. Model receives amplified gradient from separation events → τz floor breach should close

At `λ_spectral=0.0`, the spectral term is exactly zero — **baseline recovery guarantee**.

---

## Instructions

Add ~70 lines to `train.py` only. **No changes to `model.py`, `trainer_runtime.py`, or any read-only file.**

### Section A — Argument parser additions (~5 LOC)

Add after existing loss-weight arguments:

```python
parser.add_argument(
    "--lambda-spectral", type=float, default=0.0,
    help="Weight for spectral surface loss. 0.0 = exact baseline recovery."
)
parser.add_argument(
    "--spectral-hf-weight", type=float, default=2.0,
    help="Linear ramp upper bound for high-frequency bin weight (1.0 = flat)."
)
parser.add_argument(
    "--spectral-channels", type=str, default="all",
    choices=["all", "wss", "cp"],
    help="Which surface output channels to apply spectral loss to."
)
```

### Section B — Spectral loss function (~25 LOC)

Add near the existing `masked_mse` function:

```python
def spectral_surface_loss(
    pred_norm: torch.Tensor,   # [B, N, C], normalized predictions
    target_norm: torch.Tensor, # [B, N, C], normalized targets
    mask: torch.Tensor,        # [B, N], bool
    sort_idx: torch.Tensor,    # [B, N], long — argsort of streamwise z-coord
    lambda_spectral: float = 0.0,
    hf_weight: float = 2.0,
    channel_mask: torch.Tensor = None,  # [C] bool, selects which channels
) -> torch.Tensor:
    """Spectral MSE loss in streamwise-sorted spatial frequency space."""
    if lambda_spectral == 0.0:
        return pred_norm.new_tensor(0.0)

    B, N, C = pred_norm.shape
    idx = sort_idx.unsqueeze(-1).expand(-1, -1, C)      # [B, N, C]
    pred_s = pred_norm.gather(1, idx)
    tgt_s = target_norm.gather(1, idx)
    msk_s = mask.gather(1, sort_idx).float()

    # Zero padded tokens before FFT (avoid spectral leakage)
    pred_s = pred_s * msk_s.unsqueeze(-1)
    tgt_s = tgt_s * msk_s.unsqueeze(-1)

    pf = torch.fft.rfft(pred_s, dim=1)
    tf = torch.fft.rfft(tgt_s, dim=1)

    n_bins = pf.shape[1]
    w = torch.linspace(1.0, hf_weight, n_bins, device=pf.device,
                       dtype=pf.real.dtype).view(1, -1, 1)

    diff = pf - tf
    sq = diff.real**2 + diff.imag**2

    if channel_mask is not None:
        sq = sq * channel_mask.view(1, 1, -1).to(sq.device)

    return lambda_spectral * (sq * w).mean()
```

### Section C — Sort index computation in training loop (~8 LOC)

Add once per batch BEFORE forward pass:

```python
surface_z = surface_x[:, :, 2]              # streamwise coordinate [B, N]
sort_idx = surface_z.argsort(dim=1).long()  # [B, N]
```

Build channel_mask once at startup (outside the loop):

```python
if args.spectral_channels == "wss":
    _spec_chan = torch.tensor([False, True, True, True], dtype=torch.bool)
elif args.spectral_channels == "cp":
    _spec_chan = torch.tensor([True, False, False, False], dtype=torch.bool)
else:
    _spec_chan = None
```

### Section D — Loss accumulation (~7 LOC)

Add after standard MSE loss computation:

```python
loss_spectral = spectral_surface_loss(
    out["surface_preds"],
    surface_target,
    batch.surface_mask,
    sort_idx,
    lambda_spectral=args.lambda_spectral,
    hf_weight=args.spectral_hf_weight,
    channel_mask=_spec_chan,
)
loss = loss + loss_spectral
wandb.log({"train/spectral_loss": loss_spectral.item()})
```

### Important implementation gotchas

1. **AMP/bf16 safety:** if `pf.real.dtype != torch.float32`, call `.float()` on `pred_norm` and `target_norm` inside the function. **Critically — same lesson as askeladd's H27 NaN fix: compute the spectral loss in fp32 outside the autocast context. The FFT and squared-residual path is precision-sensitive.**

2. **Padding zeros before FFT is load-bearing** — `pred_s = pred_s * msk_s.unsqueeze(-1)` line removes leakage from padding artifacts.

3. **Sort is per-step** — argsort is inexpensive on GPU; don't cache.

4. **Volume tokens NOT included** — H29 applies to surface tokens only.

5. **GradNorm interaction safe** — spectral loss is additive to surface MSE, not a separate task.

6. **`channel_mask` for `wss`** selects τx, τy, τz (channels 1, 2, 3 — cp is channel 0).

---

## Recipe

```bash
SENPAI_TIMEOUT_MINUTES=1100 \
torchrun --nproc_per_node=8 train.py \
  --dataset_path /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 \
  --optimizer lion \
  --hidden-dim 512 \
  --slices 128 \
  --batch-size 4 \
  --vol-schedule "0:16384:3:32768:6:49152:9:65536" \
  --epochs 13 \
  --lambda-spectral 0.1 \
  --spectral-hf-weight 2.0 \
  --spectral-channels wss \
  --wandb-group wave30-ssfl \
  --run-name frieren-h29-ssfl-streamwise-spectral
```

**Parameter rationale:**
- `--lambda-spectral 0.1` — spectral term adds ~10% of total loss at EP1. Conservative.
- `--spectral-hf-weight 2.0` — doubles gradient at Nyquist vs. DC. Minimum meaningful ramp.
- `--spectral-channels wss` — apply spectral loss only to τx/τy/τz. cp is smooth and may destabilize. Start WSS-only.
- `--lr 9e-5` — DO NOT CHANGE (5e-4 caused 4 divergences fleet-wide)
- `SENPAI_TIMEOUT_MINUTES=1100` — same as baseline; H29 does NOT increase forward pass count (unlike H28 SAM).

**Alternative Arm B (run ONLY if Arm A kills at EP3):**

```bash
... (same base args) ...
  --lambda-spectral 0.05 \
  --spectral-hf-weight 4.0 \
  --spectral-channels all \
  --run-name frieren-h29b-ssfl-all-channels
```

---

## EP3 falsifiable gate

**ALIVE at EP3 if ALL THREE hold:**

| Metric | Threshold | Why |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 8.5% | Training has not diverged (generous; spectral loss may slow early descent) |
| `val_primary/wall_shear_z_rel_l2_pct / val_primary/wall_shear_x_rel_l2_pct` | **≤ 1.42** | **PRIMARY FALSIFIER** — τz/τx breaks below [1.44, 1.55] band attractor |
| `train/spectral_loss` | DESCENDING EP1→EP3 | Model is learning to match the spectral signature |

**KILL gate (any one triggers kill at EP3):**

| Metric | Threshold | Why |
|---|---|---|
| `val_abupt` | > 9.5% | Training has diverged; spectral loss destabilizing |
| `τz/τx` | > 1.55 | Spectral loss is making τz WORSE (wrong direction) |
| `train/spectral_loss` | flat/increasing EP1→EP3 | Spectral term gradient too weak or numerical issues |

**Mechanism check at EP1 (post first epoch, ~1.5h):**
- `train/spectral_loss` should land in [0.001, 1.0]. If > 10, halve λ. If < 1e-4, spectral term is negligible (halve hf_weight ramp).

**Stop condition for spectral loss direction:** If Arm A fails EP3 gate AND Arm B (λ=0.05, hf_weight=4.0, all channels) also fails EP3 gate, close the direction. Do not try a third λ.

---

## Baseline

Current best (PR #972, run `56bcqp3m`):

| Metric | Baseline | Direction |
|---|---|---|
| **val_abupt** | **6.126%** | merge gate |
| test_abupt | 5.844% | report only |
| **test_vol_p** | **3.643%** | floor |
| **test_SP** | **3.577%** | floor |
| test_WSS | 6.727% | goal <5.85% |

**Reproduce baseline (#972 recipe):**
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --dataset_path /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --optimizer lion --hidden-dim 512 --slices 128 --batch-size 4 \
  --vol-schedule "0:16384:3:32768:6:49152:9:65536" --epochs 13
```

---

## Predicted outcomes

**If H29 SUCCEEDS:**
- τz/τx drops below 1.42 by EP3, declines through EP13
- val_abupt < 6.0% at terminal — new fleet best
- test_WSS improves from 6.727% toward <6.0% (τz dominates WSS error)
- Stackable with H27 PRLP and H28 SAM for H30

**If H29 FAILS:**
- τz/τx stays in [1.44, 1.55] — separation-zone spectral deficit is NOT the cause of the floor
- Decisively rules out spatial-frequency explanation
- Combined with H28 SAM failure (if applicable), would point unambiguously at representation level (H24 GSTS, H26 NPCA) as the floor explanation

**Information value of failure:** Closing the frequency-domain axis would be the cleanest decisive negative we have — refining the research map to representation-or-optimization, no loss-side path remaining.

---

## Why this is Plateau Protocol tier-shift

8 confirmed Wave 30 dead ends span:
- Per-vertex/per-token loss-shape (H10b, H11b, H12, H16, H16b, H20, H22)
- Training regularization (H23 — your previous attempt)

The frequency-domain axis is **completely untested** in DrivAerML history. H29 attacks the spatial-frequency content of the gradient signal — orthogonal to every axis explored to date. This is the Plateau Protocol mandate: when 5+ consecutive experiments fail in a tier, escalate to a new tier. We're now at 8 closures in the loss-shape/regularization tier.

---

## Taste rubric

| Criterion | Score | Justification |
|---|---|---|
| Mechanistic grounding | **4/4** | Separation events are localized high-spatial-frequency in streamwise coordinates; F-principle (Xu et al. 2020) formally proves gradient descent preferentially learns low-frequency first; rfft + frequency ramp directly counteracts the bias. τz/τx band exit at EP3 is a concrete falsifier. |
| Research-state value | **4/4** | Either H29 breaks the band (confirms spectral imbalance hypothesis, opens frequency-domain stacking with H27/H28) or it doesn't (rules out spatial-frequency decisively). Result sharply updates the research map in both directions. |
| Execution value | **4/4** | ~70 LOC train.py only, no model changes, baseline-compute (no forward-pass doubling unlike H28), λ=0.0 exact baseline recovery, EP3 gate at ~6h wall-clock, clear Arm B fallback. Highest information-per-compute candidate in the queue. |

**Overall: 4/4/4** — Theoretically grounded in CFD physics + F-principle, sharply falsifiable at EP3, baseline-compute cost with zero-risk default path.

---

## Reference literature

1. **F-principle** (Xu et al. 2020) — formally proves GD preferentially learns low-frequency first. [arxiv.org/abs/1901.06523]
2. **Fourier Feature Networks** (Tancik et al., NeurIPS 2020) — MSE in direct feature space starves high-frequency components. [arxiv.org/abs/2006.10739]
3. **PINNs for Turbulence** (Wang et al. 2020) — spectral losses in Fourier-space residuals improve separation bubble prediction. [arxiv.org/abs/2005.04236]
4. **Thuerey et al. 2020** — spatial-frequency imbalance causes oversmoothing of aerodynamic shear boundaries. [arxiv.org/abs/1806.09065]
5. **Spectral Methods in Fluid Dynamics** (Canuto et al. 2006) — separation zones concentrate energy in mid-to-high streamwise wavenumbers.
