### PR TITLE
Wave 31 H56: H51-RELAUNCH NPCA+SSFL+slices192+ema9999 with EMA-aware kill gates

### DIFF
--- a/model.py
+++ b/model.py
@@ -46,6 +46,42 @@ class LinearProjection(nn.Module):
         return self.project(x)
 
 
+def compute_local_frame_proj(surface_x: torch.Tensor) -> torch.Tensor:
+    """Project global position onto a per-vertex local surface frame.
+
+    Computes ``[p·n, p·t1, p·t2]`` per vertex, where ``t1, t2`` are a
+    Gram-Schmidt tangent basis derived from the surface normal.
+
+    Computed in fp32 with an explicit eps=1e-6 in ``F.normalize`` so that
+    zero-padded tokens (normal == ``[0,0,0]``) produce zero projections
+    instead of NaN, even when called inside a bf16/fp16 autocast region.
+
+    Args:
+        surface_x: ``[B, N, >=6]`` with columns ``[x, y, z, nx, ny, nz, ...]``.
+
+    Returns:
+        ``[B, N, 3]`` with ``[p·n, p·t1, p·t2]`` per vertex, cast back to
+        the input dtype.
+    """
+    input_dtype = surface_x.dtype
+    sx = surface_x.float()
+    pos = sx[:, :, :3]
+    n = F.normalize(sx[:, :, 3:6], dim=-1, eps=1e-6)
+
+    ref_a = torch.tensor([0.0, 0.0, 1.0], device=n.device, dtype=n.dtype).expand_as(n)
+    ref_b = torch.tensor([0.0, 1.0, 0.0], device=n.device, dtype=n.dtype).expand_as(n)
+    parallel_mask = (n * ref_a).sum(-1, keepdim=True).abs() > 0.9
+    ref = torch.where(parallel_mask, ref_b, ref_a)
+
+    t1 = F.normalize(ref - (ref * n).sum(-1, keepdim=True) * n, dim=-1, eps=1e-6)
+    t2 = torch.cross(n, t1, dim=-1)
+
+    local_n = (pos * n).sum(-1, keepdim=True)
+    local_t1 = (pos * t1).sum(-1, keepdim=True)
+    local_t2 = (pos * t2).sum(-1, keepdim=True)
+    return torch.cat([local_n, local_t1, local_t2], dim=-1).to(dtype=input_dtype)
+
+
 class RFFEncoding(nn.Module):
     """Gaussian random Fourier feature coordinate encoding (Tancik et al. 2020).
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_local_frame_proj: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,7 +433,10 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_local_frame_proj = use_local_frame_proj
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
+        if use_local_frame_proj:
+            surface_extra_dim += 3
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
         if pos_encoding_mode == "string_multisigma":
@@ -462,6 +502,14 @@ class SurfaceTransolver(nn.Module):
         self.project_volume_features = (
             LinearProjection(volume_proj_in, n_hidden) if volume_proj_in > 0 else None
         )
+        if use_local_frame_proj and self.project_surface_features is not None:
+            # Identity-init: zero the 3 NEW input columns of project_surface_features
+            # so the model starts from the current baseline at step 0. The 3 new
+            # columns sit at indices [4, 5, 6] of the surface feature vector
+            # (after [nx, ny, nz, area] at [0, 1, 2, 3]). The bias is already
+            # zero-init via _init_linear, so no extra step is needed.
+            with torch.no_grad():
+                self.project_surface_features.project.weight[:, 4:7].zero_()
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.backbone = Transformer(
@@ -528,12 +576,15 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        local_proj: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
         feature_parts: list[torch.Tensor] = []
         if x.shape[-1] > self.space_dim:
             feature_parts.append(x[:, :, self.space_dim :])
+        if local_proj is not None:
+            feature_parts.append(local_proj)
         if string_sep is not None:
             feature_parts.append(string_sep(pos))
         elif rff is not None:
@@ -567,6 +618,9 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
+            local_proj = (
+                compute_local_frame_proj(surface_x) if self.use_local_frame_proj else None
+            )
             tokens.append(
                 self._encode_group(
                     surface_x,
@@ -575,6 +629,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    local_proj=local_proj,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_local_frame_proj: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_local_frame_proj": (
+            "Enable normal-projected coordinate augmentation (H26, PR "
+            "#1177). For each surface vertex, append 3 scalar features "
+            "[p.n, p.t1, p.t2] -- the global position projected onto the "
+            "vertex's local normal/tangent frame -- to the surface input "
+            "features before the projection linear. t1, t2 are a "
+            "Gram-Schmidt tangent basis from the surface normal. Goal: "
+            "give the encoder explicit local-frame position so it can "
+            "break the structural tau_z/tau_x band attractor at [1.44, "
+            "1.55]. The 3 new input columns of project_surface_features "
+            "are zero-init so step 0 is identical to the baseline. Volume "
+            "branch is unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +322,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_local_frame_proj=config.use_local_frame_proj,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -104,6 +104,9 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     use_local_frame_proj: bool = False
+    lambda_spectral: float = 0.0
+    spectral_hf_weight: float = 2.0
+    spectral_channels: str = "wss"
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -243,6 +246,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "are zero-init so step 0 is identical to the baseline. Volume "
             "branch is unchanged."
         ),
+        "lambda_spectral": (
+            "Streamwise-Spectral Frequency Loss weight (H29, PR #1182). "
+            "When > 0, adds a spectral-domain MSE term computed by sorting "
+            "surface tokens by streamwise z, taking rfft along the sorted "
+            "axis, and frequency-weighting the squared magnitude residual "
+            "with a linear ramp from 1.0 at DC to --spectral-hf-weight at "
+            "Nyquist. lambda_spectral=0.0 reproduces baseline exactly. "
+            "frieren's tuned default at solo H29 launch was 0.1; the H35 "
+            "stack PR specifies 0.05 to leave headroom for NPCA's "
+            "encoder-side gradient signal."
+        ),
+        "spectral_hf_weight": (
+            "Upper bound of the linear frequency-ramp used by the H29 "
+            "Streamwise-Spectral loss. 1.0 = flat (no upweighting); 2.0 = "
+            "double weight at the Nyquist bin. Only meaningful when "
+            "--lambda-spectral > 0."
+        ),
+        "spectral_channels": (
+            "Which surface output channels the H29 spectral loss is "
+            "applied to. 'all' = all 4 (cp + 3 wss); 'wss' = wall-shear "
+            "components only (tau_x, tau_y, tau_z); 'cp' = surface pressure "
+            "only. frieren's H29 tuned default = 'wss' (cp is smooth and "
+            "may destabilise)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -326,6 +353,98 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+SPECTRAL_CHANNEL_PRESETS: dict[str, tuple[bool, ...]] = {
+    "all": (True, True, True, True),
+    "wss": (False, True, True, True),
+    "cp": (True, False, False, False),
+}
+
+
+def spectral_channel_mask(spec: str, device: torch.device | None = None) -> torch.Tensor | None:
+    """Resolve the --spectral-channels string into a [4]-bool tensor.
+
+    Returns None when the preset is "all" (no masking needed).
+    """
+    key = (spec or "all").strip().lower()
+    if key not in SPECTRAL_CHANNEL_PRESETS:
+        raise ValueError(
+            f"Unknown --spectral-channels preset: {spec!r}. "
+            f"Choices: {sorted(SPECTRAL_CHANNEL_PRESETS)}"
+        )
+    flags = SPECTRAL_CHANNEL_PRESETS[key]
+    if all(flags):
+        return None
+    return torch.tensor(flags, dtype=torch.bool, device=device)
+
+
+def spectral_surface_loss(
+    pred_norm: torch.Tensor,
+    target_norm: torch.Tensor,
+    mask: torch.Tensor,
+    sort_idx: torch.Tensor,
+    lambda_spectral: float,
+    hf_weight: float,
+    channel_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Streamwise-Spectral Frequency Loss (H29 / PR #1182).
+
+    Sorts surface tokens by streamwise z (via ``sort_idx``), takes ``rfft``
+    along the sorted axis, then computes a frequency-weighted squared
+    magnitude residual with a linear ramp from 1.0 at DC to ``hf_weight``
+    at Nyquist. Optionally masked to a subset of output channels.
+
+    Always run in fp32 (FFT is precision-sensitive under bf16 autocast,
+    matching the lesson from askeladd's H27 NaN fix). ``lambda_spectral=0.0``
+    returns a connected-graph zero so DDP find_unused_parameters does not
+    trip. ``N=0`` empty-surface batches (data/loader pair-modalities edge
+    case documented in program.md) also short-circuit to zero; this is the
+    guard frieren added pre-launch on H29 to prevent ``torch.fft.rfft``
+    crashing on length-0 inputs.
+    """
+    if lambda_spectral == 0.0:
+        return pred_norm.float().sum() * 0.0
+    if pred_norm.shape[1] == 0:
+        return lambda_spectral * pred_norm.float().sum() * 0.0
+
+    pred_f = pred_norm.float()
+    tgt_f = target_norm.float()
+    mask_f = mask.float()
+
+    B, N, C = pred_f.shape
+    idx = sort_idx.unsqueeze(-1).expand(-1, -1, C)
+    pred_s = pred_f.gather(1, idx)
+    tgt_s = tgt_f.gather(1, idx)
+    msk_s = mask_f.gather(1, sort_idx).unsqueeze(-1)
+
+    # Zero padded tokens before FFT (avoid spectral leakage).
+    pred_s = pred_s * msk_s
+    tgt_s = tgt_s * msk_s
+
+    # norm='ortho' so Parseval preserves L2: mean(|X|^2) ~ MSE_spatial,
+    # independent of N. Without it, magnitude scales with N and dwarfs
+    # the spatial MSE (verified: default norm gave spec~100 vs frieren's
+    # observed [0.001, 1.0] target band at lambda=0.1, N=65536).
+    pf = torch.fft.rfft(pred_s, dim=1, norm="ortho")
+    tf = torch.fft.rfft(tgt_s, dim=1, norm="ortho")
+
+    n_bins = pf.shape[1]
+    w = torch.linspace(
+        1.0,
+        hf_weight,
+        n_bins,
+        device=pf.device,
+        dtype=pf.real.dtype,
+    ).view(1, -1, 1)
+
+    diff = pf - tf
+    sq = diff.real.square() + diff.imag.square()
+
+    if channel_mask is not None:
+        sq = sq * channel_mask.view(1, 1, -1).to(device=sq.device, dtype=sq.dtype)
+
+    return lambda_spectral * (sq * w).mean()
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -336,6 +455,9 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    lambda_spectral: float = 0.0,
+    spectral_hf_weight: float = 2.0,
+    spectral_channel_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -361,12 +483,29 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+    if lambda_spectral > 0.0:
+        # Compute spectral loss outside autocast for fp32 numerical safety.
+        sort_idx = batch.surface_x[:, :, 2].detach().argsort(dim=1).long()
+        spectral_term = spectral_surface_loss(
+            out["surface_preds"],
+            surface_target,
+            batch.surface_mask,
+            sort_idx,
+            lambda_spectral=lambda_spectral,
+            hf_weight=spectral_hf_weight,
+            channel_mask=spectral_channel_mask,
+        )
+        loss = loss + spectral_term
+        spectral_metric_value = float(spectral_term.detach().cpu().item())
+    else:
+        spectral_metric_value = 0.0
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "spectral_loss": spectral_metric_value,
     }
 
 
@@ -773,6 +912,11 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+        ssfl_channel_mask = (
+            spectral_channel_mask(config.spectral_channels, device=device)
+            if config.lambda_spectral > 0.0
+            else None
+        )
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1045,6 +1189,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        lambda_spectral=config.lambda_spectral,
+                        spectral_hf_weight=config.spectral_hf_weight,
+                        spectral_channel_mask=ssfl_channel_mask,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1085,6 +1232,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "spectral_loss" in batch_loss_metrics:
+                        train_log["train/spectral_loss"] = batch_loss_metrics["spectral_loss"]
+                if config.lambda_spectral > 0.0:
+                    train_log["train/lambda_spectral"] = float(config.lambda_spectral)
+                    train_log["train/spectral_hf_weight"] = float(config.spectral_hf_weight)
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1060,6 +1060,52 @@ def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccu
     return merged
 
 
+def _per_case_tau_zx_ratio(
+    case_sums_x: dict[str, list[float]],
+    case_sums_z: dict[str, list[float]],
+) -> dict[str, float]:
+    """Compute per-car tau_z_rel_l2 / tau_x_rel_l2 statistics for H26 diagnostics.
+
+    Iterates over case_ids common to both stores, builds per-case rel_l2 from
+    sqrt(error_sq / target_sq), and reports mean/std/min/max plus an
+    out-of-band counter for the [1.40, 1.60] band attractor probe.
+
+    Returns an empty dict if fewer than 2 common cases are usable.
+    """
+    ratios: list[float] = []
+    for case_id, (err_x, tgt_x) in case_sums_x.items():
+        state_z = case_sums_z.get(case_id)
+        if state_z is None:
+            continue
+        err_z, tgt_z = state_z
+        if tgt_x <= 0.0 or tgt_z <= 0.0:
+            continue
+        tau_x = math.sqrt(err_x / tgt_x)
+        tau_z = math.sqrt(err_z / tgt_z)
+        if tau_x <= 0.0:
+            continue
+        ratios.append(tau_z / tau_x)
+    if not ratios:
+        return {}
+    n = len(ratios)
+    mean_r = sum(ratios) / n
+    if n > 1:
+        var_r = sum((r - mean_r) ** 2 for r in ratios) / (n - 1)
+        std_r = math.sqrt(var_r)
+    else:
+        std_r = 0.0
+    return {
+        "tau_zx_ratio_mean": float(mean_r),
+        "tau_zx_ratio_std": float(std_r),
+        "tau_zx_ratio_min": float(min(ratios)),
+        "tau_zx_ratio_max": float(max(ratios)),
+        "tau_zx_ratio_n_outside_band": float(
+            sum(1 for r in ratios if r < 1.40 or r > 1.60)
+        ),
+        "tau_zx_ratio_n_cases": float(n),
+    }
+
+
 def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     surface_pressure_rel_l2, surface_cases = _rel_l2(accumulator.case_sums["surface_pressure"])
     wall_shear_rel_l2, wall_shear_cases = _rel_l2(accumulator.case_sums["wall_shear"])
@@ -1067,6 +1113,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    tau_zx_metrics = _per_case_tau_zx_ratio(
+        accumulator.case_sums["wall_shear_x"],
+        accumulator.case_sums["wall_shear_z"],
+    )
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1114,6 +1164,7 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
         "surface_cases": surface_cases,
         "volume_cases": volume_cases,
+        **tau_zx_metrics,
     }
 
 


### PR DESCRIPTION
## Hypothesis

**H56 H51-RELAUNCH-EMA-AWARE-GATES**: Identical hypothesis as H51 (PR #1199 closed as recipe-bug closure) — **NPCA + SSFL + slices=192 + ema=0.9999** stack — relaunched with **EMA-aware kill gates** that account for δ^step contamination math.

H51 was killed at mid-EP4 step 38,027 by a too-tight EP3-equivalent gate (`<10%`) under ema=0.9999. The trained model was healthy (train/epoch_loss matched H35 reference 10× per epoch), the variance-class mechanism was activating (τz/τx std doubled EP2→EP4 from 0.073 → 0.117 — fern's empirical observation), and was on track to enter H35's variance-class regime (target std 0.15-0.20 at EP6 → 0.25 at EP13). **The kill was an advisor recipe-bug, not a mechanism rejection.**

This relaunch isolates the dual hypothesis arms (slices=128→192 capacity expansion + ema=0.999→0.9999 EMA precision) under properly calibrated gates so we can actually observe the EP6+ informative readings.

## Why the gates were wrong on H51

`δ^step` (EMA-shadow contamination) drops slowly under ema=0.9999. At end-of-epoch boundaries (steps_per_epoch=10,864):

| Step | EP | δ^step | EMA random% | Inflated val_abupt (if trained=7%) |
|---:|---:|---:|---:|---:|
| 10,864 | 1 | 0.337 | 33.7% | ~50%+ inflated |
| 21,728 | 2 | 0.115 | 11.5% | ~25% inflated |
| **32,592** | **3** | **0.039** | **3.9%** | **~14-15%** ← H51 EMA-val landed here |
| **43,456** | **4** | **0.013** | **1.3%** | **~9-10%** |
| **65,184** | **6** | **0.0015** | **0.15%** | **~7%** ← first FULLY informative |
| 141,232 | 13 | < 1e-6 | ~0 | terminal-clean |

**H51 EP3 EMA-val 23.64% was consistent with trained-val ~12% + EMA-shadow contamination 3.9%.** The trained-val itself was on track for the H35 reference shape. The gate `<10%` at EP3 thus required the EMA-shadow to be cleaner than it physically could be under ema=0.9999.

## Instructions — relaunch H51 recipe with EMA-aware kill gates ONLY

Use the exact same recipe as H51 v3 (the one that ran). Only the kill thresholds change.

### Single-arm reproduce command (DDP8, 18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
    --lion-beta1 0.9 --lion-beta2 0.99 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 192 --model-mlp-ratio 4 \
    --use-surf-to-vol-xattn --use-ema --ema-decay 0.9999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
    --batch-size 4 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --use-local-frame-proj \
    --lambda-spectral 0.05 --spectral-hf-weight 2.0 \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
    --no-compile-model --validation-every 1 --amp-mode bf16 \
    --wandb-group wave31_h56_h51_relaunch \
    --wandb-name fern/h56-h51-relaunch-ema-aware-gates --agent fern \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<25.0,43456:val_primary/abupt_axis_mean_rel_l2_pct<15.0,65184:val_primary/abupt_axis_mean_rel_l2_pct<7.0,65184:val_primary/surface_pressure_rel_l2_pct<5.0"
```

### Key changes from H51 v3 command

| Item | H51 v3 (killed) | H56 (this relaunch) |
|---|---|---|
| `--kill-thresholds` EP3 gate | `32594:val_abupt<10.0` | `32592:val_abupt<25.0` (catastrophic-only catch) |
| EP3 SP gate | `32594:val_SP<6.0` | dropped (folds into EP6 binding) |
| EP4 gate | (none) | `43456:val_abupt<15.0` (NEW intermediate catch) |
| EP6 gate | `65228:val_abupt<7.0;65228:val_SP<5.0` | `65184:val_abupt<7.0;65184:val_SP<5.0` (corrected step, binding) |
| step values | 32,594 / 65,228 (off by +2 / +44) | **32,592 / 43,456 / 65,184 (exact epoch × steps_per_epoch)** |
| wandb group | `wave31_h51_npca_ssfl_slices192` | `wave31_h56_h51_relaunch` |

### Step-value math (for your verification)

- steps_per_epoch = 10,864 (verified empirically on H51 run via fern's check-ins)
- EP3 end = 3 × 10,864 = **32,592**
- EP4 end = 4 × 10,864 = **43,456**
- EP6 end = 6 × 10,864 = **65,184**

Earlier recipes were using 32,594 / 65,228 — these were copy-paste artifacts from a config with different batch_size/grad_accum. Memory entry `feedback_kill_thresholds_step_indexed.md` has been corrected to reflect this empirical finding.

### Mid-epoch validation note

H51 hit a mid-EP4 mini-validation at step 38,027 (between EP3 end 32,592 and EP4 end 43,456). Under `--validation-every 1`, mini-validations DO fire mid-epoch. The new EP4 gate at 43,456 is positioned so it fires AT end-of-EP4 validation (not earlier). The EP3 gate at 32,592 will fire at end-of-EP3 OR at the first mid-EP4 mini-validation, whichever happens first — but the relaxed <25% threshold accommodates EMA-shadow contamination at both.

### Mechanism diagnostics to log

In your check-in comments, report per-epoch:

- **τz/τx mean, std, n_outside_band** (the variance-class signal). H51 reached std 0.117 at mid-EP4 — H56 should continue past this to std 0.15-0.20 by EP6 and toward H35's fleet-peak 0.251 at EP13.
- **EMA-val vs train-loss separation**: at EP3 / EP4 / EP6, log EMA-val_abupt AND train/epoch_loss together so we can detect EMA-shadow lag explicitly.
- **Mean trajectory**: did mean recover from the 1.26 trough back to band-edge 1.44? H51 was climbing toward this — H56 EP6 read tells us if it stabilizes inside the band [1.44, 1.55].

### EP6 binding gate (kill if missed)

`65184:val_primary/abupt_axis_mean_rel_l2_pct<7.0` and `65184:val_primary/surface_pressure_rel_l2_pct<5.0`. At EP6 with δ^step=0.0015 (EMA-shadow ~0.15% contamination), the EMA-val is essentially clean — if val_abupt at step 65,184 is ≥ 7.0%, the stack is genuinely not working and we should not waste the remaining 7 epochs. EP6 is the first epoch where the gate measures true model quality, not EMA-shadow lag.

### Recipe-bug audit checklist (pre-flight before running)

- ✅ All flags verified to exist in current train.py argparse:
  - `--use-local-frame-proj` (hyphen form, not underscore)
  - `--lambda-spectral` (no `--use-spectral-loss` — spectral loss enabled implicitly by nonzero lambda)
  - `--rff-num-features`, `--rff-init-sigmas`, `--model-slices`, `--ema-decay`, `--ema-start-step`, `--use-surf-to-vol-xattn`, `--vol-points-schedule`, `--use-qk-norm`
- ✅ Kill-threshold step values are exact `epoch × 10864` (no copy-paste +2 / +44 offsets)
- ✅ EP3 / EP4 thresholds are EMA-shadow-aware (δ^step compositioned values)
- ✅ EP6 binding gate is at first fully-informative checkpoint (δ < 0.002)

## Baseline (PR #972, run `56bcqp3m`)

| Metric | Baseline | Floor | Direction |
|---|---:|---:|---|
| **val_primary/abupt** | **6.126%** | — | minimize, **merge gate** |
| val_VP (vol_p) | 3.643% | 3.643% | floor (rel L2) |
| val_SP (surface_p) | 3.577% | 3.577% | floor (rel L2) |
| val_WSS | 6.727% | — | minimize |
| **test_primary/abupt** | **5.844%** | — | minimize |
| test_VP | 3.643% | — | floor |
| test_SP | 3.577% | — | floor |
| test_WSS | 6.727% | — | **goal: <5.85%** |

**Merge gate**: single-model `val_primary/abupt < 6.126%` AND `test_vol_p ≤ 3.643%` AND `test_SP ≤ 3.577%`.

**Cross-experiment references**:
- **H35 NPCA+SSFL** (PR #1189, merged earlier in Wave 31) — variance-class fleet peak std 0.251 at EP13, val_abupt 6.298% terminal.
- **H51 v3** (PR #1199, closed) — same recipe + slices=192 + ema=0.9999, killed at mid-EP4 by recipe-bug. std doubled EP2→EP4 (0.073 → 0.117), mean climbing back to band-edge 1.34. Trajectory consistent with variance-class expansion.
- **H47 V-DEPTH** (nezuko PR #1194, in-flight merge candidate) — EP6 val_abupt 6.357%, projected 6.10-6.15% at terminal. Mechanism orthogonal to H56 (volume decoder sublayer growth vs variance-class encoder).

## Terminal SENPAI-RESULT format

When you reach EP13 terminal (or budget cutoff), post a SENPAI-RESULT marker with concrete numeric placeholders (no angle-brackets — those break the mark_ready_for_review JSON parse guard, both alphonse and edward independently flagged this 2026-05-19). Include:

- val_abupt, val_VP, val_SP, val_WSS, per-axis WSS (x/y/z)
- test_abupt, test_VP, test_SP, test_WSS at best EMA checkpoint
- Mechanism trajectory: per-epoch τz/τx mean, std, n_outside_band
- W&B run ID

If you hit EP6 binding gate without crossing — kill triggers, full mechanism table at point of kill, no test eval needed (we won't merge under those conditions).

If you reach EP13 with val_abupt < 6.126% AND test floors held — merge candidate.
