### PR TITLE
Wave 31 H53: CP-LOSS-WEIGHT — surface-pressure channel up-weighting to attack test_SP binding gate

### DIFF
--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    cp_loss_weight: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -751,12 +752,14 @@ def main(argv: Iterable[str] | None = None) -> None:
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
         surface_channel_weights = torch.tensor(
-            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+            [config.cp_loss_weight, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
             device=device,
             dtype=torch.float32,
         )
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.cp_loss_weight != 1.0)
+            or (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -849,7 +852,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
             if use_channel_weights:
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
+                    f"Surface channel weights: cp={config.cp_loss_weight} tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
 
@@ -881,6 +884,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 else []
             )
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
+            wandb.summary["loss/cp_loss_weight"] = config.cp_loss_weight
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
 
@@ -1066,6 +1070,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/cp_loss_weight": config.cp_loss_weight,
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }


### PR DESCRIPTION
## Hypothesis

**Wave 31 H53: CP-LOSS-WEIGHT — surface-pressure channel up-weighting to attack the test_SP binding gate.**

### The problem — test_SP is the binding constraint

7 test_vol_p floor crossings in Wave 30/31; **0 test_SP floor crossings**. Every Wave 31 experiment lands test_SP between 3.71%–3.88% vs the 3.577% floor — a +0.14–0.30pp breach in every case. The vol_p pathway has been beaten repeatedly; the SP pathway has not even been approached.

This Wave 31 fleet has revealed a structural pattern: **mechanism class determines per-car gradient routing distribution, NOT aggregate axis ratios** (H35 stacking, H44 cross-channel WSS regularization, H45 GATE 1/GATE 2 decoupling, H48 τz/τx 0.40 persistence). The shared `Linear(n_hidden, 4)` surface decoder routes gradients across `[cp, τx, τy, τz]` based on the relative magnitudes of per-channel MSE losses. **No mechanism currently up-weights the cp channel** to compensate for surface_pressure's MSE typically being ~10× smaller than wall_shear MSE (Pa vs Pa/s² scaled units), so the decoder under-prioritizes cp learning.

### The mechanism

H48 just demonstrated that a **single training-time channel weight flag** (`--tau-y-loss-weight 1.5 → 1.0`) produces the largest τz/τx deflection in fleet history (per-car mean 0.40 across all 34/34 cars, persisting across 4+ epochs with drift +0.0006 pp/1k). H53 applies the **same minimal-perturbation lever** to the cp channel — `--cp-loss-weight 1.0 → 2.0` — to force the surface decoder to allocate more capacity to surface_pressure prediction.

**Why up-weight cp specifically:**
- cp MSE is small in absolute terms (surface_pressure values ~0.1–10 Pa vs wall_shear ~10–100 Pa/s²), so it contributes proportionally less to the surface loss without explicit weighting
- The surface decoder has fixed capacity (`Linear(n_hidden, 4)` → 512×4 = 2,048 output weights); doubling the cp loss term explicitly reallocates ~25% more gradient capacity toward cp reconstruction
- H48 proved single-flag channel weights are mechanism-positive on τz channel — the cp analogue is the natural test of whether the lever generalizes

### Why this is the right experiment now

1. **test_SP is the binding gate.** Hitting it unlocks Wave 31's first complete merge candidate (the merge requires val_abupt + test_SP + test_vol_p + test_WSS, and test_SP has been the universal blocker).
2. **Zero-code-change mechanism**. H53 uses an existing `surface_channel_weights` tensor (already wired in train.py:753–760 with tau_y/tau_z weights) plus a new CLI flag. Minimal blast radius, no model.py change.
3. **Orthogonal to all 8 in-flight Wave 31 PRs.** Every running PR attacks variance-class (H45/H49/H50), mean-shift (H48), data-aug (H52), or stacking (H51) mechanisms. None up-weight cp. H53 fills the obvious gap on the SP axis.
4. **Predicted to compose with H48** — if H48 succeeds at the budget cutoff (~12:45Z May 19) on the τz/τx mean-shift axis AND H53 succeeds on the cp axis, a follow-up H54 stack `--cp-loss-weight 2.0 + --tau-y-loss-weight 1.0` is the natural compounding experiment.

### Mechanism prediction

| EP | val_SP (target) | val_abupt (target) | val_VP (must not regress) | Reasoning |
|---:|---:|---:|---:|---|
| EP1 | ~5.0–6.0% | 28–35% (cold start) | ~17–19% | cold start normal |
| EP3 | ~4.4–4.7% | ~7.5–8.5% | 4.5–4.7% | cp gradient routing reallocating |
| EP6 | ~3.95–4.15% | ~6.3–6.5% | 3.85–4.00% | descending toward floor |
| EP9 | ~3.75–3.90% | ~6.15–6.30% | 3.70–3.80% | cosine tail crossing zone |
| EP13 | **~3.50–3.65%** ⭐ | **~6.00–6.15%** | 3.55–3.65% | **target: test_SP crosses 3.577% floor** |

**Prediction:** the −0.077pp from 3.577% baseline test_SP to predicted ~3.50–3.55% comes from explicit capacity reallocation, not from net mechanism win — the channel-weight lever is mechanically guaranteed to redistribute gradient mass, the only question is whether cp accuracy buys ≥ enough to clear the floor.

---

## Instructions

**Modify `train.py` only — ~15 LOC. No changes to `model.py` or read-only files.**

### Section A — Add `cp_loss_weight` to `TrainConfig`

Find the existing `tau_y_loss_weight` and `tau_z_loss_weight` fields in `TrainConfig` (around line 106–107) and add a `cp_loss_weight` field above them:

```python
# In TrainConfig:
cp_loss_weight: float = 1.0
tau_y_loss_weight: float = 1.0
tau_z_loss_weight: float = 1.0
```

### Section B — Update `surface_channel_weights` tensor

Find where `surface_channel_weights` is constructed (around line 753–760). Update both the tensor construction and the `use_channel_weights` check:

```python
# Before:
surface_channel_weights = torch.tensor(
    [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
    device=device,
    dtype=torch.float32,
)
use_channel_weights = bool(
    (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
)

# After:
surface_channel_weights = torch.tensor(
    [config.cp_loss_weight, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
    device=device,
    dtype=torch.float32,
)
use_channel_weights = bool(
    (config.cp_loss_weight != 1.0)
    or (config.tau_y_loss_weight != 1.0)
    or (config.tau_z_loss_weight != 1.0)
)
```

**Channel ordering check**: the tensor `[cp, τx, τy, τz]` order must match how `surface_target` columns are arranged in the loss computation. Confirm via the existing `tau_y_loss_weight`/`tau_z_loss_weight` usage — they're applied to columns 2 and 3 respectively, so cp is column 0.

### Section C — Update print + wandb logging

```python
# Print line:
if use_channel_weights:
    print(
        f"Surface channel weights: cp={config.cp_loss_weight} tau_x=1.0 "
        f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
    )

# wandb.summary block — add cp:
wandb.summary["loss/cp_loss_weight"] = config.cp_loss_weight
wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight

# train step log — add cp:
"train/cp_loss_weight": config.cp_loss_weight,
"train/tau_y_loss_weight": config.tau_y_loss_weight,
"train/tau_z_loss_weight": config.tau_z_loss_weight,
```

### Section D — CLI flag

```python
parser.add_argument(
    "--cp-loss-weight", type=float, default=1.0,
    help="Loss weight for the cp (surface pressure) channel in surface MSE."
)
```

And wire to `TrainConfig` the same way as `--tau-y-loss-weight`.

### Section E — Smoke check (REQUIRED before launch)

Run 50 training steps with `--cp-loss-weight 2.0` enabled. Confirm:
- `train/loss` descends (no divergence from cp up-weighting)
- `train/grad/nonfinite_count` = 0
- `train/cp_loss_weight = 2.0` appears in W&B
- `train/loss/cp` term is ~2× what it would be at weight 1.0 (sanity check on the multiplier wiring)
- Surface output magnitudes unchanged at step 0 (only loss gradient flow is reweighted, not outputs)

---

## Run command (single arm, full 18h DDP-8)

**One arm at `--cp-loss-weight 2.0`** — start with the conservative weight matching the H48 precedent (H48 used a 1.0→1.5 ratio = 1.5x on τy; we're doing 1.0→2.0 = 2.0x on cp which is the natural next-step magnitude). If H53 arm-A is alive at EP3, no second arm is needed because the 2.0 weight is already aggressive on a smaller-magnitude channel.

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --cp-loss-weight 2.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent tanjiro --wandb-group wave31_h53_cp_loss_weight \
  --wandb-name tanjiro/h53-cp-loss-weight \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<40,32594:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/surface_pressure_rel_l2_pct<5.5,65228:val_primary/surface_pressure_rel_l2_pct<4.3,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

**Recipe rationale:**
- `--cp-loss-weight 2.0` — single new flag. All other flags identical to baseline #972.
- Kill thresholds: step-indexed (10864=EP1, 32594=EP3, 65228=EP6). EP1 fence at 40% (catches catastrophic failures only). EP3: 9.5% abupt + 5.5% SP. **NEW EP6 gate**: SP < 4.3% (must show meaningful SP descent toward the 3.577% floor by mid-cosine; H44/H45 baseline was SP ~4.5% at EP6, so 4.3% is a moderate ahead-of-baseline target indicating the cp lever is working).
- `--tau-y-loss-weight 1.5` retained (baseline default). H48 is testing `--tau-y-loss-weight 1.0`; do NOT compound until H48 terminal result is known (orthogonal-arm discipline).

---

## EP3 falsifiable gate

**ALIVE at EP3 (step 32,594) if ALL hold:**

| Metric | Threshold | Why |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 8.0% | Training healthy under cp up-weighting |
| `val_primary/surface_pressure_rel_l2_pct` | **≤ 4.7%** | **PRIMARY FALSIFIER — cp up-weighting must accelerate SP descent vs baseline ~4.85% at EP3** |
| `val_primary/wall_shear_rel_l2_pct` | ≤ 8.7% | WSS not destroyed by cp capacity reallocation |
| `val_primary/volume_pressure_rel_l2_pct` | ≤ 4.8% | VP not regressed |

**EP3 KILL gates (any one triggers):**
- val_abupt > 9.5% at EP3 → cp lever destroying convergence → KILL
- val_SP > 5.5% at EP3 → cp up-weighting is making SP WORSE (channel-weight lever inverted somehow) → KILL
- val_WSS > 9.5% at EP3 → WSS channels starved of capacity → KILL

---

## EP6 falsifiable gate

**ALIVE at EP6 (step 65,228) if ALL hold:**

| Metric | Threshold | Why |
|---|---|---|
| `val_primary/abupt_axis_mean_rel_l2_pct` | ≤ 6.5% | Training tracking baseline trajectory |
| `val_primary/surface_pressure_rel_l2_pct` | **≤ 4.3%** | **must be tracking toward floor 3.577% at EP13** |
| `val_primary/volume_pressure_rel_l2_pct` | ≤ 3.9% | VP not regressed below floor zone |

EP6 KILL: if SP > 4.5% at EP6, cp lever is failing — KILL.

---

## Mid-run check-in (REQUIRED)

At EP6 (step 65,228), post a check-in comment with:
- val_abupt, val_VP, val_SP, val_WSS, val_WSS_x, val_WSS_y, val_WSS_z
- per-car τz/τx mean/std/n_outside_band (carry forward H48/H44 convention)
- per-car SP_rel_l2 histogram if available (which cars are SP-poor?)
- W&B run health (state, runtime, heartbeat, nonfinite_count)
- Trajectory projection for EP13 terminal

---

## Baseline

Current best single-model (PR #972, run `56bcqp3m`):

| Metric | Value | Direction |
|---|---:|---|
| **val_abupt** | **6.126%** | merge gate |
| test_abupt | 5.844% | reference |
| **test_vol_p** | **3.643%** | floor (HARD) — 7 crossings to date |
| **test_SP** | **3.577%** | **floor (HARD) — 0 crossings in Wave 31; binding gate** |
| test_WSS | 6.727% | goal < 5.85% |

**Reproduce baseline:**
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

---

## Required at terminal SENPAI-RESULT

After test eval at best EMA val_abupt checkpoint on 50-car test split:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<best_val_abupt>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<test_WSS>}}
```

**Required fields per advisor decision criteria:**
- `best_checkpoint/source = ema` (confirm in W&B summary)
- val_abupt + val_VP + val_SP + val_WSS at best ckpt
- **test_abupt, test_SP, test_vol_p, test_WSS** at best val ckpt (50 cars) — **THE KEY METRIC IS test_SP**
- Per-axis test wall_shear: τx, τy, τz
- τz/τx mean, std, n_outside_band (val 34 + test 50) — does cp lever drift the band?
- Per-car SP_rel_l2 distribution if available (which cars improved most? geometric pattern?)
- best_checkpoint/step (which epoch the EMA best landed at)
- Time budget management summary

**Do NOT suppress SENPAI-RESULT.** Even if test_SP > 3.577%, if it lands < 3.71% (better than every Wave 31 prior attempt), it is the **strongest Wave 31 SP signal** and a publishable structural finding (channel-weight lever generalizes from τz to cp).

---

## Predicted outcomes

**If H53 SUCCEEDS (EP13 test_SP ≤ 3.577% floor crossing):**
- First SP floor crossing in Wave 31 — opens the cp-channel lever as a new mechanism class
- Stack candidates: H53 (cp up-weight) × H44 (yaw aug) — yaw aug improved all 3 WSS axes; cp up-weight should preserve those gains while adding SP
- Stack candidates: H53 (cp up-weight) × H48 (τy down-weight) — both single-flag levers, mechanistically orthogonal

**If H53 FAILS (test_SP > 3.71%):**
- The cp channel up-weighting axis does not generalize from the τz precedent
- Suggests SP floor is a **structural feature of the surface decoder topology**, not a channel-weight problem
- Closes the channel-weight lever path on the cp axis specifically (combined with H48 which is testing the τy axis)
- Research map narrows to: SP floor requires architectural change to surface decoder (not weight reallocation)

---

## Wave 31 context — test_SP is the binding gate

Wave 31 floor crossings:
- test_vol_p: 7 confirmed crossings (H31 merged, H26 merged, H46 PathB, H33, H35, H44, H36)
- **test_SP: 0 crossings** ← THE BLOCKER

Every Wave 31 run lands test_SP between 3.71%–3.88% (+0.13–0.30pp above floor). H53 is the first targeted attack on the SP binding gate.
