### PR TITLE
Wave 33 H100: WSS-Z-DEDICATED-HEAD — separate tau_z decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_wss_z_dedicated_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_wss_z_dedicated_head = use_wss_z_dedicated_head
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,12 +483,34 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if use_wss_z_dedicated_head:
+                # PR #1265 (H100): split the shared surface head so tau_z
+                # gets its own representational capacity. surface_main_out
+                # produces channels [cp, tau_x, tau_y] and surface_wss_z_out
+                # produces channel [tau_z]; the forward concatenates them
+                # back to [B, N, 4] for the downstream contract.
+                self.surface_out = None
+                self.surface_main_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, 3),
+                )
+                self.surface_main_out.apply(_init_linear)
+                self.surface_wss_z_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, 1),
+                )
+                self.surface_wss_z_out.apply(_init_linear)
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
+                self.surface_main_out = None
+                self.surface_wss_z_out = None
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),
@@ -498,6 +522,8 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+            self.surface_main_out = None
+            self.surface_wss_z_out = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -622,7 +648,13 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_wss_z_dedicated_head and self.surface_main_out is not None:
+                main_preds = self.surface_main_out(surface_hidden)
+                wss_z_preds = self.surface_wss_z_out(surface_hidden)
+                surface_preds = torch.cat([main_preds, wss_z_preds], dim=-1)
+                surface_preds = surface_preds * surface_mask.unsqueeze(-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_wss_z_dedicated_head: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_wss_z_dedicated_head": (
+            "Dedicate a separate 2-layer MLP head to the tau_z output "
+            "channel (PR #1265 / H100). Splits the shared 4-channel "
+            "self.surface_out into surface_main_out (cp, tau_x, tau_y) "
+            "and surface_wss_z_out (tau_z) and concatenates them back to "
+            "the [B, N, 4] downstream contract. Adds ~262K params."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +316,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_wss_z_dedicated_head=config.use_wss_z_dedicated_head,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**WSS-Z-DEDICATED-OUTPUT-HEAD** — tau_z (vertical wall shear stress) is the binding test-set axis with the deepest val→test divergence of any channel (−0.640pp gap from H90 study). The current shared `self.surface_out` forces cp, tau_x, tau_y, and tau_z through a single 2-layer MLP bottleneck. We hypothesize that **tau_z needs its own dedicated decoder capacity** — splitting it into a separate 2-layer MLP head that can develop tau_z-specific inductive bias without competing with the other channels for shared decoder weights.

**Why this is the architectural version of what H93 (loss-weighting) couldn't do:**

Your H93 run (tau_y=2.5 D NEGATIVE) showed that per-tau-channel loss-weighting FAILS under Lion sign-update because it only modulates gradient ratio, not representational capacity. The mechanism was: 67% stronger gradient signal on tau_y produced WORSE val_WSS_y than all canonical siblings — over-rebalancing penalty.

**This is the architectural test of the same intuition**: instead of modulating the budget flowing into the shared decoder (which Lion normalizes anyway), we give tau_z its own decoder weights entirely. Representational capacity, not budget.

**Evidence that tau_z is architecture-bound:**
- test_WSS_z range 8.93-9.66% across H78-H92 (15 independent variants) — no single-flag mechanism has moved it substantially
- H92 (tau_z=3.0 loss-weight D NEG): target axis DEGRADED — mechanism falsified
- H89 (depth=6 backbone B PARTIAL HISTORIC): test_WSS_z REGRESSED (+0.129pp) — not encoder-bound
- val→test WSS_z gap = −0.640pp (deepest of any channel) — strong test-set divergence suggesting local geometric features driving tau_z are not well-captured

**Implementation**: New flag `--use-wss-z-dedicated-head` splits the current 4-channel `self.surface_out` into:
- `self.surface_main_out`: 2-layer MLP → 3ch (cp, tau_x, tau_y)
- `self.surface_wss_z_out`: 2-layer MLP → 1ch (tau_z)
- Concatenate back to [B, N, 4] as `torch.cat([main_preds, wss_z_preds], dim=-1)` for downstream contract

Memory cost: +262K params (0.03% model) — comparable to H96 split-heads (+263K params).

**Orthogonality to other Wave 33 attacks:**
- H96 (fern): splits SP vs WSS (cp | tau_x/y/z) — H100 splits differently (cp/tau_x/tau_y | tau_z)
- H97 (alphonse): bidirectional xattn module — different location
- H98 (askeladd): extra transformer block before decoder — different location
- H99 (frieren): deeper MLP in shared surface_out — H100 is a targeted split not a depth increase

**Key falsifiable predictions at terminal:**
- test_WSS_z < 9.0% → dedicated capacity begins to compress binding axis
- test_WSS_z < 8.5% → significant architectural crack of binding axis (MAJOR finding)
- test_WSS < 6.727% → overall WSS goal broken (currently no single-flag variant has done this)

## Instructions

**Step 1: Add CLI flag in `train.py`**

Find the `--use-surf-to-vol-xattn` argument block and add:
```python
parser.add_argument("--use-wss-z-dedicated-head", action="store_true", default=False,
                    help="Dedicate a separate 2-layer MLP head to tau_z output channel")
```

Pass `use_wss_z_dedicated_head=args.use_wss_z_dedicated_head` wherever `use_surf_to_vol_xattn` is passed to the model constructor.

**Step 2: Add the head in `model.py` `__init__`**

Add `use_wss_z_dedicated_head: bool = False` to the constructor signature.

In the `if use_aux_decoder_heads:` block (around line 477), **after** the existing `self.surface_out` definition and its `apply(_init_linear)` call, add:

```python
if use_wss_z_dedicated_head:
    # Dedicated tau_z head: separate 2-layer MLP for vertical WSS axis
    # surface_main_out outputs 3ch (cp, tau_x, tau_y)
    # surface_wss_z_out outputs 1ch (tau_z)
    self.surface_main_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, 3),  # cp + tau_x + tau_y
    )
    self.surface_main_out.apply(_init_linear)
    self.surface_wss_z_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, 1),  # tau_z only
    )
    self.surface_wss_z_out.apply(_init_linear)
else:
    self.surface_main_out = None
    self.surface_wss_z_out = None
```

Also store the flag: `self.use_wss_z_dedicated_head = use_wss_z_dedicated_head`

**Step 3: Update `model.py` `forward`**

Find the surface prediction block (around line 624):
```python
if surface_x is not None:
    surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

Replace with:
```python
if surface_x is not None:
    if self.use_wss_z_dedicated_head and self.surface_main_out is not None:
        main_preds = self.surface_main_out(surface_hidden)    # [B, N, 3]
        wss_z_preds = self.surface_wss_z_out(surface_hidden)  # [B, N, 1]
        surface_preds = torch.cat([main_preds, wss_z_preds], dim=-1)  # [B, N, 4]
        surface_preds = surface_preds * surface_mask.unsqueeze(-1)
    else:
        surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

**Step 4: Run with canonical recipe + new flag**

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-wss-z-dedicated-head \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name thorfinn/h100-wss-z-dedicated-head \
  --wandb-group wave33_h100_wss_z_dedicated_head
```

**Note on channel ordering**: DrivAerML surface output is ordered [cp, tau_x, tau_y, tau_z] (positions 0,1,2,3). The split is: `surface_main_out` → channels 0-2 (cp, tau_x, tau_y), `surface_wss_z_out` → channel 3 (tau_z). Verify this matches `data/loader.py` surface label ordering before running.

**Startup verification**: Confirm the run logs param count showing `surface_main_out` (3 output channels) and `surface_wss_z_out` (1 output channel). `self.surface_out` should NOT appear in param count when `--use-wss-z-dedicated-head` is active.

## Baseline

Current single-model SOTA (PR #972, W&B `56bcqp3m`):

| Metric | Value |
|---|---:|
| val_abupt | 6.126% (merge gate) |
| test_abupt | 5.844% |
| test_VP | 3.643% (floor) |
| test_SP | 3.577% (floor) |
| test_WSS | 6.727% (goal) |
| test_WSS_z | ~8.750% (canonical range 8.75-9.10 across fleet) |

**Merge gate:** `val_abupt < 6.126%` AND `test_VP ≤ 3.643%` AND `test_SP ≤ 3.577%` AND `test_WSS ≤ 6.727%`

**Best Wave 32 val_abupt**: 6.045% (H87), 6.119% (H89 B PARTIAL HISTORIC)

W&B baseline: `56bcqp3m` (https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m)

## Connection to your previous work

Your H93 (tau_y=2.5 loss-weight) demonstrated that per-channel emphasis via Lion sign-update is a dead end — 67% stronger gradient produced WORSE target axis performance. This is the architectural test of the same intuition:

| Approach | H93 (yours) | H100 (yours) |
|---|---|---|
| Target axis | tau_y (to test, then τ_z class) | tau_z (binding axis) |
| Mechanism | Loss-weight rebalancing | Dedicated decoder MLP |
| Why it failed/may work | Lion normalizes step magnitude | Adds representational capacity |
| Expected signal | tau_z < 8.5% if arch is lever | tau_z < 8.5% |
