### PR TITLE
Wave 30 H18d: Channel-decoupled τ_z-only area weighting (isolate band-break mechanism)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,7 +54,10 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    compute_area_vertex_weights,
+    channel_decoupled_area_weighted_mse,
     masked_mse,
+    masked_weighted_mse,
     metric_namespace,
     weighted_channel_mse,
     parse_kill_thresholds,
@@ -105,6 +108,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    use_area_weighted_loss: bool = False
+    area_weight_channels: str = "all"
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -220,6 +225,24 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "use_area_weighted_loss": (
+            "Enable per-vertex area-weighted surface loss (H18). Each surface "
+            "vertex's squared error is multiplied by its panel area, "
+            "normalized so the mean weight over masked vertices per sample is "
+            "1.0 — preserves loss magnitude vs. uniform-MSE so existing LR / "
+            "channel weights remain calibrated. Volume pressure is unaffected. "
+            "Combine with --area-weight-channels to control which surface "
+            "channels receive the area weighting (H18d channel decoupling)."
+        ),
+        "area_weight_channels": (
+            "Surface channels that receive per-vertex area weighting when "
+            "--use-area-weighted-loss is on. 'all' (default) applies the area "
+            "weight to cp, tau_x, tau_y, tau_z uniformly (matches H18). "
+            "'tau_z_only' (H18d main) applies the area weight ONLY to tau_z "
+            "(channel 3); cp/tau_x/tau_y use uniform vertex weighting to "
+            "avoid low-area starvation of the cp loss. 'wss' applies the "
+            "area weight to tau_x/tau_y/tau_z; cp uses uniform weighting."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -240,7 +263,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    allowed_awc = {"all", "tau_z_only", "wss"}
+    if config.area_weight_channels not in allowed_awc:
+        raise ValueError(
+            f"--area-weight-channels must be one of {sorted(allowed_awc)}, "
+            f"got {config.area_weight_channels!r}"
+        )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -321,10 +351,17 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_area_weighted_loss: bool = False,
+    area_weight_channels: str = "all",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    vertex_weights: torch.Tensor | None = None
+    area_metrics: dict[str, float] = {}
+    if use_area_weighted_loss:
+        vertex_weights = compute_area_vertex_weights(batch.surface_x, batch.surface_mask)
+        area_metrics = _area_weight_diagnostics(vertex_weights, batch.surface_mask)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,12 +369,26 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if vertex_weights is not None and area_weight_channels != "all":
+            surface_loss = channel_decoupled_area_weighted_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                vertex_weights=vertex_weights,
+                channel_weights=surface_channel_weights,
+                area_weight_channels=area_weight_channels,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
+                vertex_weights=vertex_weights,
+            )
+        elif vertex_weights is not None:
+            surface_loss = masked_weighted_mse(
+                out["surface_preds"], surface_target, batch.surface_mask, vertex_weights
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
@@ -346,12 +397,36 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+    }
+    metrics.update(area_metrics)
+    return loss, metrics
+
+
+def _area_weight_diagnostics(
+    vertex_weights: torch.Tensor,
+    surface_mask: torch.Tensor,
+) -> dict[str, float]:
+    """Summary stats for the per-vertex area weights (masked vertices only)."""
+    with torch.no_grad():
+        mask_bool = surface_mask.bool()
+        valid_weights = vertex_weights[mask_bool]
+        if valid_weights.numel() == 0:
+            return {}
+        w_max = float(valid_weights.max().item())
+        w_min = float(valid_weights.min().item())
+        w_p95 = float(torch.quantile(valid_weights.float(), 0.95).item())
+        dyn_range = w_max / max(w_min, 1e-8)
+    return {
+        "area_weighted/vertex_weight_max": w_max,
+        "area_weighted/vertex_weight_min": w_min,
+        "area_weighted/vertex_weight_p95": w_p95,
+        "area_weighted/effective_dynamic_range": dyn_range,
     }
 
 
@@ -364,6 +439,9 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_area_weighted_loss: bool = False,
+    area_weight_channels: str = "all",
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -371,11 +449,20 @@ def per_task_train_losses(
     All five share the same forward graph so the GradNorm balancer can
     extract per-task gradient norms via ``torch.autograd.grad`` with
     ``retain_graph=True``.
+
+    When ``use_area_weighted_loss`` is True the area weight is applied per
+    surface channel according to ``area_weight_channels`` (matches the main
+    train_loss path): ``all`` weights every channel; ``tau_z_only`` weights
+    only tau_z; ``wss`` weights tau_x/tau_y/tau_z. Volume pressure stays
+    unweighted since it lives on a different mesh.
     """
 
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    vertex_weights: torch.Tensor | None = None
+    if use_area_weighted_loss:
+        vertex_weights = compute_area_vertex_weights(batch.surface_x, batch.surface_mask)
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -384,10 +471,35 @@ def per_task_train_losses(
             volume_mask=batch.volume_mask,
         )
         surface_pred = out["surface_preds"]
-        sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
-        taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
-        tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
-        tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+        if vertex_weights is not None:
+            apply_cp = area_weight_channels == "all"
+            apply_taux = area_weight_channels in ("all", "wss")
+            apply_tauy = area_weight_channels in ("all", "wss")
+            apply_tauz = True  # all 3 modes weight tau_z
+
+            def _ch_loss(slice_idx: slice, apply_w: bool) -> torch.Tensor:
+                if apply_w:
+                    return masked_weighted_mse(
+                        surface_pred[..., slice_idx],
+                        surface_target[..., slice_idx],
+                        batch.surface_mask,
+                        vertex_weights,
+                    )
+                return masked_mse(
+                    surface_pred[..., slice_idx],
+                    surface_target[..., slice_idx],
+                    batch.surface_mask,
+                )
+
+            sp_loss = _ch_loss(slice(0, 1), apply_cp)
+            taux_loss = _ch_loss(slice(1, 2), apply_taux)
+            tauy_loss = _ch_loss(slice(2, 3), apply_tauy)
+            tauz_loss = _ch_loss(slice(3, 4), apply_tauz)
+        else:
+            sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
+            taux_loss = masked_mse(surface_pred[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+            tauy_loss = masked_mse(surface_pred[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+            tauz_loss = masked_mse(surface_pred[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
         vp_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
     return [sp_loss, taux_loss, tauy_loss, tauz_loss, vp_loss]
 
@@ -883,6 +995,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_area_weighted_loss"] = config.use_area_weighted_loss
+            wandb.summary["loss/area_weight_channels"] = config.area_weight_channels
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -937,10 +1051,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                area_diag_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        use_area_weighted_loss=config.use_area_weighted_loss,
+                        area_weight_channels=config.area_weight_channels,
                     )
+                    if config.use_area_weighted_loss:
+                        with torch.no_grad():
+                            _vw = compute_area_vertex_weights(
+                                batch.surface_x.to(device), batch.surface_mask.to(device)
+                            )
+                            area_diag_metrics = _area_weight_diagnostics(
+                                _vw, batch.surface_mask.to(device)
+                            )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
                     )
@@ -1030,7 +1159,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_area_weighted_loss=config.use_area_weighted_loss,
+                        area_weight_channels=config.area_weight_channels,
                     )
+                    if config.use_area_weighted_loss:
+                        for diag_key in (
+                            "area_weighted/vertex_weight_max",
+                            "area_weighted/vertex_weight_min",
+                            "area_weighted/vertex_weight_p95",
+                            "area_weighted/effective_dynamic_range",
+                        ):
+                            if diag_key in batch_loss_metrics:
+                                area_diag_metrics[diag_key] = batch_loss_metrics.pop(diag_key)
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1072,6 +1212,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if area_diag_metrics:
+                    train_log.update({f"train/{k}": v for k, v in area_diag_metrics.items()})
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,11 +837,35 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_weighted_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    vertex_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Per-vertex-weighted masked MSE.
+
+    pred / target: [B, N, C]; mask: [B, N]; vertex_weights: [B, N].
+    ``vertex_weights`` should be pre-normalized so the mean over masked
+    vertices in each sample equals 1.0; this preserves the loss magnitude
+    relative to ``masked_mse`` and keeps existing learning rates / channel
+    weights calibrated. Weights are broadcast over the channel axis so the
+    same vertex weighting applies to every output channel.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    weights_dev = vertex_weights.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    sq_err = (pred - target).square()
+    weighted_sq_err = sq_err * weights_dev
+    return masked_mean(weighted_sq_err, mask)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,
     mask: torch.Tensor,
     weights: torch.Tensor,
+    vertex_weights: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Per-channel weighted masked MSE with a single mean over all entries.
 
@@ -852,6 +876,12 @@ def weighted_channel_mse(
     and only changes the relative gradient budget across channels — it does NOT
     decompose into per-channel means (which would double-weight the smaller
     channels and was the failure mode of PR #353).
+
+    When ``vertex_weights`` is supplied ([B, N], normalized so mean over masked
+    vertices = 1), each vertex's squared error is also multiplied by its own
+    weight. Channel and vertex weights compose multiplicatively; the
+    pre-normalization keeps the overall scale equal to ``weighted_channel_mse``
+    with uniform vertex weights.
     """
     if pred.numel() == 0:
         return pred.sum() * 0.0
@@ -863,9 +893,118 @@ def weighted_channel_mse(
     sq_err = (pred - target).square()
     mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     weighted = sq_err * weights_dev * mask_dev
+    if vertex_weights is not None:
+        weighted = weighted * vertex_weights.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
+def compute_area_vertex_weights(
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    area_channel_idx: int = 6,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Per-sample area-normalized vertex weights for surface losses.
+
+    surface_x: [B, N, C_in] with raw per-vertex panel area at channel
+    ``area_channel_idx`` (default 6, matches ``data.loader.SURFACE_X_DIM``).
+    surface_mask: [B, N] with 1.0 on valid vertices.
+
+    Returns: [B, N] weights normalized per-sample so the mean over masked
+    vertices equals 1.0. This is a numerically-safe Voronoi-style discrete
+    approximation of ``∫ |τ-τ̂|^2 dA`` (DoMINO, arXiv 2501.13350); per-sample
+    (not per-batch) normalization keeps it consistent under DDP since each
+    rank sees full samples.
+    """
+    raw_area = surface_x[..., area_channel_idx].to(dtype=torch.float32)
+    raw_area = torch.clamp(raw_area, min=eps)
+    mask_float = surface_mask.to(dtype=raw_area.dtype, device=raw_area.device)
+    area_sum = (raw_area * mask_float).sum(dim=1, keepdim=True)
+    n_valid = mask_float.sum(dim=1, keepdim=True).clamp_min(1.0)
+    area_mean = (area_sum / n_valid).clamp_min(eps)
+    return raw_area / area_mean
+
+
+def channel_decoupled_area_weighted_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    vertex_weights: torch.Tensor,
+    channel_weights: torch.Tensor | None = None,
+    area_weight_channels: str = "all",
+) -> torch.Tensor:
+    """Channel-decoupled area-weighted masked MSE for surface targets (H18d).
+
+    pred / target: [B, N, 4]; mask: [B, N]; vertex_weights: [B, N], pre-normalized
+    so mean over masked vertices = 1 (matches ``compute_area_vertex_weights``).
+    channel_weights: [C] optional per-channel scale (composes multiplicatively).
+    area_weight_channels:
+        ``"all"``        — vertex weight applies to every channel (matches H18).
+        ``"tau_z_only"`` — vertex weight applies ONLY to channel 3 (tau_z);
+                           channels 0/1/2 (cp, tau_x, tau_y) use uniform vertex
+                           weighting. H18d main arm.
+        ``"wss"``        — vertex weight applies to channels 1/2/3 (tau_x/y/z);
+                           channel 0 (cp) uses uniform vertex weighting.
+
+    Channel-mean normalization (divide by ``valid * C``) keeps the scale
+    consistent with ``masked_mse``: with ``vertex_weights`` ones everywhere and
+    no ``channel_weights``, this reproduces ``masked_mse`` exactly.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    if pred.dim() != 3 or pred.shape != target.shape:
+        raise ValueError(
+            f"pred/target must be [B,N,C], got pred={tuple(pred.shape)}, target={tuple(target.shape)}"
+        )
+    B, N, C = pred.shape
+    device = pred.device
+    dtype = pred.dtype
+    vw = vertex_weights.to(device=device, dtype=dtype)
+    if vw.shape != (B, N):
+        raise ValueError(
+            f"vertex_weights must be [B,N]=({B},{N}), got {tuple(vw.shape)}"
+        )
+
+    if area_weight_channels == "all":
+        eff = vw.unsqueeze(-1).expand(B, N, C)
+    elif area_weight_channels == "tau_z_only":
+        if C != 4:
+            raise ValueError(
+                f"area_weight_channels='tau_z_only' expects C=4, got C={C}"
+            )
+        ones_3 = torch.ones((B, N, 3), device=device, dtype=dtype)
+        eff = torch.cat([ones_3, vw.unsqueeze(-1)], dim=-1)
+    elif area_weight_channels == "wss":
+        if C != 4:
+            raise ValueError(
+                f"area_weight_channels='wss' expects C=4, got C={C}"
+            )
+        ones_1 = torch.ones((B, N, 1), device=device, dtype=dtype)
+        vw_3 = vw.unsqueeze(-1).expand(B, N, 3)
+        eff = torch.cat([ones_1, vw_3], dim=-1)
+    else:
+        raise ValueError(
+            f"unknown area_weight_channels={area_weight_channels!r}; "
+            "expected one of {'all','tau_z_only','wss'}"
+        )
+
+    mask_dev = mask.to(device=device, dtype=dtype).unsqueeze(-1)
+    sq_err = (pred - target).square()
+    weighted = sq_err * eff * mask_dev
+    if channel_weights is not None:
+        ch_w = channel_weights.to(device=device, dtype=dtype)
+        if ch_w.shape[-1] != C:
+            raise ValueError(
+                f"channel_weights last-dim {ch_w.shape[-1]} must equal pred C={C}"
+            )
+        weighted = weighted * ch_w
+    valid = mask_dev.sum()
+    denominator = (valid * C).clamp_min(1.0)
+    if bool(valid.detach().cpu().item() > 0):
         return weighted.sum() / denominator
     return pred.sum() * 0.0
 


### PR DESCRIPTION
## Hypothesis

**H18d — Channel-decoupled τ_z-only area weighting.** Apply per-vertex area weights ONLY to the τ_z channel of the surface loss; keep cp, τ_x, τ_y at uniform vertex weighting (baseline).

### Why H18d follows from H18's evidence

The H18 (#1163, closed) terminal result was uniquely informative in Wave 30:
- **test τz/τx = 1.418** — DEEPEST test-side band-break in fleet history (val faded 1.412→1.489 but TEST HELD at 1.418)
- **test_vol_p = 3.485% < 3.643% floor** — ONLY floor-passing volume_pressure in active Wave 30 fleet
- val_abupt = 6.569% / test_abupt = 6.222% — primary metric regression
- test_SP = 3.916% (+0.339pp floor breach), test_WSS = 7.269% (+0.542pp above goal)

**Mechanism diagnosis from H18**: Position-based per-vertex weighting CAN shift the τ_z prediction band attractor (proven). The failure mode is the recipe — DR=7400× across **all 4 channels** starved low-area sharp-edge vertices (mirror seams, wheel-well lips, B-pillar corners with weight ~0.003×), causing the SP/abupt regression. The applied area weights mean p95=3.72, max ~24, min ~0.003.

**Hypothesis**: The band-break mechanism is **τ_z-specific** (high-area horizontal panels are where τ_z is over-predicted; cp/τ_x/τ_y don't have the same horizontal-panel bias). Isolating the area weight to τ_z should preserve the band-break while eliminating the cp/SP starvation that drove the regression.

### Causal chain

1. H18 area weighting applies to the per-vertex channel-MEAN MSE → all 4 channels (cp, τ_x, τ_y, τ_z) get the same area weight at each vertex
2. Cp and τ_x/τ_y don't need area-weighting (their per-vertex error structure is not horizontal-panel-biased)
3. Low-area panels (sharp edges) get the same vertex weight ~0.003 applied to cp → cp loss starves there → SP regression
4. H18d masks the area weight to ONLY the τ_z residual contribution → cp/τ_x/τ_y use uniform vertex weight → SP starvation eliminated
5. τ_z residuals on high-area horizontal panels still get the ~20-25× area weight → band-break preserved

### Orthogonality

H18d is orthogonal to all 9 Wave 30 closures (it's a position-based per-vertex weighting, not residual-based) AND to all 7 active runs (H24 GSTS, H25 ALGP, H26 NPCA, H27 PRLP, H28 SAM, H29 SSFL, H21 per-component output heads) — none of them apply position-based per-channel loss masking.

Composable with H27 PRLP (loss-normalization-space orthogonal), H28 SAM (optimizer-space orthogonal), H29 SSFL (frequency-domain orthogonal) for future H31 stacking.

---

## Instructions

Modify `target/train.py` only — ~10 LOC change. Build on the H18 area-weighted loss infrastructure already present on your prior branch — the change is to mask the area weight to the τ_z channel slot only.

### Step 1: Add CLI flag (3 LOC)

Add after existing `--use-area-weighted-loss` argument:

```python
parser.add_argument(
    "--area-weight-channels", type=str, default="all",
    choices=["all", "tau_z_only", "wss"],
    help="Which surface channels apply area-weighted vertex weighting. "
         "'all' (H18 default) applies to cp, tau_x, tau_y, tau_z. "
         "'tau_z_only' (H18d): area weight applies ONLY to tau_z (channel 3); cp/tau_x/tau_y use uniform vertex weight. "
         "'wss': area weight applies to tau_x, tau_y, tau_z (channels 1,2,3); cp uses uniform vertex weight."
)
```

### Step 2: Modify the area-weighted loss function (~7 LOC)

Locate your existing area-weighted surface loss computation (the one that multiplies `vertex_weight` by per-vertex MSE). Replace the unified `(vertex_weight * MSE).mean()` with a channel-aware computation:

```python
# Compute per-vertex per-channel squared error: shape [B, N, C]
sq_err = (pred_norm - target_norm) ** 2  # [B, N, 4]
mask_f = mask.float().unsqueeze(-1)       # [B, N, 1]

if args.area_weight_channels == "all":
    # H18 behavior: area weight applies to all channels (channel-mean MSE)
    per_vertex_mse = (sq_err.mean(dim=-1)) * mask.float()  # [B, N]
    surface_loss = (vertex_weight * per_vertex_mse).sum() / mask.float().sum().clamp(min=1.0)

elif args.area_weight_channels == "tau_z_only":
    # H18d: area weight applies ONLY to channel 3 (tau_z); others uniform
    weighted_per_vertex_tauz = vertex_weight * (sq_err[..., 3] * mask.float())  # [B, N]
    loss_tauz = weighted_per_vertex_tauz.sum() / mask.float().sum().clamp(min=1.0)
    loss_other = (sq_err[..., :3] * mask_f).mean(dim=-1).sum() / mask.float().sum().clamp(min=1.0)
    # Combine — 3/4 weight for other channels, 1/4 weight for tau_z (matches channel-mean baseline)
    surface_loss = (3.0 * loss_other + loss_tauz) / 4.0

elif args.area_weight_channels == "wss":
    # H18d-WSS variant: area weight on tau_x, tau_y, tau_z (channels 1, 2, 3); cp uniform
    sq_err_wss = sq_err[..., 1:]  # [B, N, 3]
    weighted_per_vertex_wss = vertex_weight.unsqueeze(-1) * sq_err_wss * mask_f  # [B, N, 3]
    loss_wss = weighted_per_vertex_wss.sum() / (mask.float().sum().clamp(min=1.0) * 3.0)
    loss_cp = (sq_err[..., 0] * mask.float()).sum() / mask.float().sum().clamp(min=1.0)
    surface_loss = (loss_cp + 3.0 * loss_wss) / 4.0
```

**Important notes:**

1. The final factor of `1/4` (or equivalent) preserves the **channel-mean scale of the surface loss**. Without this normalization, the H18d loss magnitude differs from baseline by 4× and you'll need to retune the `--surface-loss-weight`. Keep the channel-mean factor so you can use baseline `--surface-loss-weight 2.0`.
2. Apply existing `tau-y-loss-weight 1.5` / `tau-z-loss-weight 2.0` (from H18 command) AFTER the channel split — they multiply the τ_y and τ_z component contributions. Verify these still apply in your H18d implementation.
3. Mask handling matters — keep `mask.float()` factors consistent so padded tokens don't contribute. The existing H18 mask treatment can be reused.
4. **Verify baseline recovery**: with `--area-weight-channels all` and uniform `vertex_weight=1.0` everywhere, H18d should produce IDENTICAL loss values to baseline.

### Step 3: Logging (~2 LOC)

Add to your W&B logging:
- `train/surface_loss_tauz_area` — the area-weighted τ_z component
- `train/surface_loss_other_uniform` — the uniform cp+τ_x+τ_y component
- (Optional) per-channel weight statistics like H18 reported

---

## Recipe

Same H18 recipe but with `--area-weight-channels tau_z_only`:

```bash
SENPAI_TIMEOUT_MINUTES=1100 \
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-area-weighted-loss \
  --area-weight-channels tau_z_only \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h18d_tau_z_only \
  --wandb-name tanjiro/h18d-channel-decoupled-area-18h \
  --agent tanjiro
```

**Parameter rationale:**
- `--area-weight-channels tau_z_only` — the new flag; isolates area weighting to τ_z channel
- All other args identical to H18 (your prior run) — same DR=7400× per-vertex weight distribution, just applied to one channel slot
- `--surface-loss-weight 2.0` — preserved, channel-mean factor in the new loss path keeps scale consistent
- `--lr 9e-5` — NEVER change

**Optional Arm B (parallel sweep, run only if Arm A insufficient):**

```bash
... (same base args) ...
  --area-weight-channels wss \
  --wandb-group wave30_h18d_tau_z_only \
  --wandb-name tanjiro/h18d-wss-channels-18h
```

Arm B (`wss`) keeps area weighting on all 3 τ channels but releases cp to uniform weighting. Tests whether the failure mode is specifically `cp ↔ low-area starvation` vs. broader τ_y/τ_x starvation.

**My recommendation: Run Arm A (`tau_z_only`) FIRST. Only run Arm B if Arm A holds the band-break but with residual τ_y/τ_x regression that prevents merge.**

---

## EP3 falsifiable gate

**H18d is ALIVE at EP3 if ALL THREE hold:**

| Metric | Threshold | Rationale |
|---|---|---|
| `val_primary/wall_shear_z_rel_l2_pct / val_primary/wall_shear_x_rel_l2_pct` | **≤ 1.42** | **PRIMARY** — band-break must persist as in H18 EP3 (1.412) |
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 7.5% | Tighter than H18 EP3 7.787% — if channel decoupling works, val_abupt should improve |
| `val_primary/surface_pressure_rel_l2_pct` | ≤ 4.50% | H18 EP3 was 5.033% — H18d must show measurable SP recovery |

**KILL gate (any one triggers kill at EP3):**

| Metric | Threshold | Why |
|---|---|---|
| `val_abupt` | > 8.5% | Training has diverged or recipe broken |
| `τz/τx` | > 1.50 | Channel decoupling lost the band-break mechanism — confirms area-weighting axis dead |
| `val_SP` | > 5.5% | SP starvation NOT fixed by channel decoupling — H18 cp regression was NOT channel-coupling-driven |

**Mechanism check at EP1**: confirm the area weight statistics still produce the same per-vertex distribution as H18 (mean p95~3.7, max~24, min~0.003). Log the histogram first 500 steps to verify the implementation reuses the H18 weight computation correctly.

---

## Baseline

Current best (PR #972, run `56bcqp3m`):

| Metric | Baseline | Direction | H18 terminal | H18d target |
|---|---|---|---|---|
| **val_abupt** | **6.126%** | merge gate | 6.569% (FAIL +0.443pp) | **< 6.126%** |
| test_abupt | 5.844% | report | 6.222% (FAIL +0.378pp) | **< 5.844%** |
| **test_vol_p** | **3.643%** | floor | 3.485% (PASS −0.158pp ✓) | **PRESERVE** ≤ 3.643 |
| **test_SP** | **3.577%** | floor | 3.916% (BREACH +0.339pp) | **RECOVER** ≤ 3.577 |
| test_WSS | 6.727% | goal <5.85% | 7.269% (FAIL +0.542pp) | **< 6.727%** |
| **test τz/τx** | ~1.46 | informational | **1.418** (★ band-break) | **PRESERVE** ≤ 1.42 |

**Critical baseline-vs-H18 deltas H18d must address:**
- val_SP: H18 EP3 5.033% → H18d EP3 target ≤ 4.50% (channel decoupling must reduce cp starvation by ≥ 0.5pp)
- val_abupt: H18 EP3 7.787% → H18d EP3 target ≤ 7.5%
- τz/τx: H18 EP3 1.412 → H18d EP3 target ≤ 1.42 (preserve band-break)

---

## Predicted outcomes

**If H18d SUCCEEDS** (band-break preserved + SP recovered):
- val_abupt < 6.126% — **new fleet best, first Wave 30 winner**
- test τz/τx ≤ 1.42 — band-break confirmed without channel coupling
- test_SP returns to ≤ 3.577% floor
- test_vol_p still passes floor (likely improved via cleaner τ_z signal)
- Composable with H27 PRLP, H28 SAM, H29 SSFL for H31 stacking

**If H18d FAILS** (band-break lost OR SP still breached):
- If band-break is lost (τz/τx > 1.50): confirms area-weighting needs channel coupling — area-weighting axis decisively closed even with decoupling
- If band-break holds but SP still breached: rules out channel-coupling as the failure mode — points to intra-channel DR (recipe issue) — escalate to H18b/c (clamped or sqrt) in next round
- Either way: closes the position-based per-vertex weighting sub-axis with much higher information value than another fresh tier-shift

---

## Information value table

| Outcome | Probability | Research-state update |
|---|---|---|
| H18d wins (band-break + SP recovered + baseline beat) | ~25% | NEW BASELINE; first Wave 30 winner; mechanism confirmed channel-specific |
| H18d holds band-break but SP still breached | ~25% | Failure is DR not coupling → H18 next variant is sqrt-area or clamped-DR |
| H18d loses band-break | ~25% | Area-weighting MUST be channel-coupled to work → axis closed even with decoupling |
| H18d marginal / mixed | ~25% | Intermediate signal informs H18c (sqrt) vs H18b (clamp) priority |

Expected info per compute: **HIGHEST** of the three suggested H18 follow-ups. Same 14h DDP-8 budget as baseline.

---

## Taste rubric

| Criterion | Score | Justification |
|---|---|---|
| Mechanistic grounding | 4/4 | H18 proved position-based area-weighting CAN shift τz/τx (test 1.418). The failure mode (SP starvation) is precisely diagnosed as low-area cp loss-channel starvation. H18d's channel-decoupling directly addresses the diagnosed failure while preserving the proven mechanism. |
| Research-state value | 4/4 | Either H18d wins (new baseline + first Wave 30 winner) OR isolates the band-break mechanism vs. DR-recipe failure mode. Both outcomes sharply update the research map. Strongest follow-up among the three student-suggested variants (H18b clamped, H18c sqrt, H18d channel-decoupled). |
| Execution value | 4/4 | ~10 LOC change to train.py, reuses H18 weight computation infrastructure entirely, same 14h DDP-8 budget. `area_weight_channels=all` is exact baseline recovery. Lowest implementation risk among the three variants. |

**Overall: 4/4/4** — Evidence-following follow-up to the deepest mechanism signal in Wave 30 history, with clean falsification at EP3 and minimal implementation risk.
