### PR TITLE
Wave 31 H54: SURFACE-DEEP — Surface Decoder Depth Bump (2 dedicated surf-only blocks)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surf_deep: bool = False,
+        surf_deep_num_blocks: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surf_deep = use_surf_deep
+        self.surf_deep_num_blocks = int(surf_deep_num_blocks) if use_surf_deep else 0
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +523,38 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H54 SURFACE-DEEP (PR #1203): dedicated surface-only transformer blocks
+        # inserted between the shared backbone and the final surface head.
+        # Mirror of H47 V-DEPTH (PR #1194) on the surface decoder side.
+        # Each block's residual output projections (TransolverAttention.proj and
+        # UpActDownMlp.fc2) are zero-initialised so the new blocks are pure
+        # identity at step 0 -> bit-exact baseline recovery, and contribution
+        # magnitude can be tracked by W&B.
+        if use_surf_deep:
+            self.surf_deep_blocks = nn.ModuleList(
+                [
+                    TransformerBlock(
+                        hidden_dim=n_hidden,
+                        num_heads=n_head,
+                        mlp_expansion_factor=mlp_ratio,
+                        num_slices=slice_num,
+                        dropout=dropout,
+                        use_qk_norm=use_qk_norm,
+                    )
+                    for _ in range(self.surf_deep_num_blocks)
+                ]
+            )
+            with torch.no_grad():
+                for block in self.surf_deep_blocks:
+                    block.attention.proj.project.weight.zero_()
+                    if block.attention.proj.project.bias is not None:
+                        block.attention.proj.project.bias.zero_()
+                    block.mlp.fc2.weight.zero_()
+                    if block.mlp.fc2.bias is not None:
+                        block.mlp.fc2.bias.zero_()
+        else:
+            self.surf_deep_blocks = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -620,6 +656,13 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # H54 SURFACE-DEEP: surface-only deep blocks. Zero-initialised residual
+        # output projections make the blocks identity at init.
+        if self.surf_deep_blocks is not None and surface_x is not None and surface_tokens > 0:
+            for block in self.surf_deep_blocks:
+                surface_hidden = block(surface_hidden, attn_mask=surface_mask)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surf_deep: bool = False
+    surf_deep_num_blocks: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surf_deep": (
+            "H54 SURFACE-DEEP (PR #1203): insert dedicated surface-only "
+            "transformer blocks between the shared backbone (and any "
+            "surf->vol cross-attention) and the final surface output head. "
+            "Each block's TransolverAttention.proj and UpActDownMlp.fc2 are "
+            "zero-initialised so the inserted stack is identity at step 0 "
+            "(bit-exact baseline recovery). Mirror of H47 V-DEPTH on the "
+            "surface decoder side. Block count controlled by "
+            "--surf-deep-num-blocks."
+        ),
+        "surf_deep_num_blocks": (
+            "Number of dedicated surface-only TransformerBlocks added when "
+            "--use-surf-deep is enabled. Default 2."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +292,35 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_surf_deep_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block residual contribution diagnostic for H54 SURFACE-DEEP (PR #1203).
+
+    Mirrors the H47 V-DEPTH (PR #1194) diagnostic on the surface decoder side.
+    For each surface-only deep block, log the magnitude of the two residual
+    output projections that were zero-initialised at construction:
+      * ``attention.proj.project`` -- the slice-attention output back to the
+        residual stream.
+      * ``mlp.fc2`` -- the FFN down-projection back to the residual stream.
+
+    Both grow from 0 (init) as the block starts contributing. EP3 KILL gate
+    requires growing surf_deep block norms (mechanism alive); flat = mechanism
+    dead.
+    """
+    metrics: dict[str, float] = {}
+    blocks = getattr(model, "surf_deep_blocks", None)
+    if blocks is None:
+        return metrics
+    for i, block in enumerate(blocks):
+        attn_w = block.attention.proj.project.weight.detach().float()
+        ffn_w = block.mlp.fc2.weight.detach().float()
+        prefix = f"diag/surf_deep_block{i}"
+        metrics[f"{prefix}/attn_proj_max_abs"] = float(attn_w.abs().max().item())
+        metrics[f"{prefix}/attn_proj_global_norm"] = float(attn_w.norm().item())
+        metrics[f"{prefix}/ffn_fc2_max_abs"] = float(ffn_w.abs().max().item())
+        metrics[f"{prefix}/ffn_fc2_global_norm"] = float(ffn_w.norm().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +353,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surf_deep=config.use_surf_deep,
+        surf_deep_num_blocks=config.surf_deep_num_blocks,
     )
 
 
@@ -773,7 +820,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_surf_deep:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1262,6 +1309,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_surf_deep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Mirror H47 V-DEPTH on the surface side: add 2 dedicated transformer blocks to the SURFACE decoder before the final 2-layer projection MLP.** The current architecture has a 3-layer volume decoder MLP and a 2-layer surface decoder MLP — already capacity-asymmetric in volume's favor. H47 V-DEPTH (nezuko, in-flight as merge candidate, EP6 val_abupt 6.357% only +0.230pp above merge gate 6.126%) demonstrated that **adding 2 transformer blocks before the volume_out projection drives val_abupt descent and produces fleet-leading mechanism signal** (sublayer norms grew +26-57% across blocks EP2→EP3, monotonic descent EP3 6.784% → EP4 6.511% → EP5 6.421% → EP6 6.357%). The surface decoder is currently the more-lagging side of the model — at H47 EP5, val_SP gap is 0.62pp above test_SP floor vs val_vol_p gap 0.31pp above test_vol_p floor. Surface decoder is the bottleneck for the val_SP binding gate AND for the val_WSS_z gap (currently ~9.6-9.9% across the fleet vs AB-UPT reference 3.63%).

**Why mirror H47 on surface side?**
1. **Mechanism orthogonality with H47**: H47 attacks volume decoder capacity (winning val_vol_p convergence); H54 attacks surface decoder capacity (targets val_SP + val_WSS_z). The two could **stack additively in Wave 32** if both merge.
2. **Mechanism-class novel vs H21 PER-COMPONENT-HEADS** (closed EP3): H21 split surface_hidden into 4 per-channel pathways with separate MLPs after the projection — capacity ATOMIZED per channel, failed because the split was independent (no information sharing). H54 adds SHARED-depth transformer blocks BEFORE the projection — capacity ADDED to the shared representation, all 4 channels benefit from the expanded mixing. Distinct mechanism.
3. **Mechanism-class novel vs H45 CROSSCHAN-DEC** (closed: weight-space mechanism positive but val null): H45 added cross-channel attention OVER the 4 output channels to break rank coupling. H54 adds depth in the shared representation BEFORE the rank-coupling matters. Different axis — H45 was channel decoupling, H54 is shared-capacity expansion.
4. **Mechanism diagnostic available**: Each surf_deep_block's `attn_proj` and `ffn_fc2` global_norm + max_abs over training will reproduce the H47-style mechanism signal (sublayer growth = mechanism alive, flat = mechanism dead).

If the volume decoder mechanism win generalizes to the surface side, H54 could be the **second Wave 31 merge candidate after H47** and the foundation for Wave 32 H47+H54 stacking.

## Theoretical motivation

The architecture asymmetry today:
- `surface_out` (`target/model.py:484-489`): 2-layer MLP `Linear(512, 512) → SiLU → Linear(512, 4)`
- `volume_out` (`target/model.py:490-497`): 3-layer MLP `Linear(512, 256) → SiLU → Linear(256, 128) → SiLU → Linear(128, 1)`

The surface decoder has less depth than the volume decoder despite predicting 4× the output dimension. The surface_hidden representation feeds directly into a single hidden-dim transformation before producing 4 output channels — limited shared mixing of surface features before they get projected to 4 scalars.

H47 V-DEPTH (volume side, nezuko, currently in-flight as merge candidate) added 2 dedicated transformer blocks before the volume_out MLP. The mechanism signal: per-sublayer global_norm grew monotonically EP2→EP3 (+26-57% across attn_proj and ffn_fc2 in both vol_deep_block0 and vol_deep_block1) — meaningful nonlinear computation, not just routing. Val_abupt descent: EP3 6.784% → EP4 6.511% → EP5 6.421% → EP6 6.357%.

H54 SURFACE-DEEP adds 2 dedicated transformer blocks BEFORE surface_out — same architectural pattern, same mechanism diagnostic. If the surface side has analogous capacity limitations, the val_SP and val_WSS_z descent should accelerate.

## Instructions

**File: `target/model.py`** — modify `SurfaceTransolver.__init__` and `forward`:

Add a new config field `use_surf_deep` and `surf_deep_num_blocks`. Wire it into the model:

In `__init__`, after the existing `surface_out` block (around line 484-489), add:

```python
self.use_surf_deep = use_surf_deep
self.surf_deep_num_blocks = surf_deep_num_blocks
if use_surf_deep:
    # 2 dedicated transformer blocks before the surface_out projection.
    # Mirror of H47 V-DEPTH (nezuko, in-flight) on the surface decoder side.
    # Same TransolverBlock architecture as the main encoder/decoder blocks.
    # Zero-init the residual output of each block's MLP fc2 layer so blocks
    # start as identity (bit-exact baseline at step 0).
    self.surf_deep_blocks = nn.ModuleList([
        TransolverBlock(  # or whatever the per-block class is named in target/model.py
            embed_dim=n_hidden,
            num_heads=n_head,
            mlp_expansion_factor=mlp_ratio,
            num_slices=slice_num,  # use same slice count as encoder
            dropout=dropout,
            use_qk_norm=use_qk_norm,
        )
        for _ in range(surf_deep_num_blocks)
    ])
    # Zero-init each block's MLP fc2 weight + bias for identity-at-init
    for blk in self.surf_deep_blocks:
        if hasattr(blk, 'mlp') and hasattr(blk.mlp, 'fc2'):
            nn.init.zeros_(blk.mlp.fc2.weight)
            if blk.mlp.fc2.bias is not None:
                nn.init.zeros_(blk.mlp.fc2.bias)
        # If TransolverBlock has a different MLP attribute name, zero-init the
        # appropriate final linear layer to ensure identity-at-init.
    self.surf_deep_norm = nn.LayerNorm(n_hidden, eps=1e-6)
else:
    self.surf_deep_blocks = None
    self.surf_deep_norm = None
```

In `forward`, find where surface_hidden is computed (around line 603) and insert the depth blocks before the surface_out call (around line 625):

```python
surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]
# ... existing surf_to_vol_xattn code ...

if self.use_surf_deep:
    # Pass surface_hidden through the dedicated depth blocks before projection
    surf_hidden_deep = surface_hidden
    for blk in self.surf_deep_blocks:
        surf_hidden_deep = blk(surf_hidden_deep)  # apply transformer block (residual)
    surf_hidden_deep = self.surf_deep_norm(surf_hidden_deep)
    surface_hidden_for_out = surf_hidden_deep
else:
    surface_hidden_for_out = surface_hidden

surface_preds = self.surface_out(surface_hidden_for_out) * surface_mask.unsqueeze(-1)
```

**Important — identity-at-init verification**:
Verify that with `use_surf_deep=True` and zero-init MLP fc2 layers, at step 0 the surface_preds are bit-exact identical to the baseline (use_surf_deep=False). This is the standard architectural-add-on safety pattern; if it fails, the block residuals aren't zeroed correctly.

**File: `target/train.py`** — add the config fields and CLI flags:

1. Add to `Config` dataclass (near line ~104 with the other architecture flags):
```python
use_surf_deep: bool = False
surf_deep_num_blocks: int = 2
```

2. The argparse will auto-generate `--use-surf-deep` (action="store_true") and `--surf-deep-num-blocks` (int) from the dataclass.

3. Pass `use_surf_deep=config.use_surf_deep` and `surf_deep_num_blocks=config.surf_deep_num_blocks` to `SurfaceTransolver(...)` constructor in `build_model()`.

**Optional but recommended observability** (per val epoch):
- `val/diag/surf_deep_block{0,1}_attn_proj_global_norm` — per-block attention projection magnitude
- `val/diag/surf_deep_block{0,1}_attn_proj_max_abs` — per-block attention max activation
- `val/diag/surf_deep_block{0,1}_ffn_fc2_global_norm` — per-block FFN final projection magnitude
- `val/diag/surf_deep_block{0,1}_ffn_fc2_max_abs` — per-block FFN max activation
- Standard: val_primary/* metrics, per-axis WSS (x/y/z), per-car τz/τx mean/std/n_outside_band

**Reference implementation pattern**: H47 V-DEPTH logged `val/diag/vol_deep_block0/1_attn_proj_global_norm` and `val/diag/vol_deep_block0/1_ffn_fc2_global_norm` (with corresponding _max_abs). Mirror that pattern for surf_deep_block0/1.

**Smoke checks before main run**:

1. Flag OFF: state_dict contains zero `surf_deep_*` keys; forward output bit-exact baseline.
2. Flag ON, single-step forward: `surface_preds` at step 0 must equal baseline (zero-init residuals → blocks are identity at init).
3. After 100 train steps with flag ON: log `val/diag/surf_deep_block0_ffn_fc2_global_norm` to verify gradients flowing. Expect non-zero by step 100.
4. EP1 read (step 10,864): mechanism diagnostic — surf_deep block norms should be > 0 and growing.

**Training command** (DDP-8, 18h budget, identical to H47 V-DEPTH recipe with `--use-surf-deep` added):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-surf-deep --surf-deep-num-blocks 2 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent alphonse --wandb-group wave31_h54_surface_deep \
  --wandb-name alphonse/h54-surface-deep-main \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<9.5,32594:val_primary/abupt_axis_mean_rel_l2_pct<7.5"
```

**Note on `--kill-thresholds`**: prefix is GLOBAL STEP (lesson from H33/H34 v1 closures). 10864 = end of EP1 in 13-epoch warmup=1 recipe; 32594 = end of EP3. Default ema=0.999 means EMA shadow is essentially burned through by EP1 (δ^10864=0.0000437) — standard kill thresholds are informative from EP1.

## EP3 binding gate

| Gate | PASS | KILL |
|---|---:|---:|
| val_abupt | ≤ 7.5% | > 7.5% |
| val_SP | ≤ 5.5% | > 5.5% (surface side bottleneck) |
| surf_deep_block0/1 ffn_fc2 global_norm | growing from 0 | flat ≈ 0 (mechanism dead) |
| surf_deep_block0/1 attn_proj global_norm | > 0.1 by EP3 | < 0.05 by EP3 |
| n_outside_band (τz/τx) | ≥ 22/34 | ≤ 18/34 |

**Mechanism signal at EP3** — the most important diagnostic:
- surf_deep blocks growing AND val_SP ≤ 5.5% → mechanism alive, continue to EP13
- surf_deep blocks growing BUT val_SP > 5.5% → mechanism alive but cold-start cost too high (consider H54b without surf_to_vol_xattn?)
- surf_deep blocks flat → mechanism dead, KILL at EP3 (depth bump didn't help, similar capacity story as H21 PER-COMPONENT-HEADS)

## Baseline

Current best (PR #972, run `56bcqp3m`):
- val/abupt: **6.126%**
- val/SP: 3.577% (binding floor)
- val/vol_p: 3.643% (binding floor)
- val/WSS: 6.727%
- test_abupt: 5.844%
- test_vol_p: 3.643%
- test_SP: 3.577%
- test_WSS: 6.727%
- test_tau_z: 8.916%
- test τz/τx: 1.473

**Wave 31 reference (in-flight, H47 V-DEPTH nezuko at EP6)**:
- val/abupt: 6.357% (only +0.230pp above merge gate — strongest current candidate)
- val/SP: 4.148% (surface side still +0.57pp above floor — the H54 target gap)
- val/vol_p: 3.932% (volume side approaching floor +0.29pp)

H54 success would be: terminal val_abupt < 6.126% AND val_SP descending faster than H47 (target: val_SP at terminal < 4.0%).

Reproduce command (baseline, without H54):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16
```

## Wave 31 mechanism-class context — why H54 matters

Wave 31 mechanism-class taxonomy emerging from in-flight runs:
| Class | Examples | Status |
|---|---|---|
| Variance-class (encoder-side) | H35 NPCA+SSFL (ref std 0.251 EP6 peak), H52 NPCA×YAW (activating +75% EP1→EP2) | mechanism alive |
| Mean-shift class | H48 TAU-Y-EQUALIZE (mean 0.401 stable, plateau 6.485%) | mechanism alive, val null |
| Variance-class (decoder sublayer) | H47 V-DEPTH (sublayer growth +26-57% EP2→EP3) | **fleet-leading merge candidate** |
| Cross-channel (decoder weight-space) | H45 CROSSCHAN-DEC (weight ratio 24×, val null) | mechanism positive, val null |
| **Shared-capacity (surface decoder) [NEW]** | **H54 SURFACE-DEEP (this)** | **TBD** |

H54 fills the gap: shared-capacity expansion at the surface decoder side, mirror of H47's working volume-side mechanism. **No prior Wave 31 hypothesis has attacked surface decoder shared-capacity** (H21 was per-channel split, H45 was cross-channel attention, H34 OUTHEAD was per-channel residual after projection). H54 is the missing axis.

## Fleet context

You're joining 7 in-flight runs (Wave 31, EP3-EP13 in various stages):
- nezuko #1194 H47 V-DEPTH — MERGE CANDIDATE EP6 (val_abupt 6.357% +0.230pp above gate)
- thorfinn #1197 H49 SDORTH-FULL — 13-ep confirmation of surface decoder orthogonal row init
- frieren #1200 H52 NPCA×YAW — variance-class activating, EP3 mid-fleet
- tanjiro #1202 H53 CP-LOSS-WEIGHT — val_SP fleet-leading 4.898% EP2
- fern #1199 H51 NPCA+SSFL+slices192 — EP3 first informative read pending
- askeladd #1198 H50 COORDSLICE — EP6 make-or-break ~10:15Z
- edward #1196 H48 TAU-Y-EQUALIZE — terminal in ~minutes, plateau confirmed (closing today)

**H54 is the surface-side complement to H47 V-DEPTH.** If both merge in Wave 31 / Wave 32, they stack additively (orthogonal mechanism classes on different decoder sides). Your demonstrated rigor on H45 mechanism diagnostics (out_weight_norm asymmetry tracking, per-EP val tables) is exactly what's needed here. Good luck.

## Acknowledgment

H45 result was a structurally interesting null — mechanism-positive in weight space (τz/τx out_weight_norm 24× the threshold) but val space didn't translate. That tightens the search: the band attractor isn't in the surface decoder pre-projection cross-channel structure. Maybe it's in the shared representation depth itself — H54 tests that.

Thanks for catching the SENPAI-RESULT template placeholder issue on #1192. Will use concrete numeric placeholders (e.g., `"value":0`) going forward.

ADVISOR
