### PR TITLE
Wave 31 H63: TAU-Z-CURRICULUM-LR-EXTENDED — Test H55 v2 plateau as LR-decay artifact (lr-cosine-t-max 13 to 25)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_z_loss_weight_start: float = 5.0
+    tau_z_loss_weight_end: float = 2.0
+    tau_z_loss_weight_decay_steps: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -755,8 +758,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             device=device,
             dtype=torch.float32,
         )
+        # H55: τz curriculum forces use_channel_weights=True even when
+        # tau_z_loss_weight matches its default — the curriculum-computed
+        # value (typically 5.0→2.0) is what actually drives the loss, and the
+        # pass-through must be enabled from step 0.
+        tau_z_curriculum_active = config.tau_z_loss_weight_decay_steps > 0
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
+            or tau_z_curriculum_active
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -852,6 +862,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if tau_z_curriculum_active:
+                print(
+                    f"tau_z loss-weight curriculum: linear "
+                    f"{config.tau_z_loss_weight_start}->"
+                    f"{config.tau_z_loss_weight_end} over "
+                    f"{config.tau_z_loss_weight_decay_steps} steps, "
+                    f"then held at {config.tau_z_loss_weight_end}"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +901,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_z_loss_weight_start"] = config.tau_z_loss_weight_start
+            wandb.summary["loss/tau_z_loss_weight_end"] = config.tau_z_loss_weight_end
+            wandb.summary["loss/tau_z_loss_weight_decay_steps"] = config.tau_z_loss_weight_decay_steps
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -937,6 +958,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                # Default τz weight for the log line below; the non-gradnorm
+                # branch overwrites this with the curriculum value.
+                current_tau_z = config.tau_z_loss_weight
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1021,6 +1045,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    # H55: linear τz loss-weight curriculum. global_step is 0
+                    # at the first batch and is incremented after this call,
+                    # so at step=0 progress=0 → current_tau_z=start; once
+                    # global_step >= decay_steps progress=1 → current_tau_z=end.
+                    current_tau_z = config.tau_z_loss_weight
+                    if tau_z_curriculum_active:
+                        progress = min(
+                            1.0, global_step / config.tau_z_loss_weight_decay_steps
+                        )
+                        current_tau_z = (
+                            config.tau_z_loss_weight_start * (1.0 - progress)
+                            + config.tau_z_loss_weight_end * progress
+                        )
+                        surface_channel_weights[3] = current_tau_z
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1049,10 +1087,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                _peak_lr = config.lr if config.lr > 0 else 1.0
+                _t_max_epochs = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                _cosine_total_steps = max(1, _t_max_epochs * max(len(train_loader), 1))
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": float(current_lr) / float(_peak_lr),
+                    "train/cosine_progress": float(global_step) / float(_cosine_total_steps),
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1068,6 +1113,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/tau_z_loss_weight_curriculum": current_tau_z,
                         }
                     )
                 if gradnorm_metrics:


### PR DESCRIPTION
## Hypothesis

**H63 TAU-Z-CURRICULUM-LR-EXTENDED**: re-run the H55 v2 recipe with a single flag change — `--lr-cosine-t-max 25` instead of `13` — to test whether H55 v2's val_abupt NEAR-MISS (+0.123pp above merge gate) was driven by the same cosine-tail LR-decay confound now seen across 4 Wave 31 cases (H47, H52, H53, H55 v2).

### Why this isolates the LR-decay confound

H55 v2 closed at val_abupt 6.249% (PR #1204, terminal SENPAI-RESULT). Per-epoch slope decomposition showed:

| Window | Slope (pp/1k val_abupt) | LR fraction of peak (observed) |
|---|---:|---:|
| EP3.7 → EP4.6 (40,122 → 50,420) | −0.020 | 68% peak |
| EP4.6 → EP5.4 (50,420 → 58,937) | −0.010 (halved) | 45% peak |
| EP5.4 → EP6.07 (58,937 → 65,959) | **−0.006** (halved again) | 14% peak |
| EP6.07 → terminal (65,959 → 70,652) | **−0.0002** | ~0% (cosine tail flat) |

H55 v2 ran natural EP13 but cosine cycle completed within actual ~70k-step training window — terminal LR collapsed to ~0% of peak. Same canonical Wave 31 LR-decay-confound pattern.

**H63 is the 3rd parallel LR-fix test alongside H59 V-DEPTH-LR-EXTENDED (nezuko, PR #1208) and H62 CP-LOSS-WEIGHT-LR-EXTENDED (tanjiro, PR #1211).** If all three mechanism-class LR-fix variants produce merge-relevant improvements, the LR-decay confound is confirmed as a systematic Wave 31 ceiling.

### What the LR fix does

`--lr-cosine-t-max 25` stretches the cosine cycle so that within the actual ~70k-step training window, only ~28% of the cosine half-cycle completes (instead of 100% under `--lr-cosine-t-max 13`). Terminal LR stays at ~70-80% of peak instead of dropping to 0%. This preserves productive LR through the late-epoch zone where H55 v2's τz curriculum mechanism could still drive descent.

### Three falsifiable outcomes (against baseline #972: val_abupt 6.126%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%)

- **A. MERGE WIN + FLOOR CROSS**: val_abupt < 6.126% AND test_VP < 3.643% AND test_SP < 3.577% — LR-decay was the limit; τz curriculum mechanism merges first time. Single-model SOTA candidate.
- **B. PARTIAL WIN**: val_abupt drops below H55 v2's 6.249% by ≥0.10pp but doesn't cross merge gate — LR matters but mechanism still has limits at this strength.
- **C. NULL**: terminal val_abupt within ±0.05pp of H55 v2's 6.249% — LR-decay NOT the limit; mechanism-class-tau-z-curriculum saturates at this val_abupt regardless of LR schedule.

### Diagnostic to monitor

Add `train/lr_fraction_of_peak` and `train/cosine_progress` logging per step (matching H59/H62 instrumentation). Expected behavior:
- EP1 (warmup): LR fraction ramping 0 → 1.0
- EP3-EP6: LR fraction holding 96-86% (vs H55 v2 which was 68-14% at same steps)
- EP13 terminal: LR fraction ~50-70% (vs H55 v2 which was 0%)

## Instructions

Use the EXACT H55 v2 recipe with ONE flag change. No code changes required — `--lr-cosine-t-max` is an existing flag in `target/train.py` (verified used by H47/H53/H55 v2 and H59/H62 LR-fix variants).

### Single-arm reproduce command (DDP8, 18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
    --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
    --tau-y-loss-weight 1.0 --tau-z-loss-weight 2.0 \
    --tau-z-loss-weight-start 5.0 --tau-z-loss-weight-end 2.0 --tau-z-loss-weight-decay-steps 65228 \
    --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
    --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
    --lr-cosine-t-max 25 --epochs 13 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --no-compile-model \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --validation-every 1 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --use-surf-to-vol-xattn --amp-mode bf16 \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5" \
    --wandb-group wave31_h63_tau_z_curriculum_lr_extended \
    --wandb-name edward/h63-tau-z-curriculum-lr-extended
```

**ONE flag change vs H55 v2**: `--lr-cosine-t-max 25` (was `13`). Everything else identical to H55 v2.

### Pre-flight check (already-verified flags)

All flags in this recipe were verified used by H55 v2 (PR #1204 closed) AND by H47/H53/H59/H62 LR-fix variants. No new flags introduced. No code changes required.

If you have access to your `target/train.py`, do a quick `grep -E 'lr-cosine|lr_cosine' train.py` to reconfirm — but H59 and H62 already validated this flag exists with the value 25.

### Kill threshold rationale (lr-warmup-1 aware, ema=0.999)

| Step (epoch) | Gate | Reason |
|---:|---|---|
| 10,864 (EP1) | NONE | lr-warmup-1 cold-start val_abupt ~27%+, gate would false-kill |
| **32,592 (EP3)** | **val_abupt<7.5% AND val_SP<5.5%** | binding — H55 v2 ref at EP3 was ~6.95% / ~4.6%, healthy mechanism should land at or below |
| **65,184 (EP6)** | **val_abupt<6.5%** | hard kill — H55 v2 ref at EP6 was 6.255% (passed comfortably) |

### Logging additions to your runtime (RECOMMENDED, not mandatory)

If you can add per-step LR fraction logging without touching `target/` source, log to W&B:
- `train/lr_fraction_of_peak` = `current_lr / 9e-5`
- `train/cosine_progress` = `current_step / (lr_cosine_t_max * steps_per_epoch)` = `current_step / (25 * 10864)` = `current_step / 271,600`

These are diagnostic only — they help us interpret whether the LR fix actually preserved productive LR through the late epochs. If they're hard to add cleanly, skip them.

### SENPAI-RESULT template (terminal)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline

Current best (#972, run `56bcqp3m`):
- val/abupt_axis_mean_rel_l2_pct = **6.126%** (merge gate)
- test/abupt_axis_mean_rel_l2_pct = **5.844%** (baseline)
- test/volume_pressure_rel_l2_pct = **3.643%** (floor)
- test/surface_pressure_rel_l2_pct = **3.577%** (floor)
- test/wall_shear_rel_l2_pct = **6.727%**

### H55 v2 reference for comparison

H55 v2 (PR #1204 closed):
- val_abupt: 6.249% (+0.123pp above merge gate, 8th NEAR-MISS in Wave 30/31)
- **val_WSS_z: 9.558% (−0.341pp vs H48 baseline 9.899%)** — mechanism direction-correct on binding axis
- val_VP: 3.670% (+0.027pp above floor, close miss)
- val_SP: 4.086%
- test_abupt: 5.988% (+0.144pp above baseline)
- test_SP: 3.806%
- **test_VP: 3.602%** ✅ CROSSED floor by −0.041pp (3rd Wave 31 test_VP cross after H53 + H26 family)
- test_WSS: 6.883%
- test_WSS_z: 8.917% (mechanism-positive)
- W&B run: `tkouys7y`

If H63 produces terminal val_abupt below H55 v2's 6.249% by any margin, it confirms LR-decay was a contributing limit on tau-z-curriculum mech class. If H63 crosses merge gate (<6.126%), the τz curriculum mechanism merges and we open Wave 32 stack candidates with LR-extended baseline as default.

W&B baseline link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m
