### PR TITLE
Wave 31 H65: SURFACE-DEEP-LR-EXTENDED — Test H54 v2 plateau as LR-decay artifact (lr-cosine-t-max 13 to 25)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surf_deep: bool = False,
+        surf_deep_num_blocks: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surf_deep = use_surf_deep
+        self.surf_deep_num_blocks = int(surf_deep_num_blocks) if use_surf_deep else 0
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +523,38 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H54 SURFACE-DEEP (PR #1203): dedicated surface-only transformer blocks
+        # inserted between the shared backbone and the final surface head.
+        # Mirror of H47 V-DEPTH (PR #1194) on the surface decoder side.
+        # Each block's residual output projections (TransolverAttention.proj and
+        # UpActDownMlp.fc2) are zero-initialised so the new blocks are pure
+        # identity at step 0 -> bit-exact baseline recovery, and contribution
+        # magnitude can be tracked by W&B.
+        if use_surf_deep:
+            self.surf_deep_blocks = nn.ModuleList(
+                [
+                    TransformerBlock(
+                        hidden_dim=n_hidden,
+                        num_heads=n_head,
+                        mlp_expansion_factor=mlp_ratio,
+                        num_slices=slice_num,
+                        dropout=dropout,
+                        use_qk_norm=use_qk_norm,
+                    )
+                    for _ in range(self.surf_deep_num_blocks)
+                ]
+            )
+            with torch.no_grad():
+                for block in self.surf_deep_blocks:
+                    block.attention.proj.project.weight.zero_()
+                    if block.attention.proj.project.bias is not None:
+                        block.attention.proj.project.bias.zero_()
+                    block.mlp.fc2.weight.zero_()
+                    if block.mlp.fc2.bias is not None:
+                        block.mlp.fc2.bias.zero_()
+        else:
+            self.surf_deep_blocks = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -620,6 +656,13 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # H54 SURFACE-DEEP: surface-only deep blocks. Zero-initialised residual
+        # output projections make the blocks identity at init.
+        if self.surf_deep_blocks is not None and surface_x is not None and surface_tokens > 0:
+            for block in self.surf_deep_blocks:
+                surface_hidden = block(surface_hidden, attn_mask=surface_mask)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -1096,10 +1096,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                cosine_t_max_epochs = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress_epoch = max(0, epoch - config.lr_warmup_epochs)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": float(current_lr / config.lr) if config.lr > 0 else 0.0,
+                    "train/cosine_progress": float(cosine_progress_epoch / max(1, cosine_t_max_epochs)),
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surf_deep: bool = False
+    surf_deep_num_blocks: int = 2
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surf_deep": (
+            "H54 SURFACE-DEEP (PR #1203): insert dedicated surface-only "
+            "transformer blocks between the shared backbone (and any "
+            "surf->vol cross-attention) and the final surface output head. "
+            "Each block's TransolverAttention.proj and UpActDownMlp.fc2 are "
+            "zero-initialised so the inserted stack is identity at step 0 "
+            "(bit-exact baseline recovery). Mirror of H47 V-DEPTH on the "
+            "surface decoder side. Block count controlled by "
+            "--surf-deep-num-blocks."
+        ),
+        "surf_deep_num_blocks": (
+            "Number of dedicated surface-only TransformerBlocks added when "
+            "--use-surf-deep is enabled. Default 2."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +292,35 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_surf_deep_metrics(model: nn.Module) -> dict[str, float]:
+    """Per-block residual contribution diagnostic for H54 SURFACE-DEEP (PR #1203).
+
+    Mirrors the H47 V-DEPTH (PR #1194) diagnostic on the surface decoder side.
+    For each surface-only deep block, log the magnitude of the two residual
+    output projections that were zero-initialised at construction:
+      * ``attention.proj.project`` -- the slice-attention output back to the
+        residual stream.
+      * ``mlp.fc2`` -- the FFN down-projection back to the residual stream.
+
+    Both grow from 0 (init) as the block starts contributing. EP3 KILL gate
+    requires growing surf_deep block norms (mechanism alive); flat = mechanism
+    dead.
+    """
+    metrics: dict[str, float] = {}
+    blocks = getattr(model, "surf_deep_blocks", None)
+    if blocks is None:
+        return metrics
+    for i, block in enumerate(blocks):
+        attn_w = block.attention.proj.project.weight.detach().float()
+        ffn_w = block.mlp.fc2.weight.detach().float()
+        prefix = f"diag/surf_deep_block{i}"
+        metrics[f"{prefix}/attn_proj_max_abs"] = float(attn_w.abs().max().item())
+        metrics[f"{prefix}/attn_proj_global_norm"] = float(attn_w.norm().item())
+        metrics[f"{prefix}/ffn_fc2_max_abs"] = float(ffn_w.abs().max().item())
+        metrics[f"{prefix}/ffn_fc2_global_norm"] = float(ffn_w.norm().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +353,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surf_deep=config.use_surf_deep,
+        surf_deep_num_blocks=config.surf_deep_num_blocks,
     )
 
 
@@ -773,7 +820,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_surf_deep:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1262,6 +1309,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_surf_deep_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**H65 SURFACE-DEEP-LR-EXTENDED**: re-run the H54 v2 recipe with a single flag change — `--lr-cosine-t-max 25` instead of `13` — to test whether H54 v2's val_abupt NEAR-MISS (+0.122pp above merge gate) was driven by the same cosine-tail LR-decay confound now seen across 5 Wave 31 cases (H47, H52, H53, H55 v2, H54 v2).

### Why this isolates the LR-decay confound

H54 v2 closed at val_abupt 6.248% (PR #1203, terminal SENPAI-RESULT). Per-EP slope decomposition showed:

| Window | Slope (val_abupt) | Status |
|---|---:|:--|
| EP6→EP7 | -3.7 bp/ep | productive |
| EP7→EP8 | -2.9 bp/ep | productive |
| **EP8→EP9** | **-0.8 bp/ep** | ⬇ slope quartered (LR fraction ~25% peak) |
| EP9→EP10 | -0.8 bp/ep | LR-tail plateau |
| EP10→EP11 | -0.8 bp/ep | LR-tail plateau |
| EP11→EP12 (mid) | -0.32 bp/ep | terminal LR ~2-4% peak |

H54 v2 hit budget cutoff mid-EP12 with surf_deep blocks fully alive (×9-18 sublayer growth) but val_abupt slope collapsed to ~0 by EP9. Same canonical Wave 31 LR-decay-confound pattern.

**H65 is the 4th parallel LR-fix test alongside H59 V-DEPTH-LR-EXTENDED (nezuko, PR #1208), H62 CP-LOSS-WEIGHT-LR-EXTENDED (tanjiro, PR #1211), and H63 TAU-Z-CURRICULUM-LR-EXTENDED (edward, PR #1212).** If all four mechanism-class LR-fix variants produce merge-relevant improvements, the LR-decay confound is confirmed as a systematic Wave 31 ceiling across 4 orthogonal mechanism classes (variance-class-decoder-sublayer / variance-class-cp-loss-weight / variance-class-time-varying-loss / shared-capacity-surface).

### What the LR fix does

`--lr-cosine-t-max 25` stretches the cosine cycle so that within the actual ~70k-step training window, only ~28% of the cosine half-cycle completes (instead of 100% under `--lr-cosine-t-max 13`). Terminal LR stays at ~70-80% of peak instead of dropping to 0%. This preserves productive LR through the late-epoch zone where H54 v2's surf_deep blocks could still drive descent.

### Three falsifiable outcomes (against baseline #972: val_abupt 6.126%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%)

- **A. MERGE WIN + FLOOR CROSS**: val_abupt < 6.126% AND test_VP < 3.643% AND test_SP < 3.577% — LR-decay was the limit; surf_deep mechanism merges first time. Single-model SOTA candidate. Confirms shared-capacity-surface as 4th merging class.
- **B. PARTIAL WIN**: val_abupt drops below H54 v2's 6.248% by ≥0.10pp but doesn't cross merge gate — LR matters but mechanism still has limits at this strength.
- **C. NULL**: terminal val_abupt within ±0.05pp of H54 v2's 6.248% — LR-decay NOT the limit for THIS mechanism class; shared-capacity-surface saturates at this val_abupt regardless of LR schedule.

### Diagnostic to monitor

Add `train/lr_fraction_of_peak` and `train/cosine_progress` logging per step (matching H59/H62/H63 instrumentation). Expected behavior:
- EP1 (warmup): LR fraction ramping 0 → 1.0
- EP3-EP6: LR fraction holding 96-86% (vs H54 v2 which was 68-14% at same steps)
- EP12 terminal: LR fraction ~55-70% (vs H54 v2 which was 2-4%)

Keep H54 v2's surf_deep_block{0,1} mechanism diagnostics — sublayer attn_proj/ffn_fc2 global_norm and max_abs per epoch. Compare H65 EP6 to H54 v2 EP12 to check whether the mechanism saturates faster or continues growing under preserved LR.

## Instructions

Use the EXACT H54 v2 recipe with ONE flag change. No code changes required — `--lr-cosine-t-max` is an existing flag in `target/train.py` (verified used by H47/H53/H55 v2 and H59/H62/H63 LR-fix variants). The `--use-surf-deep` code is already merged on the branch from H54 v2.

### Single-arm reproduce command (DDP8, 18h budget, 13 epochs)

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --agent alphonse --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
    --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
    --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
    --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
    --lr-cosine-t-max 25 --epochs 13 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --no-compile-model \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --validation-every 1 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --use-surf-to-vol-xattn --use-surf-deep --surf-deep-num-blocks 2 \
    --amp-mode bf16 \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5" \
    --wandb-group wave31_h65_surface_deep_lr_extended \
    --wandb-name alphonse/h65-surface-deep-lr-extended
```

**ONE flag change vs H54 v2**: `--lr-cosine-t-max 25` (was `13`). Everything else identical to H54 v2 (which is itself a single-flag-added variant of the baseline recipe with `--use-surf-deep --surf-deep-num-blocks 2`).

### Pre-flight check (already-verified flags)

All flags in this recipe were verified used by H54 v2 (PR #1203 closed) AND by H47/H53/H59/H62/H63 LR-fix variants. `--use-surf-deep` code is already merged on your `alphonse/h54-surface-decoder-depth` parent branch — no new code changes required for H65.

If you have access to your `target/train.py`, do a quick `grep -E 'lr-cosine|lr_cosine' train.py` to reconfirm — but H59/H62/H63 already validated this flag exists with the value 25.

### Kill threshold rationale (lr-warmup-1 aware, ema=0.999)

| Step (epoch) | Gate | Reason |
|---:|---|---|
| 10,864 (EP1) | NONE | lr-warmup-1 cold-start val_abupt ~26%+, gate would false-kill |
| **32,592 (EP3)** | **val_abupt<7.5% AND val_SP<5.5%** | binding — H54 v2 ref at EP3 was 6.74% / 4.43%, healthy mechanism should land at or below |
| **65,184 (EP6)** | **val_abupt<6.5%** | hard kill — H54 v2 ref at EP6 was 6.33% (passed comfortably) |

### SENPAI-RESULT template (terminal)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline

Current best (#972, run `56bcqp3m`):
- val/abupt_axis_mean_rel_l2_pct = **6.126%** (merge gate)
- test/abupt_axis_mean_rel_l2_pct = **5.844%** (baseline)
- test/volume_pressure_rel_l2_pct = **3.643%** (floor)
- test/surface_pressure_rel_l2_pct = **3.577%** (floor)
- test/wall_shear_rel_l2_pct = **6.727%**

### H54 v2 reference for direct comparison

H54 v2 (PR #1203 closed):
- val_abupt: 6.248% (+0.122pp above merge gate, 10th NEAR-MISS in Wave 30/31)
- val_SP: 4.071% (+0.494pp above floor)
- val_VP: 3.699% (+0.056pp above floor, NEAR-MISS)
- val_WSS_z: 9.580% (mechanism direction-correct)
- test_abupt: 6.042% (+0.198pp above baseline)
- test_SP: 3.803% (+0.226pp above floor)
- test_VP: 3.693% (+0.050pp above floor, NEAR-MISS)
- test_WSS: 6.954% (+0.227pp above goal)
- test_WSS_z: 9.016% (+0.100pp vs baseline 8.916%)
- W&B run: `apbnjinz`
- Surf_deep mechanism diagnostics: block0 ffn_fc2 norm 5.6→68.2 (×12.1), block1 ffn_fc2 norm 7.6→70.4 (×9.2), ×9-18 growth across all 8 diagnostics — **mechanism fully alive throughout EP1→EP12**

If H65 produces terminal val_abupt below H54 v2's 6.248% by any margin, it confirms LR-decay was a contributing limit on shared-capacity-surface mechanism. If H65 crosses merge gate (<6.126%), the surf_deep mechanism merges and we open Wave 32 stack candidates (H47+H54, H53+H54, H54+H55v2) with LR-extended baseline as default.

W&B baseline link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m
W&B H54 v2 link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/apbnjinz
