### PR TITLE
Wave 33 H108: SURFACE-OUT-PARALLEL-MLP-RESIDUAL-DECODER

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_surface_out_parallel_mlp_residual: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_surface_out_parallel_mlp_residual = use_surface_out_parallel_mlp_residual
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,35 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Wave 33 H108: parallel 2-layer MLP residual on the surface decoder
+        # output. NEW mechanism class: DECODER ENSEMBLE / PARALLEL DIVERSITY.
+        # A second independently-initialized Linear(n_hidden, n_hidden) ->
+        # SiLU -> Linear(n_hidden, surface_output_dim) MLP runs in parallel
+        # to self.surface_out and is summed as a residual contribution.
+        # The output linear is zero-init so the residual is exactly zero
+        # at step 0 (identity preservation); the model learns to use
+        # ensemble-style decoder diversity from warmup onward.
+        #
+        # Contrast with H102 (LEADER, surface_out width 1x->2x) which widens
+        # the SAME MLP path. H108 keeps both paths at original width and
+        # adds a SECOND complete path -- tests whether functional diversity
+        # (two independent function approximators summed) beats capacity
+        # (single wider function approximator) at matched ~265K param cost.
+        if use_surface_out_parallel_mlp_residual:
+            self.surface_out_parallel_mlp = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, self.surface_output_dim),
+            )
+            # Normal init for the first linear (matching surface_out's init
+            # pattern), then zero-init the OUTPUT linear so the residual
+            # contribution is exactly zero at step 0 (identity preservation).
+            self.surface_out_parallel_mlp.apply(_init_linear)
+            nn.init.zeros_(self.surface_out_parallel_mlp[-1].weight)
+            nn.init.zeros_(self.surface_out_parallel_mlp[-1].bias)
+        else:
+            self.surface_out_parallel_mlp = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -622,7 +653,18 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            # Wave 33 H108: add parallel-MLP residual. Zero at step 0
+            # (identity preservation); learns a diverse second decoder
+            # mapping during training. Gated on surface_hidden being
+            # non-empty so volume-only views (N_S = 0) skip the residual;
+            # DDP find_unused_parameters handles that case from train.py.
+            if (
+                self.surface_out_parallel_mlp is not None
+                and surface_hidden.shape[1] > 0
+            ):
+                surface_preds = surface_preds + self.surface_out_parallel_mlp(surface_hidden)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_surface_out_parallel_mlp_residual: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_surface_out_parallel_mlp_residual": (
+            "Wave 33 H108: add a zero-init parallel 2-layer MLP "
+            "(Linear(n_hidden, n_hidden) -> SiLU -> Linear(n_hidden, "
+            "surface_output_dim)) that runs in parallel to self.surface_out "
+            "and is summed as a residual contribution. Output linear is "
+            "zero-init so identity at step 0; ~265K params matched to "
+            "H102 width 1x->2x. NEW mechanism class: DECODER ENSEMBLE / "
+            "PARALLEL DIVERSITY -- tests whether two independently-trained "
+            "decoder paths summed beat a single wider decoder at matched "
+            "cost (functional diversity vs representational capacity)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +320,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_surface_out_parallel_mlp_residual=config.use_surface_out_parallel_mlp_residual,
     )
 
 
@@ -773,7 +786,12 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # H108 surface_out_parallel_mlp is gated on surface_hidden being
+            # non-empty (N_S > 0); volume-only views (N_S = 0) skip the
+            # parallel-MLP residual, leaving its params with no gradient
+            # on those ranks. Same DDP unused-param hazard as the surf->vol
+            # xattn above, so the same find_unused_parameters fix applies.
+            if config.use_surf_to_vol_xattn or config.use_surface_out_parallel_mlp_residual:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**H108 — SURFACE-OUT-PARALLEL-MLP-RESIDUAL-DECODER: zero-init parallel 2-layer MLP added as residual to existing `surface_out`**

NEW Wave 33 mechanism class — **DECODER ENSEMBLE / PARALLEL DIVERSITY**. Tests whether adding a **second, independently-initialized 2-layer MLP** that runs in parallel to the existing `surface_out` MLP and is summed as a residual contribution beats H102's **single wider MLP** strategy at **matched parameter cost**.

### Conceptual contrast: width vs. diversity

H102 (LEADER, val 6.124% gate cracked) hypothesis: bottleneck of `surface_out` is **representational capacity** — wider hidden dimension lets the decoder learn a richer single transform.

H108 hypothesis: bottleneck is **functional diversity** — two independently-trained MLPs of the same shape can learn **complementary** decoder transforms (different local minima of decoder output mapping), and their sum exploits ensemble-like averaging WITHIN A SINGLE MODEL at matched param cost. This is the implicit-ensemble / decoder-diversity hypothesis. Different inductive bias than width.

### Wave 33 mechanism class table (with H108 slotting into new class)

| PR | Mechanism class | Mechanism | Side | Params | Verdict / Status |
|----|-----------------|-----------|------|--------|------------------|
| H97 alphonse #1262 | bidirectional-xattn | vol↔surf info-flow | both | +1M | in-flight (borderline A WIN) |
| H102 tanjiro #1268 | **width** | surface_out hidden 1×→2× | surface | +266K | **🟢 GATE CRACKED val 6.124%** |
| H104 edward #1269 | width | volume_out hidden 1×→2× | volume | +229K | in-flight |
| H101 nezuko #1266 | info-at-input | positions [0:3] | surface | +3K | **CLOSED B PARTIAL** (test_VP cross at +3K params) |
| H105 fern #1271 | info-at-input | normals [3:6] | surface | +2K | mid-cosine |
| H106 frieren #1276 | info-at-input | xyz+sdf [0:4] | volume | +2.5K | in-flight |
| H103 askeladd #1270 | FiLM | vol-context modulation | cross | +525K | in-flight |
| H107 thorfinn #1277 | self-context | global-surf-pool residual | surface | +262K | in-flight |
| **H108 nezuko THIS PR** | **🟣 decoder ensemble / parallel diversity** (NEW CLASS) | **parallel-MLP residual** | **surface** | **+265K** | **NEW** |

### Why this mechanism class is orthogonal to all in-flight

- **vs H102 width**: H102 widens the SAME 2-layer MLP path (`Linear(512, 1024) → SiLU → Linear(1024, 4)`). H108 adds a SECOND parallel `Linear(512, 512) → SiLU → Linear(512, 4)` path with its own init — different optimization trajectory, two independent functions summed. Matched ~265K param cost.
- **vs H107 self-context**: H107 adds **global-context info** to hidden state. H108 adds **alternative output mapping** at same hidden state. Orthogonal: H107 = "richer input to decoder", H108 = "two decoder paths".
- **vs H101 info-residual**: H101 adds raw-feature info at decoder input. H108 adds parallel output mapping. Orthogonal.

### Predicted axis impact

- **test_abupt**: improvement expected if functional diversity dominates over width. Comparing H108 vs H102 at matched param cost is the key reading.
- **All channels (SP / VP / WSS_x/y/z)**: relatively even improvement expected — diversity helps all 4 surface outputs uniformly.
- If H108 ≈ H102: width and diversity are interchangeable axes; no benefit from ensemble structure.
- If H108 > H102: diversity wins → Wave 34 compound H102 + H108 (width + diversity) becomes top priority.
- If H108 < H102: width is the binding constraint; close H108 class.

## Instructions

Implement a new flag `--use-surface-out-parallel-mlp-residual` (default `False`) that adds a parallel 2-layer MLP residual contribution to `surface_out`.

### 1. `model.py` changes

Add constructor argument in `SurfaceTransolver.__init__`:

```python
# In __init__ args:
use_surface_out_parallel_mlp_residual: bool = False,
```

```python
# After other use_* attrs:
self.use_surface_out_parallel_mlp_residual = use_surface_out_parallel_mlp_residual
```

Add the parallel MLP (zero-init output layer for identity-at-init), placed AFTER the existing `surface_out` construction at around line 489:

```python
# Wave 33 H108: parallel 2-layer MLP residual on surface decoder output.
# NEW mechanism class: DECODER ENSEMBLE / PARALLEL DIVERSITY.
# A second independently-initialized MLP runs in parallel to surface_out
# and is summed as residual. Output linear is zero-init so identity at
# step 0; the model learns to use ensemble-style decoder diversity from
# the warmup epoch onward.
#
# Contrast with H102 (LEADER) which widens the SAME MLP path. H108 keeps
# both paths at original width and adds a SECOND complete path — tests
# whether diversity (two independent function approximators summed) beats
# capacity (single wider function approximator) at matched ~265K param cost.
if use_surface_out_parallel_mlp_residual:
    self.surface_out_parallel_mlp = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, self.surface_output_dim),
    )
    # Normal init for the first linear (matching surface_out's init pattern),
    # then zero-init the OUTPUT linear so the residual contribution is exactly
    # zero at step 0 (identity preservation).
    self.surface_out_parallel_mlp.apply(_init_linear)
    nn.init.zeros_(self.surface_out_parallel_mlp[-1].weight)
    nn.init.zeros_(self.surface_out_parallel_mlp[-1].bias)
else:
    self.surface_out_parallel_mlp = None
```

In `forward`, inject the residual when computing `surface_preds` at around line 625:

```python
if surface_x is not None:
    # Existing surface_out path:
    surface_preds = self.surface_out(surface_hidden)
    # Wave 33 H108: add parallel-MLP residual. Zero at step 0
    # (identity preservation); learns diverse output mapping during training.
    if self.surface_out_parallel_mlp is not None:
        surface_preds = surface_preds + self.surface_out_parallel_mlp(surface_hidden)
    surface_preds = surface_preds * surface_mask.unsqueeze(-1)
else:
    ...
```

**Critical — DDP find_unused_parameters:** mirror H105's handling. When the flag is ON AND a batch is surface-empty (`N_S = 0`), the parallel MLP receives no gradient. Set `find_unused_parameters=True` for that DDP wrap path. Inspect H105's `train.py` changes for the exact spelling.

### 2. `train.py` changes

Add the CLI argument and pass through to model construction:

```python
parser.add_argument("--use-surface-out-parallel-mlp-residual", action="store_true",
                    help="Wave 33 H108: zero-init parallel 2-layer MLP residual on surface decoder output (decoder ensemble / parallel diversity mechanism class)")
```

```python
# In model construction:
use_surface_out_parallel_mlp_residual=args.use_surface_out_parallel_mlp_residual,
```

Mirror H105's `train.py` find_unused_parameters gating for this flag.

### 3. Smoke test

Before kicking off the full run, verify identity at init: run a forward pass at step 0 with the flag on, confirm `surface_preds` is bit-identical to flag-off baseline. Specifically check: `(parallel_mlp_output - 0).abs().max() == 0.0`. Same pattern as H105/H107.

### 4. Train command (DDP 8 GPUs)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-surface-out-parallel-mlp-residual \
  --lr 9e-5 \
  --batch-size 4 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name nezuko/h108-surface-out-parallel-mlp-residual-decoder \
  --wandb-group h108-surface-out-parallel-mlp-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

Verify exact flag spellings with `python train.py --help` before kickoff.

### Parameter count verification

Expected new params:
- `Linear(512, 512)`: 262,656 (262,144 weight + 512 bias)
- `Linear(512, 4)`: 2,052 (2,048 weight + 4 bias)
- **Total: ~265K params** (matched H102 width cost of +266K, within 0.4%)

Print the trainable param count at startup and confirm Δ vs canonical ≈ +265K.

## Baseline

**Single-model merge gate:** val_abupt < **6.126%** AND test_VP ≤ **3.643%** AND test_SP ≤ **3.577%** AND test_WSS ≤ **6.727%**.

**Baseline reference run (canonical):** `56bcqp3m`
- val_abupt 6.126%, test_abupt 5.844%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%
- test_WSS_x/y/z = 5.83 / 7.10 / 9.83

**Canonical val→test slope:** −0.282pp typical.

**Wave 33 fleet at H108 kickoff (8/8 WIP zero idle):**
- H97 alphonse (bidir-xattn +1M): val 6.211% at 91.6% — borderline A WIN
- H102 tanjiro (surf-width +266K): **val 6.124% at 94.8% — 🟢 GATE CRACKED** (LEADER, terminal imminent)
- H104 edward (vol-width +229K): val 6.196% at 92.8% — borderline B PARTIAL (best val_VP 3.606%)
- H105 fern (surf-normals +2K): mid-cosine
- H106 frieren (vol-info-residual +2.5K): early cosine
- H107 thorfinn (surf-global-context +262K): just kicked off
- H101 nezuko (surf-positions +3K): **CLOSED B PARTIAL** (test_VP cross −0.129pp at +3K — extreme parameter efficiency, sleeper hit)
- **H108 nezuko THIS PR** (parallel-MLP residual +265K): NEW

**If H102 merges to baseline during H108 in-flight, rebase H108 onto the new baseline.** H108's mechanism is independent of H102's width axis (same param budget, orthogonal mechanism direction: diversity vs capacity).

## Falsifiable outcomes

| Outcome | Signal | Action |
|---|---|---|
| **A WIN** | val_abupt < 6.126% AND all test floors hold | Merge → Wave 34 compound H102+H108 (width + diversity) |
| **B PARTIAL** | val_abupt < 6.20% OR ≥1 test floor cross | Wave 34 stage as compound member |
| **C NULL** | val_abupt 6.25-6.40%, all channels neutral | Close — diversity NOT a binding axis at matched param cost (width wins) |
| **D NEG** | val_abupt > 6.40% OR strong regression | Close — parallel-path interference |

**Key reading: H108 vs H102 head-to-head at matched ~265K params.**
- If H108 ≤ H102 val_abupt: diversity ≥ width at matched cost → Wave 34 compound H102+H108 = two complete diverse decoder paths via direct sum
- If H108 > H102 val_abupt by >0.05pp: width is binding constraint, close diversity axis
- If H108 ≈ H102 (within 0.05pp): diversity is orthogonal axis, Wave 34 compound still likely productive

**Reproduce command (full):**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-surface-out-parallel-mlp-residual --lr 9e-5 --batch-size 4 --epochs 13 \
  --lr-warmup-epochs 1 --ema-decay 0.999 --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name nezuko/h108-surface-out-parallel-mlp-residual-decoder \
  --wandb-group h108-surface-out-parallel-mlp-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```
