### PR TITLE
H48 TAU-Y-EQUALIZE: reduce tau-y-loss-weight 1.5→1.0 to free τz gradient capacity

### DIFF
--- a/train.py
+++ b/train.py
@@ -1261,6 +1261,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 log_metrics.update(primary_metric_log("val_primary", val_metrics["val_surface"]))
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
+                val_surface_metrics = val_metrics["val_surface"]
+                if "tau_zx_ratio_mean" in val_surface_metrics:
+                    log_metrics["mechanism/tau_zx_ratio_mean"] = val_surface_metrics["tau_zx_ratio_mean"]
+                    log_metrics["mechanism/tau_zx_ratio_std"] = val_surface_metrics["tau_zx_ratio_std"]
+                    log_metrics["mechanism/n_outside_band_1.44_1.55"] = val_surface_metrics["tau_zx_n_outside_band"]
+                    log_metrics["mechanism/tau_zx_ratio_cars"] = val_surface_metrics["tau_zx_ratio_cars"]
                 log_metrics.update(collect_string_sep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -910,6 +910,9 @@ class EvalAccumulator:
     case_sums: dict[str, dict[str, list[float]]] = field(
         default_factory=lambda: {key: {} for key in EVAL_KEYS}
     )
+    tau_pred_abs_case: dict[str, dict[str, list[float]]] = field(
+        default_factory=lambda: {"x": {}, "y": {}, "z": {}}
+    )
 
 
 def _masked_sse_count(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> tuple[float, int]:
@@ -935,6 +938,21 @@ def _accumulate_case_rel_l2(
     state = store.setdefault(case_id, [0.0, 0.0])
     state[0] += error_sq
     state[1] += target_sq
+
+
+def _accumulate_case_abs_sum(
+    store: dict[str, list[float]],
+    *,
+    case_id: str,
+    values: torch.Tensor,
+) -> None:
+    if values.numel() == 0:
+        return
+    abs_sum = float(values.float().abs().sum().detach().cpu().item())
+    count = float(values.numel())
+    state = store.setdefault(case_id, [0.0, 0.0])
+    state[0] += abs_sum
+    state[1] += count
 
 
 def _rel_l2(store: dict[str, list[float]]) -> tuple[float, float]:
@@ -1031,6 +1049,11 @@ def accumulate_eval_batch(
                     pred=surface_pred_valid[:, channel : channel + 1],
                     target=surface_target_valid[:, channel : channel + 1],
                 )
+                _accumulate_case_abs_sum(
+                    accumulator.tau_pred_abs_case[axis],
+                    case_id=case_id,
+                    values=surface_pred_valid[:, channel],
+                )
         volume_valid = batch.volume_mask[case_idx].bool()
         if bool(volume_valid.any()):
             _accumulate_case_rel_l2(
@@ -1057,6 +1080,12 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
                 state = merged.case_sums[key].setdefault(case_id, [0.0, 0.0])
                 state[0] += values[0]
                 state[1] += values[1]
+        for axis, axis_store in accumulator.tau_pred_abs_case.items():
+            merged_axis = merged.tau_pred_abs_case.setdefault(axis, {})
+            for case_id, values in axis_store.items():
+                state = merged_axis.setdefault(case_id, [0.0, 0.0])
+                state[0] += values[0]
+                state[1] += values[1]
     return merged
 
 
@@ -1067,6 +1096,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_pred_ratio_stats = _tau_pred_ratio_stats(accumulator.tau_pred_abs_case)
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1144,48 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_pred_ratio_stats,
+    }
+
+
+def _tau_pred_ratio_stats(
+    tau_pred_abs_case: dict[str, dict[str, list[float]]],
+) -> dict[str, float]:
+    tau_x_case = tau_pred_abs_case.get("x", {})
+    tau_z_case = tau_pred_abs_case.get("z", {})
+    ratios: list[float] = []
+    for case_id, x_state in tau_x_case.items():
+        z_state = tau_z_case.get(case_id)
+        if z_state is None:
+            continue
+        x_sum, x_count = x_state
+        z_sum, z_count = z_state
+        if x_count <= 0.0 or z_count <= 0.0:
+            continue
+        x_mean_abs = x_sum / x_count
+        z_mean_abs = z_sum / z_count
+        if not math.isfinite(x_mean_abs) or x_mean_abs <= 0.0:
+            continue
+        if not math.isfinite(z_mean_abs):
+            continue
+        ratios.append(z_mean_abs / x_mean_abs)
+    n_cars = len(ratios)
+    if n_cars == 0:
+        return {
+            "tau_zx_ratio_mean": float("nan"),
+            "tau_zx_ratio_std": float("nan"),
+            "tau_zx_n_outside_band": 0.0,
+            "tau_zx_ratio_cars": 0.0,
+        }
+    mean = sum(ratios) / n_cars
+    var = sum((r - mean) ** 2 for r in ratios) / n_cars
+    std = math.sqrt(var)
+    n_outside = sum(1 for r in ratios if (r < 1.44 or r > 1.55))
+    return {
+        "tau_zx_ratio_mean": float(mean),
+        "tau_zx_ratio_std": float(std),
+        "tau_zx_n_outside_band": float(n_outside),
+        "tau_zx_ratio_cars": float(n_cars),
     }
 
 
@@ -1371,6 +1443,7 @@ def define_wandb_metrics() -> None:
         "train/weight_type/*",
         "train/weight_hist/*",
         "train/weight_hist_param/*",
+        "mechanism/*",
         "lr",
     ):
         wandb.define_metric(metric_prefix, step_metric="global_step")
@@ -1480,6 +1553,12 @@ def run_final_evaluation(
     }
     for split_name, metrics in full_val_metrics.items():
         full_val_log.update(metric_namespace("full_val", split_name, metrics))
+    full_val_surface = full_val_metrics["val_surface"]
+    if "tau_zx_ratio_mean" in full_val_surface:
+        full_val_log["mechanism/full_val_tau_zx_ratio_mean"] = full_val_surface["tau_zx_ratio_mean"]
+        full_val_log["mechanism/full_val_tau_zx_ratio_std"] = full_val_surface["tau_zx_ratio_std"]
+        full_val_log["mechanism/full_val_n_outside_band_1.44_1.55"] = full_val_surface["tau_zx_n_outside_band"]
+        full_val_log["mechanism/full_val_tau_zx_ratio_cars"] = full_val_surface["tau_zx_ratio_cars"]
     try:
         assert_required_finite_metrics(full_val_log, "full_val_primary")
     except RuntimeError as exc:
@@ -1500,6 +1579,12 @@ def run_final_evaluation(
     }
     for split_name, metrics in test_metrics.items():
         test_log.update(metric_namespace("test", split_name, metrics))
+    test_surface_metrics = test_metrics["test_surface"]
+    if "tau_zx_ratio_mean" in test_surface_metrics:
+        test_log["mechanism/test_tau_zx_ratio_mean"] = test_surface_metrics["tau_zx_ratio_mean"]
+        test_log["mechanism/test_tau_zx_ratio_std"] = test_surface_metrics["tau_zx_ratio_std"]
+        test_log["mechanism/test_n_outside_band_1.44_1.55"] = test_surface_metrics["tau_zx_n_outside_band"]
+        test_log["mechanism/test_tau_zx_ratio_cars"] = test_surface_metrics["tau_zx_ratio_cars"]
     try:
         assert_required_finite_metrics(test_log, "test_primary")
     except RuntimeError as exc:


### PR DESCRIPTION
## Hypothesis — H48 TAU-Y-EQUALIZE

**Reduce `--tau-y-loss-weight` from 1.5 → 1.0** to equalize the surface loss across all three wall-shear components (τx, τy, τz) and test whether the τy gradient surplus is the training-time cause of the τz/τx band attractor.

### Mechanistic rationale

The τz/τx band attractor (mean(τz/τx) → [1.44, 1.55] at convergence) has resisted every intervention tried in Waves 24–31 that did not change the decoder weight initialization or architecture. Six mechanism axes probed (V2S xattn, NPCA, WALLDIST, SSFL, SLICEPE, ANCHOR-SLICE) confirm the attractor is stable under gradient-level perturbations from the outside.

The current baseline loss weights are:
- τx: implicit weight 1.0 (no dedicated flag — absorbed in `surface_loss_weight × 0.25`)
- τy: `--tau-y-loss-weight 1.5` → 1.5× extra gradient priority
- τz: `--tau-z-loss-weight 2.0` → 2.0× extra gradient priority

τy currently receives 1.5× more gradient signal than τx, yet the band attractor locks τz/τx at a ratio where τz is NOT systematically harder to fit (τy is often harder on OOD configs). This asymmetry between τy and τx may cause the surface decoder to bias its row-structure toward capturing the (τx, τy) space disproportionately, creating the attractor indirectly: as long as τy is over-weighted, the decoder's shared capacity is shaped by the (τx, τy) subspace, and τz inherits that geometry.

**Hypothesis:** Reducing τy weight from 1.5 → 1.0 equalizes gradient pressure across τx and τy, removes the τy gradient surplus that may be biasing the decoder's capacity allocation, and gives τz a larger relative share of the surface loss gradient. If the band attractor is partially maintained by this τy surplus, this change should allow τz/τx mean to drift below the 1.44 lower edge or raise std(τz/τx) above the 0.15 variance-break gate.

**This is a pure training-flag change** — no code modifications, zero OOM risk.

### Prior evidence
- `--tau-z-loss-weight` axis exhausted: values 2.0 (baseline), 3.0, 3.5 — all null or KILL. Direct τz up-weighting does not break the attractor.
- `--tau-y-loss-weight 2.5` tried once (combined with vol×2.0 + tau-z×3.0, PR closed NEGATIVE) — but this bundled 3 changes simultaneously, and the τy increase went the wrong direction (more τy, not less).
- `--tau-y-loss-weight 1.0` as a **standalone single-flag change has never been tested**.

## Instructions

**Single flag change only.** Do not modify any other hyperparameter or code.

Change `--tau-y-loss-weight 1.5` → `--tau-y-loss-weight 1.0`.

**Training command (Path A — 13 epochs):**

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.0 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent edward \
  --wandb-group wave31_h48_tau_y_equalize \
  --wandb-name edward/h48-tau-y-equalize-main \
  --kill-thresholds "step>=10864:val_primary/abupt_axis_mean_rel_l2_pct<50,step>=10864:val_primary/vol_p_rel_l2_pct<30,step>=32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5"
```

**Kill thresholds use step numbers, NOT epoch numbers.** EP1 end = step 10,864; EP3 end = step 32,594. Do NOT use `3:` for EP3 — use `step>=32594:`.

### Mechanism metrics to log at each checkpoint

Post after EP1, EP3, EP6, EP9, EP13 (terminal):

```python
import wandb
import numpy as np

# After eval loop, compute from val predictions:
# tau_z_pred, tau_x_pred = per-car mean absolute values of τz and τx predictions
# For each car c in val set:
ratio_per_car = tau_z_abs_mean[c] / tau_x_abs_mean[c]  # shape [34]
tau_zx_mean = np.mean(ratio_per_car)
tau_zx_std = np.std(ratio_per_car)
n_outside_band = np.sum((ratio_per_car < 1.44) | (ratio_per_car > 1.55))

wandb.log({
    "mechanism/tau_zx_ratio_mean": tau_zx_mean,
    "mechanism/tau_zx_ratio_std": tau_zx_std,
    "mechanism/n_outside_band_1.44_1.55": n_outside_band,
})
```

**Mechanism-positive gate:** std(τz/τx) ≥ 0.15 OR mean(τz/τx) < 1.44 at any checkpoint.

**EP3 hard gate:**
| Gate | PASS | KILL |
|---|---:|---:|
| val_abupt | ≤ 9.5% | > 9.5% |
| val_VP | ≤ 30% (gross sanity) | > 30% |

### Report format

Post after each EP gate:

```
EP<N> update (step <step>, run <run-id>):
- val_abupt: X.XXX%
- val_VP: X.XXX%
- val_SP: X.XXX%
- val_WSS: X.XXX%
- τz/τx mean: X.XXX (band=[1.44,1.55])
- τz/τx std: X.XXX (mechanism gate ≥0.15)
- n_outside_band: N/34
```

At terminal EP13, include SENPAI-RESULT marker.

## Baseline

Current best single-model (PR #972, run `56bcqp3m`):
- val_abupt: **6.126%**
- val_VP: 3.643%
- val_SP: 3.577%
- val_WSS: 6.727%
- test_abupt: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: **6.727%** (target: beat Transolver-3 SOTA 5.85%)
- test_tau_z: 8.916%

**τz/τx band attractor baseline:** mean ≈ 1.496, std ≈ 0.085 (below 0.15 mechanism gate)

### Baseline reproduce command (without H48):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

## Wave 31 fleet context

| Student | PR | Hypothesis | Status |
|---|---|---|---|
| askeladd | #1187 | H33 SLICEPE | Running → EP6 gate |
| fern | #1189 | H35 NPCA+SSFL | Running → EP6 gate |
| frieren | #1190 | H44 YAW-AUG | Running → EP13 terminal |
| tanjiro | #1191 | H36 ANCHOR-SLICE | Running → EP6 gate |
| alphonse | #1192 | H45 CROSSCHAN v2 | Running → EP1 pending |
| thorfinn | #1193 | H46 SDORTH (Path B) | Running → EP3 pending |
| nezuko | #1194 | H47 V-DEPTH (Path B) | Running → EP1 pending |
| **edward** | **#this** | **H48 TAU-Y-EQUALIZE** | **new** |
