### PR TITLE
Wave 33 H107: SURFACE-GLOBAL-CONTEXT-RESIDUAL-DECODER — Zero-init self-pool additive residual at surface decoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surface_global_context_residual: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surface_global_context_residual = use_surface_global_context_residual
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,22 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Wave 33 H107: zero-init Linear(n_hidden, n_hidden) projection of the
+        # mask-aware mean-pooled surface_hidden, broadcast as an additive
+        # residual to per-token surface_hidden BEFORE self.surface_out.
+        # Identity at init (zero weight and bias) so baseline is preserved
+        # at step 0; model learns to consume global surface context
+        # (flow regime, body geometry summary) at the per-token decoder.
+        # NEW mechanism class: self-context-at-decoder. Different from H103
+        # (FiLM, volume-pool, multiplicative) and from H101/H105 (raw input
+        # features, info-at-input). Source = surface self-pool, combine = add.
+        if use_surface_global_context_residual:
+            self.surface_global_context_proj = nn.Linear(n_hidden, n_hidden, bias=True)
+            nn.init.zeros_(self.surface_global_context_proj.weight)
+            nn.init.zeros_(self.surface_global_context_proj.bias)
+        else:
+            self.surface_global_context_proj = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -622,6 +640,18 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            # Wave 33 H107: inject mask-aware mean-pooled surface_hidden as
+            # a zero-init additive residual broadcast to per-token
+            # surface_hidden. Identity at step 0; lets the per-token
+            # decoder consume global surface context (flow regime, body
+            # geometry summary) that is otherwise lost between slice
+            # compression and the per-point output head.
+            if self.surface_global_context_proj is not None and surface_hidden.shape[1] > 0:
+                mask_f = surface_mask.unsqueeze(-1).to(surface_hidden.dtype)
+                mask_sum = mask_f.sum(dim=1).clamp(min=1.0)
+                pooled = (surface_hidden * mask_f).sum(dim=1) / mask_sum
+                context_residual = self.surface_global_context_proj(pooled).unsqueeze(1)
+                surface_hidden = surface_hidden + context_residual
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/scripts/h107_smoke_identity.py
+++ b/scripts/h107_smoke_identity.py
@@ -1,0 +1,126 @@
+"""H107 identity-at-init smoke test.
+
+Builds two SurfaceTransolver instances with identical seeds — one with the
+flag off, one with the flag on — and verifies that `surface_preds`,
+`volume_preds`, and `surface_hidden` are bit-identical at step 0. Also
+checks: (a) the projection params exist when on / absent when off,
+(b) param-count delta matches the predicted +n_hidden*(n_hidden+1).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import torch
+
+from model import SurfaceTransolver
+
+
+def build(seed: int, *, flag: bool, n_hidden: int = 64) -> SurfaceTransolver:
+    torch.manual_seed(seed)
+    return SurfaceTransolver(
+        n_layers=2,
+        n_hidden=n_hidden,
+        n_head=2,
+        mlp_ratio=4,
+        slice_num=32,
+        use_aux_decoder_heads=True,
+        use_surface_global_context_residual=flag,
+    )
+
+
+def count_params(m: torch.nn.Module) -> int:
+    return sum(p.numel() for p in m.parameters())
+
+
+def main() -> int:
+    n_hidden = 64
+    n_surf = 17
+    n_vol = 23
+    batch = 2
+
+    model_off = build(0, flag=False, n_hidden=n_hidden).eval()
+    model_on = build(0, flag=True, n_hidden=n_hidden).eval()
+
+    # 1. Flag-off projection must not exist.
+    assert model_off.surface_global_context_proj is None
+    assert model_on.surface_global_context_proj is not None
+
+    # 2. Zero-init: both weight and bias must be exactly zero.
+    proj = model_on.surface_global_context_proj
+    assert torch.equal(proj.weight, torch.zeros_like(proj.weight))
+    assert torch.equal(proj.bias, torch.zeros_like(proj.bias))
+
+    # 3. Param-count delta = n_hidden * n_hidden + n_hidden.
+    expected_delta = n_hidden * n_hidden + n_hidden
+    actual_delta = count_params(model_on) - count_params(model_off)
+    assert actual_delta == expected_delta, (
+        f"param delta mismatch: expected {expected_delta}, got {actual_delta}"
+    )
+
+    # 4. Inputs.
+    torch.manual_seed(123)
+    surface_x = torch.randn(batch, n_surf, model_on.surface_input_dim)
+    surface_mask = torch.ones(batch, n_surf, dtype=torch.bool)
+    surface_mask[0, -3:] = False  # ragged mask on rank 0
+    volume_x = torch.randn(batch, n_vol, model_on.volume_input_dim)
+    volume_mask = torch.ones(batch, n_vol, dtype=torch.bool)
+    volume_mask[1, -5:] = False
+
+    with torch.no_grad():
+        out_off = model_off(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        out_on = model_on(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+
+    # 5. surface_preds, volume_preds, surface_hidden must match exactly.
+    for k in ("surface_preds", "volume_preds", "surface_hidden", "volume_hidden"):
+        a, b = out_off[k], out_on[k]
+        assert a.shape == b.shape, f"{k}: shape mismatch {a.shape} vs {b.shape}"
+        max_abs = (a - b).abs().max().item()
+        assert max_abs == 0.0, f"{k}: not bit-identical at init (max_abs={max_abs})"
+
+    # 6. Volume-only path: surface_x=None must still work (gate avoids proj).
+    with torch.no_grad():
+        out_vol_only_on = model_on(volume_x=volume_x, volume_mask=volume_mask)
+        out_vol_only_off = model_off(volume_x=volume_x, volume_mask=volume_mask)
+    for k in ("surface_preds", "volume_preds"):
+        a, b = out_vol_only_off[k], out_vol_only_on[k]
+        assert a.shape == b.shape, f"volume-only {k}: shape mismatch {a.shape} vs {b.shape}"
+        if a.numel() == 0:
+            continue
+        max_abs = (a - b).abs().max().item()
+        assert max_abs == 0.0, f"volume-only {k}: not bit-identical (max_abs={max_abs})"
+
+    # 7. Non-identity post-training (perturb weights): outputs should differ.
+    with torch.no_grad():
+        model_on.surface_global_context_proj.weight.add_(
+            torch.randn_like(model_on.surface_global_context_proj.weight) * 0.01
+        )
+        out_on_perturbed = model_on(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+    diff = (out_on_perturbed["surface_preds"] - out_off["surface_preds"]).abs().max().item()
+    assert diff > 0.0, "after perturbing proj weights, outputs should differ"
+
+    print("H107 smoke test PASSED")
+    print(f"  param_delta = {actual_delta} (expected {expected_delta})")
+    print(f"  surface_preds shapes: off={out_off['surface_preds'].shape} on={out_on['surface_preds'].shape}")
+    print(f"  identity-at-init: bit-identical across surface_preds, volume_preds, surface_hidden, volume_hidden")
+    print(f"  post-perturbation diff: {diff:.6e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_global_context_residual: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surface_global_context_residual": (
+            "Wave 33 H107: add zero-init Linear(n_hidden, n_hidden) "
+            "projection of the mask-aware mean-pooled surface_hidden, "
+            "broadcast as an additive residual to per-token surface_hidden "
+            "BEFORE self.surface_out. Identity at init (weight and bias "
+            "zero) so baseline is preserved at step 0. NEW mechanism class "
+            "self-context-at-decoder: lets the per-token surface decoder "
+            "consume global surface context (flow regime, body geometry) "
+            "that is otherwise lost between slice compression and the "
+            "per-point output head. Different from H103 (FiLM volume-pool "
+            "multiplicative) and H101/H105 (raw input features at input)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_global_context_residual=config.use_surface_global_context_residual,
     )
 
 
@@ -773,7 +787,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # H107 surface_global_context_proj is gated on surface_hidden
+            # being non-empty (N_S > 0); volume-only views (N_S = 0) skip
+            # the residual, leaving the projection's params with no
+            # gradient. Same DDP unused-param hazard as the surf->vol
+            # xattn above, so the same find_unused_parameters fix applies.
+            if config.use_surf_to_vol_xattn or config.use_surface_global_context_residual:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**H107 — SURFACE-GLOBAL-CONTEXT-RESIDUAL-DECODER: zero-init Linear(n_hidden → n_hidden) projecting globally-pooled `surface_hidden` as additive residual to per-token `surface_hidden` before `surface_out`**

NEW Wave 33 mechanism class — **SELF-CONTEXT-AT-DECODER**. Orthogonal to all 8 currently-in-flight Wave 33 mechanisms (width, info-at-input, bidirectional-xattn, FiLM, depth/task-head closed). Tests whether the per-token surface decoder is missing access to **global surface context** (whole-body flow regime, geometry summary) that is implicitly encoded in slice-tokens but not directly available at the decoder.

### Wave 33 mechanism class table (with H107 slotting into new class)

| PR | Mechanism class | Mechanism | Side | Params | Verdict / Status |
|----|-----------------|-----------|------|--------|------------------|
| H97 alphonse #1262 | bidirectional-xattn | vol↔surf info-flow | both | +1M | in-flight (borderline A WIN, val 6.211% at 91.6%) |
| H102 tanjiro #1268 | width | surface_out hidden 1×→2× | surface | +266K | **🟢 GATE CRACKED val 6.124%** at 94.8% — A WIN/B PARTIAL projected |
| H104 edward #1269 | width | volume_out hidden 1×→2× | volume | +229K | in-flight (borderline B PARTIAL, val 6.196% at 92.8%) |
| H101 nezuko #1266 | info-at-input | positions [0:3] | surface | +1.5K | in-flight (borderline A WIN, val 6.231% at 90.8%) |
| H105 fern #1271 | info-at-input | normals [3:6] | surface | +2K | mid-cosine (val 6.565% at 56.4%) |
| H106 frieren #1276 | info-at-input | xyz+sdf [0:4] | volume | +2.5K | just kicked off |
| H103 askeladd #1270 | FiLM (vol-context modulation) | γ,β on surface | cross | +525K | in-flight (C NULL likely, val 6.361%) |
| **H107 thorfinn THIS PR** | **🟣 self-context** (NEW CLASS) | **pooled-surface additive** | **surface** | **+262K** | **NEW** |

### Mechanism rationale

- Backbone slice-attention compresses 65,536 surface points into 128 slice tokens. Per-point features at decoder reflect local slice memberships plus residual self-attention context.
- **Global self-context** (e.g., overall flow regime, body geometry summary, scale-invariant yaw/inlet conditions) is implicitly encoded in the slice tokens but is NOT directly accessible at the per-token decoder query.
- A zero-init Linear(n_hidden → n_hidden) on globally mean-pooled `surface_hidden`, broadcast as additive residual to per-token `surface_hidden`, lets the decoder learn to consume global surface context **without disrupting baseline at step 0**.
- Different from H103 (FiLM, multiplicative, **volume**-pooled context → surface): H107 uses **surface** self-pool with **additive** residual. Different signal source AND different combine.
- Different from H101/H105/H106 (info-at-INPUT): H107 is **context-at-decoder-internal-state** sourced from global pool, not raw input features.

### Predicted axis impact

- **test_SP**: direct improvement candidate — surface pressure has strong global dependence (Bernoulli, body-wide pressure field). Per-point SP prediction benefits from global flow regime context. Plateau of 11 variants 3.78-3.95% range may finally crack.
- **test_WSS_***: indirect — local shear depends on local boundary layer, not global flow. Modest benefit expected.
- **test_VP**: minimal — volume decoder untouched.
- **test_abupt**: proportional to SP+WSS improvements.

## Instructions

Implement a new flag `--use-surface-global-context-residual` (default `False`) that:

### 1. `model.py` changes (mirror H105 pattern, see commit `3723f08`)

Add constructor argument and stored attribute in `SurfaceTransolver.__init__`:

```python
# In __init__ args:
use_surface_global_context_residual: bool = False,
```

```python
# After other use_* attrs:
self.use_surface_global_context_residual = use_surface_global_context_residual
```

Add the projection layer (zero-init for identity-at-init):

```python
# Wave 33 H107: zero-init Linear(n_hidden, n_hidden) projection of
# globally-pooled surface_hidden, broadcast as additive residual to
# per-token surface_hidden BEFORE self.surface_out. Identity at init.
# NEW mechanism class: self-context-at-decoder. Different from H103
# (FiLM volume-pooled multiplicative modulation) — H107 uses
# surface-self-pool with additive residual. Lets per-token decoder
# learn to consume global flow regime / body-geometry summary.
if use_surface_global_context_residual:
    self.surface_global_context_proj = nn.Linear(n_hidden, n_hidden, bias=True)
    nn.init.zeros_(self.surface_global_context_proj.weight)
    nn.init.zeros_(self.surface_global_context_proj.bias)
else:
    self.surface_global_context_proj = None
```

In `forward`, inject the context residual into `surface_hidden` AFTER the existing surface_hidden is computed (line ~603) and BEFORE `surface_out` is applied (line ~625):

```python
if surface_x is not None:
    # Wave 33 H107: inject global surface context as zero-init residual.
    # Identity at step 0; model learns to use global summary as per-token
    # decoder context.
    if self.surface_global_context_proj is not None and surface_x.shape[1] > 0:
        # Mean-pool over surface tokens, respecting the surface mask.
        # surface_mask is shape [B, N_S] (1 for valid, 0 for padded).
        mask_sum = surface_mask.sum(dim=1, keepdim=True).clamp(min=1.0)  # [B, 1]
        pooled = (surface_hidden * surface_mask.unsqueeze(-1)).sum(dim=1) / mask_sum  # [B, n_hidden]
        context_residual = self.surface_global_context_proj(pooled).unsqueeze(1)  # [B, 1, n_hidden]
        surface_hidden = surface_hidden + context_residual  # broadcast add to [B, N_S, n_hidden]
    surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
else:
    ...
```

**Important — DDP find_unused_parameters:** mirror H105's handling. When the flag is on AND a batch is volume-only (`N_S = 0`), the projection participates in the autograd graph but receives no gradient — set `find_unused_parameters=True` for that DDP wrap path. Inspect H105's `train.py` changes for the exact spelling.

### 2. `train.py` changes

Add the CLI argument and pass through to model construction:

```python
parser.add_argument("--use-surface-global-context-residual", action="store_true",
                    help="Wave 33 H107: zero-init residual from globally-pooled surface_hidden to per-token surface_hidden before surface_out")
```

```python
# In model construction:
use_surface_global_context_residual=args.use_surface_global_context_residual,
```

Mirror H105's `train.py` find_unused_parameters gating.

### 3. Smoke test

Before kicking off the full run, verify identity at init: run a forward pass at step 0 with the flag on, confirm `surface_preds` is bit-identical to flag-off baseline. (Same as H105's pattern.)

### 4. Train command (DDP 8 GPUs)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-surface-global-context-residual \
  --lr 9e-5 \
  --batch-size 4 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name thorfinn/h107-surface-global-context-residual-decoder \
  --wandb-group h107-surface-global-context-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

Verify exact flag spellings with `python train.py --help` before kickoff.

## Baseline

**Single-model merge gate:** val_abupt < **6.126%** AND test_VP ≤ **3.643%** AND test_SP ≤ **3.577%** AND test_WSS ≤ **6.727%**.

**Baseline reference run (canonical):** `56bcqp3m`
- val_abupt 6.126%, test_abupt 5.844%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%
- test_WSS_x/y/z = 5.83 / 7.10 / 9.83

**Canonical val→test slope:** −0.282pp typical.

**Wave 33 fleet at H107 kickoff (8/8 WIP):**
- H97 alphonse (bidir-xattn +1M): val 6.211% at 91.6% — borderline A WIN
- H101 nezuko (surf-positions +1.5K): val 6.231% at 90.8% — borderline A WIN (cheapest)
- H102 tanjiro (surf-width +266K): **val 6.124% at 94.8% — 🟢 GATE CRACKED, A WIN trajectory** (LEADER)
- H103 askeladd (FiLM +525K): val 6.361% at 92.6% — C NULL likely
- H104 edward (vol-width +229K): val 6.196% at 92.8% — borderline B PARTIAL (best val_VP 3.606%)
- H105 fern (surf-normals +2K): val 6.565% at 56.4% — mid-cosine, matched-phase tied H101
- H106 frieren (vol-info-residual +2.5K): just kicked off (~14h ETA)
- **H107 thorfinn THIS PR** (surf-global-context +262K): NEW

If H102 merges to baseline during H107 in-flight, rebase H107 onto the new baseline. The mechanism is independent of H102's width axis — it adds a different decoder enhancement direction.

## Falsifiable outcomes

| Outcome | Signal | Action |
|---|---|---|
| **A WIN** | val_abupt < 6.126% AND all test floors hold | Merge → Wave 34 compound H102+H107 (width + context) |
| **B PARTIAL** | val_abupt < 6.20% OR test_SP cross floor 3.577 (11-plateau crack) | Wave 34 stage |
| **C NULL** | val_abupt 6.25-6.40%, all channels neutral | Close — self-context bounded |
| **D NEG** | val_abupt > 6.40% OR strong regression | Close — global-context disruption |

**Key early signal:** if val_SP drops below 5.0% at EP3 step ~32,594 (typically val_SP at EP3 is ~5.2% for canonical), that's a strong indicator that the context-residual is unlocking SP-axis improvement.

**Expected mid-cosine signal (EP6):** val_abupt ~5.7-6.0% range with val_SP ~4.0% range. Compare to H102 surface-wider's EP6 trajectory.

**Reproduce command (full):**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-surface-global-context-residual --lr 9e-5 --batch-size 4 --epochs 13 \
  --lr-warmup-epochs 1 --ema-decay 0.999 --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name thorfinn/h107-surface-global-context-residual-decoder \
  --wandb-group h107-surface-global-context-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```
