### PR TITLE
Wave 32 H95: SURF-LOSS-PUSH-FURTHER — Direct H87 follow-up (surface_loss_weight 1.5→1.25)

### DIFF
--- a/launch_h95.sh
+++ b/launch_h95.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+export SENPAI_TIMEOUT_MINUTES=1100
+exec torchrun --standalone --nproc-per-node=8 train.py \
+    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+    --manifest data/split_manifest.json \
+    --epochs 13 --batch-size 4 \
+    --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
+    --model-slices 128 --model-dropout 0.0 \
+    --train-surface-points 65536 --eval-surface-points 65536 \
+    --train-volume-points 16384 --eval-volume-points 65536 \
+    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
+    --surface-loss-weight 1.25 --volume-loss-weight 1.0 \
+    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
+    --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
+    --use-ema --ema-decay 0.999 --ema-start-step 50 \
+    --use-surf-to-vol-xattn \
+    --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
+    --weight-decay 5e-4 --grad-clip-norm 0.5 \
+    --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
+    --amp-mode bf16 --no-compile-model \
+    --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
+    --wandb-name tanjiro/h95-surf-loss-push-further \
+    --wandb-group wave32_h95_surf_loss_push_further

--- a/query_h95.py
+++ b/query_h95.py
@@ -1,0 +1,50 @@
+"""Focused H95 W&B query for status checks."""
+import wandb
+
+api = wandb.Api()
+run = api.run("wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/ze0bohdu")
+s = run.summary_metrics
+
+print(f"State: {run.state}")
+print(f"Step: {s.get('_step')} / 70664")
+rt = s.get('_runtime', 0)
+print(f"Runtime: {rt/3600:.2f}h" if rt else "Runtime: unknown")
+
+print("\n=== Latest val/val_surface (primary) ===")
+for k in ['abupt_axis_mean_rel_l2_pct', 'surface_pressure_rel_l2_pct',
+          'volume_pressure_rel_l2_pct', 'wall_shear_rel_l2_pct',
+          'wall_shear_x_rel_l2_pct', 'wall_shear_y_rel_l2_pct',
+          'wall_shear_z_rel_l2_pct']:
+    full = f'val/val_surface/{k}'
+    v = s.get(full)
+    if v is not None:
+        print(f"  {k}: {v:.4f}")
+
+print("\n=== Best checkpoint snapshot ===")
+for k in sorted(s.keys()):
+    if 'best_checkpoint' in k and isinstance(s.get(k), (int, float)):
+        print(f"  {k}: {s.get(k)}")
+
+print("\n=== test/* metrics (if any) ===")
+test_keys = [k for k in s.keys() if k.startswith('test')]
+for k in sorted(test_keys):
+    v = s.get(k)
+    if isinstance(v, (int, float)):
+        print(f"  {k}: {v}")
+if not test_keys:
+    print("  (none yet — test eval only runs at end)")
+
+print("\n=== loss/* snapshot ===")
+for k in sorted(s.keys()):
+    if k.startswith('loss/') and isinstance(s.get(k), (int, float)):
+        print(f"  {k}: {s.get(k):.6f}")
+
+print("\n=== NaN counts ===")
+for k in sorted(s.keys()):
+    if 'nan' in k.lower() and isinstance(s.get(k), (int, float)) and s.get(k):
+        print(f"  {k}: {s.get(k)}")
+
+print("\n=== Last grad/global_norm ===")
+for k in sorted(s.keys()):
+    if 'global_norm' in k and k.startswith('train/grad'):
+        print(f"  {k}: {s.get(k)}")

--- a/query_h95_terminal.py
+++ b/query_h95_terminal.py
@@ -1,0 +1,166 @@
+"""Terminal H95 results collection — comprehensive comparison vs H87 and baseline.
+
+H95: surface_loss_weight=1.25 (ze0bohdu)
+H87: surface_loss_weight=1.5 (jpspxktf) — previous best
+#972 baseline: canonical surface_loss_weight=2.0 (56bcqp3m)
+"""
+import wandb
+import numpy as np
+
+api = wandb.Api()
+ENTITY = "wandb-applied-ai-team"
+PROJECT = "senpai-v1-drivaerml-ddp8"
+
+H95_ID = "ze0bohdu"
+H87_ID = "jpspxktf"
+BASELINE_ID = "56bcqp3m"
+
+
+def fetch(run_id):
+    return api.run(f"{ENTITY}/{PROJECT}/{run_id}")
+
+
+def get_summary(run, prefix=""):
+    s = run.summary_metrics
+    return {k: v for k, v in s.items() if (prefix == "" or k.startswith(prefix))}
+
+
+def print_section(title):
+    print(f"\n{'=' * 70}\n{title}\n{'=' * 70}")
+
+
+run_h95 = fetch(H95_ID)
+print_section(f"H95 RUN STATE — {H95_ID}")
+print(f"State: {run_h95.state}")
+s95 = run_h95.summary_metrics
+print(f"Step: {s95.get('_step')} / 70664")
+rt = s95.get('_runtime', 0)
+if rt:
+    print(f"Runtime: {rt / 3600:.2f}h")
+
+# Terminal val/val_surface metrics (primary)
+print_section("H95 — LATEST val/val_surface metrics")
+val_keys = [
+    'abupt_axis_mean_rel_l2_pct',
+    'surface_pressure_rel_l2_pct',
+    'volume_pressure_rel_l2_pct',
+    'wall_shear_rel_l2_pct',
+    'wall_shear_x_rel_l2_pct',
+    'wall_shear_y_rel_l2_pct',
+    'wall_shear_z_rel_l2_pct',
+]
+for k in val_keys:
+    full = f'val/val_surface/{k}'
+    v = s95.get(full)
+    if v is not None:
+        print(f"  val/val_surface/{k}: {v:.4f}")
+
+print_section("H95 — TEST metrics (terminal only)")
+test_keys_found = [k for k in s95.keys() if k.startswith('test')]
+if test_keys_found:
+    for k in sorted(test_keys_found):
+        v = s95.get(k)
+        if isinstance(v, (int, float)):
+            print(f"  {k}: {v:.4f}")
+else:
+    print("  (no test metrics yet — only present at terminal)")
+
+print_section("H95 — Loss bucket effective magnitudes (mechanism check)")
+loss_keys = ['loss/surface_loss', 'loss/volume_loss', 'loss/total_loss',
+             'loss/surface_loss_weight', 'loss/volume_loss_weight',
+             'loss/tau_y_loss_weight', 'loss/tau_z_loss_weight']
+for k in loss_keys:
+    v = s95.get(k)
+    if v is not None:
+        print(f"  {k}: {v}")
+sl = s95.get('loss/surface_loss')
+vl = s95.get('loss/volume_loss')
+if sl and vl:
+    print(f"  → surface_loss / volume_loss = {sl / vl:.3f}x (expected ~1.25x for H95)")
+
+print_section("H95 — NaN counts / stability")
+nan_keys = [k for k in s95.keys() if 'nan' in k.lower() and isinstance(s95.get(k), (int, float)) and s95.get(k)]
+if nan_keys:
+    for k in nan_keys:
+        print(f"  {k}: {s95.get(k)}")
+else:
+    print("  No NaN events recorded ✓")
+
+print_section("H95 — final grad norms")
+gn_keys = ['train/grad/global_norm', 'train/grad/global_norm_pre_clip']
+for k in gn_keys:
+    v = s95.get(k)
+    if v is not None:
+        print(f"  {k}: {v:.4f}")
+
+# ===== H87 baseline comparison =====
+print_section(f"H87 SIBLING ({H87_ID}) — surface_loss_weight=1.5 — for direct comparison")
+try:
+    run_h87 = fetch(H87_ID)
+    s87 = run_h87.summary_metrics
+    print(f"State: {run_h87.state}")
+    print("Val/val_surface terminal:")
+    for k in val_keys:
+        full = f'val/val_surface/{k}'
+        v = s87.get(full)
+        if v is not None:
+            print(f"  val/val_surface/{k}: {v:.4f}")
+    print("Test:")
+    test_h87 = [k for k in s87.keys() if k.startswith('test')]
+    for k in sorted(test_h87):
+        v = s87.get(k)
+        if isinstance(v, (int, float)):
+            print(f"  {k}: {v:.4f}")
+    print("Loss buckets:")
+    for k in ['loss/surface_loss', 'loss/volume_loss']:
+        v = s87.get(k)
+        if v is not None:
+            print(f"  {k}: {v}")
+    sl87 = s87.get('loss/surface_loss')
+    vl87 = s87.get('loss/volume_loss')
+    if sl87 and vl87:
+        print(f"  → H87 ratio surface/volume = {sl87 / vl87:.3f}x")
+except Exception as e:
+    print(f"  Failed to load H87: {e}")
+
+# ===== #972 baseline comparison =====
+print_section(f"#972 baseline ({BASELINE_ID}) — surface_loss_weight=2.0 — canonical")
+try:
+    run_base = fetch(BASELINE_ID)
+    sb = run_base.summary_metrics
+    print(f"State: {run_base.state}")
+    print("Val/val_surface terminal:")
+    for k in val_keys:
+        full = f'val/val_surface/{k}'
+        v = sb.get(full)
+        if v is not None:
+            print(f"  val/val_surface/{k}: {v:.4f}")
+    print("Test:")
+    test_base = [k for k in sb.keys() if k.startswith('test')]
+    for k in sorted(test_base):
+        v = sb.get(k)
+        if isinstance(v, (int, float)):
+            print(f"  {k}: {v:.4f}")
+except Exception as e:
+    print(f"  Failed to load baseline: {e}")
+
+# ===== Slope analysis from history =====
+print_section("H95 — val_abupt history (last 12 val reads)")
+try:
+    hist = run_h95.history(
+        keys=['_step', 'val/val_surface/abupt_axis_mean_rel_l2_pct',
+              'val/val_surface/surface_pressure_rel_l2_pct',
+              'val/val_surface/volume_pressure_rel_l2_pct',
+              'val/val_surface/wall_shear_rel_l2_pct'],
+        pandas=False,
+    )
+    seen = [h for h in hist if h.get('val/val_surface/abupt_axis_mean_rel_l2_pct') is not None]
+    for h in seen[-12:]:
+        st = h.get('_step')
+        ab = h.get('val/val_surface/abupt_axis_mean_rel_l2_pct')
+        sp = h.get('val/val_surface/surface_pressure_rel_l2_pct')
+        vp = h.get('val/val_surface/volume_pressure_rel_l2_pct')
+        ws = h.get('val/val_surface/wall_shear_rel_l2_pct')
+        print(f"  step={st}  abupt={ab:.3f}  SP={sp:.3f}  VP={vp:.3f}  WSS={ws:.3f}")
+except Exception as e:
+    print(f"  Failed: {e}")

--- a/query_run.py
+++ b/query_run.py
@@ -1,0 +1,106 @@
+import wandb
+import numpy as np
+import sys
+import os
+
+api = wandb.Api()
+
+entity = "wandb-applied-ai-team"
+project = "senpai-v1-drivaerml-ddp8"
+run_id = "ze0bohdu"
+
+path = f"{entity}/{project}/{run_id}"
+run = api.run(path)
+
+print(f"=== RUN STATE ===")
+print(f"ID: {run.id}")
+print(f"Name: {run.name}")
+print(f"State: {run.state}")
+
+s = run.summary_metrics
+print(f"\n=== LATEST STEP ===")
+print(f"_step: {s.get('_step')}")
+
+print(f"\n=== VAL PRIMARY METRICS ===")
+val_keys = [k for k in s.keys() if 'val' in k.lower() or 'surface_pressure' in k.lower() or 'SP' in k or 'VP' in k or 'WSS' in k or 'abupt' in k.lower()]
+for k in sorted(val_keys):
+    print(f"  {k}: {s.get(k)}")
+
+print(f"\n=== ALL SUMMARY KEYS (filtered) ===")
+for k in sorted(s.keys()):
+    v = s.get(k)
+    if any(x in k for x in ['val', 'test', 'loss', 'grad', 'nan', 'NaN', 'SP', 'VP', 'WSS', 'abupt', 'surface', 'volume']):
+        print(f"  {k}: {v}")
+
+print(f"\n=== RUNTIME ===")
+print(f"runtime: {s.get('_runtime')} seconds")
+if s.get('_runtime'):
+    rt = s.get('_runtime')
+    print(f"  = {rt/3600:.2f} hours")
+print(f"timestamp: {s.get('_timestamp')}")
+
+# Check test metrics
+print(f"\n=== TEST METRICS IN SUMMARY ===")
+test_keys = [k for k in s.keys() if k.startswith('test')]
+if test_keys:
+    for k in sorted(test_keys):
+        print(f"  {k}: {s.get(k)}")
+else:
+    print("  (none found)")
+
+# Now scan history for loss and grad norm
+print(f"\n=== SCANNING HISTORY FOR LOSS/GRAD ===")
+keys_to_scan = [
+    "loss/surface_loss", "loss/volume_loss", "loss/total_loss",
+    "train/grad/global_norm", "train/loss/surface_loss", "train/loss/volume_loss",
+    "grad/global_norm",
+]
+# Try to get latest values
+try:
+    rows = list(run.scan_history(keys=keys_to_scan, page_size=1000))
+    if rows:
+        last = rows[-1]
+        print(f"  Last row step: {last.get('_step')}")
+        for k in keys_to_scan:
+            if k in last:
+                print(f"  {k}: {last[k]}")
+
+        # Check surface/volume ratio
+        surf = None
+        vol = None
+        for k in ['loss/surface_loss', 'train/loss/surface_loss']:
+            if k in last and last[k] is not None:
+                surf = last[k]
+                break
+        for k in ['loss/volume_loss', 'train/loss/volume_loss']:
+            if k in last and last[k] is not None:
+                vol = last[k]
+                break
+        if surf and vol:
+            print(f"  surf/vol ratio: {surf/vol:.4f}")
+    else:
+        print("  No rows returned")
+except Exception as e:
+    print(f"  Error: {e}")
+
+# Get all loss-related keys from summary
+print(f"\n=== LOSS VALUES FROM SUMMARY ===")
+for k in sorted(s.keys()):
+    if 'loss' in k.lower():
+        print(f"  {k}: {s.get(k)}")
+
+print(f"\n=== GRAD NORM FROM SUMMARY ===")
+for k in sorted(s.keys()):
+    if 'grad' in k.lower() or 'norm' in k.lower():
+        print(f"  {k}: {s.get(k)}")
+
+print(f"\n=== NaN COUNTS FROM SUMMARY ===")
+for k in sorted(s.keys()):
+    if 'nan' in k.lower():
+        print(f"  {k}: {s.get(k)}")
+
+# Best val checkpoint
+print(f"\n=== BEST CHECKPOINT METRICS ===")
+for k in sorted(s.keys()):
+    if 'best' in k.lower():
+        print(f"  {k}: {s.get(k)}")


### PR DESCRIPTION
## Hypothesis

**`--surface-loss-weight 1.5 → 1.25` — direct H87 follow-up, finer-grained step in the productive direction.**

H87 (your prior experiment, just terminal) was a **historic Wave 32 result**: FIRST variant to clear merge gate (val_abupt 6.045% vs gate 6.126% by −0.081pp) AND cleanest test_VP cross in fleet (test_VP 3.495% vs floor 3.643% by −0.148pp). The mechanism (surface_loss_weight 2.0 → 1.5) is the **strongest single-flag axis in the entire Wave 32 campaign**.

**This experiment tests whether the productive direction has more headroom: does surface_loss_weight=1.25 land even closer to or below the AND-gate test_SP floor (3.577%), or does H87's 1.5 represent the substrate sweet spot?**

## Why this should work (mechanism)

- **H87 established the direction**: reducing surface:volume gradient ratio from 2:1 (canonical) → 1.5:1 (H87) produces fleet-best val_abupt + cleanest test_VP cross.
- **H87's only AND-gate miss was test_SP +0.157pp** (the smallest SP miss in Wave 32 — 7 prior variants landed +0.142 to +0.358pp). H80 identified test_SP as architectural-bound, BUT H87's +0.157pp miss is at the low end of the plateau — suggesting the surface representation might still have headroom under different ratio configurations.
- **H95 ratio = 1.25:1** sits BETWEEN H87 (1.5:1) and full parity (1.0:1). Tests the productive direction further while not going extreme (1:1 would equalize surface and volume — likely too aggressive based on prior data).
- **Mechanism**: lower surface_loss_weight means surface head receives LESS gradient signal per training step. Under Lion's sign-update, this rebalances which direction the parameters move at each step in favor of volume-head dominant updates. If test_SP at H87's 1.5 was 3.734%, the question is whether 1.25 lands at ~3.65% (close to floor) or worsens to ~3.85% (past plateau).
- **Memory cost: zero** (loss weights are scalars).

## Falsifiable outcomes

- **A MERGE WIN**: `val_abupt < 6.045%` AND `test_VP ≤ 3.495%` AND `test_SP ≤ 3.577%` (compared against H87 not baseline #972 — H87 is the new best on tay) → MERGE
- **B PARTIAL paper-positive**: val_abupt clears gate (better than H87) but test_SP still misses
- **C NULL**: val_abupt within ±0.05pp of H87's 6.045%, test_VP within ±0.05pp of H87's 3.495 (no movement)
- **D NEGATIVE**: val_abupt > 6.126% (regress past gate) OR test_VP > 3.643% (regress past floor)

**Key signals**:
- **If H95 test_SP < 3.65%**: H87's sweet spot was NOT 1.5 — surface plateau is partially crackable via further ratio reduction → Wave 33 sweep 1.0, 0.75
- **If H95 test_SP > 3.85%**: further surface weight reduction starves surface head past plateau breakpoint → H87's 1.5 IS the substrate sweet spot → Wave 33 compound H87 with orthogonal mechanism (H88 heads, H89 depth, H94 vol_loss=1.5)
- **If H95 val_abupt < 6.0%**: the productive direction has more headroom (rare result) → continue reduction sweep

## Risk consideration

Pushing surface_loss_weight further down could **further starve surface head representation**, worsening test_SP past the 3.85% plateau breakpoint. Mitigations:
- **EP3 kill threshold preserved at `<8.5`** (canonical safety floor)
- **EP6 kill threshold preserved at `<6.7`**
- **Conservative −16.7% step** (1.5 → 1.25) is smaller than H87's −25% step (2.0 → 1.5) — should not over-shoot

## Instructions

Single-flag delta vs the canonical Wave 32 baseline: **`--surface-loss-weight 2.0 → 1.25`** (H87 was 1.5). All other flags match canonical Wave 32 substrate.

### Exact reproduce command (copy-paste, only line changed: `--surface-loss-weight 1.25`)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 1.25 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name tanjiro/h95-surf-loss-push-further \
  --wandb-group wave32_h95_surf_loss_push_further
```

### Specific diagnostics to log

Beyond the standard terminal SENPAI-RESULT marker, please report:

- **Per-channel val/test deltas** vs H87 (val_abupt 6.045, test_VP 3.495, test_SP 3.734, test_WSS 6.944) AND vs baseline #972: which axes gained vs lost from the further reduction?
- **val→test slope** per channel: how does H95's slope compare to H87's? Critical to confirm slope behavior is mechanism-consistent across the reduction sweep.
- **Per-bucket effective loss magnitudes**: at terminal, what is `loss/surface_loss / loss/volume_loss`? Should be ~1.25x (vs H87's ~1.5x, canonical ~2x). Validates mechanism is engaging.
- **No instability check**: NaN counts, train_loss spikes, train/grad/global_norm distribution.

## Baseline (current best — what to beat)

| Metric | Validation | Test | Notes |
|---|---:|---:|---|
| **PR #972 baseline** | | | |
| val_abupt | **6.126%** | — | hard gate |
| test_VP | — | **3.643%** | hard floor |
| test_SP | — | **3.577%** | hard floor (BINDING) |
| test_WSS | — | **6.727%** | goal |
| test_abupt | — | 5.844% | secondary |
| **H87 (NEW best val on tay)** | | | |
| val_abupt | 6.045% | — | beats gate by −0.081pp |
| test_VP | — | 3.495% | crosses floor by −0.148pp |
| test_SP | — | 3.734% | misses floor by +0.157pp |
| test_WSS | — | 6.944% | above goal |
| test_abupt | — | 5.987% | regress vs #972 |

**Baseline W&B run**: `56bcqp3m` (PR #972)
**H87 W&B run**: `jpspxktf`
**Repository**: https://github.com/morganmcg1/DrivAerML

### Notes
- Single-flag clean: only `--surface-loss-weight 1.5 → 1.25` differs vs H87 (which was the previous best)
- DDP 8 GPUs (per CLAUDE.md hard constraint)
- `--lr-cosine-t-max 13` (NOT 25)
- VRAM unchanged from canonical ~77 GB peak (loss weights don't affect memory)
- The PRIMARY paper-facing claim should be on val_abupt + test_VP improvement vs H87; the secondary question is test_SP behavior at finer-grained ratio
- **Closes Wave 32+33's data-side loss-rebalance sweet-spot search**: combined with H94 (vol_loss=1.5), the three points {canonical 2:1, H87 1.5:1, H95 1.25:1, H94 2:1.5} characterize the surf:vol ratio landscape
