### PR TITLE
Wave 31 H45: ANCHOR-CROSSCHAN-DEC — Surface Decoder Cross-Channel Attention

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_crosschan_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_crosschan_decoder = use_crosschan_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,63 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H45 cross-channel decoder attention (PR #1192). Self-attention over
+        # the 4 surface output channels {cp, tau_x, tau_y, tau_z} just BEFORE
+        # the final projection — each channel develops its own residual
+        # representation that the projection then maps. Tests the
+        # rank-coupling-escape hypothesis at the surface decoder level.
+        #
+        # Deviation from PR-as-written: PR used surface_hidden_normed as a
+        # single K/V (L_k=1), which makes softmax degenerate to 1.0 and yields
+        # identical residuals across all 4 channels — see PR comment for the
+        # math. Fix: build per-channel representations (hidden + channel
+        # offset) and self-attend across the 4 channels so each Q_i actually
+        # attends to 4 distinct K/V. crosschan_out is zero-init -> identity at
+        # step 0. We also down-project to crosschan_dim=128 before attention
+        # to keep [B*N, C, D] intermediates within the 80 GB budget at
+        # B=4, N=65536; this changes param overhead from ~3.4M (PR estimate)
+        # down to ~0.34M (~2% of baseline) which is fine because the
+        # information bottleneck is C=4 channels, not D-dim hidden state.
+        if use_crosschan_decoder:
+            crosschan_dim = max(64, n_hidden // 4)  # 128 when n_hidden=512
+            self.crosschan_dim = crosschan_dim
+            self.crosschan_down = nn.Linear(n_hidden, crosschan_dim)
+            self.crosschan_attn = nn.MultiheadAttention(
+                embed_dim=crosschan_dim,
+                num_heads=4,
+                dropout=0.0,
+                batch_first=True,
+            )
+            self.crosschan_query_embed = nn.Parameter(
+                torch.zeros(1, self.surface_output_dim, crosschan_dim)
+            )
+            # std=1.0 (DETR-style): channel offset embeddings dominate the
+            # shared hidden_down term in q_proj/k_proj output, giving 4 channels
+            # distinct attention patterns at init. Smaller std=0.02-0.3 leaves
+            # attention uniform (entropy ~ log(4)).
+            nn.init.normal_(self.crosschan_query_embed, std=1.0)
+            # Per-channel output projection: each channel gets its own
+            # Linear(Dc, 1). With shared crosschan_attn outputs and a SHARED
+            # output projection, per-channel residual variation is bounded by
+            # the (small) channel-wise variation in attended representations.
+            # Per-channel projections amplify the mechanism: even if
+            # attended[v, c] is similar across c, distinct weight vectors
+            # W_c produce strongly channel-distinct residuals. Zero-init
+            # weights/biases preserve bit-exact baseline at step 0.
+            self.crosschan_out_weight = nn.Parameter(
+                torch.zeros(self.surface_output_dim, crosschan_dim)
+            )
+            self.crosschan_out_bias = nn.Parameter(
+                torch.zeros(self.surface_output_dim)
+            )
+        else:
+            self.crosschan_dim = 0
+            self.crosschan_down = None
+            self.crosschan_attn = None
+            self.crosschan_query_embed = None
+            self.crosschan_out_weight = None
+            self.crosschan_out_bias = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -623,9 +682,65 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.crosschan_attn is not None and surface_hidden.shape[1] > 0:
+                B, N, _ = surface_hidden.shape
+                C = self.surface_output_dim
+                Dc = self.crosschan_dim
+                # Project to lower-dim subspace for crosschan attention to keep
+                # [B*N, C, Dc] intermediates small.
+                hidden_down = self.crosschan_down(surface_hidden)
+                # Per-channel representations: shared vertex repr + channel offset.
+                channel_repr = (
+                    hidden_down.unsqueeze(2).expand(-1, -1, C, -1)
+                    + self.crosschan_query_embed
+                ).reshape(B * N, C, Dc)
+                # Flash backend rejects B*N=262144 with "invalid argument" —
+                # force mem_efficient backend which handles large batch sizes.
+                with torch.backends.cuda.sdp_kernel(
+                    enable_flash=False, enable_mem_efficient=True, enable_math=True
+                ):
+                    attended, _ = self.crosschan_attn(
+                        channel_repr,
+                        channel_repr,
+                        channel_repr,
+                        need_weights=False,
+                    )
+                # Per-channel output projection: residual[v, c] =
+                #   crosschan_out_weight[c] · attended[v, c] + crosschan_out_bias[c]
+                # Implemented as elementwise product + sum across the Dc dim.
+                channel_residuals = (
+                    attended * self.crosschan_out_weight.unsqueeze(0)
+                ).sum(dim=-1) + self.crosschan_out_bias  # [B*N, C]
+                channel_residuals = channel_residuals.reshape(B, N, C)
+                channel_residuals = channel_residuals * surface_mask.unsqueeze(-1)
+                surface_preds = surface_preds + channel_residuals
+                self._last_crosschan_residuals = channel_residuals.detach()
+                # Diagnostic attention weights at eval only — need_weights=True
+                # forces the math backend which materializes the attention matrix.
+                if not self.training and (B * N) > 0:
+                    sample_n = min(512, B * N)
+                    sample_repr = channel_repr[:sample_n]
+                    _, attn_weights = self.crosschan_attn(
+                        sample_repr,
+                        sample_repr,
+                        sample_repr,
+                        need_weights=True,
+                        average_attn_weights=True,
+                    )
+                    self._last_crosschan_attn_weights = attn_weights.detach()
+                else:
+                    self._last_crosschan_attn_weights = None
+                self._last_crosschan_mask = surface_mask.detach()
+            else:
+                self._last_crosschan_residuals = None
+                self._last_crosschan_attn_weights = None
+                self._last_crosschan_mask = None
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+            self._last_crosschan_residuals = None
+            self._last_crosschan_attn_weights = None
+            self._last_crosschan_mask = None
 
         if volume_x is not None:
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)

--- a/model.py
+++ b/model.py
@@ -680,6 +680,9 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        crosschan_residuals: torch.Tensor | None = None
+        crosschan_mask: torch.Tensor | None = None
+        crosschan_attn_weights: torch.Tensor | None = None
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
             if self.crosschan_attn is not None and surface_hidden.shape[1] > 0:
@@ -714,7 +717,10 @@ class SurfaceTransolver(nn.Module):
                 channel_residuals = channel_residuals.reshape(B, N, C)
                 channel_residuals = channel_residuals * surface_mask.unsqueeze(-1)
                 surface_preds = surface_preds + channel_residuals
-                self._last_crosschan_residuals = channel_residuals.detach()
+                crosschan_residuals = channel_residuals.detach()
+                crosschan_mask = surface_mask.detach()
+                self._last_crosschan_residuals = crosschan_residuals
+                self._last_crosschan_mask = crosschan_mask
                 # Diagnostic attention weights at eval only — need_weights=True
                 # forces the math backend which materializes the attention matrix.
                 if not self.training and (B * N) > 0:
@@ -727,10 +733,8 @@ class SurfaceTransolver(nn.Module):
                         need_weights=True,
                         average_attn_weights=True,
                     )
-                    self._last_crosschan_attn_weights = attn_weights.detach()
-                else:
-                    self._last_crosschan_attn_weights = None
-                self._last_crosschan_mask = surface_mask.detach()
+                    crosschan_attn_weights = attn_weights.detach()
+                self._last_crosschan_attn_weights = crosschan_attn_weights
             else:
                 self._last_crosschan_residuals = None
                 self._last_crosschan_attn_weights = None
@@ -754,4 +758,7 @@ class SurfaceTransolver(nn.Module):
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
+            "crosschan_residuals": crosschan_residuals,
+            "crosschan_mask": crosschan_mask,
+            "crosschan_attn_weights": crosschan_attn_weights,
         }

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_crosschan_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_crosschan_decoder": (
+            "Enable H45 cross-channel surface decoder attention (PR #1192). "
+            "Self-attention over the 4 surface output channels {cp, tau_x, "
+            "tau_y, tau_z} just before the final projection. Each channel "
+            "develops its own residual representation (hidden + channel "
+            "offset) and self-attends across the 4 channels, then projects "
+            "to a per-channel scalar residual that is added to the baseline "
+            "surface_out output. Zero-init crosschan_out -> bit-exact "
+            "baseline at step 0. Tests the rank-coupling-escape hypothesis "
+            "for the [1.44, 1.55] tau_z/tau_x band attractor."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -294,6 +306,70 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_crosschan_metrics(model: nn.Module) -> dict[str, float]:
+    """H45 cross-channel decoder observability (PR #1192).
+
+    Logged whenever `use_crosschan_decoder=True`:
+      - crosschan/query_embed_norm/{cp,tau_x,tau_y,tau_z}: per-channel offset norm
+      - crosschan/out_weight_norm: shared output projection weight norm
+      - crosschan/residual_abs_mean/{cp,tau_x,tau_y,tau_z}: per-channel residual
+        magnitude (snapshot of last forward pass, masked to valid surface points)
+      - crosschan/residual_asymmetry_ratio: ratio of tau_z residual mean to tau_x
+        residual mean (mechanism diagnostic; >1.5 = asymmetric escape, ~1.0 =
+        symmetric collapse)
+      - crosschan/attn_entropy_mean: average entropy of 4-way attention weights
+        per channel-query (high = channels attending broadly, low = collapsed)
+    """
+
+    metrics: dict[str, float] = {}
+    if getattr(model, "crosschan_attn", None) is None:
+        return metrics
+
+    channel_names = ["cp", "tau_x", "tau_y", "tau_z"]
+    query_embed = model.crosschan_query_embed.detach().float()
+    out_weight = model.crosschan_out_weight.detach().float()  # [C, Dc]
+    out_bias = model.crosschan_out_bias.detach().float()  # [C]
+    metrics["crosschan/out_weight_norm"] = float(out_weight.norm().item())
+    for i, name in enumerate(channel_names):
+        metrics[f"crosschan/query_embed_norm/{name}"] = float(
+            query_embed[0, i].norm().item()
+        )
+        metrics[f"crosschan/out_weight_norm/{name}"] = float(out_weight[i].norm().item())
+        metrics[f"crosschan/out_bias/{name}"] = float(out_bias[i].item())
+
+    residuals = getattr(model, "_last_crosschan_residuals", None)
+    mask = getattr(model, "_last_crosschan_mask", None)
+    if residuals is not None and mask is not None:
+        residuals_f = residuals.float()
+        mask_f = mask.float().unsqueeze(-1)
+        denom = mask_f.sum().clamp_min(1.0)
+        per_channel_abs_mean = (residuals_f.abs() * mask_f).sum(dim=(0, 1)) / denom
+        for i, name in enumerate(channel_names):
+            metrics[f"crosschan/residual_abs_mean/{name}"] = float(
+                per_channel_abs_mean[i].item()
+            )
+        tau_x_mean = float(per_channel_abs_mean[1].item())
+        tau_z_mean = float(per_channel_abs_mean[3].item())
+        if tau_x_mean > 0:
+            metrics["crosschan/residual_asymmetry_ratio"] = tau_z_mean / tau_x_mean
+        else:
+            metrics["crosschan/residual_asymmetry_ratio"] = 0.0
+
+    attn_weights = getattr(model, "_last_crosschan_attn_weights", None)
+    if attn_weights is not None:
+        # attn_weights: [B*N, num_queries=4, num_keys=4] after average_attn_weights
+        probs = attn_weights.float().clamp_min(1e-12)
+        entropy = -(probs * probs.log()).sum(dim=-1)  # [B*N, 4]
+        metrics["crosschan/attn_entropy_mean"] = float(entropy.mean().item())
+        metrics["crosschan/attn_entropy_max"] = float(entropy.max().item())
+        metrics["crosschan/attn_entropy_min"] = float(entropy.min().item())
+        # Diagonal mass: how much each channel attends to itself vs others.
+        diag = probs.diagonal(dim1=-2, dim2=-1)  # [B*N, 4]
+        metrics["crosschan/attn_diag_mean"] = float(diag.mean().item())
+
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +384,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_crosschan_decoder=config.use_crosschan_decoder,
     )
 
 
@@ -773,7 +850,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_crosschan_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1262,6 +1339,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_crosschan_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -1340,6 +1340,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
                 log_metrics.update(collect_crosschan_metrics(base_model))
+                # Promote eval-accumulated crosschan diagnostics to top-level
+                # (val_metrics ships them through accumulator plumbing because
+                # forward-side instance attributes are not reliably visible to
+                # the post-eval collect step in the DDP path).
+                for key, value in val_metrics["val_surface"].items():
+                    if key.startswith("crosschan/"):
+                        log_metrics[key] = value
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -897,6 +897,9 @@ EVAL_KEYS = (
 )
 
 
+_CROSSCHAN_CHANNELS: tuple[str, ...] = ("cp", "tau_x", "tau_y", "tau_z")
+
+
 @dataclass
 class EvalAccumulator:
     surface_loss_sse: float = 0.0
@@ -910,6 +913,19 @@ class EvalAccumulator:
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
+    # Cross-channel decoder diagnostics (PR #1192). Plumbed through the forward
+    # output dict because instance-attribute side effects from forward() are
+    # not reliably observable across the DDP eval path.
+    crosschan_residual_abs_sum: list[float] = field(
+        default_factory=lambda: [0.0] * len(_CROSSCHAN_CHANNELS)
+    )
+    crosschan_residual_count: int = 0
+    crosschan_attn_entropy_sum: float = 0.0
+    crosschan_attn_entropy_count: int = 0
+    crosschan_attn_entropy_max: float = float("-inf")
+    crosschan_attn_entropy_min: float = float("inf")
+    crosschan_attn_diag_sum: float = 0.0
+    crosschan_attn_diag_count: int = 0
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -972,6 +988,7 @@ def accumulate_eval_batch(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+    _accumulate_crosschan_diag(accumulator, out)
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
@@ -1041,6 +1058,42 @@ def accumulate_eval_batch(
             )
 
 
+def _accumulate_crosschan_diag(
+    accumulator: EvalAccumulator, out: dict[str, torch.Tensor | None]
+) -> None:
+    residuals = out.get("crosschan_residuals")
+    mask = out.get("crosschan_mask")
+    if residuals is not None and mask is not None:
+        residuals_f = residuals.float()
+        mask_f = mask.float().unsqueeze(-1)
+        denom = float(mask_f.sum().detach().cpu().item())
+        if denom > 0.0:
+            per_channel_abs_sum = (residuals_f.abs() * mask_f).sum(dim=(0, 1))
+            per_channel_abs_sum_cpu = per_channel_abs_sum.detach().cpu().tolist()
+            for i, value in enumerate(per_channel_abs_sum_cpu):
+                if i < len(accumulator.crosschan_residual_abs_sum):
+                    accumulator.crosschan_residual_abs_sum[i] += float(value)
+            accumulator.crosschan_residual_count += int(denom)
+
+    attn_weights = out.get("crosschan_attn_weights")
+    if attn_weights is not None:
+        probs = attn_weights.float().clamp_min(1e-12)
+        entropy = -(probs * probs.log()).sum(dim=-1)  # [B*N, C]
+        accumulator.crosschan_attn_entropy_sum += float(entropy.sum().detach().cpu().item())
+        accumulator.crosschan_attn_entropy_count += int(entropy.numel())
+        accumulator.crosschan_attn_entropy_max = max(
+            accumulator.crosschan_attn_entropy_max,
+            float(entropy.max().detach().cpu().item()),
+        )
+        accumulator.crosschan_attn_entropy_min = min(
+            accumulator.crosschan_attn_entropy_min,
+            float(entropy.min().detach().cpu().item()),
+        )
+        diag = probs.diagonal(dim1=-2, dim2=-1)  # [B*N, C]
+        accumulator.crosschan_attn_diag_sum += float(diag.sum().detach().cpu().item())
+        accumulator.crosschan_attn_diag_count += int(diag.numel())
+
+
 def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccumulator:
     merged = EvalAccumulator()
     for accumulator in accumulators:
@@ -1057,6 +1110,21 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
                 state = merged.case_sums[key].setdefault(case_id, [0.0, 0.0])
                 state[0] += values[0]
                 state[1] += values[1]
+        for i, value in enumerate(accumulator.crosschan_residual_abs_sum):
+            if i < len(merged.crosschan_residual_abs_sum):
+                merged.crosschan_residual_abs_sum[i] += value
+        merged.crosschan_residual_count += accumulator.crosschan_residual_count
+        merged.crosschan_attn_entropy_sum += accumulator.crosschan_attn_entropy_sum
+        merged.crosschan_attn_entropy_count += accumulator.crosschan_attn_entropy_count
+        if accumulator.crosschan_attn_entropy_count > 0:
+            merged.crosschan_attn_entropy_max = max(
+                merged.crosschan_attn_entropy_max, accumulator.crosschan_attn_entropy_max
+            )
+            merged.crosschan_attn_entropy_min = min(
+                merged.crosschan_attn_entropy_min, accumulator.crosschan_attn_entropy_min
+            )
+        merged.crosschan_attn_diag_sum += accumulator.crosschan_attn_diag_sum
+        merged.crosschan_attn_diag_count += accumulator.crosschan_attn_diag_count
     return merged
 
 
@@ -1086,7 +1154,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     loss = (accumulator.surface_loss_sse + accumulator.volume_loss_sse) / max(
         accumulator.surface_loss_count + accumulator.volume_loss_count, 1
     )
-    return {
+    finalized: dict[str, float] = {
         "loss": loss,
         "surface_loss": accumulator.surface_loss_sse / max(accumulator.surface_loss_count, 1),
         "volume_loss": accumulator.volume_loss_sse / max(accumulator.volume_loss_count, 1),
@@ -1115,6 +1183,38 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
     }
+    crosschan_metrics = _finalize_crosschan_diagnostics(accumulator)
+    if crosschan_metrics:
+        finalized.update(crosschan_metrics)
+    return finalized
+
+
+def _finalize_crosschan_diagnostics(accumulator: EvalAccumulator) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    res_count = accumulator.crosschan_residual_count
+    if res_count > 0:
+        per_channel_mean: list[float] = []
+        for i, name in enumerate(_CROSSCHAN_CHANNELS):
+            mean_val = accumulator.crosschan_residual_abs_sum[i] / float(res_count)
+            metrics[f"crosschan/residual_abs_mean/{name}"] = mean_val
+            per_channel_mean.append(mean_val)
+        tau_x_mean = per_channel_mean[1]
+        tau_z_mean = per_channel_mean[3]
+        if tau_x_mean > 0.0:
+            metrics["crosschan/residual_asymmetry_ratio"] = tau_z_mean / tau_x_mean
+        else:
+            metrics["crosschan/residual_asymmetry_ratio"] = 0.0
+    if accumulator.crosschan_attn_entropy_count > 0:
+        metrics["crosschan/attn_entropy_mean"] = (
+            accumulator.crosschan_attn_entropy_sum / float(accumulator.crosschan_attn_entropy_count)
+        )
+        metrics["crosschan/attn_entropy_max"] = accumulator.crosschan_attn_entropy_max
+        metrics["crosschan/attn_entropy_min"] = accumulator.crosschan_attn_entropy_min
+    if accumulator.crosschan_attn_diag_count > 0:
+        metrics["crosschan/attn_diag_mean"] = (
+            accumulator.crosschan_attn_diag_sum / float(accumulator.crosschan_attn_diag_count)
+        )
+    return metrics
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Hypothesis

**The [1.44, 1.55] τz/τx band attractor lives in the SURFACE DECODER's residual representation, NOT in any encoder-side, loss-side, optimizer-side, regularization-side, or auxiliary-head pathway.** This conclusion is now structurally locked by 9 cold-start fades across 5 different mechanism axes in Wave 30 (H18/H20/H24/H25/H26 Path B/H29/H30 V2S/H18d/H31).

The surface decoder currently projects the trunk's 512-d hidden state through a single shared `Linear(512, 4)` final layer to produce {cp, τ_x, τ_y, τ_z}. **The 4 output rows of this projection share the same SiLU-activated hidden vector.** If the τ_x and τ_z rows are weight-coupled in the projection geometry — even slightly — gradients flowing back through any encoder/loss/optimizer attack get filtered through this shared bottleneck and converge to the same τz/τx ratio.

**Direct attack at the surface decoder level**: insert a cross-channel attention layer over the 4 output dimensions JUST BEFORE the final projection. Each channel becomes a query that attends to the others' representations. With zero-init final attention layer (bit-exact baseline at init), the layer learns to escape the rank-1 coupling if and only if escape is gradient-beneficial.

**Mechanism distinction from prior surface-side attempts:**
- H21 per-component heads (decoder capacity): split the trunk per-channel → CLOSED EP3 (capacity wasn't the issue)
- H25 ALGP aux head: add separate τ-aux head → CLOSED EP3 (auxiliary supervision doesn't reach the projection)
- H34 OUTHEAD (in-flight, edward): residual per-channel MLPs after projection → corrects projection-output coupling
- **H45 CROSSCHAN-DEC**: cross-channel attention BEFORE the projection — modifies the representation each channel projects from, not the projection itself

H45 is mechanism-class-novel: NONE of the 18 closed Wave 30 hypotheses, NONE of the 6 in-flight runs, and NONE of the prior Wave 31 hypotheses (H35-H44) attack the surface decoder's pre-projection representation. This is the missing axis after Wave 30 closure analysis.

## Theoretical motivation

If the surface decoder's final projection `Linear(512, 4)` has approximately rank-coupled rows for τ_x and τ_z (let's call this the projection-rank hypothesis), then **the attractor is set by the alignment between the τ_x row and the τ_z row of the projection matrix**. Any attack that doesn't change this alignment can't break the attractor.

Cross-channel attention before projection lets each channel develop its own residual representation that the projection then maps. If τ_z develops a representation orthogonal to τ_x's representation, the rank coupling breaks even if the projection rows stay correlated — because the channels project from different vectors.

This is the "decoupling-via-input-orthogonalization" pattern that's been productive in NeRF (residual per-channel coordinate frames), DETR (per-class query embeddings), and SpiderSolver (per-task token spaces). DrivAerML's Transolver has none of these.

## Instructions

**File: `target/model.py`** — modify `SurfaceTransolver.__init__` and `forward`:

In `__init__`, add after the existing `self.surface_out` block (around line 484-489):

```python
self.use_crosschan_decoder = use_crosschan_decoder
if use_crosschan_decoder:
    # Cross-channel attention over the 4 surface output dimensions.
    # Each channel develops its own representation via attention to others'
    # representations BEFORE the final projection. Zero-init output -> identity at init.
    self.crosschan_attn = nn.MultiheadAttention(
        embed_dim=n_hidden,    # 512
        num_heads=4,            # one head per output channel
        dropout=0.0,
        batch_first=True,
    )
    # Channel-specific learnable queries, one per output channel
    self.crosschan_query_embed = nn.Parameter(
        torch.zeros(1, self.surface_output_dim, n_hidden)  # [1, 4, 512]
    )
    nn.init.normal_(self.crosschan_query_embed, std=0.02)
    # Output projection from per-channel representation to scalar contribution
    # Zero-init -> bit-exact baseline at step 0
    self.crosschan_out = nn.Linear(n_hidden, 1)
    nn.init.zeros_(self.crosschan_out.weight)
    nn.init.zeros_(self.crosschan_out.bias)
else:
    self.crosschan_attn = None
    self.crosschan_query_embed = None
    self.crosschan_out = None
```

In `forward`, find where `surface_pred = self.surface_out(surface_hidden_normed)` is computed (after the final norm). Add a cross-channel attention residual:

```python
surface_pred = self.surface_out(surface_hidden_normed)  # [B, N, 4]
if self.use_crosschan_decoder:
    B, N, D = surface_hidden_normed.shape  # D = 512
    # Treat each surface vertex as a "batch" of 4 channel-queries that attend
    # to the same hidden representation. To make this tractable, we use the
    # learned query_embed as the queries and surface_hidden_normed as keys/values
    # at each vertex. Output: per-channel attended representation [B, N, 4, D].
    queries = self.crosschan_query_embed.expand(B * N, -1, -1)  # [B*N, 4, 512]
    hidden_flat = surface_hidden_normed.reshape(B * N, 1, D)    # [B*N, 1, 512]
    # MHA: queries attend to single key/value per vertex (i.e., the hidden state)
    attended, _ = self.crosschan_attn(queries, hidden_flat, hidden_flat)  # [B*N, 4, 512]
    # Per-channel scalar contribution from the attended representation
    channel_residuals = self.crosschan_out(attended).squeeze(-1)  # [B*N, 4]
    channel_residuals = channel_residuals.reshape(B, N, 4)        # [B, N, 4]
    surface_pred = surface_pred + channel_residuals
```

**File: `target/train.py`** — thread the flag through:

1. Add `use_crosschan_decoder: bool = False` to `Config` dataclass near `use_per_channel_aux_heads` (~line 104-110).
2. Add CLI arg `--use-crosschan-decoder` (action="store_true").
3. Pass `use_crosschan_decoder=config.use_crosschan_decoder` to `SurfaceTransolver` constructor in `build_model()` (~line 297).

**Parameter overhead**:
- crosschan_attn (MHA, embed_dim=512, num_heads=4): 4×(512²×3 + 512) ≈ 3.15M params (4 heads × Q/K/V projections + bias) plus output projection ~262K → ~3.4M total
- crosschan_query_embed: 4×512 = 2048
- crosschan_out: 513 = 513
- **Total: ~3.4M extra params, ~6.5% overhead on top of ~52M baseline**

This is the largest LOC change in Wave 31 so far (~50 LOC vs H44's ~40 LOC). Worth it because it's mechanism-class-novel.

**Smoke checks before main run:**

1. Flag OFF (`use_crosschan_decoder=False`): state_dict contains zero `crosschan_*` keys; forward output bit-exact baseline.
2. Flag ON, single-step forward: `surface_pred` at step 0 must equal baseline (zero-init `crosschan_out.weight=0, crosschan_out.bias=0` → `channel_residuals == 0`). Verify `channel_residuals.abs().max() == 0` at step 0.
3. After 100 train steps with flag ON: log `crosschan_out/weight_norm` to verify gradients flowing. Expect non-zero by step 100.
4. After 100 steps: log attention weight entropy `attn_weights.entropy(dim=-1).mean()` — should be > 0 (channels learning to attend), not collapsed to identity-only.

**Optional but recommended observability** (log per val epoch):
- `crosschan/weight_norm/{cp,tau_x,tau_y,tau_z}` — per-channel projection weight magnitude
- `crosschan/attn_entropy_mean` — average entropy of attention weights (high = channels attending broadly, low = collapsed)
- `crosschan/residual_abs_mean/{cp,tau_x,tau_y,tau_z}` — per-channel residual magnitude on val
- `crosschan/residual_asymmetry_ratio` = residual_abs_mean(tau_z) / residual_abs_mean(tau_x) — **mechanism diagnostic**: should grow > 1.5 if rank-coupling escape is alive, ≈ 1.0 if symmetric (no mechanism)
- Standard: per-EP τz/τx mean/std, n_outside_band

**Training command** (DDP-8, 18h budget, identical to recent Wave 30/31 recipes):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-crosschan-decoder \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent alphonse --wandb-group wave31_h45_crosschan_dec \
  --wandb-name alphonse/h45-crosschan-dec-main \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/abupt_axis_mean_rel_l2_pct<7.5"
```

**Note on `--kill-thresholds`**: prefix is GLOBAL STEP (lesson from H33/H34 v1 closures). 10864 = end of EP1 in 13-epoch warmup=1 recipe; 32594 = end of EP3.

## EP3 binding gate

| Gate | PASS | KILL |
|---|---:|---:|
| val_abupt | ≤ 7.0% | > 7.5% |
| τz/τx mean | ≤ 1.45 (band edge break) | > 1.60 above-band drift |
| std(τz/τx) | ≥ 0.10 mechanism alive | < 0.06 collapsed |
| crosschan/residual_abs_mean(tau_z) | > 0 growing | = 0 stuck |
| crosschan/residual_asymmetry_ratio | > 1.5 asymmetric | ≈ 1.0 symmetric |
| n_outside_band | ≥ 22/34 | ≤ 18/34 |

**Mechanism signal at EP3** — the most important diagnostic:
- `crosschan/residual_asymmetry_ratio` > 1.5 AND `std(τz/τx)` ≥ 0.10 → CROSSCHAN MECHANISM ALIVE, continue to EP13 regardless of val_abupt (mechanism-positive even if marginal)
- ratio ≈ 1.0 AND std < 0.06 → cross-channel attention collapsed to identity, hypothesis FALSIFIED, KILL at EP3
- ratio > 1.5 BUT val_abupt > 7.5% → mechanism alive but cold-start cost is too high; reduce attention dropout? consider H45b

## Baseline

Current best (PR #972, run `56bcqp3m`):
- val/abupt: **6.126%**
- val/SP: 3.577% (floor)
- val/vol_p: 3.643% (floor)
- val/WSS: 6.727%
- test_abupt: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: 6.727%
- test_tau_z: 8.916%
- test τz/τx: 1.473

Reproduce command (without H45):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

## Wave 30 closure context — why this hypothesis matters

H45 is the response to the 18-closure Wave 30 structural finding:

| Mechanism axis attacked | Closure example | Result |
|---|---|---|
| Loss-shape (vertex/channel/frequency/spatial) | 9 closures (H10b/H11b/H12/H16/H16b/H20/H22/H23/H29) | All fade |
| Per-vertex position weighting | 2 closures (H18 coupled, H18d decoupled) | Both fade or above-band |
| Decoder capacity | H21 | EP3 dead |
| Auxiliary head | H25 ALGP | EP3 kill fade |
| Train-eval space | H27 PRLP | EP3 kill |
| Attention mechanism | H32 DIFFATTN | EP1 catastrophic |
| Optimizer | H28 SAM | EP2 fade + crash |
| Encoder slice-temp | H24 GSTS | EP13 not-a-merge |
| Encoder input feature | H31 WALLDIST | First test_vol_p floor crossing BUT surface fade |
| **Surface decoder pre-projection structure** | **NEVER ATTEMPTED** | **H45** |

If H45 EP3 mechanism gate passes (ratio > 1.5 AND std ≥ 0.10), this is the first surface-side architecture win in Wave 30/31. If it fails, the band attractor's "downstream-of-everything" property tightens further and we've narrowed the search.

## Fleet context

You're joining 7 in-flight runs (4 Wave 30 finishing today, 3 Wave 31 in mid-EP1):
- tanjiro #1191 H36 ANCHOR-SLICE — RUNNING mid-EP1 (architecture-side, slice-query side)
- frieren #1190 H44 YAW-AUG — RUNNING mid-EP1 (data augmentation, first in Wave 31)
- fern #1189 H35 NPCA-SSFL stack — RUNNING mid-EP3 (Wave 30 stack)
- askeladd #1187 H33 SLICEPE v2 — mid-EP4 (slice positional embedding)
- edward #1188 H34 OUTHEAD v2 — mid-EP3 (per-channel residual after projection, complementary to H45)
- nezuko #1184 H30 V2S xattn — terminal pending (likely 19th DE)
- thorfinn #1177 H26 NPCA 18h — terminal pending (mechanism-positive but val gap)

**H45 is the most mechanism-class-novel hypothesis on the docket.** Your H31 mechanism analysis demonstrated exactly the level of rigor this needs. Good luck.
