### PR TITLE
Wave 33 H104: VOLUME-OUT-WIDER-MLP — Volume decoder width 1× → 2× (mirror H102)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        volume_out_width_factor: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.volume_out_width_factor = volume_out_width_factor
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -487,12 +489,17 @@ class SurfaceTransolver(nn.Module):
                 nn.Linear(n_hidden, self.surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
+            # H104: parameterize volume_out hidden dims by volume_out_width_factor.
+            # At factor=1.0 byte-identical to canonical (256, 128); at 2.0 widens
+            # to (512, 256) (+229K params).
+            vol_hidden_1 = int(n_hidden * volume_out_width_factor // 2)
+            vol_hidden_2 = int(n_hidden * volume_out_width_factor // 4)
             self.volume_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden // 2),
+                nn.Linear(n_hidden, vol_hidden_1),
                 nn.SiLU(),
-                nn.Linear(n_hidden // 2, n_hidden // 4),
+                nn.Linear(vol_hidden_1, vol_hidden_2),
                 nn.SiLU(),
-                nn.Linear(n_hidden // 4, self.volume_output_dim),
+                nn.Linear(vol_hidden_2, self.volume_output_dim),
             )
             self.volume_out.apply(_init_linear)
         else:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    volume_out_width_factor: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "volume_out_width_factor": (
+            "H104: width multiplier for the volume_out 3-layer decoder MLP "
+            "hidden dims (1.0 == canonical n_hidden/2 -> n_hidden/4; 2.0 "
+            "doubles each hidden width). At 1.0 the volume_out is "
+            "byte-identical to the canonical head. Only takes effect when "
+            "the auxiliary decoder heads branch is active."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +316,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        volume_out_width_factor=config.volume_out_width_factor,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Wave 33 H104: VOLUME-OUT-WIDER-MLP — Widen the volume decoder MLP hidden dimensions 1× → 2× (mirror of tanjiro's H102 on the volume side)**

Wave 32 closure: depth (H89), heads (H88), slices (H91), mlp_ratio (H86), loss-weighting (H87/H94/H95/H92/H93) all add encoder/training capacity but fail to crack the test_SP/WSS plateau and the test_VP+SP+WSS AND-gate. The binding constraint is DECODER-side. Wave 33 attacks the decoder from many angles.

**H102 (tanjiro)** widens the SURFACE decoder MLP 1×→2× to test if surface_out is capacity-bound. **H104 (this) mirrors that attack on the VOLUME decoder** — keeping the existing 3-layer funnel topology but scaling each hidden width 1×→2×. Together H102 + H104 map the decoder-capacity plane across both output heads.

Volume decoder (current canonical):
- `Sequential(Linear(512, 256), SiLU, Linear(256, 128), SiLU, Linear(128, volume_dim))` ≈ 164K params

H104 (`volume_out_width_factor=2.0`):
- `Sequential(Linear(512, 512), SiLU, Linear(512, 256), SiLU, Linear(256, volume_dim))` ≈ 393K params
- **Param delta: +229K params** (similar order to H102's +266K)

At `volume_out_width_factor=1.0`, byte-identical to canonical (`int(n_hidden * 1.0 // 2) == n_hidden // 2`).

**Why this is the right next attack on edward's slot**:
1. Edward closed H94 (vol_loss_weight=1.5) at **B PARTIAL with test_VP −0.061pp CROSS** — direct evidence that the volume head responds to capacity perturbations on the test_VP axis. The volume-loss-weight nudge could not flip Lion sign-update dominance but it DID engage VP compression. **H104 asks: if the volume decoder is given more parameter capacity (not gradient capacity), does test_VP cross by more?**
2. Symmetric to surface: H102 tests if surface_out is the binding factor for SP/WSS plateau; H104 tests if volume_out is the binding factor for VP floor. Both are clean architectural attacks at the decoder.
3. **No throughput risk** — volume_out is applied per-token but volume tokens are sampled (16384-65536) and there's no self-attention added. Trivial param increase, no compute envelope concern.

## Outcomes

- **H104 wins** (test_VP < 3.643 AND val_abupt < 6.126%): volume decoder is capacity-bound → escalate to width=3× or compound with surface-side H102 if both clear.
- **H104 marginal** (test_VP CROSS but val gate misses): consistent with volume-capacity-helps-VP-but-shared-trunk-binds — informative for Wave 34 trunk attacks.
- **H104 loses** (all axes regress or stay flat): volume_out is NOT capacity-bound at 512-hidden trunk → decoder funnel shape (not width) may matter, OR trunk-side is the binding constraint.
- **H102 + H104 both win**: decoder-width is the productive axis across both heads → compound for Wave 34.
- **H102 + H104 both fail**: decoder MLP capacity (raw width) is NOT the binding constraint → confirms decoder STRUCTURE (heads/positions/attention) attacks (H96-H101) are more productive.

## Physics motivation

Volume pressure is a scalar field with sharp gradients near the body surface, separation regions, and wake. A wider MLP hidden layer can capture more nonlinear feature combinations at the body-volume interface. The 1.33:1 surf:vol ratio in H94 produced test_VP improvement; H104 tests whether per-token decoder representational capacity (vs gradient share) is the unlocking factor on the same axis.

## Orthogonal to Wave 33 in-flight

- H96 (fern): WSS-dedicated decoder split (surface)
- H97 (alphonse): bidirectional xattn (vol↔surf info flow)
- H99 (frieren): surface decoder DEEPER (3-layer)
- H100 (thorfinn): tau_z dedicated head (surface)
- H101 (nezuko): geom residual decoder (surface input signal)
- H102 (tanjiro): surface decoder WIDER (this PR's surface twin)
- H103 (askeladd): volume context FiLM decoder (surface, vol→surf via pooling)
- **H104 (this): volume decoder WIDER — the only Wave 33 attack on the volume output head**

## Instructions

### Code changes — `target/model.py`

1. Add `volume_out_width_factor: float = 1.0` to `SurfaceTransolver.__init__` signature.
2. In the `use_aux_decoder_heads` branch (around line 490), parameterize the volume_out hidden dims:
   ```python
   vol_hidden_1 = int(n_hidden * volume_out_width_factor // 2)  # canonical 256, H104 512
   vol_hidden_2 = int(n_hidden * volume_out_width_factor // 4)  # canonical 128, H104 256
   self.volume_out = nn.Sequential(
       nn.Linear(n_hidden, vol_hidden_1),
       nn.SiLU(),
       nn.Linear(vol_hidden_1, vol_hidden_2),
       nn.SiLU(),
       nn.Linear(vol_hidden_2, self.volume_output_dim),
   )
   self.volume_out.apply(_init_linear)
   ```
3. At `volume_out_width_factor=1.0`, this is byte-identical to canonical (`int(512 * 1.0 // 2) == 256`, `int(512 * 1.0 // 4) == 128`).
4. **No changes to forward pass.** API stays the same.
5. Keep the `else` branch (`use_aux_decoder_heads=False`) unchanged — it's a different code path used by older checkpoints.

### Code changes — `target/train.py`

Add CLI flag:
```python
parser.add_argument(
    "--volume-out-width-factor",
    type=float,
    default=1.0,
    help="Width multiplier for volume_out hidden layer dims (1.0=canonical, 2.0=H104 wider MLP)",
)
```

Pass through:
```python
model = SurfaceTransolver(
    ...
    volume_out_width_factor=args.volume_out_width_factor,
    ...
)
```

### Training command (DDP 8 GPUs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --volume-out-width-factor 2.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name edward/h104-volume-out-wider-mlp \
  --wandb-group wave33_h104_volume_out_wider_mlp
```

### What to report (terminal SENPAI-RESULT comment)

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS_x/y/z + matching test_)
2. **Param count delta** vs canonical (~+229K)
3. **val→test slope per channel** — compare to H94 (which had test_VP CROSS via gradient route)
4. **Direct H104 vs H102 (tanjiro)** comparison when both terminal:
   - If H104 (volume-wider) clears val gate but H102 (surface-wider) doesn't → volume-decoder is the bottleneck
   - If H102 clears but H104 doesn't → surface-decoder is the bottleneck
   - Both clear → compound decoder-width attack in Wave 34
   - Neither clears → decoder MLP capacity is NOT the binding constraint

## Baseline

Single-model corrected-split baseline (PR #972 nezuko, run `zxnhtagj`):
- **val_abupt: 6.126%** (merge gate)
- test_abupt: 5.844%
- test_VP: 3.643% (floor) ; test_SP: 3.577% (floor) ; test_WSS: 6.727% (goal)
- test_WSS_x/y/z: 5.962/7.435/8.945

**Wave 32 best-in-class loss-rebalance closures (your context):**
- H87 (surf_loss=1.5) terminal: val_abupt 6.045% CLEAR gate, test_VP 3.495% CROSS, test_SP 3.734% (B PARTIAL HISTORIC — but per Issue #1056 NOT merged)
- H94 (vol_loss=1.5 — your previous PR) terminal: val_abupt 6.357% MISS +0.231pp, test_VP **3.582% CROSS −0.061pp** ✓ (B PARTIAL — definitive Lion sign-update asymmetry)
- H89 (depth=6) terminal: val_abupt 6.119% CLEAR, test_VP 3.482% DEEPEST CROSS, test_SP 3.709% (B PARTIAL HISTORIC)
- H91 (slices=192) terminal: val_abupt 6.175% MISS +0.049pp, test_WSS_z **8.95% FLEET-BEST** (B PARTIAL)

**Wave 33 in-flight architectural decoder attacks (parallel to H104):**
- H96 fern (PR #1261): WSS-DEDICATED-DECODER-HEAD running, healthy
- H97 alphonse (PR #1262): BIDIRECTIONAL-XATTN running, ahead of canonical at EP2
- H99 frieren (PR #1264): SURFACE-OUT-DEEPER-MLP (decoder depth-axis)
- H100 thorfinn (PR #1265): WSS-Z-DEDICATED-HEAD (separate tau_z decoder)
- H101 nezuko (PR #1266): GEOM-RESIDUAL-DECODER (xyz position residual at decoder)
- H102 tanjiro (PR #1268): SURFACE-OUT-WIDER-MLP (decoder width-axis on surface side — pair with H104)
- H103 askeladd (assigned shortly): VOLUME-CONTEXT-FILM-DECODER

## Success criteria

- **A WIN merge**: val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
- **B PARTIAL**: val gate clear OR test_VP crosses floor (matches H94's contribution pattern)
- **Key mechanism signal**: test_VP deeper crossing than H94's 3.582% would confirm volume_out is capacity-bound and points to compound-attack in Wave 34
- **Critical pair with H102**: H104 vs H102 will be cited in Wave 33 closure as the canonical decoder-width-symmetric-vs-asymmetric map across heads

H104 is your transition from Wave 32 → Wave 33. You closed loss-weighting via H94 with a clean B PARTIAL on test_VP — H104 takes the same axis-of-attack (volume head capacity) to a parameter-level mechanism instead of gradient-level. Trivial code change, low operational risk, direct comparison to your previous PR.
