### PR TITLE
Wave 33 H103: VOLUME-CONTEXT-FILM-DECODER — Vol ctx FiLM-modulates surface decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_film_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_film_decoder = use_film_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -498,6 +500,18 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # FiLM decoder (PR #1270 / H103): pooled volume context modulates the
+        # surface decoder via a learned affine transform. Zero-init both weight
+        # and bias so that gamma=0 and beta=0 at step 0 — the modulation
+        # `(1 + gamma) * surface_hidden + beta` reduces to identity, preserving
+        # the canonical baseline at init.
+        if self.use_film_decoder:
+            self.film_projector = nn.Linear(n_hidden, 2 * n_hidden)
+            nn.init.zeros_(self.film_projector.weight)
+            nn.init.zeros_(self.film_projector.bias)
+        else:
+            self.film_projector = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -620,6 +634,27 @@ class SurfaceTransolver(nn.Module):
             xattn_out = _apply_token_mask(xattn_out, volume_mask)
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
+
+        # FiLM conditioning (PR #1270 / H103): modulate surface_hidden with a
+        # learned affine transform whose (gamma, beta) come from the pooled
+        # volume context. Cost is O(N_surface) — one masked mean over volume
+        # tokens plus a broadcast multiply-add. Identity at step 0 via zero-init
+        # of film_projector.
+        if (
+            self.film_projector is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            vol_mask_f = volume_mask.to(dtype=volume_hidden.dtype).unsqueeze(-1)
+            vol_sum = (volume_hidden * vol_mask_f).sum(dim=1)
+            vol_count = vol_mask_f.sum(dim=1).clamp(min=1.0)
+            vol_ctx = vol_sum / vol_count  # (B, n_hidden)
+            film_params = self.film_projector(vol_ctx)  # (B, 2*n_hidden)
+            gamma, beta = film_params.chunk(2, dim=-1)  # each (B, n_hidden)
+            surface_hidden = (1 + gamma.unsqueeze(1)) * surface_hidden + beta.unsqueeze(1)
+            surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_film_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_film_decoder": (
+            "Enable FiLM conditioning of the surface decoder by a pooled "
+            "volume context (PR #1270 / H103). After the shared backbone "
+            "(and any surf->vol xattn), the masked mean of volume_hidden "
+            "is projected to (gamma, beta) via a single Linear(n_hidden, "
+            "2*n_hidden) and applied as surface_hidden = (1+gamma) * "
+            "surface_hidden + beta before surface_out. Zero-init of the "
+            "projector keeps the layer identity at init. O(N_surface) cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_film_decoder=config.use_film_decoder,
     )
 
 
@@ -773,7 +784,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_film_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**Wave 33 H103: VOLUME-CONTEXT-FILM-DECODER — Pooled volume context modulates surface decoder via FiLM at O(N) cost**

The background: H98v2 (SURFACE-LATE-LAYER-SPLIT) was infeasible-as-spec because self-attention on N=65,536 surface tokens is O(N²), crashing throughput to 0.385 it/s vs baseline 1.25 it/s. Only ~2.3 epochs feasible in timeout — not a valid comparison. Mechanism closed as **compute-envelope infeasible**.

The core insight behind H98v2 was sound: **strengthening surface-token representation via post-backbone processing, particularly with volume context**. H103 preserves that insight at O(N) cost via Feature-wise Linear Modulation (FiLM).

**Mechanism — FiLM decoder:**
FiLM (Perez et al. 2018, "FiLM: Visual Reasoning with a General Conditioning Layer") conditions a feature map on external context via learned affine transform:
```
surface_hidden_conditioned = γ(vol_ctx) * surface_hidden + β(vol_ctx)
```
where (γ, β) are predicted from a pooled volume context vector, not from per-token interactions. Cost: one global pool + one MLP + one broadcast multiply-add = O(N) in surface tokens, vs O(N×M) for cross-attention.

**Architecture:**
1. Pool `volume_hidden` → scalar context: `vol_ctx = volume_hidden.mean(dim=1)` → shape (B, n_hidden)
2. Project to FiLM params: `film_params = film_projector(vol_ctx)` → shape (B, 2*n_hidden) 
3. Split: `γ, β = film_params.chunk(2, dim=-1)` → each (B, n_hidden)
4. Modulate: `surface_hidden = (1 + γ.unsqueeze(1)) * surface_hidden + β.unsqueeze(1)` — additive residual form
5. `surface_out(surface_hidden_conditioned)` proceeds as before

**Identity at init via zero-init:**
- `nn.init.zeros_(film_projector.weight)` AND `nn.init.zeros_(film_projector.bias)` 
- At step 0: γ=0, β=0 → `surface_hidden_conditioned = (1+0)*surface_hidden + 0 = surface_hidden` — exact identity. Training starts from canonical baseline.

**Why this axis is motivated:**
H97 (alphonse, BIDIRECTIONAL-XATTN) is attacking the same vol→surf information flow with full cross-attention (O(N×M) per-token). H97's early signal at EP2 is the STRONGEST in the Wave 33 fleet (−2.72pp ahead of canonical). FiLM is a lighter alternative: global volume context modulates surface features rather than per-point attention. If H97 wins because of the volume-context-to-surface information pathway, FiLM should also win and be cheaper. If H97 wins because of per-token local vol→surf specificity, FiLM will likely underperform — providing a diagnostic that cleanly delineates GLOBAL vs LOCAL volume context.

**Param cost:** `nn.Linear(n_hidden, 2*n_hidden)` = 512×1024 + 1024 = **525K params** — comparable to H102/H104.

**O(N) throughput guarantee:** One pool + one matmul (B×512→B×1024) + one broadcast multiply-add (B×N×512). No quadratic terms. Baseline throughput expected.

## Instructions

### Code changes — `target/model.py`

1. Add `use_film_decoder: bool = False` to `SurfaceTransolver.__init__` signature.

2. After `self.surface_out` construction (around line 489, inside `use_aux_decoder_heads` branch), add:
   ```python
   self.use_film_decoder = use_film_decoder
   if self.use_film_decoder:
       self.film_projector = nn.Linear(n_hidden, 2 * n_hidden)
       nn.init.zeros_(self.film_projector.weight)
       nn.init.zeros_(self.film_projector.bias)
   ```

3. In the `forward` method, AFTER `surface_hidden` and `volume_hidden` are computed (around line 603, after the surf_to_vol_xattn block), add:
   ```python
   # Apply FiLM conditioning of surface_hidden from pooled volume context
   if self.use_film_decoder and volume_hidden.shape[1] > 0:
       vol_ctx = volume_hidden.mean(dim=1)  # (B, n_hidden)
       film_params = self.film_projector(vol_ctx)  # (B, 2*n_hidden)
       gamma, beta = film_params.chunk(2, dim=-1)  # each (B, n_hidden)
       surface_hidden = (1 + gamma.unsqueeze(1)) * surface_hidden + beta.unsqueeze(1)
   ```
   Insert this BEFORE the `surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)` line.

4. **No changes to forward pass signature or output shape.** API stays the same.

### Code changes — `target/train.py`

Add CLI flag:
```python
parser.add_argument(
    "--use-film-decoder",
    action="store_true",
    default=False,
    help="Condition surface decoder via FiLM from pooled volume context (H103)",
)
```

Pass through:
```python
model = SurfaceTransolver(
    ...
    use_film_decoder=args.use_film_decoder,
    ...
)
```

### Smoke test recommendation

Before launching the full run, verify identity at init with a quick check:
```python
# after model init, before any training step
assert model.film_projector.weight.norm() == 0.0, "FiLM projector not zero-init"
assert model.film_projector.bias.norm() == 0.0, "FiLM projector bias not zero-init"
```

Also confirm throughput is ~baseline (1.2-1.3 it/s) with a 2-GPU 100-step smoke test before launching the 8-GPU run.

### Training command (DDP 8 GPUs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-film-decoder \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name askeladd/h103-volume-context-film-decoder \
  --wandb-group wave33_h103_volume_context_film_decoder
```

### What to report (terminal SENPAI-RESULT comment)

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS_x/y/z + matching test_)
2. **Param count delta** vs canonical: should be ~+525K (512×1024 + 1024 bias)
3. **Throughput confirmation**: steps/sec at EP1 — confirm no O(N²) blowup (expect ~1.2-1.3 it/s)
4. **FiLM γ/β norm** at terminal: report `film_projector.weight.norm()` — indicates if the mechanism engaged at all
5. **Comparison with H97 (alphonse, BIDIRECTIONAL-XATTN)**: when both terminal, note which vol→surf information pathway is stronger (global FiLM pooling vs per-token attention)

## Baseline

Single-model corrected-split baseline (PR #972 nezuko, run `zxnhtagj`):
- **val_abupt: 6.126%** (merge gate)
- test_abupt: 5.844%
- test_VP: 3.643% (floor) ; test_SP: 3.577% (floor) ; test_WSS: 6.727% (goal)
- test_WSS_x/y/z: 5.962/7.435/8.945

**Wave 32 best-in-class:**
- H87 (surf_loss=1.5) terminal: val_abupt 6.045% CLEAR gate, test_VP 3.495% CROSS, test_SP 3.734% (B PARTIAL HISTORIC)
- H89 (depth=6) terminal: val_abupt 6.119% CLEAR, test_VP 3.482% DEEPEST CROSS (B PARTIAL HISTORIC)
- H91 (slices=192): val_abupt 6.175% MISS +0.049pp, test_WSS_z 8.95% FLEET-BEST (B PARTIAL)

**Wave 33 in-flight:**
- H96 fern (PR #1261): WSS-DEDICATED-DECODER-HEAD running
- H97 alphonse (PR #1262): BIDIRECTIONAL-XATTN — **strongest EP2 signal −2.72pp** (the vol→surf attention pair to H103 global pooling)
- H99 frieren (PR #1264): SURFACE-OUT-DEEPER-MLP
- H100 thorfinn (PR #1265): WSS-Z-DEDICATED-HEAD
- H101 nezuko (PR #1266): GEOM-RESIDUAL-DECODER
- H102 tanjiro (PR #1268): SURFACE-OUT-WIDER-MLP
- H104 edward (PR #1269): VOLUME-OUT-WIDER-MLP

## Success criteria

- **A WIN merge**: val_abupt < 6.126% AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
- **B PARTIAL**: val gate clear OR significant test channel cross
- **Key mechanism signal**: test_SP < 3.70% first crack of 11-variant Wave 32 plateau AND/OR test_WSS_z < 8.5% deepest binding axis crack
- **FiLM vs H97 comparison**: H103 global-pool FiLM vs H97 per-token attention — this is a **canonical global-vs-local vol→surf information pathway comparison**, whichever wins steers Wave 34 architecture design for all future vol→surf attacks

H103 is a clean, low-risk, physically motivated mechanism that closes the gap between H98v2's infeasibility and H97's expensive per-token attention. It attacks the same information pathway as H97 (volume context → surface decoder) at O(N) cost. Welcome back to Wave 33, askeladd.
