### PR TITLE
Wave 31 H50: Coordinate-conditioned slice IDs (COORDSLICE, DAB-DETR analogue)

### DIFF
--- a/model.py
+++ b/model.py
@@ -71,6 +71,44 @@ class RFFEncoding(nn.Module):
         return torch.cat([proj.sin(), proj.cos()], dim=-1)
 
 
+class MultiSigmaRFFEncoding(nn.Module):
+    """Multi-sigma Gaussian random Fourier features for 3D coordinate encoding.
+
+    Encodes ``in_dim``-dimensional coordinates using ``len(sigmas)`` independent
+    RFF banks at different length scales, concatenated along the feature dim.
+    Output dimension is ``2 * num_features * len(sigmas)`` (sin + cos per bank).
+
+    All projection matrices are registered as non-trainable buffers so they
+    travel with the model across devices and DDP ranks.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        num_features: int = 32,
+        sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0),
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigmas = sigmas
+        for i, sigma in enumerate(sigmas):
+            self.register_buffer(f"B_{i}", torch.randn(in_dim, num_features) * sigma)
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features * len(self.sigmas)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        parts: list[torch.Tensor] = []
+        for i in range(len(self.sigmas)):
+            B = getattr(self, f"B_{i}").to(dtype=x.dtype)
+            proj = 2.0 * math.pi * (x @ B)
+            parts.append(proj.sin())
+            parts.append(proj.cos())
+        return torch.cat(parts, dim=-1)
+
+
 class StringSeparableEncoding(nn.Module):
     """STRING-separable positional encoding.
 
@@ -234,6 +272,9 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +285,7 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_coord_slice_pe = use_coord_slice_pe
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -258,6 +300,26 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+
+        if use_coord_slice_pe:
+            # Multi-sigma RFF encoding of 3D slice centroids → additive PE for slice tokens.
+            # Uses 4 sigmas covering sub-car (0.25m) to full-car (2.0m) length scales.
+            self.coord_pe_rff = MultiSigmaRFFEncoding(
+                in_dim=3,
+                num_features=coord_slice_pe_rff_features,
+                sigmas=(0.25, 0.5, 1.0, 2.0),
+            )
+            rff_out_dim = self.coord_pe_rff.output_dim  # 2 * rff_features * 4 sigmas
+            # Project from RFF space to per-head D_head additive PE: [B,S,rff_out] → [B,S,H*D_head]
+            self.coord_pe_proj = nn.Linear(rff_out_dim, num_heads * self.dim_head)
+            # Init at small scale (O(1/sqrt(D_head)) per H33 lesson; avoids sub-gradient-floor init)
+            with torch.no_grad():
+                w_std = self.coord_pe_proj.weight.std().clamp(min=1e-8)
+                self.coord_pe_proj.weight.mul_(coord_slice_pe_init_scale / w_std)
+                nn.init.zeros_(self.coord_pe_proj.bias)
+        else:
+            self.coord_pe_rff = None
+            self.coord_pe_proj = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -274,8 +336,42 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        if self.use_coord_slice_pe and coords is not None:
+            # Stop-grad on centroid computation: avoids routing absorption /
+            # softmax polarization where the model would game slice_weights to
+            # position centroids rather than route content. Gradient flows
+            # only to coord_pe_proj.weight via the differentiable Linear.
+            with torch.no_grad():
+                # slice_weights: [B, H, N, S] — average over heads to get per-token slice probs
+                slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
+                # Normalise per slice so centroids are proper weighted means
+                slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
+                # Weighted average of 3D coords → slice centroids
+                slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
+                coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
+            coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head] — grad flows to .weight
+            B_size, S_size = slice_centroids.shape[:2]
+            coord_pe = coord_pe.view(B_size, S_size, self.num_heads, self.dim_head).permute(0, 2, 1, 3)  # [B, H, S, D_head]
+            slice_tokens = slice_tokens + coord_pe
+            if not self.training:
+                # Stash diagnostics for val-time logging via collect_coord_slice_pe_metrics
+                with torch.no_grad():
+                    self._last_slice_centroids = slice_centroids.detach()  # [B, S, 3]
+                    flat = slice_tokens.detach()  # [B, H, S, D_head] — post-PE input to qkv
+                    fnorm = flat / (flat.norm(dim=-1, keepdim=True) + 1e-9)
+                    cos = torch.einsum("bhsd,bhtd->bhst", fnorm, fnorm)  # [B, H, S, S]
+                    S_dim = cos.shape[-1]
+                    eye = torch.eye(S_dim, device=cos.device, dtype=cos.dtype).unsqueeze(0).unsqueeze(0)
+                    off_diag_sum = (cos * (1.0 - eye)).sum(dim=(-2, -1))
+                    off_diag_mean = (off_diag_sum / (S_dim * (S_dim - 1))).mean()
+                    self._last_inter_slice_cos = float(off_diag_mean.item())
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +399,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +412,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, coords=coords)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +443,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +457,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_coord_slice_pe=use_coord_slice_pe,
+                    coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+                    coord_slice_pe_init_scale=coord_slice_pe_init_scale,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, coords=coords)
         return x
 
 
@@ -382,6 +500,9 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +517,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_coord_slice_pe = use_coord_slice_pe
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +594,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -562,6 +687,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -578,6 +704,8 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -592,10 +720,19 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        # Build concatenated coords tensor in the same token order as the hidden states.
+        # Pad masked-out tokens to zero so they don't skew slice centroids.
+        if self.use_coord_slice_pe and coords_list:
+            coords = torch.cat(coords_list, dim=1)  # [B, N_surf+N_vol, 3]
+            coords = coords * attn_mask.unsqueeze(-1).to(dtype=coords.dtype)
+        else:
+            coords = None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, coords=coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/safety_check_h50.py
+++ b/safety_check_h50.py
@@ -1,0 +1,128 @@
+"""H50 COORDSLICE init-time safety check (rank 0, no DDP, no training).
+
+Compares flag-off vs flag-on at-init:
+  - state_dict key presence: flag-off must have no coord_pe_* keys
+  - param count delta: flag-on must add expected number of params
+  - finite outputs: forward pass produces finite logits
+  - magnitude ratio: |surface_hidden| and |volume_hidden| at init within 5%
+
+If magnitude ratio exceeds 5%, recommend lowering --coord-slice-pe-init-scale.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from model import SurfaceTransolver
+from data import SURFACE_X_DIM, VOLUME_X_DIM
+
+
+def build(use_coord_slice_pe: bool, init_scale: float, seed: int = 0) -> SurfaceTransolver:
+    torch.manual_seed(seed)
+    return SurfaceTransolver(
+        space_dim=3,
+        surface_input_dim=SURFACE_X_DIM,
+        volume_input_dim=VOLUME_X_DIM,
+        n_layers=5,
+        n_hidden=512,
+        n_head=4,
+        mlp_ratio=4,
+        slice_num=128,
+        rff_num_features=16,
+        rff_sigma=1.0,
+        rff_init_sigmas=[0.25, 0.5, 1.0, 2.0, 4.0],
+        pos_encoding_mode="string_separable",
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+        use_coord_slice_pe=use_coord_slice_pe,
+        coord_slice_pe_rff_features=32,
+        coord_slice_pe_init_scale=init_scale,
+    )
+
+
+def fake_batch(B: int, Ns: int, Nv: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(123)
+    return {
+        "surface_x": torch.randn(B, Ns, SURFACE_X_DIM),
+        "surface_mask": torch.ones(B, Ns, dtype=torch.float32),
+        "volume_x": torch.randn(B, Nv, VOLUME_X_DIM),
+        "volume_mask": torch.ones(B, Nv, dtype=torch.float32),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--init-scale", type=float, default=0.088)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--surface-points", type=int, default=2048)
+    parser.add_argument("--volume-points", type=int, default=2048)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    # Build flag-off baseline and flag-on H50
+    m_off = build(use_coord_slice_pe=False, init_scale=args.init_scale).to(device).eval()
+    m_on = build(use_coord_slice_pe=True, init_scale=args.init_scale).to(device).eval()
+
+    # --- state_dict check ---
+    off_keys = set(m_off.state_dict().keys())
+    on_keys = set(m_on.state_dict().keys())
+    off_pe_keys = [k for k in off_keys if "coord_pe" in k]
+    on_pe_keys = [k for k in on_keys if "coord_pe" in k]
+    print(f"\n[state_dict] flag-off coord_pe_* keys: {len(off_pe_keys)} (expect 0)")
+    print(f"[state_dict] flag-on  coord_pe_* keys: {len(on_pe_keys)} (expect > 0)")
+    assert len(off_pe_keys) == 0, "flag-off must contain no coord_pe_* keys"
+    assert len(on_pe_keys) > 0, "flag-on must contain coord_pe_* keys"
+
+    # --- param count ---
+    p_off = sum(p.numel() for p in m_off.parameters())
+    p_on = sum(p.numel() for p in m_on.parameters())
+    extra = p_on - p_off
+    print(f"\n[params] flag-off: {p_off:,}")
+    print(f"[params] flag-on:  {p_on:,}")
+    print(f"[params] extra:    {extra:,} ({extra/p_off*100:.3f}% of baseline)")
+
+    # --- forward pass ---
+    batch = fake_batch(args.batch_size, args.surface_points, args.volume_points)
+    batch = {k: v.to(device) for k, v in batch.items()}
+
+    with torch.no_grad():
+        out_off = m_off(**batch)
+        out_on = m_on(**batch)
+
+    print("\n[forward] outputs:")
+    for k in ("surface_preds", "volume_preds", "surface_hidden", "volume_hidden"):
+        v_off = out_off[k]
+        v_on = out_on[k]
+        finite_off = torch.isfinite(v_off).all().item()
+        finite_on = torch.isfinite(v_on).all().item()
+        mag_off = v_off.detach().abs().mean().item()
+        mag_on = v_on.detach().abs().mean().item()
+        ratio = mag_on / max(mag_off, 1e-12)
+        within_5pct = 0.95 <= ratio <= 1.05
+        flag = "OK" if within_5pct else "WARN"
+        print(
+            f"  {k:18s}: off|{mag_off:.4e} on|{mag_on:.4e}  ratio={ratio:.4f}  "
+            f"finite_off={finite_off} finite_on={finite_on} [{flag}]"
+        )
+        assert finite_off and finite_on, f"{k} produced non-finite outputs"
+
+    # Report inter_slice_cos at init (should be high since coord_pe is tiny initially)
+    print("\n[init] inter_slice_cos per layer (from one fwd):")
+    for i, block in enumerate(m_on.backbone.blocks):
+        isc = getattr(block.attention, "_last_inter_slice_cos", None)
+        if isc is not None:
+            print(f"  L{i}: inter_slice_cos_post_pe = {isc:.4f}")
+
+    print("\nSafety check complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_coord_slice_pe: bool = False
+    coord_slice_pe_rff_features: int = 32
+    coord_slice_pe_init_scale: float = 0.088
     debug: bool = False
 
 
@@ -294,6 +297,57 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_coord_slice_pe_metrics(model: nn.Module) -> dict[str, float]:
+    """Log coord-slice PE diagnostics per Transformer block.
+
+    Static metrics: per-layer coord_pe_proj weight/bias statistics.
+    Dynamic metrics (captured during last val forward): slice_centroid
+    distribution (mean/std/range per axis, across-slice spread) and
+    inter_slice_cos on the post-PE slice_tokens (mechanism diagnostic
+    aligned with H33's pattern for direct comparison).
+    """
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return metrics
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return metrics
+    all_inter_slice_cos: list[float] = []
+    for i, block in enumerate(blocks):
+        attn = getattr(block, "attention", None)
+        if attn is None:
+            continue
+        proj = getattr(attn, "coord_pe_proj", None)
+        if proj is None:
+            continue
+        w = proj.weight.detach().float()
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_norm"] = float(w.norm().item())
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_std"] = float(w.std().item())
+        b = proj.bias.detach().float()
+        metrics[f"coord_slice_pe/block_{i}/proj_bias_norm"] = float(b.norm().item())
+        centroids = getattr(attn, "_last_slice_centroids", None)
+        if centroids is not None:
+            c = centroids.float()  # [B, S, 3]
+            for axis_i, axis in enumerate(("x", "y", "z")):
+                ca = c[..., axis_i]
+                metrics[f"coord_slice_pe/block_{i}/centroid_mean_{axis}"] = float(ca.mean().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_std_{axis}"] = float(ca.std().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_range_{axis}"] = float(
+                    (ca.max() - ca.min()).item()
+                )
+            metrics[f"coord_slice_pe/block_{i}/centroid_spread"] = float(c.std(dim=1).mean().item())
+        isc = getattr(attn, "_last_inter_slice_cos", None)
+        if isc is not None:
+            metrics[f"coord_slice_pe/block_{i}/inter_slice_cos_post_pe"] = float(isc)
+            all_inter_slice_cos.append(float(isc))
+    if all_inter_slice_cos:
+        metrics["coord_slice_pe/global/inter_slice_cos_mean"] = float(
+            sum(all_inter_slice_cos) / len(all_inter_slice_cos)
+        )
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +362,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_coord_slice_pe=config.use_coord_slice_pe,
+        coord_slice_pe_rff_features=config.coord_slice_pe_rff_features,
+        coord_slice_pe_init_scale=config.coord_slice_pe_init_scale,
     )
 
 
@@ -1262,6 +1319,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_coord_slice_pe_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**H50 COORDSLICE — Coordinate-Conditioned Slice Identities (DAB-DETR Analogue).** Replace H33's free-floating learnable slice positional embedding with slice IDs derived from physical 3D coordinates of each slice's centroid. This is the DAB-DETR / Anchor DETR analogue applied to the Transolver slice attention block: instead of free-learnable per-slice positional encodings (which H33 showed collapse to L0-dominance with non-monotonic depth pattern), tie each slice's positional identity to a data-derived geometric anchor.

### Why this is the right next move

H33 SLICEPE (closed 21:25Z, PR #1187) ran free-learnable `slice_pe[1, H, S, D_head]` at every layer for 13 epochs. Findings:
1. **Mechanism FALSIFIED**: depth-monotonic differentiation didn't emerge — instead L0 dominated (`inter_slice_cos` = 0.085) while L1-L4 stayed near uniform (0.019–0.029). Pattern is non-monotonic L0 >> L4 ≈ L2 > L1 ≈ L3.
2. **σ=0.02 init was below gradient floor** but model auto-grew to σ≈0.15 (8× growth) — confirms literature O(1/√D) ≈ 0.088 recommendation but emergent.
3. **test_vol_p crossed floor** (3.522 ≤ 3.643, −0.121pp) — H33 is the 4th vol_p crossing in Wave 30/31, but val_abupt + test_SP blocked merge.
4. **L0-dominance insight**: L0 attends directly to raw geometric input and benefits most from per-slice positional disambiguation; deeper layers prefer content-routing.

The natural follow-up — flagged HIGH priority by the student per literature: tie slice IDs to **physical coordinates** instead of free parameters. References:
- **DAB-DETR** (ICLR 2022, arXiv:2201.12329): treats object queries as 4D anchor boxes, gating cross-attention with explicit spatial reference. Replaces free-floating learnable queries with data-grounded positional anchors → faster convergence, better localization.
- **Anchor DETR** (AAAI 2022, arXiv:2109.07107): anchor-based query positional encoding instead of fully-learnable. Demonstrates that grounded positional priors outperform free-floating learnable IDs in many settings.
- **Conditional DETR** (ICCV 2021, arXiv:2108.06152): conditional spatial queries derived from content; identifies positional anchor as the missing inductive bias.

In Transolver, the slice attention block uses learnable `in_project_slice: Linear(dim_head, num_slices)` to compute per-token slice assignment weights. Each slice's identity is therefore implicit in `slice_weights` — but the additive PE H33 tested was free of any geometric grounding. **H50 ties the slice positional encoding to the centroid of each slice's actual 3D-coordinate distribution at runtime.**

### Mechanism prediction

With coordinate-conditioned slice IDs:
- **L0 should benefit more** than H33 (cleaner positional signal grounded in physics, vs auto-grown noise that took 5+ epochs to converge)
- **Deeper layers receive a stable positional context** for their content-routing operations (vs H33's L1-L4 near-uniform pattern)
- **Slice clustering becomes interpretable**: each slice has a meaningful 3D anchor (centroid of attended tokens) that the model can use as a hard-coded "where" reference, freeing slice tokens to specialize on "what"
- **Mechanism for val_abupt + test_SP improvement**: coordinate-grounded slices align with the H26 NPCA / H31 WALLDIST family of encoder-input positional successes that produced 1st and 2nd test_vol_p floor crossings. H50 brings physical grounding back to the slice-PE pathway

### Hypothesis predictions

1. **L0 inter_slice_cos** higher than H33's 0.085 (cleaner signal); L1-L4 lower than H33's 0.019-0.029 (deeper layers receive coordinate context for free instead of trying to learn it)
2. **val_abupt** ≤ baseline 6.126% (vs H33's 6.472% — +0.346pp regression; vs baseline target)
3. **test_vol_p** ≤ 3.643% floor (preserve H33's positive vol_p signal via the slice→volume cross-attention pathway)
4. **test_SP** ≤ 3.577% floor (this is the critical question — H33 regressed to 3.793% on test_SP because free-learnable PE added noise to surface decoder; coordinate-grounded PE should be less noisy)
5. **τz/τx** behavior — coordinate-grounded slices may produce **std spread** (H26 NPCA / H31 WALLDIST family pattern) rather than band-attractor-respecting

## Instructions

### Code changes

Implement in `model.py` and `train.py`:

**1. CLI flags** (`train.py` Config):
```python
use_coord_slice_pe: bool = False
coord_slice_pe_rff_features: int = 32  # frequency features for RFF encoding of 3D centroids
coord_slice_pe_init_scale: float = 0.088  # use O(1/sqrt(D)) per H33 lesson; D_head=128 → 0.088
```

Thread `--use-coord-slice-pe`, `--coord-slice-pe-rff-features`, `--coord-slice-pe-init-scale` flags through `parser.add_argument` → `Config` → `build_model`.

**2. Pass coordinates to slice attention** (`model.py`):

The Transolver forward pass receives input features `x[B, N, hidden_dim]`. You need raw 3D coordinates `coords[B, N, 3]` available inside `TransolverAttention.forward`. Two clean approaches:

- **Option A (preferred, minimal-thread)**: pass `coords` as additional argument through `SurfaceTransolver.forward → Transformer.forward → TransformerBlock.forward → TransolverAttention.forward`. The input `coords` come from the dataset's raw xyz position channels — already used by the existing `string_separable` RFF pos-encoding at the input head, so they exist in the model entry point.

- **Option B (parallel state)**: store coords in a thread-local context manager. More complex; only use if Option A becomes mechanically painful.

**3. New `TransolverAttention` module** (`model.py`):

In `TransolverAttention.__init__`:
```python
if use_coord_slice_pe:
    # RFF encoding of 3D centroids
    self.coord_pe_rff = RandomFourierFeatures(in_dim=3, out_dim=coord_slice_pe_rff_features, sigmas=(0.25, 0.5, 1.0, 2.0))
    # Project to per-head additive PE
    self.coord_pe_proj = nn.Linear(coord_slice_pe_rff_features * 2 * 4, num_heads * self.dim_head)  # *2 sin/cos, *4 sigmas
    # Init at small scale per H33 lesson (O(1/sqrt(D_head)) ≈ 0.088 for D_head=128)
    with torch.no_grad():
        self.coord_pe_proj.weight.mul_(coord_slice_pe_init_scale / (self.coord_pe_proj.weight.std() + 1e-8))
```

(Use the existing `RandomFourierFeatures` class from `model.py` if it exists; otherwise reuse the `string_separable` machinery. The exact RFF module structure is up to you — what matters is encoding 3D centroids to dim_head features.)

In `TransolverAttention.forward`:
```python
slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)

if self.use_coord_slice_pe:
    # Compute slice centroids from coords (per-batch, per-slice 3D anchors)
    # slice_weights: [B, H, N, S] — average across heads for a single positional anchor per slice
    slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
    slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
    slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
    # RFF encode + project to per-head additive PE
    coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
    coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head]
    coord_pe = coord_pe.view(B, S, num_heads, dim_head).permute(0, 2, 1, 3)  # [B, H, S, D_head]
    slice_tokens = slice_tokens + coord_pe  # additive injection

qkv = self.qkv(slice_tokens)
# ... rest unchanged
```

**4. Add per-layer telemetry** (`train.py` — analogous to H33's `collect_slice_pe_metrics`):

```python
def collect_coord_slice_pe_metrics(model):
    metrics = {}
    for layer_idx, block in enumerate(get_transformer_blocks(model)):
        if hasattr(block.attention, 'coord_pe_proj'):
            # Probe the coord_pe_proj weight statistics
            W = block.attention.coord_pe_proj.weight
            metrics[f'coord_pe/L{layer_idx}/weight_norm'] = W.norm().item()
            metrics[f'coord_pe/L{layer_idx}/weight_std'] = W.std().item()
            # During val pass, also capture sample slice_centroid stats and inter_slice_cos on coord_pe
            # (you'll need to hook the forward pass; or compute via a probe forward on a val batch)
    return metrics
```

Log per-layer `coord_pe` statistics AND a sample of `slice_centroids` distribution (range, std across slices) at each val epoch. This is the canonical diagnostic for H50: do slice centroids spread out spatially over training, or collapse?

**5. Safety check at init** (analogous to H33 v2 — non-destructive verification):

Before launching the full training run, verify:
- Flag-off state_dict contains zero `coord_pe_*` keys
- Flag-on at init: `volume_hidden` magnitude ratio vs baseline ≈ 1.0 ± 0.05 (no H32-style collapse)
- Flag-on at init: `surface_hidden` magnitude ratio ≈ 1.0 ± 0.05
- All outputs finite
- Param count: `n_layers × num_heads × dim_head × (rff_features × 8)` weights + biases. For 5 × 4 × 128 × (32×8) = 655,360 weight params + 2,560 bias = ~658k extra params (about 2× H33's 327k — still negligible).

If init-time magnitude ratio drifts >5%, scale down `coord_slice_pe_init_scale` until safe.

### Training command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-coord-slice-pe --coord-slice-pe-rff-features 32 --coord-slice-pe-init-scale 0.088 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent askeladd --wandb-group askeladd-h50-coordslice \
  --wandb-name askeladd/h50-coordslice-main \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5,32594:val_primary/abupt_axis_mean_rel_l2_pct<7.5"
```

**Kill threshold notes** (PREFIX = GLOBAL STEP, NOT EPOCH):
- step 10864 = end of EP1 in this 13-ep recipe (warmup=1)
- step 32594 ≈ end of EP3
- step 65228 ≈ end of EP6
- Set EP1 hard kill at val_abupt < 9.5% (H33 EP1 was 29.6%, well above 9.5% — so this gate would only trigger if H50 has catastrophic init divergence; matches H33 v2's gate)
- Set EP3 hard kill at val_abupt < 7.5% (H33 EP3 was 6.87%, well below; H50 should land in similar range if non-destructive). Tighter than H33's 9.5% so we kill early if H50 underperforms H33's trajectory.

### Diagnostics to log at each val epoch

1. Per-layer `coord_pe_proj` weight norm + std (5 numbers)
2. Per-layer `slice_centroids` stats over a fixed val batch: mean centroid position, std across slices (proxy for "do slices spread out spatially?"), min/max ranges per axis
3. Per-layer `inter_slice_cos` for `slice_tokens + coord_pe` (the post-PE input to qkv) — compare against H33's L0=0.085 / L1-L4=0.019-0.029 pattern
4. The standard val metrics + τz/τx mean (and per-car if possible)

### Required at terminal SENPAI-RESULT

When the budget cutoff fires (~14h training + 1.5h test eval = ~15.5h total), post a terminal SENPAI-RESULT with:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>",...],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val_abupt>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<test_WSS>}}
```

Required fields:
- **best_checkpoint/source = ema** (confirm in W&B summary)
- val_abupt at best ckpt
- val_WSS at best ckpt
- **test_abupt, test_SP, test_vol_p, test_WSS** at best val ckpt (run eval_ckpt.py on test split, 50 cars)
- τz/τx (val 34 cars and test 50 cars): mean/std/min/max/n_outside_band (the per-car distribution — H33 missed this; H50 should add it)
- `coord_pe` per-layer final readings (norm/std + slice_centroid spread)
- `inter_slice_cos` per-layer reading
- Time budget management summary

## Baseline

Current best metrics (baseline #972, run `56bcqp3m`):
- val_abupt: **6.126%**
- test_abupt: 5.844%
- test_vol_p: **3.643%** (floor — H33 crossed at 3.522%)
- test_SP: **3.577%** (floor — H33 missed at 3.793%, the binding gate)
- test_WSS: 6.727%
- test τz/τx: 1.473 (band [1.44, 1.55])

**H33 SLICEPE** results (closed 21:25Z, PR #1187, run `u58fwoym`):
- val_abupt: 6.472% (+0.346pp regression)
- test_vol_p: 3.522% (PASS −0.121pp)
- test_SP: 3.793% (FAIL +0.216pp)
- test τz/τx: 1.487 (in band)
- inter_slice_cos L0=0.085, L1=0.019, L2=0.029, L3=-0.001, L4=0.028 (L0-dominant, depth-non-monotonic)

**H50 success criteria** (priorities in descending order):
1. **PRIMARY (merge gate)**: val_abupt < 6.126% AND test_SP ≤ 3.577% AND test_vol_p ≤ 3.643%
2. **SECONDARY (mech-win)**: test_vol_p ≤ 3.643% preserved + L0-dominance pattern flips (cleaner per-layer mechanism than H33)
3. **TERTIARY (band-attractor data)**: τz/τx std spread on val/test (H26/H31 family pattern) or mean deflection (H46 family pattern)

**Reproduce baseline**:
```bash
cd /workspace/senpai/target && python eval_ckpt.py --checkpoint <baseline-ckpt-path>
```

Baseline W&B: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/56bcqp3m`

## Notes

- **Scope discipline**: H50 changes ONE thing — `--use-coord-slice-pe` flag. Do NOT bundle with input-only PE, L0-only PE, σ=0.088 sweep, or LinearNO drop-attn. Those are reserved for H51/H52/H53.
- **H36 ANCHOR-SLICE-QUERIES** is currently running (tanjiro, PR #1191) and modulates the **Q projection** with learnable anchor offsets — that's a different mechanism class (Q modulation, free-learnable anchors). H50 conditions slice_pe on **data-derived centroids** (additive PE, coordinate-grounded). These are orthogonal and could stack later if both produce signal.
- **Init scale lesson from H33**: σ=0.02 is below gradient signal floor; model auto-grew to σ≈0.15. Use σ=0.088 = O(1/√D_head) for D_head=128 as your starting point. If init-time safety check shows magnitude collapse, scale down to σ=0.05 or 0.02 + warmup.
- Use `--wandb-group askeladd-h50-coordslice` so any follow-up sweeps cluster cleanly in W&B.
