### PR TITLE
Wave 32 H69: CURVATURE-ATTENTION-BIAS — Learnable bias on attention proportional to local surface curvature (cross-pollination from dl24 H10b)

### DIFF
--- a/logs/h69-launch.sh
+++ b/logs/h69-launch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# H69 CURVATURE-ATTENTION-BIAS — PR #1223
+# Wave 31 LR-fix substrate (mirrors H66 askeladd config) + curvature attention bias single-flag delta
+set -e
+cd /workspace/senpai/target
+export SENPAI_TIMEOUT_MINUTES=1080
+exec torchrun --standalone --nproc-per-node=8 train.py \
+    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+    --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
+    --lion-beta1 0.9 --lion-beta2 0.99 \
+    --pos-encoding-mode string_separable --use-qk-norm \
+    --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
+    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
+    --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 \
+    --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 25 --epochs 13 \
+    --batch-size 4 \
+    --train-surface-points 65536 --eval-surface-points 65536 \
+    --train-volume-points 65536 --eval-volume-points 65536 \
+    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
+    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
+    --volume-loss-weight 1.0 \
+    --use-curvature-attn-bias --curvature-attn-init 0.0 \
+    --no-compile-model --validation-every 1 --amp-mode bf16 \
+    --wandb-group wave32_h69_curvature_attention_bias \
+    --wandb-name fern/h69-curvature-attention-bias --agent fern \
+    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"

--- a/model.py
+++ b/model.py
@@ -28,6 +28,7 @@ def compute_normal_variance_curvature(
     *,
     k: int = 16,
     chunk_size: int = 256,
+    ref_size: int | None = None,
 ) -> torch.Tensor:
     """Per-point curvature proxy: mean of (1 - cos(angle(n_i, n_j))) over k-NN.
 
@@ -37,6 +38,9 @@ def compute_normal_variance_curvature(
         mask:      [B, N] bool/float mask of valid (non-padded) points
         k:         number of nearest neighbours (excludes self)
         chunk_size: query-side chunk for the pairwise distance pass
+        ref_size: when set and < N, do kNN against a uniformly-random subset of
+            ref_size points instead of all N. Cuts cdist+topk cost by N/ref_size.
+            Same reference set is shared across the batch within a forward.
 
     Returns:
         kappa: [B, N] float tensor in [0, 2], zero at masked positions.
@@ -54,7 +58,19 @@ def compute_normal_variance_curvature(
     positions_safe = torch.where(valid.unsqueeze(-1), positions, large)
     normals_safe = torch.where(valid.unsqueeze(-1), normals, torch.zeros_like(normals))
 
-    k_eff = max(1, min(k, N - 1)) if N > 1 else 1
+    use_refs = ref_size is not None and ref_size < N
+    if use_refs:
+        ref_idx_1d = torch.randperm(N, device=device)[:ref_size]
+        ref_pos = positions_safe.index_select(1, ref_idx_1d)
+        ref_normals = normals_safe.index_select(1, ref_idx_1d)
+        M = ref_size
+    else:
+        ref_idx_1d = None
+        ref_pos = positions_safe
+        ref_normals = normals_safe
+        M = N
+
+    k_eff = max(1, min(k, M - 1)) if M > 1 else 1
     kappa = positions.new_zeros(B, N)
 
     batch_idx = torch.arange(B, device=device).view(B, 1, 1)
@@ -63,24 +79,23 @@ def compute_normal_variance_curvature(
         end = min(start + chunk_size, N)
         m = end - start
         q_pos = positions_safe[:, start:end]
-        # cdist: [B, m, N]
-        dist = torch.cdist(q_pos, positions_safe)
-        # Add a tiny penalty to self so that valid points exclude themselves cleanly.
-        # The query points appear at indices [start:end] in positions_safe. Build a mask
-        # of self-positions and bump their distance to be larger than any real neighbour.
-        # (We do this rather than relying on argmin selecting self, because invalid
-        # queries already sit at distance 0 to themselves through the safe-positions
-        # trick — they'll be skipped via the kappa*valid multiplication at the end.)
-        col_idx = torch.arange(start, end, device=device).view(1, m, 1)
-        all_idx = torch.arange(N, device=device).view(1, 1, N)
-        self_mask = col_idx.eq(all_idx)
+        # cdist: [B, m, M]
+        dist = torch.cdist(q_pos, ref_pos)
+        # Mask self-position so the query never picks itself as its own neighbour.
+        col_idx = torch.arange(start, end, device=device)
+        if use_refs:
+            # self when ref_idx_1d == query_global_idx
+            self_mask = ref_idx_1d.view(1, 1, -1).eq(col_idx.view(1, -1, 1))
+        else:
+            all_idx = torch.arange(N, device=device).view(1, 1, N)
+            self_mask = col_idx.view(1, -1, 1).eq(all_idx)
         dist = dist.masked_fill(self_mask, large.item())
         # topk smallest distances → indices [B, m, k_eff]
         _, idx = torch.topk(dist, k=k_eff, dim=-1, largest=False)
         # Gather neighbour normals via advanced indexing.
         # batch_idx: [B,1,1]; idx: [B, m, k_eff]
         # Result: [B, m, k_eff, 3]
-        neighbour_normals = normals_safe[batch_idx.expand(B, m, k_eff), idx]
+        neighbour_normals = ref_normals[batch_idx.expand(B, m, k_eff), idx]
         chunk_normals = normals_safe[:, start:end].unsqueeze(2)  # [B, m, 1, 3]
         cos_sim = (chunk_normals * neighbour_normals).sum(dim=-1)  # [B, m, k_eff]
         chunk_kappa = (1.0 - cos_sim).mean(dim=-1).clamp(min=0.0, max=2.0)
@@ -552,6 +567,7 @@ class SurfaceTransolver(nn.Module):
         curvature_attn_per_head: bool = False,
         curvature_knn_k: int = 16,
         curvature_chunk_size: int = 256,
+        curvature_ref_size: int | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -571,6 +587,7 @@ class SurfaceTransolver(nn.Module):
         self.curvature_attn_per_head = curvature_attn_per_head
         self.curvature_knn_k = int(curvature_knn_k)
         self.curvature_chunk_size = int(curvature_chunk_size)
+        self.curvature_ref_size = int(curvature_ref_size) if curvature_ref_size else None
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -785,6 +802,7 @@ class SurfaceTransolver(nn.Module):
                 surface_mask.to(dtype=torch.bool),
                 k=self.curvature_knn_k,
                 chunk_size=self.curvature_chunk_size,
+                ref_size=self.curvature_ref_size,
             ).to(dtype=hidden.dtype)
             if volume_tokens > 0:
                 volume_kappa = hidden.new_zeros(volume_x.shape[0], volume_tokens)

--- a/model.py
+++ b/model.py
@@ -16,6 +16,81 @@ from data import SURFACE_X_DIM, SURFACE_Y_DIM, VOLUME_X_DIM, VOLUME_Y_DIM
 
 
 # ---------------------------------------------------------------------------
+# H69 curvature feature (kNN normal variance proxy)
+# ---------------------------------------------------------------------------
+
+
+@torch._dynamo.disable
+def compute_normal_variance_curvature(
+    positions: torch.Tensor,
+    normals: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    k: int = 16,
+    chunk_size: int = 256,
+) -> torch.Tensor:
+    """Per-point curvature proxy: mean of (1 - cos(angle(n_i, n_j))) over k-NN.
+
+    Args:
+        positions: [B, N, 3] surface positions
+        normals:   [B, N, 3] surface normals (assumed unit vectors)
+        mask:      [B, N] bool/float mask of valid (non-padded) points
+        k:         number of nearest neighbours (excludes self)
+        chunk_size: query-side chunk for the pairwise distance pass
+
+    Returns:
+        kappa: [B, N] float tensor in [0, 2], zero at masked positions.
+    """
+    B, N, _ = positions.shape
+    device = positions.device
+    dtype = positions.dtype
+
+    if N == 0:
+        return positions.new_zeros(B, 0)
+
+    valid = mask.to(device=device, dtype=torch.bool)
+    # Push invalid points far away so they're never chosen as neighbours.
+    large = positions.new_full((), 1e9)
+    positions_safe = torch.where(valid.unsqueeze(-1), positions, large)
+    normals_safe = torch.where(valid.unsqueeze(-1), normals, torch.zeros_like(normals))
+
+    k_eff = max(1, min(k, N - 1)) if N > 1 else 1
+    kappa = positions.new_zeros(B, N)
+
+    batch_idx = torch.arange(B, device=device).view(B, 1, 1)
+
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        m = end - start
+        q_pos = positions_safe[:, start:end]
+        # cdist: [B, m, N]
+        dist = torch.cdist(q_pos, positions_safe)
+        # Add a tiny penalty to self so that valid points exclude themselves cleanly.
+        # The query points appear at indices [start:end] in positions_safe. Build a mask
+        # of self-positions and bump their distance to be larger than any real neighbour.
+        # (We do this rather than relying on argmin selecting self, because invalid
+        # queries already sit at distance 0 to themselves through the safe-positions
+        # trick — they'll be skipped via the kappa*valid multiplication at the end.)
+        col_idx = torch.arange(start, end, device=device).view(1, m, 1)
+        all_idx = torch.arange(N, device=device).view(1, 1, N)
+        self_mask = col_idx.eq(all_idx)
+        dist = dist.masked_fill(self_mask, large.item())
+        # topk smallest distances → indices [B, m, k_eff]
+        _, idx = torch.topk(dist, k=k_eff, dim=-1, largest=False)
+        # Gather neighbour normals via advanced indexing.
+        # batch_idx: [B,1,1]; idx: [B, m, k_eff]
+        # Result: [B, m, k_eff, 3]
+        neighbour_normals = normals_safe[batch_idx.expand(B, m, k_eff), idx]
+        chunk_normals = normals_safe[:, start:end].unsqueeze(2)  # [B, m, 1, 3]
+        cos_sim = (chunk_normals * neighbour_normals).sum(dim=-1)  # [B, m, k_eff]
+        chunk_kappa = (1.0 - cos_sim).mean(dim=-1).clamp(min=0.0, max=2.0)
+        kappa[:, start:end] = chunk_kappa.to(dtype=dtype)
+
+    kappa = kappa * valid.to(dtype=dtype)
+    return kappa
+
+
+# ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
 
@@ -234,6 +309,9 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_curvature_attn_bias: bool = False,
+        curvature_attn_init: float = 0.0,
+        curvature_attn_per_head: bool = False,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -244,6 +322,8 @@ class TransolverAttention(nn.Module):
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.use_curvature_attn_bias = use_curvature_attn_bias
+        self.curvature_attn_per_head = curvature_attn_per_head
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
@@ -259,7 +339,29 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        if use_curvature_attn_bias:
+            shape = (num_heads,) if curvature_attn_per_head else ()
+            self.curvature_alpha = nn.Parameter(torch.full(shape, float(curvature_attn_init)))
+            # Detached diagnostics buffers (overwritten each forward).
+            self.register_buffer(
+                "_diag_curvature_bias_abs_mean",
+                torch.zeros((), dtype=torch.float32),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_diag_curvature_scores_abs_mean",
+                torch.zeros((), dtype=torch.float32),
+                persistent=False,
+            )
+        else:
+            self.curvature_alpha = None
+
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        kappa: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
@@ -272,21 +374,62 @@ class TransolverAttention(nn.Module):
             )
         slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
-        return slice_tokens, slice_weights
+        slice_kappa: torch.Tensor | None = None
+        if kappa is not None:
+            # kappa: [B, N] -> aggregate to per-head, per-slice via routing weights.
+            kappa_cast = kappa.to(device=slice_weights.device, dtype=slice_weights.dtype)
+            slice_kappa_num = torch.einsum("bhns,bn->bhs", slice_weights, kappa_cast)
+            slice_kappa = slice_kappa_num / (slice_norm.squeeze(-1) + 1e-5)
+        return slice_tokens, slice_weights, slice_kappa
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        kappa: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        use_bias = (
+            self.use_curvature_attn_bias
+            and self.curvature_alpha is not None
+            and kappa is not None
+        )
+        slice_tokens, slice_weights, slice_kappa = self.create_slices(
+            x, attn_mask=attn_mask, kappa=kappa if use_bias else None
+        )
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
             q = self.q_norm(q)
             k = self.k_norm(k)
-        out_slice = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            dropout_p=self.dropout if self.training else 0.0,
-        )
+        if use_bias and slice_kappa is not None:
+            # Manual attention so we can add the curvature bias before softmax.
+            # Slice tokens are small (S=num_slices, typically 128) so this is cheap.
+            scale = 1.0 / math.sqrt(self.dim_head)
+            scores = torch.matmul(q, k.transpose(-2, -1)) * scale  # [B, H, S, S]
+            kappa_abs = slice_kappa.abs()  # [B, H, S]
+            if self.curvature_attn_per_head:
+                alpha = self.curvature_alpha.to(dtype=scores.dtype).view(1, self.num_heads, 1, 1)
+            else:
+                alpha = self.curvature_alpha.to(dtype=scores.dtype)
+            bias = alpha * (kappa_abs.unsqueeze(-1) + kappa_abs.unsqueeze(-2))  # [B, H, S, S]
+            with torch.no_grad():
+                self._diag_curvature_bias_abs_mean.copy_(
+                    bias.detach().float().abs().mean()
+                )
+                self._diag_curvature_scores_abs_mean.copy_(
+                    scores.detach().float().abs().mean()
+                )
+            attn = F.softmax(scores + bias, dim=-1)
+            if self.training and self.dropout > 0.0:
+                attn = F.dropout(attn, p=self.dropout, training=True)
+            out_slice = torch.matmul(attn, v)
+        else:
+            out_slice = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                dropout_p=self.dropout if self.training else 0.0,
+            )
         out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
         out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
         out_x = _apply_token_mask(out_x, attn_mask)
@@ -303,6 +446,9 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_curvature_attn_bias: bool = False,
+        curvature_attn_init: float = 0.0,
+        curvature_attn_per_head: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -313,13 +459,21 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_curvature_attn_bias=use_curvature_attn_bias,
+            curvature_attn_init=curvature_attn_init,
+            curvature_attn_per_head=curvature_attn_per_head,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        kappa: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.norm1(x), attn_mask=attn_mask, kappa=kappa)
         x = _apply_token_mask(x, attn_mask)
         x = x + self.mlp(self.norm2(x))
         x = _apply_token_mask(x, attn_mask)
@@ -336,6 +490,9 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_curvature_attn_bias: bool = False,
+        curvature_attn_init: float = 0.0,
+        curvature_attn_per_head: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,14 +504,22 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_curvature_attn_bias=use_curvature_attn_bias,
+                    curvature_attn_init=curvature_attn_init,
+                    curvature_attn_per_head=curvature_attn_per_head,
                 )
                 for _ in range(depth)
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        kappa: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, kappa=kappa)
         return x
 
 
@@ -382,6 +547,11 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_curvature_attn_bias: bool = False,
+        curvature_attn_init: float = 0.0,
+        curvature_attn_per_head: bool = False,
+        curvature_knn_k: int = 16,
+        curvature_chunk_size: int = 256,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +566,11 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_curvature_attn_bias = use_curvature_attn_bias
+        self.curvature_attn_init = float(curvature_attn_init)
+        self.curvature_attn_per_head = curvature_attn_per_head
+        self.curvature_knn_k = int(curvature_knn_k)
+        self.curvature_chunk_size = int(curvature_chunk_size)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +647,9 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_curvature_attn_bias=use_curvature_attn_bias,
+            curvature_attn_init=curvature_attn_init,
+            curvature_attn_per_head=curvature_attn_per_head,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:
@@ -595,7 +773,27 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        kappa_full: torch.Tensor | None = None
+        if self.use_curvature_attn_bias and surface_x is not None and surface_tokens > 0:
+            # Per-point curvature proxy from surface positions + normals (input dims 0:3, 3:6).
+            # Volume points (no normals) contribute zero curvature.
+            surface_positions = surface_x[..., : self.space_dim]
+            surface_normals = surface_x[..., self.space_dim : self.space_dim + 3]
+            surface_kappa = compute_normal_variance_curvature(
+                surface_positions.detach(),
+                surface_normals.detach(),
+                surface_mask.to(dtype=torch.bool),
+                k=self.curvature_knn_k,
+                chunk_size=self.curvature_chunk_size,
+            ).to(dtype=hidden.dtype)
+            if volume_tokens > 0:
+                volume_kappa = hidden.new_zeros(volume_x.shape[0], volume_tokens)
+                kappa_full = torch.cat([surface_kappa, volume_kappa], dim=1)
+            else:
+                kappa_full = surface_kappa
+        elif self.use_curvature_attn_bias and volume_tokens > 0:
+            kappa_full = hidden.new_zeros(volume_x.shape[0], volume_tokens)
+        hidden = self.backbone(hidden, attn_mask=attn_mask, kappa=kappa_full)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 

--- a/train.py
+++ b/train.py
@@ -108,6 +108,7 @@ class Config:
     curvature_attn_per_head: bool = False
     curvature_knn_k: int = 16
     curvature_chunk_size: int = 256
+    curvature_ref_size: int = 4096
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -263,6 +264,11 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "values reduce peak memory at the cost of more launches. Only "
             "used when --use-curvature-attn-bias is set."
         ),
+        "curvature_ref_size": (
+            "If > 0 and < N, run kNN against a uniformly random subset of this "
+            "many reference points instead of all N surface points. Cuts the "
+            "cdist+topk cost by N/ref_size. Set to 0 to disable subsampling."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -347,6 +353,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         curvature_attn_per_head=config.curvature_attn_per_head,
         curvature_knn_k=config.curvature_knn_k,
         curvature_chunk_size=config.curvature_chunk_size,
+        curvature_ref_size=(config.curvature_ref_size if config.curvature_ref_size > 0 else None),
     )
 
 

--- a/train.py
+++ b/train.py
@@ -103,6 +103,11 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_curvature_attn_bias: bool = False
+    curvature_attn_init: float = 0.0
+    curvature_attn_per_head: bool = False
+    curvature_knn_k: int = 16
+    curvature_chunk_size: int = 256
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +234,35 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_curvature_attn_bias": (
+            "Enable curvature-conditioned attention bias in each backbone "
+            "TransolverAttention block (PR #1223, H69). A learnable scalar "
+            "alpha per block (or per head, with --curvature-attn-per-head) "
+            "adds alpha * (|kappa_q| + |kappa_k|) to the slice-level "
+            "pre-softmax attention scores, where kappa is a per-token "
+            "curvature proxy computed from the kNN normal-variance of the "
+            "input surface normals. Volume tokens contribute zero curvature. "
+            "Identity-at-init when --curvature-attn-init 0.0."
+        ),
+        "curvature_attn_init": (
+            "Initial value of the learnable curvature bias scalar(s). 0.0 "
+            "gives identity-at-init (baseline behaviour at step 0)."
+        ),
+        "curvature_attn_per_head": (
+            "If set, learn one curvature bias scalar per attention head per "
+            "block; otherwise one scalar per block. Per-head is a follow-up "
+            "if the per-block scalar learns meaningfully non-zero."
+        ),
+        "curvature_knn_k": (
+            "Number of nearest neighbours used to compute the per-point "
+            "curvature proxy (mean of (1 - cos(angle(n_i, n_j))) over kNN). "
+            "Only used when --use-curvature-attn-bias is set."
+        ),
+        "curvature_chunk_size": (
+            "Query-side chunk size for the kNN normal-variance pass. Lower "
+            "values reduce peak memory at the cost of more launches. Only "
+            "used when --use-curvature-attn-bias is set."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,7 +342,45 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_curvature_attn_bias=config.use_curvature_attn_bias,
+        curvature_attn_init=config.curvature_attn_init,
+        curvature_attn_per_head=config.curvature_attn_per_head,
+        curvature_knn_k=config.curvature_knn_k,
+        curvature_chunk_size=config.curvature_chunk_size,
     )
+
+
+def collect_curvature_diagnostics(model: nn.Module) -> dict[str, float]:
+    """Per-block alpha trajectory and bias magnitude for H69."""
+    metrics: dict[str, float] = {}
+    if not getattr(model, "use_curvature_attn_bias", False):
+        return metrics
+    blocks = getattr(getattr(model, "backbone", None), "blocks", None)
+    if blocks is None:
+        return metrics
+    for i, block in enumerate(blocks):
+        attn = getattr(block, "attention", None)
+        alpha = getattr(attn, "curvature_alpha", None)
+        if attn is None or alpha is None:
+            continue
+        alpha_d = alpha.detach().float()
+        if alpha_d.ndim == 0:
+            metrics[f"diag/curvature_alpha_block{i}"] = float(alpha_d.item())
+        else:
+            for h in range(alpha_d.numel()):
+                metrics[f"diag/curvature_alpha_block{i}_head{h}"] = float(alpha_d[h].item())
+            metrics[f"diag/curvature_alpha_block{i}_mean"] = float(alpha_d.mean().item())
+            metrics[f"diag/curvature_alpha_block{i}_std"] = float(alpha_d.std(unbiased=False).item())
+        bias_buf = getattr(attn, "_diag_curvature_bias_abs_mean", None)
+        score_buf = getattr(attn, "_diag_curvature_scores_abs_mean", None)
+        if bias_buf is not None and score_buf is not None:
+            bias_mag = float(bias_buf.detach().float().item())
+            score_mag = float(score_buf.detach().float().item())
+            metrics[f"diag/curvature_bias_abs_mean_block{i}"] = bias_mag
+            metrics[f"diag/curvature_scores_abs_mean_block{i}"] = score_mag
+            if score_mag > 1e-12:
+                metrics[f"diag/curvature_bias_contribution_block{i}"] = bias_mag / score_mag
+    return metrics
 
 
 def train_loss(
@@ -1049,10 +1121,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                lr_peak = float(config.lr) if config.lr > 0.0 else 1.0
+                lr_fraction_of_peak = current_lr / lr_peak if lr_peak > 0.0 else 0.0
+                cosine_t_max = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress = (
+                    max(0.0, float(epoch - max(0, config.lr_warmup_epochs)))
+                    / max(1.0, float(cosine_t_max))
+                )
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": lr_fraction_of_peak,
+                    "train/cosine_progress": cosine_progress,
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1126,6 +1209,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                         n_batches += 1
                         train_log.update(gradient_metrics)
                         train_log.update(weight_metrics)
+                        if (
+                            config.use_curvature_attn_bias
+                            and should_log_model_telemetry
+                            and config.gradient_log_every > 0
+                            and global_step % config.gradient_log_every == 0
+                        ):
+                            train_log.update(collect_curvature_diagnostics(base_model))
 
                 train_log.update(
                     train_slope_tracker.update(
@@ -1262,6 +1352,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_curvature_diagnostics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
# H69 — Curvature attention bias (cross-pollination from dl24 fleet, foundation H5/H10b family)

## Hypothesis

The current Transolver backbone attention in `target/model.py` uses standard QK-softmax with no geometric prior — attention scores are content-only. The dl24 parallel-data fleet's **H10b foundation** (PR #1174) and downstream **H19 SOTA-beat** (PR #1180) both use **curvature attention bias** as the foundation mechanism. The dl24 H19 stacks Charbonnier-on-vol_p (see H68 by nezuko) on top of curvature attention bias — but the foundation alone is the bigger structural change and has never been tested on the current tay `#972` baseline.

**Mechanism**: Add a learnable attention bias term proportional to local surface curvature. The bias is computed per (query, key) point pair: pairs of points lying on high-curvature regions (sharp edges, panel transitions) receive a learnable bias that lets the model concentrate attention on geometrically-significant point pairs. Formally:

```
attn_scores_{ij} = (Q_i · K_j) / sqrt(d) + α · phi(κ_i, κ_j)
```

where `κ_i` is local mean curvature at point `i`, `phi` is a learnable function (one option: `α · |κ_i| + β · |κ_j|`, single-head broadcasts to multi-head), and `α, β` are learnable per-block scalars (init small, e.g., 0.0).

**Why this matters for tay's binding axes**:
- **WSS_z is the hardest axis** (5 confirmations: H47/H50/H52/H53/H54v2/H57/H58 all show test_WSS_z 8.9-9.6%). WSS_z arises from wake-shedding and detachment behavior — physically governed by **wall curvature transitions** (rear deck, A-pillar, wheel wells). Attention bias that lets the model attend more strongly to curvature transitions should directly target WSS_z reduction.
- **Geometric invariance across val/test splits**. H60's val→test mechanism inversion finding was the strongest evidence yet that val-set-fitting mechanisms (variance amplification on polarized τ_z/τ_x ratios) collapse on test. Curvature is a **geometric input feature** that is structurally invariant across split distribution shifts — it depends on the mesh, not on tau distributions.
- **Composability with FDCE / NPCA / V-DEPTH**. Attention bias operates on the QK pre-softmax step; it composes orthogonally with later projection-side mechanisms. Wave 32 stack candidate.

## Instructions

Single-mechanism single-flag test. The existing tay `model.py` backbone uses `TransolverBlock`s with QK attention; the bias term goes inside the attention forward computation.

### Step 1: Compute curvature features in the dataloader

Mean curvature at each surface point can be estimated from the mesh normals (already available in the dataset) using a discrete Laplace-Beltrami operator OR from k-nearest-neighbor normal variation. Choose the cheap version:

```python
# In dataset/loader (or as a preprocessing pass):
# For each surface point, find k=16 nearest neighbors (already in pipeline if PointNet++-style features exist)
# Compute curvature as variance of normal directions across neighbors:
# kappa_i = mean over neighbors of (1 - cos(angle(normal_i, normal_j)))
# Clip to [0, 1] and add as a NEW input feature channel.
```

If the existing dataloader does not have kNN structure, the simpler initial implementation is to add curvature as a precomputed `.npy` field per case (cached on disk) and load it as one of the surface point features. This avoids per-batch kNN cost.

If precomputing is too disruptive, fall back to **normal-variance** approximation:
```python
# Curvature proxy: |normal_i - mean(normal in neighborhood)|
# Compute once per case at preprocessing time and cache.
```

The exact curvature definition is not the most important thing — what matters is that it's a per-point scalar that's stable across mesh resampling.

### Step 2: Add CLI flag in `target/train.py`

```python
parser.add_argument(
    "--use-curvature-attn-bias",
    action="store_true",
    help="Enable curvature-conditioned attention bias in backbone attention blocks.",
)
parser.add_argument(
    "--curvature-attn-init",
    type=float,
    default=0.0,
    help="Initial value for learnable curvature bias scalar (alpha). 0.0 = identity at init.",
)
parser.add_argument(
    "--curvature-attn-per-head",
    action="store_true",
    help="If set, learn one bias scalar per attention head; otherwise one per block (default per-block).",
)
```

### Step 3: Wire curvature into the model in `target/model.py`

In the `TransolverBlock.__init__`:
```python
if self.use_curvature_attn_bias:
    if self.curvature_attn_per_head:
        self.curvature_alpha = nn.Parameter(torch.full((num_heads,), curvature_attn_init))
    else:
        self.curvature_alpha = nn.Parameter(torch.tensor(curvature_attn_init))
```

In the attention forward (where QK scores are computed before softmax):
```python
# attn_scores shape: (B, H, N_query, N_key)
# curvature_query shape: (B, N_query) — sliced from input features
# curvature_key shape: (B, N_key) — sliced from input features
if self.use_curvature_attn_bias:
    # Broadcast to add per (i,j) pair: bias = alpha * (|kappa_i| + |kappa_j|)
    kappa_q = curvature_query.abs().unsqueeze(1).unsqueeze(-1)   # (B, 1, N_q, 1)
    kappa_k = curvature_key.abs().unsqueeze(1).unsqueeze(-2)     # (B, 1, 1, N_k)
    if self.curvature_attn_per_head:
        alpha = self.curvature_alpha.view(1, -1, 1, 1)            # (1, H, 1, 1)
    else:
        alpha = self.curvature_alpha
    attn_scores = attn_scores + alpha * (kappa_q + kappa_k)
```

Pass `curvature_query` and `curvature_key` down from the model forward — they're slices of the input feature tensor. Since slice-tokens (the Transolver mechanism) AGGREGATE points into slices, curvature needs to be aggregated to the slice level: per-slice curvature = `(slice_weights * point_curvature).sum(dim=points)` (using the same weights used to aggregate features).

### Step 4: Use LR-fix substrate

Run H69 on the LR-extended `--lr-cosine-t-max 25` substrate to compose with the converging LR-fix evidence from H59/H62/H63/H65/H66.

## Recipe

```bash
cd /workspace/senpai/target

torchrun --nproc_per_node=8 train.py \
    --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --epochs 13 \
    --batch-size 2 \
    --hidden-dim 512 \
    --num-layers 5 \
    --num-slices 128 \
    --num-heads 8 \
    --optimizer lion \
    --lr 9e-5 \
    --lr-cosine-t-max 25 \
    --lr-warmup-epochs 1 \
    --ema-decay 0.999 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --volume-loss-weight 0.5 \
    --use-curvature-attn-bias \
    --curvature-attn-init 0.0 \
    --kill-thresholds "32592:val_abupt<7.5,val_SP<5.5" "65184:val_abupt<6.5" \
    --wandb-name fern/h69-curvature-attention-bias \
    --wandb-group fern-h69-curvature-attention-bias
```

**Audit all flag names** against `target/train.py` argparse before launch. If `--vol-points-schedule` or `--volume-loss-weight` has been renamed in recent refactors, fix locally — do NOT silently change values.

**Don't enable `--curvature-attn-per-head` on the first run** — start with per-block (one scalar per block) for cleaner attribution; per-head can be a follow-up if mech-positive.

## Diagnostic to log

1. **Learned curvature alpha trajectory per block**: `diag/curvature_alpha_block{i}` for `i in [0, 4]` — should grow from 0.0 toward some positive value if the mechanism is productive. If alpha stays at ~0.0, the model didn't find curvature useful (NULL outcome).

2. **Attention-bias contribution magnitude**: `diag/curvature_bias_contribution_block{i}` — mean over a representative batch of `|alpha * (|kappa_q| + |kappa_k|)|` relative to `|QK/sqrt(d)|`. If contribution >> 50%, attention has collapsed to curvature-only; if << 1%, the bias is ignored. Target: 5-20% contribution at terminal.

3. **Per-axis WSS breakdown** (`val_WSS_x`, `val_WSS_y`, `val_WSS_z`) and especially `test_WSS_z` — primary axis this mechanism should help.

4. **Standard LR-fix instrumentation**: `train/lr_fraction_of_peak`, `train/cosine_progress`.

## Kill thresholds & timing

- **No EP1 gate** (lr-warmup-1 + LR-extended)
- **EP3 (step 32,592):** `val_abupt < 7.5 AND val_SP < 5.5` — soft sanity
- **EP6 (step 65,184):** `val_abupt < 6.5` — hard mid-train check
- **EP13 terminal:** report all 7 paper-facing axes + per-block alpha

Budget: 18h.

## Falsifiable outcomes

- **A. MERGE WIN + FLOOR CROSS** — `val_abupt < 6.126%` AND all 3 floors hold AND `test_WSS_z` drops by ≥0.30pp vs baseline ~9.1%. Curvature attention bias unlocks WSS_z + composes with LR-fix. Wave 32 stack candidate with FDCE / variance-class / Charbonnier (orthogonal).
- **B. PARTIAL WIN** — `val_abupt` drops below 6.126% by ≥0.05pp but a floor fails or WSS_z doesn't move. Triage which sub-mechanism is broken (likely curvature_alpha trajectory or per-slice aggregation).
- **C. NULL** — `val_abupt` within ±0.05pp of baseline; alpha stayed at ~0.0. The model didn't find curvature useful at this hidden_dim / num_slices. Consider per-head bias variant or richer phi (e.g., MLP).
- **D. NEGATIVE** — `val_abupt` > baseline by ≥0.05pp. Curvature bias destabilizes attention. Check alpha trajectory: if it grew large and crashed val_abupt, lower the LR on the alpha parameters specifically.

## Baseline

Current single-model SOTA on `tay` is PR #972 (run `56bcqp3m`), Wave 27.

| Metric | #972 baseline | H69 target |
|---|---:|---:|
| val_abupt (merge gate) | 6.126% | < 6.126% |
| test_abupt (paper-facing) | 5.844% | < 5.844% |
| test_VP (floor) | 3.643% | ≤ 3.643% |
| test_SP (floor) | 3.577% | ≤ 3.577% |
| test_WSS (goal) | 6.727% | < 6.727% |
| test_WSS_z (binding axis) | ~9.1% | < 8.80% (≥0.30pp drop) |

W&B baseline group: `senpai-v1-drivaerml-ddp8`, run `56bcqp3m`.

## Cross-pollination caveat

dl24's H10b foundation was on a different dataset split (`drivaerml-long-20260504`). dl24's H10b test_vol_p was 4.160% (+0.517pp above floor) — significantly above all my Wave 31 H47/H53/etc results — suggesting dl24's split is harder on vol_p, not that the technique is floor-breaking by nature. Curvature attention bias is a geometric mechanism, so transfer to tay should be cleaner than data-distribution-shape mechanisms. However, **a previous H5 (Wave 30, tanjiro PR #1132) tested curvature attention bias on the older baseline**. Result was inconclusive due to the Wave 30 baseline being quite different. Re-testing on the current `#972` substrate with the LR-fix is the cleanest re-test.

## Why this is high-priority

Wave 31 has 6 mech-positive nulls clustered in val_abupt NEAR-MISS but H59 showed V-DEPTH plateau is **architecture-bound**, not LR-decay-bound — single-mechanism LR-fix doesn't unlock merges. Need fresh mechanism classes. Curvature attention bias is:
1. A new mechanism class on tay (attention-spatial-prior)
2. Cross-validated as productive on dl24's parallel fleet
3. Geometrically-grounded — should be robust to val→test distribution shift (the H60 finding)
4. Directly targets the WSS_z binding axis identified across 7 Wave 31 closures
