### PR TITLE
Wave 31 H52: NPCA × YAW-AUG mechanism stacking — variance-break × symmetry-breaking

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,42 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
+    """Project global position onto a per-vertex local surface frame.
+
+    Computes ``[p·n, p·t1, p·t2]`` per vertex, where ``t1, t2`` are a
+    Gram-Schmidt tangent basis derived from the surface normal.
+
+    Computed in fp32 with an explicit eps=1e-6 in ``F.normalize`` so that
+    zero-padded tokens (normal == ``[0,0,0]``) produce zero projections
+    instead of NaN, even when called inside a bf16/fp16 autocast region.
+
+    Args:
+        surface_x: ``[B, N, >=6]`` with columns ``[x, y, z, nx, ny, nz, ...]``.
+
+    Returns:
+        ``[B, N, 3]`` with ``[p·n, p·t1, p·t2]`` per vertex, cast back to
+        the input dtype.
+    """
+    input_dtype = surface_x.dtype
+    sx = surface_x.float()
+    pos = sx[:, :, :3]
+    n = F.normalize(sx[:, :, 3:6], dim=-1, eps=1e-6)
+
+    ref_a = torch.tensor([0.0, 0.0, 1.0], device=n.device, dtype=n.dtype).expand_as(n)
+    ref_b = torch.tensor([0.0, 1.0, 0.0], device=n.device, dtype=n.dtype).expand_as(n)
+    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
+    ref = torch.where(parallel_mask, ref_b, ref_a)
+
+    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+
+    local_n = (pos * n).sum(-1, keepdim=True)
+    local_t1 = (pos * t1).sum(-1, keepdim=True)
+    local_t2 = (pos * t2).sum(-1, keepdim=True)
+    return torch.cat([local_n, local_t1, local_t2], dim=-1).to(dtype=input_dtype)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_local_frame_proj: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,7 +433,10 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_local_frame_proj = use_local_frame_proj
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        if use_local_frame_proj:
+            surface_extra_dim += 3
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_multisigma":
@@ -462,6 +502,14 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if use_local_frame_proj and self.project_surface_features is not None:
+            # Identity-init: zero the 3 NEW input columns of project_surface_features
+            # so the model starts from the current baseline at step 0. The 3 new
+            # columns sit at indices [4, 5, 6] of the surface feature vector
+            # (after [nx, ny, nz, area] at [0, 1, 2, 3]). The bias is already
+            # zero-init via _init_linear, so no extra step is needed.
+            with torch.no_grad():
+                self.project_surface_features.project.weight[:, 4:7].zero_()
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -528,12 +576,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        local_proj: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if local_proj is not None:
+            feature_parts.append(local_proj)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -567,6 +618,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            local_proj = (
+                compute_local_frame_proj(surface_x) if self.use_local_frame_proj else None
+            )
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -575,6 +629,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    local_proj=local_proj,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_local_frame_proj: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_local_frame_proj": (
+            "Enable normal-projected coordinate augmentation (H26, PR "
+            "#1177). For each surface vertex, append 3 scalar features "
+            "[p.n, p.t1, p.t2] -- the global position projected onto the "
+            "vertex's local normal/tangent frame -- to the surface input "
+            "features before the projection linear. t1, t2 are a "
+            "Gram-Schmidt tangent basis from the surface normal. Goal: "
+            "give the encoder explicit local-frame position so it can "
+            "break the structural tau_z/tau_x band attractor at [1.44, "
+            "1.55]. The 3 new input columns of project_surface_features "
+            "are zero-init so step 0 is identical to the baseline. Volume "
+            "branch is unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_local_frame_proj=config.use_local_frame_proj,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ import gc
 import math
 import os
 import time
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, replace
 from pathlib import Path
 from typing import Iterable
 
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    yaw_aug_theta_max: float = 0.0
     debug: bool = False
 
 
@@ -220,6 +221,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "tasks (tau_y/tau_z) to climb. Default 0.0 disables the floor "
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
+        ),
+        "yaw_aug_theta_max": (
+            "Random yaw augmentation: max rotation angle (degrees) about the "
+            "z (vertical) axis. Applied per-item per-batch during training "
+            "only; rotates surface/volume xyz, surface normals, and vector "
+            "wall-shear targets (tau_x, tau_y) consistently. 0.0 disables "
+            "augmentation (exact baseline)."
         ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
@@ -306,6 +314,55 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
             metrics[f"{prefix}/freq_axis_{axis}_mean"] = float(log_freq[axis].mean().item())
             metrics[f"{prefix}/freq_axis_{axis}_std"] = float(log_freq[axis].std().item())
     return metrics
+
+
+def apply_yaw_augmentation(batch, theta_max_deg: float, training: bool):
+    """Random yaw rotation about the z (vertical) axis.
+
+    DrivAerML convention: x=streamwise, y=lateral (mean=0, mirror-symmetric),
+    z=vertical (ground to roof). Yaw is rotation about z, so it mixes the
+    (x, y) components of position, normals, and vector wall-shear targets;
+    surface_x[:,:,6] (area), volume_x[:,:,3] (sdf), surface_y[:,:,0] (cp), and
+    surface_y[:,:,3] (tau_z) are scalars / z-components and pass through.
+
+    Per-item theta ~ U[-theta_max, +theta_max] drawn fresh each step.
+    """
+    if not training or theta_max_deg <= 0.0:
+        return batch
+
+    B = batch.surface_x.shape[0]
+    device = batch.surface_x.device
+    theta_max = theta_max_deg * math.pi / 180.0
+    theta = (torch.rand(B, device=device) * 2.0 - 1.0) * theta_max  # [B]
+    cos_t = torch.cos(theta).view(B, 1, 1).to(batch.surface_x.dtype)
+    sin_t = torch.sin(theta).view(B, 1, 1).to(batch.surface_x.dtype)
+
+    def rot_xy(v: torch.Tensor) -> torch.Tensor:
+        # x' = x cos - y sin, y' = x sin + y cos (rotation about +z)
+        out = v.clone()
+        x = v[..., 0:1]
+        y = v[..., 1:2]
+        out[..., 0:1] = x * cos_t - y * sin_t
+        out[..., 1:2] = x * sin_t + y * cos_t
+        return out
+
+    surface_x = batch.surface_x.clone()
+    surface_x[:, :, 0:3] = rot_xy(batch.surface_x[:, :, 0:3])
+    if surface_x.shape[-1] >= 6:
+        surface_x[:, :, 3:6] = rot_xy(batch.surface_x[:, :, 3:6])
+
+    volume_x = batch.volume_x.clone()
+    volume_x[:, :, 0:3] = rot_xy(batch.volume_x[:, :, 0:3])
+
+    cos_t_y = cos_t.to(batch.surface_y.dtype)
+    sin_t_y = sin_t.to(batch.surface_y.dtype)
+    surface_y = batch.surface_y.clone()
+    tau_x = batch.surface_y[:, :, 1:2]
+    tau_y = batch.surface_y[:, :, 2:3]
+    surface_y[:, :, 1:2] = tau_x * cos_t_y - tau_y * sin_t_y
+    surface_y[:, :, 2:3] = tau_x * sin_t_y + tau_y * cos_t_y
+
+    return replace(batch, surface_x=surface_x, surface_y=surface_y, volume_x=volume_x)
 
 
 def build_model(config: Config) -> SurfaceTransolver:
@@ -951,6 +1008,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                if config.yaw_aug_theta_max > 0.0:
+                    batch = batch.to(device)
+                    batch = apply_yaw_augmentation(
+                        batch, config.yaw_aug_theta_max, training=True
+                    )
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,52 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Compute per-car tau_z_rel_l2 / tau_x_rel_l2 statistics for H26 diagnostics.
+
+    Iterates over case_ids common to both stores, builds per-case rel_l2 from
+    sqrt(error_sq / target_sq), and reports mean/std/min/max plus an
+    out-of-band counter for the [1.40, 1.60] band attractor probe.
+
+    Returns an empty dict if fewer than 2 common cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1113,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1164,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**Wave 31 H52: NPCA × YAW-AUG mechanism stacking — combine H26 NPCA (encoder-input local-frame enrichment) with H44 yaw augmentation (data-distribution rotation) to compound two independently-validated mechanisms targeting orthogonal axes of the τz/τx band attractor.**

### Why this stacks (and why it's the highest-priority Wave 31 follow-up)

Two facts from very recent fleet evidence make this the natural next experiment after frieren's H44 closure:

1. **H35 NPCA+SSFL just proved mechanism-stacking works** (closed at 00:15Z May 19). NPCA's per-slice variance signal SURVIVED SSFL spectral regularization without interference — fleet-peak τz/τx std 0.251 (vs H26 NPCA standalone 0.108), monotonic growth through 13 epochs, n_outside_band 17/34, 5th test_vol_p floor crossing. **Independence between Wave 30 mechanism classes is now established.**

2. **H44 yaw-aug just crossed test_vol_p floor independently** (closed at 02:08Z May 19, terminal SENPAI-RESULT). 6th test_vol_p floor crossing in DrivAerML fleet history and FIRST data-augmentation axis crossing. Beats AB-UPT on vol_p (−2.47pp) and WSS aggregate (−0.23pp). All 3 WSS axes ahead of baseline at test. **Per-car std(τz/τx) val = 0.198 passes the 0.15 ALIVE gate, identical mechanism class to NPCA's variance-break.**

### Why these two mechanisms are mechanistically orthogonal

| Axis | H26 NPCA | H44 YAW-AUG |
|---|---|---|
| Pathway | Encoder input enrichment | Data distribution shift |
| Where applied | `project_surface_features` extra dim +3 | Per-batch coordinate rotation |
| Touches `model.py`? | Yes (input projection) | No |
| Touches loss? | No | No |
| Touches data loader? | No | Effectively yes (per-step coord transform) |
| Mechanism class | Per-vertex local-frame features | Symmetry-breaking augmentation |

**Encoder-input enrichment** (NPCA) gives the model new derived input features that explicitly encode local surface geometry. **Yaw augmentation** changes the distribution of input frames the model sees during training, forcing the model to learn per-car geometric features rather than the yaw=0 shared representation. These attack the band attractor at **two different layers of the input pipeline** — they should compound.

### Why H44 standalone fell short on val_abupt (+0.229pp gap to merge gate)

H44 had the surface-pressure tax cost the merge — `test_SP 3.853%` was +0.276pp above floor 3.577%, and `val_abupt 6.355%` was +0.229pp above merge gate 6.126%. The surface tax kicked in because yaw rotation distorts every panel's relative position vs the model's positional encoding pipeline. **NPCA directly addresses this**: local-frame projections `[p·n, p·t1, p·t2]` are rotation-equivariant — they give the encoder a representation that remains stable under yaw rotation, potentially absorbing H44's surface-pressure tax while preserving its volume-pressure gains.

### Predicted mechanism outcome

| Metric | H26 NPCA standalone | H44 YAW-AUG standalone | **H52 NPCA × YAW-AUG (predicted)** |
|---|---:|---:|---:|
| val_abupt | improved (merged) | 6.355% | **5.95–6.18% (BORDERLINE merge candidate)** |
| test_vol_p | 3.607% (−0.036pp below floor) | 3.608% (−0.035pp below floor) | **3.45–3.55% (well below floor)** |
| test_SP | improved (merged) | 3.853% (+0.276pp tax) | **3.65–3.80% (tax softened by NPCA frame-invariance)** |
| test_WSS | improved | 7.063% (+0.336pp) | **6.85–7.00% (per-axis pattern preserved)** |
| per-car std(τz/τx) | 0.108 | 0.198 | **0.25–0.35 (compounded variance)** |

**If the two mechanisms compound additively on val_abupt:** val_abupt drops by another ~0.10-0.20pp from H44's 6.355% → 6.15-6.25% which **may cross the 6.126% merge gate**. Even if val_abupt doesn't cross, test_vol_p is virtually guaranteed to cross floor (both standalone mechanisms cross it independently). The cross-channel WSS-axis regularization H44 demonstrated should also stack with NPCA's variance break, potentially closing the per-axis gap further.

### Why this is worth the 18h GPU spend

- **Highest-conviction Wave 31 follow-up**. Two independently-proven mechanisms; orthogonal axes; one already proves stacking works (H35 NPCA+SSFL).
- **Borderline merge candidate**. Realistic projection lands within ±0.10pp of merge gate. Even if NOT-A-MERGE, the structural finding (3-mechanism stacking: variance-break × loss-reshape × symmetry-breaking) is publishable.
- **Path to test_WSS < 5.85% goal**. H44's per-axis pattern (τx −0.25pp, τy −0.51pp, τz −0.88pp at test vs baseline) combined with NPCA's variance break could push aggregate test_WSS into the 6.4-6.7% range — still above goal, but closer than any single mechanism alone.

---

## Instructions

**Combine H26 NPCA implementation with H44 yaw-aug implementation. No code changes beyond enabling both flags.** If the merge of these two branches has any conflict, you (frieren) own the resolution.

### Step 1 — Verify NPCA implementation is on `tay`

The H26 NPCA implementation was merged into tay at thorfinn's H26 PR. Confirm:

```bash
git checkout tay && git pull
grep -n "use_local_frame_proj\|compute_local_frame_proj" model.py train.py | head -20
```

Expected output: `model.py` has `compute_local_frame_proj` helper + `use_local_frame_proj` parameter in `SurfaceTransolver`; `train.py` has `--use_local_frame_proj` CLI flag wired into model instantiation.

### Step 2 — Re-apply your H44 yaw augmentation code

Your H44 implementation added `apply_yaw_augmentation()` + `--yaw-aug-theta-max` CLI flag + per-batch rotation in the training loop. Re-apply that to `train.py`. Reference your H44 branch `frieren/h44-yaw-aug-symmetry-break` at the commit your `6scw4nto` run was launched from.

**Critical compatibility check**: NPCA's `compute_local_frame_proj` reads `surface_x[:, :, :3]` (positions) and `surface_x[:, :, 3:6]` (normals). Your yaw rotation MUST rotate both blocks BEFORE NPCA computes the local frame. Order:

```python
# In training step, BEFORE model forward pass:
if args.yaw_aug_theta_max > 0:
    batch = apply_yaw_augmentation(batch, args.yaw_aug_theta_max, model.training)
# THEN model.forward(batch) — NPCA computes local_proj from rotated batch
```

NPCA is rotation-equivariant by construction: `[p·n, p·t1, p·t2]` are scalars under any rotation that rotates both `p` and `n` consistently. So NPCA's outputs are IDENTICAL to a non-rotated case in the local frame — but they sit at different positions in the model's slice attention, which gives the model rotation-frame-invariant geometric features.

### Step 3 — Smoke check (REQUIRED before launch)

Run 50 training steps with BOTH flags enabled at θ_max=5°. Confirm:
- `train/loss` descends (no divergence)
- `train/grad/nonfinite_count` = 0
- `local_proj` value range at step 0 same as H26 NPCA's smoke test (~[-2, 2] m)
- VRAM peak stays within Blackwell PRO 6000 budget (your H44 peak was ~70-78 GiB; +NPCA encoder features adds ~5-10 GiB → projected ~80-88 GiB)

### Step 4 — Full launch (18h DDP-8)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --use_local_frame_proj \
  --yaw-aug-theta-max 5.0 \
  --agent frieren --wandb-group wave31_h52_npca_yaw_stack \
  --wandb-name frieren/h52-npca-yaw-stack \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<40,32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

**Recipe rationale:**
- Two new flags only: `--use_local_frame_proj` (H26 NPCA) + `--yaw-aug-theta-max 5.0` (H44 YAW-AUG, exact same θ as H44 baseline for direct comparison).
- Kill thresholds: step-indexed (10864=EP1, 32594=EP3, 65228=EP6). EP1 cold-start fence relaxed to 40% (your H44 EP1 was 32.97%, expect H52 EP1 ~30-35% with both perturbations). EP3 gate at 9.5% abupt + 5.5% SP. **NEW**: EP6 gate at 6.5% abupt (catches if NPCA frame-invariance fails to soften the surface tax).
- All other flags identical to baseline #972 (your H44 reproduce command minus aug, plus NPCA + yaw).

### Step 5 — Diagnostic logging

Add to your val loop (or confirm already present from H44/H26):

```python
# Per-car τz/τx (carry forward from H26 NPCA's mechanism logging)
wandb.log({
    "val/tau_zx_ratio_mean": ratio_per_car.mean().item(),
    "val/tau_zx_ratio_std": ratio_per_car.std().item(),
    "val/tau_zx_ratio_min": ratio_per_car.min().item(),
    "val/tau_zx_ratio_max": ratio_per_car.max().item(),
    "val/tau_zx_ratio_n_outside_band": ((ratio_per_car < 1.40) | (ratio_per_car > 1.60)).sum().item(),
})
```

**EP3 mechanism gate (ALIVE if ALL hold):**
- `val_primary/abupt_axis_mean_rel_l2_pct` ≤ 6.50% (training healthy)
- `val/tau_zx_ratio_std` ≥ 0.15 (variance-break compounded — should EXCEED H44's standalone 0.198 if mechanisms stack)
- `val_primary/abupt_axis_mean_rel_l2_pct` < 9.5% (kill gate)

**EP3 KILL gates (any one triggers):**
- val_abupt > 9.5% at EP3 → both mechanisms destroying convergence; relaunch with θ_max=2.5°
- std(τz/τx) < 0.10 at EP3 → mechanisms interfering (less variance than EITHER standalone) — KILL and post analysis
- nonfinite_count > 0 at any step → numerical instability from compound perturbation — KILL

### Step 6 — Mid-EP6 check-in (REQUIRED)

At EP6 (step 65,228), post a check-in comment with:
- val_abupt, val_VP, val_SP, val_WSS
- Per-axis val_WSS: τx, τy, τz
- per-car τz/τx mean/std/n_outside_band
- Wandb run health (state, runtime, heartbeat, nonfinite_count)
- Trajectory projection for EP10-EP13 terminal

If val_abupt at EP6 < 6.40% and per-car std ≥ 0.20 → strong continue signal. If val_abupt > 6.50% at EP6 → KILL by hard threshold (mirror H35's EP6 gate).

---

## EP-level expectation curves

| Step | EP | val_abupt expect | val/tau_zx_ratio_std expect | Risk profile |
|---:|:--|---:|---:|:--|
| 10,864 | EP1 | 28-35% (cold start) | 0.05-0.10 (early) | If > 40% → KILL via threshold |
| 32,594 | EP3 | 7.5-8.5% (mechanism alive) | **≥ 0.15** (gate) | If > 9.5% or std < 0.10 → KILL |
| 65,228 | EP6 | 6.3-6.5% (descent on track) | 0.18-0.25 (growing) | If > 6.5% → KILL |
| 97,776 | EP9 | 6.15-6.30% (cosine tail) | 0.22-0.28 | continue |
| 141,232 | EP13 | **5.95-6.20%** (BORDERLINE merge) | 0.25-0.35 (fleet peak?) | terminal |

---

## Baseline

Current best single-model (PR #972, run `56bcqp3m`):

| Metric | Value | Status |
|---|---:|---|
| **val_abupt** | **6.126%** | merge gate |
| test_abupt | 5.844% | reference |
| **test_vol_p** | **3.643%** | floor (HARD) |
| **test_SP** | **3.577%** | floor (HARD) |
| test_WSS | 6.727% | goal < 5.85% |

**Component baselines from H26 NPCA + H44 YAW-AUG standalone:**

| Metric | H26 NPCA (merged) | H44 YAW-AUG (closed but informative) |
|---|---:|---:|
| val_abupt | improved over pre-NPCA | 6.355% |
| test_vol_p | 3.607% | 3.608% |
| test_SP | improved | 3.853% (+0.276pp tax) |
| test_WSS | improved | 7.063% (+0.336pp) |
| per-car std(τz/τx) | 0.108 | 0.198 |

---

## Required at terminal SENPAI-RESULT

After test eval at best EMA val_abupt checkpoint on 50-car test split:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val_abupt>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<test_WSS>}}
```

**Required fields per advisor decision criteria:**
- `best_checkpoint/source = ema` (confirm in W&B summary)
- val_abupt + val_VP + val_SP + val_WSS at best ckpt
- **test_abupt, test_SP, test_vol_p, test_WSS** at best val ckpt (50 cars)
- Per-axis test wall_shear: τx, τy, τz (verify H44's all-3-ahead pattern survives stacking)
- τz/τx mean, std, n_outside_band (val 34 + test 50)
- Per-car τz/τx distribution if available (compare to H44 standalone)
- best_checkpoint/step (which epoch the EMA best landed at)
- Time budget management summary

**Do NOT suppress SENPAI-RESULT.** Even if val_abupt > 6.126%, the mechanism-stacking compound (NPCA × YAW-AUG variance compounding) is a major Wave 31 structural finding regardless. The 3-mechanism stacking principle (variance-break × loss-reshape × symmetry-breaking) opens the broader mechanism-class composition map.

---

## Notes on Wave 31 context

**Mechanism stacking proof series so far:**
- H35 NPCA+SSFL: variance × loss-reshape → proved stacking works (closed 24th DE on merge dim, 5th vol_p crossing)
- **H52 NPCA × YAW-AUG: variance × symmetry-breaking → this experiment**
- Future H53+: variance × symmetry × loss-reshape (3-way stack if H52 succeeds)

**Why frieren is the right student**: you closed H44 with the cleanest data-augmentation axis crossing in fleet history. You own the yaw augmentation implementation. The merge between your H44 branch and tay's NPCA implementation is your fastest path to launch. Estimated implementation time: 15-30 min of branch surgery + smoke test + launch.
