### PR TITLE
Wave 32 H70: SLICE-TEMP-CURRICULUM-LR-EXTENDED — H61 LR-fix variant (cosine T_max 13 to 25 + curriculum stretched proportionally)

### DIFF
--- a/model.py
+++ b/model.py
@@ -259,12 +259,63 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
+        # H61 slice-temperature curriculum hook. `slice_temperature_runtime`
+        # is a runtime-modulated multiplier on the softmax temperature; the
+        # effective temperature is `self.temperature * slice_temperature_runtime`.
+        # At runtime=1.0 the math is byte-equal to baseline. Set externally
+        # per training step (see train.py:set_slice_temperature_runtime).
+        self.slice_temperature_runtime: float = 1.0
+        # Optional per-block slice-attention entropy diagnostic. When
+        # `capture_slice_entropy=True`, each forward accumulates batch-summed
+        # entropy + token-count into the two buffers; mean_slice_entropy
+        # returns the ratio. Reset via reset_slice_entropy_stats().
+        self.capture_slice_entropy: bool = False
+        self.register_buffer(
+            "_slice_entropy_sum", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+        self.register_buffer(
+            "_slice_entropy_count", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+
+    def reset_slice_entropy_stats(self) -> None:
+        self._slice_entropy_sum.zero_()
+        self._slice_entropy_count.zero_()
+
+    @property
+    def mean_slice_entropy(self) -> float:
+        count = float(self._slice_entropy_count.item())
+        if count <= 0.0:
+            return 0.0
+        return float(self._slice_entropy_sum.item()) / count
+
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        # H61 curriculum: divide logits by an additional runtime temperature.
+        # At runtime=1.0 this branch is skipped → byte-equal to baseline.
+        if self.slice_temperature_runtime != 1.0:
+            slice_logits = slice_logits / max(self.slice_temperature_runtime, 1e-6)
         slice_weights = F.softmax(slice_logits, dim=-1)
+        if self.capture_slice_entropy:
+            with torch.no_grad():
+                # slice_weights shape: (B, num_heads, N, num_slices). Entropy
+                # of the per-point routing distribution, in nats. Mask masked
+                # tokens out of the average so padded rows don't bias the stat.
+                ent_per_point = -(slice_weights * (slice_weights + 1e-9).log()).sum(dim=-1)
+                if attn_mask is not None:
+                    mask = attn_mask[:, None, :].to(device=ent_per_point.device, dtype=ent_per_point.dtype)
+                    weighted = ent_per_point * mask
+                    self._slice_entropy_sum.add_(weighted.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        (mask.sum() * float(ent_per_point.shape[1])).to(torch.float32)
+                    )
+                else:
+                    self._slice_entropy_sum.add_(ent_per_point.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        torch.tensor(float(ent_per_point.numel()), device=ent_per_point.device, dtype=torch.float32)
+                    )
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,

--- a/train.py
+++ b/train.py
@@ -1169,14 +1169,28 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                cosine_t_max_epochs = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress_epoch = max(0, epoch - config.lr_warmup_epochs)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": float(current_lr / config.lr) if config.lr > 0 else 0.0,
+                    "train/cosine_progress": float(cosine_progress_epoch / max(1, cosine_t_max_epochs)),
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                     "train/slice_temperature": current_slice_tau,
+                    "train/slice_temperature_curriculum_done": (
+                        1.0
+                        if (
+                            config.slice_temperature_decay_steps > 0
+                            and global_step >= config.slice_temperature_decay_steps
+                        )
+                        else 0.0
+                    ),
                 }
                 if not loss_is_nonfinite:
                     train_log.update(

--- a/train.py
+++ b/train.py
@@ -1360,17 +1360,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
-            # H61: hold the runtime slice temperature at the current
-            # training-time value (current_slice_tau) for the EMA val pass.
-            # This matches the advisor's spec ("pass compute_slice_temperature
-            # on each forward call") and avoids a train-val temperature
-            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
-            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
-            # the logged stat is rank-local, not globally reduced.
+            # H61: pin the runtime slice temperature to `slice_temperature_end`
+            # (the curriculum endpoint, default 1.0) for the EMA val pass so
+            # val_abupt is measured at the deployed-temperature routing,
+            # directly apples-to-apples with the H47/H48/H35 references that
+            # never saw a curriculum. Per-block slice-attention entropy is
+            # captured at this same temperature; with DDP8 each rank sees
+            # ~1/8 of val cases so the logged stat is rank-local, not
+            # globally reduced.
             reset_slice_entropy_stats(base_model)
             set_slice_temperature_runtime(
                 base_model,
-                current_slice_tau,
+                config.slice_temperature_end,
                 capture_entropy=True,
             )
             val_metrics = {
@@ -1385,7 +1386,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for name, loader in val_loaders.items()
             }
             slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
-            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
+            set_slice_temperature_runtime(base_model, 1.0, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
-from model import SurfaceTransolver
+from model import SurfaceTransolver, TransolverAttention
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    slice_temperature_start: float = 1.0
+    slice_temperature_end: float = 1.0
+    slice_temperature_decay_steps: int = 0
     debug: bool = False
 
 
@@ -220,6 +223,28 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "slice_temperature_start": (
+            "H61 slice-attention temperature curriculum: starting value of "
+            "the runtime softmax temperature applied on top of the learnable "
+            "per-head temperature in TransolverAttention. Logits are divided "
+            "by max(slice_temperature_runtime, 1e-6) before softmax. Values "
+            ">1 produce a warmer (more diffuse) routing distribution; the "
+            "default 1.0 is byte-equal to baseline. The temperature linearly "
+            "decays from `start` to `end` over `decay_steps` global optimizer "
+            "steps, then holds at `end` for the rest of training."
+        ),
+        "slice_temperature_end": (
+            "H61 slice-attention temperature curriculum: terminal value held "
+            "for global_step >= slice_temperature_decay_steps. Default 1.0 "
+            "matches baseline. See --slice-temperature-start."
+        ),
+        "slice_temperature_decay_steps": (
+            "H61 slice-attention temperature curriculum: number of global "
+            "optimizer steps over which the temperature linearly decays from "
+            "`start` to `end`. Set to 0 (default) to disable the curriculum "
+            "and hold at `end` for the whole run. Recommended for the H61 "
+            "spec: 65184 (end of EP6 at 13-epoch DDP8 budget)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -274,6 +299,90 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def compute_slice_temperature(
+    global_step: int,
+    *,
+    start: float,
+    end: float,
+    decay_steps: int,
+) -> float:
+    """H61 curriculum: linear decay from `start` at step 0 to `end` at
+    step `decay_steps`, then hold at `end`. When `decay_steps <= 0` or
+    start == end, returns `end` (curriculum disabled / no-op)."""
+
+    if decay_steps <= 0 or start == end:
+        return float(end)
+    if global_step >= decay_steps:
+        return float(end)
+    progress = float(global_step) / float(decay_steps)
+    return float(start) + (float(end) - float(start)) * progress
+
+
+def set_slice_temperature_runtime(
+    base_model: nn.Module,
+    value: float,
+    *,
+    capture_entropy: bool | None = None,
+) -> None:
+    """Set the runtime slice-softmax temperature on every TransolverAttention
+    submodule. If `capture_entropy` is provided, also toggles the per-block
+    slice-attention entropy capture flag."""
+
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.slice_temperature_runtime = float(value)
+            if capture_entropy is not None:
+                module.capture_slice_entropy = bool(capture_entropy)
+
+
+def reset_slice_entropy_stats(base_model: nn.Module) -> None:
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.reset_slice_entropy_stats()
+
+
+def collect_slice_entropy_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Read per-block mean slice-attention entropy from each TransolverAttention.
+    Returns `diag/slice_attn_entropy_block{i}` (entropy in nats) and
+    `diag/slice_n_eff_block{i}` (= exp(H), the effective number of active
+    slices). Uniform upper bound at num_slices=S is log(S) nats / N_eff=S."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    entropies: list[float] = []
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            ent = module.mean_slice_entropy
+            metrics[f"diag/slice_attn_entropy_block{block_idx}"] = ent
+            metrics[f"diag/slice_n_eff_block{block_idx}"] = float(math.exp(ent))
+            entropies.append(ent)
+            block_idx += 1
+    if entropies:
+        mean_entropy = sum(entropies) / float(len(entropies))
+        metrics["diag/slice_attn_entropy_mean"] = mean_entropy
+        metrics["diag/slice_n_eff_mean"] = float(math.exp(mean_entropy))
+    return metrics
+
+
+def collect_slice_learnable_temperature_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Per-block stats of the learnable per-head temperature in
+    TransolverAttention. Diagnoses whether the gradient is auto-adjusting
+    `self.temperature` to compensate for the runtime curriculum — a known
+    failure mode of fixed-endpoint temperature annealing."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            t = module.temperature.detach().float().flatten()
+            metrics[f"diag/slice_learn_temp_block{block_idx}_mean"] = float(t.mean().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_std"] = float(t.std().item()) if t.numel() > 1 else 0.0
+            metrics[f"diag/slice_learn_temp_block{block_idx}_min"] = float(t.min().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_max"] = float(t.max().item())
+            block_idx += 1
+    return metrics
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -936,6 +1045,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                # H61: set the runtime slice-softmax temperature for this
+                # forward. `global_step` is the pre-increment value, so step 0
+                # uses `start` and `decay_steps` (exclusive) is the first step
+                # at which `end` applies.
+                current_slice_tau = compute_slice_temperature(
+                    global_step,
+                    start=config.slice_temperature_start,
+                    end=config.slice_temperature_end,
+                    decay_steps=config.slice_temperature_decay_steps,
+                )
+                set_slice_temperature_runtime(base_model, current_slice_tau)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1056,6 +1176,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/slice_temperature": current_slice_tau,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(
@@ -1239,6 +1360,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
+            # H61: hold the runtime slice temperature at the current
+            # training-time value (current_slice_tau) for the EMA val pass.
+            # This matches the advisor's spec ("pass compute_slice_temperature
+            # on each forward call") and avoids a train-val temperature
+            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
+            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
+            # the logged stat is rank-local, not globally reduced.
+            reset_slice_entropy_stats(base_model)
+            set_slice_temperature_runtime(
+                base_model,
+                current_slice_tau,
+                capture_entropy=True,
+            )
             val_metrics = {
                 name: evaluate_split(
                     model,
@@ -1250,6 +1384,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
                 for name, loader in val_loaders.items()
             }
+            slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
+            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:
@@ -1262,6 +1398,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(slice_entropy_metrics)
+                log_metrics.update(collect_slice_learnable_temperature_metrics(base_model))
+                log_metrics["train/slice_temperature_at_val"] = current_slice_tau
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
# H70 — SLICE-TEMP-CURRICULUM-LR-EXTENDED (LR-fix variant of H61 + curriculum stretched proportionally)

## Hypothesis

H61 (PR #1210, frieren, closed 2026-05-20) tested slice-attention temperature curriculum τ=1.5→1.0 over EP1-6 on the legacy `--lr-cosine-t-max 13` substrate. Result: **B PARTIAL outcome with first Wave 31 test_VP floor cross under lr-cosine-t-max=13** (test_VP=3.6315%, −0.012pp under floor), but val_abupt missed merge gate by +0.215pp. **Structural finding**: H61 is the 7th confirmed Wave 31 LR-decay-confound case — slope halved every epoch from EP2-terminal (−2.40 → −0.118 → −0.040 → −0.011 → ~0). **Curriculum complete at EP6 (τ=1.0) but residual slope already collapsed to ~−0.011 pp/1k**, suggesting model couldn't exploit sharpened routing at low LR through terminal.

**H70 hypothesis**: Combine two changes:
1. **`--lr-cosine-t-max 25`** (LR-fix substrate, matching H59/H62/H63/H65/H66 triangulation). Keeps LR at 56-90% peak through EP6-terminal vs H61's 2.5% peak at terminal.
2. **`--slice-temperature-decay-steps 130368`** (curriculum stretched to EP12, matching the LR-extension). Original H61 had decay over 65,184 steps (EP6); stretching to 130,368 keeps the curriculum active over the same proportion of the LR-extended schedule.

This is the **first attention-routing-temperature LR-fix variant on tay**. Given the H61 finding that curriculum-completion-without-LR equals plateau, H70 should let post-curriculum sharpened attention operate at productive LR through terminal.

## Why this composes (and what it tests)

- **Mechanism class #14 (attention-routing-temperature-curriculum)** is confirmed mech-positive on tay via H61 (B PARTIAL + floor cross).
- **LR-fix axis** is being tested in 5 parallel mech-class runs (H59 V-DEPTH, H62 CP-LOSS-WEIGHT, H63 TAU-Z-CURR, H65 SURFACE-DEEP, H66 COORDSLICE) — H70 adds attention-temperature as the 6th class on this axis.
- **Critical note from H62 (closed today)**: LR-fix actively HURTS CP-LOSS-WEIGHT class (D NEGATIVE, val_abupt +0.216pp WORSE than H53 parent across all axes). H70 tests whether attention-temperature class behaves like V-DEPTH (LR-fix helps test channels) or CP-LOSS-WEIGHT (LR-fix actively hurts). The class differentiation diagnostic is the highest-value Wave 31 finding.

## Instructions

Single-mechanism single-flag (well, two-flag) change vs H61:

1. **Inherit ALL of H61's slice-temperature implementation** — your prior commits `0496551` + `1a09b9e` already contain the `TransolverAttention.slice_temperature_runtime`, byte-equiv default, unit-tested smoke, per-block entropy diagnostic. No new model.py changes needed.

2. **Change two CLI flags** in the launch recipe:
   - `--lr-cosine-t-max 25` (was 13 in H61)
   - `--slice-temperature-decay-steps 130368` (was 65184 in H61)

3. **Add LR-fix instrumentation** matching H59/H62/H63/H65/H66:
   - `train/lr_fraction_of_peak` (current LR / peak LR)
   - `train/cosine_progress` (current cosine progress fraction 0→1 over t_max)

Everything else identical to H61.

## Recipe

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
    --lion-beta1 0.9 --lion-beta2 0.99 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 25 --epochs 13 \
    --batch-size 4 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
    --no-compile-model --validation-every 1 --amp-mode bf16 \
    --slice-temperature-start 1.5 --slice-temperature-end 1.0 --slice-temperature-decay-steps 130368 \
    --wandb-group wave32_h70_slice_temp_lr_extended \
    --wandb-name frieren/h70-slice-temp-lr-extended --agent frieren \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

## Kill thresholds (lr-warmup-1 + LR-extended aware)

- **No EP1 gate** — lr-warmup-1 cold-start floor 30%+
- **EP3 (step 32,592)**: `val_abupt < 7.5 AND val_SP < 5.5` — same as H61
- **EP6 (step 65,184)**: `val_abupt < 6.5` — same as H61
- **EP13 terminal**: full SENPAI-RESULT marker

## Diagnostic monitoring

Per-step:
- `train/slice_temperature` (curriculum value, decay over 130,368 steps now)
- `train/lr_fraction_of_peak` (NEW for LR-fix tracking)
- `train/cosine_progress` (NEW for LR-fix tracking)
- `train/loss`, `train/grad_norm`, `train/nonfinite_loss`, `train/nonfinite_grad`

Per-validation (1 epoch):
- `diag/slice_attn_entropy_block{i}` for i in [0,4]
- `diag/slice_attn_n_eff_block{i}` for i in [0,4]
- `val_primary/*` and `test_primary/*` standard suite

Curriculum-completion sanity check at step 130,368: log a one-time "curriculum complete" marker so we can find the EP12 boundary precisely in W&B.

## Falsifiable outcomes

- **A. MERGE WIN + DEEPER FLOOR CROSS**: `val_abupt < 6.126%` AND `test_VP < 3.6315%`. Attention-routing-temperature class merges first time + deeper floor cross than H61. Mech class #14 promoted to Wave 32 stack-eligible.
- **B. PARTIAL**: `val_abupt` drops below H61 6.341% by ≥0.05pp, no merge. LR-fix helped attention-temperature but class still has ceiling at current model capacity.
- **C. NULL**: `val_abupt` within ±0.05pp of H61 6.341%. Attention-temperature class is architecture-bound (like V-DEPTH on val) — LR has no effect.
- **D. NEGATIVE**: `val_abupt` > H61 6.341% by ≥0.05pp. LR-fix actively HURTS attention-temperature class (like CP-LOSS-WEIGHT/H62). Class needs LR-decay as PART OF the curriculum.

## Baseline targets

Current best (#972, run `56bcqp3m`):
- val/abupt_axis_mean_rel_l2_pct = **6.126%** (merge gate)
- test/abupt_axis_mean_rel_l2_pct = **5.844%** (paper-facing)
- test/volume_pressure_rel_l2_pct = **3.643%** (floor) — H61 already crossed at 3.6315%
- test/surface_pressure_rel_l2_pct = **3.577%** (floor)
- test/wall_shear_rel_l2_pct = **6.727%**

H61 reference (parent):
- val_abupt = 6.341% (H61 PARTIAL bucket)
- test_VP = 3.6315% (H61 floor cross)
- test_abupt = 6.004%
- test_SP = 3.777%
- test_WSS = 6.921%

W&B baseline: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m

## Pre-flight audit checklist

Before launching, verify each flag exists in `target/train.py` argparse:
- `--slice-temperature-start` (added in H61 commits)
- `--slice-temperature-end` (added in H61 commits)
- `--slice-temperature-decay-steps` (added in H61 commits)
- `--lr-cosine-t-max` (existing — verify spelling)
- All other flags inherited from H61 — verify nothing else has been renamed in recent refactors

If a phantom flag crashes the launch, fix and re-launch; do NOT silently rename.
