### PR TITLE
Wave 31 H35: NPCA + SSFL Stack — combine two Wave 30 surviving mechanisms (variance-break + loss-reshape)

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,42 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
+    """Project global position onto a per-vertex local surface frame.
+
+    Computes ``[p·n, p·t1, p·t2]`` per vertex, where ``t1, t2`` are a
+    Gram-Schmidt tangent basis derived from the surface normal.
+
+    Computed in fp32 with an explicit eps=1e-6 in ``F.normalize`` so that
+    zero-padded tokens (normal == ``[0,0,0]``) produce zero projections
+    instead of NaN, even when called inside a bf16/fp16 autocast region.
+
+    Args:
+        surface_x: ``[B, N, >=6]`` with columns ``[x, y, z, nx, ny, nz, ...]``.
+
+    Returns:
+        ``[B, N, 3]`` with ``[p·n, p·t1, p·t2]`` per vertex, cast back to
+        the input dtype.
+    """
+    input_dtype = surface_x.dtype
+    sx = surface_x.float()
+    pos = sx[:, :, :3]
+    n = F.normalize(sx[:, :, 3:6], dim=-1, eps=1e-6)
+
+    ref_a = torch.tensor([0.0, 0.0, 1.0], device=n.device, dtype=n.dtype).expand_as(n)
+    ref_b = torch.tensor([0.0, 1.0, 0.0], device=n.device, dtype=n.dtype).expand_as(n)
+    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
+    ref = torch.where(parallel_mask, ref_b, ref_a)
+
+    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+
+    local_n = (pos * n).sum(-1, keepdim=True)
+    local_t1 = (pos * t1).sum(-1, keepdim=True)
+    local_t2 = (pos * t2).sum(-1, keepdim=True)
+    return torch.cat([local_n, local_t1, local_t2], dim=-1).to(dtype=input_dtype)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_local_frame_proj: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,7 +433,10 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_local_frame_proj = use_local_frame_proj
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        if use_local_frame_proj:
+            surface_extra_dim += 3
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_multisigma":
@@ -462,6 +502,14 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if use_local_frame_proj and self.project_surface_features is not None:
+            # Identity-init: zero the 3 NEW input columns of project_surface_features
+            # so the model starts from the current baseline at step 0. The 3 new
+            # columns sit at indices [4, 5, 6] of the surface feature vector
+            # (after [nx, ny, nz, area] at [0, 1, 2, 3]). The bias is already
+            # zero-init via _init_linear, so no extra step is needed.
+            with torch.no_grad():
+                self.project_surface_features.project.weight[:, 4:7].zero_()
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -528,12 +576,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        local_proj: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if local_proj is not None:
+            feature_parts.append(local_proj)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -567,6 +618,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            local_proj = (
+                compute_local_frame_proj(surface_x) if self.use_local_frame_proj else None
+            )
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -575,6 +629,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    local_proj=local_proj,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_local_frame_proj: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_local_frame_proj": (
+            "Enable normal-projected coordinate augmentation (H26, PR "
+            "#1177). For each surface vertex, append 3 scalar features "
+            "[p.n, p.t1, p.t2] -- the global position projected onto the "
+            "vertex's local normal/tangent frame -- to the surface input "
+            "features before the projection linear. t1, t2 are a "
+            "Gram-Schmidt tangent basis from the surface normal. Goal: "
+            "give the encoder explicit local-frame position so it can "
+            "break the structural tau_z/tau_x band attractor at [1.44, "
+            "1.55]. The 3 new input columns of project_surface_features "
+            "are zero-init so step 0 is identical to the baseline. Volume "
+            "branch is unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_local_frame_proj=config.use_local_frame_proj,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -104,6 +104,9 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     use_local_frame_proj: bool = False
+    lambda_spectral: float = 0.0
+    spectral_hf_weight: float = 2.0
+    spectral_channels: str = "wss"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -243,6 +246,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "are zero-init so step 0 is identical to the baseline. Volume "
             "branch is unchanged."
         ),
+        "lambda_spectral": (
+            "Streamwise-Spectral Frequency Loss weight (H29, PR #1182). "
+            "When > 0, adds a spectral-domain MSE term computed by sorting "
+            "surface tokens by streamwise z, taking rfft along the sorted "
+            "axis, and frequency-weighting the squared magnitude residual "
+            "with a linear ramp from 1.0 at DC to --spectral-hf-weight at "
+            "Nyquist. lambda_spectral=0.0 reproduces baseline exactly. "
+            "frieren's tuned default at solo H29 launch was 0.1; the H35 "
+            "stack PR specifies 0.05 to leave headroom for NPCA's "
+            "encoder-side gradient signal."
+        ),
+        "spectral_hf_weight": (
+            "Upper bound of the linear frequency-ramp used by the H29 "
+            "Streamwise-Spectral loss. 1.0 = flat (no upweighting); 2.0 = "
+            "double weight at the Nyquist bin. Only meaningful when "
+            "--lambda-spectral > 0."
+        ),
+        "spectral_channels": (
+            "Which surface output channels the H29 spectral loss is "
+            "applied to. 'all' = all 4 (cp + 3 wss); 'wss' = wall-shear "
+            "components only (tau_x, tau_y, tau_z); 'cp' = surface pressure "
+            "only. frieren's H29 tuned default = 'wss' (cp is smooth and "
+            "may destabilise)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -326,6 +353,98 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+SPECTRAL_CHANNEL_PRESETS: dict[str, tuple[bool, ...]] = {
+    "all": (True, True, True, True),
+    "wss": (False, True, True, True),
+    "cp": (True, False, False, False),
+}
+
+
+def spectral_channel_mask(spec: str, device: torch.device | None = None) -> torch.Tensor | None:
+    """Resolve the --spectral-channels string into a [4]-bool tensor.
+
+    Returns None when the preset is "all" (no masking needed).
+    """
+    key = (spec or "all").strip().lower()
+    if key not in SPECTRAL_CHANNEL_PRESETS:
+        raise ValueError(
+            f"Unknown --spectral-channels preset: {spec!r}. "
+            f"Choices: {sorted(SPECTRAL_CHANNEL_PRESETS)}"
+        )
+    flags = SPECTRAL_CHANNEL_PRESETS[key]
+    if all(flags):
+        return None
+    return torch.tensor(flags, dtype=torch.bool, device=device)
+
+
+def spectral_surface_loss(
+    pred_norm: torch.Tensor,
+    target_norm: torch.Tensor,
+    mask: torch.Tensor,
+    sort_idx: torch.Tensor,
+    lambda_spectral: float,
+    hf_weight: float,
+    channel_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Streamwise-Spectral Frequency Loss (H29 / PR #1182).
+
+    Sorts surface tokens by streamwise z (via ``sort_idx``), takes ``rfft``
+    along the sorted axis, then computes a frequency-weighted squared
+    magnitude residual with a linear ramp from 1.0 at DC to ``hf_weight``
+    at Nyquist. Optionally masked to a subset of output channels.
+
+    Always run in fp32 (FFT is precision-sensitive under bf16 autocast,
+    matching the lesson from askeladd's H27 NaN fix). ``lambda_spectral=0.0``
+    returns a connected-graph zero so DDP find_unused_parameters does not
+    trip. ``N=0`` empty-surface batches (data/loader pair-modalities edge
+    case documented in program.md) also short-circuit to zero; this is the
+    guard frieren added pre-launch on H29 to prevent ``torch.fft.rfft``
+    crashing on length-0 inputs.
+    """
+    if lambda_spectral == 0.0:
+        return pred_norm.float().sum() * 0.0
+    if pred_norm.shape[1] == 0:
+        return lambda_spectral * pred_norm.float().sum() * 0.0
+
+    pred_f = pred_norm.float()
+    tgt_f = target_norm.float()
+    mask_f = mask.float()
+
+    B, N, C = pred_f.shape
+    idx = sort_idx.unsqueeze(-1).expand(-1, -1, C)
+    pred_s = pred_f.gather(1, idx)
+    tgt_s = tgt_f.gather(1, idx)
+    msk_s = mask_f.gather(1, sort_idx).unsqueeze(-1)
+
+    # Zero padded tokens before FFT (avoid spectral leakage).
+    pred_s = pred_s * msk_s
+    tgt_s = tgt_s * msk_s
+
+    # norm='ortho' so Parseval preserves L2: mean(|X|^2) ~ MSE_spatial,
+    # independent of N. Without it, magnitude scales with N and dwarfs
+    # the spatial MSE (verified: default norm gave spec~100 vs frieren's
+    # observed [0.001, 1.0] target band at lambda=0.1, N=65536).
+    pf = torch.fft.rfft(pred_s, dim=1, norm="ortho")
+    tf = torch.fft.rfft(tgt_s, dim=1, norm="ortho")
+
+    n_bins = pf.shape[1]
+    w = torch.linspace(
+        1.0,
+        hf_weight,
+        n_bins,
+        device=pf.device,
+        dtype=pf.real.dtype,
+    ).view(1, -1, 1)
+
+    diff = pf - tf
+    sq = diff.real.square() + diff.imag.square()
+
+    if channel_mask is not None:
+        sq = sq * channel_mask.view(1, 1, -1).to(device=sq.device, dtype=sq.dtype)
+
+    return lambda_spectral * (sq * w).mean()
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -336,6 +455,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    lambda_spectral: float = 0.0,
+    spectral_hf_weight: float = 2.0,
+    spectral_channel_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -361,12 +483,29 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+    if lambda_spectral > 0.0:
+        # Compute spectral loss outside autocast for fp32 numerical safety.
+        sort_idx = batch.surface_x[:, :, 2].detach().argsort(dim=1).long()
+        spectral_term = spectral_surface_loss(
+            out["surface_preds"],
+            surface_target,
+            batch.surface_mask,
+            sort_idx,
+            lambda_spectral=lambda_spectral,
+            hf_weight=spectral_hf_weight,
+            channel_mask=spectral_channel_mask,
+        )
+        loss = loss + spectral_term
+        spectral_metric_value = float(spectral_term.detach().cpu().item())
+    else:
+        spectral_metric_value = 0.0
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "spectral_loss": spectral_metric_value,
     }
 
 
@@ -773,6 +912,11 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        ssfl_channel_mask = (
+            spectral_channel_mask(config.spectral_channels, device=device)
+            if config.lambda_spectral > 0.0
+            else None
+        )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1045,6 +1189,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        lambda_spectral=config.lambda_spectral,
+                        spectral_hf_weight=config.spectral_hf_weight,
+                        spectral_channel_mask=ssfl_channel_mask,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1085,6 +1232,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "spectral_loss" in batch_loss_metrics:
+                        train_log["train/spectral_loss"] = batch_loss_metrics["spectral_loss"]
+                if config.lambda_spectral > 0.0:
+                    train_log["train/lambda_spectral"] = float(config.lambda_spectral)
+                    train_log["train/spectral_hf_weight"] = float(config.spectral_hf_weight)
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,52 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Compute per-car tau_z_rel_l2 / tau_x_rel_l2 statistics for H26 diagnostics.
+
+    Iterates over case_ids common to both stores, builds per-case rel_l2 from
+    sqrt(error_sq / target_sq), and reports mean/std/min/max plus an
+    out-of-band counter for the [1.40, 1.60] band attractor probe.
+
+    Returns an empty dict if fewer than 2 common cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1113,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1164,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**The two surviving Wave 30 mechanisms attack orthogonal failure modes — stack them.** Wave 30 produced exactly two non-faded mechanism wins:

1. **H26 NPCA (thorfinn)** — Normal-Projected Canonical Anchors: local-frame coordinate input (Gram-Schmidt tangent frame from surface normals) replaces global Cartesian for surface tokens. EP3 mechanism gate PASSED decisively: `std(τz/τx)` per-car grew **0.092 → 0.228** (4.56× over gate threshold, 11.4× over baseline std). 13/34 val cars outside [1.40, 1.60] band at EP3 (vs ~3/34 at baseline). **This is the only attack mechanism in Wave 30 that broke the band attractor via variance/spread.** Path A 18h retry currently mid-EP5 with val_abupt 6.541%, linear projection EP13 5.95% (would beat baseline 6.126%).

2. **H29 SSFL (frieren)** — Streamwise-Spectral Frequency Loss: spectral surface loss with streamwise-frequency upweighting. EP7 val_abupt **6.4349%** = **Wave 30 fleet-low** (vs baseline 6.126%, gap 0.31pp). Mechanism: spectral_loss term penalizes high-frequency reconstruction errors in surface fields, forcing the model to learn fine-detail patterns that MSE-loss alone smooths over. τz/τx stays inside band [1.44, 1.55] (no variance break), but **absolute val_abupt within the band drops to fleet-low**.

**The mechanism mismatch is the key insight:** H26 attacks the BAND ATTRACTOR (variance/spread of per-car τz/τx), H29 attacks ABSOLUTE ACCURACY (val_abupt scalar within whatever spread is achieved). These are mathematically orthogonal failure modes — one affects the second moment of per-car distribution, the other affects the first moment of per-car mean prediction quality.

**Stacking hypothesis:** A single training run with both NPCA (local-frame input coords) AND SSFL (spectral surface loss) should yield a model that simultaneously:
- Breaks the band attractor via NPCA's variance signal (std(τz/τx) ≥ 0.15 at EP3, matching H26 mechanism gate)
- Achieves baseline-beating absolute val_abupt via SSFL's spectral loss (target < 6.126%)

If the mechanisms are truly orthogonal, expected EP13 result: val_abupt ~5.85-6.00% with τz/τx variance ≥ 0.15. This would clear the merge gate decisively and validate Wave 30's two mechanism wins are stackable for Wave 31.

**Risk note:** Interaction is the failure mode to watch. If SSFL's high-frequency gradient signal forces all surface tokens toward a shared spectral mode, it could suppress NPCA's per-car coordinate variance. The EP3 gate `std(τz/τx) ≥ 0.15` is the early-warning check for this. If suppressed, the followup is to reduce λ_ssfl by 0.5× and re-run.

## Instructions

This experiment combines two already-implemented mechanisms from two separate branches. **Both source branches are in tay's git history** — cherry-pick the relevant changes and combine.

### Source branches to study

1. **H26 NPCA implementation**: `thorfinn/h26-npca-local-frame-retry` (PR #1177 — still open). Source files: `target/model.py` (NPCA coordinate transform in `_encode_group` or equivalent), `target/train.py` (Config flag `use_npca_local_frame: bool`).
2. **H29 SSFL implementation**: `frieren/h29-ssfl-spectral-loss` (PR #1182 — still open). Source files: `target/train.py` (loss computation, SSFL term, λ_ssfl weight, fft-based streamwise-frequency decomposition), `target/model.py` (no architectural changes for SSFL).

Read both PRs carefully — they describe their exact implementations in detail. Cherry-pick:

- From #1177: NPCA local-frame coordinate transform applied to surface tokens (volume tokens remain Cartesian).
- From #1182: SSFL spectral loss term with λ_ssfl = 0.05 (frieren's tuned value; do NOT change), streamwise-frequency upweighting (FFT along sorted z-coordinate or whatever frieren used).

### Combined Config flags to add to `train.py`

```python
@dataclass
class Config:
    # ... existing flags ...
    use_npca_local_frame: bool = False  # from H26 (already exists if thorfinn merged)
    use_ssfl_spectral_loss: bool = False  # from H29 (already exists if frieren merged)
    ssfl_weight: float = 0.05  # H29 tuned default
```

If H26 / H29 have NOT yet merged to main (they shouldn't have — they're WIP), you'll need to cherry-pick the diffs manually. Use `git log thorfinn/h26-... -- target/model.py target/train.py` and `git log frieren/h29-... -- target/train.py` to find the exact commits.

### Verification before main run

1. **Flag-off identity**: with `use_npca_local_frame=False, use_ssfl_spectral_loss=False`, state_dict and forward output must be bit-exact baseline. No new keys in state_dict, training loss identical to baseline.
2. **NPCA alone**: with `use_npca_local_frame=True, use_ssfl_spectral_loss=False`, smoke test must match H26 PR #1177's reported EP1 mechanism: τz/τx 1.386, std growing toward 0.09.
3. **SSFL alone**: with `use_npca_local_frame=False, use_ssfl_spectral_loss=True`, smoke test must match H29 PR #1182's reported EP1: spectral_loss reduces from initial value, mse_loss healthy, τz/τx 1.385.
4. **Stack**: with both flags True, smoke test 2 epochs (small surface point count, e.g. 16384) to verify (a) train completes, (b) no NaN, (c) both spectral_loss AND τz/τx mechanism are alive at EP1 reading.

### Smoke checks to log

Add these to per-epoch val logs:
- `npca/local_frame_active` (True/False — proof flag is on)
- `npca/surface_x_local_frame_norm_mean` (sanity: should be O(1))
- `ssfl/spectral_loss_value` (track magnitude — should reduce from EP1 to plateau)
- `ssfl/spectral_loss_weight` (λ_ssfl = 0.05)
- `per_car_tau_z_over_tau_x_std` (key mechanism diagnostic — should be ≥0.15 at EP3 if NPCA mechanism survives stacking)

### Training command (DDP-8, 18h budget, EP3 gate hyperparams)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-npca-local-frame --use-ssfl-spectral-loss --ssfl-weight 0.05 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent fern --wandb-group wave31_h35_npca_ssfl_stack \
  --wandb-name fern/h35-stack-main \
  --kill-thresholds "3:val_primary/abupt_axis_mean_rel_l2_pct<9.5,3:val_primary/surface_pressure_rel_l2_pct<5.5"
```

**NOTE the `--kill-thresholds` epoch indexing:** thresholds activate from epoch 3 onwards (the `3:` prefix means "from EP3"). This matches the EP3 mechanism gate below — not active during cold-start EP1-EP2 (when val_abupt is 20-28% and would trigger immediately if gated from EP1).

## EP3 binding gate

| Gate | PASS | KILL |
|---|---:|---:|
| `std(τz/τx)` per-car | ≥ 0.15 (NPCA mechanism survives stacking) | < 0.10 (suppressed) |
| val_abupt | ≤ 6.50% (SSFL not hurting convergence) | > 6.80% |
| val_vol_p_mae | ≤ 6.0 (volume pathway healthy) | > 9.0 |
| nonfinite_count | 0 | > 0 |

**Mechanism signal at EP3:**
- `std(τz/τx) ≥ 0.15 AND val_abupt ≤ 6.50%` → mechanisms stack, CONTINUE to EP13
- `std(τz/τx) < 0.10 AND val_abupt > 6.60%` → SSFL suppressed NPCA, KILL and follow up with λ_ssfl × 0.5

**EP13 success criterion:** val_abupt < 6.126% (clears baseline) AND std(τz/τx) ≥ 0.15 (preserves band-break).

## Baseline

Current best (PR #972, run `56bcqp3m`):
- val/abupt: **6.126%**
- val/SP: 3.577% (floor)
- val/vol_p: 3.643% (floor)
- val/WSS: 6.727%
- test_abupt: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: 6.727%
- test_tau_z: 8.916%

Reproduce baseline (without H35 stack):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

## Wave 30 → Wave 31 transition

This is the **first Wave 31 hypothesis** — building on Wave 30's two surviving mechanisms. The 15 closed Wave 30 hypotheses (final count: H10b, H11b, H12, H16, H16b, H20, H21, H22, H23, H24, H25, H27, H28, H32 + H24 closing this round) all share the cold-start-fade pattern: encoder/loss/optimizer/architecture mean-shift attacks fade into [1.44, 1.55] by EP3.

The Wave 31 design principle from this evidence: **prefer variance/spread attacks + loss-reshape combos over mean-shift attacks**. H35 is the direct embodiment of this principle.

If H35 succeeds (val_abupt < 6.126% AND std ≥ 0.15), Wave 31 follow-ups will be:
- H35b same recipe with `--num-slices 192` (capacity + mechanism stack)
- H36 anchor-conditioned slice queries (DAB-DETR-style spatial specialization)
- H42 NPCA-warmstart from thorfinn's best H26 checkpoint

Strong implementation discipline expected. Your H24 GSTS work was the cleanest negative result of Wave 30 — apply the same rigor to the mechanism stacking and we have the strongest shot at the first Wave 31 baseline-beat.
