### PR TITLE
Wave 33 H105: SURFACE-NORMAL-RESIDUAL-DECODER — Inject raw normals as zero-init residual to surface_hidden

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_normal_residual_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_normal_residual_decoder = use_normal_residual_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,21 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Wave 33 H105: zero-init Linear(3, n_hidden) projection of raw
+        # surface normals (surface_x[..., 3:6]) added as a residual to
+        # surface_hidden BEFORE self.surface_out. Identity at init so
+        # baseline is preserved at step 0; model learns to inject explicit
+        # normal information directly at the decoder during training.
+        # Mirror of H101 (positions) with WSS-physics-direct content:
+        # tau = mu (du_tangential / dn), so n is the differential operator
+        # argument.
+        if use_normal_residual_decoder:
+            self.normal_residual_proj = nn.Linear(3, n_hidden, bias=True)
+            nn.init.zeros_(self.normal_residual_proj.weight)
+            nn.init.zeros_(self.normal_residual_proj.bias)
+        else:
+            self.normal_residual_proj = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -622,6 +639,15 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            # Wave 33 H105: inject raw surface normals as zero-init residual
+            # at decoder input. Identity at step 0; model learns to use
+            # explicit normal info bypassing slice-attention compression
+            # bottleneck. Surface mask is applied to surface_preds below,
+            # so masked-out points have no downstream effect.
+            if self.normal_residual_proj is not None and surface_x.shape[1] > 0:
+                surface_hidden = surface_hidden + self.normal_residual_proj(
+                    surface_x[..., 3:6]
+                )
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_normal_residual_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_normal_residual_decoder": (
+            "Wave 33 H105: add zero-init Linear(3, n_hidden) projection of "
+            "raw surface normals surface_x[..., 3:6] as a residual to "
+            "surface_hidden BEFORE self.surface_out. Identity at init "
+            "(weight and bias zero) so baseline is preserved at step 0. "
+            "Param cost ~1.5K. Mirror of H101 geom-residual (positions) "
+            "with WSS-physics-direct content: n is the differential "
+            "operator argument in tau = mu (du_tang / dn)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_normal_residual_decoder=config.use_normal_residual_decoder,
     )
 
 
@@ -773,7 +784,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # H105 normal_residual_proj is also gated on surface_x being
+            # present and non-empty; same DDP unused-param hazard as the
+            # surf->vol xattn block above.
+            if config.use_surf_to_vol_xattn or config.use_normal_residual_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**Wave 33 entry — second cheap-information-axis attack on decoder input (mirror of H101 nezuko with normals instead of positions).**

Add a **zero-initialized linear projection from raw surface normals `surface_x[..., 3:6]` (3D unit vectors) to n_hidden=512**, added as a residual to `surface_hidden` BEFORE `self.surface_out`. At init the residual is identically zero (zero-init linear), preserving baseline at step 0. During training, the model learns to use raw boundary-normal information directly at the decoder, bypassing the slice-attention compression bottleneck.

Param cost: **~1,536 params** (Linear 3 → 512), negligible vs canonical 17.40M.

## Why this should work (physics-direct mechanism)

**The boundary normal is the variable of differentiation in wall shear stress**:

τ = μ (∂u_tangential / ∂**n̂**)

where μ is dynamic viscosity, u_tangential is tangential velocity, and n̂ is the unit normal to the surface. WSS is **definitionally** a normal-direction derivative. Without explicit normal information at the decoder, the model must INFER local boundary orientation from compressed slice tokens — which lose per-point orientation specifically (slice attention pools by xyz position into 128 learned slices).

**Surface_x is already 7-dim**: `xyz(3) + normals(3) + panel_area(1)`. Normals are computed at mesh preprocessing and pass into the model. They're consumed by the input projection (`surface_in`) at the encoder, but get COMPRESSED through 5 transformer layers + slice attention into 128 slice tokens (65,536 surface points → 128 slice tokens = 512× compression). Per-point normal info is NOT preserved at the decoder.

**H101 (nezuko, in-flight) is currently validating this axis with positions**:
- H101 mechanism: `surface_x[..., :3]` (raw positions) → zero-init Linear → n_hidden residual at decoder
- At step 38,196 (54%): val_abupt **6.5509%** competitive with H97 bidir-xattn (6.475% at +1M params)
- H101 is +1.5K params; H97 is +1M params — **660× param-cost ratio, val_abupt spread 0.076pp** at matched mid-cosine phase
- This is **strong evidence that decoder bottleneck is INFORMATIONAL, not CAPACITY-bound**

**H105 attacks the same axis with the most physics-essential signal for WSS**: explicit normal vectors. Compound logic:
- H101 (positions) gives spatial **location** discrimination
- H105 (normals) gives boundary **orientation** discrimination — the differential operator argument for τ
- Together they would give the decoder full local **differential geometry** (position + tangent frame)

## Why this is orthogonal to all in-flight Wave 33

| PR    | Mechanism                              | Param cost | Class                |
|-------|----------------------------------------|-----------:|----------------------|
| H97   | bidirectional vol↔surf cross-attention | +1M        | decoder input (info, per-token attn)|
| H99   | surface_out 3-layer (deeper MLP)        | +250K      | decoder internal (capacity, depth)|
| H100  | wss_z dedicated head + groupnorm        | +260K      | decoder output (task-specific)|
| H101  | positions raw residual to surface_hidden | +1.5K      | decoder input (info, geom-position)|
| H102  | surface_out hidden 1024 (wider MLP)      | +266K      | decoder internal (capacity, width)|
| H103  | FiLM γ,β from pooled volume_hidden       | +525K      | decoder modulation (info, global-pool vol)|
| H104  | volume_out hidden 2× (wider funnel)       | +229K      | decoder internal (vol capacity, width)|
| **H105** | **normals raw residual to surface_hidden** | **+1.5K** | **decoder input (info, geom-orientation)** |

H105 is on the same axis as H101 but with **distinct physical content**. WSS-specific motivation is direct (normal = differential operator argument). No overlap with H103 (global pool of volume → FiLM modulation acts multiplicatively, very different mechanism).

## Instructions

Modify `target/model.py` `SurfaceTransolver.__init__` and `SurfaceTransolver.forward`:

### 1. Add CLI flag in `target/train.py`

Add a new boolean argument:
```python
parser.add_argument(
    "--use-normal-residual-decoder",
    action="store_true",
    default=False,
    help="Wave 33 H105: add zero-init linear projection from surface_x[..., 3:6] (normals) to n_hidden as residual to surface_hidden before surface_out.",
)
```

(Audit per memory feedback: confirm the flag is actually added to argparse before launching — phantom flags from refactors crash at startup.)

### 2. In `SurfaceTransolver.__init__` (after `self.surface_out = ...` block, before the `if use_surf_to_vol_xattn:` block at model.py ~line 501):

```python
# Wave 33 H105: zero-init linear projection from surface normals to n_hidden.
# Identity at init (zero residual); model learns to inject normal info directly
# at decoder during training. Param cost +3*n_hidden ≈ 1.5K.
if use_normal_residual_decoder:
    self.normal_residual_proj = nn.Linear(3, n_hidden, bias=True)
    nn.init.zeros_(self.normal_residual_proj.weight)
    nn.init.zeros_(self.normal_residual_proj.bias)
else:
    self.normal_residual_proj = None
```

Also accept `use_normal_residual_decoder: bool = False` in `__init__` signature, and wire it from the train.py builder (matching how other Wave 33 flags are wired — copy the pattern from `use_geom_residual_decoder` if H101 has merged before you start, or from `use_surf_to_vol_xattn` for the canonical pattern).

### 3. In `SurfaceTransolver.forward`, AFTER backbone+norm produces `surface_hidden` and BEFORE `self.surface_out(surface_hidden)`:

```python
# Wave 33 H105: inject raw normals at decoder via zero-init residual.
if self.normal_residual_proj is not None:
    surface_hidden = surface_hidden + self.normal_residual_proj(surface_x[..., 3:6])
```

(Place this AFTER any analogous H101 `geom_residual_proj` line if H101 has merged before you start; the two residuals compose linearly and don't interact.)

### 4. Verify with a tiny smoke test BEFORE submitting full DDP run

Quick sanity check: at step 0, the model must produce **identical** outputs with and without `--use-normal-residual-decoder`. This validates the zero-init identity property.

### 5. Launch full DDP run

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --lr 9e-5 --lr-warmup-epochs 1 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slice-num 128 \
  --use-aux-decoder-heads \
  --use-normal-residual-decoder \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h105-normal-residual-decoder \
  --wandb-run-name "fern_h105_normal_residual_decoder"
```

(All other flags identical to canonical recipe. Use `--lr 9e-5` per the sweet-spot memo; do not change LR.)

## Decision rubric (post-terminal)

| Verdict | val_abupt vs gate 6.126% | test_axis vs floors | Decision |
|---------|-------------------------|--------------------|----------|
| **A WIN** | ≤ 6.126% | AND (test_VP ≤ 3.643 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727) | Merge → new baseline |
| **B PARTIAL** | Misses gate by ≤ +0.20pp | OR any single-flag test_* CROSS floor with no other axis regression > +0.10pp | Hold for compound staging in Wave 34 |
| **C NULL** | Misses gate by +0.20 to +0.40pp | Test channels within ±0.10pp of canonical | Close as inconclusive |
| **D NEGATIVE** | val_abupt > 6.40% OR any test_axis regress > +0.20pp | — | Close as negative |

## Baseline (from BASELINE.md)

| Channel | val (canonical H79) | test (canonical H79) | Floor / Target |
|---------|---:|---:|---:|
| abupt_axis_mean | 6.177% | 5.844% | merge gate 6.126% |
| surface_pressure | 4.097% | 3.5957% | floor 3.577% |
| volume_pressure | 3.601% | 3.643% | floor 3.643% |
| wall_shear | 6.989% | 6.727% | goal 6.727% (Issue #1056 SOTA: 5.85%) |
| wall_shear_x | 6.332% | 5.975% | — |
| wall_shear_y | 7.762% | 7.274% | — |
| wall_shear_z | 9.601% | 8.753% | binding axis |

**Baseline W&B run (canonical reference):** H79 lneicpdc on `senpai-v1-drivaerml-ddp8`.

## Reproduce command for canonical baseline

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --lr 9e-5 --lr-warmup-epochs 1 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slice-num 128 \
  --use-aux-decoder-heads
```

## Operational notes

- Use **DDP 8 GPUs** (canonical fleet recipe). Do NOT change `--lr`, `--batch-size`, `--epochs`, `--lr-warmup-epochs`, or any backbone dim — H105 is a single-flag attack.
- Estimated run time: ~14.5h (same as H101 trajectory; mechanism cost is negligible).
- VRAM: well under 96 GB cap (H101 also uses negligible additional VRAM).
- Pod: `senpai-drivaerml-ddp8-fern-*` (you're already on the right deployment).
- Use the `senpai:poll-for-work` skill to pick up this assignment.
- When terminal, post structured `SENPAI-RESULT` marker as you did for H96.
