### PR TITLE
Wave 33 H99: SURFACE-OUT-DEEPER-MLP — 3-layer surface decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -381,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_deeper_surface_mlp: bool = False,
         use_aux_decoder_heads: bool = True,
     ):
         super().__init__()
@@ -395,6 +396,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_deeper_surface_mlp = use_deeper_surface_mlp
         self.use_aux_decoder_heads = use_aux_decoder_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
@@ -481,11 +483,21 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
+            # H99: optional 3-layer surface_out mirroring volume_out depth.
+            if use_deeper_surface_mlp:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, n_hidden // 2),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden // 2, self.surface_output_dim),
+                )
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_deeper_surface_mlp: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_deeper_surface_mlp": (
+            "Deepen surface_out from a 2-layer MLP "
+            "(n_hidden -> n_hidden -> surface_output_dim) to a 3-layer MLP "
+            "(n_hidden -> n_hidden -> n_hidden//2 -> surface_output_dim) "
+            "with SiLU activations. Mirrors the depth philosophy of the "
+            "volume_out head (PR #958) to give the surface decoder more "
+            "representational capacity for SP+WSS targets. Adds ~132K "
+            "params (<0.02% of model)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_deeper_surface_mlp=config.use_deeper_surface_mlp,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**SURFACE-OUT-DEEPER-MLP** — The current `self.surface_out` is a 2-layer MLP (n_hidden → n_hidden → 4ch). The `self.volume_out` is a deeper 3-layer MLP (n_hidden → n_hidden//2 → n_hidden//4 → 1ch) specifically because volume pressure is the harder task. We hypothesize that **surface prediction is also harder than its current 2-layer decoder can express** — particularly WSS (3 channels requiring fine-grained near-wall velocity gradient precision) — and that adding a third hidden layer to `surface_out` will add representational capacity specifically in the decoder pathway.

**Motivation from H89 (depth=6, B PARTIAL HISTORIC)**:
- Backbone depth expansion (5→6 layers) cleared val gate but did NOT improve test_SP or test_WSS — all 3 WSS axes regressed.
- H89's student analysis correctly identifies: "plateau is decoder-bound or surface-positional-encoding-bound, not encoder-stack-bound."
- This is the direct architectural test: depth in the surface **decoder**, not the backbone encoder.

**Volume_out vs surface_out asymmetry**: volume_out was made deeper (3-layer) in PR #958 to address the hard vol_p task. Surface predictions — including WSS which requires resolving sub-millimeter near-wall velocity gradients — are at least as challenging and arguably benefit from the same treatment. The current 2-layer shared surface_out is the bottleneck that H96/H97/H98/H99 all attack from different angles.

**Memory cost:** Adding one hidden layer (n_hidden → n_hidden//2) to surface_out: +512×256 + 256×4 params ≈ +132K params (<0.02% model).

**Orthogonality**: Orthogonal to H96 (splits SP/WSS heads), H97 (adds xattn module), H98 (extra transformer block before decoder). All four Wave 33 attacks target the surface decoder; H99 adds raw MLP depth without architectural restructuring.

## Instructions

**Step 1: Add the CLI flag in `train.py`**

Find where `use_surf_to_vol_xattn` is added to argparse and add alongside it:
```python
parser.add_argument("--use-deeper-surface-mlp", action="store_true", default=False,
                    help="Deepen surface_out from 2-layer to 3-layer MLP (matches volume_out depth)")
```

Pass `use_deeper_surface_mlp=args.use_deeper_surface_mlp` wherever `use_surf_to_vol_xattn` is passed to the model constructor.

**Step 2: Modify `model.py` `__init__`**

Add `use_deeper_surface_mlp: bool = False` to the constructor signature alongside `use_surf_to_vol_xattn`.

Find the `if use_aux_decoder_heads:` block (around line 477) where `self.surface_out` is defined:

```python
# CURRENT (2-layer):
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),
)
```

Replace with a conditional:
```python
if use_deeper_surface_mlp:
    # 3-layer: matches depth philosophy of volume_out (PR #958)
    self.surface_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, n_hidden // 2),
        nn.SiLU(),
        nn.Linear(n_hidden // 2, self.surface_output_dim),
    )
else:
    self.surface_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, self.surface_output_dim),
    )
self.surface_out.apply(_init_linear)
```

Keep `self.surface_out.apply(_init_linear)` outside the if/else (applies to both paths).

**Step 3: Run with canonical recipe + new flag**

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-deeper-surface-mlp \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name frieren/h99-surface-out-deeper-mlp \
  --wandb-group wave33_h99_surface_out_deeper_mlp
```

**Startup verification:** Confirm new param count includes surface_out layer count of 3. Expected peak VRAM is identical to canonical (~78 GB) — the +132K params are negligible.

## Baseline

Current single-model SOTA (PR #972, W&B `56bcqp3m`):

| Metric | Value |
|---|---:|
| val_abupt | 6.126% (merge gate) |
| test_abupt | 5.844% |
| test_VP | 3.643% (floor) |
| test_SP | 3.577% (floor) |
| test_WSS | 6.727% (goal) |

**Best Wave 32 val_abupt**: 6.045% (H87) and 6.119% (H89 — just closed)
**Best Wave 32 test_VP**: 3.482% (H89, −0.161pp cross — deepest cross in fleet)

**Merge gate:** `val_abupt < 6.126%` AND `test_VP ≤ 3.643%` AND `test_SP ≤ 3.577%` AND `test_WSS ≤ 6.727%`

W&B baseline: `56bcqp3m` (https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m)

## Key falsifiable outcomes at terminal

| Signal | Prediction | Interpretation |
|---|---|---|
| val_abupt < 6.126% AND test_SP < 3.577% | A WIN | Deeper surface decoder cracks 11-variant SP plateau |
| val_abupt < 6.126% AND test_WSS < 6.727% | A WIN | Deeper decoder cracks WSS goal |
| val_abupt < 6.126% but floors miss | B PARTIAL HISTORIC | Partial decoder capacity gain — compound candidate |
| val_abupt ≥ 6.20%, all channels neutral | C NULL | Deeper MLP adds no beneficial inductive bias |
| All channels regress | D NEG | Extra layer harms convergence (unlikely given small param count) |

**Critical EP3 signal (step 32,594):** val_SP < 4.3% at EP3 indicates the deeper decoder is engaging the SP task earlier than canonical (H89 was 4.0278% at EP3). This would be the first mid-cosine signal that the surface decoder architecture is the lever.

**Prior runs with known EP3 val_SP references:**
- H88 (heads=8) EP3 val_SP: 4.4868% — best mid-cosine SP signal in fleet but did NOT survive late-cosine
- H89 (depth=6) EP3 val_SP: 4.0278% — architectural depth doesn't help SP mid-cosine
- Canonical: ~4.2-4.5% range at EP3

If H99 EP3 val_SP < 3.9% → very strong early signal that decoder depth is the SP mechanism.
