### PR TITLE
Wave 33 H102: SURFACE-OUT-WIDER-MLP — Decoder width 1× → 2× (pairs with H99 depth)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        surface_out_width_factor: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.surface_out_width_factor = surface_out_width_factor
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,10 +483,11 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
+            surf_hidden_width = int(round(n_hidden * surface_out_width_factor))
             self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
+                nn.Linear(n_hidden, surf_hidden_width),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(surf_hidden_width, self.surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    surface_out_width_factor: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "surface_out_width_factor": (
+            "Width multiplier for the surface_out MLP hidden layer (PR "
+            "#1268 H102). At 1.0 (canonical) the surface decoder is "
+            "Linear(n_hidden, n_hidden) -> SiLU -> Linear(n_hidden, "
+            "surf_dim). At 2.0 the hidden dim is widened to "
+            "2*n_hidden to test whether the test_SP/WSS plateau is bound "
+            "by insufficient nonlinear capacity in the surface decoder. "
+            "Pairs with H99 (PR #1264) which attacks the depth axis "
+            "(2-layer -> 3-layer)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        surface_out_width_factor=config.surface_out_width_factor,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Wave 33 H102: SURFACE-OUT-WIDER-MLP — Widen the surface decoder MLP hidden dimension 1× → 2× (pairs with H99's depth-axis attack)**

Wave 32 closure: depth (H89), heads (H88), slices (H91), mlp_ratio (H86) all add encoder capacity but fail to crack the test_SP/WSS plateau — confirming the binding constraint is DECODER-side, not encoder-side. Wave 33 is attacking the decoder from six different angles (H96-H101).

H99 (frieren, PR #1264) tests **decoder DEPTH** by going from 2-layer → 3-layer surface_out. H102 mirrors this on the **decoder WIDTH** axis: keep 2 layers but widen the hidden dimension 1× → 2×. Together H99 + H102 map the depth × width plane of decoder capacity expansion.

**Mechanism**:
- Current surface_out: `Sequential(Linear(n_hidden=512, 512), GELU, Linear(512, surf_dim=4))`
- H102 surface_out: `Sequential(Linear(512, 1024), GELU, Linear(1024, 4))`
- Param delta: (512 × 512 + 512 × 4) → (512 × 1024 + 1024 × 4) = ~262K → ~528K = **+266K params**

**Why width and not depth alone**: width-expansion in MLPs (e.g., transformer FFN where dim_feedforward = 4 × d_model) is well-known to be more sample-efficient than depth for fixed parameter budgets in many settings. Per Tay et al. (Switch Transformer, MoE) and the lottery-ticket hypothesis, increasing the hidden representational space can capture richer feature interactions in a single non-linear transformation. For our decoder, this tests whether the SP/WSS plateau is bound by INSUFFICIENT NONLINEAR CAPACITY in the surface_out MLP (vs depth which tests if sequential composition helps).

**Outcomes if H102 wins**: width is the productive decoder axis → escalate to width=3× or combine with H99 depth.
**Outcomes if H102 loses**: width plateaus or regresses → decoder capacity in the n_hidden=512 family is exhausted, attack must move elsewhere (cross-attention, multi-layer fusion, etc.).
**Outcomes if H99 + H102 both win marginally**: decoder capacity bound — compound depth + width for next wave.
**Outcomes if both fail**: decoder MLP capacity is NOT the binding constraint — confirms decoder structure (splits, attention, position) is more productive than raw capacity.

**Physics motivation**: Surface predictions (cp, tau_x/y/z) involve highly nonlinear functions of local geometry × velocity gradient × pressure field. A wider MLP can capture more cross-feature interactions in the single hidden layer non-linearity, potentially helping for the channel where multi-component physics meet (tau_z especially, which depends on z-axis velocity gradient bound to body curvature).

**Orthogonal to Wave 33 in-flight**:
- H96/H100: structural decoder split (where features are routed)
- H97: cross-modal info flow (vol→surf via attention)
- H98v2: extra TransformerEncoderLayer (more processing stage)
- **H99: decoder DEPTH (2→3 layer)**
- H101: input signal augmentation (position residual)
- **H102 (this): decoder WIDTH (1× → 2×) — pairs with H99 on capacity-axis map**

## Instructions

### Code changes — `target/model.py`

1. **Add CLI flag** in `target/train.py`:
   ```python
   parser.add_argument(
       "--surface-out-width-factor",
       type=float,
       default=1.0,
       help="Width multiplier for surface_out hidden layer (1.0=canonical, 2.0=H102 wider MLP)",
   )
   ```

2. **Modify `SurfaceTransolver.__init__`** — in the section where `self.surface_out` is constructed (around line 484-489), parameterize the hidden dim:
   ```python
   surf_hidden_width = int(n_hidden * surface_out_width_factor)
   self.surface_out = nn.Sequential(
       nn.Linear(n_hidden, surf_hidden_width),
       nn.GELU(),
       nn.Linear(surf_hidden_width, self.surface_output_dim),
   )
   ```
   
   This keeps 2 layers (matching canonical depth) but widens the intermediate dim by the multiplier. At `surface_out_width_factor=1.0`, this is byte-identical to canonical behavior.

3. **No changes to forward pass** — the API stays the same.

### Code changes — `target/train.py`

Pass through:
```python
model = SurfaceTransolver(
    ...
    surface_out_width_factor=args.surface_out_width_factor,
    ...
)
```

### Training command (DDP 8 GPUs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --surface-out-width-factor 2.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name tanjiro/h102-surface-out-wider-mlp \
  --wandb-group wave33_h102_surface_out_wider_mlp
```

### What to report (terminal SENPAI-RESULT comment)

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS_x/y/z + matching test_)
2. **Param count delta** vs canonical: should be ~+266K params (524K added in first Linear, 4K extra in second Linear)
3. **val→test slope per channel** — compare to H87 baseline and H91 (fleet-best test_WSS_z)
4. **Direct comparison with H99 (frieren, depth=3)** when both terminal:
   - If H102 (width=2) outperforms H99 (depth=3) → width is productive decoder axis
   - If H99 outperforms H102 → depth is productive
   - If both clear gate → compound for Wave 34

## Baseline

Single-model corrected-split baseline (PR #972 nezuko, run `zxnhtagj`):

- **val_abupt: 6.126%** (merge gate)
- test_abupt: 5.844%
- test_VP: 3.643% (floor) ; test_SP: 3.577% (floor) ; test_WSS: 6.727% (goal)
- test_WSS_x/y/z: 5.962/7.435/8.945

**Recent Wave 32 closures (best-in-class):**
- H87 (surf_loss=1.5) terminal: val_abupt 6.045% **CLEAR gate**, test_VP 3.495% **CROSS**, test_SP 3.734% (B PARTIAL HISTORIC — but loss-weighting NOT merged per Issue #1056)
- H89 (depth=6) terminal: val_abupt **6.1186% CLEAR**, test_VP **3.482% CROSS DEEPEST**, test_SP 3.709% (B PARTIAL HISTORIC)
- H91 (slices=192) terminal: val_abupt 6.1748% MISS +0.049pp, test_WSS_z **8.95% FLEET-BEST** (B PARTIAL)

**Wave 33 in-flight (parallel decoder attacks):**
- H96 (fern, PR #1261): WSS-DEDICATED-DECODER-HEAD running 66% slope engaging
- H97 (alphonse, PR #1262): BIDIRECTIONAL-XATTN early signal STRONG (EP2 −2.72pp ahead)
- H98v2 (askeladd, PR #1267): SURFACE-LATE-LAYER-SPLIT (fresh branch)
- **H99 (frieren, PR #1264): SURFACE-OUT-DEEPER-MLP (depth-axis pair to your H102 width-axis)**
- H100 (thorfinn, PR #1265): WSS-Z-DEDICATED-HEAD
- H101 (nezuko, PR #1266): GEOM-RESIDUAL-DECODER

## Success criteria

- **A WIN merge**: val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
- **B PARTIAL**: val gate clear OR significant test channel improvements
- **Key mechanism signal**: test_SP < 3.70% → first crack of 11-variant Wave 32 plateau and validates "decoder width" as productive
- **H99 comparison**: this is a DIRECT pair experiment with H99. The H102 vs H99 comparison will be cited in Wave 33 closure documentation as the canonical decoder-width-vs-depth map.

H102 is your transition to Wave 33. You closed Wave 32 loss-weighting (H95 C NULL confirming H87 sweet spot) — H102 is a clean, well-defined, low-friction decoder-capacity attack that pairs with H99 to map the full capacity axis.
