### PR TITLE
Wave 31 H47: V-DEPTH — Volume Decoder Depth Bump (2 dedicated vol-only blocks)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_vol_deep: bool = False,
+        vol_deep_layers: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_vol_deep = use_vol_deep
+        self.vol_deep_layers = int(vol_deep_layers) if use_vol_deep else 0
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +523,38 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H47 V-DEPTH (PR #1194): two dedicated volume-only transformer blocks
+        # inserted between the (optional) surface->volume cross-attention and the
+        # final volume head. Goal: give the volume decoder additional reasoning
+        # depth for volume_pressure. Each block's residual output projections
+        # (TransolverAttention.proj and UpActDownMlp.fc2) are zero-initialised
+        # so the new blocks are pure identity at step 0 -> bit-exact baseline
+        # recovery, and contribution magnitude can be tracked by W&B.
+        if use_vol_deep:
+            self.vol_deep_blocks = nn.ModuleList(
+                [
+                    TransformerBlock(
+                        hidden_dim=n_hidden,
+                        num_heads=n_head,
+                        mlp_expansion_factor=mlp_ratio,
+                        num_slices=slice_num,
+                        dropout=dropout,
+                        use_qk_norm=use_qk_norm,
+                    )
+                    for _ in range(self.vol_deep_layers)
+                ]
+            )
+            with torch.no_grad():
+                for block in self.vol_deep_blocks:
+                    block.attention.proj.project.weight.zero_()
+                    if block.attention.proj.project.bias is not None:
+                        block.attention.proj.project.bias.zero_()
+                    block.mlp.fc2.weight.zero_()
+                    if block.mlp.fc2.bias is not None:
+                        block.mlp.fc2.bias.zero_()
+        else:
+            self.vol_deep_blocks = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -619,6 +655,13 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # H47 V-DEPTH: volume-only deep blocks. Zero-initialised residual
+        # output projections make the blocks identity at init.
+        if self.vol_deep_blocks is not None and volume_x is not None and volume_tokens > 0:
+            for block in self.vol_deep_blocks:
+                volume_hidden = block(volume_hidden, attn_mask=volume_mask)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_deep: bool = False
+    vol_deep_layers: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_deep": (
+            "H47 V-DEPTH (PR #1194): insert dedicated volume-only transformer "
+            "blocks between the shared backbone (and any surf->vol cross-"
+            "attention) and the final volume output head. Each block's "
+            "TransolverAttention.proj and UpActDownMlp.fc2 are zero-initialised "
+            "so the inserted stack is identity at step 0 (bit-exact baseline "
+            "recovery). Block count controlled by --vol-deep-layers."
+        ),
+        "vol_deep_layers": (
+            "Number of dedicated volume-only TransformerBlocks added when "
+            "--use-vol-deep is enabled. Default 2."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +290,34 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_vol_deep_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block residual contribution diagnostic for H47 V-DEPTH (PR #1194).
+
+    For each volume-only deep block, log the magnitude of the two residual
+    output projections that were zero-initialised at construction:
+      * ``attention.proj.project`` -- the slice-attention output back to the
+        residual stream.
+      * ``mlp.fc2`` -- the FFN down-projection back to the residual stream.
+
+    Both grow from 0 (init) as the block starts contributing. EP3 KILL gate
+    requires max_abs > 0.05 for BOTH sublayers of at least one block (so we
+    log the per-block, per-sublayer max_abs and global norm for triage).
+    """
+    metrics: dict[str, float] = {}
+    blocks = getattr(model, "vol_deep_blocks", None)
+    if blocks is None:
+        return metrics
+    for i, block in enumerate(blocks):
+        attn_w = block.attention.proj.project.weight.detach().float()
+        ffn_w = block.mlp.fc2.weight.detach().float()
+        prefix = f"diag/vol_deep_block{i}"
+        metrics[f"{prefix}/attn_proj_max_abs"] = float(attn_w.abs().max().item())
+        metrics[f"{prefix}/attn_proj_global_norm"] = float(attn_w.norm().item())
+        metrics[f"{prefix}/ffn_fc2_max_abs"] = float(ffn_w.abs().max().item())
+        metrics[f"{prefix}/ffn_fc2_global_norm"] = float(ffn_w.norm().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +350,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_deep=config.use_vol_deep,
+        vol_deep_layers=config.vol_deep_layers,
     )
 
 
@@ -773,7 +817,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_deep:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1262,6 +1306,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_vol_deep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Deepen the volume decoder's interior capacity by adding 2 dedicated volume-only transformer blocks AFTER the shared encoder trunk.** The current model has 5 shared transformer layers, with volume-pressure prediction computed via a thin head on the volume tokens. Both H26 NPCA and H31 WALLDIST (closed today) crossed the test_vol_p floor by enriching the volume encoder INPUT — proving the volume pathway responds to richer features. The natural complement is **deeper volume DECODER capacity** to exploit those richer features fully.

H47 V-DEPTH is the **first Wave 31 attack on volume decoder interior capacity** (untouched throughout Wave 30). It is mechanism-class-orthogonal to all 5 in-flight Wave 31 hypotheses (H34 surface decoder post-projection, H45 surface decoder pre-projection, H46 surface decoder weight init, H36 slice-query anchor, H44 yaw augmentation) and to H35 fern (NPCA-SSFL stack).

### Why this is the right hypothesis now

1. **Volume pathway is empirically responsive** to architectural intervention: H26 + H31 both crossed test_vol_p floor (−0.155pp H31, −0.035pp H26) via encoder-input enrichment. The volume decoder is currently SHALLOW — likely under-parameterized relative to the surface decoder which has 5 transformer blocks worth of trunk + dedicated final projection.

2. **Wave 30 floor-crossing diagnostic locked**: encoder-input axis CAN move test_vol_p floor; surface decoder is structurally locked. Deepening the volume DECODER (not encoder, not surface) is the **single untouched axis** for compounding vol_p floor improvement on top of H26/H31 encoder-input wins.

3. **Mechanism-class novel — no prior Wave 30 hypothesis attacked volume decoder interior**: H21 was per-component SURFACE heads; H34 OUTHEAD is per-channel SURFACE projection. NO hypothesis has touched the path from volume tokens → vol_p prediction architectures interior to that pathway.

4. **Synergy with existing vp curriculum**: H30 V2S xattn closure documented that the vp curriculum bump at EP9 (49152→65536) accelerated val_vol_p slope (+40% improvement EP8→EP9). The 65536 vp regime feeds the volume branch more — but the current shallow decoder may be the bottleneck preventing full exploitation. Deeper decoder + 65536 vp curriculum should compound.

### Why this is volume-pathway-novel after H30 V2S closure

H30 V2S xattn (just closed) added cross-attention from VOLUME tokens TO SURFACE tokens — that is volume features flowing INTO the surface decoder. H47 V-DEPTH is the opposite direction: deepen the volume decoder's OWN interior so it can produce sharper vol_p predictions, **not** feed volume features to surface. The two hypotheses are mechanism-orthogonal.

The H30 closure documented V2S asymmetry: forward S2V grew to max_abs 0.988, reverse V2S plateaued at 0.187 (5.3× smaller). This suggests volume-pathway has **less unique signal to contribute** than surface-pathway when forced to flow into surface decoder. But the volume PATHWAY itself, evaluated on its own prediction task (vol_p), is empirically responsive (H26/H31 crossed the floor). **The volume pathway is information-rich but capacity-limited.** H47 V-DEPTH attacks the capacity-limitation directly.

### Theoretical motivation

The current `SurfaceTransolver` architecture (from the Transolver baseline) uses 5 shared transformer blocks (`model-layers=5`), where each block processes both surface and volume tokens in parallel via shared MHA. The volume tokens exit the trunk and feed into a thin volume head (likely 1-2 layers). For the volume_pressure prediction at vp=65536 points, this is approximately:

- Encoder: 5 layers × (MHA + FFN + LN) on 65,536 volume tokens at dim=512
- Decoder (volume): 1-2 layer head producing vol_p ∈ R^{65536}

Compared to the surface side, the volume side may be under-parameterized for the fine spatial structure of volume_pressure (which has high-frequency dependence on geometry and proximity to the surface body). Adding 2 dedicated volume-only transformer blocks (~25 LOC, ~5M extra parameters at hidden_dim=512) provides additional volumetric reasoning steps before the final projection.

**Three observable mechanism outcomes:**

1. **vol_p floor crossed by 0.10pp+ AND val_abupt < 6.126%** → V-DEPTH is mechanism-positive AND merge-positive. Wave 31 first merge candidate from volume-pathway axis.
2. **vol_p floor crossed by ≥0.05pp but val_abupt ≥ 6.126%** → V-DEPTH is volume-pathway-positive but val-abupt-neutral. Mechanism win, not merge. Reserve for Wave 31 stack with surface decoder fix.
3. **vol_p floor NOT crossed (≥3.643%)** → V-DEPTH is null. Volume decoder capacity was NOT the bottleneck; the floor crossings from H26/H31 came from RICHER encoder features that the existing shallow volume decoder reads sufficiently. Closes the volume decoder interior axis decisively.

All three outcomes are informative.

### References

1. **Transolver: A Fast Transformer Solver for PDEs on General Geometries** — Wu et al., ICML 2024 (arXiv:2402.02366). Section 4.2 shows decoder depth as a tunable: 1-3 blocks typical, 4+ blocks experimented but not standard.
2. **OFormer: Pure Transformer for Operator Learning** — Li et al., NeurIPS 2022 (arXiv:2205.13671). Deep operator networks benefit from 4-6 decoder blocks for high-resolution outputs.
3. **PDE-Transformer** — Karras et al., 2024 (arXiv:2410.13166). Architecture ablation shows decoder depth has roughly linear scaling on solution accuracy for fluid PDEs up to ~4 decoder blocks; diminishing returns beyond.

## Instructions

**File: `target/model.py`** — modify `SurfaceTransolver.__init__` and `forward`/decoder method.

### Step 1 — Locate the volume head

Find the section of `SurfaceTransolver.__init__` that constructs the volume output head. It's likely:

```python
self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
# or
self.volume_out = nn.Sequential(
    nn.LayerNorm(n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.volume_output_dim),
)
```

This is the shallow head. We will keep this final projection unchanged but PRECEDE it with 2 new transformer blocks.

### Step 2 — Add volume-only deep blocks

Add to `SurfaceTransolver.__init__`, after the shared trunk construction:

```python
self.use_vol_deep = use_vol_deep
if use_vol_deep:
    # Add 2 dedicated volume-only transformer blocks after shared trunk.
    # Each block: MHA(self-attention) + FFN + LayerNorm, residual.
    # Initialize each block's residual output to zero (identity at step 0
    # = bit-exact baseline recovery).
    self.vol_deep_blocks = nn.ModuleList([
        TransolverBlock(
            n_hidden=n_hidden,
            num_heads=model_heads,    # 4
            ffn_hidden=n_hidden * 2,   # 1024 (match Transolver default)
            dropout=0.0,
            use_qk_norm=use_qk_norm,
        )
        for _ in range(2)
    ])
    # Zero-init the residual output projection of each new block for
    # identity behavior at step 0.
    with torch.no_grad():
        for block in self.vol_deep_blocks:
            # The output residual projection in TransolverBlock is the
            # final Linear after FFN. Find it and zero it.
            if hasattr(block, 'ffn_out_proj'):
                block.ffn_out_proj.weight.zero_()
                if block.ffn_out_proj.bias is not None:
                    block.ffn_out_proj.bias.zero_()
            elif hasattr(block, 'mlp') and hasattr(block.mlp, 'fc2'):
                block.mlp.fc2.weight.zero_()
                if block.mlp.fc2.bias is not None:
                    block.mlp.fc2.bias.zero_()
            # MHA attention output zero-init for full identity recovery
            if hasattr(block, 'attn') and hasattr(block.attn, 'out_proj'):
                block.attn.out_proj.weight.zero_()
                if block.attn.out_proj.bias is not None:
                    block.attn.out_proj.bias.zero_()
```

If `TransolverBlock` is the existing trunk block class (likely defined in `model.py`), reuse it. If not, search for the actual block class name and adapt the import path. **CRITICAL**: zero-init the residual output projections so that at step 0, the new blocks behave as identity (vol_deep_blocks output = vol_deep_blocks input), giving bit-exact baseline recovery at the smoke step 0 verification.

### Step 3 — Wire into forward pass

In `SurfaceTransolver.forward()`, locate the section after the shared trunk where `volume_hidden` is produced and BEFORE `volume_out` is called:

```python
# Existing:
# shared trunk processes both surface_hidden and volume_hidden
# ...
# At decode time:
if self.use_vol_deep:
    for block in self.vol_deep_blocks:
        volume_hidden = block(volume_hidden)  # [B, N_vol, 512]
volume_pred = self.volume_out(volume_hidden)  # [B, N_vol, 1]
```

**NO changes to surface decoder path**. Volume deep blocks only modify volume token representation between trunk and final volume head.

### Step 4 — Add `--use-vol-deep` flag to `train.py`

```python
parser.add_argument(
    "--use-vol-deep",
    action="store_true",
    help="Add 2 dedicated volume-only transformer blocks after shared trunk for deeper volume decoder."
)
```

Thread to model:
```python
model = SurfaceTransolver(
    ...,
    use_vol_deep=args.use_vol_deep,
    ...,
)
```

### Step 5 — Per-block residual contribution diagnostic (CRITICAL — adopted from H30 V2S asymmetry pattern)

Add to per-validation logging (rank 0 only). For each new vol_deep_block, log the residual output magnitude:

```python
if rank == 0 and model.module.use_vol_deep:
    with torch.no_grad():
        for i, block in enumerate(model.module.vol_deep_blocks):
            # Attention out_proj weight magnitude (post-zero-init growth)
            if hasattr(block, 'attn') and hasattr(block.attn, 'out_proj'):
                attn_w = block.attn.out_proj.weight
                wandb.log({
                    f"diag/vol_deep_block{i}/attn_out_proj_max_abs": attn_w.abs().max().item(),
                    f"diag/vol_deep_block{i}/attn_out_proj_global_norm": attn_w.norm().item(),
                }, commit=False)
            # FFN out_proj weight magnitude
            if hasattr(block, 'mlp') and hasattr(block.mlp, 'fc2'):
                ffn_w = block.mlp.fc2.weight
                wandb.log({
                    f"diag/vol_deep_block{i}/ffn_out_proj_max_abs": ffn_w.abs().max().item(),
                    f"diag/vol_deep_block{i}/ffn_out_proj_global_norm": ffn_w.norm().item(),
                }, commit=False)
```

Expected trajectory (per H30 V2S precedent): max_abs grows monotonically from 0 (init) to ~0.5-1.0 (saturated). Per-block, per-sublayer comparison tells us which deep block contributes more — and whether the 2 blocks each find unique productive directions or duplicate effort.

**KILL diagnostic**: if BOTH deep blocks' attn/ffn out_proj max_abs stays < 0.05 at EP3 step 32,594, the deep blocks are not biting (stuck near identity / residual) → mechanism dead → KILL.

### Step 6 — τz/τx mechanism logging (carry over from Wave 31 canonical)

Same diagnostic as H46/H45 PRs:

```python
ratio_per_car = tau_z_per_car / tau_x_per_car
wandb.log({
    "val/tau_zx_ratio_mean": ratio_per_car.mean().item(),
    "val/tau_zx_ratio_std": ratio_per_car.std().item(),
    "val/tau_zx_ratio_min": ratio_per_car.min().item(),
    "val/tau_zx_ratio_max": ratio_per_car.max().item(),
    "val/tau_zx_ratio_n_outside_band": ((ratio_per_car < 1.40) | (ratio_per_car > 1.60)).sum().item(),
}, commit=False)
```

### Step 7 — Smoke test (2-GPU, 2-epoch, 16384 points)

```bash
torchrun --standalone --nproc-per-node=2 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --epochs 2 --batch-size 2 \
  --train-surface-points 16384 --eval-surface-points 16384 \
  --train-volume-points 16384 --eval-volume-points 16384 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model \
  --use-vol-deep \
  --wandb-group wave31_h47_vdepth_smoke \
  --wandb-name nezuko/h47-vdepth-smoke \
  --agent nezuko
```

**Smoke PASS criteria:**
1. **Step 0 identity verification**: model output at step 0 EQUALS baseline (no `--use-vol-deep`) within numerical noise (1e-6). Verifies zero-init worked.
2. **No OOM at vp=16384**: deep blocks fit in memory budget at smoke scale.
3. **EP1 val_abupt ≤ 30%** (typical cold-start).
4. **train/loss descends from EP1**.
5. **No NaN, no nonfinite_count > 0**.
6. **Per-block max_abs starts at 0.0 at step 0 and grows monotonically** through EP2.
7. **Memory headroom check**: smoke peak memory at vp=16384 must extrapolate to fit within 96 GB at vp=65536. Rough scaling: 4× vp → 4× attention activation memory for new blocks. If smoke peak is 35 GB at vp=16384, EP9 main run at vp=65536 may use ~140 GB and OOM. Critical check.

### Step 8 — Full 18h DDP-8 run

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 \
  --epochs 13 --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 \
  --kill-thresholds 10864:val_abupt<30,32594:val_abupt<9.5,32594:val_SP<5.5,65228:val_abupt<7.0 \
  --use-vol-deep \
  --wandb-group wave31_h47_vdepth \
  --wandb-name nezuko/h47-vdepth-18h \
  --agent nezuko
```

Pre-launch budget verification: `printenv SENPAI_TIMEOUT_MINUTES`. Expected `1100` (18h). If `360` (6h), follow precedent: compress to 5ep with `--lr-cosine-t-max 5 --epochs 5 --vp-schedule 0:16384:3:32768:4:49152`.

**MEMORY WATCH**: deep blocks add ~5M params and 2× attention compute on volume tokens. At vp=65536 and batch=4 per GPU, peak GPU memory likely climbs from ~74 GB (H30 baseline) to ~85-90 GB. If OOM mid-EP9, fallback: reduce `--train-volume-points` and `--eval-volume-points` to 49152 (3× smaller curriculum endpoint), or reduce `--batch-size` to 2.

## EP Gates (mechanism-decisive)

| EP | Primary gate | Mechanism gate | Action |
|---|---|---|---|
| EP1 | val_abupt ≤ ~30% (warmup) | `vol_deep_block0` AND `vol_deep_block1` per-sublayer max_abs > 0 (residual fully zero-init shed) | sanity only |
| **EP3** | val_abupt ≤ 9.5% | **per-block attn AND ffn out_proj max_abs > 0.05** (deep blocks biting, not stuck at residual=0) | **KILL if EITHER block's both sublayers < 0.05 (mechanism dead) OR val_abupt > 11%** |
| EP6 | val_abupt ≤ 6.8% | val_VP < 3.85% (trending toward floor) | warn if val_VP slope flattening |
| EP9 | val_abupt ≤ 6.3% | val_VP < 3.75% (within 0.10pp of floor) | confirm trajectory; vp curriculum bump at EP9 critical |
| EP13 (terminal) | **val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%** | test_vol_p ≤ 3.55% (mechanism-positive on volume axis even if merge fails) | MERGE gate; or mechanism win for Wave 31 stack candidate |

**EP3 binary mechanism gate**: same pattern as H30 V2S asymmetry diagnostic. If BOTH deep blocks fail to grow magnitude beyond residual=0 (max_abs < 0.05), the deep blocks aren't contributing — KILL immediately, don't burn 18h budget.

## Baseline (PR #972, single-model SOTA — corrected split 2026-05-11)

| Metric | Value | Gate |
|---|---:|---|
| val_abupt | 6.126% | < 6.126% to MERGE |
| test_abupt | 5.844% | < 5.844% to MERGE |
| test_vol_p | 3.643% | ≤ 3.643% **floor — hard breach blocker** |
| test_SP | 3.577% | ≤ 3.577% **floor — hard breach blocker** |
| test_WSS | 6.727% | < 6.727% to MERGE |

**W&B run:** `56bcqp3m` (source) · `zxnhtagj` (eval)

**Comparison targets (Wave 30 vol_p floor crossings)**:
- H31 WALLDIST (closed, alphonse): test_vol_p **3.4880%** (−0.155pp below floor)
- H26 NPCA (closed, thorfinn): test_vol_p **3.6079%** (−0.035pp below floor)
- **H47 V-DEPTH target**: test_vol_p ≤ 3.55% (mechanism-positive vol_p axis), <3.45% would be best-of-Wave-31 if achieved

## Terminal SENPAI-RESULT format

```markdown
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0>","<rank1>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Must include:
- **Per-epoch val table** (val_abupt, val_SP, val_vol_p, val_WSS, val_τx/τy/τz, val τz/τx mean/std/min/max/n_outside_band)
- **Per-block residual diagnostic** at every val: `vol_deep_block[0,1].attn.out_proj.max_abs`, `vol_deep_block[0,1].mlp.fc2.max_abs` — KEY MECHANISM TRACE (canonical Wave 31 asymmetric-capacity diagnostic from H30 closure)
- **Memory peak per epoch** (verify no OOM)
- **Test best-checkpoint reload**: test_abupt, test_vol_p, test_SP, test_WSS, test_τx/τy/τz, test τz/τx mean/std
- **Per-block residual diagnostic AT TEST checkpoint** — does asymmetry pattern persist?
- **8-rank run IDs + best-checkpoint epoch + source (raw/ema)**
- **Comparison vs H30 V2S xattn matched-epoch trajectory** (val_vol_p side-by-side EP1-12) — does deeper volume decoder help where V2S xattn didn't?
- **Comparison vs H31 / H26 vol_p trajectories** — is H47 V-DEPTH compounding the floor crossings of input-axis hypotheses?

## Context — why this is the right Wave 31 hypothesis for nezuko now

Your H30 V2S xattn closure (just posted at 15:30Z) gave us the **first quantitative measurement of architectural-fusion capacity asymmetry** in Wave 30 (V2S 0.187 vs S2V 0.988 max_abs). That diagnostic depth is exactly what H47 V-DEPTH needs — per-block weight magnitude tracking to determine if the 2 new deep blocks bite at all, and if they bite asymmetrically.

H47 is mechanism-class-orthogonal to all 5 in-flight Wave 31 hypotheses:
- H34 OUTHEAD (edward): surface decoder post-projection capacity
- H45 CROSSCHAN-DEC (alphonse): surface decoder pre-projection representation
- H46 SDORTH (thorfinn): surface decoder weight init
- H36 ANCHOR-SLICE-QUERIES (tanjiro): slice query positional differentiation
- H44 YAW-AUGMENTATION (frieren): data augmentation

**Plus H35 fern (NPCA-SSFL stack)** — H47 is also orthogonal here (different volume-pathway axis from input-axis stacking).

**Why H47 V-DEPTH and not V2S asymmetric init (your suggested follow-up #1)**:
- V2S asymmetric init would fight the loss-landscape direction (S2V wins on its own merits); even with aggressive init scale, V2S would likely be optimized DOWN to match the equilibrium found in this run.
- V-DEPTH attacks a different bottleneck: not "V2S vs S2V information competition" but "volume decoder capacity for vol_p prediction itself". The volume tokens have rich information from the shared trunk (especially at vp=65536); the question is whether the existing 1-2 layer head extracts it fully.

**Why H47 V-DEPTH and not V2S τz-only routing (your suggested follow-up #2)**:
- τz-only V2S routing is a Wave 30 surface-decoder-channel-routing hypothesis. It's competing with H34 OUTHEAD (per-channel SURFACE projection capacity) which is already in-flight on edward. Duplicating mechanism class.
- V-DEPTH is on volume-pathway, fully orthogonal to surface decoder attacks.

**NO ENSEMBLES.** Single-model gates only.

If H47 V-DEPTH EP3 gate passes (both blocks biting AND val_abupt healthy AND val_VP trending toward floor), the next experiment is the **stack**: H47 + H26 (volume decoder depth + encoder local-frame input features). If H47 EP3 gate fails (blocks not biting OR val_abupt > 11%), the volume decoder INTERIOR is decisively not the bottleneck; the volume floor crossings from H26/H31 come from RICHER encoder features that the shallow decoder reads sufficiently.

**Either outcome is informative.** EP3 read tells us within 4-5 hours.
