### PR TITLE
Wave 31 H36: Anchor-Conditioned Slice Queries (DAB-DETR line)

### DIFF
--- a/model.py
+++ b/model.py
@@ -226,6 +226,119 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class AnchorSliceModulator(nn.Module):
+    """Learned 3D anchor positions that modulate slice queries via positional encoding.
+
+    Each of S slices owns a learnable anchor A_s in R^3 (raw DrivAerML surface
+    coordinates). The anchor is encoded via a sigma-ladder RFF and passed
+    through a 2-layer MLP whose output is ADDED to the slice query vector
+    inside TransolverAttention (DAB-DETR style anchor-to-query injection).
+    Zero-init on the final MLP layer means the modulator outputs 0 at step 0,
+    so a freshly constructed model is bit-exact with the baseline before any
+    training updates have moved the anchor parameters or MLP weights.
+
+    The modulator is instantiated once on the SurfaceTransolver and the same
+    output is passed to every backbone layer so the anchor matrix learns
+    globally rather than per-layer.
+    """
+
+    def __init__(
+        self,
+        n_slices: int,
+        hidden_dim: int,
+        num_heads: int,
+        n_rff: int = 16,
+        rff_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        anchor_bounds: tuple[tuple[float, float], tuple[float, float], tuple[float, float]] = (
+            (-0.5, 3.9),
+            (-1.0, 1.0),
+            (-0.3, 1.2),
+        ),
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.n_slices = n_slices
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.dim_head = hidden_dim // num_heads
+        self.anchor_bounds = tuple(tuple(float(b) for b in pair) for pair in anchor_bounds)
+        self.rff_sigmas = tuple(float(s) for s in rff_sigmas)
+        self.n_rff = int(n_rff)
+
+        self.anchors = nn.Parameter(torch.zeros(n_slices, 3))
+        self._init_anchors_grid()
+
+        rff_dim = 2 * self.n_rff * len(self.rff_sigmas)
+        Bs = [torch.randn(3, self.n_rff) * (1.0 / s) for s in self.rff_sigmas]
+        self.register_buffer("rff_B", torch.cat(Bs, dim=-1))
+
+        self.mlp = nn.Sequential(
+            nn.Linear(rff_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+        )
+        nn.init.trunc_normal_(self.mlp[0].weight, std=0.02)
+        nn.init.zeros_(self.mlp[0].bias)
+        nn.init.zeros_(self.mlp[2].weight)
+        nn.init.zeros_(self.mlp[2].bias)
+
+    def _init_anchors_grid(self) -> None:
+        n = self.n_slices
+        (xmin, xmax), (ymin, ymax), (zmin, zmax) = self.anchor_bounds
+        nx, ny, nz = self._choose_grid_dims(n, (xmax - xmin, ymax - ymin, zmax - zmin))
+        xs = torch.linspace(xmin, xmax, nx)
+        ys = torch.linspace(ymin, ymax, ny)
+        zs = torch.linspace(zmin, zmax, nz)
+        grid = torch.stack(torch.meshgrid(xs, ys, zs, indexing="ij"), dim=-1).reshape(-1, 3)
+        with torch.no_grad():
+            self.anchors.copy_(grid[:n])
+
+    @staticmethod
+    def _choose_grid_dims(n: int, extents: tuple[float, float, float]) -> tuple[int, int, int]:
+        """Pick (nx, ny, nz) for an anchor grid in a bbox of given extents.
+
+        Prefers low-waste factorings (nx*ny*nz close to n) first, then picks the
+        factoring with closest density per axis (aspect-ratio matching). The
+        waste tier is n // 8 — zero waste wins by default for clean factorings
+        like 128 = 8*4*4, and only fall back to wasteful aspect-matched grids
+        when no clean factoring is close.
+        """
+        ex, ey, ez = (max(e, 1e-6) for e in extents)
+        candidates: list[tuple[int, float, int, int, int]] = []
+        for nx in range(1, n + 1):
+            for ny in range(1, n + 1):
+                if nx * ny > n:
+                    break
+                nz = int(math.ceil(n / (nx * ny)))
+                total = nx * ny * nz
+                if total < n:
+                    continue
+                waste = total - n
+                ratio_x, ratio_y, ratio_z = nx / ex, ny / ey, nz / ez
+                avg = (ratio_x + ratio_y + ratio_z) / 3.0
+                spread = (
+                    (ratio_x - avg) ** 2 + (ratio_y - avg) ** 2 + (ratio_z - avg) ** 2
+                )
+                candidates.append((waste, spread, nx, ny, nz))
+        if not candidates:
+            k = int(math.ceil(n ** (1.0 / 3.0)))
+            return k, k, k
+        min_waste = min(c[0] for c in candidates)
+        threshold = min_waste + max(1, n // 8)
+        filtered = [c for c in candidates if c[0] <= threshold]
+        filtered.sort(key=lambda c: (c[1], c[0]))
+        _, _, nx, ny, nz = filtered[0]
+        return nx, ny, nz
+
+    def forward(self) -> torch.Tensor:
+        proj = self.anchors @ self.rff_B.to(dtype=self.anchors.dtype)
+        rff = torch.cat([proj.sin(), proj.cos()], dim=-1)
+        mod = self.mlp(rff)
+        mod = mod.view(self.n_slices, self.num_heads, self.dim_head)
+        return mod.permute(1, 0, 2).contiguous()
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -274,13 +387,20 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        anchor_mod: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
             q = self.q_norm(q)
             k = self.k_norm(k)
+        if anchor_mod is not None:
+            q = q + anchor_mod.to(dtype=q.dtype).unsqueeze(0)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -317,9 +437,14 @@ class TransformerBlock(nn.Module):
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        anchor_mod: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, anchor_mod=anchor_mod)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -352,9 +477,14 @@ class Transformer(nn.Module):
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        anchor_mod: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, anchor_mod=anchor_mod)
         return x
 
 
@@ -382,6 +512,14 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_anchor_slice_queries: bool = False,
+        anchor_n_rff: int = 16,
+        anchor_rff_sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0, 4.0),
+        anchor_bounds: tuple[tuple[float, float], tuple[float, float], tuple[float, float]] = (
+            (-0.5, 3.9),
+            (-1.0, 1.0),
+            (-0.3, 1.2),
+        ),
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +534,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_anchor_slice_queries = use_anchor_slice_queries
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -473,6 +612,17 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
         )
+        if use_anchor_slice_queries:
+            self.anchor_modulator = AnchorSliceModulator(
+                n_slices=slice_num,
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                n_rff=anchor_n_rff,
+                rff_sigmas=tuple(anchor_rff_sigmas),
+                anchor_bounds=anchor_bounds,
+            )
+        else:
+            self.anchor_modulator = None
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
@@ -595,7 +745,8 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        anchor_mod = self.anchor_modulator() if self.anchor_modulator is not None else None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, anchor_mod=anchor_mod)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 
@@ -640,3 +791,28 @@ class SurfaceTransolver(nn.Module):
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+
+    def anchor_telemetry(self) -> dict[str, float]:
+        if self.anchor_modulator is None:
+            return {}
+        with torch.no_grad():
+            A = self.anchor_modulator.anchors.detach()
+            n = A.shape[0]
+            if n < 2:
+                return {}
+            dist = torch.cdist(A, A)
+            mask = ~torch.eye(n, dtype=torch.bool, device=A.device)
+            non_diag = dist[mask]
+            mod = self.anchor_modulator().detach()
+            return {
+                "model/anchor_pairwise_dist_mean": float(non_diag.mean().item()),
+                "model/anchor_pairwise_dist_std": float(non_diag.std().item()),
+                "model/anchor_pairwise_dist_min": float(non_diag.min().item()),
+                "model/anchor_pairwise_dist_max": float(non_diag.max().item()),
+                "model/anchor_x_range": float((A[:, 0].max() - A[:, 0].min()).item()),
+                "model/anchor_y_range": float((A[:, 1].max() - A[:, 1].min()).item()),
+                "model/anchor_z_range": float((A[:, 2].max() - A[:, 2].min()).item()),
+                "model/anchor_mod_abs_mean": float(mod.abs().mean().item()),
+                "model/anchor_mod_abs_max": float(mod.abs().max().item()),
+                "model/anchor_mod_rms": float(mod.float().pow(2).mean().sqrt().item()),
+            }

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_anchor_slice_queries: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_anchor_slice_queries": (
+            "Enable H36 Anchor-Conditioned Slice Queries (DAB-DETR line). "
+            "Injects S learnable 3D anchor positions (one per slice) into the "
+            "Transolver slice queries via an RFF + MLP modulator shared "
+            "across backbone layers. The MLP final layer is zero-initialised "
+            "so step 0 is bit-exact with the baseline. Anchors are "
+            "initialised on a uniform grid over the DrivAerML surface "
+            "bounding box."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,7 +318,16 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_anchor_slice_queries=config.use_anchor_slice_queries,
     )
+
+
+def collect_anchor_metrics(model: nn.Module) -> dict[str, float]:
+    fn = getattr(model, "anchor_telemetry", None)
+    if fn is None:
+        return {}
+    metrics = fn()
+    return metrics or {}
 
 
 def train_loss(
@@ -1262,6 +1281,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_anchor_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,51 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Per-car tau_z_rel_l2 / tau_x_rel_l2 statistics (variance-class mechanism reading).
+
+    Builds per-case rel_l2 from sqrt(error_sq / target_sq) for tau_x and tau_z,
+    then reports mean/std/min/max plus a counter for cases that escape the
+    [1.40, 1.60] band attractor. Returns an empty dict if fewer than 2 common
+    cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1112,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1163,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**Wave 31 H36: Anchor-Conditioned Slice Queries — learned 3D spatial anchors modulate slice attention queries to force per-region specialization and break the τz/τx band attractor.**

### The problem

Transolver's S=128 slice queries are **spatially anonymous**: they pool surface tokens into 128 context slices via learned softmax weights, but the slice query vectors `q_s ∈ R^d` carry no positional information about WHERE in the car geometry each slice "attends". The model is free to learn a single globally-averaged τz/τx coupling mode that applies to all 400 cars uniformly — which is precisely the [1.44, 1.55] band attractor.

**The fix:** Inject learned 3D anchor positions A ∈ R^{S×3} into each slice query. Slice s receives query `q_s' = q_s + MLP_anchor(PE(A_s))`. Each anchor A_s is a free parameter that learns to specialize to a spatial region (windshield, A-pillar, underbody, wake), forcing that slice to develop a geometry-specific τz/τx representation.

### Prior evidence

- **H33 SLICEPE** (askeladd, in-flight, EP1 promising signal): adds fixed positional encoding (σ=0.02) to slice queries. H36 is strictly more expressive: **learned** anchor positions + MLP-gated modulation vs. fixed-σ PE only. If H33 succeeds, H36 is the higher-capacity follow-up. If H33 fails at its EP3 gate, H36 attacks the same axis with greater expressivity.
- **DAB-DETR** (Liu et al., ICLR 2022): anchor-modulated query injection in DETR. Same principle — anchors in 2D image space are injected as sine PE into decoder queries, dramatically improving detection of small objects. DrivAerML 3D automotive geometry is the natural analogue.
- **SpiderSolver** (Li et al., ICLR 2025): anchor-node queries for 2D PDE surrogates. Direct architectural precedent — anchor queries in function space enable geometry-specific specialization without destroying the learned slice structure.
- **H26 NPCA** (thorfinn, in-flight, mechanism-positive): the only Wave 30 mechanism win uses a geometry-informed coordinate representation (normal-aligned local frames). H36 attacks the same "geometry-awareness" axis from the architecture side rather than the input encoding side.

### Mechanism prediction

1. Anchors learn to distribute over car surface geometry (windshield front, A-pillars, underbody, C-pillar, tail)
2. Each slice develops a specialization signature for its anchor region's geometric features
3. Per-car variance in τz/τx increases: cars with different A-pillar angles now activate different slices differently, rather than all hitting the same shared mode
4. This is a **variance-class** mechanism (like H26 NPCA), not a mean-shift mechanism (like the 11 closed mean-shift attacks)

### Why this is mechanistically distinct from all 17 closures + 5 in-flight experiments

- No prior Wave 30 or Wave 31 experiment uses learned 3D anchor positions in slice queries
- H33 SLICEPE uses fixed PE — H36 uses learned anchor positions with MLP gating (strictly more expressive)
- H26 NPCA changes input coordinates — H36 changes query modulation (orthogonal intervention)
- H34 OUTHEAD adds auxiliary output heads — H36 modulates the attention query (different circuit)
- H30 V2S xattn adds cross-attention from volume to surface — H36 changes slice specialization (different pathway)

---

## Instructions

Add ~60 LOC to `model.py` only. **No changes to `train.py`, `trainer_runtime.py`, or any read-only file** (the anchor matrix is a model parameter, not a training recipe parameter).

### Section A — Import and constant (~2 LOC)

In `model.py`, add at the top near other imports:
```python
import math
```
(if not already present)

### Section B — Anchor module (~35 LOC)

Add a new class near the existing slice-attention code in `model.py`:

```python
class AnchorSliceModulator(nn.Module):
    """Learned 3D anchor positions that modulate slice queries via positional encoding.
    
    Each of the S slices gets an anchor position A_s ∈ R^3 (in the same coordinate
    frame as surface_x[:, :, :3]). The anchor is encoded via a σ-ladder RFF and
    passed through a 2-layer MLP whose output is ADDED to the slice query vector.
    
    Zero-init on the final MLP layer ensures flag-on→flag-off is near-identity at step 0.
    """
    def __init__(self, n_slices: int, hidden_dim: int, n_rff: int = 16,
                 rff_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0)):
        super().__init__()
        self.n_slices = n_slices
        
        # Learned anchor positions, initialized on a uniform grid over [-1, 1]^3
        # Anchors are in NORMALIZED coordinate space — check surface_x range and adjust
        self.anchors = nn.Parameter(torch.zeros(n_slices, 3))
        self._init_anchors_grid()
        
        # RFF positional encoding (same σ-ladder as existing string_separable PE)
        rff_dim = 2 * n_rff * len(rff_sigmas)  # sin/cos × n_rff × n_sigmas
        self.rff_sigmas = rff_sigmas
        self.register_buffer('rff_B', self._make_rff_matrix(n_rff, rff_sigmas))
        
        # 2-layer MLP: rff_dim → hidden_dim → hidden_dim
        self.mlp = nn.Sequential(
            nn.Linear(rff_dim, hidden_dim),
            nn.SiLU(),
            nn.Linear(hidden_dim, hidden_dim),
        )
        # CRITICAL: zero-init final layer so modulation = 0 at step 0 (flag-on = flag-off)
        nn.init.zeros_(self.mlp[-1].weight)
        nn.init.zeros_(self.mlp[-1].bias)
    
    def _init_anchors_grid(self):
        """Initialize anchors on a uniform 3D grid over [-0.5, 0.5]^3."""
        n = self.n_slices
        # Cube root grid, pad to n_slices
        k = math.ceil(n ** (1/3))
        pts = torch.linspace(-0.5, 0.5, k)
        grid = torch.stack(torch.meshgrid(pts, pts, pts, indexing='ij'), dim=-1)
        grid = grid.reshape(-1, 3)[:n]  # take first n_slices
        with torch.no_grad():
            self.anchors.copy_(grid)
    
    def _make_rff_matrix(self, n_rff, sigmas):
        """Random Fourier features: shape [3, n_rff * len(sigmas)]."""
        Bs = [torch.randn(3, n_rff) * (1.0 / s) for s in sigmas]
        return torch.cat(Bs, dim=-1)  # [3, n_rff * len(sigmas)]
    
    def forward(self) -> torch.Tensor:
        """Returns anchor modulation vectors: [S, hidden_dim]"""
        # Encode anchors: [S, 3] × [3, n_rff*n_σ] → [S, n_rff*n_σ]
        proj = self.anchors @ self.rff_B.to(self.anchors.device)  # [S, n_rff*n_σ]
        rff = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # [S, 2*n_rff*n_σ]
        return self.mlp(rff)  # [S, hidden_dim]
```

### Section C — Integration into the Transolver slice-attention layer (~15 LOC)

In `model.py`, find the Transolver class (or whichever class builds the slice attention). You need to:

1. **Add the modulator to `__init__`** (gated by flag):
```python
# Add flag to model config / __init__ signature:
self.use_anchor_slice_queries = use_anchor_slice_queries  # new bool arg
if use_anchor_slice_queries:
    self.anchor_modulator = AnchorSliceModulator(
        n_slices=num_slices,
        hidden_dim=hidden_dim,
        n_rff=16,
        rff_sigmas=(0.25, 0.5, 1.0, 2.0, 4.0),
    )
```

2. **Apply modulation in `forward`** — find where slice queries `q` (shape `[S, d]` or `[B, S, d]`) are used in slice-attention. Add the anchor offset BEFORE the attention computation:
```python
if self.use_anchor_slice_queries:
    anchor_mod = self.anchor_modulator()  # [S, hidden_dim]
    # q has shape [S, d] or [B, S, d] depending on your implementation
    # If [S, d]: q = q + anchor_mod
    # If [B, S, d]: q = q + anchor_mod.unsqueeze(0)
    q = q + anchor_mod  # CHECK the shape of q in your existing code
```

3. **Add CLI flag to `train.py`** (~3 LOC):
```python
parser.add_argument("--use-anchor-slice-queries", action="store_true", default=False,
                    help="Inject learned 3D anchor positions into slice queries.")
```
And wire it through to `build_model(args)`.

### Critical implementation notes

1. **Coordinate frame for anchors**: The anchor positions A_s must be in the SAME coordinate frame as `surface_x[:, :, :3]`. Check what coordinate range `surface_x` uses (likely normalized, check your data loader or existing PE computation). If surface_x is in raw CFD space (e.g., x ∈ [-1, 5] meters), initialize anchors in that range instead of [-0.5, 0.5].

2. **Zero-init is load-bearing**: `nn.init.zeros_(self.mlp[-1].weight)` and `nn.init.zeros_(self.mlp[-1].bias)` ensure that at step 0, `anchor_modulator.forward() == 0` for all slices. This means **flag-on is bit-exact baseline at step 0**. Verify with smoke check: forward pass at step 0 with and without `--use-anchor-slice-queries`, check that surface outputs are identical.

3. **Apply at EVERY layer or just the first layer?** Apply to ALL Transolver layers (each layer has its own slice-attention). The anchor modulator is SHARED across layers — same A_s for each layer, but gradient flows back through all layers, so anchors learn globally.

4. **RFF buffers not parameters**: `self.rff_B` is registered as a buffer (not a parameter). Anchors are parameters. MLPs are parameters. Total new parameters: 128×3 (anchors) + MLP params (16×5×2 × 512 + 512 = ~87K per layer) = ~88K total (~0.5% of baseline 18M params).

5. **Anchor diversity logging**: At EP3, log `mean_pairwise_anchor_dist` to wandb to verify anchors haven't collapsed:
```python
if wandb.run is not None:
    with torch.no_grad():
        A = model.anchor_modulator.anchors  # [S, 3]
        dist = torch.cdist(A, A)  # [S, S]
        mask = ~torch.eye(len(A), dtype=bool, device=A.device)
        wandb.log({"model/anchor_pairwise_dist_mean": dist[mask].mean().item()})
```

6. **Smoke checks** (do all before main launch):
   - **Flag-off bit-exact**: Run 50 steps without `--use-anchor-slice-queries`, save a checkpoint. Run 50 steps WITH the flag, check `|output_with - output_without|.max() < 1e-6` at step 0.
   - **Gradient flow**: After 100 training steps, `model.anchor_modulator.anchors.grad.abs().max() > 0` (anchors are receiving gradient).
   - **Anchor spread**: At step 0, `mean_pairwise_anchor_dist` should match the grid initialization (~0.35 for 128-point uniform cube grid). After 1 epoch it should have moved.

---

## Run command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent tanjiro --wandb-group wave31_h36_anchor_slice_queries \
  --wandb-name tanjiro/h36-anchor-slice-queries \
  --use-anchor-slice-queries \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<40,32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5"
```

**All other flags identical to baseline #972. New flag:** `--use-anchor-slice-queries`.

**`--kill-thresholds` are step-indexed** (10864=EP1, 32594=EP3). EP1 fence: val_abupt < 40% (catastrophic failure only). EP3 gate: < 9.5% abupt AND < 5.5% SP.

---

## EP3 falsifiable gate

**ALIVE at EP3 (step 32594) if ALL hold:**

| Metric | Threshold | Why |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 6.60% | Training not destabilized by anchor modulation |
| `std(τz/τx) per-car` | **≥ 0.15** | **PRIMARY FALSIFIER — anchor specialization must INCREASE per-car variance** |
| `model/anchor_pairwise_dist_mean` | **≥ 0.10** | Anchors must have spread spatially (not collapsed to mean position) |

**KILL gate (any one triggers):**

| Condition | Action |
|---|---|
| `val_abupt > 9.5%` at EP3 | Anchor modulation destabilizing training — KILL |
| `std(τz/τx) < 0.05` at EP3 | Anchor specialization NOT driving variance — KILL |
| `anchor_pairwise_dist < 0.05` at EP3 | Anchors collapsed — KILL (check MLP_anchor scale) |

**How to compute std(τz/τx) per-car at EP3:**
In the validation loop, collect per-car τz_i and τx_i, then:
```python
tau_ratios = [tz_i / tx_i for tz_i, tx_i in zip(tau_z_per_car, tau_x_per_car)]
wandb.log({
    "val/tau_ratio_per_car_std": np.std(tau_ratios),
    "val/tau_ratio_per_car_hist": wandb.Histogram(tau_ratios),
})
```
If per-car tracking isn't in the codebase, reference H26 NPCA's implementation in `thorfinn/h26-*` branch.

---

## EP1 mechanism check (post first epoch, ~1.5h)

Log these at EP1 to confirm healthy initialization:
1. `model/anchor_pairwise_dist_mean` — should be ~0.20-0.35 (spread from grid init). If < 0.05, anchors collapsed immediately (check learning rate on anchor params vs rest of model).
2. `val_primary/abupt_axis_mean_rel_l2_pct` — should be in normal cold-start range 20-30%. If > 35%, modulation is perturbing the baseline too aggressively (check zero-init).
3. `train/grad/nonfinite_count` — must be 0.

---

## Baseline

Current best single-model (PR #972, run `56bcqp3m`):

| Metric | Value | Direction |
|---|---|---|
| **val_abupt** | **6.126%** | merge gate |
| test_abupt | 5.844% | reference |
| **test_vol_p** | **3.643%** | floor (HARD) |
| **test_SP** | **3.577%** | floor (HARD) |
| test_WSS | 6.727% | goal < 5.85% |

**Reproduce baseline:**
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

---

## Predicted outcomes

**If H36 SUCCEEDS (EP3 std(τz/τx) ≥ 0.15, val_abupt ≤ 6.60%):**
- Spatial anchor specialization is breaking the τz/τx band attractor — same mechanism class as H26 NPCA but from the architecture side rather than the input encoding side
- Opens the anchor-query axis for stacking: H36 + NPCA local frame = H45 GeoTransolver (anchors in geometry-relative coordinates)
- If std(τz/τx) ≥ 0.25 at EP3: extremely strong signal (H26 NPCA had std ~0.228 at EP3 mechanism gate)

**If H36 FAILS (EP3 std(τz/τx) < 0.05, val_abupt in baseline range):**
- Spatial anchor positions in slice queries cannot break the attractor — learned positional specialization is insufficient without geometric coordinate transformation (i.e., H26 NPCA's local frame is the essential ingredient, not just query modulation)
- Combined with H33 SLICEPE result (in-flight), closes the "slice positional awareness" axis
- Research map narrows further: NPCA local frame is the load-bearing mechanism, not query-side spatial information

---

## Research context

You just closed H18d (channel-decoupled area weighting), which decisively falsified τz-specific physics as the cause of the band attractor. H36 attacks a completely orthogonal mechanism: the query-side spatial anonymity of slice attention.

**16 Wave 30 dead ends + 1 mechanism win (H26 NPCA). The only remaining positive signal is variance-class mechanisms (H26 NPCA style). H36 is the architecture-side variance-class attack.**

**Reference papers:**
1. **DAB-DETR** (Liu et al., ICLR 2022) — "DAB-DETR: Dynamic Anchor Boxes are Better Queries for DETR" — anchor-modulated query injection in detection transformers. [arXiv:2201.12329]
2. **SpiderSolver** (Li et al., ICLR 2025) — anchor-node queries for 2D PDE surrogates with complex geometries. Direct architectural precedent.
3. **Transolver** (Wu et al., NeurIPS 2024) — original slice-attention paper; H36 adds anchor modulation on top of the base Transolver design.
