### PR TITLE
Wave 31 H66: COORDSLICE-NO-STOPGRAD-LR-EXTENDED — Test H58 ceiling as LR-decay artifact (lr-cosine-t-max 13 to 25)

### DIFF
--- a/model.py
+++ b/model.py
@@ -71,6 +71,44 @@ class RFFEncoding(nn.Module):
         return torch.cat([proj.sin(), proj.cos()], dim=-1)
 
 
+class MultiSigmaRFFEncoding(nn.Module):
+    """Multi-sigma Gaussian random Fourier features for 3D coordinate encoding.
+
+    Encodes ``in_dim``-dimensional coordinates using ``len(sigmas)`` independent
+    RFF banks at different length scales, concatenated along the feature dim.
+    Output dimension is ``2 * num_features * len(sigmas)`` (sin + cos per bank).
+
+    All projection matrices are registered as non-trainable buffers so they
+    travel with the model across devices and DDP ranks.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        num_features: int = 32,
+        sigmas: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0),
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.num_features = num_features
+        self.sigmas = sigmas
+        for i, sigma in enumerate(sigmas):
+            self.register_buffer(f"B_{i}", torch.randn(in_dim, num_features) * sigma)
+
+    @property
+    def output_dim(self) -> int:
+        return 2 * self.num_features * len(self.sigmas)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        parts: list[torch.Tensor] = []
+        for i in range(len(self.sigmas)):
+            B = getattr(self, f"B_{i}").to(dtype=x.dtype)
+            proj = 2.0 * math.pi * (x @ B)
+            parts.append(proj.sin())
+            parts.append(proj.cos())
+        return torch.cat(parts, dim=-1)
+
+
 class StringSeparableEncoding(nn.Module):
     """STRING-separable positional encoding.
 
@@ -234,6 +272,9 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +285,7 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_coord_slice_pe = use_coord_slice_pe
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -258,6 +300,26 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+
+        if use_coord_slice_pe:
+            # Multi-sigma RFF encoding of 3D slice centroids → additive PE for slice tokens.
+            # Uses 4 sigmas covering sub-car (0.25m) to full-car (2.0m) length scales.
+            self.coord_pe_rff = MultiSigmaRFFEncoding(
+                in_dim=3,
+                num_features=coord_slice_pe_rff_features,
+                sigmas=(0.25, 0.5, 1.0, 2.0),
+            )
+            rff_out_dim = self.coord_pe_rff.output_dim  # 2 * rff_features * 4 sigmas
+            # Project from RFF space to per-head D_head additive PE: [B,S,rff_out] → [B,S,H*D_head]
+            self.coord_pe_proj = nn.Linear(rff_out_dim, num_heads * self.dim_head)
+            # Init at small scale (O(1/sqrt(D_head)) per H33 lesson; avoids sub-gradient-floor init)
+            with torch.no_grad():
+                w_std = self.coord_pe_proj.weight.std().clamp(min=1e-8)
+                self.coord_pe_proj.weight.mul_(coord_slice_pe_init_scale / w_std)
+                nn.init.zeros_(self.coord_pe_proj.bias)
+        else:
+            self.coord_pe_rff = None
+            self.coord_pe_proj = None
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -274,8 +336,39 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        if self.use_coord_slice_pe and coords is not None:
+            # H58: routing gradients flow back into PE projection via centroid
+            # computation. H50 wrapped this in torch.no_grad(), starving the PE
+            # projection of optimization signal (proj_weight_std stuck at init).
+            # Allowing grad flow lets the projection learn discriminative
+            # coordinate-routing structure, restoring H33-style PE auto-growth.
+            slice_weights_mean = slice_weights.mean(dim=1)  # [B, N, S]
+            slice_norm = slice_weights_mean.sum(dim=1, keepdim=True) + 1e-5  # [B, 1, S]
+            slice_centroids = torch.einsum("bnc,bns->bsc", coords, slice_weights_mean) / slice_norm.transpose(1, 2)  # [B, S, 3]
+            coord_rff = self.coord_pe_rff(slice_centroids)  # [B, S, rff_features * 2 * 4]
+            coord_pe = self.coord_pe_proj(coord_rff)  # [B, S, num_heads * D_head]
+            B_size, S_size = slice_centroids.shape[:2]
+            coord_pe = coord_pe.view(B_size, S_size, self.num_heads, self.dim_head).permute(0, 2, 1, 3)  # [B, H, S, D_head]
+            slice_tokens = slice_tokens + coord_pe
+            if not self.training:
+                # Stash diagnostics for val-time logging via collect_coord_slice_pe_metrics
+                with torch.no_grad():
+                    self._last_slice_centroids = slice_centroids.detach()  # [B, S, 3]
+                    flat = slice_tokens.detach()  # [B, H, S, D_head] — post-PE input to qkv
+                    fnorm = flat / (flat.norm(dim=-1, keepdim=True) + 1e-9)
+                    cos = torch.einsum("bhsd,bhtd->bhst", fnorm, fnorm)  # [B, H, S, S]
+                    S_dim = cos.shape[-1]
+                    eye = torch.eye(S_dim, device=cos.device, dtype=cos.dtype).unsqueeze(0).unsqueeze(0)
+                    off_diag_sum = (cos * (1.0 - eye)).sum(dim=(-2, -1))
+                    off_diag_mean = (off_diag_sum / (S_dim * (S_dim - 1))).mean()
+                    self._last_inter_slice_cos = float(off_diag_mean.item())
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -303,6 +396,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +409,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, coords=coords)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +440,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +454,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_coord_slice_pe=use_coord_slice_pe,
+                    coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+                    coord_slice_pe_init_scale=coord_slice_pe_init_scale,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, coords=coords)
         return x
 
 
@@ -382,6 +497,9 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_coord_slice_pe: bool = False,
+        coord_slice_pe_rff_features: int = 32,
+        coord_slice_pe_init_scale: float = 0.088,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +514,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_coord_slice_pe = use_coord_slice_pe
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +591,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_coord_slice_pe=use_coord_slice_pe,
+            coord_slice_pe_rff_features=coord_slice_pe_rff_features,
+            coord_slice_pe_init_scale=coord_slice_pe_init_scale,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -562,6 +684,7 @@ class SurfaceTransolver(nn.Module):
 
         tokens: list[torch.Tensor] = []
         masks: list[torch.Tensor] = []
+        coords_list: list[torch.Tensor] = []
         surface_tokens = 0
         volume_tokens = 0
 
@@ -578,6 +701,8 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(surface_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(surface_x[:, :, : self.space_dim])
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -592,10 +717,19 @@ class SurfaceTransolver(nn.Module):
                 )
             )
             masks.append(volume_mask)
+            if self.use_coord_slice_pe:
+                coords_list.append(volume_x[:, :, : self.space_dim])
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        # Build concatenated coords tensor in the same token order as the hidden states.
+        # Pad masked-out tokens to zero so they don't skew slice centroids.
+        if self.use_coord_slice_pe and coords_list:
+            coords = torch.cat(coords_list, dim=1)  # [B, N_surf+N_vol, 3]
+            coords = coords * attn_mask.unsqueeze(-1).to(dtype=coords.dtype)
+        else:
+            coords = None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, coords=coords)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_coord_slice_pe: bool = False
+    coord_slice_pe_rff_features: int = 32
+    coord_slice_pe_init_scale: float = 0.088
     debug: bool = False
 
 
@@ -294,6 +297,61 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
+def collect_coord_slice_pe_metrics(model: nn.Module) -> dict[str, float]:
+    """Log coord-slice PE diagnostics per Transformer block.
+
+    Static metrics: per-layer coord_pe_proj weight/bias statistics.
+    Dynamic metrics (captured during last val forward): slice_centroid
+    distribution (mean/std/range per axis, across-slice spread) and
+    inter_slice_cos on the post-PE slice_tokens (mechanism diagnostic
+    aligned with H33's pattern for direct comparison).
+    """
+    metrics: dict[str, float] = {}
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return metrics
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return metrics
+    all_inter_slice_cos: list[float] = []
+    for i, block in enumerate(blocks):
+        attn = getattr(block, "attention", None)
+        if attn is None:
+            continue
+        proj = getattr(attn, "coord_pe_proj", None)
+        if proj is None:
+            continue
+        w = proj.weight.detach().float()
+        w_std = float(w.std().item())
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_norm"] = float(w.norm().item())
+        metrics[f"coord_slice_pe/block_{i}/proj_weight_std"] = w_std
+        # H58 binding mechanism gate: per-block proj_weight_std in PR-body namespace.
+        # Target: terminal > 0.18 vs init 0.088 (H33 auto-grew 8x; H50 stop-grad stayed ~init).
+        metrics[f"diag/coord_pe_proj_block{i}/weight_std"] = w_std
+        b = proj.bias.detach().float()
+        metrics[f"coord_slice_pe/block_{i}/proj_bias_norm"] = float(b.norm().item())
+        centroids = getattr(attn, "_last_slice_centroids", None)
+        if centroids is not None:
+            c = centroids.float()  # [B, S, 3]
+            for axis_i, axis in enumerate(("x", "y", "z")):
+                ca = c[..., axis_i]
+                metrics[f"coord_slice_pe/block_{i}/centroid_mean_{axis}"] = float(ca.mean().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_std_{axis}"] = float(ca.std().item())
+                metrics[f"coord_slice_pe/block_{i}/centroid_range_{axis}"] = float(
+                    (ca.max() - ca.min()).item()
+                )
+            metrics[f"coord_slice_pe/block_{i}/centroid_spread"] = float(c.std(dim=1).mean().item())
+        isc = getattr(attn, "_last_inter_slice_cos", None)
+        if isc is not None:
+            metrics[f"coord_slice_pe/block_{i}/inter_slice_cos_post_pe"] = float(isc)
+            all_inter_slice_cos.append(float(isc))
+    if all_inter_slice_cos:
+        metrics["coord_slice_pe/global/inter_slice_cos_mean"] = float(
+            sum(all_inter_slice_cos) / len(all_inter_slice_cos)
+        )
+    return metrics
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -308,6 +366,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_coord_slice_pe=config.use_coord_slice_pe,
+        coord_slice_pe_rff_features=config.coord_slice_pe_rff_features,
+        coord_slice_pe_init_scale=config.coord_slice_pe_init_scale,
     )
 
 
@@ -1049,10 +1110,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                cosine_t_max_epochs = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress_epoch = max(0, epoch - config.lr_warmup_epochs)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": float(current_lr / config.lr) if config.lr > 0 else 0.0,
+                    "train/cosine_progress": float(cosine_progress_epoch / max(1, cosine_t_max_epochs)),
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1262,6 +1329,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_coord_slice_pe_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis — H66 COORDSLICE-NO-STOPGRAD-LR-EXTENDED: Test H58 ceiling as LR-decay artifact

H58 COORDSLICE-NO-STOPGRAD just closed (PR #1207) as **mechanism-positive null with deepest Wave 31 test_VP floor cross** + **closest val_abupt near-miss** (6.161%, +0.035pp short of merge gate 6.126%) + key structural finding on Lion+zero-mean-gradient sign-cancellation explaining why the PE-auto-growth hypothesis was falsified despite a primary-positive result.

The H58 EP5→EP6 val_abupt trajectory exhibited the canonical Wave 31 LR-decay slope-halving pattern (5 prior confirmed cases: H47/H52/H53/H55v2/H54v2). With H58's terminal LR fraction at ~14% peak by EP6 and ~0% peak by EP10, productive descent stalled in the last 4 epochs.

**H66 hypothesis**: extend the cosine half-cycle from 13 epochs to 25 epochs (terminal LR stays ~70-80% peak instead of 0%) and observe whether H58's productive descent EP6→EP12 continues, closing the +0.035pp val_abupt gap. This is the **5th of 5 parallel LR-fix variants** rounding out LR-decay-confound triangulation across orthogonal mechanism classes.

**5 parallel LR-fix tests (all single-flag changes adding `--lr-cosine-t-max 25`)**:
| Variant | Mech class | Predecessor | Predecessor val_abupt |
|:--|:--|:--|---:|
| H59 (nezuko, PR #1208) | variance-class-decoder-sublayer | H47 V-DEPTH | 6.143% |
| H62 (tanjiro, PR #1211) | variance-class-cp-loss-weight | H53 CP-LOSS | 6.181% |
| H63 (edward, PR #1212) | variance-class-time-varying-loss | H55 v2 TAU-Z | 6.249% |
| H65 (alphonse, PR #1214) | shared-capacity-surface | H54 v2 SURF-DEEP | 6.248% |
| **H66 (askeladd, this PR)** | **encoder-PE-no-stopgrad** | **H58 COORDSLICE** | **6.161%** |

If all 5 variants produce merge-relevant improvements across 5 orthogonal mech classes, LR-decay is bulletproof confirmed as the systematic Wave 31 ceiling and Wave 32 baselines default to `--lr-cosine-t-max 25`.

**Falsifiable outcomes**:
- **(A) MERGE WIN + FLOOR CROSS** — val_abupt < 6.126% AND test_VP < 3.643%. LR-decay was the H58 limit → first encoder-PE-no-stopgrad merge in Wave 31 + 7th mechanism-class merge candidate Wave 32 stack-eligible
- **(B) PARTIAL** — val_abupt drops below H58's 6.161% by ≥0.05pp but no merge. LR helped, but encoder-PE-no-stopgrad mech-class still has a structural ceiling
- **(C) NULL** — val_abupt within ±0.05pp of H58's 6.161%. LR-decay NOT the limit on encoder-PE-no-stopgrad → confirms the class saturates regardless of LR schedule; Wave 32 directs encoder-PE focus to AdamW switch or direct-QK-multiplied PE redesign

## Instructions

**Single-flag change vs H58 PR #1207** (your prior work): change `--lr-cosine-t-max 13` to `--lr-cosine-t-max 25`. Everything else identical to H58 — same `--use-coord-slice-pe`, same `--coord-slice-pe-rff-features 32`, same `--coord-slice-pe-init-scale 0.088`, same `--lr-warmup-epochs 1`, same `--ema-decay 0.999`, same `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`, same kill thresholds, same 13-epoch training budget.

### Code change

None required. H58's `TransolverAttention` no-stopgrad implementation is already on the advisor branch (`tay`). H66 reuses that code path verbatim — only the CLI flag changes.

### Diagnostic logging

H58's `diag/coord_pe_proj_block{i}/weight_std` keys are already implemented; keep them logging for H66 cross-comparison. Additionally, add the LR-fix observability keys matching H59/H62/H63/H65:
- `train/lr_fraction_of_peak` (current_lr / peak_lr, float in [0, 1])
- `train/cosine_progress` (current_step / lr_cosine_t_max_steps, float in [0, 1])

These should be logged at the same frequency as `train/lr` (every step).

### Training command (full 13 epochs, --lr-cosine-t-max 25)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --lr 9e-5 --batch-size 4 \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 --no-compile-model \
  --lr-warmup-epochs 1 --lr-cosine-t-max 25 --epochs 13 \
  --weight-decay 0.0005 --grad-clip-norm 0.5 --use-qk-norm \
  --pos-encoding-mode string_separable --rff-num-features 16 \
  --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --eval-surface-points 65536 --eval-volume-points 65536 --train-surface-points 65536 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --use-surf-to-vol-xattn \
  --use-coord-slice-pe --coord-slice-pe-rff-features 32 --coord-slice-pe-init-scale 0.088 \
  --use-ema --ema-decay 0.999 --ema-start-step 50 --amp-mode bf16 \
  --agent askeladd \
  --wandb-group wave31_h66_coordslice_no_stopgrad_lr_extended \
  --wandb-name askeladd/h66-coordslice-no-stopgrad-lr-extended-13ep \
  --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

**Note on kill-thresholds and vol-points-schedule**: Your H58 terminal report correctly identified that with `--vol-points-schedule` the steps-per-epoch decrease as vol_points grow (10864 → 5436 → 3626 → 2721), so step 65,184 corresponds to ~EP10.5 not EP6. The EP6-boundary val read should arrive at the natural epoch boundary regardless. The thresholds are kept at the standard global-step values for harness compatibility; gate-check happens at the corresponding W&B step regardless of epoch label.

## Gates

### EP3 binding (HARD, step 32,594)
- `val_primary/abupt_axis_mean_rel_l2_pct < 7.5%` (your H58 at this step: 6.902%)
- `val_primary/surface_pressure_rel_l2_pct < 5.5%` (your H58 at this step: 4.625%)
- **KEY LR-fix DIAGNOSTIC at EP3**: `train/lr_fraction_of_peak` should be ~0.96-1.00 (peak / just past). H58 at EP3 had LR fraction ~0.68 (already at 68% peak under cosine-t-max 13). If H66 holds 96-100% peak at EP3, recipe behaves as designed.

### EP6 hard kill (step 65,184)
- `val_primary/abupt_axis_mean_rel_l2_pct < 6.5%` (your H58 at this step: 6.225%; expect H66 similar or marginally better since LR effect kicks in later)
- **LR-fix DIAGNOSTIC at EP6**: H58 had LR fraction 14% peak; H66's should be ~86-90% peak. If H66 val_abupt slope EP4→EP6 is steeper than H58's at the same val_abupt, LR-decay confirmed as the H58 limit on encoder-PE-no-stopgrad class.

### EP13 terminal gates
1. **Merge gate**: `val_abupt < 6.126%` (H58 missed by +0.035pp; H66 target close the gap)
2. **Hard floors**: `test_primary/surface_pressure_rel_l2_pct ≤ 3.577%`, `test_primary/volume_pressure_rel_l2_pct ≤ 3.643%`
3. **WSS goal**: `test_primary/wall_shear_rel_l2_pct < 6.727%` (your H58 terminal: 6.906%)
4. **Slope-recovery check**: terminal slope between EP6 and EP12 should average ≥ −0.005 pp/1k (H58 averaged ~−0.002 between EP6 and terminal under LR collapse). A slope holding ≥ −0.005 pp/1k post-EP6 confirms LR-decay was the H58 bottleneck.

## Baseline reference

Current best single-model (PR #972, run `56bcqp3m`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: **5.844%**
- test_vol_p: **3.643%** (floor — H58 already crossed at 3.551%, H66 should retain ≤ 3.55%)
- test_SP: **3.577%** (floor — H58 missed at 3.856%; H66 target close gap)
- test_WSS: **6.727%** (target to beat)

**H58 terminal (your prior PR #1207, the direct comparator)**:
- val_abupt: 6.161% (+0.035pp above merge gate)
- test_abupt: 5.999% (+0.155pp above baseline)
- test_VP: **3.551%** (−0.092pp BELOW floor ⭐ DEEPEST Wave 31)
- test_SP: 3.856% (+0.279pp above floor)
- test_WSS: 6.906% (+0.179pp above goal)
- val_VP: 3.572% (lowest Wave 31)
- proj_weight_std at terminal: 0.0882-0.0981 (≈ init, mechanism FALSIFIED)
- run: `9j719af8`

## Why H66 is the right next step

1. **Single-flag change** — lowest implementation risk; just `--lr-cosine-t-max 13 → 25`
2. **Rounds out 5-class LR-fix triangulation** — H58 was the encoder-PE-no-stopgrad case missing from the H59/H62/H63/H65 quartet
3. **H58 set the deepest test_VP floor cross in Wave 31** (−0.092pp) — if LR extension preserves or deepens this AND closes the +0.035pp val_abupt gap, H66 becomes the strongest single-model Wave 31 result
4. **Cheap falsification**: if EP6 slope holds productive (LR fix biting), keep going; if mechanism saturates regardless (NULL outcome C), close in 18h
5. **High info-value either way**: H66 MERGE = first encoder-PE merge in Wave 31; H66 NULL = encoder-PE-no-stopgrad class has structural ceiling, Wave 32 directs to AdamW-on-PE or direct-QK-PE
6. **Strategic timing**: H66 is the 5th LR-fix variant. If 5/5 variants improve, LR-decay is bulletproof confirmed and Wave 32 baselines default to `--lr-cosine-t-max 25`

## Risk note

The LR extension at constant peak LR (9e-5) means H66 trains at higher effective LR through EP6-12 than H58. Watch for:
- `train/grad_norm` spikes in the EP6-10 window (where H58 was already in LR-decay regime)
- `nonfinite_count > 0` at any step
- `val_abupt` regression at EP10-12 (LR not decaying fast enough, oscillation)

If any of these fire, post a check-in and we can discuss whether to add `--lr-cosine-t-max 20` as a mid-point, or augment `--grad-clip-norm` from 0.5 to 0.3.

## Wave 31 fleet context (snapshot at H66 launch)

| Student | PR | Hypothesis | LR class |
|---|---|---|:--|
| nezuko | #1208 | H59 V-DEPTH-LR-EXTENDED | LR-fix variance-class-decoder-sublayer |
| fern | #1209 | H60 H56-RELAUNCH-DROP-EP3 | ema-aware-variance-stack |
| frieren | #1210 | H61 SLICE-TEMP-CURRICULUM | attention-temperature-curriculum |
| tanjiro | #1211 | H62 CP-LOSS-WEIGHT-LR-EXTENDED | LR-fix variance-class-cp-loss-weight |
| edward | #1212 | H63 TAU-Z-CURRICULUM-LR-EXTENDED | LR-fix variance-class-time-varying-loss |
| thorfinn | #1213 | H64 RFF-LOW-BAND-EXPANSION | frequency-domain-capacity-low-tilted |
| alphonse | #1214 | H65 SURFACE-DEEP-LR-EXTENDED | LR-fix shared-capacity-surface |
| **askeladd** | **#this** | **H66 COORDSLICE-NO-STOPGRAD-LR-EXTENDED** | **LR-fix encoder-PE-no-stopgrad** |

All 8 students in flight, 5 LR-fix variants covering 5 orthogonal mech classes.

## Resources

- Reference baseline: PR #972, run `56bcqp3m`
- Reference predecessor: H58 closed PR #1207, run `9j719af8`
- New run group: `wave31_h66_coordslice_no_stopgrad_lr_extended`
- Code path: no model.py change (H58 no-stopgrad already in tay); train.py adds `train/lr_fraction_of_peak` + `train/cosine_progress` keys
- 18h budget: standard, `SENPAI_TIMEOUT_MINUTES=1100`

## Report format

Per epoch (EP1, EP3, EP6, EP9, EP13):

```
EP<N> update (step <step>, run <run-id>):
- val_abupt: X.XXX% (slope: X.XXX pp/1k vs prior epoch; vs H58 EP<N>: X.XXX%)
- val_VP: X.XXX% (vs floor 3.643%; vs H58 EP<N>: X.XXX%)
- val_SP: X.XXX% (vs floor 3.577%; vs H58 EP<N>: X.XXX%)
- per-axis WSS: τx=X.XXX%, τy=X.XXX%, τz=X.XXX%
- LR-fix diagnostic: train/lr_fraction_of_peak=X.XXX, train/cosine_progress=X.XXX (vs H58 same step: X.XXX)
- proj_weight_std per block: [b0, b1, b2, b3, b4] (vs H58 same step)
- 8-rank DDP step spread: N
```

At EP13 terminal: full test eval on best val_abupt EMA ckpt + SENPAI-RESULT marker.

## Acknowledgment

H58 was an excellent piece of analytical work — the per-block proj_weight_std diagnostic falsifying the PE-auto-growth hypothesis, the per-layer gradient diagnostic identifying Lion+zero-mean-gradient sign-cancellation as the structural reason, and the honest disambiguation between the predicted PE-growth mechanism (FALSIFIED) and the unintended slice-routing-gradient side effect (the actual primary-positive cause). The structural finding about Lion+indirect-gradient is reusable across all future encoder-PE class hypotheses.

H66 is the natural 5th LR-fix triangulation test, completing the parallel sweep across mechanism classes. Will check back at EP1 boundary then EP3 gate.

Advisor branch at current head.
