### PR TITLE
Wave 33 H98: SURFACE-LATE-LAYER-SPLIT — extra surface-only transformer block

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-05-22 (latest invocation: 2026-05-22 ~16:16 UTC)
+- **Date:** 2026-05-22 (latest invocation: 2026-05-22 ~17:50 UTC)
 - **Branch:** tay
 - **W&B project:** wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
 - **Thread share note:** Issue #1056 is shared with another advisor ("dl24") running a parallel fleet on `drivaerml-long-20260504`. The dl24-prefixed students are real but **NOT under tay advisorship** — visible context for cross-pollination only.
@@ -46,10 +46,49 @@ These are architecturally clean hypotheses that **add representational capacity 
 - If test_SP also improves → cross-validation that the plateau is BOTH decoder-shared-trunk AND backbone
 
 ### Wave 33 architectural candidates queue (in priority order):
-1. **H96 (fern, in-flight EP3)**: split SP/WSS decoder heads — first attack
-2. **H97 (alphonse, NEW PR #1262)**: bidirectional surf↔vol cross-attention — second attack
-3. **H98 (next idle)**: WSS-to-SP cross-attention — third attack
-4. **H99 (next idle)**: compound H96 + H97 if both produce signal
+1. **H96 (fern, PR #1261, in-flight)**: split SP/WSS decoder heads — first attack
+2. **H97 (alphonse, PR #1262, in-flight)**: bidirectional surf↔vol cross-attention — second attack
+3. **H98 (askeladd, PR #1263, NEW)**: surface-late-layer-split — one extra surface-only TransformerEncoderLayer post-backbone, identity at init — third attack
+4. **H99 (next idle)**: compound H96 + H97 if both produce signal, OR WSS-to-SP cross-attention (depends on H96 architecture being available)
+
+**Per-tau-channel loss-weight class CLOSED (2026-05-22 17:50Z):** H92 (tau_z=3.0 D NEG, PR #1252) + H93 (tau_y=2.5, thorfinn in-flight PR #1254) together falsify per-channel loss reweighting under Lion. test_WSS_z is architecture-bound.
+
+## 🟡 ~17:50Z (2026-05-22) — H92 TAU-Z-LOSS-PUSH CLOSED **D NEGATIVE** (askeladd) — per-tau-channel loss-weight class DEFINITIVELY CLOSED + askeladd reassigned H98 SURFACE-LATE-LAYER-SPLIT (PR #1263)
+
+**Closure: PR #1252 H92 (askeladd) — D NEGATIVE**:
+- val_abupt 6.3235% MISS gate +0.198pp
+- test_VP 3.5629% CROSS floor −0.080pp ✓ (incidental, only channel)
+- test_SP 3.8335% MISS floor +0.257pp
+- test_WSS 7.0405% REGRESS +0.314pp
+- **test_WSS_z 9.051% vs hypothesis target <8.5% — FAILED**
+- **val_WSS_z 9.601% = WORSE than ALL canonical-recipe siblings** (H88/H89/H91 all 9.48-9.50%)
+
+**Mechanism falsification:** Under Lion sign-update, per-channel loss-weight reallocates gradient ratio but does NOT add representational capacity. The 50% stronger tau_z signal failed to compress val_WSS_z below canonical-recipe baselines — it degraded it. **Per-tau-channel reweighting is architecture-irrelevant under Lion sign-update.**
+
+**Combined with H93 (tau_y=2.5, thorfinn in-flight), per-tau-channel loss-weight class is CLOSED.**
+
+### Reassignment: PR #1263 H98 askeladd SURFACE-LATE-LAYER-SPLIT
+
+`--use-surface-extra-block` (new flag) — adds one extra `TransformerEncoderLayer` applied ONLY to `surface_hidden` after the shared L=5 backbone, before `surface_out`. Volume tokens skip this extra block entirely. Identity at init via zero-init out_proj + linear2.
+
+**Mechanism**: late-stage surface specialization — the added block can refine surface representations with surface-only attention patterns, decoupled from volume-domain interference. Orthogonal to H96 (decoder-head separation) and H97 (bidirectional xattn topology).
+
+**Key signal at terminal**:
+- test_WSS_z < 8.5% → binding axis first crack via surface-specialization
+- test_SP < 3.577% → first mechanism to crack 10-variant test_SP plateau
+
+### Current fleet status — 8/8 WIP, zero idle (post H92 closure + H98 assignment):
+
+| Run | PR | Mech | Status |
+|---|---|---|:--|
+| alphonse H97 | #1262 | bidirectional xattn (NEW Wave 33) | in-flight |
+| **askeladd H98** | **#1263** | **surface-late-layer-split (NEW Wave 33)** | **NEW ASSIGNMENT** |
+| edward H94 | #1257 | vol_loss=1.5 | in-flight |
+| fern H96 | #1261 | WSS-dedicated-decoder-head (Wave 33) | in-flight |
+| frieren H89 | #1249 | layers=6 | in-flight |
+| nezuko H91 | #1251 | slices=192 | in-flight |
+| tanjiro H95 | #1258 | surf_loss=1.25 | in-flight |
+| thorfinn H93 | #1254 | tau_y=2.5 (PUSH) | in-flight |
 
 ## 🔴 ~16:16Z (2026-05-22) — H90 LR-DOWNWARD-SWEEP CLOSED **D NEGATIVE** (alphonse) + alphonse reassigned H97 BIDIRECTIONAL-XATTN (PR #1262)
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,3 +1,47 @@
+## 2026-05-22 17:50 — PR #1252: H92 TAU-Z-LOSS-PUSH (askeladd, CLOSED) — **OUTCOME D NEGATIVE** — mechanism FALSIFIED: per-tau-channel loss-weight class closed definitively. test_WSS_z WORSE than all canonical-recipe siblings. askeladd reassigned H98 SURFACE-LATE-LAYER-SPLIT (PR #1263).
+
+- **Branch**: `askeladd/h92-tau-z-loss-push` (closed at 17:50Z 2026-05-22)
+- **W&B run**: `or56xz4x` (rank 0; finished at step 70,652, 13.97h training time, EP12 EMA best)
+- **Hypothesis**: Single-flag `--tau-z-loss-weight 2.0→3.0` (+50%) on canonical Wave 32 substrate. First-ever per-tau-channel loss weight sweep. Hypothesis: stronger gradient signal on binding WSS_z axis would preferentially compress test_WSS_z < 8.5%.
+
+### Results
+
+| Metric | H92 | Baseline #972 / floor | Δ | Verdict |
+|---|---:|---:|---:|:--|
+| **val_abupt (gate)** | 6.3235% | 6.126% | +0.198pp ❌ | MISS gate |
+| **test_abupt** | 6.0723% | 5.844% | +0.228pp ❌ | regress |
+| **test_VP (floor)** | 3.5629% | 3.643% | **−0.080pp ✓** | CROSS (incidental) |
+| **test_SP (floor)** | 3.8335% | 3.577% | +0.257pp ❌ | BREACH |
+| **test_WSS (goal)** | 7.0405% | 6.727% | +0.314pp ❌ | REGRESS above goal |
+| test_WSS_x | 6.275% | ~6.1% | — | neutral |
+| test_WSS_y | 7.639% | ~7.4% | — | neutral |
+| **test_WSS_z (binding)** | **9.051%** | ~8.96% | +0.09pp ❌ | **FAILED — should be <8.5%** |
+
+### Per-WSS-axis cross-sibling comparison (val_WSS_z, canonical tau_z=2.0 siblings)
+
+| Variant | tau_z weight | val_WSS_z | test_WSS_z |
+|---|---|---:|---:|
+| H88 (heads=8) | 2.0 | 9.493% | 9.498% |
+| H89 (depth=6) | 2.0 | ~9.50% | ~9.50% |
+| H91 (slices=192) | 2.0 | 9.485% | ~9.5% |
+| **H92 (tau_z=3.0)** | **3.0** | **9.601%** | **9.051%** |
+
+**H92 val_WSS_z is WORSE than ALL canonical-recipe siblings.** The tau_z weight change actually DEGRADED val WSS_z while providing only marginal test improvement.
+
+### Mechanism Falsification
+
+**Per-tau-channel loss-weight class DEFINITIVELY CLOSED.** Under Lion sign-update, per-channel loss-weight scales gradient ratio entering the surface head, but Lion normalizes step magnitude to ±lr. The 50% stronger tau_z signal does NOT add representational capacity — it merely redistributes budget within existing capacity. Combined with H93 (tau_y=2.5, thorfinn PR #1254, in-flight), this class is closed regardless of H93 outcome.
+
+**Program-level finding:** test_WSS_z (fleet range 8.93-9.66% across H78-H92) is **ARCHITECTURE-BOUND, not loss-budget-bound.** The productive direction is architectural separation of WSS prediction (H96 split-heads, H97 bidirectional xattn, H98 surface-late-layer-split).
+
+**Incidental test_VP CROSS (3.5629%)**: joins H75/H76/H82/H83/H84 as 5th single-flag to cross test_VP floor. Volume-favoring pattern consistent. Not a merge candidate (AND-gate fails on 3/4 paper-facing channels).
+
+### Reassignment
+
+- askeladd → **Wave 33 H98: SURFACE-LATE-LAYER-SPLIT** (PR #1263) — adds one extra TransformerEncoderLayer applied only to surface tokens between shared backbone and surface decoder head. Identity at init (zero-init out_proj + linear2). Tests late-stage surface specialization as WSS binding axis mechanism. Orthogonal to H96 (decoder-head separation) and H97 (bidirectional xattn).
+
+---
+
 ## 2026-05-22 16:16 — PR #1250: H90 LR-DOWNWARD-SWEEP (alphonse, CLOSED) — **OUTCOME D NEGATIVE** — all 4 paper-facing test channels regress, val_abupt misses gate +0.193pp. Closes LR-magnitude sweep class: canonical lr=9e-5 confirmed substrate sweet spot.
 
 - **Branch**: `alphonse/h90-lr-downward-sweep` (closed at 16:16Z 2026-05-22)


### PR DESCRIPTION
## Hypothesis — H98: SURFACE-LATE-LAYER-SPLIT

**Wave 33, Third Architectural Attack — Orthogonal to H96 (decoder split) and H97 (bidirectional xattn)**

The shared 5-layer Transolver backbone must simultaneously optimize representations for two physically distinct tasks: (a) surface pressure (SP — normal stress, smooth spatial variation), and (b) wall shear stress (WSS — tangential velocity gradient, high-frequency near-wall structure). The final backbone layer produces a single shared `surface_hidden` tensor that is fed directly to `surface_out`. This forces the last layer's attention patterns to balance smooth-SP and high-freq-WSS objectives, leading to compromised representations for both.

**Hypothesis:** Adding a single dedicated transformer block applied ONLY to `surface_hidden` AFTER the shared backbone, BEFORE the decoder, will give surface features an extra layer of self-attention + FFN refinement specialized for surface field prediction (WSS+SP combined). Volume tokens skip this extra block entirely. This is a "late-stage surface specialization" mechanism.

**Physical motivation:**
- test_WSS_z (binding axis, fleet range 8.93-9.66%) is ARCHITECTURE-BOUND not loss-budget-bound (H92/H93 definitive falsification)
- H96 tests decoder-head separation (SP vs WSS trunks) — this tests backbone-tail separation (surface vs volume self-attention)
- H97 tests bidirectional xattn — this is orthogonal (pure surface self-attention refinement, no cross-task mixing)
- Surface near-wall features have different length-scales than volume bulk features; an extra shared-surface attention block can refine these simultaneously without volume-domain interference

**Key signal to watch:**
- test_WSS_z < 8.5% → first crack of binding axis = mechanism signal
- val_abupt < 6.126% + test floors (VP ≤ 3.643%, SP ≤ 3.577%) = A WIN
- test_SP improvement (floor 3.577%) would be FIRST crack of 10-variant test_SP plateau (H78-H97 all 3.73-3.95%)

## Instructions

Implement a single new flag `--use-surface-extra-block` (bool, default False) that appends one extra Transformer block applied only to `surface_hidden` between the backbone and the decoder head.

### Step 1 — Add to `model.py`

In the `SurfaceTransolver.__init__` (around line 360–500), after constructing `self.surface_out`, add:

```python
# H98: Surface-Late-Layer-Split — extra transformer block for surface tokens only
self.use_surface_extra_block = use_surface_extra_block
if use_surface_extra_block:
    # One extra encoder block: MHA (n_head heads, embed=n_hidden) + FFN (hidden=n_hidden*mlp_ratio)
    # Using same hyperparams as backbone blocks for consistency
    self.surface_extra_block = nn.TransformerEncoderLayer(
        d_model=n_hidden,
        nhead=n_head,
        dim_feedforward=n_hidden * mlp_ratio,
        dropout=dropout,
        activation="gelu",
        batch_first=True,
        norm_first=True,  # Pre-LN matches backbone style
    )
    self.surface_extra_norm = nn.LayerNorm(n_hidden)
    # Zero-init the final linear of the FFN so it is identity at init
    # (safe for Lion — preserves all existing gradients at step 0)
    nn.init.zeros_(self.surface_extra_block.linear2.weight)
    nn.init.zeros_(self.surface_extra_block.linear2.bias)
    # Zero-init the MHA out_proj too
    nn.init.zeros_(self.surface_extra_block.self_attn.out_proj.weight)
    nn.init.zeros_(self.surface_extra_block.self_attn.out_proj.bias)
```

Add `use_surface_extra_block: bool = False` to the `__init__` signature.

In the `forward` method (around line 600–625), after `surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]` and BEFORE the `surf_to_vol_xattn` block, add:

```python
if self.use_surface_extra_block and surface_x is not None and surface_tokens > 0:
    # Apply extra block to surface tokens only; volume pathway untouched
    surface_hidden = self.surface_extra_block(surface_hidden)
    surface_hidden = _apply_token_mask(
        self.surface_extra_norm(surface_hidden), surface_mask
    )
```

### Step 2 — Add to `train.py`

In the `TrainingConfig` dataclass, add:
```python
use_surface_extra_block: bool = False
```

In the argparse section (look for the `--use-surf-to-vol-xattn` arg block, ~line 223), add:
```python
parser.add_argument(
    "--use-surface-extra-block",
    action="store_true",
    default=False,
    dest="use_surface_extra_block",
    help=(
        "H98: Add one extra TransformerEncoderLayer applied only to surface tokens "
        "after the shared backbone, before the decoder head. Volume pathway is "
        "unaffected. Identity at init (zero out_proj and linear2). "
        "Expected: +~2M params, ~+2% memory, ~+3% wall-clock per step."
    ),
)
```

In the model constructor call (look for `use_surf_to_vol_xattn=config.use_surf_to_vol_xattn`), add:
```python
use_surface_extra_block=config.use_surface_extra_block,
```

### Step 3 — Verify

Run a 1-step smoke test to confirm it starts without error:
```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 1 --batch-size 4 \
  --use-surface-extra-block \
  [... rest of canonical flags ...] \
  --wandb-name askeladd/h98-smoke-test
```

Check that: (1) training starts, (2) loss is finite at step 1, (3) param count is ~+2M vs canonical.

### Step 4 — Full training run

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-surface-extra-block \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name askeladd/h98-surface-late-layer-split \
  --wandb-group wave33_h98_surface_late_layer_split
```

**Kill thresholds** (global step based):
- EP1 gate (step 10864): val_abupt > 35% → kill (startup fault)
- EP3 gate (step 32594): val_abupt > 8.5% → kill (not converging)
- EP6 gate (step 65228): val_abupt > 6.7% → kill (plateau, not beating baseline)

**Note on kill thresholds:** These use global_step ≥ N (not epoch N). Step counts are for the standard 13-EP recipe with this batch size and dataset.

## Baseline (single-model SOTA, PR #972)

| Metric | Value |
|---|---|
| val_abupt | 6.126% ← **gate to beat** |
| test_abupt | 5.844% |
| test_vol_p (floor) | 3.643% ← **must not regress** |
| test_SP (floor) | 3.577% ← **must not regress** |
| test_WSS (goal) | 6.727% ← **must improve** |
| test_WSS_x | ~6.1% |
| test_WSS_y | ~7.4% |
| test_WSS_z (binding) | ~8.96% ← **primary diagnostic axis** |

W&B baseline run: `56bcqp3m`

## Success criteria

| Grade | Condition |
|---|---|
| A WIN | val_abupt < 6.126% AND test_WSS < 6.727% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% |
| B PARTIAL | test_WSS_z < 8.5% OR test_SP < 3.577% (first crack of either binding axis) |
| C NULL | val_abupt within 0.1pp of gate, no channel regressions |
| D NEGATIVE | val_abupt > 6.3% OR all 3+ paper-facing channels regress vs baseline |

**Primary diagnostic:** At EP3 (step ~32594), report val_WSS_z — if > 9.5% (worse than canonical), the extra block is hurting; kill and report.

## Per-WSS-axis reporting required

At terminal, report all three WSS axes (val and test):
- val_WSS_x, val_WSS_y, val_WSS_z
- test_WSS_x, test_WSS_y, test_WSS_z

This is the primary mechanism diagnostic (H92 falsification confirmed WSS_z is architecture-bound; we need to track whether this extra layer moves the needle).
