### PR TITLE
Wave 30 H33: Learnable slice positional embedding (SLICEPE)

### DIFF
--- a/model.py
+++ b/model.py
@@ -234,6 +234,7 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_slice_pe: bool = False,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,12 +245,20 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_slice_pe = use_slice_pe
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+        if use_slice_pe:
+            # H33 SLICEPE: learnable per-slice position embedding added before SDPA
+            # to give each slice token a stable identity independent of content routing.
+            self.slice_pe = nn.Parameter(
+                torch.zeros(1, self.num_heads, self.num_slices, self.dim_head)
+            )
+            nn.init.normal_(self.slice_pe, std=0.02)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
         if use_qk_norm:
@@ -276,6 +285,8 @@ class TransolverAttention(nn.Module):
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        if self.use_slice_pe:
+            slice_tokens = slice_tokens + self.slice_pe
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +314,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_slice_pe: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,6 +325,7 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_slice_pe=use_slice_pe,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -336,6 +349,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_slice_pe: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,6 +361,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_slice_pe=use_slice_pe,
                 )
                 for _ in range(depth)
             ]
@@ -380,6 +395,7 @@ class SurfaceTransolver(nn.Module):
         rff_init_sigmas: list[float] | None = None,
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
+        use_slice_pe: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
     ):
@@ -394,6 +410,7 @@ class SurfaceTransolver(nn.Module):
         self.rff_init_sigmas = list(rff_init_sigmas) if rff_init_sigmas else None
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
+        self.use_slice_pe = use_slice_pe
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
@@ -472,6 +489,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_slice_pe=use_slice_pe,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ class Config:
     rff_init_sigmas: str = ""
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
+    use_slice_pe: bool = False
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
@@ -294,6 +295,39 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_slice_pe_metrics(model: nn.Module) -> dict[str, float]:
+    """H33 SLICEPE: monitor learnable per-slice embedding growth & inter-slice spread."""
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return metrics
+    all_norms: list[float] = []
+    for layer_idx, block in enumerate(backbone.blocks):
+        attn = getattr(block, "attention", None)
+        if attn is None or not getattr(attn, "use_slice_pe", False):
+            continue
+        pe = attn.slice_pe.detach().float()  # (1, H, S, D)
+        prefix = f"slice_pe/layer_{layer_idx}"
+        metrics[f"{prefix}/abs_mean"] = float(pe.abs().mean().item())
+        metrics[f"{prefix}/std"] = float(pe.std().item())
+        # Per-slice L2 norm (avg over heads): how "loud" is each slice's identity?
+        slice_norm = pe.norm(dim=-1).mean(dim=1)  # (1, S)
+        metrics[f"{prefix}/slice_norm_mean"] = float(slice_norm.mean().item())
+        metrics[f"{prefix}/slice_norm_std"] = float(slice_norm.std().item())
+        all_norms.append(float(slice_norm.mean().item()))
+        # Inter-slice cosine spread: 1 - mean off-diagonal cosine (0=identical, 1=orthogonal)
+        flat = pe.squeeze(0).reshape(pe.shape[1], pe.shape[2], -1)  # (H, S, D)
+        norm = flat / (flat.norm(dim=-1, keepdim=True) + 1e-9)
+        cos = torch.einsum("hsd,htd->hst", norm, norm)  # (H, S, S)
+        S = cos.shape[-1]
+        eye = torch.eye(S, device=cos.device, dtype=cos.dtype).unsqueeze(0)
+        off_diag_mean = ((cos * (1 - eye)).sum(dim=(1, 2)) / (S * (S - 1))).mean()
+        metrics[f"{prefix}/inter_slice_cos_mean"] = float(off_diag_mean.item())
+    if all_norms:
+        metrics["slice_pe/global/slice_norm_mean"] = float(sum(all_norms) / len(all_norms))
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -307,6 +341,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         rff_init_sigmas=parse_rff_init_sigmas(config.rff_init_sigmas),
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
+        use_slice_pe=config.use_slice_pe,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
     )
 
@@ -1262,6 +1297,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_slice_pe_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

Slice tokens in `TransolverAttention` are generated purely from **content-based routing** (softmax over `slice_logits = in_project_slice(x_mid) / temperature`). They carry no explicit positional identity — a slice's "address" in embedding space is entirely determined by which input points route to it, not where in 3D space those points live.

This creates a positional symmetry: the model can only distinguish between slice tokens by CONTENT, not by LOCATION. Over the course of training, all 128 slices must compete to specialise via content alone. The band attractor [1.44, 1.55] may be a direct consequence: a dominant, shared-content mode that spans all slices and routes indiscriminately to τz prediction.

**SLICEPE adds a learnable per-slice position embedding** `P ∈ R^{H × S × D_head}`, zero-initialised, added to `slice_tokens` before SDPA. This gives each slice a stable "address" that is independent of input content — allowing the model to learn "slice 42 covers the underbody/wake region" and develop region-specialised attention routing for τz vs τx features.

### Why this might break the band attractor

- With slice identity, τz-specific physics (horizontal panels, underbody, rear wake) can be routed to dedicated slices with specialised attention patterns
- Without slice identity, slice routing depends only on content, and any global physics mode (e.g. the τz/τx ratio) that appears consistently will saturate all slices with the same signal
- The band attractor's dominant mode (τz ≈ 1.5 × τx, fleet-wide) is exactly the kind of shared content mode that lacks slice identity to route around

### Safety properties (key lesson from H32 DIFFATTN failure)

H32 failed because subtractive SDPA destroyed slice-token MAGNITUDE at init (effective magnitude ~0.31× baseline), which catastrophically broke the volume pathway (volume tokens have no residual fallback from slice tokens). SLICEPE is safe from this failure mode:
- **Zero-init + small σ=0.02**: at step 0, `P ~ N(0, 0.02)` — a 2% perturbation to slice_tokens, not a magnitude collapse
- **Additive**: no multiplication or subtraction, no magnitude dampening
- **Both pathways intact**: surface and volume tokens both attend against the same slice_tokens with SLICEPE — no asymmetric pathway destruction
- **Gated**: `use_slice_pe=False` recovers exact baseline

### Parameter overhead

`H × S × D_head × n_layers = 4 × 128 × 128 × 5 = 327,680 params ≈ 1.9% of baseline 17.66M`. Negligible memory cost.

## Instructions

**Changes are in `model.py` (~15 LOC) + `train.py` (~5 LOC), all gated by `use_slice_pe=False` baseline flag.**

### Step 1 — `train.py`: Add config flag

In `class Config` (near `use_qk_norm: bool = False`, line ~104), add:
```python
use_slice_pe: bool = False
```

### Step 2 — `train.py`: Thread through `build_model`

In `build_model()`, add to `SurfaceTransolver(...)`:
```python
use_slice_pe=config.use_slice_pe,
```

### Step 3 — `model.py`: Thread through `SurfaceTransolver.__init__`

Add `use_slice_pe: bool = False` to `SurfaceTransolver.__init__` signature (alongside `use_qk_norm`). Pass it through to `Transformer(...)` constructor.

### Step 4 — `model.py`: Thread through `Transformer.__init__`

Add `use_slice_pe: bool = False` parameter. Pass through to each `TransformerBlock(...)`.

### Step 5 — `model.py`: Thread through `TransformerBlock.__init__`

Add `use_slice_pe: bool = False` parameter. Pass through to `TransolverAttention(...)`.

### Step 6 — `model.py`: Implement in `TransolverAttention.__init__`

Add `use_slice_pe: bool = False` to `TransolverAttention.__init__` signature. After the existing `self.qkv = ...` line (~line 252), add:
```python
self.use_slice_pe = use_slice_pe
if use_slice_pe:
    self.slice_pe = nn.Parameter(torch.zeros(1, self.num_heads, self.num_slices, self.dim_head))
    nn.init.normal_(self.slice_pe, std=0.02)
```

### Step 7 — `model.py`: Implement in `TransolverAttention.forward`

After the line `slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)` (line ~278), add:
```python
if self.use_slice_pe:
    slice_tokens = slice_tokens + self.slice_pe
```

Everything else in `forward` is unchanged.

### Smoke test

Before launching, verify the flag works:
```python
import torch
from model import SurfaceTransolver

# Flag off — exact baseline path
m_off = SurfaceTransolver(n_hidden=64, n_head=4, slice_num=16, n_layers=2, use_slice_pe=False)
assert not any('slice_pe' in k for k in m_off.state_dict())

# Flag on — slice_pe params present and zero-ish at init
m_on = SurfaceTransolver(n_hidden=64, n_head=4, slice_num=16, n_layers=2, use_slice_pe=True)
assert any('slice_pe' in k for k in m_on.state_dict())
for k, v in m_on.named_parameters():
    if 'slice_pe' in k:
        assert v.abs().max() < 0.1, f"slice_pe too large at init: {v.abs().max()}"
print("Smoke PASS")
```

### Training command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-slice-pe \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent askeladd --wandb-group askeladd-h33-slicepe \
  --wandb-name askeladd/h33-slicepe-main
```

## EP3 Gate and Kill Criteria

**EP3 survival gate** (after EP3 completes):
- τz/τx ≤ **1.42** AND val_abupt ≤ **8.5%** → CONTINUE to EP13
- KILL if at any epoch: val_abupt > 9.5%, τz/τx > 1.55, nonfinite > 0, val_SP > 5.5%

**Safety check at EP1** (new for H33 given H32 lesson):
- val_volume_p_mae should be normal cold-start range (5-10 range, not 30+)
- If val_volume_p_mae > 20 at EP1: report immediately before proceeding (slice_pe init too large, or threaded incorrectly into volume path)

## Baseline

Single-model baseline — PR #972, W&B run `56bcqp3m`:

| Metric | Baseline |
|--------|----------|
| val_abupt | 6.126% |
| test_abupt | 5.844% |
| test_vol_p | 3.643% |
| test_SP | 3.577% |
| test_WSS | 6.727% |

**Single-model merge gate:** val_abupt < 6.126% AND test_vol_p ≤ 3.643% AND test_SP ≤ 3.577%

Reproduce baseline:
```bash
cd target/ && torchrun --nproc_per_node=8 train.py \
  --lr 9e-5 --batch_size 4 \
  --vol_sample_schedule "0:16384:3:32768:6:49152:9:65536" \
  --wandb_group baseline-reproduce
```
