### PR TITLE
Wave 31 H44: Random Yaw Augmentation (symmetry-break data aug)

### DIFF
--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ import gc
 import math
 import os
 import time
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, replace
 from pathlib import Path
 from typing import Iterable
 
@@ -138,6 +138,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    yaw_aug_theta_max: float = 0.0
     debug: bool = False
 
 
@@ -220,6 +221,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "yaw_aug_theta_max": (
+            "Random yaw augmentation: max rotation angle (degrees) about the "
+            "z (vertical) axis. Applied per-item per-batch during training "
+            "only; rotates surface/volume xyz, surface normals, and vector "
+            "wall-shear targets (tau_x, tau_y) consistently. 0.0 disables "
+            "augmentation (exact baseline)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -292,6 +300,55 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
             metrics[f"{prefix}/freq_axis_{axis}_mean"] = float(log_freq[axis].mean().item())
             metrics[f"{prefix}/freq_axis_{axis}_std"] = float(log_freq[axis].std().item())
     return metrics
+
+
+def apply_yaw_augmentation(batch, theta_max_deg: float, training: bool):
+    """Random yaw rotation about the z (vertical) axis.
+
+    DrivAerML convention: x=streamwise, y=lateral (mean=0, mirror-symmetric),
+    z=vertical (ground to roof). Yaw is rotation about z, so it mixes the
+    (x, y) components of position, normals, and vector wall-shear targets;
+    surface_x[:,:,6] (area), volume_x[:,:,3] (sdf), surface_y[:,:,0] (cp), and
+    surface_y[:,:,3] (tau_z) are scalars / z-components and pass through.
+
+    Per-item theta ~ U[-theta_max, +theta_max] drawn fresh each step.
+    """
+    if not training or theta_max_deg <= 0.0:
+        return batch
+
+    B = batch.surface_x.shape[0]
+    device = batch.surface_x.device
+    theta_max = theta_max_deg * math.pi / 180.0
+    theta = (torch.rand(B, device=device) * 2.0 - 1.0) * theta_max  # [B]
+    cos_t = torch.cos(theta).view(B, 1, 1).to(batch.surface_x.dtype)
+    sin_t = torch.sin(theta).view(B, 1, 1).to(batch.surface_x.dtype)
+
+    def rot_xy(v: torch.Tensor) -> torch.Tensor:
+        # x' = x cos - y sin, y' = x sin + y cos (rotation about +z)
+        out = v.clone()
+        x = v[..., 0:1]
+        y = v[..., 1:2]
+        out[..., 0:1] = x * cos_t - y * sin_t
+        out[..., 1:2] = x * sin_t + y * cos_t
+        return out
+
+    surface_x = batch.surface_x.clone()
+    surface_x[:, :, 0:3] = rot_xy(batch.surface_x[:, :, 0:3])
+    if surface_x.shape[-1] >= 6:
+        surface_x[:, :, 3:6] = rot_xy(batch.surface_x[:, :, 3:6])
+
+    volume_x = batch.volume_x.clone()
+    volume_x[:, :, 0:3] = rot_xy(batch.volume_x[:, :, 0:3])
+
+    cos_t_y = cos_t.to(batch.surface_y.dtype)
+    sin_t_y = sin_t.to(batch.surface_y.dtype)
+    surface_y = batch.surface_y.clone()
+    tau_x = batch.surface_y[:, :, 1:2]
+    tau_y = batch.surface_y[:, :, 2:3]
+    surface_y[:, :, 1:2] = tau_x * cos_t_y - tau_y * sin_t_y
+    surface_y[:, :, 2:3] = tau_x * sin_t_y + tau_y * cos_t_y
+
+    return replace(batch, surface_x=surface_x, surface_y=surface_y, volume_x=volume_x)
 
 
 def build_model(config: Config) -> SurfaceTransolver:
@@ -936,6 +993,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                if config.yaw_aug_theta_max > 0.0:
+                    batch = batch.to(device)
+                    batch = apply_yaw_augmentation(
+                        batch, config.yaw_aug_theta_max, training=True
+                    )
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(


### PR DESCRIPTION
## Hypothesis

**Wave 31 H44: Random Yaw Augmentation — symmetry-breaking data augmentation to disrupt the τz/τx [1.44, 1.55] band attractor.**

### The problem

Every DrivAerML training car is at yaw=0 — perfectly aligned with the streamwise axis. The model has seen 400+ cases, all yaw=0, and has learned a shared representation that exploits this left-right symmetry. My hypothesis: the τz/τx band attractor [1.44, 1.55] is partially a **symmetry-exploitation artefact** — when every training car is yaw=0, the model learns that τz and τx are coupled in a specific ratio that reflects the symmetric boundary condition, not the per-car geometry. This is the first data-augmentation attack in DrivAerML experiment history (all 16 prior closures were loss or architecture changes).

### Why this matters now

H29 SSFL (your previous experiment) has just been closed as the **16th Wave 30 dead end and decisive loss-shape falsifier.** The spectral loss term descended 99% cleanly across 13 epochs while τz/τx stayed pinned at 1.500→1.532 — the band attractor is NOT spatial-frequency-mediated. The loss-shape axis is fully closed. The remaining unattacked tiers are: **data augmentation (you are here), representation/geometry (H26 NPCA — the only win), and decoder structure (H34 OUTHEAD in-flight)**.

Random yaw augmentation addresses the augmentation tier directly:
- **If it works:** τz/τx variance increases (per-car, the ratio becomes less correlated with the yaw=0 symmetry) and val_abupt < 6.126%. The model has learned to distinguish per-car geometry, not the shared yaw=0 mode.
- **If it fails:** The band attractor is NOT a yaw-symmetry artefact. Closes the data-augmentation tier cleanly. Combined with H29 SSFL closure, the research map narrows to representation (NPCA-class) and decoder-structure attacks.

### Mechanism prediction

1. Random yaw θ ~ U[-θ_max, +θ_max] per batch, applied consistently to inputs and targets
2. Model cannot memorize the yaw=0 symmetric representation — each batch presents a differently-oriented car
3. To correctly predict the rotated-frame targets, the model MUST learn per-car geometric features rather than shared yaw=0 couplings
4. This reduces the τz/τx coupling bias → per-car variance increases → band exit measurable at EP3 via std(τz/τx)

**Key novelty:** This is the first augmentation attack; **every** prior failure used fixed training geometry. Orthogonal to loss-shape (H29 just closed), architecture (H32/H33/H34 in-flight), and coordinate representation (H26 NPCA win).

---

## Instructions

Add ~40 LOC to `train.py` only. **No changes to `model.py`, `trainer_runtime.py`, or any read-only file.**

### Section A — Argument parser additions (~4 LOC)

```python
parser.add_argument(
    "--yaw-aug-theta-max", type=float, default=0.0,
    help="Max yaw angle (degrees) for random yaw augmentation. 0.0 = disabled (exact baseline)."
)
```

### Section B — Yaw rotation utility (~20 LOC)

Add near the top of `train.py`, after imports:

```python
import math

def apply_yaw_augmentation(batch, theta_max_deg: float, training: bool):
    """Randomly rotate the batch around the y (vertical) axis.
    Rotates INPUT coordinates and normals, AND consistently rotates VECTOR targets.
    Pressure (cp) is a scalar → unchanged. Wall shear (τx, τz) rotate under yaw.
    Only applied during training.
    """
    if not training or theta_max_deg <= 0.0:
        return batch
    
    B = batch.surface_x.shape[0]
    device = batch.surface_x.device
    theta_max = theta_max_deg * math.pi / 180.0
    theta = (torch.rand(B, device=device) * 2 - 1) * theta_max  # [B] ~ U[-θ, +θ]
    
    cos_t = torch.cos(theta)   # [B]
    sin_t = torch.sin(theta)   # [B]
    
    def rot_xz(v, cos_t, sin_t):
        """Apply y-axis rotation to x,z columns of a [B, N, C] tensor.
        Rotation: x' = x*cos(θ) + z*sin(θ), z' = -x*sin(θ) + z*cos(θ). y unchanged."""
        cos_e = cos_t.view(B, 1, 1)
        sin_e = sin_t.view(B, 1, 1)
        x = v[:, :, 0:1]
        z = v[:, :, 2:3]
        v = v.clone()
        v[:, :, 0:1] = x * cos_e + z * sin_e   # x'
        v[:, :, 2:3] = -x * sin_e + z * cos_e  # z'
        return v
    
    # Rotate surface input: xyz coords (first 3 cols) and surface normals (next 3 cols)
    # The exact column slices depend on your surface_x structure — check how NPCA reads
    # surface_x[:, :, :3] and surface_x[:, :, 3:6]. Same pattern here.
    batch_surface_x = batch.surface_x.clone()
    batch_surface_x[:, :, :3] = rot_xz(batch.surface_x[:, :, :3], cos_t, sin_t)
    if batch.surface_x.shape[-1] >= 6:  # normals present
        batch_surface_x[:, :, 3:6] = rot_xz(batch.surface_x[:, :, 3:6], cos_t, sin_t)
    batch.surface_x = batch_surface_x
    
    # Rotate volume input: xyz coords (first 3 cols)
    batch.volume_x = batch.volume_x.clone()
    batch.volume_x[:, :, :3] = rot_xz(batch.volume_x[:, :, :3], cos_t, sin_t)
    
    # Rotate vector surface targets consistently.
    # CRITICAL: find the τx and τz column indices in surface_target.
    # In the standard output ordering (cp, τx, τy, τz), col 1=τx, col 3=τz.
    # Verify by checking your train.py surface output channel definitions.
    # τy is NOT rotated (y-axis rotation does not mix y-components).
    if hasattr(batch, 'surface_target') and batch.surface_target is not None:
        st = batch.surface_target.clone()
        tau_x_col = 1   # verify against your output channel order
        tau_z_col = 3   # verify against your output channel order
        cos_e = cos_t.view(B, 1, 1)
        sin_e = sin_t.view(B, 1, 1)
        tau_x = st[:, :, tau_x_col:tau_x_col+1]
        tau_z = st[:, :, tau_z_col:tau_z_col+1]
        st[:, :, tau_x_col:tau_x_col+1] = tau_x * cos_e + tau_z * sin_e
        st[:, :, tau_z_col:tau_z_col+1] = -tau_x * sin_e + tau_z * cos_e
        batch.surface_target = st
    
    return batch
```

### Section C — Training loop integration (~5 LOC)

Inside the per-batch training loop, immediately BEFORE the model forward pass:

```python
if args.yaw_aug_theta_max > 0:
    batch = apply_yaw_augmentation(batch, args.yaw_aug_theta_max, model.training)
```

### Important implementation notes

1. **Verify column ordering** — before launch, print `surface_target[0, 0, :]` on one batch and check that τx and τz indices match `tau_x_col` and `tau_z_col` above. A quick `assert` before training is fine.

2. **Smoke check — baseline recovery at θ_max=0.0** — run 50 steps with `--yaw-aug-theta-max 0.0`. Loss should be bit-exact with no-aug run. This is the zero-cost safety check.

3. **Smoke check — θ_max=90.0 stress test** — run 50 steps at 90°. Check that output WSS has changed vs. θ=0 (confirms rotation is applied), and that NaN/Inf count stays 0 (confirms numerical stability).

4. **AMP/bf16 safety** — the `.clone()` calls ensure the rotation operates on detached views. No precision issues expected, but monitor `train/grad/nonfinite_count`.

5. **Do NOT rotate volume targets** (volume_pressure is a scalar field → rotation-invariant).

6. **Do NOT rotate surface_target[:, :, 0] (cp)** — pressure is a scalar.

7. **Per-batch random θ** — re-sample θ at each batch, NOT once per epoch. The stochasticity must be per-step.

### Run command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent frieren --wandb-group wave31_h44_yaw_augmentation \
  --wandb-name frieren/h44-yaw-aug-5deg \
  --yaw-aug-theta-max 5.0 \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<40,32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5"
```

**Parameter rationale:**
- `--yaw-aug-theta-max 5.0` — conservative start. ±5° is enough to break the yaw=0 symmetry without destroying the training signal. Car aerodynamics changes significantly at ±5° yaw in separation zones.
- `--kill-thresholds` — step-indexed (10864=EP1, 32594=EP3). EP1 fence: val_abupt < 40% (catches catastrophic failures only). EP3 gate: < 9.5% abupt AND < 5.5% SP.
- All other flags identical to baseline #972.

**If val_abupt > 6.80% at EP2:** reduce `--yaw-aug-theta-max 2.5` and relaunch. Augmentation is too aggressive. Do NOT proceed to EP3 if EP2 > 6.80%.

**If mechanism is alive at EP3 (std(τz/τx) ≥ 0.15):** post check-in with EP3 τz/τx distribution and continue to EP13.

---

## EP3 falsifiable gate

**ALIVE at EP3 if ALL hold:**

| Metric | Threshold | Why |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 6.50% | Training not degraded by augmentation |
| `std(τz/τx) per-car` | **≥ 0.15** | **PRIMARY FALSIFIER — yaw aug must increase per-car variance** |
| `val_primary/abupt_axis_mean_rel_l2_pct` | < 9.5% | Not diverged (kill gate) |

**KILL gate (any one triggers):**

| Condition | Action |
|---|---|
| `val_abupt > 6.80%` at EP2 | Kill, relaunch with θ_max=2.5° |
| `val_abupt > 9.5%` at EP3 | Kill — augmentation is destroying convergence |
| `std(τz/τx) < 0.05` at EP3 | Kill — yaw augmentation NOT increasing variance (symmetry not the cause) |

**How to compute std(τz/τx) per-car:**
```python
# In your EP3 validation readout, compute τz/τx per car:
tau_z = wandb.run.summary.get("val_primary/wall_shear_z_rel_l2_pct")
tau_x = wandb.run.summary.get("val_primary/wall_shear_x_rel_l2_pct")
# For per-car std: during validation loop, collect per-car τz and τx, then:
# std_per_car = np.std([tz_i/tx_i for tz_i, tx_i in zip(tau_z_per_car, tau_x_per_car)])
```
If per-car tracking isn't already in the codebase, add a wandb histogram log in the val loop. Reference H26 NPCA's implementation of per-car std tracking (thorfinn's branch).

---

## EP3 mechanism read — what to log

At EP3 (step 32594), alongside the standard val metrics, log:
1. **τz/τx ratio** (val_primary/wall_shear_z / val_primary/wall_shear_x)
2. **std(τz/τx) per-car** — add per-car tracking to val loop (see H26 reference)
3. **Histograms**: `wandb.log({"val/tau_ratio_per_car": wandb.Histogram(tau_ratios)})` — 34 values
4. **val_WSS** — critical metric given H44's direct WSS-reduction mechanism

**If EP3 std(τz/τx) ≥ 0.15:** the yaw augmentation is increasing variance across cars — same mechanism signature as H26 NPCA. This is a STRONG positive signal. Continue to EP13.

**If EP3 std(τz/τx) = 0.05-0.15:** marginal, post check-in and await advisor decision.

**If EP3 τz/τx ≤ 1.42 (mean):** exceptional positive — augmentation directly disrupting the band attractor's mean. This would be unexpected (NPCA was variance-first, not mean-first) but highly valuable. Continue to EP13.

---

## Baseline

Current best single-model (PR #972, run `56bcqp3m`):

| Metric | Value | Direction |
|---|---|---|
| **val_abupt** | **6.126%** | merge gate |
| test_abupt | 5.844% | reference |
| **test_vol_p** | **3.643%** | floor (HARD) |
| **test_SP** | **3.577%** | floor (HARD) |
| test_WSS | 6.727% | goal < 5.85% |

**Reproduce baseline:**
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

---

## Predicted outcomes

**If H44 SUCCEEDS (EP3 std(τz/τx) ≥ 0.15, val_abupt ≤ 6.50%):**
- Yaw symmetry-exploitation is a partial cause of the band attractor
- Opens the data-augmentation tier for further attack
- Stack with H26 NPCA to get H44b: NPCA (coordinate representation) + YAW-AUG (symmetry breaking) — the combination that forces both geometric specialization AND anti-symmetry-collapse

**If H44 FAILS (EP3 std(τz/τx) < 0.05, val_abupt in baseline range):**
- Yaw symmetry-exploitation is NOT a cause of the band attractor
- Closes the data-augmentation tier cleanly (combined with 16 loss/architecture closures)
- Research map narrows to REPRESENTATION-only: NPCA-class mechanisms are the only proven path

---

## Wave 31 context

**16 Wave 30 dead ends classified by tier:**
- Loss-shape (spatial): H10b/H11b/H12/H16/H16b/H20/H22 — 7 closures
- Training-regularization: H23 — 1 closure
- Per-vertex position: H18 — 1 closure  
- Decoder capacity: H21 — 1 closure
- Aux head: H25 — 1 closure
- Train-eval gap: H27 — 1 closure
- Optimizer: H28 SAM — 1 closure
- Encoder slice-temp: H24 GSTS — 1 closure
- **Frequency-domain loss-shape: H29 SSFL — 1 closure (your just-closed experiment)**

**Data augmentation tier: NEVER ATTACKED** — H44 is the first attempt.

**Active tiers with positive signals:**
- Representation/coordinate: H26 NPCA (only Wave 30 mechanism win — variance break, not mean shift)
- Decoder structure: H34 OUTHEAD (in-flight), H35 NPCA+SSFL stack (in-flight)
