### PR TITLE
Wave 33 H101: GEOM-RESIDUAL-DECODER — Zero-init xyz position residual at surface decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_geom_residual_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_geom_residual_decoder = use_geom_residual_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,19 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H101: zero-init geometric residual projection from raw xyz position
+        # into n_hidden, added to surface_hidden before surface_out. Identity
+        # at init (zero residual). During training, the decoder learns to
+        # recover spatial discrimination lost in the 128-slice bottleneck.
+        if use_geom_residual_decoder:
+            self.geom_residual_proj = nn.Linear(space_dim, n_hidden)
+            nn.init.zeros_(self.geom_residual_proj.weight)
+            nn.init.zeros_(self.geom_residual_proj.bias)
+            self.geom_residual_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        else:
+            self.geom_residual_proj = None
+            self.geom_residual_norm = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -622,6 +637,12 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            if self.use_geom_residual_decoder:
+                surface_xyz = surface_x[..., : self.space_dim]
+                geom_residual = self.geom_residual_proj(surface_xyz)
+                geom_residual = _apply_token_mask(geom_residual, surface_mask)
+                surface_hidden = self.geom_residual_norm(surface_hidden + geom_residual)
+                surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_geom_residual_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_geom_residual_decoder": (
+            "Enable zero-init geometric residual projection at the surface "
+            "decoder (H101). Adds a Linear(3, n_hidden) projection from raw "
+            "surface xyz positions, applied as a residual to surface_hidden "
+            "before surface_out, followed by LayerNorm. Both weight and bias "
+            "are zero-initialised so the residual is identity at init. "
+            "Restores fine-grained spatial discrimination lost in the "
+            "slice-attention bottleneck (128 slices for ~10^6 surface points). "
+            "Adds ~1.5K params (3*n_hidden + n_hidden + 2*n_hidden LayerNorm)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_geom_residual_decoder=config.use_geom_residual_decoder,
     )
 
 
@@ -748,6 +760,17 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())
+        if config.use_geom_residual_decoder and state.is_main:
+            proj = model.geom_residual_proj
+            w_norm = float(proj.weight.detach().float().norm().item())
+            b_norm = float(proj.bias.detach().float().norm().item())
+            geom_params = sum(p.numel() for p in proj.parameters()) + sum(
+                p.numel() for p in model.geom_residual_norm.parameters()
+            )
+            print(
+                f"H101 geom_residual_proj at init: weight_norm={w_norm:.6e} "
+                f"bias_norm={b_norm:.6e} extra_params={geom_params}"
+            )
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
         surface_channel_weights = torch.tensor(
@@ -773,7 +796,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_geom_residual_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1321,6 +1344,20 @@ def main(argv: Iterable[str] | None = None) -> None:
         total_minutes = (time.time() - train_start) / 60.0
         if state.is_main:
             print(f"\nTraining done in {total_minutes:.1f} min")
+            if config.use_geom_residual_decoder:
+                proj = base_model.geom_residual_proj
+                w_norm = float(proj.weight.detach().float().norm().item())
+                b_norm = float(proj.bias.detach().float().norm().item())
+                print(
+                    f"H101 geom_residual_proj at end: weight_norm={w_norm:.6e} "
+                    f"bias_norm={b_norm:.6e}"
+                )
+                wandb.summary.update(
+                    {
+                        "geom_residual_proj/weight_norm_end": w_norm,
+                        "geom_residual_proj/bias_norm_end": b_norm,
+                    }
+                )
 
         if early_stop_reason is not None:
             wandb.summary.update(


### PR DESCRIPTION
## Hypothesis

**Wave 33 H101: GEOM-RESIDUAL-DECODER — Inject raw surface positions as zero-init residual at surface decoder**

Across the Wave 32 architectural Tier-2 sweep, capacity-via-encoder (depth H89, slices H91, heads H88, mlp_ratio H86) all hit a structural ceiling: the SP/WSS plateau (test_SP 3.74–3.95% across 11 variants, test_WSS_z 8.95–9.66%) cannot be cracked by adding parameters to the slice-attention backbone. Per H80 closure analysis and Issue #1056 Morgan guidance, the binding constraint is **decoder-side, not encoder-side**.

Wave 33 attacks the decoder. H96 (split heads cp vs WSS), H97 (vol→surf xattn), H98 (surface transformer block), H99 (deeper surface MLP), H100 (tau_z dedicated head) all attack the decoder's *internal* structure. **H101 attacks a different axis: the decoder's *input signal*.**

**Mechanism**: The slice-attention backbone compresses N=65,536 surface points → 128 slice tokens → re-expands to N. This bottleneck necessarily loses fine-grained spatial discrimination. cp depends on perpendicular pressure gradient, tau_x/y/z depend on local velocity gradients tangent to surface — both quantities are spatially varying functions of position. The decoder receives slice-attention-compressed features but no direct positional skip-connection.

H101 adds a **zero-initialized linear projection from raw surface position (xyz) to n_hidden**, then adds the output as a residual to surface_hidden BEFORE surface_out. At init the model is identical to canonical (zero residual). During training, the model learns to recover lost positional discrimination directly at the decoder.

**Why this should crack SP/WSS plateau**: H91 (slices=192) closed B PARTIAL with test_WSS_z 8.95% — fleet-best on WSS_z but failed test_SP and test_WSS_x. Slice expansion improves spatial discrimination indirectly (more tokens). H101 tests this directly — does explicit positional skip improve the spatially-varying prediction channels (SP, all WSS axes)?

**Physics motivation**: cp and tau are spatial functions f(x,y,z). The slice-attention encoder learns a coarse spatial basis (128 slices over a body with ~10^6 surface points). For final per-point prediction, having raw position info available at the decoder is theoretically motivated — analogous to U-Net skip connections or NeRF positional encoding at output.

**Orthogonal to Wave 33 in-flight**:
- H96/H100: structural decoder split (where features are routed)
- H97: cross-modal info flow (vol→surf via attention)
- H98: extra processing layer (more compute on surface)
- H99: deeper MLP (more capacity in decoder)
- **H101: input signal augmentation (NEW INFORMATION at decoder, not more compute)**

## Instructions

### Code changes — `target/model.py`

1. **Add CLI flag** in argparse (in `target/train.py`):
   ```python
   parser.add_argument(
       "--use-geom-residual-decoder",
       action="store_true",
       help="Add zero-init residual projection from raw surface_x positions to surface_hidden before surface_out (H101)",
   )
   ```

2. **Add `self.geom_residual_proj` module** in `SurfaceTransolver.__init__` (gated by config flag):
   ```python
   self.use_geom_residual_decoder = use_geom_residual_decoder
   if self.use_geom_residual_decoder:
       # Project raw 3D position (xyz) → n_hidden, ZERO-INIT for identity at start
       self.geom_residual_proj = nn.Linear(3, n_hidden)
       nn.init.zeros_(self.geom_residual_proj.weight)
       nn.init.zeros_(self.geom_residual_proj.bias)
       self.geom_residual_norm = nn.LayerNorm(n_hidden)
   ```

3. **Apply residual in forward pass** — locate the block at `model.py:624-625` where `surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)`. Add the residual application IMMEDIATELY BEFORE this line:
   ```python
   if surface_x is not None:
       if self.use_geom_residual_decoder:
           # surface_x has shape [B, N, num_features]; positions are first 3 dims
           surface_xyz = surface_x[..., :3]  # [B, N, 3]
           geom_residual = self.geom_residual_proj(surface_xyz)  # [B, N, n_hidden]
           geom_residual = _apply_token_mask(geom_residual, surface_mask)
           surface_hidden = self.geom_residual_norm(surface_hidden + geom_residual)
           surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
       surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
   ```

4. **Verify `surface_x[..., :3]` is xyz position**: open `target/data.py` (or wherever the dataset loader is) and confirm the surface feature tensor's first 3 dims are positions (typical convention). If positions are at a different offset, update the slice accordingly (e.g., `surface_x[..., pos_start:pos_start+3]`). If unclear, add a print in dataset loading to confirm before running training.

### Code changes — `target/train.py`

Pass the new flag through to the model config:
```python
model = SurfaceTransolver(
    ...
    use_geom_residual_decoder=args.use_geom_residual_decoder,
    ...
)
```

### Training command (DDP 8 GPUs, ~13 epochs, ~12-13h wall-clock)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-geom-residual-decoder \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name nezuko/h101-geom-residual-decoder \
  --wandb-group wave33_h101_geom_residual_decoder
```

### What to report (terminal SENPAI-RESULT comment)

In addition to the standard SENPAI-RESULT marker with terminal val/test_abupt:

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS_x/y/z + matching test_)
2. **val→test slope per channel** — H91 had strongest SP val→test slope (−0.312pp) of Wave 32; track if H101 produces similar or better SP val→test slope
3. **Param count delta**: should be small (~1.5K params: 3*512 weights + 512 biases = 2,048 from geom_residual_proj, plus LayerNorm params = ~1,024). Confirm by printing model.parameters().
4. **Verify zero-init**: print value of `self.geom_residual_proj.weight.norm()` at step 0 to confirm identity behavior at start
5. **At end of training**, print `self.geom_residual_proj.weight.norm()` to see how much the model learned to use the geom residual

## Baseline

Single-model corrected-split baseline (PR #972 nezuko, run `zxnhtagj`):

- **val_abupt: 6.126%** (merge gate)
- test_abupt: 5.844%
- test_VP: 3.643% (floor)
- test_SP: 3.577% (floor)
- test_WSS: 6.727% (floor)
- test_WSS_x: 5.962%, test_WSS_y: 7.435%, test_WSS_z: 8.945%

**Reference siblings (Wave 32 architectural Tier-2):**
- H89 (depth=6) terminal: val_abupt 6.1186% **CLEAR gate**, test_VP 3.482%, test_SP 3.709%, test_WSS 6.832%, test_WSS_z 9.087%
- **H91 (slices=192) terminal: val_abupt 6.1748% MISS gate +0.049pp, test_VP 3.5768% CROSS floor, test_SP 3.7467%, test_WSS 6.9142%, test_WSS_z 8.9496% (fleet-best)**

**Wave 33 in-flight (parallel attacks):**
- H96 (fern, PR #1261): WSS-DEDICATED-DECODER-HEAD running healthy at 66% (EP5 val 6.457%, slope −0.0164 engaging)
- H97 (alphonse, PR #1262): BIDIRECTIONAL-XATTN
- H98 (askeladd, PR #1263): SURFACE-LATE-LAYER-SPLIT (currently needs_rebase)
- H99 (frieren, PR #1264): SURFACE-OUT-DEEPER-MLP
- H100 (thorfinn, PR #1265): WSS-Z-DEDICATED-HEAD

## Success criteria

- **A WIN merge**: val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
- **B PARTIAL**: val gate clear OR significant test channel improvements
- **Key mechanism signal**: test_SP < 3.70% would be FIRST crack of 11-variant Wave 32 plateau (3.74-3.95%) and would validate "decoder input signal augmentation" as productive direction
- **Key mechanism signal**: test_WSS_z < 8.5% would be unprecedented and would break the binding axis on the WSS channel

H101 is your transition to Wave 33. You closed Wave 32 (H91 B PARTIAL with fleet-best test_WSS_z 8.95%) — H101 lets you take a clean shot at decoder-side architectural attacks complementary to the H96-H100 wave.
