### PR TITLE
Wave 32 H68: CHARBONNIER-VOL-P — Charbonnier loss on volume pressure (cross-pollination from dl24 H19)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_charbonnier,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -85,6 +86,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    vol_loss_type: str = "mse"
+    charbonnier_eps: float = 1e-3
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -229,6 +232,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "vol_loss_type": (
+            "Loss function for volume_pressure target. 'mse' (default) is "
+            "masked squared error. 'charbonnier' is "
+            "sqrt((pred-target)^2 + eps^2) - eps, which transitions smoothly "
+            "from quadratic for small errors to linear for large errors, "
+            "bounding outlier-driven gradient magnitude. Cross-pollinated "
+            "from dl24 H19 (PR #1180). Surface loss is unaffected."
+        ),
+        "charbonnier_eps": (
+            "Epsilon (smoothing constant) for Charbonnier loss. Applied as "
+            "sqrt((pred-target)^2 + eps^2) - eps. Smaller eps approaches "
+            "L1 behaviour; larger eps approaches MSE behaviour. Default "
+            "1e-3 matches dl24 H19. Only used when --vol-loss-type=charbonnier."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -240,7 +257,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    if config.vol_loss_type not in {"mse", "charbonnier"}:
+        raise ValueError(
+            f"--vol-loss-type must be one of {{'mse', 'charbonnier'}}; got "
+            f"{config.vol_loss_type!r}"
+        )
+    if config.charbonnier_eps <= 0.0:
+        raise ValueError(
+            f"--charbonnier-eps must be positive; got {config.charbonnier_eps}"
+        )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -321,6 +348,11 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_loss_type: str = "mse",
+    charbonnier_eps: float = 1e-3,
+    retain_volume_grad: bool = False,
+    vol_loss_diag: dict[str, float] | None = None,
+    volume_pred_out: dict | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -341,7 +373,25 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_preds = out["volume_preds"]
+        if retain_volume_grad and volume_preds.requires_grad:
+            volume_preds.retain_grad()
+        if volume_pred_out is not None:
+            volume_pred_out["volume_preds"] = volume_preds
+        if vol_loss_type == "charbonnier":
+            volume_loss = masked_charbonnier(
+                volume_preds, volume_target, batch.volume_mask, eps=charbonnier_eps
+            )
+            if vol_loss_diag is not None:
+                _populate_vol_loss_diag(
+                    volume_preds, volume_target, batch.volume_mask, charbonnier_eps, vol_loss_diag
+                )
+        else:
+            volume_loss = masked_mse(volume_preds, volume_target, batch.volume_mask)
+            if vol_loss_diag is not None:
+                _populate_vol_loss_diag(
+                    volume_preds, volume_target, batch.volume_mask, None, vol_loss_diag
+                )
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -353,6 +403,45 @@ def train_loss(
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+
+
+def _populate_vol_loss_diag(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    charbonnier_eps: float | None,
+    diag: dict[str, float],
+) -> None:
+    """Fill ``diag`` with per-element loss-distribution stats over masked entries.
+
+    Always logs the MSE per-element distribution; when ``charbonnier_eps`` is
+    provided also logs the Charbonnier per-element distribution alongside it
+    so both shapes are comparable in the W&B stream.
+    """
+    with torch.no_grad():
+        flat_mask = mask.to(device=pred.device, dtype=torch.bool)
+        if not bool(flat_mask.any()):
+            return
+        sq = (pred - target).square()
+        per_elt_mse = sq[flat_mask].float().reshape(-1)
+        diag["vol_loss_diag/mse_mean"] = float(per_elt_mse.mean().item())
+        diag["vol_loss_diag/mse_std"] = float(per_elt_mse.std(unbiased=False).item())
+        diag["vol_loss_diag/mse_max"] = float(per_elt_mse.max().item())
+        q = torch.tensor([0.5, 0.9, 0.99], device=per_elt_mse.device)
+        quantiles = torch.quantile(per_elt_mse, q)
+        diag["vol_loss_diag/mse_p50"] = float(quantiles[0].item())
+        diag["vol_loss_diag/mse_p90"] = float(quantiles[1].item())
+        diag["vol_loss_diag/mse_p99"] = float(quantiles[2].item())
+        if charbonnier_eps is not None:
+            char = torch.sqrt(sq + charbonnier_eps * charbonnier_eps) - charbonnier_eps
+            per_elt_char = char[flat_mask].float().reshape(-1)
+            diag["vol_loss_diag/char_mean"] = float(per_elt_char.mean().item())
+            diag["vol_loss_diag/char_std"] = float(per_elt_char.std(unbiased=False).item())
+            diag["vol_loss_diag/char_max"] = float(per_elt_char.max().item())
+            cq = torch.quantile(per_elt_char, q)
+            diag["vol_loss_diag/char_p50"] = float(cq[0].item())
+            diag["vol_loss_diag/char_p90"] = float(cq[1].item())
+            diag["vol_loss_diag/char_p99"] = float(cq[2].item())
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -937,6 +1026,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                vol_loss_diag: dict[str, float] = {}
+                volume_pred_holder: dict = {}
+                will_log_vol_diag = (
+                    balancer is None
+                    and config.gradient_log_every > 0
+                    and ((global_step + 1) % config.gradient_log_every == 0)
+                )
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1030,6 +1126,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_loss_type=config.vol_loss_type,
+                        charbonnier_eps=config.charbonnier_eps,
+                        retain_volume_grad=will_log_vol_diag,
+                        vol_loss_diag=vol_loss_diag if will_log_vol_diag else None,
+                        volume_pred_out=volume_pred_holder if will_log_vol_diag else None,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1049,10 +1150,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                peak_lr = config.lr if config.lr > 0.0 else 1.0
+                lr_fraction_of_peak = current_lr / peak_lr if peak_lr != 0 else 0.0
+                warmup_e = max(0, config.lr_warmup_epochs)
+                cosine_t_max = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress = max(0.0, float(epoch - warmup_e)) / float(max(1, cosine_t_max))
+                cosine_progress = min(1.0, cosine_progress)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": lr_fraction_of_peak,
+                    "train/cosine_progress": cosine_progress,
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1072,11 +1183,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if vol_loss_diag:
+                    train_log.update(vol_loss_diag)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
+                    if (
+                        will_log_vol_diag
+                        and "volume_preds" in volume_pred_holder
+                        and volume_pred_holder["volume_preds"].grad is not None
+                    ):
+                        vp_grad = volume_pred_holder["volume_preds"].grad.detach().float()
+                        vp_grad_norm = float(vp_grad.norm().item())
+                        vp_grad_max = float(vp_grad.abs().max().item())
+                        train_log["train/vol_p_grad/l2_norm"] = vp_grad_norm
+                        train_log["train/vol_p_grad/max_abs"] = vp_grad_max
+                        if vp_grad.numel() > 0:
+                            train_log["train/vol_p_grad/mean_abs"] = float(vp_grad.abs().mean().item())
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
                             base_model.parameters(),

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,18 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Charbonnier loss with token-mask; matches masked_mse signature and reduction."""
+    sq = (pred - target).square()
+    err = torch.sqrt(sq + eps * eps) - eps
+    return masked_mean(err, mask)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
# H68 — Charbonnier loss on volume pressure (cross-pollination from dl24 fleet)

## Hypothesis

The current volume-pressure (vol_p) loss in `train.py` (line 344) uses masked MSE: `(pred - target)^2`. The dl24 fleet's H19 (PR #1180, advisor parallel-data fleet) achieved their strongest single-model improvement on test_wss + test_abupt by applying **Charbonnier loss** to vol_p (and tau_z) instead of MSE. Direct number comparison is invalid (dl24 trains on `drivaerml-long-20260504` parallel dataset, NOT my data root `drivaerml_processed_rawcanon_20260511`) — but the technique transfer is high-value cross-pollination intelligence.

**Charbonnier loss formula:**
```
charbonnier(x, y, eps) = sqrt((x - y)^2 + eps^2) - eps
```

(Subtracting `eps` makes it zero at perfect prediction; some implementations drop this constant — it doesn't affect gradients.)

**Why Charbonnier helps on vol_p specifically:**
1. **Outlier robustness** — Volume pressure has a long-tailed error distribution (some near-wake / wing-tip points are physically harder than freestream). MSE's quadratic penalty causes outlier-driven gradient noise that dominates the bulk-distribution signal. Charbonnier transitions smoothly from quadratic (`x^2/2` for small `|x|`) to linear (`|x|` for large `|x|`), bounding outlier gradient magnitude.
2. **Smoother gradient landscape near zero** — vs L1 which has a discontinuous gradient at zero. With Lion (sign-only updates), this matters less than with AdamW, but the loss-landscape smoothing still helps the surrogate by removing the noise floor.
3. **Reshapes loss landscape to favor wss-relevant features** — dl24's empirical finding: the rebalancing between bulk-distribution accuracy and tail accuracy reallocates capacity from outlier-fitting to mean-flow-feature fitting, which is exactly what helps test_wss.

**Why this mechanism class is fresh on tay:** The current Wave 31 mech taxonomy has no loss-function-shape class. All 13 prior classes are about loss weighting (CP-LOSS, tau-z-curr), capacity allocation (V-DEPTH, SURFACE-DEEP, FDCE), or PE/attention structure (coord-slice, FDCE). Charbonnier is a **loss-curvature-shape** mechanism class — a fundamentally different lever.

## Instructions

Single-mechanism single-flag test. Modify `target/train.py`:

### Step 1: Add a `masked_charbonnier` function
Add to `target/train.py` near the existing `masked_mse` import (line 57) or in the same module if it's defined there:

```python
def masked_charbonnier(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor, eps: float = 1e-3) -> torch.Tensor:
    """Charbonnier loss with token-mask. Matches masked_mse signature & reduction."""
    sq = (pred - target).square()
    err = torch.sqrt(sq + eps * eps) - eps
    if mask is not None:
        err = err * mask.unsqueeze(-1).to(err.dtype)
        denom = mask.sum().clamp_min(1.0) * pred.shape[-1]
    else:
        denom = err.numel()
    return err.sum() / denom
```

(Match the exact reduction convention of `masked_mse` — if `masked_mse` uses `.mean()` over masked entries directly, mirror that. Check the existing implementation in the module where it's defined and copy its shape handling.)

### Step 2: Add CLI flag
In the argparse section, add:

```python
parser.add_argument(
    "--vol-loss-type",
    type=str,
    choices=["mse", "charbonnier"],
    default="mse",
    help="Loss function for volume pressure target.",
)
parser.add_argument(
    "--charbonnier-eps",
    type=float,
    default=1e-3,
    help="Epsilon for Charbonnier loss (smoothing constant).",
)
```

### Step 3: Switch in `compute_loss` (or equivalent)
At `target/train.py:344` where `volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)` is computed:

```python
if config.vol_loss_type == "charbonnier":
    volume_loss = masked_charbonnier(
        out["volume_preds"], volume_target, batch.volume_mask, eps=config.charbonnier_eps
    )
else:
    volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
```

**Keep surface_loss unchanged** — this is a single-axis vol_p test. (dl24 H19 applies Charbonnier to BOTH vol_p and tau_z under GradNorm; we isolate to vol_p first to attribute mechanism direction cleanly. tau_z + GradNorm becomes a follow-up.)

### Step 4: Use LR-fix substrate
H59/H62/H63/H65/H66 are all testing `--lr-cosine-t-max 25` vs the prior 13 — converging evidence on the LR-decay-confound. Run H68 on the LR-extended substrate to compose with that finding.

## Recipe

```bash
cd /workspace/senpai/target

torchrun --nproc_per_node=8 train.py \
    --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --epochs 13 \
    --batch-size 2 \
    --hidden-dim 512 \
    --num-layers 5 \
    --num-slices 128 \
    --num-heads 8 \
    --optimizer lion \
    --lr 9e-5 \
    --lr-cosine-t-max 25 \
    --lr-warmup-epochs 1 \
    --ema-decay 0.999 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --volume-loss-weight 0.5 \
    --vol-loss-type charbonnier \
    --charbonnier-eps 1e-3 \
    --kill-thresholds "32592:val_abupt<7.5,val_SP<5.5" "65184:val_abupt<6.5" \
    --wandb-name nezuko/h68-charbonnier-vol-p \
    --wandb-group nezuko-h68-charbonnier-vol-p
```

**Audit the flag names** — verify `--vol-points-schedule`, `--volume-loss-weight`, `--lr-cosine-t-max`, `--ema-decay`, `--kill-thresholds` all exist in `target/train.py` argparse with these exact spellings. If a phantom flag crashes the launch, fix and re-launch; do NOT silently rename.

## Diagnostic to log

Beyond standard metrics, log:

1. **Per-sample loss histogram** at EP1, EP6, EP13 — `train/vol_p_per_sample_loss_hist` (bins log-spaced, range `[1e-6, 1.0]`). Used to verify outlier compression: Charbonnier should reduce the high-error tail vs MSE baseline.

2. **Effective gradient magnitude** for volume_preds: `train/vol_p_grad_norm` (L2 norm of `volume_preds.grad` per step, mean-reduced over batch). Charbonnier should produce **smaller, more uniform** grad norms than MSE; if Charbonnier grad norms are >= MSE's, the loss-landscape-reshaping hypothesis is falsified.

3. **Standard LR-fix instrumentation**: `train/lr_fraction_of_peak` and `train/cosine_progress` (matching H59/H62/H63/H65/H66 conventions).

## Kill thresholds & timing

- **No EP1 gate** (lr-warmup-1 recipe + LR-extended cosine = EP1 val_abupt ~33% expected)
- **EP3 (step 32,592):** `val_abupt < 7.5 AND val_SP < 5.5` — soft sanity check
- **EP6 (step 65,184):** `val_abupt < 6.5` — hard kill if mechanism is dead at midpoint
- **EP13 terminal:** report all 7 paper-facing axes (val_abupt, test_abupt, test_VP, test_SP, test_WSS_{x,y,z})

Budget: SENPAI_TIMEOUT_MINUTES=1100 (18h), expect ~14-15h on 8×96GB. If wall-clock exceeds 17h, post a check-in comment.

## Falsifiable outcomes

- **A. MERGE WIN + FLOOR CROSS** — `val_abupt < 6.126%` AND `test_VP < 3.643%` AND `test_SP < 3.577%` AND `test_WSS < 6.727%`. Charbonnier unlocks the variance-class ceiling and is a Wave 32 stack-eligible mechanism. Compose with H58's no-stopgrad slice-routing and/or H47's V-DEPTH for stack tests.
- **B. PARTIAL WIN** — `val_abupt` drops below baseline 6.126% by ≥0.05pp but a floor fails. Charbonnier is mech-positive but the rebalancing breaks one of test_VP/test_SP. Triage which axis broke and propose tau_z-axis variant (`--tau-z-loss-type charbonnier`).
- **C. NULL** — `val_abupt` within ±0.05pp of baseline 6.126%. Loss-function-shape class saturates at the current model capacity / data distribution. Move on.
- **D. NEGATIVE** — `val_abupt` > baseline 6.126% by ≥0.05pp. Charbonnier hurts on tay's vol_p distribution. Document the val/test split distribution-shape difference vs dl24.

## Baseline

Current single-model SOTA on `tay` is PR #972 (run `56bcqp3m`), Wave 27.

| Metric | #972 baseline | H68 target |
|---|---:|---:|
| val_abupt (merge gate) | 6.126% | < 6.126% |
| test_abupt (paper-facing) | 5.844% | < 5.844% |
| test_VP (floor) | 3.643% | ≤ 3.643% |
| test_SP (floor) | 3.577% | ≤ 3.577% |
| test_WSS (goal) | 6.727% | < 6.727% |

W&B baseline group: `senpai-v1-drivaerml-ddp8`, run `56bcqp3m`.

## Cross-pollination caveat

dl24's H19 was on a different dataset split (`drivaerml-long-20260504`). dl24's H10b base showed test_vol_p=4.160% on their data (+0.517pp above floor) — significantly above all my Wave 31 H47/H53/etc results (test_VP 3.6-3.9%) — suggesting dl24's test split is HARDER on vol_p. dl24's floor breaches may be data artifacts, not technique limits. The technique transfer to tay may produce **larger margins** on tay's easier vol_p split, but it could equally produce a different mechanism direction.

## Why this is high-priority

Wave 31 has 6 mech-positive nulls clustered in the val_abupt NEAR-MISS zone (H58 +0.035pp, H53 +0.055pp, H57 +0.091pp, H50 +0.094pp, H54v2 +0.122pp, H55v2 +0.123pp, H59 +0.156pp). Five parallel LR-fix tests (H59/H62/H63/H65/H66) are running but H59's terminal showed V-DEPTH is **architecture-bound, not LR-decay-bound** — the LR fix alone does not unlock merge wins on that class. We need a fundamentally NEW mechanism class. Charbonnier vol_p (loss-curvature-shape, never tested on tay) is a strong candidate that's cross-validated on dl24's parallel fleet.
