### PR TITLE
Wave 33 H98 (v2): SURFACE-LATE-LAYER-SPLIT — extra surface-only transformer block

### DIFF
--- a/model.py
+++ b/model.py
@@ -381,6 +381,7 @@ class SurfaceTransolver(nn.Module):
         pos_encoding_mode: str = "sincos",
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
+        use_surface_late_layer: bool = False,
         use_aux_decoder_heads: bool = True,
     ):
         super().__init__()
@@ -395,6 +396,7 @@ class SurfaceTransolver(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
+        self.use_surface_late_layer = use_surface_late_layer
         self.use_aux_decoder_heads = use_aux_decoder_heads
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
@@ -498,6 +500,32 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # H98: SURFACE-LATE-LAYER-SPLIT (PR #1267). Extra TransformerEncoderLayer
+        # applied only to surface_hidden AFTER the shared backbone AND the
+        # surf_to_vol_xattn, immediately before the surface decoder head. Volume
+        # pathway untouched; volume's xattn query reads the raw post-backbone
+        # surface representation so late-stage refinement is decoupled from
+        # volume optimization. Identity at init via zero-init of MHA out_proj
+        # and FFN linear2 (the two residual sublayer outputs) so the block
+        # contributes nothing at step 0. norm_first=True matches the backbone's
+        # pre-LN style.
+        if use_surface_late_layer:
+            self.surface_late_layer = nn.TransformerEncoderLayer(
+                d_model=n_hidden,
+                nhead=n_head,
+                dim_feedforward=int(n_hidden * mlp_ratio),
+                dropout=0.0,
+                activation="gelu",
+                batch_first=True,
+                norm_first=True,
+            )
+            nn.init.zeros_(self.surface_late_layer.linear2.weight)
+            nn.init.zeros_(self.surface_late_layer.linear2.bias)
+            nn.init.zeros_(self.surface_late_layer.self_attn.out_proj.weight)
+            nn.init.zeros_(self.surface_late_layer.self_attn.out_proj.bias)
+        else:
+            self.surface_late_layer = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -622,6 +650,16 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            if self.surface_late_layer is not None and surface_tokens > 0:
+                # H98: late-stage surface refinement, applied AFTER surf_to_vol_xattn
+                # so volume reads the raw post-backbone surface. src_key_padding_mask
+                # is True for padded positions (1.0 = valid in surface_mask, 0.0 =
+                # padded), so they don't contribute to attention.
+                src_key_padding_mask = ~surface_mask.bool()
+                surface_hidden = self.surface_late_layer(
+                    surface_hidden, src_key_padding_mask=src_key_padding_mask
+                )
+                surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_late_layer: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surface_late_layer": (
+            "H98 (PR #1267): Append one extra nn.TransformerEncoderLayer "
+            "applied only to surface tokens AFTER the shared backbone AND "
+            "the surf_to_vol_xattn, immediately before the surface decoder "
+            "head. Volume pathway is unaffected (volume's xattn query reads "
+            "the raw post-backbone surface). Pre-LN style (norm_first=True) "
+            "matches the backbone; d_model follows --model-hidden-dim, nhead "
+            "--model-heads, ff --model-hidden-dim*--model-mlp-ratio, "
+            "dropout=0.0. Zero-init of MHA out_proj and FFN linear2 makes "
+            "the block identity at init (preserves baseline at epoch 0). "
+            "Targets the architecture-bound test_WSS_z (binding axis ~9 pct) "
+            "and the 11-variant test_SP plateau by giving surface tokens "
+            "late-stage self-attention decoupled from volume optimization."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +323,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_late_layer=config.use_surface_late_layer,
     )
 
 
@@ -779,6 +795,19 @@ def main(argv: Iterable[str] | None = None) -> None:
         base_model = unwrap_model(model)
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+            if getattr(base_model, "surface_late_layer", None) is not None:
+                # H98 identity-at-init verification: zero-init of MHA out_proj +
+                # FFN linear2 makes the residual sublayer outputs all-zero, so
+                # the TransformerEncoderLayer is a no-op at step 0.
+                late = base_model.surface_late_layer
+                late_param_count = sum(p.numel() for p in late.parameters())
+                init_out_proj_norm = float(late.self_attn.out_proj.weight.detach().norm().item())
+                init_linear2_norm = float(late.linear2.weight.detach().norm().item())
+                print(
+                    f"H98 surface_late_layer: +{late_param_count / 1e6:.2f}M params; "
+                    f"init self_attn.out_proj.weight.norm={init_out_proj_norm:.6e}; "
+                    f"init linear2.weight.norm={init_linear2_norm:.6e}"
+                )
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
@@ -1368,6 +1397,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             global_step=global_step,
             total_minutes=total_minutes,
         )
+        if getattr(base_model, "surface_late_layer", None) is not None:
+            # H98 post-training norms: track how much the model learned to use
+            # the late layer relative to identity-at-init (both norms start at 0).
+            late = base_model.surface_late_layer
+            final_out_proj_norm = float(late.self_attn.out_proj.weight.detach().norm().item())
+            final_linear2_norm = float(late.linear2.weight.detach().norm().item())
+            print(
+                f"H98 surface_late_layer final: "
+                f"self_attn.out_proj.weight.norm={final_out_proj_norm:.6e}; "
+                f"linear2.weight.norm={final_linear2_norm:.6e}"
+            )
+            wandb.summary.update(
+                {
+                    "h98/surface_late_layer/final_out_proj_norm": final_out_proj_norm,
+                    "h98/surface_late_layer/final_linear2_norm": final_linear2_norm,
+                }
+            )
         wandb.finish()
     finally:
         cleanup_distributed(state)


### PR DESCRIPTION
## Hypothesis

**Wave 33 H98 (v2 — fresh branch): SURFACE-LATE-LAYER-SPLIT — add a single TransformerEncoderLayer on surface tokens only, post-backbone, identity at init**

This is a re-assignment of H98 SURFACE-LATE-LAYER-SPLIT on a fresh branch from current tay. The original PR #1263 had stale research/* docs causing merge conflict; closed in favor of this fresh assignment. Hypothesis mechanism is unchanged.

Per Wave 32 closure findings (depth/heads/width/LR/slices all fail test_SP/WSS plateau), the binding constraint is decoder-side. Wave 33 attacks the decoder. The five existing Wave 33 attacks each target a different decoder/output axis:
- H96 (fern, PR #1261): WSS-DEDICATED-DECODER-HEAD — splits cp head vs WSS head
- H97 (alphonse, PR #1262): BIDIRECTIONAL-XATTN — adds vol→surf attention
- H99 (frieren, PR #1264): SURFACE-OUT-DEEPER-MLP — 2-layer → 3-layer surface trunk
- H100 (thorfinn, PR #1265): WSS-Z-DEDICATED-HEAD — splits tau_z separately
- H101 (nezuko, PR #1266): GEOM-RESIDUAL-DECODER — zero-init position residual at decoder

**H98 attacks LATE-STAGE SURFACE SPECIALIZATION**: add one extra `TransformerEncoderLayer` applied ONLY to surface_hidden, between the shared backbone and the surface decoder. This gives surface tokens an additional self-attention + feedforward stage of processing AFTER the shared encoder, allowing surface-specific feature refinement without modifying the volume pathway.

**Orthogonal to other Wave 33 attacks**: H96/H100 are decoder-head splits (where features are routed); H97 is cross-modal info flow; H99 deepens MLP; H101 augments input signal. H98 adds a full transformer block (self-attention + FFN) — a deeper structural change on the surface pathway only.

**Identity-at-init via zero-initialized residual outputs**: The added TransformerEncoderLayer's `out_proj` (in self-attention) and the second `linear2` (in FFN) are zero-initialized so the layer outputs all zeros at start. Combined with the standard residual `x = x + sublayer(x)` structure, the surface tokens pass through unchanged at step 0. Training then learns to use the extra processing only where it helps.

## Instructions

### Code changes — `target/model.py`

1. **Add CLI flag** in `target/train.py` argparse:
   ```python
   parser.add_argument(
       "--use-surface-late-layer",
       action="store_true",
       help="Add a single TransformerEncoderLayer on surface tokens only between backbone and surface_out, identity at init (H98)",
   )
   ```

2. **In `SurfaceTransolver.__init__`** (after backbone definition, before `self.surface_out`):
   ```python
   self.use_surface_late_layer = use_surface_late_layer
   if self.use_surface_late_layer:
       # Standard TransformerEncoderLayer with same dims as backbone
       self.surface_late_layer = nn.TransformerEncoderLayer(
           d_model=n_hidden,
           nhead=n_heads,
           dim_feedforward=n_hidden * mlp_ratio,
           dropout=0.0,
           activation="gelu",
           batch_first=True,
           norm_first=True,  # pre-norm to match backbone convention
       )
       # Zero-init both residual outputs so layer is identity at start
       nn.init.zeros_(self.surface_late_layer.self_attn.out_proj.weight)
       nn.init.zeros_(self.surface_late_layer.self_attn.out_proj.bias)
       nn.init.zeros_(self.surface_late_layer.linear2.weight)
       nn.init.zeros_(self.surface_late_layer.linear2.bias)
   ```

3. **Apply the late layer in forward pass** — at `model.py:~624`, immediately before the `surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)` line:
   ```python
   if surface_x is not None:
       if self.use_surface_late_layer:
           # Apply extra transformer block on surface tokens only, with key_padding_mask
           # surface_mask is [B, N] with 1.0 = valid, 0.0 = padded
           src_key_padding_mask = ~surface_mask.bool()  # True for positions to ignore
           surface_hidden = self.surface_late_layer(
               surface_hidden, src_key_padding_mask=src_key_padding_mask
           )
           surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
       surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
   ```

4. **Verify backbone configuration**: confirm `n_heads`, `mlp_ratio`, `n_hidden` are the same instance attributes used elsewhere in `__init__`. If named differently (e.g., `self.heads`, `self.mlp_ratio`), use those exact names.

### Code changes — `target/train.py`

Pass through to model:
```python
model = SurfaceTransolver(
    ...
    use_surface_late_layer=args.use_surface_late_layer,
    ...
)
```

### Training command (DDP 8 GPUs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-surface-late-layer \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name askeladd/h98-surface-late-layer-split-v2 \
  --wandb-group wave33_h98_surface_late_layer_split
```

### What to report (terminal SENPAI-RESULT)

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS_x/y/z + matching test_)
2. **Param count delta**: should be ~(n_hidden^2 × (1 + 4*mlp_ratio + 4)) = 512² × (1 + 16 + 4) ≈ 5.5M added params from the extra TransformerEncoderLayer
3. **Verify identity at init**: print value of `self.surface_late_layer.linear2.weight.norm()` AND `self.surface_late_layer.self_attn.out_proj.weight.norm()` at step 0 to confirm both are zero
4. **At end of training**, print same norms to see how much the model learned to use the late layer
5. **Compare engagement vs siblings**: if test_SP < 3.70 or test_WSS_z < 8.5%, the late-stage surface specialization mechanism IS productive

## Baseline

Single-model corrected-split baseline (PR #972 nezuko):
- **val_abupt: 6.126%** (merge gate)
- test_abupt: 5.844%; test_VP: 3.643% (floor); test_SP: 3.577% (floor); test_WSS: 6.727% (goal)
- test_WSS_x: 5.962%, test_WSS_y: 7.435%, test_WSS_z: 8.945%

**Recent Wave 32 architectural Tier-2 closures**:
- H89 (depth=6) terminal: val_abupt **6.1186% CLEAR gate**, test_VP **3.482% CROSS**, test_SP 3.709%, test_WSS_z 9.087% (B PARTIAL HISTORIC)
- H91 (slices=192) terminal: val_abupt 6.1748% NARROW MISS gate +0.049pp, test_VP **3.5768% CROSS**, test_WSS_z **8.95% FLEET-BEST** (B PARTIAL)

**Wave 33 fleet (parallel attacks all in-flight)**:
- H96 (fern, PR #1261) running 66%, EP5 val 6.457%, slope −0.0164 engaging
- H97 (alphonse, PR #1262), H99 (frieren, PR #1264), H100 (thorfinn, PR #1265), H101 (nezuko, PR #1266)

## Success criteria

- **A WIN merge**: val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
- **Key mechanism signal**: test_SP < 3.70% → first crack of 11-variant Wave 32 plateau (3.74-3.95%) and validates "late-stage surface specialization" as productive direction
- **Key mechanism signal**: test_WSS_z < 8.5% → binding axis cracked on WSS channel

Sorry for the churn on the rebase — the fresh branch should give you a clean shot at H98. Get this running, askeladd, and your GPU slot resumes Wave 33 attack #3.
