### PR TITLE
Wave 33 H96: WSS-DEDICATED-DECODER-HEAD — Split shared surface MLP into separate SP + WSS decoder trunks

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_split_surface_heads: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_split_surface_heads = use_split_surface_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,12 +483,35 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if use_split_surface_heads:
+                # H96: split surface_pressure (1 ch) and wall_shear_stress (3 ch)
+                # into two parallel 2-layer MLP trunks. Backbone produces shared
+                # surface_hidden; only the FINAL decoder MLP splits per-task.
+                # Standard _init_linear on both heads (no zero-init): Lion sign
+                # update is undefined on a zero output and would burn early steps
+                # escaping the zero manifold.
+                self.surface_pressure_head = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, 1),
+                )
+                self.surface_wss_head = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, 3),
+                )
+                self.surface_pressure_head.apply(_init_linear)
+                self.surface_wss_head.apply(_init_linear)
+                self.surface_out = None
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
+                self.surface_pressure_head = None
+                self.surface_wss_head = None
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),
@@ -496,7 +521,14 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
+            if use_split_surface_heads:
+                raise ValueError(
+                    "use_split_surface_heads requires use_aux_decoder_heads=True "
+                    "(split heads are defined as MLPs, not LinearProjection)."
+                )
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_pressure_head = None
+            self.surface_wss_head = None
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
@@ -622,7 +654,12 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.surface_pressure_head is not None:
+                cp_pred = self.surface_pressure_head(surface_hidden)
+                wss_pred = self.surface_wss_head(surface_hidden)
+                surface_preds = torch.cat([cp_pred, wss_pred], dim=-1) * surface_mask.unsqueeze(-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_split_surface_heads: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_split_surface_heads": (
+            "H96 (PR #1261): split the shared 2-layer surface decoder MLP "
+            "into two parallel task-specific 2-layer MLP heads — one for "
+            "surface_pressure (1 channel, smooth scalar field) and one for "
+            "wall_shear_stress (3 channels, near-wall directional gradient "
+            "field). The shared Transolver backbone still produces a single "
+            "surface_hidden tensor; only the final decoder MLP splits. Both "
+            "heads use _init_linear (trunc_normal). Adds ~263K params and "
+            "no DDP graph changes. Requires --use-aux-decoder-heads (default)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_split_surface_heads=config.use_split_surface_heads,
     )
 
 
@@ -342,6 +354,16 @@ def train_loss(
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # Per-head decomposition (H96 diagnostic): unweighted MSE on cp vs WSS
+        # slices so we can detect per-head gradient-budget drift when the
+        # decoder is split. Cheap (~2 extra masked_mse calls) and logged
+        # unconditionally so fleet-wide comparisons stay apples-to-apples.
+        surface_loss_cp = masked_mse(
+            out["surface_preds"][..., 0:1], surface_target[..., 0:1], batch.surface_mask
+        )
+        surface_loss_wss = masked_mse(
+            out["surface_preds"][..., 1:4], surface_target[..., 1:4], batch.surface_mask
+        )
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
@@ -352,6 +374,8 @@ def train_loss(
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "surface_loss_cp": float(surface_loss_cp.detach().cpu().item()),
+        "surface_loss_wss": float(surface_loss_wss.detach().cpu().item()),
     }
 
 
@@ -1066,6 +1090,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/surface_loss_cp": batch_loss_metrics["surface_loss_cp"],
+                            "train/surface_loss_wss": batch_loss_metrics["surface_loss_wss"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }


### PR DESCRIPTION
## Hypothesis

**Wave 33 entry — first architectural attack on the WSS-specific decoder direction per Issue #1056 (Morgan's guidance).**

**`Split the shared self.surface_out MLP into two parallel decoder heads`** — one for surface_pressure (1 channel) and one for wall_shear_stress (3 channels). Each gets its own dedicated 2-layer MLP trunk, separating the representations the two physically distinct tasks require.

**Direct response to H88 finding** (your prior experiment, just closed B PARTIAL): test_WSS axes ALL regressed vs baseline (+0.128 / +0.210 / +0.215pp on x/y/z), while head granularity 4→8 produced fleet-best val_SP at EP3 that did not survive to terminal. The mechanism finding is: **wall_shear and surface_pressure currently share the SAME decoder MLP** in `self.surface_out` (model.py lines 484-489), forcing them to share representations through a single 2-layer trunk. This bottlenecks WSS-specific expressivity.

## Why this should work (mechanism)

- **Physical motivation**: surface_pressure (normal stress) and wall_shear_stress (tangential gradient of velocity) have **fundamentally different spatial structure**. SP is a smooth scalar field over surface; WSS is a directional gradient field highly sensitive to local geometry/boundary layer (near-wall behavior). Forcing them to share a decoder MLP limits WSS expressivity.
- **H88 evidence**: increasing attention heads (4→8) helped val_SP at EP3 but did NOT help WSS axes at all (all regressed). This means the bottleneck for WSS is NOT attention capacity but decoder representation capacity.
- **H86 evidence**: increasing mlp_ratio (4→6) at the SHARED-decoder layer 1.5× FFN was D NEG. More capacity at the SAME shared decoder doesn't help.
- **Mechanism distinction**: H96 is NOT capacity expansion. It's capacity SEPARATION — same total params (with marginal head doubling) but routed through TASK-SPECIFIC trunks.
- **Issue #1056 architectural priority**: per Morgan's 2026-05-22 guidance, "dedicated WSS output head with its own decoder trunk, separate from the shared surface MLP" is the highest-priority next architectural direction.
- **Add capacity ratio**: each new head is a 2-layer MLP (n_hidden=512). Current `surface_out` is ~263K params. New split heads are ~526K total = +263K params (~0.03% of model). Memory cost negligible.

## Falsifiable outcomes

- **A MERGE WIN**: `val_abupt < 6.126%` AND `test_VP ≤ 3.643%` AND `test_SP ≤ 3.577%` AND `test_WSS ≤ 6.727%` AND no test_abupt regress → MERGE (full goal)
- **A WIN partial**: val_abupt clears gate AND test_WSS drops by ≥ 0.1pp vs baseline 6.727% (even if other channels don't all clear) — strong evidence for the WSS architectural direction
- **B PARTIAL**: test_WSS improves but val_abupt doesn't clear gate, OR test_WSS regresses but test_SP improves (means head split benefits SP not WSS)
- **C NULL**: val_abupt within ±0.05pp of #972 baseline 6.126, test channels all unchanged ±0.05pp
- **D NEGATIVE**: val_abupt > 6.20% OR test_WSS regresses > +0.10pp (means head split actively HURTS — would be surprising given mechanism)

**Key signals**:
- **If test_WSS < 6.727%**: FIRST mechanism in fleet to crack WSS goal on tay → MAJOR finding, opens full Wave 33 WSS-architectural sweep (WSS-geom xattn, WSS-SP xattn)
- **If test_WSS_z < 8.5%**: binding axis broken → confirms decoder separation removes shared-trunk bottleneck
- **If test_SP < 3.65%**: capacity separation also benefits SP-axis (would mean the plateau is BOTH a decoder-shared-trunk issue AND a backbone issue — interesting cross-validation)
- **If test_WSS regresses but test_SP improves**: the shared trunk was favoring WSS at SP's expense (would falsify the WSS-head hypothesis but confirm asymmetric coupling)

## Risk consideration

- **Risk**: SP and WSS share underlying flow physics (near-wall pressure gradients drive WSS), so separating their decoders might LOSE the implicit coupling. Mitigation: the backbone (5 Transformer layers) still produces shared `surface_hidden`. Only the FINAL decoder MLP splits.
- **Risk**: slightly more params (~+263K, ~0.03%) — negligible memory + training time impact, no batch size change needed.
- **Risk**: WSS prediction quality depends on accurate surface geometry; if the shared trunk was learning a strong geometry → WSS mapping, splitting might force the WSS head to relearn geometry → WSS from scratch. Mitigation: zero-init the second-layer Linear in each new head so init behavior matches current shared head exactly at step 0.

## Instructions

### Step 1 — Code change to model.py

In `model.py` at lines 484-489 (the `use_aux_decoder_heads=True` branch), replace the single `self.surface_out` with two parallel heads when a new flag is set:

```python
# Add a parameter use_split_surface_heads: bool = False to __init__
if use_aux_decoder_heads:
    if use_split_surface_heads:
        # H96: split surface_pressure (1 channel) and wall_shear_stress (3 channel) heads.
        # Each gets its own dedicated 2-layer MLP trunk.
        # Final concat preserves [B, N, 4] output contract for downstream.
        self.surface_pressure_head = nn.Sequential(
            nn.Linear(n_hidden, n_hidden),
            nn.SiLU(),
            nn.Linear(n_hidden, 1),  # cp only
        )
        self.surface_wss_head = nn.Sequential(
            nn.Linear(n_hidden, n_hidden),
            nn.SiLU(),
            nn.Linear(n_hidden, 3),  # tau_x, tau_y, tau_z
        )
        self.surface_pressure_head.apply(_init_linear)
        self.surface_wss_head.apply(_init_linear)
        self.surface_out = None  # explicit
    else:
        # Existing canonical: single shared 2-layer MLP
        self.surface_out = nn.Sequential(...)  # unchanged
```

In forward() at line 624-625, replace the single surface_preds computation:

```python
if surface_x is not None:
    if getattr(self, 'surface_pressure_head', None) is not None:
        cp_pred = self.surface_pressure_head(surface_hidden)
        wss_pred = self.surface_wss_head(surface_hidden)
        surface_preds = torch.cat([cp_pred, wss_pred], dim=-1) * surface_mask.unsqueeze(-1)
    else:
        surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

### Step 2 — Add CLI flag to train.py argparse

Add a new boolean flag `--use-split-surface-heads` (default False for backward compat). Pipe it through the SurfaceTransolver constructor.

### Step 3 — Exact reproduce command (single-flag delta from canonical Wave 32 baseline)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-split-surface-heads \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name fern/h96-wss-dedicated-head \
  --wandb-group wave33_h96_wss_dedicated_head
```

### Diagnostics to log

Beyond the standard terminal SENPAI-RESULT marker, please report:

- **Per-axis WSS test metrics**: test_wall_shear_axis_x/y/z_rel_l2_pct — critical for identifying which WSS axis benefits most
- **Per-channel val deltas vs H88** (val_abupt 6.21, val_SP 4.14, val_VP 3.63, val_WSS 7.01, val_WSS_z 9.50): does the head split flip any channels?
- **Param count comparison**: total params with/without split — should differ by ~263K
- **Train loss decomposition**: at terminal, `loss/surface_loss` + `loss/volume_loss` (should be roughly similar to canonical baseline). Watch for any change in `loss/wall_shear` if logged separately.
- **No-instability check**: NaN counts, train_loss spikes, grad_global_norm distribution at EP3/EP6/EP9.

## Baseline (current best on tay — what to beat)

| Metric | Validation | Test | Notes |
|---|---:|---:|---|
| **PR #972 baseline (current best)** | | | |
| val_abupt | **6.126%** | — | hard gate |
| test_abupt | — | 5.844% | secondary |
| test_VP | — | **3.643%** | hard floor |
| test_SP | — | **3.577%** | hard floor (BINDING per H80) |
| test_WSS | — | **6.727%** | goal — campaign target Transolver-3 = 5.85 |
| test_WSS_x | — | 5.975% | |
| test_WSS_y | — | 7.274% | |
| test_WSS_z | — | 8.753% | binding axis |

**Baseline W&B run**: `56bcqp3m` (PR #972 corrected-split eval `zxnhtagj`)
**Repository**: https://github.com/morganmcg1/DrivAerML

### Notes
- **Single-flag clean**: only `--use-split-surface-heads` differs vs canonical Wave 32 substrate (no other changes from #972 + standard Wave 32 recipe).
- DDP 8 GPUs (per CLAUDE.md hard constraint)
- `--lr-cosine-t-max 13` (NOT 25)
- VRAM expected ~77-78 GB peak (+0.5% from head split, negligible)
- **Per Issue #1056**: this is the FIRST attack in the new Wave 33 architectural direction. If it works, follow-ups will add WSS↔geom cross-attention and WSS↔SP cross-attention.
- **Per CLAUDE.md**: All advisor work lives on `tay`. PR targets `tay`, branch off `tay`, merge squashes into `tay`.
