### PR TITLE
Wave 30 H30: Volume-to-Surface Cross-Attention (V2S xattn)

### DIFF
--- a/model.py
+++ b/model.py
@@ -381,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_vol_to_surf_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
     ):
         super().__init__()
@@ -395,6 +396,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_vol_to_surf_xattn = use_vol_to_surf_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
@@ -519,6 +521,27 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Volume->surface cross-attention (H30, PR #1184): single MHA sublayer
+        # where surface hidden states (Q) attend to volume hidden states (K/V).
+        # Brings off-body flow physics (separation, wake, recirculation) into
+        # the surface decoder to attack the tau_z prediction floor. Mirrors the
+        # surf_to_vol_xattn topology in reverse direction. Zero-init out_proj
+        # weight AND bias so the sublayer is identity at init (preserves
+        # baseline behavior at epoch 0).
+        if use_vol_to_surf_xattn:
+            self.vol_to_surf_xattn = nn.MultiheadAttention(
+                embed_dim=n_hidden,
+                num_heads=n_head,
+                batch_first=True,
+                dropout=dropout,
+            )
+            self.vol_to_surf_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+            nn.init.zeros_(self.vol_to_surf_xattn.out_proj.weight)
+            nn.init.zeros_(self.vol_to_surf_xattn.out_proj.bias)
+        else:
+            self.vol_to_surf_xattn = None
+            self.vol_to_surf_xattn_norm = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -620,6 +643,23 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        if (
+            self.vol_to_surf_xattn is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            xattn_out, _ = self.vol_to_surf_xattn(
+                query=surface_hidden,
+                key=volume_hidden,
+                value=volume_hidden,
+                need_weights=False,
+            )
+            xattn_out = _apply_token_mask(xattn_out, surface_mask)
+            surface_hidden = self.vol_to_surf_xattn_norm(surface_hidden + xattn_out)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_to_surf_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_to_surf_xattn": (
+            "Enable volume->surface cross-attention (H30, PR #1184). After "
+            "the surface->volume xattn block (if enabled), a single "
+            "nn.MultiheadAttention sublayer lets surface hidden states (Q) "
+            "attend to volume hidden states (K/V), fusing off-body flow "
+            "physics into the surface decoder. Zero-init out_proj weight "
+            "and bias guarantee baseline recovery at epoch 0. Mirrors the "
+            "surf_to_vol_xattn topology and shares embed_dim/num_heads "
+            "with --model-hidden-dim / --model-heads."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_to_surf_xattn=config.use_vol_to_surf_xattn,
     )
 
 
@@ -773,7 +785,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_to_surf_xattn:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**H30 — Volume-to-Surface Cross-Attention (V2S xattn).** Add a single cross-attention sublayer where surface hidden states (Q) attend to volume hidden states (K/V), inserted AFTER the existing surface→volume xattn block. Volume tokens carry off-body flow physics — separation, recirculation, wake structure — that physically *determines* boundary-layer separation events at the surface. The current architecture passes information surface→volume only (via `--use-surf-to-vol-xattn` from PR #823). H30 closes the loop with the reverse direction.

**Direct motivation from H18 (PR #1163):** the H18 area-weighted MSE produced a unique test-side band-break (test τz/τx 1.418, deepest in fleet history) and the only floor-PASSING test_vol_p (3.485% vs 3.643% baseline). The mechanism analysis explicitly identified that surface→volume cross-attention propagated better-fitted τ_z INTO vol_p. **The reverse direction has never been tested**, and the physical chain runs the other way: volume flow → separation → surface τ_z. If V2S feeds the volume-encoded separation physics back into the surface τ_z prediction, the band attractor [1.44, 1.55] should break for the right reason (physics-grounded), not via a noisy mechanism-shift.

**Combined with H21's NOT-A-MERGE diagnostic (PR #1171):** H21 demonstrated that decoder capacity is NOT the τ_z bottleneck — adding more MLP capacity to the τ_z head changed how existing encoder features were read out, not how much information was available. H21 closed the channel-coupled output-head capacity axis. H30 attacks the orthogonal axis: **encoder feature content**, specifically by injecting volume-encoded physics into surface tokens.

### Mechanism

1. Volume tokens encode the off-body flow field: pressure gradients, velocity recirculation patterns, wake position, mirror/A-pillar/wheel-well separation lines
2. Surface tokens currently see only their own geometry + the encoded backbone features that don't preserve off-body context
3. V2S xattn lets each surface token query the volume token set: "what off-body physics is happening near my location?"
4. The answer informs τ_z prediction — boundary layer separation is determined by adverse pressure gradient (encoded in volume) and detachment-line geometry (encoded in surface)
5. Surface output head receives features that fuse on-surface geometry with off-body physics → better τ_z prediction

### Orthogonality

| Closed / Active | Axis | H30 orthogonal? |
|---|---|:--|
| H10b/H11b/H12/H16/H16b/H20/H22 (CLOSED) | per-vertex / loss-shape | YES — H30 is encoder-fusion |
| H18 (CLOSED) | position-density area weight | YES — H30 is cross-modal feature |
| H21 (CLOSED) | per-channel decoder MLP | YES — H30 modifies encoder features fed TO decoders |
| H23 (CLOSED) | EMA self-distillation | YES — H30 is architectural |
| H24 GSTS (active) | encoder slice temperature | YES — H30 is cross-modal, not per-slice |
| H25 ALGP (active) | aux gradient prediction | YES — H30 is architectural fusion |
| H26 NPCA (active) | normal-projected coord aug | YES — H30 is cross-modal feature, not input feature |
| H27 PRLP (active) | per-component rel-L2 proxy | YES — H30 doesn't touch loss |
| H28 SAM (active) | optimizer sharpness | YES — H30 is architectural |
| H29 SSFL (active) | spatial-frequency loss | YES — H30 doesn't touch loss |
| H18d (active) | channel-decoupled area weight | YES — H30 is encoder, not loss |

**Full orthogonality confirmed across all 10 closed + all 7 active Wave 30 runs.**

## Instructions

All implementation in `model.py` + small CLI flag in `train.py`. **No changes to `trainer_runtime.py`, eval code, or loss code.**

### Step 1 — Add `--use-vol-to-surf-xattn` flag to `train.py`

In the model-construction block, add the CLI flag and pass it to `SurfaceTransolver`:

```python
parser.add_argument(
    "--use-vol-to-surf-xattn",
    action="store_true",
    help="Add volume-to-surface cross-attention sublayer. Surface tokens (Q) "
         "attend to volume tokens (K/V) to fuse off-body flow physics into "
         "surface predictions. Zero-init out_proj guarantees baseline recovery."
)

# In the SurfaceTransolver(...) construction call, add:
use_vol_to_surf_xattn=args.use_vol_to_surf_xattn,
```

### Step 2 — Add the xattn block to `SurfaceTransolver.__init__`

Mirror the existing `surf_to_vol_xattn` block at `model.py:508-520`. After the surf_to_vol block, add:

```python
# Volume->surface cross-attention (PR #THIS): single MHA sublayer where
# surface hidden states (Q) attend to volume hidden states (K/V).
# Brings off-body flow physics (separation, wake, recirculation) into
# the surface decoder to attack the τ_z prediction floor. Zero-init
# out_proj weight AND bias so the sublayer is identity at init.
if use_vol_to_surf_xattn:
    self.vol_to_surf_xattn = nn.MultiheadAttention(
        embed_dim=n_hidden,
        num_heads=n_head,
        batch_first=True,
        dropout=dropout,
    )
    self.vol_to_surf_xattn_norm = nn.LayerNorm(n_hidden, eps=1e-6)
    nn.init.zeros_(self.vol_to_surf_xattn.out_proj.weight)
    nn.init.zeros_(self.vol_to_surf_xattn.out_proj.bias)
else:
    self.vol_to_surf_xattn = None
    self.vol_to_surf_xattn_norm = None
```

Add `use_vol_to_surf_xattn` to the `__init__` signature and `self.use_vol_to_surf_xattn = ...` to the assignments block.

### Step 3 — Apply V2S in `forward` AFTER existing S2V (in `model.py:607-622`)

After the existing surf_to_vol_xattn block, add a near-symmetric mirror:

```python
if (
    self.vol_to_surf_xattn is not None
    and surface_x is not None
    and volume_x is not None
    and surface_tokens > 0
    and volume_tokens > 0
):
    xattn_out, _ = self.vol_to_surf_xattn(
        query=surface_hidden,
        key=volume_hidden,
        value=volume_hidden,
        need_weights=False,
    )
    xattn_out = _apply_token_mask(xattn_out, surface_mask)
    surface_hidden = self.vol_to_surf_xattn_norm(surface_hidden + xattn_out)
    surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
```

This block must execute AFTER the existing S2V block so that volume_hidden already contains surface-aware features (forming a closed cross-modal fusion loop).

### Step 4 — Smoke test (~10 min, 2-rank, ~200 steps)

Before main launch, verify three properties:

1. **Zero-init baseline recovery (--use-vol-to-surf-xattn NOT set)**: training loss trajectory and val metrics at EP0 must match baseline exactly (within fp32 numerical precision). Run a 2-rank smoke with `--use-vol-to-surf-xattn` UNSET and confirm step-0 loss equals baseline step-0 loss.

2. **xattn instantiation correctness with flag set**: with `--use-vol-to-surf-xattn` set, instantiate the model and verify `model.vol_to_surf_xattn` is `nn.MultiheadAttention`, `vol_to_surf_xattn.out_proj.weight.abs().max() == 0.0`, and `vol_to_surf_xattn.out_proj.bias.abs().max() == 0.0`.

3. **Forward shape correctness**: run a single forward pass with non-empty surface and volume tensors; confirm `surface_preds` shape unchanged from baseline.

### Step 5 — Main run with `--use-vol-to-surf-xattn`

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --use-surf-to-vol-xattn --use-vol-to-surf-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --no-compile-model --batch-size 4 --validation-every 1 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --wandb-group wave30_h30_v2s_xattn \
  --wandb-name nezuko/h30-v2s-xattn-18h --agent nezuko
```

Note `--use-surf-to-vol-xattn` is also enabled (it's part of baseline). This run adds the REVERSE direction on top of baseline architecture.

### EP3 falsifiable gate

**H30 is ALIVE at EP3 if all three hold:**

1. `val_primary/abupt_axis_mean_rel_l2_pct ≤ 8.5%` — training has not diverged
2. `val_primary/wall_shear_z_rel_l2_pct / val_primary/wall_shear_x_rel_l2_pct ≤ 1.42` — τz/τx breaks below the [1.44, 1.55] attractor band
3. `train/surface_loss` descending normally — V2S xattn is not destabilizing the surface branch

**KILL conditions at EP3:**
- val_abupt > 9.5%
- τz/τx > 1.55
- val_SP > 5.0% (V2S shouldn't hurt cp prediction; if it does, the architecture is broken)
- Any `train/grad/nonfinite_count` > 0

### Watch items

1. **xattn attention entropy at EP3**: if V2S xattn weights become near-uniform across volume tokens (~ln(V) entropy), the mechanism is not biting — surface tokens aren't differentiating which volume regions matter for their prediction. Track `train/v2s_xattn/attn_entropy` if you can log it.

2. **τz/cp ratio at EP3 vs EP1**: if V2S helps τ_z specifically (the hypothesis), τz/cp should DROP across training (cp accuracy roughly stable; τ_z accuracy improves). If τz/cp is stable or rises, V2S is helping all channels equally or wrong direction.

3. **test side parity with val**: this is the load-bearing signal — H18 had val-side fade + test-side survival (test τz/τx 1.418 vs val 1.489). If V2S has the same val/test divergence pattern, it's worth running terminal regardless of val-side noise.

## Baseline

Current best `val_primary/abupt_axis_mean_rel_l2_pct = 6.126%` from PR #972 (run `56bcqp3m`). Test metrics from PR #972 (best-checkpoint reload):

| Metric | Baseline | Floor |
|---|---:|---:|
| test_abupt | 5.844% | — |
| test_vol_p | 3.643% | 3.643% |
| test_SP | 3.577% | 3.577% |
| test_WSS | 6.727% | — |
| test_τ_x | (TBD per W&B) | — |
| test_τ_z | (TBD per W&B) | — |

Baseline reproduce: same command as Step 5 above but with `--use-vol-to-surf-xattn` removed.

H30's merge gate: `val_abupt < 6.126%` AND `test_SP ≤ 3.577%` AND `test_vol_p ≤ 3.643%`.
