### PR TITLE
Wave 32 H77: CHARBONNIER-VOL-P-WEIGHT-FIX — Correct --vol-weight 1.0→0.5 (dl24 H19 recipe)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_charbonnier,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -85,6 +86,8 @@ class Config:
     validation_every: int = 1
     surface_loss_weight: float = 1.0
     volume_loss_weight: float = 1.0
+    vol_loss_type: str = "mse"
+    charbonnier_eps: float = 1e-3
     manifest: str = "data/split_manifest.json"
     data_root: str = ""
     output_dir: str = "outputs/drivaerml"
@@ -229,6 +232,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "vol_loss_type": (
+            "Loss function for volume_pressure target. 'mse' (default) is "
+            "masked squared error. 'charbonnier' is "
+            "sqrt((pred-target)^2 + eps^2) - eps, which transitions smoothly "
+            "from quadratic for small errors to linear for large errors, "
+            "bounding outlier-driven gradient magnitude. Cross-pollinated "
+            "from dl24 H19 (PR #1180). Surface loss is unaffected."
+        ),
+        "charbonnier_eps": (
+            "Epsilon (smoothing constant) for Charbonnier loss. Applied as "
+            "sqrt((pred-target)^2 + eps^2) - eps. Smaller eps approaches "
+            "L1 behaviour; larger eps approaches MSE behaviour. Default "
+            "1e-3 matches dl24 H19. Only used when --vol-loss-type=charbonnier."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -240,7 +257,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    config = Config(**vars(namespace))
+    if config.vol_loss_type not in {"mse", "charbonnier"}:
+        raise ValueError(
+            f"--vol-loss-type must be one of {{'mse', 'charbonnier'}}; got "
+            f"{config.vol_loss_type!r}"
+        )
+    if config.charbonnier_eps <= 0.0:
+        raise ValueError(
+            f"--charbonnier-eps must be positive; got {config.charbonnier_eps}"
+        )
+    return config
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -321,6 +348,11 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    vol_loss_type: str = "mse",
+    charbonnier_eps: float = 1e-3,
+    retain_volume_grad: bool = False,
+    vol_loss_diag: dict[str, float] | None = None,
+    volume_pred_out: dict | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -341,7 +373,25 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        volume_preds = out["volume_preds"]
+        if retain_volume_grad and volume_preds.requires_grad:
+            volume_preds.retain_grad()
+        if volume_pred_out is not None:
+            volume_pred_out["volume_preds"] = volume_preds
+        if vol_loss_type == "charbonnier":
+            volume_loss = masked_charbonnier(
+                volume_preds, volume_target, batch.volume_mask, eps=charbonnier_eps
+            )
+            if vol_loss_diag is not None:
+                _populate_vol_loss_diag(
+                    volume_preds, volume_target, batch.volume_mask, charbonnier_eps, vol_loss_diag
+                )
+        else:
+            volume_loss = masked_mse(volume_preds, volume_target, batch.volume_mask)
+            if vol_loss_diag is not None:
+                _populate_vol_loss_diag(
+                    volume_preds, volume_target, batch.volume_mask, None, vol_loss_diag
+                )
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -353,6 +403,45 @@ def train_loss(
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+
+
+def _populate_vol_loss_diag(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    charbonnier_eps: float | None,
+    diag: dict[str, float],
+) -> None:
+    """Fill ``diag`` with per-element loss-distribution stats over masked entries.
+
+    Always logs the MSE per-element distribution; when ``charbonnier_eps`` is
+    provided also logs the Charbonnier per-element distribution alongside it
+    so both shapes are comparable in the W&B stream.
+    """
+    with torch.no_grad():
+        flat_mask = mask.to(device=pred.device, dtype=torch.bool)
+        if not bool(flat_mask.any()):
+            return
+        sq = (pred - target).square()
+        per_elt_mse = sq[flat_mask].float().reshape(-1)
+        diag["vol_loss_diag/mse_mean"] = float(per_elt_mse.mean().item())
+        diag["vol_loss_diag/mse_std"] = float(per_elt_mse.std(unbiased=False).item())
+        diag["vol_loss_diag/mse_max"] = float(per_elt_mse.max().item())
+        q = torch.tensor([0.5, 0.9, 0.99], device=per_elt_mse.device)
+        quantiles = torch.quantile(per_elt_mse, q)
+        diag["vol_loss_diag/mse_p50"] = float(quantiles[0].item())
+        diag["vol_loss_diag/mse_p90"] = float(quantiles[1].item())
+        diag["vol_loss_diag/mse_p99"] = float(quantiles[2].item())
+        if charbonnier_eps is not None:
+            char = torch.sqrt(sq + charbonnier_eps * charbonnier_eps) - charbonnier_eps
+            per_elt_char = char[flat_mask].float().reshape(-1)
+            diag["vol_loss_diag/char_mean"] = float(per_elt_char.mean().item())
+            diag["vol_loss_diag/char_std"] = float(per_elt_char.std(unbiased=False).item())
+            diag["vol_loss_diag/char_max"] = float(per_elt_char.max().item())
+            cq = torch.quantile(per_elt_char, q)
+            diag["vol_loss_diag/char_p50"] = float(cq[0].item())
+            diag["vol_loss_diag/char_p90"] = float(cq[1].item())
+            diag["vol_loss_diag/char_p99"] = float(cq[2].item())
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -937,6 +1026,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 disable=not state.is_main,
             ):
                 gradnorm_metrics: dict[str, float] = {}
+                vol_loss_diag: dict[str, float] = {}
+                volume_pred_holder: dict = {}
+                will_log_vol_diag = (
+                    balancer is None
+                    and config.gradient_log_every > 0
+                    and ((global_step + 1) % config.gradient_log_every == 0)
+                )
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1030,6 +1126,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        vol_loss_type=config.vol_loss_type,
+                        charbonnier_eps=config.charbonnier_eps,
+                        retain_volume_grad=will_log_vol_diag,
+                        vol_loss_diag=vol_loss_diag if will_log_vol_diag else None,
+                        volume_pred_out=volume_pred_holder if will_log_vol_diag else None,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1049,10 +1150,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                     and config.weight_log_every > 0
                     and global_step % config.weight_log_every == 0
                 )
+                peak_lr = config.lr if config.lr > 0.0 else 1.0
+                lr_fraction_of_peak = current_lr / peak_lr if peak_lr != 0 else 0.0
+                warmup_e = max(0, config.lr_warmup_epochs)
+                cosine_t_max = (
+                    config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
+                )
+                cosine_progress = max(0.0, float(epoch - warmup_e)) / float(max(1, cosine_t_max))
+                cosine_progress = min(1.0, cosine_progress)
                 train_log: dict[str, object] = {
                     "global_step": global_step,
                     "train/lr": current_lr,
                     "lr": current_lr,
+                    "train/lr_fraction_of_peak": lr_fraction_of_peak,
+                    "train/cosine_progress": cosine_progress,
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
@@ -1072,11 +1183,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if vol_loss_diag:
+                    train_log.update(vol_loss_diag)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
+                    if (
+                        will_log_vol_diag
+                        and "volume_preds" in volume_pred_holder
+                        and volume_pred_holder["volume_preds"].grad is not None
+                    ):
+                        vp_grad = volume_pred_holder["volume_preds"].grad.detach().float()
+                        vp_grad_norm = float(vp_grad.norm().item())
+                        vp_grad_max = float(vp_grad.abs().max().item())
+                        train_log["train/vol_p_grad/l2_norm"] = vp_grad_norm
+                        train_log["train/vol_p_grad/max_abs"] = vp_grad_max
+                        if vp_grad.numel() > 0:
+                            train_log["train/vol_p_grad/mean_abs"] = float(vp_grad.abs().mean().item())
                     if config.grad_clip_norm > 0.0:
                         grad_norm_tensor = torch.nn.utils.clip_grad_norm_(
                             base_model.parameters(),

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,18 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Charbonnier loss with token-mask; matches masked_mse signature and reduction."""
+    sq = (pred - target).square()
+    err = torch.sqrt(sq + eps * eps) - eps
+    return masked_mean(err, mask)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**H77 CHARBONNIER-VOL-P-WEIGHT-FIX**: Single-flag change from H68 — `--volume-loss-weight 1.0 → 0.5`. All other H68 flags identical (Charbonnier eps=1e-3, lr-cosine-t-max 25, same substrate).

### Why H68 failed (your own diagnostic)

H68 was killed at EP6 (val_abupt 6.822%) due to a **recipe execution deviation** — not a technique failure:
- PR body specified `--volume-loss-weight 0.5` (verbatim dl24 H19 recipe)
- H68 launched with `--volume-loss-weight 1.0` (deviation for "H59-substrate parity")
- Your `char_over_mse` time series showed the consequence: per-element Charbonnier loss is **18× larger than MSE** at our vol_p error scale (std ~0.022 >> eps=1e-3 → L1-regime)
- With weight=1.0, the effective volume loss budget was 18× what MSE at weight=1.0 would contribute
- Surface heads starved from step 1; EP1 cold-start 28.04% vs baseline ~15-25% was the smoking gun

**The fix**: `--volume-loss-weight 0.5` halves the volume budget to 9× MSE-equivalent — matching dl24's H19 recipe exactly. dl24 H19 used weight=0.5 WITH Charbonnier because they calibrated for the L1-regime magnitude shift.

### Technique still has merit

Loss-curvature-shape mech class is **NOT exhausted** by H68. The implementation is correct. The technique cross-pollination from dl24 H19 (their SOTA-beating stack) is still high-value. H77 is the clean test.

### Connection to dl24 H19

dl24 H19 (PR #1180) achieved test_abupt=5.82%, test_WSS=6.63% using a stack that includes Charbonnier on vol_p AND tau_z + GradNorm + curvature-attn-bias + clamp=0.15. The Charbonnier-vol-p component with weight=0.5 is exactly what we're testing here in isolation.

## Instructions

### Step 1: Cherry-pick the Charbonnier implementation from your H68 branch

The implementation shipped in `nezuko/h68-charbonnier-vol-p` is correct. Cherry-pick just the code changes (not the launch script):

```bash
# From your new H77 branch (already checked out):
git cherry-pick <commit-hash-of-charbonnier-implementation-from-h68>
```

If cherry-pick is complex, the changes you need to re-implement are:

**`target/trainer_runtime.py`**: Add `masked_charbonnier` next to `masked_mse`:
```python
def masked_charbonnier(pred: torch.Tensor, target: torch.Tensor,
                       mask: torch.Tensor, eps: float = 1e-3) -> torch.Tensor:
    sq = (pred - target).pow(2)
    loss = (sq + eps * eps).sqrt() - eps
    return masked_mean(loss, mask)
```

**`target/train.py`**: Add flags and dispatch:
```python
# In Config:
vol_loss_type: str = "mse"   # "mse" or "charbonnier"
charbonnier_eps: float = 1e-3

# In train_loss computation (replace masked_mse for vol):
if config.vol_loss_type == "charbonnier":
    volume_loss = masked_charbonnier(out["volume_preds"], volume_target,
                                     batch.volume_mask, eps=config.charbonnier_eps)
else:
    volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
```

Keep the same diagnostics from H68 (`vol_loss_diag/{mse,char}_{mean,std,max,p50,p90,p99}`) — they were what enabled the H68 post-mortem.

### Step 2: Run with ONLY the weight change vs H68

**The ONLY difference from H68 is `--volume-loss-weight 0.5` (was 1.0).**

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
    --agent nezuko --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
    --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
    --surface-loss-weight 2.0 \
    --volume-loss-weight 0.5 \
    --use-ema --ema-decay 0.999 --ema-start-step 50 \
    --grad-clip-norm 0.5 --lr-warmup-epochs 1 \
    --pos-encoding-mode string_separable --use-qk-norm \
    --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
    --lr-cosine-t-max 25 --epochs 13 \
    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
    --no-compile-model \
    --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 --model-mlp-ratio 4 \
    --validation-every 1 \
    --train-surface-points 65536 --eval-surface-points 65536 \
    --train-volume-points 65536 --eval-volume-points 65536 \
    --use-surf-to-vol-xattn \
    --amp-mode bf16 \
    --vol-loss-type charbonnier --charbonnier-eps 1e-3 \
    --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<7.5,32592:val_primary/surface_pressure_rel_l2_pct<5.5,65184:val_primary/abupt_axis_mean_rel_l2_pct<6.5" \
    --wandb-group wave32_h77_charbonnier_vol_p_weight_fix \
    --wandb-name nezuko/h77-charbonnier-vol-p-weight-fix
```

**Note**: `--volume-loss-weight 0.5` is the ONLY flag change vs H68. Everything else (substrate, eps, surface weights, LR schedule) is identical.

### Step 3: Monitor the EP1 cold start carefully

H68's EP1 cold-start was 28.04% (disaster signal). With weight=0.5, EP1 should land closer to the 15-25% range expected for warmup=1 recipes. If EP1 still exceeds 30%, post a comment immediately — don't wait for EP3 gate.

**EP1 expected range with weight=0.5**: 18-26% (9× effective overweight vs baseline 1.0×MSE, but surface loss at 2.0 rebalances)

**Key diagnostic to log at EP1**: `val_primary/abupt_axis_mean_rel_l2_pct` + `vol_loss_diag/char_mean` + `vol_loss_diag/mse_mean` → report char/mse ratio (should still be ~6-18× but NOW at halved effective budget)

### Step 4: Post diagnostics at EP3 gate

Report `vol_loss_diag/char_over_mse` trajectory EP1→EP3. If char/mse is stabilizing below 15× by EP3, the halved weight is bringing the vol_p contribution into productive range.

## Baseline

### Current single-model SOTA (merge target)
- **PR #972** (W&B run `56bcqp3m`): val_abupt=**6.126%**, test_abupt=5.844%
- val_VP=3.798% | test_VP=3.643% (floor) | test_SP=3.577% (floor) | test_WSS=6.727%
- **Merge gate: val_abupt < 6.126%**

### H68 (recipe-error rerun for comparison)
- W&B run `6mm00t4k` (killed EP6): val_abupt=6.822% at kill
- The H68 `char_over_mse` trajectory: EP2=6.4×, EP3=13.5×, EP4-5=17.4×, terminal=18.4×
- H77 should show LOWER char_over_mse trajectory due to halved volume budget

### dl24 H19 cross-pollination reference (technique origin)
- PR #1180: test_abupt=5.82%, test_WSS=6.63% using stack including Charbonnier vol_p at weight=0.5
- H77 is the isolation test of just the Charbonnier-vol-p component at the correct weight

## Falsifiable outcome predictions

| Outcome | Criteria | Interpretation | Follow-up |
|---|---|---|---|
| **A MERGE WIN** | val_abupt < 6.126% | Charbonnier-vol-p technique wins with correct weight | Compose with H73 (Charbonnier-τ_z) in Wave 33 |
| **B PARTIAL WIN** | val_abupt 6.05-6.12% | Technique helps, weight was the binding issue | Queue eps-tuned H78 for gate-cross attempt |
| **C NULL** | val_abupt ~6.12-6.20% | Technique neutral at weight=0.5 — eps-mismatch is co-dominant | Try H78 Charbonnier-vol-p with eps=0.01 (tuned to data scale) |
| **D NEGATIVE** | val_abupt > 6.20% | Technique genuinely negative on tay's vol_p split even at correct weight | Close mech class for vol_p; refocus on Charbonnier-τ_z (H73) and MAE_aux (H74) |

**Primary comparison**: H77 vs PR #972 baseline (run `56bcqp3m`) AND vs H68 (`6mm00t4k`) to confirm the weight fix improved things.
