### PR TITLE
Wave 31 H59: V-DEPTH-LR-EXTENDED — Test H47 plateau as LR-decay artifact (lr-cosine-t-max 13 → 25)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_vol_deep: bool = False,
+        vol_deep_layers: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_vol_deep = use_vol_deep
+        self.vol_deep_layers = int(vol_deep_layers) if use_vol_deep else 0
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +523,38 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H47 V-DEPTH (PR #1194): two dedicated volume-only transformer blocks
+        # inserted between the (optional) surface->volume cross-attention and the
+        # final volume head. Goal: give the volume decoder additional reasoning
+        # depth for volume_pressure. Each block's residual output projections
+        # (TransolverAttention.proj and UpActDownMlp.fc2) are zero-initialised
+        # so the new blocks are pure identity at step 0 -> bit-exact baseline
+        # recovery, and contribution magnitude can be tracked by W&B.
+        if use_vol_deep:
+            self.vol_deep_blocks = nn.ModuleList(
+                [
+                    TransformerBlock(
+                        hidden_dim=n_hidden,
+                        num_heads=n_head,
+                        mlp_expansion_factor=mlp_ratio,
+                        num_slices=slice_num,
+                        dropout=dropout,
+                        use_qk_norm=use_qk_norm,
+                    )
+                    for _ in range(self.vol_deep_layers)
+                ]
+            )
+            with torch.no_grad():
+                for block in self.vol_deep_blocks:
+                    block.attention.proj.project.weight.zero_()
+                    if block.attention.proj.project.bias is not None:
+                        block.attention.proj.project.bias.zero_()
+                    block.mlp.fc2.weight.zero_()
+                    if block.mlp.fc2.bias is not None:
+                        block.mlp.fc2.bias.zero_()
+        else:
+            self.vol_deep_blocks = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -619,6 +655,13 @@ class SurfaceTransolver(nn.Module):
             )
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
+            volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # H47 V-DEPTH: volume-only deep blocks. Zero-initialised residual
+        # output projections make the blocks identity at init.
+        if self.vol_deep_blocks is not None and volume_x is not None and volume_tokens > 0:
+            for block in self.vol_deep_blocks:
+                volume_hidden = block(volume_hidden, attn_mask=volume_mask)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_vol_deep: bool = False
+    vol_deep_layers: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_vol_deep": (
+            "H47 V-DEPTH (PR #1194): insert dedicated volume-only transformer "
+            "blocks between the shared backbone (and any surf->vol cross-"
+            "attention) and the final volume output head. Each block's "
+            "TransolverAttention.proj and UpActDownMlp.fc2 are zero-initialised "
+            "so the inserted stack is identity at step 0 (bit-exact baseline "
+            "recovery). Block count controlled by --vol-deep-layers."
+        ),
+        "vol_deep_layers": (
+            "Number of dedicated volume-only TransformerBlocks added when "
+            "--use-vol-deep is enabled. Default 2."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +290,34 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_vol_deep_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block residual contribution diagnostic for H47 V-DEPTH (PR #1194).
+
+    For each volume-only deep block, log the magnitude of the two residual
+    output projections that were zero-initialised at construction:
+      * ``attention.proj.project`` -- the slice-attention output back to the
+        residual stream.
+      * ``mlp.fc2`` -- the FFN down-projection back to the residual stream.
+
+    Both grow from 0 (init) as the block starts contributing. EP3 KILL gate
+    requires max_abs > 0.05 for BOTH sublayers of at least one block (so we
+    log the per-block, per-sublayer max_abs and global norm for triage).
+    """
+    metrics: dict[str, float] = {}
+    blocks = getattr(model, "vol_deep_blocks", None)
+    if blocks is None:
+        return metrics
+    for i, block in enumerate(blocks):
+        attn_w = block.attention.proj.project.weight.detach().float()
+        ffn_w = block.mlp.fc2.weight.detach().float()
+        prefix = f"diag/vol_deep_block{i}"
+        metrics[f"{prefix}/attn_proj_max_abs"] = float(attn_w.abs().max().item())
+        metrics[f"{prefix}/attn_proj_global_norm"] = float(attn_w.norm().item())
+        metrics[f"{prefix}/ffn_fc2_max_abs"] = float(ffn_w.abs().max().item())
+        metrics[f"{prefix}/ffn_fc2_global_norm"] = float(ffn_w.norm().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +350,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_vol_deep=config.use_vol_deep,
+        vol_deep_layers=config.vol_deep_layers,
     )
 
 
@@ -773,7 +817,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_vol_deep:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1049,10 +1093,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                cosine_t_max_epochs = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress_epoch = max(0, epoch - config.lr_warmup_epochs)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": float(current_lr / config.lr) if config.lr > 0 else 0.0,
+                    "train/cosine_progress": float(cosine_progress_epoch / max(1, cosine_t_max_epochs)),
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1262,6 +1312,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_vol_deep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis — H59 V-DEPTH-LR-EXTENDED: Test H47's plateau as LR-decay artifact, not depth limitation

H47 V-DEPTH just closed (PR #1194) as **mechanism-positive null with test_VP +0.010pp NEAR-MISS on the floor** — the tightest test_VP floor approach for the volume-decoder-depth mechanism class. Your terminal analysis identified the cosine-LR scheduling mismatch as the dominant confound:

> "The W&B summary shows `train/lr = 0.0` at terminal step 70,652 despite the run ending only halfway through the 141,232-step plan. Hypothesis: the cosine LR scheduler was configured for the actual training-step budget (915 min × steps/min) rather than the nominal 13-epoch budget. If so, the val_abupt plateau is partly a cosine-LR-decay artifact, not a true expressivity asymptote."

**Empirical confirmation from W&B**:

| Step | LR | Fraction of peak | val_abupt slope (pp/1k) |
|---:|---:|---:|---:|
| 14,133 (peak post-warmup) | 9.00e-05 | 100% | — |
| EP3→EP4 (28k→43k) | 99-90% peak | productive zone | **−0.034** (productive) |
| EP4→EP5 (43k→52k) | 80-70% peak | mid-decay | −0.015 |
| EP5→EP6 (52k→62k) | 60-45% peak | mid-decay | −0.011 |
| EP6→terminal (62k→70k) | 30-2.5% peak | near-zero LR | **−0.0011 (plateau)** |

**The val_abupt slope collapsed 30× from EP3→EP4 (−0.034 pp/1k at 90% peak LR) to terminal (−0.0011 pp/1k at 2.5% peak LR). The plateau is overwhelmingly LR-decay artifact.**

### H59 hypothesis

Same H47 V-DEPTH architecture (`--use-vol-deep --vol-deep-layers 2` with all your existing zero-init residual + per-block diagnostic logging), but with **`--lr-cosine-t-max 25` instead of 13**. This stretches the cosine cycle so that within your actual ~70k-step training window, the cosine completes only ~28% of its cycle (instead of 100%), keeping terminal LR at **~70-80% of peak instead of 2.5%**.

**Falsifiable outcomes** (in priority order):

- **(A) MERGE WIN**: val_abupt < 6.126% AND test_VP < 3.643%. The plateau was fully LR-decay; H47's actual expressivity capacity reaches the merge gate. Wave 31 first depth-class merge. **Probability: HIGH** — given the slope was still −0.011 pp/1k at EP5 (60% peak LR), maintaining 70-80% peak LR should give slope of −0.020 to −0.025 pp/1k throughout, accumulating to −0.6 to −0.8pp val_abupt drop over 70k steps starting from EP4's 6.421%, landing at 5.6-5.8%.

- **(B) PARTIAL WIN**: val_abupt 6.05-6.20% (improvement over H47 6.273%) + test_VP crosses floor (≤ 3.643%, below H47 NEAR-MISS 3.6533%) + mechanism diagnostic intact (productive block1>block0 asymmetry continues). Confirms most of the plateau was LR-decay. Wave 32 stack candidate with H35/H53/H57.

- **(C) NULL**: val_abupt regresses or fails to improve over H47. LR-decay was NOT the dominant confound; depth-budget is truly the expressivity limit at 2-block + 5-layer-trunk. Closes the LR-extension axis decisively.

## Instructions

**Single change vs H47 PR #1194**: change `--lr-cosine-t-max 13` to `--lr-cosine-t-max 25` in the full training command. Everything else stays identical — same H47 architecture (`--use-vol-deep --vol-deep-layers 2`), same vol curriculum, same diagnostic logging, same `--epochs 13` budget (the SENPAI_TIMEOUT_MINUTES wall-clock cap will determine the actual terminal step).

### Code change

**No code changes required.** The `--lr-cosine-t-max` flag already exists. This is a recipe-only change.

If for any reason `--lr-cosine-t-max 25` produces a flag error (e.g., the trainer rejects values >`--epochs`), please verify by reading `target/train.py` argparse and report back. If the flag is constrained, fallback options:
1. **Fallback 1**: Use `--lr-cosine-t-max 18` (instead of 25) — keeps terminal LR at ~50% of peak in your actual training window.
2. **Fallback 2**: Add a `--lr-cosine-floor` flag with value `2.7e-5` (= 30% of peak 9e-5) to prevent late-cosine LR collapse. Check if this flag exists; if not, this becomes a code-level change to `target/train.py` (low effort).

### Diagnostic — add LR-trajectory + per-block residual + τz/τx ratio (carry-over from H47)

Continue all H47 diagnostics:

- `diag/vol_deep_block{0,1}/attn_out_proj_max_abs` + `/global_norm`
- `diag/vol_deep_block{0,1}/mlp_fc2_max_abs` + `/global_norm`
- `val/tau_zx_ratio_mean/std/min/max/n_outside_band` (NEW — Wave 31 canonical, was missed in H47)

**Add new H59-specific diagnostic** for LR monitoring:

```python
if rank == 0:
    wandb.log({
        "train/lr_fraction_of_peak": current_lr / peak_lr,  # e.g., 0.85 = 85% of peak
        "train/cosine_progress": current_step / lr_cosine_t_max_steps,  # e.g., 0.28 = 28% through cosine
    }, commit=False)
```

This lets us verify the cosine extension is working as designed throughout training.

### Pre-flight verification (BEFORE full launch)

1. **Smoke test 100 steps** with `--lr-cosine-t-max 25 --epochs 1` to verify the flag accepts a value > epochs. Check that `train/lr` after warmup-end matches expected trajectory: at step 14,133 (post-warmup), `current_lr / 9e-5` should be ~1.0; at step ~10,864 (pre-warmup end), should still be in warmup phase.
2. **Init bit-exactness vs H47**: smoke check that the architecture matches H47's (same zero-init residuals on vol_deep_blocks). If you have the H47 smoke check script (`smoke_check_h47.py`), reuse it.

### Training command (full 13 epochs wall-clock)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --lion-beta1 0.9 --lion-beta2 0.99 \
  --pos-encoding-mode string_separable --use-qk-norm \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 25 --epochs 13 \
  --batch-size 4 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
  --no-compile-model --validation-every 1 --use-vol-deep --vol-deep-layers 2 \
  --amp-mode bf16 \
  --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5" \
  --wandb-group wave31_h59_vdepth_lr_extended \
  --wandb-name nezuko/h59-vdepth-lr-extended-13ep \
  --agent nezuko
```

**Kill thresholds** (lr-warmup-1 aware, EP3-binding — no EP1 gate per Wave 31 canonical):
- NO EP1 gate (lr-warmup-1 makes EP1 val_abupt 25-35% structurally — no useful signal)
- EP3 binding (step 32,592): `val_abupt < 7.5%` AND `val_SP < 5.5%` (your H47 cleared EP3 at 6.78% / 4.51%)
- EP6 hard kill (step 65,184): `val_abupt < 6.5%` (your H47 cleared EP6 at 6.28%)

## Gates

### EP3 binding (HARD)
- `val_primary/abupt_axis_mean_rel_l2_pct < 7.5%` (your H47 EP3: 6.78%)
- `val_primary/surface_pressure_rel_l2_pct < 5.5%` (your H47 EP3: 4.51%)
- **NEW H59 mechanism check**: `train/lr_fraction_of_peak` should be > 85% (cosine still in productive zone). If LR is already < 60% at EP3, the cosine extension isn't taking effect; verify the flag.

### EP6 hard kill
- `val_primary/abupt_axis_mean_rel_l2_pct < 6.5%` (your H47 EP6: 6.28%)
- LR fraction of peak should be > 60% (significantly higher than H47's ~50% at this position)

### EP10-12 binding terminal gates (if run reaches terminal)
1. **Merge gate**: `val_abupt < 6.126%` (H47 missed by +0.147pp at LR 2.5% peak; H59 with extended LR target: <6.10%)
2. **Hard floors**: `test_primary/surface_pressure_rel_l2_pct ≤ 3.577%`, `test_primary/volume_pressure_rel_l2_pct ≤ 3.643%` (H47 test_VP NEAR-MISS at 3.6533%; H59 target: cross by ≥0.05pp = ≤3.59%)
3. **WSS goal**: `test_primary/wall_shear_rel_l2_pct < 6.727%` (H47 terminal: 6.99%)
4. **LR-extension confirmation**: terminal `train/lr_fraction_of_peak > 70%` confirms cosine cycle didn't complete

## Baseline reference

Current best single-model (PR #972, run `56bcqp3m`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: **5.844%**
- test_vol_p: **3.643%** (floor)
- test_SP: **3.577%** (floor)
- test_WSS: **6.727%** (target to beat)

**H47 V-DEPTH terminal (your prior PR #1194)**:
- val_abupt: 6.273% (+0.147pp above merge gate)
- test_abupt: 6.049% (+0.205pp above baseline)
- test_VP: **3.6533% (+0.010pp NEAR-MISS on floor)** ⭐
- test_SP: 3.769% (+0.192pp above floor)
- test_WSS: 6.993% (+0.266pp above baseline)
- Terminal LR: 2.29e-6 (2.5% of peak 9e-5)

## Why H59 is the right next step

1. **Single-flag change** — lowest implementation risk; just `--lr-cosine-t-max 25` instead of 13
2. **Directly attacks the dominant suspected confound**: H47's terminal analysis identified LR-decay as the most plausible cause of the val_abupt plateau
3. **High probability of crossing test_VP floor**: H47 was at +0.010pp NEAR-MISS; extended LR maintains productive descent of val_VP (which was ALSO descending through every cosine stage)
4. **Cheap to falsify**: if LR-fraction-of-peak doesn't stay >85% at EP3, hypothesis is dead in 5h
5. **Preserves H47's mechanism**: vol_deep_blocks already biting strongly (b1.ffn norm 75.32); extended LR gives them more time to find productive configurations
6. **High info-value either way**: H59 merge = depth-class confirmed merge-positive after LR-fix (Wave 32 stack candidate H35 + H47 + H53 + H57). H59 null = depth at 2-block-5-trunk is truly expressivity-limited and the test_VP near-miss won't close — attention shifts to slice-count expansion (H35 NPCA+SSFL+slices=192 stack approach)

## Risk note — LR-extension memory/stability

Extended-cosine LR keeps the optimizer in productive descent territory longer. Potential risks:

- **No risk to memory**: LR-schedule change doesn't affect activations or weights size
- **Mild risk to grad_norm**: at higher mid-training LR, grad_norm could be slightly higher; standard `--grad-clip-norm 0.5` should handle it
- **Watch `train/grad_norm` at EP4-EP6**: at H47's EP5 (peak-decay = 70% LR), grad_norm should be ~30-40% higher than H47's same window. If grad_norm spikes (>1.0), post a check-in.

## Wave 31 fleet context (snapshot at H59 launch ~15:45Z May 19)

| Student | PR | Hypothesis | Status |
|---|---|---|---|
| frieren | #1200 | H52 NPCA×YAW-AUG | mid-EP4, mechanism alive |
| tanjiro | #1202 | H53 CP-LOSS-WEIGHT | **STRONGEST MERGE CANDIDATE** (projected merge at budget cut ~17:50Z) |
| alphonse | #1203 | H54 v2 SURFACE-DEEP | EP2 healthy, surf_deep diagnostic pending |
| edward | #1204 | H55 v2 TAU-Z-CURRICULUM | EP2 mechanism alive on τz (−0.164pp vs H48) |
| fern | #1205 | H56 NPCA+SSFL+slices=192+ema=0.9999 | early stage |
| thorfinn | #1206 | H57 FDCE | EP2 cold-start advantage carrying (−0.078pp val_abupt vs H48) |
| askeladd | #1207 | H58 COORDSLICE-NO-STOPGRAD | pre-EP1 |
| **nezuko** | **#this** | **H59 V-DEPTH-LR-EXTENDED** | **NEW — H47 LR-fix follow-up** |

H59 mechanism orthogonality:
- Direct H47 follow-up (architectural mechanism preserved + LR scheduling fix)
- Orthogonal to all 7 in-flight PRs (different mechanism class within Wave 31; only architecture continuation of H47)
- If H59 merges, the variance-class-decoder-sublayer class becomes the 2nd proven merge class (after variance-class-encoder-input H35), making Wave 32 a 3+ axis stack opportunity

## Resources

- Reference baseline: PR #972, run `56bcqp3m`
- Reference predecessor: H47 closed PR #1194, run `dp7gbsjb`
- New run group: `wave31_h59_vdepth_lr_extended`
- Code path: train.py argparse only — single-flag change (or trivial 2-line addition if --lr-cosine-floor doesn't exist)
- 18h budget: standard, `SENPAI_TIMEOUT_MINUTES=1100`

## Report format

Per epoch (EP1, EP3, EP6, EP9, EP13 if reached):

```
EP<N> update (step <step>, run <run-id>):
- val_abupt: X.XXX% (slope: X.XXX pp/1k vs prior epoch; vs H47 EP<N>: X.XXX%)
- val_VP: X.XXX% (vs floor 3.643%; vs H47 EP<N>: X.XXX%)
- val_SP: X.XXX% (vs floor 3.577%; vs H47 EP<N>: X.XXX%)
- train/lr_fraction_of_peak: X.XXX (target >70% at terminal)
- per-block vol_deep diagnostic: b0.attn / b0.ffn / b1.attn / b1.ffn max_abs
- 8-rank DDP step spread: N
```

At terminal: full test eval on best val_abupt EMA ckpt + SENPAI-RESULT marker.

## Acknowledgment

H47 was outstanding work — the per-block residual diagnostic ("canonical Wave 31 asymmetric-capacity trace"), the productive block1>block0 asymmetry confirmation, the LR-decay-as-confound terminal analysis. Your follow-up suggestion #2 (cosine-LR scheduling investigation) is the highest-EV next experiment given the data, and is the H59 assignment. The mechanism diagnostic carries over unchanged.

Will check back at EP3 (~5-6h after launch) for the binding read. Advisor branch at `a61151b`.
