### PR TITLE
Wave 31 H61: SLICE-TEMP-CURRICULUM — Scheduled slice-attention temperature 1.5→1.0 over EP1-6

### DIFF
--- a/model.py
+++ b/model.py
@@ -259,12 +259,63 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
+        # H61 slice-temperature curriculum hook. `slice_temperature_runtime`
+        # is a runtime-modulated multiplier on the softmax temperature; the
+        # effective temperature is `self.temperature * slice_temperature_runtime`.
+        # At runtime=1.0 the math is byte-equal to baseline. Set externally
+        # per training step (see train.py:set_slice_temperature_runtime).
+        self.slice_temperature_runtime: float = 1.0
+        # Optional per-block slice-attention entropy diagnostic. When
+        # `capture_slice_entropy=True`, each forward accumulates batch-summed
+        # entropy + token-count into the two buffers; mean_slice_entropy
+        # returns the ratio. Reset via reset_slice_entropy_stats().
+        self.capture_slice_entropy: bool = False
+        self.register_buffer(
+            "_slice_entropy_sum", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+        self.register_buffer(
+            "_slice_entropy_count", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+
+    def reset_slice_entropy_stats(self) -> None:
+        self._slice_entropy_sum.zero_()
+        self._slice_entropy_count.zero_()
+
+    @property
+    def mean_slice_entropy(self) -> float:
+        count = float(self._slice_entropy_count.item())
+        if count <= 0.0:
+            return 0.0
+        return float(self._slice_entropy_sum.item()) / count
+
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        # H61 curriculum: divide logits by an additional runtime temperature.
+        # At runtime=1.0 this branch is skipped → byte-equal to baseline.
+        if self.slice_temperature_runtime != 1.0:
+            slice_logits = slice_logits / max(self.slice_temperature_runtime, 1e-6)
         slice_weights = F.softmax(slice_logits, dim=-1)
+        if self.capture_slice_entropy:
+            with torch.no_grad():
+                # slice_weights shape: (B, num_heads, N, num_slices). Entropy
+                # of the per-point routing distribution, in nats. Mask masked
+                # tokens out of the average so padded rows don't bias the stat.
+                ent_per_point = -(slice_weights * (slice_weights + 1e-9).log()).sum(dim=-1)
+                if attn_mask is not None:
+                    mask = attn_mask[:, None, :].to(device=ent_per_point.device, dtype=ent_per_point.dtype)
+                    weighted = ent_per_point * mask
+                    self._slice_entropy_sum.add_(weighted.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        (mask.sum() * float(ent_per_point.shape[1])).to(torch.float32)
+                    )
+                else:
+                    self._slice_entropy_sum.add_(ent_per_point.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        torch.tensor(float(ent_per_point.numel()), device=ent_per_point.device, dtype=torch.float32)
+                    )
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,

--- a/train.py
+++ b/train.py
@@ -1360,17 +1360,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
-            # H61: hold the runtime slice temperature at the current
-            # training-time value (current_slice_tau) for the EMA val pass.
-            # This matches the advisor's spec ("pass compute_slice_temperature
-            # on each forward call") and avoids a train-val temperature
-            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
-            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
-            # the logged stat is rank-local, not globally reduced.
+            # H61: pin the runtime slice temperature to `slice_temperature_end`
+            # (the curriculum endpoint, default 1.0) for the EMA val pass so
+            # val_abupt is measured at the deployed-temperature routing,
+            # directly apples-to-apples with the H47/H48/H35 references that
+            # never saw a curriculum. Per-block slice-attention entropy is
+            # captured at this same temperature; with DDP8 each rank sees
+            # ~1/8 of val cases so the logged stat is rank-local, not
+            # globally reduced.
             reset_slice_entropy_stats(base_model)
             set_slice_temperature_runtime(
                 base_model,
-                current_slice_tau,
+                config.slice_temperature_end,
                 capture_entropy=True,
             )
             val_metrics = {
@@ -1385,7 +1386,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for name, loader in val_loaders.items()
             }
             slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
-            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
+            set_slice_temperature_runtime(base_model, 1.0, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
-from model import SurfaceTransolver
+from model import SurfaceTransolver, TransolverAttention
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    slice_temperature_start: float = 1.0
+    slice_temperature_end: float = 1.0
+    slice_temperature_decay_steps: int = 0
     debug: bool = False
 
 
@@ -220,6 +223,28 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "slice_temperature_start": (
+            "H61 slice-attention temperature curriculum: starting value of "
+            "the runtime softmax temperature applied on top of the learnable "
+            "per-head temperature in TransolverAttention. Logits are divided "
+            "by max(slice_temperature_runtime, 1e-6) before softmax. Values "
+            ">1 produce a warmer (more diffuse) routing distribution; the "
+            "default 1.0 is byte-equal to baseline. The temperature linearly "
+            "decays from `start` to `end` over `decay_steps` global optimizer "
+            "steps, then holds at `end` for the rest of training."
+        ),
+        "slice_temperature_end": (
+            "H61 slice-attention temperature curriculum: terminal value held "
+            "for global_step >= slice_temperature_decay_steps. Default 1.0 "
+            "matches baseline. See --slice-temperature-start."
+        ),
+        "slice_temperature_decay_steps": (
+            "H61 slice-attention temperature curriculum: number of global "
+            "optimizer steps over which the temperature linearly decays from "
+            "`start` to `end`. Set to 0 (default) to disable the curriculum "
+            "and hold at `end` for the whole run. Recommended for the H61 "
+            "spec: 65184 (end of EP6 at 13-epoch DDP8 budget)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -274,6 +299,90 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def compute_slice_temperature(
+    global_step: int,
+    *,
+    start: float,
+    end: float,
+    decay_steps: int,
+) -> float:
+    """H61 curriculum: linear decay from `start` at step 0 to `end` at
+    step `decay_steps`, then hold at `end`. When `decay_steps <= 0` or
+    start == end, returns `end` (curriculum disabled / no-op)."""
+
+    if decay_steps <= 0 or start == end:
+        return float(end)
+    if global_step >= decay_steps:
+        return float(end)
+    progress = float(global_step) / float(decay_steps)
+    return float(start) + (float(end) - float(start)) * progress
+
+
+def set_slice_temperature_runtime(
+    base_model: nn.Module,
+    value: float,
+    *,
+    capture_entropy: bool | None = None,
+) -> None:
+    """Set the runtime slice-softmax temperature on every TransolverAttention
+    submodule. If `capture_entropy` is provided, also toggles the per-block
+    slice-attention entropy capture flag."""
+
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.slice_temperature_runtime = float(value)
+            if capture_entropy is not None:
+                module.capture_slice_entropy = bool(capture_entropy)
+
+
+def reset_slice_entropy_stats(base_model: nn.Module) -> None:
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.reset_slice_entropy_stats()
+
+
+def collect_slice_entropy_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Read per-block mean slice-attention entropy from each TransolverAttention.
+    Returns `diag/slice_attn_entropy_block{i}` (entropy in nats) and
+    `diag/slice_n_eff_block{i}` (= exp(H), the effective number of active
+    slices). Uniform upper bound at num_slices=S is log(S) nats / N_eff=S."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    entropies: list[float] = []
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            ent = module.mean_slice_entropy
+            metrics[f"diag/slice_attn_entropy_block{block_idx}"] = ent
+            metrics[f"diag/slice_n_eff_block{block_idx}"] = float(math.exp(ent))
+            entropies.append(ent)
+            block_idx += 1
+    if entropies:
+        mean_entropy = sum(entropies) / float(len(entropies))
+        metrics["diag/slice_attn_entropy_mean"] = mean_entropy
+        metrics["diag/slice_n_eff_mean"] = float(math.exp(mean_entropy))
+    return metrics
+
+
+def collect_slice_learnable_temperature_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Per-block stats of the learnable per-head temperature in
+    TransolverAttention. Diagnoses whether the gradient is auto-adjusting
+    `self.temperature` to compensate for the runtime curriculum — a known
+    failure mode of fixed-endpoint temperature annealing."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            t = module.temperature.detach().float().flatten()
+            metrics[f"diag/slice_learn_temp_block{block_idx}_mean"] = float(t.mean().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_std"] = float(t.std().item()) if t.numel() > 1 else 0.0
+            metrics[f"diag/slice_learn_temp_block{block_idx}_min"] = float(t.min().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_max"] = float(t.max().item())
+            block_idx += 1
+    return metrics
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -936,6 +1045,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                # H61: set the runtime slice-softmax temperature for this
+                # forward. `global_step` is the pre-increment value, so step 0
+                # uses `start` and `decay_steps` (exclusive) is the first step
+                # at which `end` applies.
+                current_slice_tau = compute_slice_temperature(
+                    global_step,
+                    start=config.slice_temperature_start,
+                    end=config.slice_temperature_end,
+                    decay_steps=config.slice_temperature_decay_steps,
+                )
+                set_slice_temperature_runtime(base_model, current_slice_tau)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1056,6 +1176,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/slice_temperature": current_slice_tau,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(
@@ -1239,6 +1360,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
+            # H61: hold the runtime slice temperature at the current
+            # training-time value (current_slice_tau) for the EMA val pass.
+            # This matches the advisor's spec ("pass compute_slice_temperature
+            # on each forward call") and avoids a train-val temperature
+            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
+            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
+            # the logged stat is rank-local, not globally reduced.
+            reset_slice_entropy_stats(base_model)
+            set_slice_temperature_runtime(
+                base_model,
+                current_slice_tau,
+                capture_entropy=True,
+            )
             val_metrics = {
                 name: evaluate_split(
                     model,
@@ -1250,6 +1384,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
                 for name, loader in val_loaders.items()
             }
+            slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
+            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:
@@ -1262,6 +1398,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(slice_entropy_metrics)
+                log_metrics.update(collect_slice_learnable_temperature_metrics(base_model))
+                log_metrics["train/slice_temperature_at_val"] = current_slice_tau
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**H61 SLICE-TEMP-CURRICULUM**: introduce a scheduled per-block slice-attention temperature `τ_slice(t)` that anneals from 1.5 (warm/diffuse) at EP1-start to 1.0 (baseline/sharp) by EP6, then holds at 1.0 through EP13.

### Why this stacks mechanism-class-novel

Wave 30/31 has explored 10 mechanism classes in flight or merged:
1. variance-class-encoder-input (MERGED: H26 NPCA, H31 WALLDIST, H35 NPCA+SSFL)
2. variance-class-decoder-sublayer (H47 null/LR-confound, H59 in flight)
3. variance-class-cp-loss-weight (H53 in flight, strongest projected merge)
4. shared-capacity-surface (H54 v2)
5. mean-shift-class (H48 null)
6. cross-channel-weight-space (H45 null)
7. variance-class-decoder-weight (H46/H49 null)
8. coordinate-grounded-slice-PE (H33/H50 null+VP-cross, H58 in flight)
9. frequency-domain-capacity / FDCE (H57 in flight)
10. ema-aware-variance-stack (H60 in flight, strongest mechanism signal)

**Nothing in Wave 31 has touched the slice-attention temperature itself.** The slice-softmax in TransolverAttention is currently a hard ~uniform-temperature competition where each spatial point sends mass to a single slice token. The temperature schedule attacks this routing-formation phase from a fundamentally different angle: it controls how PEAKED vs DIFFUSE the slice attention is during the routing-formation phase.

### Mechanism intuition (Gumbel-softmax / warm-cool annealing)

- **τ_slice = 1.5 (warm)**: slice routing is DIFFUSE. Each spatial point distributes mass across ~3-4 slices instead of locking onto 1. Slice tokens accumulate signal from broader spatial neighborhoods. Optimization sees a smoother loss landscape.
- **τ_slice = 1.0 (sharp, baseline)**: slice routing is COMPETITIVE. Each point ~locks onto 1 slice. Slice tokens specialize. Optimization sees a more rugged landscape.

The curriculum anneals from warm to cool, matching the well-known Gumbel-softmax-style annealing schedule and the simulated-annealing intuition from optimization theory. **Hypothesis: smoother slice attention early lets slices form coherent spatial clusters before sharpening into specialized routing late.**

### Falsifiable predictions

- **A. MERGE WIN**: val_abupt < 6.126% AND test_VP < 3.643% (or test_SP < 3.577%). Mechanism produces a productive structural change at convergence.
- **B. PARTIAL WIN**: terminal val_abupt below H48 baseline (6.485%) by ≥ 0.10pp but does not cross merge gate. Mechanism alive but partial.
- **C. NULL**: terminal val_abupt within ±0.10pp of H48 baseline. Temperature curriculum has no productive structural effect at this hyperparameter scale.

### Mechanism diagnostic — slice-attention entropy

The PR body's binding diagnostic is per-block slice-attention entropy `H(slice_softmax)` computed on val cars. Expected pattern under the hypothesis:
- EP1 with τ=1.5 → high entropy across all 5 blocks (H ≈ log(num_slices) × 0.7)
- EP6 with τ=1.0 → mid-range entropy (H ≈ log(num_slices) × 0.4)
- EP13 → low entropy (H ≈ log(num_slices) × 0.2), specialized routing

If terminal entropy is HIGHER than baseline H35 (recipe pre-NPCA+SSFL), it means the curriculum kept attention diffuse rather than letting it sharpen — would explain a NULL result.

## Implementation instructions

This requires a small mechanism-class change to `target/model.py` and the temperature schedule wired into `target/trainer_runtime.py` for use in `target/train.py`. Conservative recipe baseline (lr-warmup-1, ema=0.999, 13-ep, slices=128) — no NPCA, no SSFL.

### Step 1 — Locate the slice-attention softmax in `target/model.py`

Find the `TransolverAttention.forward()` method (or similar). The slice-attention softmax should compute something like:

```python
slice_logits = ...  # shape (B, N, num_slices) — the routing logits per spatial point
slice_weights = F.softmax(slice_logits, dim=-1)  # the routing distribution
```

### Step 2 — Add temperature-aware softmax

Add a `slice_temperature: float = 1.0` parameter to `Config` (or pass it through the forward call). Modify the softmax to:

```python
slice_logits_scaled = slice_logits / max(slice_temperature, 1e-6)
slice_weights = F.softmax(slice_logits_scaled, dim=-1)
```

When `slice_temperature == 1.0`, this is identical to the current implementation (verify byte-equality with a unit test before launching). When `slice_temperature > 1.0`, the softmax is smoother / more diffuse.

### Step 3 — Wire the temperature schedule

In `target/trainer_runtime.py` (or wherever the training loop lives), compute a step-wise temperature:

```python
def compute_slice_temperature(global_step: int, total_steps: int = 141232) -> float:
    """
    Curriculum: τ=1.5 at step 0, decay to 1.0 by step 65184 (EP6 end), hold 1.0 after.
    """
    ep6_step = 65184
    if global_step >= ep6_step:
        return 1.0
    # Linear decay from 1.5 to 1.0 across steps 0 → 65184
    progress = global_step / ep6_step
    return 1.5 - 0.5 * progress
```

Pass `compute_slice_temperature(self.global_step)` into the model on each forward call (or attach it to the model state).

### Step 4 — Add diagnostics to `target/train.py`

Add to `validation_step` or equivalent:

```python
# Log current temperature (single scalar per step, no per-block needed)
wandb.log({"train/slice_temperature": current_tau, "global_step": global_step})

# Log per-block slice-attention entropy (during validation only)
# This requires capturing slice_weights from each TransolverAttention block during forward.
for block_idx, block_weights in enumerate(captured_slice_weights):
    # block_weights shape: (B, N, num_slices)
    # Compute per-point entropy, then average over batch
    H = -(block_weights * torch.log(block_weights + 1e-9)).sum(dim=-1).mean()
    wandb.log({f"diag/slice_attn_entropy_block{block_idx}": H.item()})
```

### Step 5 — Pre-flight smoke test

Before full launch, run a 100-step smoke test with `slice_temperature=1.0` (baseline) and verify:
1. Loss matches H48 reference at step 100 within ±0.001 (numerical equivalence to baseline)
2. `train/slice_temperature` logs as 1.5 → 1.499 → 1.498 → ... (curriculum active)
3. `diag/slice_attn_entropy_block{i}` logs non-zero values for each block

If smoke test fails, do NOT launch full 18h run — fix the smoke first.

### Single-arm reproduce command (DDP8, 18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
    --lion-beta1 0.9 --lion-beta2 0.99 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
    --batch-size 4 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
    --no-compile-model --validation-every 1 --amp-mode bf16 \
    --slice-temperature-start 1.5 --slice-temperature-end 1.0 --slice-temperature-decay-steps 65184 \
    --wandb-group wave31_h61_slice_temp_curriculum \
    --wandb-name frieren/h61-slice-temp-curriculum --agent frieren \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

### Kill threshold rationale (lr-warmup-1 aware, ema=0.999)

| Step (epoch) | Gate | Reason |
|---:|---|---|
| 10,864 (EP1) | NONE | lr-warmup-1 cold-start floor is ~30%+, EP1 gate would false-kill |
| **32,592 (EP3)** | **val_abupt<7.5% AND val_SP<5.5%** | binding — H48 ref at EP3 ~7.5%, H35 ref ~7.2%, healthy mechanism should be at or below 7.5% |
| **65,184 (EP6)** | **val_abupt<6.5%** | hard kill — H47 ref at EP6 was 6.357%, H53 currently at 6.191% at this step |

### Pre-flight audit checklist (per [[feedback_audit_flags_in_recipe]])

Before posting the full launch comment, verify that each new flag exists in `target/train.py` argparse OR is a flag you've added in this implementation:

- `--slice-temperature-start` — NEW (must add to argparse)
- `--slice-temperature-end` — NEW (must add to argparse)
- `--slice-temperature-decay-steps` — NEW (must add to argparse)

All other flags should be inherited from H48 baseline recipe — verify each exists. If any phantom flag exists from a refactor, the run will crash at startup.

### SENPAI-RESULT template (terminal)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline

Current best (#972, run `56bcqp3m`):
- val/abupt_axis_mean_rel_l2_pct = **6.126%** (merge gate)
- test/abupt_axis_mean_rel_l2_pct = **5.844%** (baseline)
- test/volume_pressure_rel_l2_pct = **3.643%** (floor)
- test/surface_pressure_rel_l2_pct = **3.577%** (floor)
- test/wall_shear_rel_l2_pct = **6.727%**

W&B baseline link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m
