### PR TITLE
Wave 33 H106: VOLUME-GEOM-RESIDUAL-DECODER — Zero-init xyz+sdf residual at volume decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_volume_geom_residual_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_volume_geom_residual_decoder = use_volume_geom_residual_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,22 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Wave 33 H106: zero-init Linear(volume_input_dim=4, n_hidden) projection
+        # of raw volume input features (volume_x[..., 0:4] = xyz + sdf) added as
+        # a residual to volume_hidden BEFORE self.volume_out. Identity at init
+        # so baseline is preserved at step 0; model learns to inject explicit
+        # geometric info (positions + signed distance) directly at the volume
+        # decoder during training. Mirror of H101 (surface positions) and H105
+        # (surface normals); extends info-at-decoder-input thesis to volume side.
+        # SDF is the canonical volume-side physics signal (boundary-layer regime,
+        # pressure gradient).
+        if use_volume_geom_residual_decoder:
+            self.volume_geom_residual_proj = nn.Linear(self.volume_input_dim, n_hidden, bias=True)
+            nn.init.zeros_(self.volume_geom_residual_proj.weight)
+            nn.init.zeros_(self.volume_geom_residual_proj.bias)
+        else:
+            self.volume_geom_residual_proj = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -628,6 +646,13 @@ class SurfaceTransolver(nn.Module):
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
 
         if volume_x is not None:
+            # Wave 33 H106: inject raw volume input features (xyz + sdf) as a
+            # zero-init residual at decoder input. Identity at step 0; model
+            # learns to use explicit geometric info bypassing slice-attention
+            # compression bottleneck. Volume mask is applied to volume_preds
+            # below, so masked-out points have no downstream effect.
+            if self.volume_geom_residual_proj is not None and volume_x.shape[1] > 0:
+                volume_hidden = volume_hidden + self.volume_geom_residual_proj(volume_x)
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
         else:
             batch_size = surface_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_volume_geom_residual_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_volume_geom_residual_decoder": (
+            "Wave 33 H106: add zero-init Linear(volume_input_dim=4, n_hidden) "
+            "projection of raw volume input features volume_x[..., 0:4] "
+            "(xyz + sdf) as a residual to volume_hidden BEFORE self.volume_out. "
+            "Identity at init (weight and bias zero) so baseline is preserved "
+            "at step 0. Param cost ~2.5K. Mirror of H101 (surface positions) "
+            "and H105 (surface normals); extends info-at-decoder-input thesis "
+            "to volume side. SDF is the canonical volume-side physics signal "
+            "for boundary-layer regime and pressure-gradient structure."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_volume_geom_residual_decoder=config.use_volume_geom_residual_decoder,
     )
 
 
@@ -773,7 +785,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # H106 volume_geom_residual_proj is also gated on volume_x being
+            # present and non-empty; same DDP unused-param hazard as the
+            # surf->vol xattn block above when a batch is surface-only (N_V=0).
+            if config.use_surf_to_vol_xattn or config.use_volume_geom_residual_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**H106 — VOLUME-GEOM-RESIDUAL-DECODER: zero-init Linear(4 → n_hidden) projecting `volume_x[..., 0:4]` (xyz + sdf) as residual to `volume_hidden` before `volume_out`**

Mirror of H101 (surface positions, +1.5K params, in-flight) and H105 (surface normals, +2K params, in-flight) — extends the **info-at-decoder-input** thesis from the surface decoder to the volume decoder. SDF is the canonical volume-side physics signal (signed distance to nearest body surface determines boundary-layer regime and pressure gradient structure). xyz positions provide raw spatial coordinates orthogonal to any positional-encoding learned in the backbone.

### Wave 33 mechanism class table (this PR completes the 3-axis info-at-input sweep)

| PR | Mechanism | Side | Signal | Params | Status |
|----|-----------|------|--------|--------|--------|
| H101 nezuko #1266 | info-residual | surface | xyz positions [0:3] | +1.5K | in-flight (borderline A WIN) |
| H105 fern #1271 | info-residual | surface | normals [3:6] | +2K | in-flight (mid-cosine) |
| **H106 frieren THIS PR** | **info-residual** | **volume** | **xyz + sdf [0:4]** | **+2.5K** | **NEW** |

If H106 clears gate, the Wave 34 compound priority becomes:
- **H101+H105+H106 (full info-at-input on both decoders)** — predicted strongest compound at < +6K total params
- H101+H106 (positions on both sides) — symmetric info-at-input mirror

### Mechanism rationale

- Backbone slice-attention (128 slice tokens) compresses 65,536 volume points into a coarse latent representation — per-point spatial information is implicitly preserved through positional encoding learnt by the model, but the raw geometric signal (xyz + SDF) is not directly routed to the volume decoder
- A zero-init `Linear(4, n_hidden)` residual at `volume_hidden` (after surf→vol xattn if applicable, before `volume_out`) lets the volume decoder consume **raw spatial coordinates + signed distance to body** without disrupting baseline at step 0
- Identity at init → minimum-disruption A/B test (verified by smoke test that surface_preds + volume_preds are bit-identical at step 0)
- Mirror of H101's mechanism. Closes the "info-at-input" axis: if BOTH H101 (surface positions) and H106 (volume positions+sdf) clear gate, we have proven the info-at-input thesis generalizes across both decoders.

### Predicted axis impact

- **test_VP** (volume pressure, current best 3.643 ≤ floor): direct improvement candidate — SDF provides explicit boundary-distance prior for pressure gradient structure
- **test_abupt** (volume contributes 1/4 of overall): proportional improvement
- **test_WSS_***: indirect (surface-side metric) but bidir surf↔vol xattn (H97 if merged) may propagate volume-decoder improvement to WSS

## Instructions

Implement a new flag `--use-volume-geom-residual-decoder` (default `False`) that:

### 1. `model.py` changes

Add constructor argument and stored attribute (mirror H105 pattern, see commit `3723f08`):

```python
# In SurfaceTransolver.__init__ args:
use_volume_geom_residual_decoder: bool = False,
```

```python
# After other use_* attrs:
self.use_volume_geom_residual_decoder = use_volume_geom_residual_decoder
```

Add the projection layer near the existing `normal_residual_proj` construction (after surf_to_vol_xattn block):

```python
# Wave 33 H106: zero-init Linear(VOLUME_X_DIM=4, n_hidden) projection of
# raw volume input features (volume_x[..., 0:4] = xyz + sdf) added as a
# residual to volume_hidden BEFORE self.volume_out. Identity at init.
# Mirror of H101 (surface positions) and H105 (surface normals), extends
# info-at-decoder-input thesis to volume side. SDF is the canonical
# volume-side physics signal (boundary-layer regime, pressure gradient).
if use_volume_geom_residual_decoder:
    self.volume_geom_residual_proj = nn.Linear(self.volume_input_dim, n_hidden, bias=True)
    nn.init.zeros_(self.volume_geom_residual_proj.weight)
    nn.init.zeros_(self.volume_geom_residual_proj.bias)
else:
    self.volume_geom_residual_proj = None
```

In `forward`, inject the residual into `volume_hidden` after the optional surf→vol xattn and before `volume_out`. The injection block lives between the existing xattn application (around `volume_hidden = self.surf_to_vol_xattn_norm(...)` / `_apply_token_mask(...)`) and `volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)`:

```python
if volume_x is not None:
    # Wave 33 H106: inject raw volume input (xyz + sdf) as zero-init residual
    # at decoder input. Identity at step 0; model learns to use explicit
    # geometric info bypassing slice-attention compression bottleneck.
    if self.volume_geom_residual_proj is not None and volume_x.shape[1] > 0:
        volume_hidden = volume_hidden + self.volume_geom_residual_proj(volume_x)
    volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
else:
    volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
```

**Important — DDP find_unused_parameters:** mirror H105's handling. When the flag is on AND a batch is surface-only (`N_V = 0`), the projection participates in the autograd graph but receives no gradient — set `find_unused_parameters=True` for that DDP wrap path. Inspect H105's `train.py` changes for the exact spelling.

### 2. `train.py` changes

Add the CLI argument and pass through to model construction:

```python
# in argparse:
parser.add_argument("--use-volume-geom-residual-decoder", action="store_true",
                    help="Wave 33 H106: zero-init residual from volume_x (xyz+sdf) to volume_hidden")
```

```python
# in model construction kwargs:
use_volume_geom_residual_decoder=args.use_volume_geom_residual_decoder,
```

Mirror H105's `train.py` find_unused_parameters logic gate.

### 3. Smoke test

Before kicking off the full run, verify identity at init: run forward pass at step 0 with the flag on, confirm `volume_preds` is bit-identical to flag-off baseline. (Same as H105's verification.)

### 4. Train command (DDP 8 GPUs)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-volume-geom-residual-decoder \
  --lr 9e-5 \
  --batch-size 4 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name frieren/h106-volume-geom-residual-decoder \
  --wandb-group h106-volume-geom-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

Verify exact flag spellings with `python train.py --help` before kickoff.

## Baseline

**Single-model merge gate:** val_abupt < **6.126%** AND test_VP ≤ **3.643%** AND test_SP ≤ **3.577%** AND test_WSS ≤ **6.727%**.

**Baseline reference run (canonical):** `56bcqp3m`
- val_abupt 6.126%, val_VP ~3.4, val_SP ~3.7, val_WSS ~6.5
- test_abupt 5.844%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%, test_WSS_x/y/z = 5.83 / 7.10 / 9.83

**Canonical val→test slope:** −0.282pp typical (val_abupt → test_abupt).

**Wave 33 fleet snapshot at H106 kickoff (in-flight, mid/late-cosine):**
- H97 alphonse (bidir-xattn +1M): val_abupt 6.211% at 91.6% → borderline A WIN
- H100 thorfinn (wss_z-head +260K): val_abupt 6.298% at 92.3% → B PARTIAL likely
- H101 nezuko (surface-positions-residual +1.5K): val_abupt 6.231% at 90.8% → borderline A WIN (most parameter-efficient candidate)
- H102 tanjiro (surface-width +266K): val_abupt **6.176%** at 84.6% → **A WIN trajectory** (FLEET LEADER)
- H103 askeladd (FiLM +525K): val_abupt 6.440% at 82.1% → C NULL likely
- H104 edward (volume-width +229K): val_abupt 6.243% at 82.2% → borderline A WIN
- H105 fern (surface-normals-residual +2K): val_abupt 6.565% at 56.4% mid-cosine

If H102/H101 merge during H106 in-flight, rebase H106 onto new tay baseline.

## Falsifiable outcomes

| Outcome | Signal | Action |
|---|---|---|
| **A WIN** | val_abupt < 6.126% AND all test floors hold | Merge → new baseline → Wave 34 compound H101+H105+H106 (full info-at-input sweep) |
| **B PARTIAL** | val_abupt < 6.20% OR single-flag test floor cross | Wave 34 stage as compound member |
| **C NULL** | val_abupt 6.20-6.40%, all channels neutral | Close — info-at-input bounded to surface-side only |
| **D NEG** | val_abupt > 6.40% OR test regression on volume metrics | Close — volume_hidden disrupted by raw input injection |

**Expected mid-cosine signal (EP3, step ~32,594):** val_abupt 5.0-5.5% range (matching H101's EP3 ~5.2%), val_VP < 4.0% (volume metric strongest early indicator).

**Reproduce command (full):**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-volume-geom-residual-decoder --lr 9e-5 --batch-size 4 --epochs 13 \
  --lr-warmup-epochs 1 --ema-decay 0.999 --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name frieren/h106-volume-geom-residual-decoder \
  --wandb-group h106-volume-geom-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```
