### PR TITLE
Wave 32 H73: CHARBONNIER-TAU-Z — Charbonnier loss on τ_z axis (dl24 H19 cross-pollination)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_charbonnier,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,8 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    tau_z_loss_type: str = "mse"
+    charbonnier_eps: float = 1e-3
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -220,6 +223,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "tau_z_loss_type": (
+            "Loss function for the τ_z surface channel (channel 3 of the "
+            "4-channel surface target [cp, tau_x, tau_y, tau_z]). 'mse' = "
+            "standard masked MSE on all 4 channels jointly (default). "
+            "'charbonnier' = split path: MSE on channels [cp, tau_x, tau_y] "
+            "and pseudo-Huber sqrt((pred-target)^2 + eps^2) - eps on tau_z. "
+            "Recombined as (3 * loss_mse_other + tau_z_loss_weight * "
+            "loss_charb_tauz) / (3 + tau_z_loss_weight), which preserves the "
+            "baseline total loss magnitude when tau_z_loss_weight=1.0 and "
+            "only changes the per-sample gradient shape on tau_z."
+        ),
+        "charbonnier_eps": (
+            "Charbonnier transition eps. Residuals |r| << eps behave "
+            "quadratically (L2-like); |r| >> eps behave linearly (L1-like) "
+            "with gradient magnitude bounded by 1. For z-score normalized "
+            "targets (sigma=1), eps=1e-3 puts the transition far below "
+            "typical residual magnitudes, so most of training is in the "
+            "L1-bounded-gradient regime. Only used when "
+            "--tau-z-loss-type=charbonnier."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -321,10 +344,14 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_z_loss_type: str = "mse",
+    tau_z_loss_weight: float = 1.0,
+    charbonnier_eps: float = 1e-3,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    extra_metrics: dict[str, float] = {}
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -332,7 +359,30 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if tau_z_loss_type == "charbonnier":
+            # Surface channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]. Run MSE
+            # on the first 3 channels and Charbonnier on tau_z. Recombine with
+            # the original masked_mse reduction (sum / valid_points * n_channels)
+            # so when tau_z_loss_weight=1.0 the total loss budget matches the
+            # 4-channel MSE baseline exactly.
+            preds = out["surface_preds"]
+            loss_sp_tauxy = masked_mse(preds[..., 0:3], surface_target[..., 0:3], batch.surface_mask)
+            loss_tauz_charb = masked_charbonnier(
+                preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask, eps=charbonnier_eps
+            )
+            surface_loss = (3.0 * loss_sp_tauxy + tau_z_loss_weight * loss_tauz_charb) / (
+                3.0 + tau_z_loss_weight
+            )
+            # Diagnostic only: same-batch MSE on tau_z for engagement ratio.
+            loss_tauz_mse = masked_mse(preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+            extra_metrics["tau_z_loss_diag/char_loss"] = float(loss_tauz_charb.detach().cpu().item())
+            extra_metrics["tau_z_loss_diag/mse_loss"] = float(loss_tauz_mse.detach().cpu().item())
+            mse_val = float(loss_tauz_mse.detach().cpu().item())
+            char_val = float(loss_tauz_charb.detach().cpu().item())
+            extra_metrics["tau_z_loss_diag/char_over_mse"] = (
+                char_val / mse_val if mse_val > 1e-12 else 0.0
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -346,13 +396,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(extra_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -883,6 +935,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/tau_z_loss_type"] = config.tau_z_loss_type
+            wandb.summary["loss/charbonnier_eps"] = config.charbonnier_eps
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1084,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_z_loss_type=config.tau_z_loss_type,
+                        tau_z_loss_weight=config.tau_z_loss_weight,
+                        charbonnier_eps=config.charbonnier_eps,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1127,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for diag_key in (
+                        "tau_z_loss_diag/char_loss",
+                        "tau_z_loss_diag/mse_loss",
+                        "tau_z_loss_diag/char_over_mse",
+                    ):
+                        if diag_key in batch_loss_metrics:
+                            train_log[f"train/{diag_key}"] = batch_loss_metrics[diag_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/train.py
+++ b/train.py
@@ -360,21 +360,43 @@ def train_loss(
             volume_mask=batch.volume_mask,
         )
         if tau_z_loss_type == "charbonnier":
-            # Surface channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]. Run MSE
-            # on the first 3 channels and Charbonnier on tau_z. Recombine with
-            # the original masked_mse reduction (sum / valid_points * n_channels)
-            # so when tau_z_loss_weight=1.0 the total loss budget matches the
-            # 4-channel MSE baseline exactly.
+            # Surface channels are [cp=0, tau_x=1, tau_y=2, tau_z=3]. Replace
+            # MSE on tau_z with Charbonnier while preserving weighted_channel_mse's
+            # reduction (sum_over_entries / valid_points * n_channels) and its
+            # per-channel weighting. surface_channel_weights = [1, 1, tau_y_w,
+            # tau_z_w] is the same vector consumed by the MSE path's
+            # weighted_channel_mse — using it here gives true sibling parity
+            # with H68: only the loss curvature on tau_z differs.
             preds = out["surface_preds"]
-            loss_sp_tauxy = masked_mse(preds[..., 0:3], surface_target[..., 0:3], batch.surface_mask)
+            mask_dev = batch.surface_mask.to(device=preds.device, dtype=preds.dtype).unsqueeze(-1)
+            valid_points = mask_dev.sum()
+            if surface_channel_weights is not None:
+                ch_weights = surface_channel_weights.to(device=preds.device, dtype=preds.dtype)
+            else:
+                ch_weights = torch.tensor(
+                    [1.0, 1.0, 1.0, tau_z_loss_weight],
+                    device=preds.device,
+                    dtype=preds.dtype,
+                )
+            # MSE on channels 0-2 (cp, tau_x, tau_y) with their per-channel weights.
+            sq_err_3 = (preds[..., 0:3] - surface_target[..., 0:3]).square()
+            weighted_3 = sq_err_3 * ch_weights[0:3] * mask_dev
+            # Charbonnier on channel 3 (tau_z) with its per-channel weight.
+            delta_z = preds[..., 3:4] - surface_target[..., 3:4]
+            charb_z = torch.sqrt(delta_z * delta_z + charbonnier_eps * charbonnier_eps) - charbonnier_eps
+            weighted_z = charb_z * ch_weights[3:4] * mask_dev
+            denom = (valid_points * float(preds.shape[-1])).clamp_min(1.0)
+            if bool(valid_points.detach().cpu().item() > 0):
+                surface_loss = (weighted_3.sum() + weighted_z.sum()) / denom
+            else:
+                surface_loss = preds.sum() * 0.0
+            # Diagnostics: tau_z Charbonnier vs same-batch MSE (per-channel mean,
+            # unweighted) so the outlier-compression trajectory is directly
+            # comparable across runs regardless of tau_z_loss_weight.
+            loss_tauz_mse = masked_mse(preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
             loss_tauz_charb = masked_charbonnier(
                 preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask, eps=charbonnier_eps
             )
-            surface_loss = (3.0 * loss_sp_tauxy + tau_z_loss_weight * loss_tauz_charb) / (
-                3.0 + tau_z_loss_weight
-            )
-            # Diagnostic only: same-batch MSE on tau_z for engagement ratio.
-            loss_tauz_mse = masked_mse(preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
             extra_metrics["tau_z_loss_diag/char_loss"] = float(loss_tauz_charb.detach().cpu().item())
             extra_metrics["tau_z_loss_diag/mse_loss"] = float(loss_tauz_mse.detach().cpu().item())
             mse_val = float(loss_tauz_mse.detach().cpu().item())

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,33 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Charbonnier (pseudo-Huber) loss with a [B, N] token mask.
+
+    charbonnier(r) = sqrt(r^2 + eps^2) - eps; gradient magnitude is bounded
+    by 1 for large |r| (robust to outliers vs MSE) while staying smooth and
+    quadratic near r = 0. Reduction mirrors ``masked_mse``: divides by
+    (valid points) * (num channels) so the per-channel mean is preserved
+    when this is composed with channel-split MSE in surface losses.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    delta = pred - target
+    values = torch.sqrt(delta * delta + eps * eps) - eps
+    weighted = values * mask_f
+    valid_points = mask_f.sum()
+    denom = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denom
+    return pred.sum() * 0.0
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
# H73 — Charbonnier loss on τ_z (cross-pollination from dl24 H19/H23 stack)

## Hypothesis

Wall-shear-stress τ_z is the **binding difficulty axis** in tay's fleet — every Wave 31 mech class shows WSS_z as the hardest axis (highest per-axis error, z>y>x consistently). The current τ_z loss in `trainer_runtime.py` uses masked MSE: `(pred - target)^2`.

**Charbonnier loss** (pseudo-Huber) replaces this:
```
charbonnier(pred, target, eps) = sqrt((pred - target)^2 + eps^2) - eps
```

This is a **loss-curvature-shape** mechanism: same total loss budget, different per-sample gradient profile. MSE over-weights outlier τ_z errors (geometric complexity near wing tips, wheel-house separation zones) relative to bulk mean-flow signal. Charbonnier caps gradient magnitude at 1.0 for large residuals while maintaining smooth quadratic behavior near zero — reshaping the optimization landscape to favor mean-flow-feature accuracy over outlier-fitting.

**Why τ_z specifically (not τ_x or τ_y):**
1. Five Wave 31 confirmations of z-dominance: every mech-positive class shows WSS_z highest per-axis error
2. dl24 fleet validation: H19 (PR #1180) first applied Charbonnier to τ_z (part of H10b's WSS Charbonnier stack) + vol_p. H23 (PR #1218) extends to τ_y+τ_z. dl24 H19 achieved Wave's first test_wss SOTA-beat — the τ_z Charbonnier is central to that stack.
3. **Single-axis isolation on tay** for clean attribution: H68 (nezuko, running in parallel) is testing the vol_p variant. H73 isolates the τ_z variant. Neither is confounded by the other yet.

**Mech class:** loss-curvature-shape on τ_z. New class on tay — no prior Wave 28–31 experiment tested Charbonnier on any surface axis.

## Instructions

### Step 1: Add `masked_charbonnier` to `trainer_runtime.py`

Add this function immediately after `masked_mse` (around line 836 of `trainer_runtime.py`):

```python
def masked_charbonnier(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    eps: float = 1e-3,
) -> torch.Tensor:
    """Charbonnier (pseudo-Huber) loss with token mask.

    Gradient is bounded by 1 in magnitude — robust to outliers vs MSE.
    Same mask reduction convention as masked_mse.
    """
    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
    delta = pred - target
    values = torch.sqrt(delta * delta + eps * eps) - eps   # [B, N, C]
    weighted = values * mask_f
    denom = mask_f.sum().clamp_min(1.0) * pred.shape[-1]
    return weighted.sum() / denom
```

**Verify the reduction matches `masked_mse`** — if `masked_mse` reduces differently (e.g. sums over channels vs divides), mirror that exactly.

### Step 2: Export from `trainer_runtime.py` imports in `train.py`

In `train.py` around line 57 where `masked_mse` and `weighted_channel_mse` are imported, add `masked_charbonnier` to the same import line.

### Step 3: Add CLI flags

In `train.py` Config dataclass (look for the block where `tau_y_loss_weight` and `tau_z_loss_weight` are defined), add:

```python
tau_z_loss_type: str = "mse"       # "mse" or "charbonnier"
charbonnier_eps: float = 1e-3
```

In the `parse_args` / help text section, add a help string entry for `tau_z_loss_type`:
```python
"tau_z_loss_type": "Loss function for the τ_z surface channel. 'mse' = standard MSE (default). 'charbonnier' = pseudo-Huber.",
```

**Audit: verify both flags survive argparse** — test with `python train.py --tau-z-loss-type charbonnier --help` after implementation.

### Step 4: Switch τ_z to Charbonnier in `train_loss`

In `train.py` around line 336–343, the current surface loss path is:

```python
if (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0):
    surface_loss = weighted_channel_mse(out["surface_preds"], surface_target, ...)
else:
    surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

Replace with a new condition that handles the Charbonnier τ_z case. Surface channels are `[cp=0, τ_x=1, τ_y=2, τ_z=3]`:

```python
if config.tau_z_loss_type == "charbonnier":
    # Split: MSE on [cp, tau_x, tau_y], Charbonnier on [tau_z]
    preds = out["surface_preds"]
    tgt   = surface_target
    mask  = batch.surface_mask
    loss_sp_tauxy = masked_mse(preds[..., 0:3], tgt[..., 0:3], mask)
    loss_tauz = masked_charbonnier(preds[..., 3:4], tgt[..., 3:4], mask, eps=config.charbonnier_eps)
    # weight tau_z loss by tau_z_loss_weight if set (composes with existing per-axis weighting)
    loss_tauz_w = config.tau_z_loss_weight * loss_tauz
    # weighted average: 3 MSE channels + 1 Charbonnier channel
    surface_loss = (3.0 * loss_sp_tauxy + loss_tauz_w) / (3.0 + config.tau_z_loss_weight)
elif (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0):
    surface_loss = weighted_channel_mse(out["surface_preds"], surface_target, ...)
else:
    surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
```

> **If the above split-then-recombine averaging feels wrong**, the simpler alternative is to add Charbonnier as a **supplementary loss term** (additive, not replacing MSE):
> ```python
> if config.tau_z_loss_type == "charbonnier":
>     surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
>     tauz_charb = masked_charbonnier(out["surface_preds"][..., 3:4], surface_target[..., 3:4], batch.surface_mask, eps=config.charbonnier_eps)
>     surface_loss = surface_loss + 0.1 * tauz_charb   # supplementary weight 0.1 as starting point
> ```
> **Use the full-replacement approach (split-then-recombine) unless it feels unclean given the actual code structure you see.** The replacement approach is cleaner for mechanism isolation.

### Step 5: Add diagnostic logging

In the val loop where per-channel diagnostics are logged (search for `tau_y_loss_weight` W&B log lines), add:

```python
if config.tau_z_loss_type == "charbonnier":
    # Log Charbonnier outlier compression trajectory
    tauz_charb_val = masked_charbonnier(
        out["surface_preds"][..., 3:4], surface_target[..., 3:4],
        batch.surface_mask, eps=config.charbonnier_eps
    )
    metrics["tau_z_loss_diag/char_loss"] = float(tauz_charb_val.detach().cpu().item())
```

The key diagnostic is whether Charbonnier loss stabilizes or continues to compress as training progresses — H68 is tracking `vol_loss_diag/char_max` for vol_p; mirror that pattern here for τ_z.

## Recipe

```bash
cd /workspace/senpai/target

torchrun --nproc_per_node=8 train.py \
    --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --epochs 13 \
    --batch-size 2 \
    --hidden-dim 512 \
    --num-layers 5 \
    --num-slices 128 \
    --num-heads 8 \
    --optimizer lion \
    --lr 9e-5 \
    --lr-cosine-t-max 25 \
    --lr-warmup-epochs 1 \
    --ema-decay 0.999 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --volume-loss-weight 0.5 \
    --tau-z-loss-type charbonnier \
    --charbonnier-eps 1e-3 \
    --kill-thresholds "32592:val_abupt<7.5,val_SP<5.5" "65184:val_abupt<6.5" \
    --wandb-name edward/h73-charbonnier-tau-z \
    --wandb-group edward-h73-charbonnier-tau-z
```

**Before launch audit:** verify all flags exist in `train.py` argparse with exact spellings. If a flag crashes startup, fix and re-launch — do NOT proceed with the run if you suspect a flag was silently ignored.

**Implementation notes from sibling experiment:**
H68 (nezuko, `--vol-loss-type charbonnier`) is testing the vol_p variant in parallel. If you hit any implementation uncertainty, check H68's branch for the `masked_charbonnier` function — nezuko's implementation (once pushed) is the exact same function. But this PR is self-contained: implement from the instructions above.

## Kill thresholds & timing

- **No EP1 gate** (lr-warmup=1 + LR-extended cosine → EP1 val_abupt ~33% expected)
- **EP3 (step 32,592):** `val_abupt < 7.5 AND val_SP < 5.5` — soft sanity check
- **EP6 (step 65,184):** `val_abupt < 6.5` — hard kill if mechanism shows no descent
- **EP13 terminal:** report all 7 paper-facing axes

Budget: `SENPAI_TIMEOUT_MINUTES=1100` (18h).

## Falsifiable outcomes

| Outcome | Condition | Interpretation |
|---|---|---|
| **A. MERGE WIN** | val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% | Charbonnier unlocks τ_z ceiling — stack-eligible for Wave 32 composition |
| **B. PARTIAL WIN** | val_abupt drops ≥0.05pp below 6.126% but a floor breaches | Mech-positive but rebalancing breaks another axis; triage + compose with floor-fix |
| **C. NULL** | val_abupt within ±0.05pp of 6.126% | Loss-curvature-shape saturates at current model capacity for τ_z |
| **D. NEGATIVE** | val_abupt > 6.126% by ≥0.05pp | Charbonnier destabilizes τ_z training on tay's distribution |

**Compare val_WSS per-axis (WSS_x/y/z):** if Charbonnier helps WSS_z specifically but not WSS_x/y, that's strong mech-class attribution evidence even under C/D overall.

**Sibling test (H68):** If H68 (vol_p) produces D NEGATIVE and H73 (τ_z) produces A MERGE WIN (or vice versa), this reveals that loss-curvature-shape is axis-specific — not a general loss replacement. That's a high-value finding.

## Baseline

Current single-model SOTA on `tay`: PR #972 (W&B run `56bcqp3m`)

| Metric | #972 baseline | H73 target |
|---|---:|:---|
| val_abupt (merge gate) | **6.126%** | < 6.126% |
| test_abupt (paper-facing) | 5.844% | < 5.844% |
| test_VP (floor) | 3.643% | ≤ 3.643% |
| test_SP (floor) | 3.577% | ≤ 3.577% |
| test_WSS (goal) | 6.727% | < 6.727% |
| test_WSS_z (binding axis) | — | watch for specific improvement |

W&B baseline group: `senpai-v1-drivaerml-ddp8`, run `56bcqp3m`.

## Why this is the right next experiment for you

You've just closed H63 (τ_z-curriculum, C NULL — mech-positive but saturated at ~6.25% regardless of LR schedule). That experiment established that the τ_z axis has a learnable structure that mechanisms can engage — but the *curriculum-schedule* lever is exhausted. H73 attacks the same axis from a fundamentally different angle: **loss-function shape** rather than loss weighting/scheduling. These are orthogonal levers, so H63's C NULL is not evidence against H73.

Your deep context on the τ_z axis trajectory (H55v2 → H63) makes you the best student to interpret the H73 Charbonnier effect on that axis.
