### PR TITLE
Wave 31 H49: SDORTH-FULL — Surface Decoder Orthogonal Row Init, 13-Epoch Confirmation of H46 Mechanism

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surface_orth_init: bool = False,
+        surface_orth_init_std: float = 0.02,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surface_orth_init = use_surface_orth_init
+        self.surface_orth_init_std = surface_orth_init_std
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -498,6 +502,26 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # H46 SDORTH (Wave 31): replace default trunc_normal(std=0.02) init of the
+        # final Linear in the surface decoder with orthogonal rows, rescaled to
+        # match trunc_normal magnitude exactly. Targets the [surface_output_dim, n_hidden]
+        # final projection — surface_out[-1] for aux_decoder_heads, surface_out.project
+        # for the LinearProjection branch.
+        if use_surface_orth_init:
+            if use_aux_decoder_heads:
+                final_linear = self.surface_out[-1]
+            else:
+                final_linear = self.surface_out.project
+            with torch.no_grad():
+                # gain = std * sqrt(fan_in) yields rows with expected L2 norm matching
+                # trunc_normal(std=surface_orth_init_std). For std=0.02, fan_in=512
+                # this is ~0.4525 (vs unit-norm gain=1.0).
+                fan_in = final_linear.weight.shape[1]
+                gain = surface_orth_init_std * (fan_in ** 0.5)
+                nn.init.orthogonal_(final_linear.weight, gain=gain)
+                if final_linear.bias is not None:
+                    final_linear.bias.zero_()
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).

--- a/train.py
+++ b/train.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
@@ -103,6 +104,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_orth_init: bool = False
+    surface_orth_init_std: float = 0.02
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -276,6 +279,50 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_surface_proj_row_metrics(model: nn.Module) -> dict[str, float]:
+    """H46 SDORTH (Wave 31): row-structure diagnostic for the final surface
+    decoder Linear (the [surface_output_dim, n_hidden] projection that maps
+    backbone hidden states to [cp, tau_x, tau_y, tau_z]).
+
+    Reports pairwise off-diagonal cosine similarities + row norms so the
+    advisor can verify orthogonality was applied at init and track decay
+    under training.
+    """
+    metrics: dict[str, float] = {}
+    surface_out = getattr(model, "surface_out", None)
+    if surface_out is None:
+        return metrics
+    if isinstance(surface_out, nn.Sequential):
+        final_linear = None
+        for layer in reversed(surface_out):
+            if isinstance(layer, nn.Linear):
+                final_linear = layer
+                break
+    elif hasattr(surface_out, "project") and isinstance(surface_out.project, nn.Linear):
+        final_linear = surface_out.project
+    else:
+        final_linear = None
+    if final_linear is None:
+        return metrics
+    with torch.no_grad():
+        weight = final_linear.weight.detach().float()  # [out, in]
+        out_dim = weight.shape[0]
+        if out_dim < 2:
+            return metrics
+        rows = F.normalize(weight, dim=1)
+        gram = rows @ rows.T
+        off_diag_mask = ~torch.eye(out_dim, dtype=torch.bool, device=weight.device)
+        off_diag = gram[off_diag_mask]
+        row_norms = weight.norm(dim=1)
+        metrics["surface_proj_row/cos_mean_abs"] = float(off_diag.abs().mean().item())
+        metrics["surface_proj_row/cos_max_abs"] = float(off_diag.abs().max().item())
+        metrics["surface_proj_row/row_norm_mean"] = float(row_norms.mean().item())
+        metrics["surface_proj_row/row_norm_std"] = float(row_norms.std().item())
+        metrics["surface_proj_row/row_norm_min"] = float(row_norms.min().item())
+        metrics["surface_proj_row/row_norm_max"] = float(row_norms.max().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +355,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_orth_init=config.use_surface_orth_init,
+        surface_orth_init_std=config.surface_orth_init_std,
     )
 
 
@@ -883,6 +932,25 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            # H46 SDORTH: log surface decoder final-projection row structure at init
+            # so the orth-init invariant can be verified BEFORE training starts.
+            init_surface_proj_metrics = collect_surface_proj_row_metrics(base_model)
+            if init_surface_proj_metrics:
+                init_log = {f"init/{k}": v for k, v in init_surface_proj_metrics.items()}
+                init_log["init/use_surface_orth_init"] = float(config.use_surface_orth_init)
+                init_log["init/surface_orth_init_std"] = float(config.surface_orth_init_std)
+                wandb.log(init_log, step=0)
+                wandb.summary.update(init_log)
+                print(
+                    "[INIT surface_proj] cos_max_abs={:.6f} cos_mean_abs={:.6f} "
+                    "row_norm_mean={:.5f} row_norm_std={:.5f} (use_orth_init={})".format(
+                        init_surface_proj_metrics["surface_proj_row/cos_max_abs"],
+                        init_surface_proj_metrics["surface_proj_row/cos_mean_abs"],
+                        init_surface_proj_metrics["surface_proj_row/row_norm_mean"],
+                        init_surface_proj_metrics["surface_proj_row/row_norm_std"],
+                        config.use_surface_orth_init,
+                    )
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1262,6 +1330,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                # H46 SDORTH: track final surface-projection row decorrelation drift.
+                surface_proj_metrics = collect_surface_proj_row_metrics(base_model)
+                for k, v in surface_proj_metrics.items():
+                    log_metrics[f"diag/{k}"] = v
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,54 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _tau_zx_ratio_stats(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """H46 SDORTH (Wave 31): per-car tau_z/tau_x rel-L2 ratio diagnostic.
+
+    The historical attractor for this metric sits in [1.44, 1.55]. Tracking
+    mean/std/min/max + count-outside-band per epoch reveals whether an
+    intervention deflects the projection row coupling at the val level.
+    """
+    ratios: list[float] = []
+    for case_id, x_state in case_sums_x.items():
+        z_state = case_sums_z.get(case_id)
+        if z_state is None:
+            continue
+        x_err_sq, x_tgt_sq = x_state
+        z_err_sq, z_tgt_sq = z_state
+        if x_tgt_sq <= 0.0 or z_tgt_sq <= 0.0 or x_err_sq <= 0.0:
+            continue
+        x_rel = math.sqrt(x_err_sq / x_tgt_sq)
+        z_rel = math.sqrt(z_err_sq / z_tgt_sq)
+        if x_rel <= 0.0 or not math.isfinite(x_rel) or not math.isfinite(z_rel):
+            continue
+        ratios.append(z_rel / x_rel)
+    if not ratios:
+        return {
+            "tau_zx_ratio_mean": float("nan"),
+            "tau_zx_ratio_std": float("nan"),
+            "tau_zx_ratio_min": float("nan"),
+            "tau_zx_ratio_max": float("nan"),
+            "tau_zx_ratio_n_outside_band": 0.0,
+            "tau_zx_ratio_n_cars": 0.0,
+        }
+    n = len(ratios)
+    mean = sum(ratios) / n
+    var = sum((r - mean) ** 2 for r in ratios) / max(n - 1, 1) if n > 1 else 0.0
+    std = math.sqrt(var)
+    n_outside = sum(1 for r in ratios if r < 1.40 or r > 1.60)
+    return {
+        "tau_zx_ratio_mean": mean,
+        "tau_zx_ratio_std": std,
+        "tau_zx_ratio_min": min(ratios),
+        "tau_zx_ratio_max": max(ratios),
+        "tau_zx_ratio_n_outside_band": float(n_outside),
+        "tau_zx_ratio_n_cars": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1115,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_stats = _tau_zx_ratio_stats(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1166,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_stats,
     }
 
 


### PR DESCRIPTION
## Hypothesis — H49 SDORTH-FULL: Full 13-Epoch Confirmation of Decoder Weight Init Mechanism

H46 SDORTH (closed PR #1193, Path B 5-ep screening) produced **the most important Wave 30/31 structural finding to date**: the τz/τx band attractor lives in the TRAINING TRAJECTORY, not the weight values themselves. Mechanism evidence at EP3 (best EMA ckpt on 3-ep budget):

| Diagnostic | EP3 val | EP3 test (50 cars) | Pattern |
|---|---:|---:|:--|
| `tau_zx_ratio_mean` | 1.490 (in band) | **1.431** ⭐ below band lower edge 1.44 | **FIRST test-side mean deflection in Wave 30/31** |
| `tau_zx_ratio_std` | 0.194 (>0.15 gate) | 0.112 (>0.10 baseline) | std-spread persistent |
| `tau_zx_ratio_n_outside_band` | 16/34 (47%) | 23/50 (46%) | mostly displaced from attractor |
| `surface_proj_row/cos_max_abs` | 2.3e-08 → 0.210 (2.1× baseline) | — | weight orth FULLY decayed by EP1, mechanism still active |

The orth init structure at the weight level is fully overwritten by EP1 and continues drifting past baseline through EP3. **Yet the test mean stays below band.** This proves the band attractor is path-dependent, not weight-fixed.

**H49 binding question:** Does the test τz/τx mean deflection (1.431 at EP3) PERSIST at full-budget terminal EP13, or does the additional 10 epochs of cosine-decayed training cause the test mean to rebound into the [1.44, 1.55] band attractor?

Two falsifiable outcomes:
- **(A) Mean deflection persists at EP13** → first single-model paper-facing breakthrough on the surface decoder mean-deflection axis. Mechanism-class win + likely merge candidate.
- **(B) Mean deflection rebounds to band by EP13** → confirms the training trajectory's late-stage cosine-decay phase regularizes back to the attractor, narrowing future Wave 31 attack windows to early/mid-training perturbations.

Secondary question: With 10 additional epochs of training, does test_vol_p close from 3.917% → ≤ 3.643% (clear the floor)? On the 3-ep budget, test_vol_p missed by +0.274pp and was still descending (slope visible from val_VP 4.515 → 4.031 across EP2 → EP3, −0.484pp/epoch). Linear extrapolation suggests test_vol_p could land ~3.50-3.60% on full budget — POSSIBLE merge candidate.

## Instructions

**Single change vs baseline**: add `--use-surface-orth-init --surface-orth-init-std 0.02` flags. Same orthogonal row init code from PR #1193 (already merged via the closed PR's diff — confirm the flag-keyed code path is intact in the model on the current `tay`; if not, re-apply the 3-LOC change).

**Critical**: use the FULL 13-epoch baseline-equivalent recipe (NOT the 5-ep Path B). Same vol-points schedule, same timeout, same cosine length as baseline #972.

### Training command (Path A — 13 epochs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --use-surface-orth-init --surface-orth-init-std 0.02 \
  --agent thorfinn \
  --wandb-group wave31_h49_sdorth_full \
  --wandb-name thorfinn/h49-sdorth-full-13ep \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<40,32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5"
```

**Kill thresholds use step numbers, NOT epoch numbers.** EP1 end = step 10,864; EP3 end = step 32,594. Do NOT use `3:` for EP3.

## Mechanism metrics — required logging per epoch (re-use H46 telemetry)

Per epoch (EP1, EP3, EP6, EP9, EP13) log to W&B:

```python
# τz/τx ratio diagnostics (val 34 cars)
"val_primary/tau_zx_ratio_mean": mean
"val_primary/tau_zx_ratio_std": std  
"val_primary/tau_zx_ratio_min": min
"val_primary/tau_zx_ratio_max": max
"val_primary/tau_zx_ratio_n_outside_band": count

# Surface projection orth-decay diagnostics
"surface_proj_row/cos_max_abs": max abs of off-diag row cosines
"surface_proj_row/cos_mean_abs": mean abs of off-diag row cosines  
"surface_proj_row/row_norm_mean": mean of row L2 norms
"surface_proj_row/row_norm_std": std of row L2 norms
```

At terminal: compute on TEST split (50 cars) with same code. Critical to capture test_tau_zx_ratio_mean — the binding gate.

## Gates

### EP1 sanity
- `val_primary/abupt_axis_mean_rel_l2_pct < 40%` (cold-start sanity)
- `tau_zx_ratio_mean` deflected from band attractor (e.g., < 1.40 or > 1.56) — EP1 will deflect like H46
- `surface_proj_row/cos_max_abs` rapidly growing (orth structure decaying as expected)

### EP3 mechanism gate (HARD)
- `val_primary/abupt_axis_mean_rel_l2_pct < 9.5%` (kill if violated)
- `tau_zx_ratio_std ≥ 0.15` (mechanism gate — H46 was 0.194 at EP3 with 5-ep budget, full-budget could differ in slope)
- `surface_proj_row/cos_max_abs > 0.10` (confirms orth is fully overwritten, baseline tracking)

### EP6-EP9 trajectory check
- `tau_zx_ratio_mean` trajectory: report whether mean stays deflected or rebounds
- `tau_zx_ratio_std` trajectory: report whether spread persists or fades
- val_abupt slope: confirm continuing descent
- val_VP slope: confirm continuing descent toward floor

### EP13 binding terminal gates
1. **Primary mechanism**: `test_primary/tau_zx_ratio_mean < 1.44` (the H46 EP3 test reading was 1.431 — does this persist?)
2. **Merge gate**: `val_abupt < 6.126%`
3. **Hard floors**: `test_primary/surface_pressure_rel_l2_pct ≤ 3.577%`, `test_primary/volume_pressure_rel_l2_pct ≤ 3.643%`
4. **WSS goal**: `test_primary/wall_shear_rel_l2_pct < 6.727%` (beat baseline), aspirational < 5.85% (Transolver-3 SOTA)

## Report format per epoch checkpoint

```
EP<N> update (step <step>, run <run-id>):
- val_abupt: X.XXX% (descent slope: X.XXX pp/1k steps)
- val_VP: X.XXX% (vs floor 3.643%)
- val_SP: X.XXX% (vs floor 3.577%)
- val_WSS: X.XXX% (vs goal 5.85%)
- τz/τx (val 34 cars): mean=X.XXX, std=X.XXX, min=X.XXX, max=X.XXX, n_outside_band=N/34
- surface_proj_row: cos_max_abs=X.XXX, cos_mean_abs=X.XXX, row_norm_mean=X.XXX, row_norm_std=X.XXX
- 8-rank DDP step spread: N (sanity check)
```

At EP13 terminal, run test eval on best val_abupt checkpoint via `scripts/eval_ckpt.py` and post SENPAI-RESULT.

## Baseline reference

Current best single-model (PR #972, run `56bcqp3m`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: 5.844%
- test_vol_p: **3.643%** (floor)
- test_SP: **3.577%** (floor)
- test_WSS: **6.727%** (target to beat; aspirational < 5.85% Transolver-3 SOTA)
- test τz/τx: mean ≈ 1.473, std ≈ 0.085 (band attractor)
- Reproduce: same command as above MINUS the `--use-surface-orth-init` flag pair

### H46 EP3 reference points (closed PR #1193, Path B 5-ep)
- val_abupt EP3 6.868%, slope at cutoff −8.79e-5 / step (still descending)
- test_abupt 6.595%, test_SP 4.226%, test_VP 3.917%, test_WSS 7.594%
- test τz/τx: mean 1.431 (below band ⭐), std 0.112, 23/50 (46%) cars outside band

## Wave 31 fleet context

| Student | PR | Hypothesis | Status |
|---|---|---|---|
| askeladd | #1187 | H33 SLICEPE v2 | mid-EP6 — primary mech falsified, val_VP descent toward floor |
| fern | #1189 | H35 NPCA+SSFL stack | EP7+ — fleet-peak τz/τx std 0.2464, val_VP 3.738% (0.095pp from floor) |
| frieren | #1190 | H44 YAW-AUG | EP4+ — val_VP 3.806% novel −31% descent signal |
| tanjiro | #1191 | H36 ANCHOR-SLICE | mid-EP3-EP4 — τz/τx std 0.155-0.188, variance class confirmed |
| alphonse | #1192 | H45 CROSSCHAN | EP1 pending |
| nezuko | #1194 | H47 V-DEPTH | EP1-EP3 — zero-init shedding |
| edward | #1196 | H48 TAU-Y-EQUALIZE | EP0-EP1 — just launched |
| **thorfinn** | **#this** | **H49 SDORTH-FULL** | **new — full 13-ep confirmation of H46 mechanism** |

Three orthogonal mechanism wins now characterize Wave 31:
1. H26 NPCA (encoder-input local-frame): val std 0.259, test mean preserved 1.467, test_vol_p crossing
2. H31 WALLDIST (encoder-input log-SDF): val std ~0.25, test_vol_p crossing −0.155pp
3. **H46 SDORTH (decoder weight init, NOW): test mean deflection 1.431 below band — FIRST test-side mean win**

H49 SDORTH-FULL tests whether mechanism win #3 survives the full 13-epoch budget and whether the floor breaches close.

## Why this is high info-value

The H46 closure proved the τz/τx band attractor is path-dependent (lives in training trajectory, not weight values). This is a **structural finding that reshapes the Wave 31 attack map**. H49 SDORTH-FULL is the highest-info Wave 31 follow-up because:

1. **Single-line code change already validated** at debug budget — no implementation risk
2. **Binary question with high decision value**: does mean deflection persist at terminal?
3. **Test_vol_p floor crossing is plausible**: val_VP at H46 EP3 was 4.031% with −0.484pp/epoch descent; 10 more epochs likely lands at 3.40-3.60% range
4. **Test_SP floor crossing requires both budget catch-up AND mechanism alignment**: harder, but possible if H46's per-car magnitude asymmetry (`row_norm_std 0.086`) helps SP-specific projection capacity

This run could produce Wave 31's first single-model merge winner. If it confirms, the SDORTH primitive becomes the canonical Wave 31 decoder-init component and stackable with H26/H31 encoder-input mechanisms in a future Wave 32.

## Resources

- Reference run: H46 W&B group `wave31_h46_sdorth`, rank0 `hoj593kk`
- New run group: `wave31_h49_sdorth_full`
- Baseline: PR #972, run `56bcqp3m`
- Code path: `--use-surface-orth-init` flag should already exist in `train.py` from PR #1193's merged diff (the closed PR's branch — re-cherry-pick the model.py code if needed)

If the H46 code path is no longer on `tay` (PR #1193 was closed without merge), apply the same 3-LOC change to `model.py`:

```python
# In the surface decoder __init__, after the Linear(hidden_dim, 4) projection is created:
if use_surface_orth_init:
    weight = self.surface_proj.weight  # shape [4, hidden_dim]
    nn.init.orthogonal_(weight, gain=1.0)
    target_row_norm = (6.0 / weight.shape[1]) ** 0.5 / (3.0 ** 0.5)  # Kaiming magnitude
    current_row_norm = weight.norm(dim=1, keepdim=True)
    weight.mul_(target_row_norm / current_row_norm)
```

And add the matching `--use-surface-orth-init` and `--surface-orth-init-std 0.02` argparse flags in `train.py`.

Note: `--surface-orth-init-std` is currently passed as a kwarg but the standard recipe just uses `0.02`; the orthogonality is the binding mechanism, not the magnitude scale (which is auto-derived from Kaiming).
