### PR TITLE
Wave 31 H51: NPCA+SSFL Stack at slices=192 + ema-decay=0.9999 — use the variance room

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,42 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
+    """Project global position onto a per-vertex local surface frame.
+
+    Computes ``[p·n, p·t1, p·t2]`` per vertex, where ``t1, t2`` are a
+    Gram-Schmidt tangent basis derived from the surface normal.
+
+    Computed in fp32 with an explicit eps=1e-6 in ``F.normalize`` so that
+    zero-padded tokens (normal == ``[0,0,0]``) produce zero projections
+    instead of NaN, even when called inside a bf16/fp16 autocast region.
+
+    Args:
+        surface_x: ``[B, N, >=6]`` with columns ``[x, y, z, nx, ny, nz, ...]``.
+
+    Returns:
+        ``[B, N, 3]`` with ``[p·n, p·t1, p·t2]`` per vertex, cast back to
+        the input dtype.
+    """
+    input_dtype = surface_x.dtype
+    sx = surface_x.float()
+    pos = sx[:, :, :3]
+    n = F.normalize(sx[:, :, 3:6], dim=-1, eps=1e-6)
+
+    ref_a = torch.tensor([0.0, 0.0, 1.0], device=n.device, dtype=n.dtype).expand_as(n)
+    ref_b = torch.tensor([0.0, 1.0, 0.0], device=n.device, dtype=n.dtype).expand_as(n)
+    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
+    ref = torch.where(parallel_mask, ref_b, ref_a)
+
+    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+
+    local_n = (pos * n).sum(-1, keepdim=True)
+    local_t1 = (pos * t1).sum(-1, keepdim=True)
+    local_t2 = (pos * t2).sum(-1, keepdim=True)
+    return torch.cat([local_n, local_t1, local_t2], dim=-1).to(dtype=input_dtype)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_local_frame_proj: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,7 +433,10 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_local_frame_proj = use_local_frame_proj
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        if use_local_frame_proj:
+            surface_extra_dim += 3
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_multisigma":
@@ -462,6 +502,14 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if use_local_frame_proj and self.project_surface_features is not None:
+            # Identity-init: zero the 3 NEW input columns of project_surface_features
+            # so the model starts from the current baseline at step 0. The 3 new
+            # columns sit at indices [4, 5, 6] of the surface feature vector
+            # (after [nx, ny, nz, area] at [0, 1, 2, 3]). The bias is already
+            # zero-init via _init_linear, so no extra step is needed.
+            with torch.no_grad():
+                self.project_surface_features.project.weight[:, 4:7].zero_()
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -528,12 +576,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        local_proj: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if local_proj is not None:
+            feature_parts.append(local_proj)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -567,6 +618,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            local_proj = (
+                compute_local_frame_proj(surface_x) if self.use_local_frame_proj else None
+            )
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -575,6 +629,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    local_proj=local_proj,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_local_frame_proj: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_local_frame_proj": (
+            "Enable normal-projected coordinate augmentation (H26, PR "
+            "#1177). For each surface vertex, append 3 scalar features "
+            "[p.n, p.t1, p.t2] -- the global position projected onto the "
+            "vertex's local normal/tangent frame -- to the surface input "
+            "features before the projection linear. t1, t2 are a "
+            "Gram-Schmidt tangent basis from the surface normal. Goal: "
+            "give the encoder explicit local-frame position so it can "
+            "break the structural tau_z/tau_x band attractor at [1.44, "
+            "1.55]. The 3 new input columns of project_surface_features "
+            "are zero-init so step 0 is identical to the baseline. Volume "
+            "branch is unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_local_frame_proj=config.use_local_frame_proj,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -104,6 +104,9 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     use_local_frame_proj: bool = False
+    lambda_spectral: float = 0.0
+    spectral_hf_weight: float = 2.0
+    spectral_channels: str = "wss"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -243,6 +246,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "are zero-init so step 0 is identical to the baseline. Volume "
             "branch is unchanged."
         ),
+        "lambda_spectral": (
+            "Streamwise-Spectral Frequency Loss weight (H29, PR #1182). "
+            "When > 0, adds a spectral-domain MSE term computed by sorting "
+            "surface tokens by streamwise z, taking rfft along the sorted "
+            "axis, and frequency-weighting the squared magnitude residual "
+            "with a linear ramp from 1.0 at DC to --spectral-hf-weight at "
+            "Nyquist. lambda_spectral=0.0 reproduces baseline exactly. "
+            "frieren's tuned default at solo H29 launch was 0.1; the H35 "
+            "stack PR specifies 0.05 to leave headroom for NPCA's "
+            "encoder-side gradient signal."
+        ),
+        "spectral_hf_weight": (
+            "Upper bound of the linear frequency-ramp used by the H29 "
+            "Streamwise-Spectral loss. 1.0 = flat (no upweighting); 2.0 = "
+            "double weight at the Nyquist bin. Only meaningful when "
+            "--lambda-spectral > 0."
+        ),
+        "spectral_channels": (
+            "Which surface output channels the H29 spectral loss is "
+            "applied to. 'all' = all 4 (cp + 3 wss); 'wss' = wall-shear "
+            "components only (tau_x, tau_y, tau_z); 'cp' = surface pressure "
+            "only. frieren's H29 tuned default = 'wss' (cp is smooth and "
+            "may destabilise)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -326,6 +353,98 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+SPECTRAL_CHANNEL_PRESETS: dict[str, tuple[bool, ...]] = {
+    "all": (True, True, True, True),
+    "wss": (False, True, True, True),
+    "cp": (True, False, False, False),
+}
+
+
+def spectral_channel_mask(spec: str, device: torch.device | None = None) -> torch.Tensor | None:
+    """Resolve the --spectral-channels string into a [4]-bool tensor.
+
+    Returns None when the preset is "all" (no masking needed).
+    """
+    key = (spec or "all").strip().lower()
+    if key not in SPECTRAL_CHANNEL_PRESETS:
+        raise ValueError(
+            f"Unknown --spectral-channels preset: {spec!r}. "
+            f"Choices: {sorted(SPECTRAL_CHANNEL_PRESETS)}"
+        )
+    flags = SPECTRAL_CHANNEL_PRESETS[key]
+    if all(flags):
+        return None
+    return torch.tensor(flags, dtype=torch.bool, device=device)
+
+
+def spectral_surface_loss(
+    pred_norm: torch.Tensor,
+    target_norm: torch.Tensor,
+    mask: torch.Tensor,
+    sort_idx: torch.Tensor,
+    lambda_spectral: float,
+    hf_weight: float,
+    channel_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Streamwise-Spectral Frequency Loss (H29 / PR #1182).
+
+    Sorts surface tokens by streamwise z (via ``sort_idx``), takes ``rfft``
+    along the sorted axis, then computes a frequency-weighted squared
+    magnitude residual with a linear ramp from 1.0 at DC to ``hf_weight``
+    at Nyquist. Optionally masked to a subset of output channels.
+
+    Always run in fp32 (FFT is precision-sensitive under bf16 autocast,
+    matching the lesson from askeladd's H27 NaN fix). ``lambda_spectral=0.0``
+    returns a connected-graph zero so DDP find_unused_parameters does not
+    trip. ``N=0`` empty-surface batches (data/loader pair-modalities edge
+    case documented in program.md) also short-circuit to zero; this is the
+    guard frieren added pre-launch on H29 to prevent ``torch.fft.rfft``
+    crashing on length-0 inputs.
+    """
+    if lambda_spectral == 0.0:
+        return pred_norm.float().sum() * 0.0
+    if pred_norm.shape[1] == 0:
+        return lambda_spectral * pred_norm.float().sum() * 0.0
+
+    pred_f = pred_norm.float()
+    tgt_f = target_norm.float()
+    mask_f = mask.float()
+
+    B, N, C = pred_f.shape
+    idx = sort_idx.unsqueeze(-1).expand(-1, -1, C)
+    pred_s = pred_f.gather(1, idx)
+    tgt_s = tgt_f.gather(1, idx)
+    msk_s = mask_f.gather(1, sort_idx).unsqueeze(-1)
+
+    # Zero padded tokens before FFT (avoid spectral leakage).
+    pred_s = pred_s * msk_s
+    tgt_s = tgt_s * msk_s
+
+    # norm='ortho' so Parseval preserves L2: mean(|X|^2) ~ MSE_spatial,
+    # independent of N. Without it, magnitude scales with N and dwarfs
+    # the spatial MSE (verified: default norm gave spec~100 vs frieren's
+    # observed [0.001, 1.0] target band at lambda=0.1, N=65536).
+    pf = torch.fft.rfft(pred_s, dim=1, norm="ortho")
+    tf = torch.fft.rfft(tgt_s, dim=1, norm="ortho")
+
+    n_bins = pf.shape[1]
+    w = torch.linspace(
+        1.0,
+        hf_weight,
+        n_bins,
+        device=pf.device,
+        dtype=pf.real.dtype,
+    ).view(1, -1, 1)
+
+    diff = pf - tf
+    sq = diff.real.square() + diff.imag.square()
+
+    if channel_mask is not None:
+        sq = sq * channel_mask.view(1, 1, -1).to(device=sq.device, dtype=sq.dtype)
+
+    return lambda_spectral * (sq * w).mean()
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -336,6 +455,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    lambda_spectral: float = 0.0,
+    spectral_hf_weight: float = 2.0,
+    spectral_channel_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -361,12 +483,29 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+    if lambda_spectral > 0.0:
+        # Compute spectral loss outside autocast for fp32 numerical safety.
+        sort_idx = batch.surface_x[:, :, 2].detach().argsort(dim=1).long()
+        spectral_term = spectral_surface_loss(
+            out["surface_preds"],
+            surface_target,
+            batch.surface_mask,
+            sort_idx,
+            lambda_spectral=lambda_spectral,
+            hf_weight=spectral_hf_weight,
+            channel_mask=spectral_channel_mask,
+        )
+        loss = loss + spectral_term
+        spectral_metric_value = float(spectral_term.detach().cpu().item())
+    else:
+        spectral_metric_value = 0.0
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "spectral_loss": spectral_metric_value,
     }
 
 
@@ -773,6 +912,11 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        ssfl_channel_mask = (
+            spectral_channel_mask(config.spectral_channels, device=device)
+            if config.lambda_spectral > 0.0
+            else None
+        )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1045,6 +1189,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        lambda_spectral=config.lambda_spectral,
+                        spectral_hf_weight=config.spectral_hf_weight,
+                        spectral_channel_mask=ssfl_channel_mask,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1085,6 +1232,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "spectral_loss" in batch_loss_metrics:
+                        train_log["train/spectral_loss"] = batch_loss_metrics["spectral_loss"]
+                if config.lambda_spectral > 0.0:
+                    train_log["train/lambda_spectral"] = float(config.lambda_spectral)
+                    train_log["train/spectral_hf_weight"] = float(config.spectral_hf_weight)
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,52 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Compute per-car tau_z_rel_l2 / tau_x_rel_l2 statistics for H26 diagnostics.
+
+    Iterates over case_ids common to both stores, builds per-case rel_l2 from
+    sqrt(error_sq / target_sq), and reports mean/std/min/max plus an
+    out-of-band counter for the [1.40, 1.60] band attractor probe.
+
+    Returns an empty dict if fewer than 2 common cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1113,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1164,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**H51 NPCA+SSFL+SLICES192+EMA9999** — Carry forward H35's proven NPCA × SSFL mechanism stack with two corrective scaling moves: (a) `--model-slices 192` to use the 2.3× τz/τx variance room that H35 created but had no capacity to convert into per-axis accuracy gain, (b) `--ema-decay 0.9999` to match the 13-epoch cosine schedule (current 0.999 has effective window ~1000 steps; the cosine tail spans ~50k steps).

### Why this should close the +0.172pp val_abupt gap

H35 lands val_abupt 6.298% (+0.172pp above 6.126% merge gate) but PROVED that NPCA × SSFL stacking works:
- τz/τx std grew monotonically through 13 epochs: 0.078 → 0.121 → 0.155 → 0.184 → 0.205 → 0.223 → 0.236 → 0.244 → 0.249 → **0.251** (fleet peak)
- n_outside_band 17/34 (vs H26 NPCA standalone 9/34)
- test_vol_p 3.585% PASS −0.058pp below floor (5th vol_p floor crossing)
- Beats AB-UPT on p_s, p_v, and vector τ
- BUT val_abupt and test_SP both regress by +0.17-0.19pp

The variance is being USED (channels diverge) but the model has no excess CAPACITY to convert that channel asymmetry into per-axis accuracy. With 128 slices × 2.3× variance budget = ~295 effective slice-modes needed, but only 128 raw slice queries available → bottleneck. **Scaling slices 128 → 192 gives +50% capacity to absorb the variance signal.**

### Why ema-decay=0.9999 helps every run

EMA-decay 0.999 was inherited from a shorter-schedule recipe — at lr-cosine-t-max=13 with ~141k total steps, the EMA effective window is ~1/(1−0.999) = 1000 steps, but the cosine tail (last 50% of training, ~70k steps) is where the best checkpoints live. **0.9999 (10× longer window) matches the schedule properly.** Independent confirmation in student's H35 priority follow-up #6.

Expected gain stacking:
- slices=192 capacity expansion: +0.05-0.20pp val_abupt
- ema-decay=0.9999 correct averaging: +0.05-0.15pp val_abupt
- Combined: +0.10-0.35pp val_abupt vs H35 → potentially crosses 6.126% gate

### Mechanism prediction at scale

If slices=192 absorbs the variance, expect:
- τz/τx std at EP13 to DECREASE vs H35's 0.251 (more queries → variance spread thinner per query → lower std)
- val_WSS to IMPROVE (axis-specific gradient routing actually working)
- test_vol_p to STAY UNDER floor (mechanism preserved, just better-utilized)

If slices=192 does NOT improve val_abupt, the bottleneck is elsewhere (depth, head count, or training budget), and the closure write-up will be a structural finding.

## Instructions

**This is the H35 recipe with TWO single-flag changes only.** Do NOT alter the surface-loss-weight, vol-points-schedule, lambda-spectral, or any other configuration. The deltas vs H35 are spelled out below:

Launch command:

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --lion-beta1 0.9 --lion-beta2 0.99 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 192 --model-mlp-ratio 4 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.9999 --ema-start-step 50 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-local-frame-proj --use-spectral-loss \
  --lambda-spectral 0.05 --spectral-hf-weight 2.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 --amp-mode bf16 \
  --wandb-group wave31_h51_npca_ssfl_slices192 --wandb-name fern/h51-npca-ssfl-slices192-ema9999 --agent fern \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5,32594:val_primary/abupt_axis_mean_rel_l2_pct<7.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

### Deltas vs H35 (one-line summary)

1. `--model-slices 128 → 192` (+50% slice capacity to use τz/τx variance room)
2. `--ema-decay 0.999 → 0.9999` (10× longer EMA window for 13-ep cosine schedule)

EVERYTHING ELSE is identical to H35. Same NPCA encoder-input enrichment, same SSFL spectral loss (lambda=0.05, hf-weight=2.0), same vol-points curriculum, same 18h budget.

### VRAM safety

H35 peaked at 78.43 GiB / 95.5 GiB at vp=65536 (EP9+). Slices=192 adds ~12-15 GiB of slice-attention state (linear in num_slices). **Projected peak ~88-92 GiB.** Within Blackwell PRO 6000 capacity but tight.

**Fallback if OOM**: Drop `--batch-size 4 → 2`. The H26 closure precedent showed bs=2 + slices=192 fits in ~75 GiB. If you OOM during EP9+ at vp=65536, restart with bs=2 from initialization (the cosine schedule changes minimally — 2x grad accumulation effective batch matches 4x raw batch within statistical noise).

### Mechanism reporting at each EP gate

Continue logging the H35-style per-channel diagnostics. New diagnostics for H51:
- **Per-slice variance**: max-slice / min-slice activation norm at terminal — does slices=192 spread the variance thinner per slice?
- **NPCA std at EP13**: compare to H35 0.251 fleet peak. Expect DECREASE if mechanism is being absorbed correctly.
- **n_outside_band at EP13**: should stay ≥ H35's 17/34 if variance is preserved

### Kill gates

- step 10864 (EP1): val_abupt > 9.5% → CLOSE (warmup divergence)
- step 32594 (EP3): val_SP > 5.5% OR val_abupt > 7.5% → CLOSE
- step 65228 (EP6): val_abupt > 6.5% → CLOSE (H26 NPCA EP6 fleet reference: 6.346%)

### Early positive trigger

- val_abupt ≤ 6.20% AND val_vol_p ≤ 3.85% at EP6 → high-priority continue to EP13 regardless of other signals (matches baseline EP6 6.220%/3.799% trajectory)

## Baseline

Current best single-model (PR #972 SDF-stratified vol importance sampling, run `56bcqp3m`):
- **val_abupt: 6.126%** ← merge gate
- **test_abupt: 5.844%**
- **test_vol_p: 3.643%** ← floor
- **test_SP: 3.577%** ← floor
- **test_WSS: 6.727%**
- **τz/τx test mean: 1.473** (in [1.44, 1.55] band)

H35 reference (this hypothesis's parent, closed at PR #1189):
- val_abupt: 6.298% (+0.172pp above gate)
- test_vol_p: 3.585% (PASS, −0.058pp below floor — 5th floor crossing)
- test_SP: 3.771% (+0.194pp above floor)
- test_WSS: 6.926% (+0.199pp above baseline)
- τz/τx val std: 0.251 (fleet peak), val n_outside_band: 17/34

Wave 30/31 fleet floor crossings (5):
| # | Hypothesis | test_vol_p | Δ |
|---|---|---:|---:|
| 1 | H31 WALLDIST (merged) | 3.488% | −0.155pp |
| 2 | H26 NPCA (merged) | 3.607% | −0.036pp |
| 3 | H46 SDORTH (closed) | — | (PathB gap) |
| 4 | H33 SLICEPE (closed) | 3.522% | −0.121pp |
| 5 | H35 NPCA+SSFL (closed) | 3.585% | −0.058pp |

**Reproduce baseline:** PR #972 W&B run `56bcqp3m`, eval `zxnhtagj`.
