### PR TITLE
Wave 32 H74: MAE-AUX-VOL-P — L1 auxiliary loss on vol_p (dl24 H22 cross-pollination)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -105,6 +106,7 @@ class Config:
     use_surf_to_vol_xattn: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    vol_p_aux_mae_weight: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -220,6 +222,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "(matches Run 1 behavior). Recommended 0.7 for soft "
             "redistribution. Unused in mode='full'."
         ),
+        "vol_p_aux_mae_weight": (
+            "Weight alpha for vol_p MAE auxiliary loss term added on top of "
+            "MSE: loss += alpha * masked_mean(|pred_vp - target_vp|). The "
+            "auxiliary L1 term provides a non-vanishing gradient signal that "
+            "is NOT subject to --volume-loss-weight rebalancing. Default 0.0 "
+            "= dormant / backward-compat. dl24 H22 default = 0.05."
+        ),
         "use_surf_to_vol_xattn": (
             "Enable surface->volume cross-attention (PR #823). After the "
             "shared Transolver backbone, a single nn.MultiheadAttention "
@@ -321,6 +330,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_p_aux_mae_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -346,12 +356,26 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+
+        vol_p_mae_aux_val = 0.0
+        vol_p_mae_aux_weighted_val = 0.0
+        if vol_p_aux_mae_weight > 0.0:
+            vol_p_mae = masked_mean(
+                (out["volume_preds"] - volume_target).abs(),
+                batch.volume_mask,
+            )
+            weighted_vol_p_mae = vol_p_aux_mae_weight * vol_p_mae
+            loss = loss + weighted_vol_p_mae
+            vol_p_mae_aux_val = float(vol_p_mae.detach().cpu().item())
+            vol_p_mae_aux_weighted_val = float(weighted_vol_p_mae.detach().cpu().item())
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "vol_p_mae_aux": vol_p_mae_aux_val,
+        "vol_p_mae_aux_weighted": vol_p_mae_aux_weighted_val,
     }
 
 
@@ -883,6 +907,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/vol_p_aux_mae_weight"] = config.vol_p_aux_mae_weight
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1055,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_p_aux_mae_weight=config.vol_p_aux_mae_weight,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1096,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if config.vol_p_aux_mae_weight > 0.0:
+                        train_log["train/vol_p_mae_aux"] = batch_loss_metrics["vol_p_mae_aux"]
+                        train_log["train/vol_p_mae_aux_weighted"] = batch_loss_metrics["vol_p_mae_aux_weighted"]
+                        train_log["train/vol_p_aux_mae_weight"] = config.vol_p_aux_mae_weight
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
# H74 — MAE auxiliary loss on vol_p (cross-pollination from dl24 H22)

## Hypothesis

The vol_p validation metric on tay shows a persistent floor pattern across Wave 31 mech-positive nulls: val_VP lands in the 3.6-4.2% range, with the floor at 3.643% (PR #972 baseline `test_VP`). The current vol_p loss in `train.py` uses masked MSE only — `(pred - target)^2`.

**MAE auxiliary loss adds a small L1 contribution on top of the MSE:**
```
loss_total = (existing MSE-based loss) + α × masked_mean(|pred_vp - target_vp|)
```
where `α = 0.05` (dl24 H22 default).

**Why MAE_aux helps on vol_p specifically:**

1. **Gradient floor preservation** — MSE has gradient `2(pred - target)` which vanishes as predictions approach targets. MAE has constant gradient `±1`, providing a **non-vanishing gradient signal** that prevents the optimizer from settling into a high-loss minimum. This directly addresses the val_VP "floor pattern" observation.

2. **Median-seeking vs mean-seeking optimization** — MSE minimizes squared error → converges to conditional mean. MAE minimizes absolute error → converges to conditional median. The median is **more robust to outliers** (long-tail pressure points in wake / wing-tip / wheel-house regions). Adding a small L1 term shifts the equilibrium toward median estimates without losing MSE's smoothness near zero.

3. **Orthogonal mechanism class to Charbonnier (H68)** — H68 (nezuko) replaces MSE entirely with Charbonnier (pseudo-Huber: quadratic near zero, linear at tail). MAE_aux ADDS L1 on top of MSE (loss-L1-injection). Different lever: Charbonnier reshapes the loss curve; MAE_aux adds out-of-budget gradient mass at the tail. **Could compose with H68 in future if both produce signal.**

4. **dl24 H22 (PR #1217) validation** — dl24 fleet tested MAE_aux=0.05 on top of their H19 Charbonnier+GradNorm stack. The PR design rationale was directly to attack their vol_p floor breach (test_vol_p=3.889% K=4 ensemble; H19 single-model test_vol_p was ~3.6-3.7%, similar floor to tay).

**Why this is a fresh mech class on tay:** No prior Wave 28-31 experiment tested an L1 auxiliary term on any loss component. The mechanism class loss-L1-injection is a clean orthogonal direction to:
- loss-weighting (CP-LOSS-WEIGHT, τz-curriculum — Wave 31 mech-positive nulls)
- loss-curve-shape (H68 Charbonnier vol_p, H73 Charbonnier τ_z — Wave 32 in-flight)
- variance/capacity allocation (V-DEPTH, SURFACE-DEEP)
- attention/PE structure (FDCE, slice-temp curriculum)

## Instructions

Single-mechanism, single-flag test. Modify `target/train.py`.

### Step 1: Import `masked_mean`

In `train.py` around line 57 where `masked_mse` is imported from `trainer_runtime`, add `masked_mean` to the same import:

```python
from trainer_runtime import (
    ...
    masked_mean,    # ← add this
    masked_mse,
    weighted_channel_mse,
    ...
)
```

(`masked_mean` is already defined at `trainer_runtime.py:825` — verified.)

### Step 2: Add Config field

In the `Config` dataclass (look for the block where `tau_y_loss_weight` / `tau_z_loss_weight` are defined), add:

```python
vol_p_aux_mae_weight: float = 0.0    # Default 0.0 = dormant / backward-compat
```

### Step 3: Add CLI help (optional but recommended)

In the `help_text` dict inside `parse_args`, add:

```python
"vol_p_aux_mae_weight": (
    "Weight α for vol_p MAE auxiliary loss term added on top of MSE: "
    "loss += α * masked_mean(|pred_vp - target_vp|). Default 0.0 = dormant. "
    "dl24 H22 default = 0.05."
),
```

### Step 4: Compute and inject MAE_aux in `train_loss`

Around `train.py:344` where `volume_loss = masked_mse(...)` is computed:

```python
surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
weighted_surface_loss = surface_loss_weight * surface_loss
weighted_volume_loss = volume_loss_weight * volume_loss
loss = weighted_surface_loss + weighted_volume_loss

# NEW: H74 MAE_aux injection — add L1 gradient signal on vol_p (out-of-budget,
# not subject to volume_loss_weight rebalancing).
vol_p_mae_aux_val = 0.0
if config.vol_p_aux_mae_weight > 0.0:
    vol_p_mae = masked_mean(
        (out["volume_preds"] - volume_target).abs(),
        batch.volume_mask,
    )
    loss = loss + config.vol_p_aux_mae_weight * vol_p_mae
    vol_p_mae_aux_val = float(vol_p_mae.detach().cpu().item())
```

Then add to the `metrics` dict that gets returned:

```python
metrics = {
    ...
    "vol_p_mae_aux": vol_p_mae_aux_val,
    "vol_p_mae_aux_weighted": config.vol_p_aux_mae_weight * vol_p_mae_aux_val,
}
```

### Step 5: Pass the new Config field to `train_loss` at the call site

In `main()`, the `train_loss(...)` call should receive `vol_p_aux_mae_weight=config.vol_p_aux_mae_weight` and the `train_loss` signature needs the matching kwarg with default 0.0.

### Step 6: Add diagnostic W&B logging

In the train-step W&B log dict, gated on `if config.vol_p_aux_mae_weight > 0.0`:

```python
train_log["train/vol_p_mae_aux"] = batch_loss_metrics["vol_p_mae_aux"]
train_log["train/vol_p_mae_aux_weighted"] = batch_loss_metrics["vol_p_mae_aux_weighted"]
train_log["train/vol_p_aux_mae_weight"] = config.vol_p_aux_mae_weight
```

These diagnostics let us track:
- `train/vol_p_mae_aux` (the raw L1 value) — should descend monotonically as the model converges
- `train/vol_p_mae_aux_weighted` (α * L1) — the gradient mass contribution
- Ratio `vol_p_mae_aux_weighted / volume_loss` — relative L1 vs MSE contribution

### Cross-reference implementation

dl24 H22 implementation: branch `dl24-nezuko/h22-h19-plus-maeaux`, commit `48843eb` (`H22: add --vol-p-aux-mae-weight on top of H19 Charb base`). Their implementation adds MAE_aux on top of their H19 Charbonnier+GradNorm base — for tay, you're adding it on top of plain MSE (simpler, cleaner attribution).

**Audit reminder**: verify all CLI flags exist before launch with `python train.py --vol-p-aux-mae-weight 0.05 --help`. If argparse rejects, fix and re-launch — do NOT proceed with a silently-ignored flag.

## Recipe

```bash
cd /workspace/senpai/target

torchrun --nproc_per_node=8 train.py \
    --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --epochs 13 \
    --batch-size 2 \
    --hidden-dim 512 \
    --num-layers 5 \
    --num-slices 128 \
    --num-heads 8 \
    --optimizer lion \
    --lr 9e-5 \
    --lr-cosine-t-max 13 \
    --lr-warmup-epochs 1 \
    --ema-decay 0.999 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --volume-loss-weight 0.5 \
    --vol-p-aux-mae-weight 0.05 \
    --kill-thresholds "32592:val_abupt<7.5,val_SP<5.5" "65184:val_abupt<6.5" \
    --wandb-name frieren/h74-mae-aux-vol-p \
    --wandb-group frieren-h74-mae-aux-vol-p
```

**Substrate choice**: legacy `--lr-cosine-t-max 13` (matches baseline #972). Rationale:
1. Direct comparability to baseline #972 single-model SOTA (val_abupt=6.126%, test_VP=3.643%)
2. MAE_aux is a small additive perturbation on top of MSE — does NOT change the loss curve fundamentally, so LR-substrate-class dispositions (D NEGATIVE / C NULL for routing-curriculum classes on LR-extended) don't apply
3. Keeps H68 (Charbonnier vol_p on lr-25) and H74 (MAE_aux vol_p on lr-13) on **different substrates** — clean cross-attribution across substrate × mechanism axes
4. If H74 is mech-positive on lr-13, a future H75 could test the lr-25 variant

## Diagnostic targets

Beyond standard metrics, track at EP1/EP3/EP6/EP9/EP13:

| Diagnostic | Expected trajectory if MAE_aux is productive |
|---|---|
| train/vol_p_mae_aux | descending monotonically (L1 absolute residual) |
| train/vol_p_mae_aux_weighted | α=0.05 × L1, should be 5-20% of `train/volume_loss` |
| train/volume_loss (raw MSE) | continues descending — L1 should not destabilize the MSE descent |
| val_VP per-epoch | **descending below 3.95% by EP6, toward 3.643% floor at terminal** |
| val_VP vs floor 3.643% | floor crossing watch — central A/B/C/D outcome metric |

**Anti-pattern watch**: if `train/vol_p_mae_aux_weighted > 30% of train/volume_loss`, the MAE term is dominating and we've over-weighted. Below 5%, L1 contribution is negligible. Target 5-20% band.

## Kill thresholds & timing

- **No EP1 gate** (lr-warmup=1 expected to land EP1 val_abupt ~30-35%)
- **EP3 (step 32,594):** `val_abupt < 7.5 AND val_SP < 5.5` — soft sanity check
- **EP6 (step 65,184):** `val_abupt < 6.5` — hard kill if mech shows no descent
- **EP13 terminal:** report all 7 paper-facing axes

Budget: `SENPAI_TIMEOUT_MINUTES=1100` (18h). Legacy lr-13 substrate typically lands in ~14-15h on 8×96GB.

## Falsifiable outcomes

| Outcome | Condition | Interpretation |
|---|---|---|
| **A. MERGE WIN** | val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS < 6.727% | MAE_aux unlocks vol_p floor + improves abupt aggregate — stack-eligible for Wave 32 composition |
| **B. PARTIAL WIN** | val_abupt drops ≥0.05pp below 6.126%, OR test_VP < 3.643%, but not both | Mech-positive direction; isolate which axis improved |
| **C. NULL** | val_abupt within ±0.05pp of 6.126%, val_VP within ±0.05pp of baseline | L1-injection saturates / produces no signal on tay's data split |
| **D. NEGATIVE** | val_abupt > 6.126% by ≥0.05pp | MAE_aux destabilizes vol_p training — L1 gradient mass interferes with MSE convergence |

**Sibling comparison (H68 Charbonnier vs H74 MAE_aux on vol_p):**
- If H68 = C NULL AND H74 = mech-positive → MAE_aux is the productive mechanism, Charbonnier-replacement is not
- If H68 = mech-positive AND H74 = C NULL → Charbonnier-replacement is productive, L1-injection is not
- If BOTH mech-positive → composition test (H68 + MAE_aux on top) becomes a Wave 33 candidate
- If BOTH C/D NULL → tay's vol_p axis is loss-function-shape-insensitive (data-split is qualitatively different from dl24's)

## Baseline

Current single-model SOTA on `tay`: PR #972 (W&B run `56bcqp3m`)

| Metric | #972 baseline | H74 target |
|---|---:|:---|
| val_abupt (merge gate) | **6.126%** | < 6.126% |
| test_abupt (paper-facing) | 5.844% | < 5.844% |
| **test_VP (floor)** | **3.643%** | **≤ 3.643%** (primary mechanism target) |
| test_SP (floor) | 3.577% | ≤ 3.577% |
| test_WSS (goal) | 6.727% | < 6.727% |

W&B baseline group: `senpai-v1-drivaerml-ddp8`, run `56bcqp3m`.

## Why this is the right next experiment for you

Your H72 closure analysis demonstrated three skills critical to running this experiment well:
1. **Mechanism-failure detection** — you fired the over-sparsification flag at EP2 (one epoch earlier than the PR anticipated)
2. **Quantitative attribution** — your per-block entropy + n_eff trajectory analysis cleanly attributed the failure mode
3. **Clean diagnostic discipline** — duplicate-launch detection + SIGTERM resolution + canonical W&B run flagging

H74 is a fresh mech class (loss-L1-injection) that hasn't been tested on tay. The mech-positive direction (MAE_aux helps val_VP descend) requires diagnostic-level attribution to attribute mechanism vs noise. Your H72 instrumentation discipline maps directly to this.

This single-flag, fresh-class, dl24-cross-pollination experiment composes with both currently in-flight Charbonnier variants (H68 vol_p, H73 τ_z) — clean four-cell mechanism × axis grid for Wave 32+ design decisions.
