### PR TITLE
Wave 30 H32: Differential Attention to cancel τz/τx band attractor

### DIFF
--- a/model.py
+++ b/model.py
@@ -234,6 +234,7 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_diff_attn: bool = False,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,12 +245,22 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_diff_attn = use_diff_attn
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
-        self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+        if use_diff_attn:
+            # DIFFATTN (Ye et al. 2024, arxiv:2410.05258): two parallel SDPA
+            # branches subtract to cancel the shared dominant attention mode.
+            # 6x projection produces (q1,k1,v1,q2,k2,v2) each of dim_head.
+            # Pseudocode form: sigmoid-bounded shared lambda, no subln/scale.
+            self.qkv = LinearProjection(self.dim_head, self.dim_head * 6, bias=False)
+            self.diff_lambda = nn.Parameter(torch.tensor(0.8))
+        else:
+            self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+            self.diff_lambda = None
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
         if use_qk_norm:
@@ -277,16 +288,25 @@ class TransolverAttention(nn.Module):
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
-        q, k, v = qkv.chunk(3, dim=-1)
-        if self.q_norm is not None:
-            q = self.q_norm(q)
-            k = self.k_norm(k)
-        out_slice = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            dropout_p=self.dropout if self.training else 0.0,
-        )
+        dp = self.dropout if self.training else 0.0
+        if self.use_diff_attn:
+            q1, k1, v1, q2, k2, v2 = qkv.chunk(6, dim=-1)
+            if self.q_norm is not None:
+                q1 = self.q_norm(q1)
+                k1 = self.k_norm(k1)
+                q2 = self.q_norm(q2)
+                k2 = self.k_norm(k2)
+            lam = torch.sigmoid(self.diff_lambda)
+            out_slice = (
+                F.scaled_dot_product_attention(q1, k1, v1, dropout_p=dp)
+                - lam * F.scaled_dot_product_attention(q2, k2, v2, dropout_p=dp)
+            )
+        else:
+            q, k, v = qkv.chunk(3, dim=-1)
+            if self.q_norm is not None:
+                q = self.q_norm(q)
+                k = self.k_norm(k)
+            out_slice = F.scaled_dot_product_attention(q, k, v, dropout_p=dp)
         out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
         out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
         out_x = _apply_token_mask(out_x, attn_mask)
@@ -303,6 +323,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_diff_attn: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,6 +334,7 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_diff_attn=use_diff_attn,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -336,6 +358,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_diff_attn: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,6 +370,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_diff_attn=use_diff_attn,
                 )
                 for _ in range(depth)
             ]
@@ -382,6 +406,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_diff_attn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +421,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_diff_attn = use_diff_attn
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +498,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_diff_attn=use_diff_attn,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_diff_attn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -308,6 +309,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_diff_attn=config.use_diff_attn,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The τz/τx band attractor [1.44, 1.55] is a 12-experiment-confirmed phenomenon spanning every attack axis in Wave 30 (per-vertex loss shaping, training regularisation, loss formulation, optimizer, train-eval space, encoder content). The one common thread across all failures: they all operate on the *output* of the Transolver slice-token attention, not on the attention mechanism itself.

**DIFFATTN** (Differential Transformer, Microsoft Research 2024 — [arxiv:2410.05258](https://arxiv.org/abs/2410.05258)) replaces the standard `F.scaled_dot_product_attention` in `TransolverAttention.forward` with a differential pattern:

```
out_slice = SDPA(q1, k1, v1) − sigmoid(λ) · SDPA(q2, k2, v2)
```

Mechanistic hypothesis: the Transolver slice-token SDPA introduces a shared noise floor that equally biases all tokens' τz predictions toward the band attractor. The dominant mode of the attention matrix is likely a diffuse, non-specific mixture that routes in-band physics features to τz outputs. Subtracting a second attention pattern (trained jointly) should cancel this shared dominant mode, amplifying the residual signal — the useful variation in τz that contains the out-of-band information needed to break through the floor.

This is the first hypothesis in Wave 30 that attacks the **attention mechanism itself** rather than inputs, outputs, or training dynamics. It is architecturally orthogonal to all active experiments:
- H24 GSTS: slice temperature scalar (threshold, not mechanism)
- H26 NPCA: input local frame (encoder pre-attention)
- H30 V2S: cross-modal attention (a different attention path)
- H31 WALLDIST: input log-SDF channel (encoder content)

Implementation overhead: ~60 LOC change to `model.py` + ~10 LOC to `train.py` + `build_model`. Compute overhead: 2× SDPA over slice_tokens (128 slices × 4 heads × 128-dim), which is negligible vs surface/volume embedding projections. Parameter overhead: dim_head × 3 extra QKV weights (~50K params, <0.1% of model).

## Instructions

**Changes are split across `model.py` and `train.py`. All changes are gated by a flag `use_diff_attn=False` so the baseline is recoverable.**

### Step 1 — `train.py`: Add config flag

In `class Config` (around line 104 where `use_qk_norm: bool = False` lives), add:
```python
use_diff_attn: bool = False
```

### Step 2 — `train.py`: Thread through `build_model`

In `build_model()` (line ~298), add to the `SurfaceTransolver(...)` constructor call:
```python
use_diff_attn=config.use_diff_attn,
```

### Step 3 — `model.py`: Thread through `SurfaceTransolver`

In `SurfaceTransolver.__init__` signature (line ~382), add parameter:
```python
use_diff_attn: bool = False,
```
Store it: `self.use_diff_attn = use_diff_attn`

Pass it to `Transformer(...)` constructor (line ~467):
```python
use_diff_attn=use_diff_attn,
```

### Step 4 — `model.py`: Thread through `Transformer`

In `Transformer.__init__` signature (line ~332), add parameter:
```python
use_diff_attn: bool = False,
```
Pass it through to each `TransformerBlock(...)`:
```python
use_diff_attn=use_diff_attn,
```

### Step 5 — `model.py`: Thread through `TransformerBlock`

In `TransformerBlock.__init__` signature (line ~305), add parameter:
```python
use_diff_attn: bool = False,
```
Pass it to `TransolverAttention(...)`:
```python
use_diff_attn=use_diff_attn,
```

### Step 6 — `model.py`: Implement in `TransolverAttention.__init__`

Add `use_diff_attn: bool = False` to `TransolverAttention.__init__` signature.

After the existing `self.qkv = LinearProjection(...)` line (~line 252), add:
```python
self.use_diff_attn = use_diff_attn
if use_diff_attn:
    # Replace 3× projection with 6× for (q1,k1,v1,q2,k2,v2)
    self.qkv = LinearProjection(self.dim_head, self.dim_head * 6, bias=False)
    self.diff_lambda = nn.Parameter(torch.tensor(0.8))
```

Note: this overwrites the `self.qkv` set on line 252 — that is intentional.

### Step 7 — `model.py`: Implement in `TransolverAttention.forward`

Replace the block from `qkv = self.qkv(slice_tokens)` through `out_slice = F.scaled_dot_product_attention(...)` (lines ~279–289) with:

```python
qkv = self.qkv(slice_tokens)
if self.use_diff_attn:
    q1, k1, v1, q2, k2, v2 = qkv.chunk(6, dim=-1)
    if self.q_norm is not None:
        q1 = self.q_norm(q1)
        k1 = self.k_norm(k1)
        q2 = self.q_norm(q2)
        k2 = self.k_norm(k2)
    dp = self.dropout if self.training else 0.0
    lam = torch.sigmoid(self.diff_lambda)
    out_slice = (
        F.scaled_dot_product_attention(q1, k1, v1, dropout_p=dp)
        - lam * F.scaled_dot_product_attention(q2, k2, v2, dropout_p=dp)
    )
else:
    q, k, v = qkv.chunk(3, dim=-1)
    if self.q_norm is not None:
        q = self.q_norm(q)
        k = self.k_norm(k)
    out_slice = F.scaled_dot_product_attention(
        q, k, v,
        dropout_p=self.dropout if self.training else 0.0,
    )
```

The remainder of `forward` (lines ~290–294: `einsum`, `permute`, `proj`, etc.) is unchanged.

### Training command

Use the standard 18h DDP-8 recipe with `--use_diff_attn`:

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 \
  --use_diff_attn \
  --batch_size 4 \
  --vol_sample_schedule "0:16384:3:32768:6:49152:9:65536" \
  --wandb_group askeladd-h32-diffattn \
  --wandb_name askeladd/h32-diffattn-main
```

All other hyperparameters stay at their defaults (hidden_dim=512, model_layers=5, num_slices=128, heads=4, Lion optimizer).

## EP3 Gate and Kill Criteria

**EP3 survival gate** (check after EP3 completes, ~4h into training):
- τz/τx ≤ **1.42** (must show band-escape signal below the attractor floor 1.44)
- val_abupt ≤ **8.5%** (sanity bound — model should not be dramatically worse than baseline)

**KILL immediately if at any epoch:**
- val_abupt > 9.5% (model diverged or severely degraded)
- τz/τx > 1.55 (deep in band, no escape signal)
- Any NaN/nonfinite in metrics
- val_SP > 5.5% (floor breach)

If EP3 passes the gate, run to completion (EP13 / SENPAI_TIMEOUT_MINUTES=1100).

## Baseline

Single-model baseline — PR #972, W&B run `56bcqp3m`:

| Metric | Baseline |
|--------|----------|
| val_abupt | 6.126% |
| test_abupt | 5.844% |
| test_vol_p | 3.643% |
| test_SP | 3.577% |
| test_WSS | 6.727% |
| test_τz/τx | 1.420 |

**Single-model merge gate:** val_abupt < 6.126% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%
**Stretch goal:** test_WSS < 5.85%

Reproduce baseline:
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 --batch_size 4 \
  --vol_sample_schedule "0:16384:3:32768:6:49152:9:65536" \
  --wandb_group baseline-reproduce
```
