### PR TITLE
Wave 31 H55: TAU-Z-LOSS-CURRICULUM — front-load tau_z loss weight 5.0->2.0 over EP1-6

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_z_loss_weight_start: float = 5.0
+    tau_z_loss_weight_end: float = 2.0
+    tau_z_loss_weight_decay_steps: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -755,8 +758,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             device=device,
             dtype=torch.float32,
         )
+        # H55: τz curriculum forces use_channel_weights=True even when
+        # tau_z_loss_weight matches its default — the curriculum-computed
+        # value (typically 5.0→2.0) is what actually drives the loss, and the
+        # pass-through must be enabled from step 0.
+        tau_z_curriculum_active = config.tau_z_loss_weight_decay_steps > 0
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
+            or tau_z_curriculum_active
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -852,6 +862,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if tau_z_curriculum_active:
+                print(
+                    f"tau_z loss-weight curriculum: linear "
+                    f"{config.tau_z_loss_weight_start}->"
+                    f"{config.tau_z_loss_weight_end} over "
+                    f"{config.tau_z_loss_weight_decay_steps} steps, "
+                    f"then held at {config.tau_z_loss_weight_end}"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +901,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_z_loss_weight_start"] = config.tau_z_loss_weight_start
+            wandb.summary["loss/tau_z_loss_weight_end"] = config.tau_z_loss_weight_end
+            wandb.summary["loss/tau_z_loss_weight_decay_steps"] = config.tau_z_loss_weight_decay_steps
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -937,6 +958,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                # Default τz weight for the log line below; the non-gradnorm
+                # branch overwrites this with the curriculum value.
+                current_tau_z = config.tau_z_loss_weight
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1021,6 +1045,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    # H55: linear τz loss-weight curriculum. global_step is 0
+                    # at the first batch and is incremented after this call,
+                    # so at step=0 progress=0 → current_tau_z=start; once
+                    # global_step >= decay_steps progress=1 → current_tau_z=end.
+                    current_tau_z = config.tau_z_loss_weight
+                    if tau_z_curriculum_active:
+                        progress = min(
+                            1.0, global_step / config.tau_z_loss_weight_decay_steps
+                        )
+                        current_tau_z = (
+                            config.tau_z_loss_weight_start * (1.0 - progress)
+                            + config.tau_z_loss_weight_end * progress
+                        )
+                        surface_channel_weights[3] = current_tau_z
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1068,6 +1106,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/tau_z_loss_weight_curriculum": current_tau_z,
                         }
                     )
                 if gradnorm_metrics:


### PR DESCRIPTION
## Hypothesis

**H55 TAU-Z-LOSS-CURRICULUM**: Front-load the τ_z surface loss weight at training start, then decay to a moderate value by EP6. Mechanism class: **time-varying loss weight curriculum** (NEW in Wave 31).

**Rationale**: H48 TAU-Y-EQUALIZE established the **mean-shift mechanism class** as a structural null (PR #1196, closed 2026-05-19): static τ_y loss reduction redirected gradient capacity to **τ_x** (which became easiest at 6.437% val) rather than τ_z (which became hardest at 9.899% val). Per-car τ_z/τ_x mean compressed to 0.40 (25× more extreme than H46 SDORTH), but val_abupt stuck at 6.485% (+0.359pp above merge gate 6.126%).

H55 attacks the same channel-asymmetry problem from the opposite direction. Instead of *relaxing* one channel's weight statically, **front-load τ_z early in training** so the shared backbone encodes τ_z patterns before relaxing to standard. This is conceptually a learning-rate warmup but on loss weight space. The model gets forced to attend to τ_z patterns during the high-LR backbone-shaping phase (EP1-3 = 32,594 steps), then standard balance resumes for fine-tuning EP6-13. Expected effect: τ_z residuals reduce on val/test_WSS_z (currently 9.899% val_WSS_z vs 6.437% val_WSS_x in H48 — a 3.46pp gap).

Mechanism-class novelty: distinct from H48 (static τ_y reduction → null), H53 (static cp upweight, alphonse Wave 31), and existing GradNorm dynamic balancing. Curriculum on loss weight is unexplored in the Wave 30/31 history. If it works, opens up curriculum-on-loss-weight as a new family for the test_WSS_z and surface-channel-hardness research thread.

## Instructions

Implement a linear curriculum on `tau_z_loss_weight` over the first 6 epochs. Hold the standard value through EP13.

### 1. Add curriculum flags to argparse in `train.py`

After the existing `tau_z_loss_weight` config field (around line 107), add three optional curriculum knobs:

```python
tau_z_loss_weight_start: float = 5.0          # initial value at step 0
tau_z_loss_weight_end: float = 2.0            # value at decay_steps and after
tau_z_loss_weight_decay_steps: int = 65228    # EP6 end (linear decay window)
```

And matching argparse `--tau-z-loss-weight-start`, `--tau-z-loss-weight-end`, `--tau-z-loss-weight-decay-steps` flags (kebab-case → underscore). When `decay_steps == 0`, the curriculum is disabled and the static `tau_z_loss_weight` value is used (back-compat).

### 2. Compute the per-step τ_z weight in the training loop

In the training step (around line 1029, just before the `compute_loss_step` call), replace the static `surface_channel_weights[3]` (the τ_z slot) with the curriculum-computed value:

```python
if config.tau_z_loss_weight_decay_steps > 0:
    progress = min(1.0, global_step / config.tau_z_loss_weight_decay_steps)
    current_tau_z = (
        config.tau_z_loss_weight_start * (1.0 - progress)
        + config.tau_z_loss_weight_end * progress
    )
    surface_channel_weights[3] = current_tau_z
    use_channel_weights = True  # ensure pass-through is enabled
```

Important: the `use_channel_weights` flag (line 758) is computed once at startup based on static config; it must be set to True at startup when curriculum is enabled, so the loss path actually receives the channel weight tensor.

### 3. Log the current value to W&B

After computing `current_tau_z`, add to the existing `wandb.log` block (around line 1069):

```python
"train/tau_z_loss_weight_curriculum": current_tau_z,
```

So we can see the schedule shape in W&B alongside the loss.

### 4. Curriculum schedule values

Start at **5.0** (5× the standard tau_z weight), linear decay to **2.0** by step 65228 (EP6 end on the 13-epoch 18h recipe). Hold at 2.0 from EP7-EP13. The standard cp/tau_x/tau_y weights stay at 1.0.

Volume curriculum step counts (for reference):
- EP1 end = step 10864 → curriculum reads ~4.50 (still high-attendance)
- EP3 end = step 32594 → curriculum reads ~3.50 (mid-decay)
- EP6 end = step 65228 → curriculum reaches 2.0 (fully decayed)
- EP7+ → curriculum holds at 2.0

### 5. Single-arm reproduce command

Run a single arm — DDP8, full 18h budget, 13 epochs:

```bash
cd target/
TIMEOUT_MINUTES=1100 SENPAI_MAX_EPOCHS=13 torchrun --standalone --nproc-per-node=8 train.py \
    --benchmark drivaerml --use-ddp \
    --epochs 13 --batch-size 1 --lr 9e-5 --optimizer lion \
    --hidden-dim 512 --model-layers 5 --num-slices 128 \
    --ema-decay 0.9999 --ema-start-step 0 \
    --use-rff --rff-mapping-size 256 --rff-sigma 10.0 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --surface-loss-weight 1.0 --volume-loss-weight 1.0 \
    --tau-y-loss-weight 1.0 --tau-z-loss-weight 2.0 \
    --tau-z-loss-weight-start 5.0 \
    --tau-z-loss-weight-end 2.0 \
    --tau-z-loss-weight-decay-steps 65228 \
    --kill-thresholds "32594:val_primary/abupt<10.0;65228:val_primary/abupt<7.5" \
    --eval-every-epoch --save-best-ckpt \
    --wandb-project senpai-v1-drivaerml-ddp8 \
    --wandb-group h55-tau-z-curriculum
```

### 6. Mechanism diagnostics to log

In your check-in comments, report per-epoch:

- **τ_z curriculum value**: current_tau_z at start of EP1, EP3, EP6 (should be ~5.0, ~3.5, 2.0). Confirms the schedule is firing.
- **Per-axis val MAE**: val_WSS_x, val_WSS_y, val_WSS_z. We want val_WSS_z to drop relative to H48 EP10 baseline (9.899%) without val_WSS_x/y regressing badly.
- **τ_z/τ_x per-car mean and std** (from existing mechanism telemetry). H48 saturated at mean 0.40 std 0.033. H55 should produce different attractor behavior — either band restoration (mean→[1.44,1.55]) or different drift pattern.

### EP3 binding gate (kill if missed)

Set kill threshold at step 32594 (EP3 end): `val_primary/abupt < 7.5%`. If val_abupt at step 32594 ≥ 7.5%, the curriculum is dragging training. Earlier kill at step 10864 (EP1) set to `< 10.0%` since EP1 with high tau_z weight may have elevated abupt.

### Recipe-bug audit checklist (verify before submission)

- ✅ `--tau-y-loss-weight`, `--tau-z-loss-weight`, `--surface-loss-weight`, `--volume-loss-weight`, `--ema-decay`, `--ema-start-step`, `--use-rff`, `--rff-mapping-size`, `--rff-sigma`, `--pos-encoding-mode`, `--use-qk-norm` all exist (verified).
- ⚠ **NEW FLAGS to be added**: `--tau-z-loss-weight-start`, `--tau-z-loss-weight-end`, `--tau-z-loss-weight-decay-steps`. Confirm the kebab/underscore mapping is correct after implementing.
- ⚠ Confirm `use_channel_weights = True` when curriculum is enabled — the loss path must pass `surface_channel_weights` through, otherwise the curriculum is silently no-op.
- ⚠ Kill threshold step indices (10864, 32594, 65228) are **global_step** indices, not EP numbers.

## Baseline (PR #972, run `56bcqp3m`)

| Metric | Baseline | Floor | Direction |
|---|---:|---:|---|
| **val_primary/abupt** | **6.126%** | — | minimize, **merge gate** |
| val_VP (vol_p) | 3.643% | 3.643% | floor (rel L2) |
| val_SP (surface_p) | 3.577% | 3.577% | floor (rel L2) |
| val_WSS | 6.727% | — | minimize |
| **test_primary/abupt** | **5.844%** | — | minimize |
| test_VP | 3.643% | — | floor |
| test_SP | 3.577% | — | floor |
| test_WSS | 6.727% | — | **goal: <5.85%** |

**Merge gate**: single-model `val_primary/abupt < 6.126%` AND `test_vol_p ≤ 3.643%` AND `test_SP ≤ 3.577%`.

**Cross-experiment context**: H48 EP10 EMA terminal (mean-shift, closed null) val_WSS_z=9.899%, val_WSS_x=6.437%, val_WSS_y=8.011%. H55 should reduce the val_WSS_z gap.

## Terminal SENPAI-RESULT format

When you reach EP13 terminal, post a SENPAI-RESULT marker. Use concrete numeric placeholders if you need to draft the JSON shape — never angle-bracket placeholders. The student `mark_ready_for_review` guard validates the JSON.

Mechanism diagnostics + per-axis WSS breakdown + W&B run ID required for the close review.
