### PR TITLE
Wave 32 H72: SLICE-TEMP-DEEP-ENDPOINT — Deepen H61 τ_end 1.0→0.5 on legacy LR-decay substrate

### DIFF
--- a/model.py
+++ b/model.py
@@ -259,12 +259,63 @@ class TransolverAttention(nn.Module):
             self.q_norm = None
             self.k_norm = None
 
+        # H61 slice-temperature curriculum hook. `slice_temperature_runtime`
+        # is a runtime-modulated multiplier on the softmax temperature; the
+        # effective temperature is `self.temperature * slice_temperature_runtime`.
+        # At runtime=1.0 the math is byte-equal to baseline. Set externally
+        # per training step (see train.py:set_slice_temperature_runtime).
+        self.slice_temperature_runtime: float = 1.0
+        # Optional per-block slice-attention entropy diagnostic. When
+        # `capture_slice_entropy=True`, each forward accumulates batch-summed
+        # entropy + token-count into the two buffers; mean_slice_entropy
+        # returns the ratio. Reset via reset_slice_entropy_stats().
+        self.capture_slice_entropy: bool = False
+        self.register_buffer(
+            "_slice_entropy_sum", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+        self.register_buffer(
+            "_slice_entropy_count", torch.zeros((), dtype=torch.float32), persistent=False
+        )
+
+    def reset_slice_entropy_stats(self) -> None:
+        self._slice_entropy_sum.zero_()
+        self._slice_entropy_count.zero_()
+
+    @property
+    def mean_slice_entropy(self) -> float:
+        count = float(self._slice_entropy_count.item())
+        if count <= 0.0:
+            return 0.0
+        return float(self._slice_entropy_sum.item()) / count
+
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        # H61 curriculum: divide logits by an additional runtime temperature.
+        # At runtime=1.0 this branch is skipped → byte-equal to baseline.
+        if self.slice_temperature_runtime != 1.0:
+            slice_logits = slice_logits / max(self.slice_temperature_runtime, 1e-6)
         slice_weights = F.softmax(slice_logits, dim=-1)
+        if self.capture_slice_entropy:
+            with torch.no_grad():
+                # slice_weights shape: (B, num_heads, N, num_slices). Entropy
+                # of the per-point routing distribution, in nats. Mask masked
+                # tokens out of the average so padded rows don't bias the stat.
+                ent_per_point = -(slice_weights * (slice_weights + 1e-9).log()).sum(dim=-1)
+                if attn_mask is not None:
+                    mask = attn_mask[:, None, :].to(device=ent_per_point.device, dtype=ent_per_point.dtype)
+                    weighted = ent_per_point * mask
+                    self._slice_entropy_sum.add_(weighted.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        (mask.sum() * float(ent_per_point.shape[1])).to(torch.float32)
+                    )
+                else:
+                    self._slice_entropy_sum.add_(ent_per_point.sum().to(torch.float32))
+                    self._slice_entropy_count.add_(
+                        torch.tensor(float(ent_per_point.numel()), device=ent_per_point.device, dtype=torch.float32)
+                    )
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,

--- a/train.py
+++ b/train.py
@@ -1360,17 +1360,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
-            # H61: hold the runtime slice temperature at the current
-            # training-time value (current_slice_tau) for the EMA val pass.
-            # This matches the advisor's spec ("pass compute_slice_temperature
-            # on each forward call") and avoids a train-val temperature
-            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
-            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
-            # the logged stat is rank-local, not globally reduced.
+            # H61: pin the runtime slice temperature to `slice_temperature_end`
+            # (the curriculum endpoint, default 1.0) for the EMA val pass so
+            # val_abupt is measured at the deployed-temperature routing,
+            # directly apples-to-apples with the H47/H48/H35 references that
+            # never saw a curriculum. Per-block slice-attention entropy is
+            # captured at this same temperature; with DDP8 each rank sees
+            # ~1/8 of val cases so the logged stat is rank-local, not
+            # globally reduced.
             reset_slice_entropy_stats(base_model)
             set_slice_temperature_runtime(
                 base_model,
-                current_slice_tau,
+                config.slice_temperature_end,
                 capture_entropy=True,
             )
             val_metrics = {
@@ -1385,7 +1386,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for name, loader in val_loaders.items()
             }
             slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
-            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
+            set_slice_temperature_runtime(base_model, 1.0, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
-from model import SurfaceTransolver
+from model import SurfaceTransolver, TransolverAttention
 from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
@@ -138,6 +138,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    slice_temperature_start: float = 1.0
+    slice_temperature_end: float = 1.0
+    slice_temperature_decay_steps: int = 0
     debug: bool = False
 
 
@@ -220,6 +223,28 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "slice_temperature_start": (
+            "H61 slice-attention temperature curriculum: starting value of "
+            "the runtime softmax temperature applied on top of the learnable "
+            "per-head temperature in TransolverAttention. Logits are divided "
+            "by max(slice_temperature_runtime, 1e-6) before softmax. Values "
+            ">1 produce a warmer (more diffuse) routing distribution; the "
+            "default 1.0 is byte-equal to baseline. The temperature linearly "
+            "decays from `start` to `end` over `decay_steps` global optimizer "
+            "steps, then holds at `end` for the rest of training."
+        ),
+        "slice_temperature_end": (
+            "H61 slice-attention temperature curriculum: terminal value held "
+            "for global_step >= slice_temperature_decay_steps. Default 1.0 "
+            "matches baseline. See --slice-temperature-start."
+        ),
+        "slice_temperature_decay_steps": (
+            "H61 slice-attention temperature curriculum: number of global "
+            "optimizer steps over which the temperature linearly decays from "
+            "`start` to `end`. Set to 0 (default) to disable the curriculum "
+            "and hold at `end` for the whole run. Recommended for the H61 "
+            "spec: 65184 (end of EP6 at 13-epoch DDP8 budget)."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -274,6 +299,90 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def compute_slice_temperature(
+    global_step: int,
+    *,
+    start: float,
+    end: float,
+    decay_steps: int,
+) -> float:
+    """H61 curriculum: linear decay from `start` at step 0 to `end` at
+    step `decay_steps`, then hold at `end`. When `decay_steps <= 0` or
+    start == end, returns `end` (curriculum disabled / no-op)."""
+
+    if decay_steps <= 0 or start == end:
+        return float(end)
+    if global_step >= decay_steps:
+        return float(end)
+    progress = float(global_step) / float(decay_steps)
+    return float(start) + (float(end) - float(start)) * progress
+
+
+def set_slice_temperature_runtime(
+    base_model: nn.Module,
+    value: float,
+    *,
+    capture_entropy: bool | None = None,
+) -> None:
+    """Set the runtime slice-softmax temperature on every TransolverAttention
+    submodule. If `capture_entropy` is provided, also toggles the per-block
+    slice-attention entropy capture flag."""
+
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.slice_temperature_runtime = float(value)
+            if capture_entropy is not None:
+                module.capture_slice_entropy = bool(capture_entropy)
+
+
+def reset_slice_entropy_stats(base_model: nn.Module) -> None:
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            module.reset_slice_entropy_stats()
+
+
+def collect_slice_entropy_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Read per-block mean slice-attention entropy from each TransolverAttention.
+    Returns `diag/slice_attn_entropy_block{i}` (entropy in nats) and
+    `diag/slice_n_eff_block{i}` (= exp(H), the effective number of active
+    slices). Uniform upper bound at num_slices=S is log(S) nats / N_eff=S."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    entropies: list[float] = []
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            ent = module.mean_slice_entropy
+            metrics[f"diag/slice_attn_entropy_block{block_idx}"] = ent
+            metrics[f"diag/slice_n_eff_block{block_idx}"] = float(math.exp(ent))
+            entropies.append(ent)
+            block_idx += 1
+    if entropies:
+        mean_entropy = sum(entropies) / float(len(entropies))
+        metrics["diag/slice_attn_entropy_mean"] = mean_entropy
+        metrics["diag/slice_n_eff_mean"] = float(math.exp(mean_entropy))
+    return metrics
+
+
+def collect_slice_learnable_temperature_metrics(base_model: nn.Module) -> dict[str, float]:
+    """Per-block stats of the learnable per-head temperature in
+    TransolverAttention. Diagnoses whether the gradient is auto-adjusting
+    `self.temperature` to compensate for the runtime curriculum — a known
+    failure mode of fixed-endpoint temperature annealing."""
+
+    metrics: dict[str, float] = {}
+    block_idx = 0
+    for module in base_model.modules():
+        if isinstance(module, TransolverAttention):
+            t = module.temperature.detach().float().flatten()
+            metrics[f"diag/slice_learn_temp_block{block_idx}_mean"] = float(t.mean().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_std"] = float(t.std().item()) if t.numel() > 1 else 0.0
+            metrics[f"diag/slice_learn_temp_block{block_idx}_min"] = float(t.min().item())
+            metrics[f"diag/slice_learn_temp_block{block_idx}_max"] = float(t.max().item())
+            block_idx += 1
+    return metrics
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -936,6 +1045,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                # H61: set the runtime slice-softmax temperature for this
+                # forward. `global_step` is the pre-increment value, so step 0
+                # uses `start` and `decay_steps` (exclusive) is the first step
+                # at which `end` applies.
+                current_slice_tau = compute_slice_temperature(
+                    global_step,
+                    start=config.slice_temperature_start,
+                    end=config.slice_temperature_end,
+                    decay_steps=config.slice_temperature_decay_steps,
+                )
+                set_slice_temperature_runtime(base_model, current_slice_tau)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1056,6 +1176,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/slice_temperature": current_slice_tau,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(
@@ -1239,6 +1360,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
+            # H61: hold the runtime slice temperature at the current
+            # training-time value (current_slice_tau) for the EMA val pass.
+            # This matches the advisor's spec ("pass compute_slice_temperature
+            # on each forward call") and avoids a train-val temperature
+            # mismatch in EP1-EP5. Capture per-block slice-attention entropy
+            # across this pass; with DDP8 each rank sees ~1/8 of val cases so
+            # the logged stat is rank-local, not globally reduced.
+            reset_slice_entropy_stats(base_model)
+            set_slice_temperature_runtime(
+                base_model,
+                current_slice_tau,
+                capture_entropy=True,
+            )
             val_metrics = {
                 name: evaluate_split(
                     model,
@@ -1250,6 +1384,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
                 for name, loader in val_loaders.items()
             }
+            slice_entropy_metrics = collect_slice_entropy_metrics(base_model)
+            set_slice_temperature_runtime(base_model, current_slice_tau, capture_entropy=False)
 
             if state.is_main:
                 if raw_val_metrics is not None:
@@ -1262,6 +1398,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(slice_entropy_metrics)
+                log_metrics.update(collect_slice_learnable_temperature_metrics(base_model))
+                log_metrics["train/slice_temperature_at_val"] = current_slice_tau
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**H72 SLICE-TEMP-DEEP-ENDPOINT**: take the H61 mech-positive B PARTIAL result (val_abupt 6.341%, test_VP 3.6315% CROSSING floor) and **deepen** the curriculum endpoint — change `--slice-temperature-end` from **1.0** to **0.5** while keeping everything else from H61 identical (legacy LR-decay substrate `--lr-cosine-t-max 13`, same start τ=1.5, same EP6-boundary `--slice-temperature-decay-steps 65184`).

### Why this is the right next experiment after H70 D NEGATIVE closure

H70 (PR #1224) tested the OTHER way to extend the H61 curriculum — keeping τ_end=1.0 but stretching the schedule onto an LR-extended substrate (`--lr-cosine-t-max 25`). It closed **OUTCOME D NEGATIVE +2.298pp**: 2nd Wave 32 LR-fix variant to falsify on a routing/weighting-curriculum class (joining H62 CP-LOSS-WEIGHT D NEGATIVE). The Wave 32 binding lesson from H62 + H70:

> **Routing/weighting-curriculum classes (CP loss weights, attention temperature, slice-temperature decay) need LR-decay as a co-dependent ingredient of productive dynamics. The LR-extended substrate keeps the model in high-exploration regime exactly when the curriculum needs to be settling into a sharpened distribution, creating destructive interference.**

H72 takes the **inverse** axis — stay on the legacy LR-decay substrate that empirically works for routing-curriculum classes, and push the τ-curriculum *deeper* into the sharpened regime. This isolates "deeper sharpening" from any LR-substrate confound.

### H61's "curriculum-complete-then-plateau" finding motivates this

H61's per-epoch slope trajectory:
- EP1→EP2: −2.40 pp/1k steps
- EP2→EP3: −0.118 pp/1k
- EP3→EP4: −0.040 pp/1k
- EP4→EP5: −0.011 pp/1k
- EP5+ : ~0 (curriculum complete + LR decayed)

The curriculum hit τ=1.0 at step 65,212 (≈ EP6) but the slope had **already collapsed to −0.011 pp/1k by EP5** — essentially zero. Two hypotheses for the floor:

1. **Sharpening floor**: τ=1.0 is the natural end of the schedule, and once routing has specialized at τ=1.0 there is no productive headroom to find. Pushing τ_end below 1.0 might not help — the slice softmax is already in competitive specialization mode at τ=1.0 (this is the *baseline default*).
2. **Under-sharpened**: τ=1.0 might still be too diffuse for late-training optimization. Pushing τ_end to 0.5 makes the slice softmax twice as peaked (logits scaled by 2.0 inside the softmax), forcing each spatial point to lock more aggressively onto its assigned slice. This could unlock the residual slope collapse.

**If H1 is right**: τ=1.0 is the natural floor and H72 produces C NULL or D NEGATIVE.

**If H2 is right**: H72 produces B PARTIAL or A MERGE WIN — deeper sharpening unlocks routing specialization that H61 left on the table.

### Mechanism intuition (Gumbel-softmax limit)

Going from τ=1.0 to τ=0.5 doubles the logit scale inside the softmax. At τ=0.5, slice routing approaches the hard-argmax limit faster — each spatial point sends ~95-99% of its mass to its top slice instead of ~70-90%. This is the **deep simulated-annealing endpoint** that the H61 curriculum pointed toward but never reached.

**Risk**: At very low τ, routing becomes too brittle and the gradient flow through the softmax saturates (gradients ~0 outside the chosen slice). Watch `diag/slice_attn_entropy_block{i}` for collapse — if entropy reaches **< 0.10 × log(num_slices)** mid-training, model has lost the ability to re-route and may stop learning effectively. The over-sparsification risk diagnostic is the binding mechanism-failure signal.

### Falsifiable predictions (per PR's four-outcome contract)

- **A. MERGE WIN**: val_abupt < 6.126% AND test_VP < 3.643%. Deeper sharpening unlocks routing specialization on a productive LR-decay substrate. First Wave 32 merge from the slice-temp-curriculum class.
- **B. PARTIAL**: val_abupt drops below H61 6.341% by ≥0.05pp but doesn't cross merge gate. Deeper-sharpening lever is productive but saturating; future sweeps can try τ_end=0.7 or τ_end=0.3.
- **C. NULL**: terminal val_abupt within ±0.05pp of H61 6.341%. τ=1.0 was already the natural floor of this curriculum class. The slope-collapse in H61 was LR-decay-limited, not τ-endpoint-limited.
- **D. NEGATIVE**: val_abupt > 6.391% (+0.05pp regression). Over-sharpening damages routing — slice softmax becomes too brittle to maintain useful gradient flow.

### Mechanism diagnostic — slice-attention entropy (continued from H61)

Per-block slice-attention entropy `H(slice_softmax)` computed during validation. Expected pattern under the hypothesis:
- EP1 with τ=1.5 → high entropy (matches H61 EP1)
- EP6 with τ=0.5 → **lower entropy than H61 EP6** (since τ=0.5 doubles logit scale vs τ=1.0)
- EP13 → terminal entropy roughly half of H61 terminal value per block

If the entropy collapse pattern is more aggressive than expected (block 0 entropy < 0.1 × log(num_slices) at EP4-5), flag the over-sparsification risk and consider an early kill check.

## Implementation instructions

This is a **single-flag change** vs H61. The slice-temperature implementation already exists on the H61 branch (frieren/h61-slice-temp-curriculum, commits **0496551** + **1a09b9e**). Inherit those commits onto the new branch before launching.

### Step 1 — Cherry-pick H61 implementation onto frieren/h72-slice-temp-deep-endpoint

```bash
# You are starting from the tip of tay (this branch was created from tay).
# Cherry-pick the H61 implementation commits in order:
git cherry-pick 0496551 1a09b9e
```

After cherry-pick, verify:
- `target/train.py` argparse contains `--slice-temperature-start`, `--slice-temperature-end`, `--slice-temperature-decay-steps`
- `target/model.py` TransolverAttention's slice-softmax uses `slice_logits / max(slice_temperature, 1e-6)` before softmax
- Smoke test at τ=1.0 produces loss byte-equal to baseline H48 (sanity check that the cherry-pick didn't introduce a regression vs tay)

### Step 2 — Launch the H72 recipe

Single-flag change vs H61: **`--slice-temperature-end 0.5`** instead of `1.0`. All other flags identical to H61 PR #1210.

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
    --lion-beta1 0.9 --lion-beta2 0.99 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --use-surf-to-vol-xattn --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --epochs 13 \
    --batch-size 4 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 --surface-loss-weight 2.0 \
    --no-compile-model --validation-every 1 --amp-mode bf16 \
    --slice-temperature-start 1.5 --slice-temperature-end 0.5 --slice-temperature-decay-steps 65184 \
    --wandb-group wave32_h72_slice_temp_deep_endpoint \
    --wandb-name frieren/h72-slice-temp-deep-endpoint --agent frieren \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5"
```

### What is changed vs H61

| Flag | H61 (parent) | H72 (this PR) | Change |
|---|---:|---:|---|
| `--slice-temperature-start` | 1.5 | 1.5 | no change |
| **`--slice-temperature-end`** | **1.0** | **0.5** | **DOUBLE the logit scale at end** |
| `--slice-temperature-decay-steps` | 65184 | 65184 | no change (EP6 boundary) |
| `--lr-cosine-t-max` | 13 | 13 | no change (legacy LR-decay substrate) |
| All other flags | (per H61) | (per H61) | no change |

This is a **clean single-flag attribution test** of "deeper sharpening" on the slice-temperature-curriculum mechanism class.

### Diagnostics to keep from H61

Per-block slice-attention entropy `diag/slice_attn_entropy_block{i}` continues to be the binding mechanism diagnostic. Add at validation time per H61's existing implementation. Also keep per-block `diag/slice_n_eff_mean` (effective slice count per spatial point — should drop further than H61 by terminal under deeper sharpening).

### Over-sparsification kill diagnostic (NEW for H72)

If `diag/slice_n_eff_mean` (mean effective slice count per point, computed as exp(entropy)) drops below **5** at any validation between EP3 and EP6, the model is over-collapsed and routing is brittle. Flag this in your EP3/EP6 update — if observed, the run is likely D NEGATIVE territory and you may want to discuss an early kill with the advisor.

### Kill thresholds (lr-warmup-1 aware, identical to H61)

| Step (epoch) | Gate | Reason |
|---:|---|---|
| 10,864 (EP1) | NONE | lr-warmup-1 cold-start floor is ~30%+, EP1 gate would false-kill (per [[feedback_ep_thresholds_recipe_dependent]]) |
| **32,592 (EP3)** | **val_abupt<7.5% AND val_SP<5.5%** | binding — healthy mechanism should match H61 EP3 (7.42%) |
| **65,184 (EP6)** | **val_abupt<6.5%** | hard kill — H61 EP6 was 6.39%, expected near or below |

### Pre-flight audit (per [[feedback_audit_flags_in_recipe]])

Before launching, verify:
- `--slice-temperature-start`, `--slice-temperature-end`, `--slice-temperature-decay-steps` exist in train.py argparse (added by cherry-picked commits 0496551 + 1a09b9e)
- All other flags inherited from H61 — no phantom flags

### EP1 launch comment (use this template)

When the run lands EP1, please post:

```
H72 EP1 read (step ~10,864):
- val_abupt: X.XX% (vs H61 EP1 34.84%)
- slice_temperature value at step 10,864: 1.417 (1.5 − 0.5 × (10864/65184) × (1.5−0.5)/0.5 = 1.5 − 0.083 = 1.417)

  Wait, the formula is: τ(s) = τ_start - (τ_start - τ_end) * min(s/decay_steps, 1)
  At step 10,864: τ = 1.5 − 1.0 × 0.1666 = 1.333

- slice_attn_entropy per block: [b0, b1, b2, b3, b4]
- slice_n_eff_mean per block: [b0, b1, b2, b3, b4]
```

### SENPAI-RESULT template (terminal)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

## Baseline

Current best (#972, run `56bcqp3m`):
- val/abupt_axis_mean_rel_l2_pct = **6.126%** (merge gate)
- test/abupt_axis_mean_rel_l2_pct = **5.844%** (baseline)
- test/volume_pressure_rel_l2_pct = **3.643%** (floor)
- test/surface_pressure_rel_l2_pct = **3.577%** (floor)
- test/wall_shear_rel_l2_pct = **6.727%**

W&B baseline link: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m

### H61 reference (parent, mech-positive B PARTIAL)

- val_abupt = **6.341%** (+0.215pp above merge gate, B PARTIAL)
- test_abupt = 6.004%
- test_VP = **3.6315%** (CROSS — −0.012pp under 3.643% floor)
- test_SP = 3.777%
- test_WSS = 6.921% (WSS_x 6.16, WSS_y 7.49, **WSS_z 8.97** — z-dominant per-axis allocation)

PR reference: [#1210](https://github.com/morganmcg1/DrivAerML/pull/1210)
W&B group: `wave31_h61_slice_temp_curriculum`

### H70 reference (LR-extended variant, OUTCOME D NEGATIVE)

H70 (PR #1224) closed as **D NEGATIVE +2.298pp**: LR-extended substrate destabilized the curriculum. Closure evidence informs the H72 design — stay on legacy `--lr-cosine-t-max 13`, only vary τ_end.

PR reference: [#1224](https://github.com/morganmcg1/DrivAerML/pull/1224)
