### PR TITLE
Wave 31 H46: SDORTH — Surface-Decoder Orthogonal Row Initialization

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surface_orth_init: bool = False,
+        surface_orth_init_std: float = 0.02,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surface_orth_init = use_surface_orth_init
+        self.surface_orth_init_std = surface_orth_init_std
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -498,6 +502,26 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # H46 SDORTH (Wave 31): replace default trunc_normal(std=0.02) init of the
+        # final Linear in the surface decoder with orthogonal rows, rescaled to
+        # match trunc_normal magnitude exactly. Targets the [surface_output_dim, n_hidden]
+        # final projection — surface_out[-1] for aux_decoder_heads, surface_out.project
+        # for the LinearProjection branch.
+        if use_surface_orth_init:
+            if use_aux_decoder_heads:
+                final_linear = self.surface_out[-1]
+            else:
+                final_linear = self.surface_out.project
+            with torch.no_grad():
+                # gain = std * sqrt(fan_in) yields rows with expected L2 norm matching
+                # trunc_normal(std=surface_orth_init_std). For std=0.02, fan_in=512
+                # this is ~0.4525 (vs unit-norm gain=1.0).
+                fan_in = final_linear.weight.shape[1]
+                gain = surface_orth_init_std * (fan_in ** 0.5)
+                nn.init.orthogonal_(final_linear.weight, gain=gain)
+                if final_linear.bias is not None:
+                    final_linear.bias.zero_()
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).

--- a/train.py
+++ b/train.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
@@ -103,6 +104,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_orth_init: bool = False
+    surface_orth_init_std: float = 0.02
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -276,6 +279,50 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_surface_proj_row_metrics(model: nn.Module) -> dict[str, float]:
+    """H46 SDORTH (Wave 31): row-structure diagnostic for the final surface
+    decoder Linear (the [surface_output_dim, n_hidden] projection that maps
+    backbone hidden states to [cp, tau_x, tau_y, tau_z]).
+
+    Reports pairwise off-diagonal cosine similarities + row norms so the
+    advisor can verify orthogonality was applied at init and track decay
+    under training.
+    """
+    metrics: dict[str, float] = {}
+    surface_out = getattr(model, "surface_out", None)
+    if surface_out is None:
+        return metrics
+    if isinstance(surface_out, nn.Sequential):
+        final_linear = None
+        for layer in reversed(surface_out):
+            if isinstance(layer, nn.Linear):
+                final_linear = layer
+                break
+    elif hasattr(surface_out, "project") and isinstance(surface_out.project, nn.Linear):
+        final_linear = surface_out.project
+    else:
+        final_linear = None
+    if final_linear is None:
+        return metrics
+    with torch.no_grad():
+        weight = final_linear.weight.detach().float()  # [out, in]
+        out_dim = weight.shape[0]
+        if out_dim < 2:
+            return metrics
+        rows = F.normalize(weight, dim=1)
+        gram = rows @ rows.T
+        off_diag_mask = ~torch.eye(out_dim, dtype=torch.bool, device=weight.device)
+        off_diag = gram[off_diag_mask]
+        row_norms = weight.norm(dim=1)
+        metrics["surface_proj_row/cos_mean_abs"] = float(off_diag.abs().mean().item())
+        metrics["surface_proj_row/cos_max_abs"] = float(off_diag.abs().max().item())
+        metrics["surface_proj_row/row_norm_mean"] = float(row_norms.mean().item())
+        metrics["surface_proj_row/row_norm_std"] = float(row_norms.std().item())
+        metrics["surface_proj_row/row_norm_min"] = float(row_norms.min().item())
+        metrics["surface_proj_row/row_norm_max"] = float(row_norms.max().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +355,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_orth_init=config.use_surface_orth_init,
+        surface_orth_init_std=config.surface_orth_init_std,
     )
 
 
@@ -883,6 +932,25 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            # H46 SDORTH: log surface decoder final-projection row structure at init
+            # so the orth-init invariant can be verified BEFORE training starts.
+            init_surface_proj_metrics = collect_surface_proj_row_metrics(base_model)
+            if init_surface_proj_metrics:
+                init_log = {f"init/{k}": v for k, v in init_surface_proj_metrics.items()}
+                init_log["init/use_surface_orth_init"] = float(config.use_surface_orth_init)
+                init_log["init/surface_orth_init_std"] = float(config.surface_orth_init_std)
+                wandb.log(init_log, step=0)
+                wandb.summary.update(init_log)
+                print(
+                    "[INIT surface_proj] cos_max_abs={:.6f} cos_mean_abs={:.6f} "
+                    "row_norm_mean={:.5f} row_norm_std={:.5f} (use_orth_init={})".format(
+                        init_surface_proj_metrics["surface_proj_row/cos_max_abs"],
+                        init_surface_proj_metrics["surface_proj_row/cos_mean_abs"],
+                        init_surface_proj_metrics["surface_proj_row/row_norm_mean"],
+                        init_surface_proj_metrics["surface_proj_row/row_norm_std"],
+                        config.use_surface_orth_init,
+                    )
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1262,6 +1330,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                # H46 SDORTH: track final surface-projection row decorrelation drift.
+                surface_proj_metrics = collect_surface_proj_row_metrics(base_model)
+                for k, v in surface_proj_metrics.items():
+                    log_metrics[f"diag/{k}"] = v
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,54 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _tau_zx_ratio_stats(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """H46 SDORTH (Wave 31): per-car tau_z/tau_x rel-L2 ratio diagnostic.
+
+    The historical attractor for this metric sits in [1.44, 1.55]. Tracking
+    mean/std/min/max + count-outside-band per epoch reveals whether an
+    intervention deflects the projection row coupling at the val level.
+    """
+    ratios: list[float] = []
+    for case_id, x_state in case_sums_x.items():
+        z_state = case_sums_z.get(case_id)
+        if z_state is None:
+            continue
+        x_err_sq, x_tgt_sq = x_state
+        z_err_sq, z_tgt_sq = z_state
+        if x_tgt_sq <= 0.0 or z_tgt_sq <= 0.0 or x_err_sq <= 0.0:
+            continue
+        x_rel = math.sqrt(x_err_sq / x_tgt_sq)
+        z_rel = math.sqrt(z_err_sq / z_tgt_sq)
+        if x_rel <= 0.0 or not math.isfinite(x_rel) or not math.isfinite(z_rel):
+            continue
+        ratios.append(z_rel / x_rel)
+    if not ratios:
+        return {
+            "tau_zx_ratio_mean": float("nan"),
+            "tau_zx_ratio_std": float("nan"),
+            "tau_zx_ratio_min": float("nan"),
+            "tau_zx_ratio_max": float("nan"),
+            "tau_zx_ratio_n_outside_band": 0.0,
+            "tau_zx_ratio_n_cars": 0.0,
+        }
+    n = len(ratios)
+    mean = sum(ratios) / n
+    var = sum((r - mean) ** 2 for r in ratios) / max(n - 1, 1) if n > 1 else 0.0
+    std = math.sqrt(var)
+    n_outside = sum(1 for r in ratios if r < 1.40 or r > 1.60)
+    return {
+        "tau_zx_ratio_mean": mean,
+        "tau_zx_ratio_std": std,
+        "tau_zx_ratio_min": min(ratios),
+        "tau_zx_ratio_max": max(ratios),
+        "tau_zx_ratio_n_outside_band": float(n_outside),
+        "tau_zx_ratio_n_cars": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1115,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_stats = _tau_zx_ratio_stats(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1166,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_stats,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**The [1.44, 1.55] τz/τx band attractor in the surface decoder is set BY THE INITIAL CONDITION of `Linear(512, 4)` final projection's row structure.** Default PyTorch Kaiming-uniform init produces row vectors that are approximately rank-1 correlated (highly aligned), which structurally couples τ_x, τ_y, τ_z, cp outputs from step 0. Gradient descent then merely refines this coupled structure rather than discovering an orthogonal decomposition.

**Direct attack: initialize the 4 rows of `Linear(512, 4)` to be mutually orthogonal** using `nn.init.orthogonal_`. This is a **3-line code change** that touches NO other model component, NO loss, NO training dynamics, NO input features. If the attractor is set by init, orthogonal rows break it from step 0. If the attractor is gradient-driven, orthogonal rows will be pulled back to coupled over training — and we learn the attractor is dynamic, not initial.

**Mechanism distinction from H45 (alphonse, in-flight) and H34 (edward, in-flight):**
- H34 OUTHEAD: per-channel MLPs AFTER projection — adds capacity downstream of projection
- H45 CROSSCHAN-DEC: cross-channel attention BEFORE projection — modifies pre-projection representation
- **H46 SDORTH**: changes ONLY the initial weight matrix of the projection itself — purely initial-condition perturbation, zero added parameters, zero added FLOPs, no architecture change

H46 is mechanism-class novel: NONE of the 19 closed Wave 30 hypotheses, NONE of the 5 in-flight Wave 31 runs, and NONE of the prior Wave 31 hypotheses (H35-H45) attack the surface decoder's WEIGHT INITIALIZATION axis. This is the cleanest possible single-variable test of the structural finding.

## Theoretical motivation

Default PyTorch `nn.Linear` uses Kaiming-uniform init: `weight ~ U(-bound, bound)` where `bound = sqrt(6 / fan_in)`. For `Linear(512, 4)`, this produces a [4, 512] weight matrix where the 4 row vectors are independently sampled but, with high probability, exhibit **substantial pairwise correlation** because they live in a 512-d ambient space.

Empirically (back-of-envelope), the expected pairwise cosine similarity between two iid Kaiming-init rows in 512-d is `O(1/sqrt(512)) ≈ 0.044` — but the absolute values of correlation across all 6 row pairs can easily reach 0.10-0.20 by chance. More importantly, the ROW SPAN is a random 4-d subspace of R^512 with no enforced orthogonality property.

`nn.init.orthogonal_` guarantees that the 4 rows are MUTUALLY ORTHOGONAL at init. The 4 channels {cp, τ_x, τ_y, τ_z} therefore project from 4 ORTHOGONAL 512-d directions at step 0. As training proceeds, gradient descent may or may not preserve this orthogonality — the OBSERVABLE is whether the τz/τx attractor breaks or re-emerges.

**Three falsifiable outcomes:**

1. **Attractor BREAKS (orthogonal rows preserve)** → the attractor was set by init, and orthogonal init is a permanent fix. We'd see test_τz/τx mean < 1.44 AND row-cos similarity stays < 0.1 at terminal.

2. **Attractor BREAKS initially then RE-EMERGES** → gradient descent pulls orthogonal rows back into coupled structure over training. We'd see EP1 τz/τx mean < 1.40 then drift back to ~1.47 by EP13. This is the "9 cold-start fade" pattern we've seen 9 times in Wave 30, but produced from a NEW initial condition — different from encoder-input deflection (H25/H26/H31) because the perturbation is at the FINAL PROJECTION not the representation feed.

3. **Attractor UNCHANGED** → orthogonal init produces the same trajectory as Kaiming. The attractor is downstream of weight init entirely — perhaps in the LR schedule, EMA dynamics, or loss landscape geometry. This would close the init-axis decisively.

All three outcomes are informative. This is the cleanest mechanism diagnostic possible for the Wave 30 structural finding.

**Precedent in the literature:**
1. **Saxe et al., "Exact solutions to the nonlinear dynamics of learning in deep linear neural networks"** (ICLR 2014). Orthogonal init produces faster convergence and avoids gradient interference between output rows.
2. **Hu et al., "Provable Benefit of Orthogonal Initialization in Optimizing Deep Linear Networks"** (NeurIPS 2020). Orthogonal init is provably better for deep networks with shared decoders.
3. **Mishkin & Matas, "All you need is a good init"** (ICLR 2016). LSUV init showed orthogonal-rescaled init breaks output coupling artifacts in classification heads.

None of these prior works specifically tests the τz/τx band attractor on CFD-physics regression — H46 is the first such test in this benchmark.

## Instructions

**File: `target/model.py`** — modify `SurfaceTransolver.__init__` to add an orthogonal-init flag for the surface output projection.

### Step 1 — Add flag to model class

In `SurfaceTransolver.__init__`, after the `self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)` line (around line 484-489), add:

```python
self.use_surface_orth_init = use_surface_orth_init
if use_surface_orth_init:
    # Initialize surface output projection rows to be mutually orthogonal.
    # The weight has shape [surface_output_dim, n_hidden] = [4, 512].
    # nn.init.orthogonal_ samples a random orthogonal matrix (4 rows are
    # mutually orthogonal unit vectors in R^512), scaled by gain=1.0.
    with torch.no_grad():
        # surface_out is a LinearProjection wrapping nn.Linear; access .project.weight
        weight = self.surface_out.project.weight  # [4, 512]
        nn.init.orthogonal_(weight, gain=1.0)
        # Zero the bias for clean comparison
        if self.surface_out.project.bias is not None:
            self.surface_out.project.bias.zero_()
```

**CRITICAL**: The default Linear init uses Kaiming-uniform, which produces rows with `||row||_2 ≈ sqrt(fan_in) / sqrt(3 * fan_in) ≈ 1/sqrt(3) ≈ 0.577`. Orthogonal init with `gain=1.0` produces rows with `||row||_2 = 1.0`. **This changes the OUTPUT SCALE by ~1.7×.** To avoid changing output scale (which would itself be a confounding variable), we must rescale orthogonal init to match Kaiming row magnitude:

```python
# After nn.init.orthogonal_:
target_row_norm = (6.0 / weight.shape[1]) ** 0.5 / (3.0 ** 0.5)  # ≈ 0.044 for fan_in=512
current_row_norm = weight.norm(dim=1, keepdim=True)  # [4, 1]
weight.mul_(target_row_norm / current_row_norm)  # rescale rows to match Kaiming magnitude
```

This is **critical** for a clean mechanism comparison — without it, we're testing init scale AND orthogonality together, not orthogonality alone.

### Step 2 — Add `--use-surface-orth-init` flag to `train.py`

```python
parser.add_argument(
    "--use-surface-orth-init",
    action="store_true",
    help="Initialize surface output projection rows to be mutually orthogonal (Kaiming-magnitude-matched)."
)
```

Thread to model instantiation:
```python
model = SurfaceTransolver(
    ...,
    use_surface_orth_init=args.use_surface_orth_init,
    ...,
)
```

### Step 3 — Pre-launch diagnostic logging (CRITICAL)

In `train.py`, add a one-time logging block right after model instantiation that logs the surface projection row structure:

```python
if rank == 0:
    with torch.no_grad():
        surface_proj_weight = model.module.surface_out.project.weight  # [4, 512]
        # Compute row-pair cosine similarities (6 pairs for 4 rows)
        rows_normed = F.normalize(surface_proj_weight, dim=1)
        cos_sim_matrix = rows_normed @ rows_normed.T  # [4, 4]
        # Off-diagonal entries are the pairwise correlations
        off_diag_mask = ~torch.eye(4, dtype=torch.bool, device=cos_sim_matrix.device)
        pairwise_cos = cos_sim_matrix[off_diag_mask]  # [12] (6 pairs × 2 directions)
        row_norms = surface_proj_weight.norm(dim=1)  # [4]
        wandb.log({
            "init/surface_proj_row_cos_mean_abs": pairwise_cos.abs().mean().item(),
            "init/surface_proj_row_cos_max_abs": pairwise_cos.abs().max().item(),
            "init/surface_proj_row_norm_mean": row_norms.mean().item(),
            "init/surface_proj_row_norm_std": row_norms.std().item(),
        }, step=0)
        print(f"[INIT] surface_proj row norms: {row_norms.tolist()}")
        print(f"[INIT] surface_proj row cosine off-diagonal: mean_abs={pairwise_cos.abs().mean().item():.4f}, max_abs={pairwise_cos.abs().max().item():.4f}")
```

Run baseline (no orth init) → expect `cos_max_abs` ≈ 0.05-0.20, random.
Run H46 (orth init) → expect `cos_max_abs` < 1e-6, exactly orthogonal.

### Step 4 — Per-epoch row-structure drift logging

Add to val loop (every epoch, rank 0 only):

```python
if rank == 0:
    with torch.no_grad():
        weight = model.module.surface_out.project.weight  # [4, 512]
        rows_normed = F.normalize(weight, dim=1)
        cos_sim_matrix = rows_normed @ rows_normed.T
        off_diag = cos_sim_matrix[~torch.eye(4, dtype=torch.bool, device=cos_sim_matrix.device)]
        wandb.log({
            "diag/surface_proj_row_cos_mean_abs": off_diag.abs().mean().item(),
            "diag/surface_proj_row_cos_max_abs": off_diag.abs().max().item(),
        }, commit=False)
```

This is the mechanism-survival diagnostic: does orthogonality persist under training?

### Step 5 — τz/τx mechanism logging (carry over from H26 standard)

Use the same per-val-car diagnostic as H26 (and now Wave 31 canonical):

```python
# After computing per-channel val metrics per car
ratio_per_car = tau_z_per_car / tau_x_per_car  # [num_val_cars]
wandb.log({
    "val/tau_zx_ratio_mean": ratio_per_car.mean().item(),
    "val/tau_zx_ratio_std": ratio_per_car.std().item(),
    "val/tau_zx_ratio_min": ratio_per_car.min().item(),
    "val/tau_zx_ratio_max": ratio_per_car.max().item(),
    "val/tau_zx_ratio_n_outside_band": ((ratio_per_car < 1.40) | (ratio_per_car > 1.60)).sum().item(),
}, commit=False)
```

### Step 6 — Smoke test (2-GPU, 2-epoch, 16384 points)

```bash
torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --epochs 2 --batch-size 2 \
  --train-surface-points 16384 --eval-surface-points 16384 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model \
  --use-surface-orth-init \
  --wandb-group wave31_h46_sdorth_smoke \
  --wandb-name thorfinn/h46-sdorth-smoke \
  --agent thorfinn
```

**Smoke PASS criteria:**
1. **Init diagnostic shows `cos_max_abs` < 1e-6 at step 0** (verifies orthogonal init applied)
2. **Row norms match Kaiming target** (~0.044 each, std < 1% — verifies magnitude rescaling)
3. **train/loss descends from EP1 cold-start** (no diverged training due to init scale)
4. No NaN / nonfinite, no OOM
5. EP1 val_abupt < 30% (similar to baseline EP1 ~25-29%)
6. **Diagnostic**: Compare smoke EP1 val τz/τx mean against baseline EP1 val τz/τx mean. Orthogonal init should produce different EP1 mean (mechanism signal at init level).

### Step 7 — Full 18h DDP-8 run

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 \
  --kill-thresholds 10864:val_abupt<30,32594:val_abupt<9.5,32594:val_SP<5.5,65228:val_abupt<7.0 \
  --use-surface-orth-init \
  --wandb-group wave31_h46_sdorth \
  --wandb-name thorfinn/h46-sdorth-18h \
  --agent thorfinn
```

Pre-launch budget verification: `printenv SENPAI_TIMEOUT_MINUTES`. Expected `1100` (18h). If `360` (6h), follow H26 Path B precedent: compress to 5ep with `--lr-cosine-t-max 5 --epochs 5 --vp-schedule 0:16384:3:32768:4:49152`.

## EP Gates (mechanism-decisive)

| EP | Primary gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | val_abupt ≤ ~30% (warmup) | EP1 init diagnostic: `cos_max_abs` < 1e-6 (orth applied) AND EP1 val_τz/τx mean differs from baseline EP1 by ≥ 0.02 | sanity only; if init not applied, KILL |
| **EP3** | val_abupt ≤ 9.5% | **`mean(τz/τx) ≤ 1.45` at val (band lower edge breached)** AND `cos_max_abs < 0.10` (orth not fully decayed) | **KILL if val_abupt > 11% OR mean > 1.60 OR orth fully collapsed (`cos_max_abs > 0.50`)** |
| EP6 | val_abupt ≤ 6.8% | `mean(τz/τx) ≤ 1.44` (band lower edge breached on val) AND `cos_max_abs < 0.30` | warn if mean rebounds to 1.50+ |
| EP9 | val_abupt ≤ 6.3% | `mean(τz/τx) ≤ 1.43` AND `cos_max_abs < 0.50` (orth persisting under training) | confirm trajectory |
| EP13 (terminal) | **val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%** | `test τz/τx mean ≤ 1.42` (the mechanism signal we need for merge) AND `test cos_max_abs < 0.60` | MERGE gate |

**EP3 binary gate is critical**: this is the FIRST experimental observation in Wave 30/31 of whether mean(τz/τx) can be DEFLECTED at EP3 from the band. Prior Wave 30 hypotheses showed std spread (H26 EP3 std 0.228) but mean stayed at 1.524 (band-low). **H46's falsifier is mean-shift, not std-spread.**

## Baseline (PR #972, single-model SOTA — corrected split 2026-05-11)

| Metric | Value | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to MERGE |
| test_abupt | 5.844% | < 5.844% to MERGE |
| test_vol_p | 3.643% | ≤ 3.643% **floor — hard breach blocker** |
| test_SP | 3.577% | ≤ 3.577% **floor — hard breach blocker** |
| test_WSS | 6.727% | < 6.727% to MERGE |

**W&B run:** `56bcqp3m` (source) · `zxnhtagj` (eval)

## Terminal SENPAI-RESULT format

```markdown
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0>","<rank1>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Must include:
- **Per-epoch val table** (val_abupt, val_SP, val_vol_p, val_WSS, val_τx, val_τy, val_τz, val_τz/τx mean+std+min+max+n_outside_band)
- **Per-epoch surface projection row diagnostic** (`cos_mean_abs`, `cos_max_abs`, row_norm trajectory) — KEY MECHANISM TRACE
- **Test best-checkpoint reload**: test_abupt, test_vol_p, test_SP, test_WSS, test_τx, test_τy, test_τz, test τz/τx (mean+std+min+max+n_outside_band)
- **Test surface projection row diagnostic** at best checkpoint
- **8-rank run IDs + best-checkpoint epoch + source (raw/ema)**
- **Comparison vs H26 NPCA matched-epoch trajectory** (mean/std at EP3, EP6, EP13)

## Context — why this is the right Wave 31 hypothesis for thorfinn now

Your H26 NPCA closure (just posted at 14:30Z) is the canonical Wave 30 mechanism-positive-accuracy-negative result. The Wave 30 structural finding is now: the surface decoder `Linear(512, 4)` projection's row coupling fixes the τz/τx mean even when the encoder produces diverse representations. Your per-car τz/τx mean+std diagnostic IS the test we need for H46.

H46 is the smallest possible attack on this structural finding: change ONLY the projection's INIT (3 LOC), test if the attractor is set by init OR is gradient-driven. This is the cleanest single-variable mechanism test conceivable. Your mechanism-analysis depth from H26 is exactly what's needed to read the diagnostic at every gate.

**Why H46 SDORTH and not the H26 + H31 stack:**
- H26 + H31 stack would compound vol_p floor crossing to ~3.45% but would also compound val_abupt regression to ~0.27pp (currently +0.220pp H26 + +0.0475pp H31) and test_SP breach to ~0.40pp. The stack would deepen the vol_p mechanism but worsen the accuracy gap — not a path to merge.
- H46 SDORTH is **mechanism-class-orthogonal to all 5 in-flight Wave 31 runs**: H45 alphonse (cross-channel attention before projection), H34 edward (per-channel MLPs after projection), H36 tanjiro (slice-query positional), H44 frieren (data augmentation), H35 fern (NPCA-SSFL stack). It hits the surface projection from the INIT axis only.
- If H46 EP3 mean drift is positive (mean drops below 1.45), this is the first Wave 30/31 EP3 mean-deflection signal — independent of the std-spread mechanism that H26 already demonstrated. Two complementary mechanism types stacked into the same architecture.

**NO ENSEMBLES.** Single-model gates only.

If H46 EP3 mean gate passes (mean drops below 1.45), the next experiment is the **stack**: H46 + H26 (orthogonal-init surface projection + NPCA local-frame input features, both attacking the band attractor from the projection-init AND encoder-input levels). If H46 EP3 mean gate fails (mean stays at 1.52+), the band attractor source is NOT initialization and the diagnosis sharpens for Wave 31 surface-decoder-axis attacks (capacity / structure / regularization).
