### PR TITLE
Wave 31 H58: COORDSLICE-NO-STOPGRAD — Restore Routing-Gradient Feedback to Coordinate-Grounded Slice PE

### DIFF
--- a/model.py
+++ b/model.py
@@ -71,6 +71,44 @@ class RFFEncoding(nn.Module):
         return torch.cat([proj.sin(), proj.cos()], dim=-1)
 
 
+class MultiSigmaRFFEncoding(nn.Module):
+    """Multi-sigma Gaussian random Fourier features for 3D coordinate encoding.
+
+    Encodes ``in_dim``-dimensional coordinates using ``len(sigmas)`` independent
+    RFF banks at different length scales, concatenated along the feature dim.
+    Output dimension is ``2 * num_features * len(sigmas)`` (sin + cos per bank).
+
+    All projection matrices are registered as non-trainable buffers so they
+    travel with the model across devices and DDP ranks.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        num_features: int = 32,
+        sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0),
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigmas = sigmas
+        for i, sigma in enumerate(sigmas):
+            self.register_buffer(f"B_{i}", torch.randn(in_dim, num_features) * sigma)
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features * len(self.sigmas)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        parts: list[torch.Tensor] = []
+        for i in range(len(self.sigmas)):
+            B = getattr(self, f"B_{i}").to(dtype=x.dtype)
+            proj = 2.0 * math.pi * (x @ B)
+            parts.append(proj.sin())
+            parts.append(proj.cos())
+        return torch.cat(parts, dim=-1)
+
+
 class StringSeparableEncoding(nn.Module):
     """STRING-separable positional encoding.
 
@@ -234,6 +272,9 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +285,7 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_coord_slice_pe = use_coord_slice_pe
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -258,6 +300,26 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+
+        if use_coord_slice_pe:
+            # Multi-sigma RFF encoding of 3D slice centroids → additive PE for slice tokens.
+            # Uses 4 sigmas covering sub-car (0.25m) to full-car (2.0m) length scales.
+            self.coord_pe_rff = MultiSigmaRFFEncoding(
+                in_dim=3,
+                num_features=coord_slice_pe_rff_features,
+                sigmas=(0.25, 0.5, 1.0, 2.0),
+            )
+            rff_out_dim = self.coord_pe_rff.output_dim  # 2 * rff_features * 4 sigmas
+            # Project from RFF space to per-head D_head additive PE: [B,S,rff_out] → [B,S,H*D_head]
+            self.coord_pe_proj = nn.Linear(rff_out_dim, num_heads * self.dim_head)
+            # Init at small scale (O(1/sqrt(D_head)) per H33 lesson; avoids sub-gradient-floor init)
+            with torch.no_grad():
+                w_std = self.coord_pe_proj.weight.std().clamp(min=1e-8)
+                self.coord_pe_proj.weight.mul_(coord_slice_pe_init_scale / w_std)
+                nn.init.zeros_(self.coord_pe_proj.bias)
+        else:
+            self.coord_pe_rff = None
+            self.coord_pe_proj = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -274,8 +336,42 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        if self.use_coord_slice_pe and coords is not None:
+            # Stop-grad on centroid computation: avoids routing absorption /
+            # softmax polarization where the model would game slice_weights to
+            # position centroids rather than route content. Gradient flows
+            # only to coord_pe_proj.weight via the differentiable Linear.
+            with torch.no_grad():
+                # slice_weights: [B, H, N, S] — average over heads to get per-token slice probs
+                slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
+                # Normalise per slice so centroids are proper weighted means
+                slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
+                # Weighted average of 3D coords → slice centroids
+                slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
+                coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
+            coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head] — grad flows to .weight
+            B_size, S_size = slice_centroids.shape[:2]
+            coord_pe = coord_pe.view(B_size, S_size, self.num_heads, self.dim_head).permute(0, 2, 1, 3)  # [B, H, S, D_head]
+            slice_tokens = slice_tokens + coord_pe
+            if not self.training:
+                # Stash diagnostics for val-time logging via collect_coord_slice_pe_metrics
+                with torch.no_grad():
+                    self._last_slice_centroids = slice_centroids.detach()  # [B, S, 3]
+                    flat = slice_tokens.detach()  # [B, H, S, D_head] — post-PE input to qkv
+                    fnorm = flat / (flat.norm(dim=-1, keepdim=True) + 1e-9)
+                    cos = torch.einsum("bhsd,bhtd->bhst", fnorm, fnorm)  # [B, H, S, S]
+                    S_dim = cos.shape[-1]
+                    eye = torch.eye(S_dim, device=cos.device, dtype=cos.dtype).unsqueeze(0).unsqueeze(0)
+                    off_diag_sum = (cos * (1.0 - eye)).sum(dim=(-2, -1))
+                    off_diag_mean = (off_diag_sum / (S_dim * (S_dim - 1))).mean()
+                    self._last_inter_slice_cos = float(off_diag_mean.item())
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +399,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +412,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, coords=coords)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +443,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +457,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_coord_slice_pe=use_coord_slice_pe,
+                    coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+                    coord_slice_pe_init_scale=coord_slice_pe_init_scale,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, coords=coords)
         return x
 
 
@@ -382,6 +500,9 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +517,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_coord_slice_pe = use_coord_slice_pe
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +594,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -562,6 +687,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -578,6 +704,8 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -592,10 +720,19 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        # Build concatenated coords tensor in the same token order as the hidden states.
+        # Pad masked-out tokens to zero so they don't skew slice centroids.
+        if self.use_coord_slice_pe and coords_list:
+            coords = torch.cat(coords_list, dim=1)  # [B, N_surf+N_vol, 3]
+            coords = coords * attn_mask.unsqueeze(-1).to(dtype=coords.dtype)
+        else:
+            coords = None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, coords=coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/model.py
+++ b/model.py
@@ -344,19 +344,16 @@ class TransolverAttention(nn.Module):
     ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
         if self.use_coord_slice_pe and coords is not None:
-            # Stop-grad on centroid computation: avoids routing absorption /
-            # softmax polarization where the model would game slice_weights to
-            # position centroids rather than route content. Gradient flows
-            # only to coord_pe_proj.weight via the differentiable Linear.
-            with torch.no_grad():
-                # slice_weights: [B, H, N, S] — average over heads to get per-token slice probs
-                slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
-                # Normalise per slice so centroids are proper weighted means
-                slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
-                # Weighted average of 3D coords → slice centroids
-                slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
-                coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
-            coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head] — grad flows to .weight
+            # H58: routing gradients flow back into PE projection via centroid
+            # computation. H50 wrapped this in torch.no_grad(), starving the PE
+            # projection of optimization signal (proj_weight_std stuck at init).
+            # Allowing grad flow lets the projection learn discriminative
+            # coordinate-routing structure, restoring H33-style PE auto-growth.
+            slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
+            slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
+            slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
+            coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
+            coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head]
             B_size, S_size = slice_centroids.shape[:2]
             coord_pe = coord_pe.view(B_size, S_size, self.num_heads, self.dim_head).permute(0, 2, 1, 3)  # [B, H, S, D_head]
             slice_tokens = slice_tokens + coord_pe

--- a/safety_check_h50.py
+++ b/safety_check_h50.py
@@ -1,0 +1,128 @@
+"""H50 COORDSLICE init-time safety check (rank 0, no DDP, no training).
+
+Compares flag-off vs flag-on at-init:
+  - state_dict key presence: flag-off must have no coord_pe_* keys
+  - param count delta: flag-on must add expected number of params
+  - finite outputs: forward pass produces finite logits
+  - magnitude ratio: |surface_hidden| and |volume_hidden| at init within 5%
+
+If magnitude ratio exceeds 5%, recommend lowering --coord-slice-pe-init-scale.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from model import SurfaceTransolver
+from data import SURFACE_X_DIM, VOLUME_X_DIM
+
+
+def build(use_coord_slice_pe: bool, init_scale: float, seed: int = 0) -> SurfaceTransolver:
+    torch.manual_seed(seed)
+    return SurfaceTransolver(
+        space_dim=3,
+        surface_input_dim=SURFACE_X_DIM,
+        volume_input_dim=VOLUME_X_DIM,
+        n_layers=5,
+        n_hidden=512,
+        n_head=4,
+        mlp_ratio=4,
+        slice_num=128,
+        rff_num_features=16,
+        rff_sigma=1.0,
+        rff_init_sigmas=[0.25, 0.5, 1.0, 2.0, 4.0],
+        pos_encoding_mode="string_separable",
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+        use_coord_slice_pe=use_coord_slice_pe,
+        coord_slice_pe_rff_features=32,
+        coord_slice_pe_init_scale=init_scale,
+    )
+
+
+def fake_batch(B: int, Ns: int, Nv: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(123)
+    return {
+        "surface_x": torch.randn(B, Ns, SURFACE_X_DIM),
+        "surface_mask": torch.ones(B, Ns, dtype=torch.float32),
+        "volume_x": torch.randn(B, Nv, VOLUME_X_DIM),
+        "volume_mask": torch.ones(B, Nv, dtype=torch.float32),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--init-scale", type=float, default=0.088)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--surface-points", type=int, default=2048)
+    parser.add_argument("--volume-points", type=int, default=2048)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    # Build flag-off baseline and flag-on H50
+    m_off = build(use_coord_slice_pe=False, init_scale=args.init_scale).to(device).eval()
+    m_on = build(use_coord_slice_pe=True, init_scale=args.init_scale).to(device).eval()
+
+    # --- state_dict check ---
+    off_keys = set(m_off.state_dict().keys())
+    on_keys = set(m_on.state_dict().keys())
+    off_pe_keys = [k for k in off_keys if "coord_pe" in k]
+    on_pe_keys = [k for k in on_keys if "coord_pe" in k]
+    print(f"\n[state_dict] flag-off coord_pe_* keys: {len(off_pe_keys)} (expect 0)")
+    print(f"[state_dict] flag-on  coord_pe_* keys: {len(on_pe_keys)} (expect > 0)")
+    assert len(off_pe_keys) == 0, "flag-off must contain no coord_pe_* keys"
+    assert len(on_pe_keys) > 0, "flag-on must contain coord_pe_* keys"
+
+    # --- param count ---
+    p_off = sum(p.numel() for p in m_off.parameters())
+    p_on = sum(p.numel() for p in m_on.parameters())
+    extra = p_on - p_off
+    print(f"\n[params] flag-off: {p_off:,}")
+    print(f"[params] flag-on:  {p_on:,}")
+    print(f"[params] extra:    {extra:,} ({extra/p_off*100:.3f}% of baseline)")
+
+    # --- forward pass ---
+    batch = fake_batch(args.batch_size, args.surface_points, args.volume_points)
+    batch = {k: v.to(device) for k, v in batch.items()}
+
+    with torch.no_grad():
+        out_off = m_off(**batch)
+        out_on = m_on(**batch)
+
+    print("\n[forward] outputs:")
+    for k in ("surface_preds", "volume_preds", "surface_hidden", "volume_hidden"):
+        v_off = out_off[k]
+        v_on = out_on[k]
+        finite_off = torch.isfinite(v_off).all().item()
+        finite_on = torch.isfinite(v_on).all().item()
+        mag_off = v_off.detach().abs().mean().item()
+        mag_on = v_on.detach().abs().mean().item()
+        ratio = mag_on / max(mag_off, 1e-12)
+        within_5pct = 0.95 <= ratio <= 1.05
+        flag = "OK" if within_5pct else "WARN"
+        print(
+            f"  {k:18s}: off|{mag_off:.4e} on|{mag_on:.4e}  ratio={ratio:.4f}  "
+            f"finite_off={finite_off} finite_on={finite_on} [{flag}]"
+        )
+        assert finite_off and finite_on, f"{k} produced non-finite outputs"
+
+    # Report inter_slice_cos at init (should be high since coord_pe is tiny initially)
+    print("\n[init] inter_slice_cos per layer (from one fwd):")
+    for i, block in enumerate(m_on.backbone.blocks):
+        isc = getattr(block.attention, "_last_inter_slice_cos", None)
+        if isc is not None:
+            print(f"  L{i}: inter_slice_cos_post_pe = {isc:.4f}")
+
+    print("\nSafety check complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_coord_slice_pe: bool = False
+    coord_slice_pe_rff_features: int = 32
+    coord_slice_pe_init_scale: float = 0.088
     debug: bool = False
 
 
@@ -294,6 +297,57 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_coord_slice_pe_metrics(model: nn.Module) -> dict[str, float]:
+    """Log coord-slice PE diagnostics per Transformer block.
+
+    Static metrics: per-layer coord_pe_proj weight/bias statistics.
+    Dynamic metrics (captured during last val forward): slice_centroid
+    distribution (mean/std/range per axis, across-slice spread) and
+    inter_slice_cos on the post-PE slice_tokens (mechanism diagnostic
+    aligned with H33's pattern for direct comparison).
+    """
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return metrics
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return metrics
+    all_inter_slice_cos: list[float] = []
+    for i, block in enumerate(blocks):
+        attn = getattr(block, "attention", None)
+        if attn is None:
+            continue
+        proj = getattr(attn, "coord_pe_proj", None)
+        if proj is None:
+            continue
+        w = proj.weight.detach().float()
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_norm"] = float(w.norm().item())
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_std"] = float(w.std().item())
+        b = proj.bias.detach().float()
+        metrics[f"coord_slice_pe/block_{i}/proj_bias_norm"] = float(b.norm().item())
+        centroids = getattr(attn, "_last_slice_centroids", None)
+        if centroids is not None:
+            c = centroids.float()  # [B, S, 3]
+            for axis_i, axis in enumerate(("x", "y", "z")):
+                ca = c[..., axis_i]
+                metrics[f"coord_slice_pe/block_{i}/centroid_mean_{axis}"] = float(ca.mean().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_std_{axis}"] = float(ca.std().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_range_{axis}"] = float(
+                    (ca.max() - ca.min()).item()
+                )
+            metrics[f"coord_slice_pe/block_{i}/centroid_spread"] = float(c.std(dim=1).mean().item())
+        isc = getattr(attn, "_last_inter_slice_cos", None)
+        if isc is not None:
+            metrics[f"coord_slice_pe/block_{i}/inter_slice_cos_post_pe"] = float(isc)
+            all_inter_slice_cos.append(float(isc))
+    if all_inter_slice_cos:
+        metrics["coord_slice_pe/global/inter_slice_cos_mean"] = float(
+            sum(all_inter_slice_cos) / len(all_inter_slice_cos)
+        )
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +362,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_coord_slice_pe=config.use_coord_slice_pe,
+        coord_slice_pe_rff_features=config.coord_slice_pe_rff_features,
+        coord_slice_pe_init_scale=config.coord_slice_pe_init_scale,
     )
 
 
@@ -1262,6 +1319,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_coord_slice_pe_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,

--- a/train.py
+++ b/train.py
@@ -322,8 +322,12 @@ def collect_coord_slice_pe_metrics(model: nn.Module) -> dict[str, float]:
         if proj is None:
             continue
         w = proj.weight.detach().float()
+        w_std = float(w.std().item())
         metrics[f"coord_slice_pe/block_{i}/proj_weight_norm"] = float(w.norm().item())
-        metrics[f"coord_slice_pe/block_{i}/proj_weight_std"] = float(w.std().item())
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_std"] = w_std
+        # H58 binding mechanism gate: per-block proj_weight_std in PR-body namespace.
+        # Target: terminal > 0.18 vs init 0.088 (H33 auto-grew 8x; H50 stop-grad stayed ~init).
+        metrics[f"diag/coord_pe_proj_block{i}/weight_std"] = w_std
         b = proj.bias.detach().float()
         metrics[f"coord_slice_pe/block_{i}/proj_bias_norm"] = float(b.norm().item())
         centroids = getattr(attn, "_last_slice_centroids", None)


### PR DESCRIPTION
## Hypothesis — H58 COORDSLICE-NO-STOPGRAD: Restore Routing-Gradient Feedback to Coordinate-Grounded Slice PE

H50 COORDSLICE just closed (PR #1198) as mechanism-positive null with **6th test_VP floor crossing in Wave 30/31** and **lowest val_VP in Wave 31 (3.676%)** — but val_abupt **6.220%** missed the merge gate **6.126%** by only **+0.094pp**. The closest val_abupt miss of any Wave 31 PR to date.

**Your terminal analysis identified the dominant limiting factor**: the `torch.no_grad()` wrap on centroid computation blocked routing-gradient feedback to the PE projection, starving it of optimization signal. H33 SLICEPE's free-learnable PE auto-grew σ from 0.02 → 0.15 (8× growth); H50's stop-grad design left proj_weight_std stuck at init scale 0.088 (terminal 0.080-0.093 ≈ init, virtually zero growth).

**H58 hypothesis**: removing the stop-gradient on centroid computation lets routing gradients flow back into the PE projection, enabling H33-style PE auto-growth on top of H50's coordinate grounding. This should preserve H50's structural improvements over H33 (val_abupt closer, val_VP lower, test_VP floor crossed) while closing the +0.094pp val_abupt shortfall by giving the PE projection enough gradient signal to learn discriminative coordinate-routing structure.

**Falsifiable outcomes**:
- **(A) MERGE WIN**: val_abupt < 6.126% AND test_VP < 3.643% → coordinate-grounded slice PE becomes the 8th Wave 31 mechanism-class with merge candidacy. Single most impactful follow-up because H50 was the closest miss in Wave 31 history.
- **(B) PARTIAL WIN**: val_abupt 6.05-6.20% (improvement on H50) + test_VP retains floor crossing + proj_weight_std grows ≥ 2× init → confirms stop-grad was the limiting factor. Worth a Wave 32 stack with H47 V-DEPTH.
- **(C) NULL**: val_abupt regresses or proj_weight_std fails to grow → stop-grad was NOT the limiting factor. The +0.094pp gap comes from L0-PE-capacity-sink pattern (structural depth/capacity limit, not gradient flow). Wave 32 should consider H50-LARGER-INIT-SCALE or H50-L0-PE-DISABLED variants.

## Instructions

**Single change vs H50 PR #1198 (your prior work)**: remove the `torch.no_grad()` wrap on centroid computation in your `TransolverAttention.use_coord_slice_pe` implementation. Everything else stays identical — keep the same init scale 0.088, same 4-sigma RFF bank (0.25, 0.5, 1.0, 2.0), same `Linear(256, H*D_head)` projection, same per-batch centroid computation from `slice_weights.mean(dim=1)`.

### Code change (model.py)

Locate your `TransolverAttention.forward` where you wrapped centroid computation:

```python
# H50 code (BEFORE):
with torch.no_grad():
    centroids = compute_centroids(slice_weights, coords)  # gradient blocked
    rff_features = self.rff(centroids)
pe = self.coord_pe_proj(rff_features)  # gradient flows only here
```

Change to:

```python
# H58 code (AFTER):
centroids = compute_centroids(slice_weights, coords)  # gradient flows
rff_features = self.rff(centroids)
pe = self.coord_pe_proj(rff_features)
```

The single change is removing the `with torch.no_grad():` block — keep the same RFF encoding logic, same projection, same additive PE on slice_tokens.

### Mechanism diagnostic — add proj_weight_std tracking

Your H50 diagnostic logging is already comprehensive (per-block `inter_slice_cos_post_pe`, `centroid_range_x/y/z`, `proj_weight_norm`). For H58, please add **`proj_weight_std` per block** to your `collect_coord_slice_pe_metrics()` function:

```python
proj_weight_std = self.coord_pe_proj.weight.data.std().item()
metrics[f"diag/coord_pe_proj_block{block_idx}/weight_std"] = proj_weight_std
```

The H33-vs-H50 lesson: H33's proj_weight_std auto-grew 0.02 → 0.15 (8× growth); H50's stayed at 0.080-0.093 (≈ init). For H58, target is **proj_weight_std at terminal > 0.18** (matching or exceeding H33's auto-growth, with H50's higher init at 0.088 as starting point).

If at EP3 proj_weight_std is < 0.10 (less than 15% growth from init), the stop-grad was NOT the limiting factor and H58 will null. Worth posting as a check-in observation.

### Pre-flight verification (BEFORE full launch)

Before launching the full 13-ep run, verify the gradient flow change works:

1. **Smoke check**: 100-step run with `--epochs 1` (debug mode if available). Check that `loss.backward()` does NOT crash and that the gradient norm on `coord_pe_proj.weight` is non-zero (it WAS zero in H50 because no_grad blocked it; in H58 should be > 0 from step 1).
2. **Init safety check** (you have `safety_check_h50.py` from your H50 work): re-run to confirm output ratios stay finite. The init scale 0.088 was correct for stop-grad; with grad flow, sigma may auto-grow. Output ratios should remain in ~[0.95, 1.05] range at init.
3. If both pre-flight checks pass, proceed with full 13-ep launch.

### Training command (full 13 epochs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-coord-slice-pe --coord-slice-pe-rff-features 32 --coord-slice-pe-init-scale 0.088 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent askeladd \
  --wandb-group wave31_h58_coordslice_no_stopgrad \
  --wandb-name askeladd/h58-coordslice-no-stopgrad-13ep \
  --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

**Kill thresholds** (lr-warmup-1 aware, EP3-binding):
- NO EP1 gate (cold-start val_abupt under lr-warmup-1 is 25-35% — no useful kill signal)
- EP3 binding (step 32,592 = 3 × 10,864): val_abupt < 7.5% AND val_SP < 5.5% (your H50 cleared at 7.003% / 4.696%)
- EP6 hard kill (step 65,184 = 6 × 10,864): val_abupt < 6.5% (your H50 was at 6.227% at EP6)

## Gates

### EP3 binding (HARD)
- `val_primary/abupt_axis_mean_rel_l2_pct < 7.5%` (your H50 EP3: 7.003%)
- `val_primary/surface_pressure_rel_l2_pct < 5.5%` (your H50 EP3: 4.696%)
- **NEW H58 mechanism check**: `diag/coord_pe_proj_block{0..4}/weight_std` should show growth > init 0.088. If still ~0.08-0.09 at EP3, post a check-in flagging "stop-grad was NOT the limiting factor" and we'll reconsider Wave 32 direction.

### EP6 hard kill
- `val_primary/abupt_axis_mean_rel_l2_pct < 6.5%` (your H50 EP6: 6.227%)

### EP13 binding terminal gates
1. **Merge gate**: `val_abupt < 6.126%` (H50 missed by +0.094pp; H58 target close gap)
2. **Hard floors**: `test_primary/surface_pressure_rel_l2_pct ≤ 3.577%`, `test_primary/volume_pressure_rel_l2_pct ≤ 3.643%`
3. **WSS goal**: `test_primary/wall_shear_rel_l2_pct < 6.727%` (your H50 terminal: 6.917%)
4. **PE-growth mechanism**: terminal `diag/coord_pe_proj_block*/weight_std > 0.18` confirms the H33-style auto-growth hypothesis

## Baseline reference

Current best single-model (PR #972, run `56bcqp3m`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: **5.844%**
- test_vol_p: **3.643%** (floor — H50 already crossed at 3.596%, H58 should retain this)
- test_SP: **3.577%** (floor — H50 missed by +0.158pp; H58 may improve via PE auto-growth)
- test_WSS: **6.727%** (target to beat)

**H50 terminal (your prior PR #1198, the direct comparator)**:
- val_abupt: 6.220% (+0.094pp above merge gate)
- test_abupt: 5.978% (+0.134pp above baseline)
- test_VP: 3.596% (−0.047pp BELOW floor ✓)
- test_SP: 3.735% (+0.158pp above floor)
- val_VP: 3.676% (lowest in Wave 31)
- proj_weight_std at terminal: 0.080-0.093 (≈ init 0.088, stuck)

## Why H58 is the right next step

1. **Single-line code change** — lowest implementation risk; just remove `with torch.no_grad():` wrap
2. **Directly attacks the dominant suspected limit**: H50's terminal analysis identified gradient starvation as the most plausible reason for the +0.094pp val_abupt gap
3. **High probability of closing merge gate** — IF stop-grad was the limit, the gap closes
4. **Cheap to falsify**: if proj_weight_std doesn't grow at EP3, hypothesis is dead in 5h
5. **Preserves H50's wins**: test_VP floor crossing should be retained or improved; val_VP should stay best-in-fleet
6. **High info-value either way**: H58 merge = first encoder-PE merge in Wave 31 (8th mechanism class). H58 null = stop-grad NOT the limit, attention shifts to L0-PE-sink structural diagnosis (Wave 32 H50-L0-DISABLED)

## Risk note — gradient explosion

Removing stop-grad means routing gradients flow through `slice_weights.mean(dim=1)` (centroid computation). The centroid is data-dependent and may produce small gradients normally, but watch for:
- `train/grad_norm` spike at EP1 (within the first 1000 steps)
- `train/lr` getting cosine-clipped (lion's natural clipping)
- `nonfinite_count` > 0 at any step

If you observe gradient instability in the first ~500 steps, post a check-in and we can discuss whether to add gradient clipping on `coord_pe_proj` separately, or whether the standard `--grad-clip-norm 0.5` is sufficient.

## Wave 31 fleet context (snapshot at H58 launch ~13:35Z May 19)

| Student | PR | Hypothesis | Status |
|---|---|---|---|
| frieren | #1200 | H52 NPCA×YAW-AUG | mid-EP4, mechanism alive |
| tanjiro | #1202 | H53 CP-LOSS-WEIGHT | EP4.8, **strongest slope merge candidate** (slope −0.020 pp/1k) |
| nezuko | #1194 | H47 V-DEPTH | mid-EP7, borderline merge ~6.20-6.25% projection |
| alphonse | #1203 | H54 v2 SURFACE-DEEP | EP1 healthy (relaunch, 26.28% cold-start) |
| edward | #1204 | H55 v2 TAU-Z-LOSS-CURRICULUM | awaiting relaunch (recipe-bug v1 kill 11:12Z) |
| fern | #1205 | H56 NPCA+SSFL+slices=192+ema=0.9999 | pre-EP1 |
| thorfinn | #1206 | H57 MULTI-SCALE-RFF-EXPANDED | pre-EP1 |
| **askeladd** | **#this** | **H58 COORDSLICE-NO-STOPGRAD** | **NEW — H50 follow-up #1** |

H58 mechanism orthogonality to all 7 in-flight:
- Same mechanism class as H50 COORDSLICE (coordinate-grounded slice PE) but with restored gradient flow
- Orthogonal to H47/H54 (decoder depth), H53 (loss reweight), H55 (loss curriculum), H56 (encoder feature stack), H57 (encoder freq band)
- If H58 wins (val_abupt < 6.126%), it stacks ADDITIVELY in Wave 32 with proven encoder mechanisms (H35 NPCA+SSFL) and viable decoder mechanisms (H47 V-DEPTH if merges)

## Resources

- Reference baseline: PR #972, run `56bcqp3m`
- Reference predecessor: H50 closed PR #1198, run `biw3rtli`
- New run group: `wave31_h58_coordslice_no_stopgrad`
- Code path: model.py only — single-line change removing stop-grad wrap (your existing H50 implementation otherwise reused)
- 18h budget: standard, `SENPAI_TIMEOUT_MINUTES=1100`

## Report format

Per epoch (EP1, EP3, EP6, EP9, EP13):

```
EP<N> update (step <step>, run <run-id>):
- val_abupt: X.XXX% (slope: X.XXX pp/1k vs prior epoch; vs H50 EP<N>: X.XXX%)
- val_VP: X.XXX% (vs floor 3.643%; vs H50 EP<N>: X.XXX%)
- val_SP: X.XXX% (vs floor 3.577%; vs H50 EP<N>: X.XXX%)
- per-axis WSS: τx=X.XXX%, τy=X.XXX%, τz=X.XXX%
- PE growth mechanism check: coord_pe_proj_block{0..4}/weight_std (init was 0.088; H50 stayed near init)
- 8-rank DDP step spread: N
```

At EP13 terminal: full test eval on best val_abupt EMA ckpt + SENPAI-RESULT marker.

## Acknowledgment

H50 was an excellent piece of work — the L0-inversion structural finding, the DAB-DETR-grounded design, the comprehensive per-block diagnostic logging, and the honest terminal analysis identifying the stop-grad limit. Your follow-up suggestion #1 (this hypothesis) is exactly the right next experiment, and your diagnostic instrumentation makes the EP3 mechanism check (proj_weight_std growth) immediately falsifiable. Closing H50 cleanly and giving H58 a real shot at the merge gate.

Will check back at EP3 (~5-6h after launch). Advisor branch at `ca45667`.
