### PR TITLE
Wave 30 H34: Per-Channel Auxiliary Output Heads (OUTHEAD) — break head-side τz/τx rank coupling

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_per_channel_aux_heads: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_per_channel_aux_heads = use_per_channel_aux_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -498,6 +500,29 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        if use_per_channel_aux_heads:
+            # H34 OUTHEAD: per-channel auxiliary residual MLP heads.
+            # Each head outputs one scalar residual added to the corresponding
+            # column of surface_out's output. Last layer is zero-initialised so
+            # aux contribution at init is exactly 0 -> bit-exact baseline at
+            # step 0; gradients can grow the residuals if τ_z/τ_x rank-coupling
+            # in the shared surface_out projection is the bottleneck.
+            self.surface_aux_heads = nn.ModuleList([
+                nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden // 2),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden // 2, 1),
+                )
+                for _ in range(self.surface_output_dim)
+            ])
+            for head in self.surface_aux_heads:
+                nn.init.kaiming_uniform_(head[0].weight, a=math.sqrt(5))
+                nn.init.zeros_(head[0].bias)
+                nn.init.zeros_(head[2].weight)
+                nn.init.zeros_(head[2].bias)
+        else:
+            self.surface_aux_heads = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -621,8 +646,16 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        surface_aux_out: torch.Tensor | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_pred = self.surface_out(surface_hidden)
+            if self.surface_aux_heads is not None:
+                # Per-channel residual corrections concatenated to [B, N, 4]
+                aux_outputs = [head(surface_hidden) for head in self.surface_aux_heads]
+                surface_aux = torch.cat(aux_outputs, dim=-1)
+                surface_aux_out = surface_aux * surface_mask.unsqueeze(-1)
+                surface_pred = surface_pred + surface_aux
+            surface_preds = surface_pred * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -639,4 +672,5 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "surface_aux_out": surface_aux_out,
         }

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_per_channel_aux_heads: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_per_channel_aux_heads": (
+            "H34 OUTHEAD: add per-channel auxiliary residual MLP heads on "
+            "top of the shared surface_out projection. Each surface output "
+            "channel (cp, tau_x, tau_y, tau_z) gets its own 2-layer "
+            "Linear -> SiLU -> Linear residual head whose last layer is "
+            "zero-initialised, so the layer is identity at init and "
+            "preserves baseline at epoch 0. Tests whether the τz/τx band "
+            "attractor is head-side rank-coupling: independent residual "
+            "capacity per channel allows τ_z to break out of the [1.44, "
+            "1.55] band if the bottleneck is in the shared final projection."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +288,97 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+SURFACE_CHANNEL_NAMES = ("cp", "tau_x", "tau_y", "tau_z")
+
+
+def collect_aux_head_weight_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-channel auxiliary head weight diagnostics (H34 OUTHEAD).
+
+    Returns the L2 norm of the zero-initialised last layer's weight (and
+    bias) for each surface output channel. A norm > 0 means gradients have
+    flowed into the head and the aux residual is no longer identically
+    zero. Per-channel growth asymmetry is the head-side rank-coupling
+    mechanism signal.
+    """
+
+    heads = getattr(model, "surface_aux_heads", None)
+    if heads is None:
+        return {}
+    metrics: dict[str, float] = {}
+    for i, head in enumerate(heads):
+        name = SURFACE_CHANNEL_NAMES[i] if i < len(SURFACE_CHANNEL_NAMES) else f"ch{i}"
+        last_layer = head[2]
+        w = last_layer.weight.detach().float()
+        b = last_layer.bias.detach().float()
+        first_w = head[0].weight.detach().float()
+        metrics[f"aux_head/last_layer_weight_norm/{name}"] = float(w.norm().item())
+        metrics[f"aux_head/last_layer_bias_norm/{name}"] = float(b.norm().item())
+        metrics[f"aux_head/first_layer_weight_norm/{name}"] = float(first_w.norm().item())
+        metrics[f"aux_head/last_layer_abs_max/{name}"] = float(w.abs().max().item())
+    return metrics
+
+
+@torch.no_grad()
+def collect_aux_head_activation_metrics(
+    base_model: nn.Module,
+    loader,
+    device: torch.device,
+    amp_mode: str,
+    max_batches: int = 2,
+) -> dict[str, float]:
+    """Per-channel aux head output magnitude diagnostics (H34 OUTHEAD).
+
+    Runs up to ``max_batches`` forward passes through the (already DDP-
+    sharded) validation loader on the unwrapped base model and accumulates
+    the masked absolute-mean of the per-channel aux output residual.
+    Intended to be called from rank 0 only after the main distributed
+    evaluate_split has finished, so the unwrapped base_model carries the
+    EMA weights and DDP collectives are no longer in flight. Computes the
+    asymmetry ratio aux_tau_z / aux_tau_x as the head-side rank-coupling
+    mechanism signal: > 1 means τ_z residual is larger than τ_x.
+    """
+
+    if getattr(base_model, "surface_aux_heads", None) is None:
+        return {}
+    was_training = base_model.training
+    base_model.eval()
+    sums = torch.zeros(len(SURFACE_CHANNEL_NAMES), device=device, dtype=torch.float32)
+    counts = torch.zeros(len(SURFACE_CHANNEL_NAMES), device=device, dtype=torch.float32)
+    for i, batch in enumerate(loader):
+        if i >= max_batches:
+            break
+        batch = batch.to(device)
+        with autocast_context(device, amp_mode):
+            out = base_model(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+        aux = out.get("surface_aux_out")
+        if aux is None:
+            continue
+        mask = batch.surface_mask.unsqueeze(-1).to(aux.dtype)
+        n_pts = mask.sum().clamp(min=1.0).float()
+        per_channel_abs_sum = (aux.float().abs() * mask.float()).sum(dim=(0, 1))
+        sums += per_channel_abs_sum
+        counts += n_pts
+    if was_training:
+        base_model.train()
+    metrics: dict[str, float] = {}
+    abs_means: list[float] = []
+    for i, name in enumerate(SURFACE_CHANNEL_NAMES):
+        cnt = float(counts[i].item())
+        m = float((sums[i] / max(cnt, 1.0)).item()) if cnt > 0 else 0.0
+        metrics[f"aux_head/abs_mean/{name}"] = m
+        abs_means.append(m)
+    if abs_means[1] > 0.0:
+        metrics["aux_head/asymmetry_ratio"] = abs_means[3] / abs_means[1]
+    else:
+        metrics["aux_head/asymmetry_ratio"] = 0.0
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +411,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_per_channel_aux_heads=config.use_per_channel_aux_heads,
     )
 
 
@@ -1262,6 +1366,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_aux_head_weight_metrics(base_model))
+                if config.use_per_channel_aux_heads:
+                    log_metrics.update(
+                        collect_aux_head_activation_metrics(
+                            base_model,
+                            val_loaders["val_surface"],
+                            device,
+                            config.amp_mode,
+                            max_batches=2,
+                        )
+                    )
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**The [1.44, 1.55] τz/τx band attractor is a head-side rank-coupling signature.** The surface output head currently projects the trunk's 512-d hidden state through a single shared `Linear(512, 4)` final layer to produce {cp, τ_x, τ_y, τ_z}. The 4 output rows share the same SiLU-activated hidden vector — if τ_x and τ_z gradients are dominated by a shared mode in the hidden space, the final projection inherits that coupling and the τz/τx ratio settles into a band determined by the projection geometry.

Wave 30 evidence for head-side coupling (10 cold-start fades from independent attack axes — encoder, loss, optimizer, architecture, input features — all converging to [1.44, 1.55]):
- **fern H24** (encoder slice-temp) → EP1 1.395 → EP11 1.551 (saturated, can't escape)
- **alphonse H25 ALGP** (auxiliary aux head) → CLOSED EP3 1.500
- **edward H28 SAM** (optimizer-space) → CLOSED EP2 1.4999 (mean-shift attack)
- **alphonse H31 WALLDIST** (input log-SDF) → 1.376 → EP4 1.541
- **nezuko H30 V2S xattn** (cross-modal fusion) → 1.428 → EP4 1.522

The only mean-shift attack that survives is **thorfinn H26 NPCA** which breaks the band via VARIANCE/SPREAD (std 0.092→0.228), not by changing the projection direction. This is consistent with the head-side hypothesis: NPCA increases per-car variance of the *input* coordinates which the head can no longer collapse into a uniform projection.

**Direct attack at the head level:** Add a per-channel auxiliary residual MLP head for each of the 4 surface output channels. Each aux head sees the same trunk output but has its own SiLU non-linearity and 2-layer projection, giving each channel its own representational capacity to deviate from the shared mode.

If the rank-1 coupling hypothesis is right, this gives τ_z and τ_x independent degrees of freedom to escape the band — without touching the trunk or training dynamics. If it's wrong, the aux heads stay near zero (residuals don't grow) and we learn the bottleneck is in the trunk.

## Instructions

**File: `target/model.py`** — modify `SurfaceTransolver.__init__` and `forward`:

In `__init__`, add a config flag and the per-channel residual head module list. After the existing `self.surface_out` block (around line 484-489), append:

```python
self.use_per_channel_aux_heads = use_per_channel_aux_heads
if use_per_channel_aux_heads:
    # Per-channel auxiliary residual heads. Each head outputs a single scalar
    # residual that is added to the corresponding column of self.surface_out's
    # output. Last layer zero-init -> identity at init (bit-exact baseline).
    self.surface_aux_heads = nn.ModuleList([
        nn.Sequential(
            nn.Linear(n_hidden, n_hidden // 2),
            nn.SiLU(),
            nn.Linear(n_hidden // 2, 1),
        )
        for _ in range(self.surface_output_dim)
    ])
    for head in self.surface_aux_heads:
        # Kaiming on first layer, zero on second
        nn.init.kaiming_uniform_(head[0].weight, a=math.sqrt(5))
        nn.init.zeros_(head[0].bias)
        nn.init.zeros_(head[2].weight)
        nn.init.zeros_(head[2].bias)
else:
    self.surface_aux_heads = None
```

(You'll need `import math` at top of `model.py` if not already imported.)

In the `forward` method, find where `surface_pred = self.surface_out(surface_hidden_normed)` is computed (after the final norm). Add an additive residual:

```python
surface_pred = self.surface_out(surface_hidden_normed)
if self.use_per_channel_aux_heads:
    # Per-channel residual corrections — each head sees the same hidden,
    # outputs its own scalar, concatenated to match surface_pred shape [B, N, 4]
    aux_outputs = [head(surface_hidden_normed) for head in self.surface_aux_heads]
    surface_aux = torch.cat(aux_outputs, dim=-1)  # [B, N, 4]
    surface_pred = surface_pred + surface_aux
```

**File: `target/train.py`** — thread the flag through:

1. Add `use_per_channel_aux_heads: bool = False` to the `Config` dataclass near the other model flags (e.g. next to `use_qk_norm`, ~line 104).
2. Add CLI arg `--use-per-channel-aux-heads` (action="store_true").
3. Pass `use_per_channel_aux_heads=config.use_per_channel_aux_heads` to `SurfaceTransolver` constructor in `build_model()` (~line 297).

**Smoke checks before main run:**

1. Flag OFF (`use_per_channel_aux_heads=False`): state_dict contains zero `surface_aux_heads.*` keys; forward output bit-exact baseline.
2. Flag ON, single-step forward: `surface_pred` at step 0 must equal baseline (zero-init final layer of aux heads → aux contribution = 0 at init). Verify `|aux_outputs[i]|.max() == 0` for all i at step 0.
3. After 100 train steps with flag ON: log `surface_aux_heads/{i}/last_layer_weight_norm` to verify gradients are flowing. Expect non-zero by step 100.
4. Parameter overhead: confirm 4 × (512×256 + 256 + 256×1 + 1) = 525,316 extra params (~3.1% overhead).

**Optional but recommended observability:** in the val loop or at each val epoch, log:
- `aux_head/cp/abs_mean`, `aux_head/tau_x/abs_mean`, `aux_head/tau_y/abs_mean`, `aux_head/tau_z/abs_mean`
- `aux_head/last_layer_norm/{cp,tau_x,tau_y,tau_z}` (verify per-channel growth)
- `aux_head/asymmetry_ratio` = aux_head/tau_z/abs_mean ÷ aux_head/tau_x/abs_mean (mechanism asymmetry signal — should grow if rank-coupling hypothesis is right)

**Training command** (DDP-8, 18h budget, identical to other Wave 30 recipes):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-per-channel-aux-heads \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent edward --wandb-group wave30_h34_outhead \
  --wandb-name edward/h34-outhead-main \
  --kill-thresholds "1:val_primary/abupt_axis_mean_rel_l2_pct<9.5,3:val_primary/abupt_axis_mean_rel_l2_pct<8.5"
```

## EP3 binding gate

| Gate | PASS | KILL |
|---|---:|---:|
| val_abupt | ≤ 8.5% | > 9.5% |
| τz/τx | ≤ 1.42 (mechanism break) | > 1.55 |
| aux_head/tau_z/last_layer_norm | > 0 (growing) | = 0 stuck |
| nonfinite_count | 0 | > 0 |

**Mechanism signal at EP3:** aux_head/tau_z/abs_mean ÷ aux_head/tau_x/abs_mean > 1.5 means aux heads developed asymmetric corrections (mechanism live). Ratio ≈ 1.0 means heads grew symmetrically, suggesting the bottleneck is in the trunk, not the head.

## Baseline

Current best (PR #972, run `56bcqp3m`):
- val/abupt: **6.126%**
- val/SP: 3.577% (floor)
- val/vol_p: 3.643% (floor)
- val/WSS: 6.727%
- test_abupt: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: 6.727%
- test_tau_z: 8.916%

Reproduce command (without H34):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

## Wave 30 fleet context (current peers)

- thorfinn H26 NPCA Path A: **mechanism PASSED** (std 0.092→0.228) — first variance-break proof
- frieren H29 SSFL: EP7 val_abupt **6.4349%** (fleet-low, +0.31pp above baseline 6.126%)
- nezuko H30 V2S xattn: EP4 6.576% (continuing, val-side fade pattern matching H18)
- alphonse H31 WALLDIST: EP4 6.417% (continuing, val_vol_p approaching floor at 3.780%)
- askeladd H33 SLICEPE: launched 05:16Z (slice-token positional embedding)
- fern H24 GSTS: EP11 6.328% (saturated, won't beat baseline)
- tanjiro H18d: EP6 marginal, CONTINUE TO EP13 with EP9 mid-gate
- **edward H34 OUTHEAD: NEW** (output-head decoupling, this PR)

If H34 EP3 mechanism gate passes, you're the second Wave 30 proof that the band attractor is escapable — but via a head-side mechanism (rank-coupling) rather than thorfinn's trunk-side mechanism (variance-break). Mechanistically distinct = strong signal for Wave 31 stacking.
