### PR TITLE
Wave 33 H109: BACKBONE-SKIP RESIDUAL DECODER

### DIFF
--- a/eval_from_checkpoint.py
+++ b/eval_from_checkpoint.py
@@ -1,0 +1,199 @@
+"""Truncation-safety eval: load local best-EMA checkpoint, run full val + test, log to existing W&B run.
+
+Used when training is truncated mid-budget (e.g. EP10 hard truncate) and the in-process
+run_final_evaluation has not executed. Single-GPU evaluation only (the full-eval loaders
+already run on rank 0 in the normal path).
+
+Usage:
+    python eval_from_checkpoint.py \
+        --run-dir outputs/drivaerml/run-77tfuj6i \
+        --run-id 77tfuj6i \
+        --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import fields
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+from data import load_data
+
+from train import Config, build_model, parse_rff_init_sigmas  # noqa: F401
+from trainer_runtime import (
+    TargetTransform,
+    evaluate_split,
+    eval_loader_for_dataset,
+    log_model_artifact,
+    metric_namespace,
+    numeric_metric_items,
+    primary_metric_log,
+    print_metrics,
+    assert_required_finite_metrics,
+)
+
+
+def _config_from_yaml(config_path: Path) -> Config:
+    with config_path.open("r") as f:
+        raw = yaml.safe_load(f)
+    valid = {f.name for f in fields(Config)}
+    kwargs = {k: v for k, v in raw.items() if k in valid}
+    return Config(**kwargs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True, help="outputs/drivaerml/run-<id>")
+    parser.add_argument("--run-id", required=True, help="W&B run id to resume")
+    parser.add_argument("--data-root", default="")
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument(
+        "--entity", default=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    )
+    parser.add_argument(
+        "--project", default=os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    )
+    parser.add_argument(
+        "--no-artifact",
+        action="store_true",
+        help="Skip artifact upload (faster; logs metrics only).",
+    )
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    config_path = run_dir / "config.yaml"
+    model_path = run_dir / "checkpoint.pt"
+    if not model_path.exists():
+        raise FileNotFoundError(f"missing checkpoint: {model_path}")
+
+    config = _config_from_yaml(config_path)
+    if args.data_root:
+        config.data_root = args.data_root
+    config.num_workers = args.num_workers
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    print(f"Loading data (eval_surface_points={config.eval_surface_points}, "
+          f"eval_volume_points={config.eval_volume_points}) ...")
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+        train_surface_points=config.train_surface_points,
+        eval_surface_points=config.eval_surface_points,
+        train_volume_points=config.train_volume_points,
+        eval_volume_points=config.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    val_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in val_splits.items()
+    }
+    test_loaders = {
+        name: eval_loader_for_dataset(ds, config, distributed_state=None)
+        for name, ds in test_splits.items()
+    }
+    print(f"Val splits: {list(val_loaders)}  Test splits: {list(test_loaders)}")
+
+    print(f"Loading checkpoint from {model_path} ...")
+    checkpoint = torch.load(model_path, map_location=device, weights_only=False)
+    if "model" not in checkpoint:
+        raise RuntimeError("checkpoint missing 'model' state dict")
+    model = build_model(config).to(device)
+    model.load_state_dict(checkpoint["model"], strict=True)
+    model.eval()
+    best_epoch = int(checkpoint.get("epoch", -1))
+    src = checkpoint.get("checkpoint_source", "?")
+    print(f"Loaded checkpoint: epoch={best_epoch}, source={src}")
+    n_params = sum(p.numel() for p in model.parameters())
+
+    print(f"Resuming W&B run {args.run_id} ...")
+    run = wandb.init(
+        entity=args.entity,
+        project=args.project,
+        id=args.run_id,
+        resume="must",
+    )
+
+    # Full val
+    print("\n=== Full val ===")
+    t0 = time.time()
+    val_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in val_loaders.items()
+    }
+    full_val_log: dict[str, object] = {
+        **primary_metric_log("full_val_primary", val_metrics["val_surface"]),
+    }
+    for split_name, metrics in val_metrics.items():
+        full_val_log.update(metric_namespace("full_val", split_name, metrics))
+    assert_required_finite_metrics(full_val_log, "full_val_primary")
+    wandb.log(full_val_log)
+    wandb.summary.update(numeric_metric_items(full_val_log))
+    print_metrics("full_val", val_metrics["val_surface"])
+    print(f"full val seconds: {time.time() - t0:.1f}")
+
+    # Test
+    print("\n=== Full test ===")
+    t0 = time.time()
+    test_metrics = {
+        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in test_loaders.items()
+    }
+    test_log: dict[str, object] = {
+        **primary_metric_log("test_primary", test_metrics["test_surface"]),
+    }
+    for split_name, metrics in test_metrics.items():
+        test_log.update(metric_namespace("test", split_name, metrics))
+    assert_required_finite_metrics(test_log, "test_primary")
+    wandb.log(test_log)
+    wandb.summary.update(numeric_metric_items(test_log))
+    print_metrics("test_surface", test_metrics["test_surface"])
+    print(f"test seconds: {time.time() - t0:.1f}")
+
+    wandb.summary.update(
+        {
+            "truncated_post_hoc_eval": 1.0,
+            "truncated_best_epoch": best_epoch,
+            "truncated_best_checkpoint_source": src,
+        }
+    )
+
+    if not args.no_artifact:
+        best_metrics_for_artifact = {
+            "epoch": best_epoch,
+            "abupt_axis_mean_rel_l2_pct": val_metrics["val_surface"][
+                "abupt_axis_mean_rel_l2_pct"
+            ],
+            "surface_pressure_mae": val_metrics["val_surface"]["surface_pressure_mae"],
+            "wall_shear_mae": val_metrics["val_surface"]["wall_shear_mae"],
+            "volume_pressure_mae": val_metrics["val_surface"]["volume_pressure_mae"],
+        }
+        print("\nUploading model artifact ...")
+        log_model_artifact(
+            run=run,
+            model_path=model_path,
+            config_path=config_path,
+            config=config,
+            best_metrics=best_metrics_for_artifact,
+            test_metrics=test_metrics,
+            n_params=n_params,
+        )
+
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_backbone_skip_residual_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_backbone_skip_residual_decoder = use_backbone_skip_residual_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -519,6 +521,22 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # Wave 33 H109: zero-init Linear(n_hidden, n_hidden) projection of
+        # pre-backbone embedded surface tokens, added as residual to
+        # post-backbone surface_hidden BEFORE self.surface_out. Identity at
+        # init via zero-init weight + bias.
+        # NEW mechanism class: ENCODER-SKIP / BACKBONE-BYPASS. Tests whether the
+        # 5-layer backbone (+ slice-attention compression) destroys per-point
+        # info that the decoder benefits from accessing directly. Generalizes
+        # H101 (raw xyz positions, +3K params B PARTIAL) to the full embedded
+        # feature representation post-surface_in projection but pre-backbone.
+        if use_backbone_skip_residual_decoder:
+            self.backbone_skip_proj = nn.Linear(n_hidden, n_hidden, bias=True)
+            nn.init.zeros_(self.backbone_skip_proj.weight)
+            nn.init.zeros_(self.backbone_skip_proj.bias)
+        else:
+            self.backbone_skip_proj = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -565,19 +583,23 @@ class SurfaceTransolver(nn.Module):
         surface_tokens = 0
         volume_tokens = 0
 
+        pre_backbone_surface: torch.Tensor | None = None
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    surface_x,
-                    rff=self.surface_rff,
-                    string_sep=self.surface_string_sep,
-                    project_features=self.project_surface_features,
-                    bias=self.surface_bias,
-                    placeholder=self.surface_placeholder,
-                )
+            surface_encoded = self._encode_group(
+                surface_x,
+                rff=self.surface_rff,
+                string_sep=self.surface_string_sep,
+                project_features=self.project_surface_features,
+                bias=self.surface_bias,
+                placeholder=self.surface_placeholder,
             )
+            tokens.append(surface_encoded)
             masks.append(surface_mask)
+            # Wave 33 H109: capture pre-backbone embedded surface tokens for
+            # zero-init skip residual injected at the decoder input.
+            if self.backbone_skip_proj is not None and surface_tokens > 0:
+                pre_backbone_surface = surface_encoded
 
         if volume_x is not None:
             volume_tokens = volume_x.shape[1]
@@ -622,6 +644,18 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            # Wave 33 H109: add zero-init skip residual from pre-backbone
+            # embedded surface tokens to post-backbone surface_hidden BEFORE
+            # surface_out. Identity at step 0 (zero-init weight + bias) so
+            # baseline is preserved; model learns to use pre-backbone
+            # per-point info that may be diluted by the 5-layer backbone +
+            # slice-attention compression. surface_mask is applied to
+            # surface_preds below so masked positions have no downstream
+            # effect.
+            if pre_backbone_surface is not None:
+                surface_hidden = surface_hidden + self.backbone_skip_proj(
+                    pre_backbone_surface
+                )
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/scripts/h109_smoke_test.py
+++ b/scripts/h109_smoke_test.py
@@ -1,0 +1,105 @@
+"""H109 smoke test: identity at init + parameter count delta."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import torch
+
+from model import SurfaceTransolver
+
+
+def build(use_h109: bool) -> SurfaceTransolver:
+    return SurfaceTransolver(
+        n_layers=5,
+        n_hidden=512,
+        n_head=4,
+        mlp_ratio=4,
+        slice_num=128,
+        rff_num_features=16,
+        rff_sigma=1.0,
+        rff_init_sigmas=[0.25, 0.5, 1.0, 2.0, 4.0],
+        pos_encoding_mode="string_separable",
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+        use_aux_decoder_heads=True,
+        use_backbone_skip_residual_decoder=use_h109,
+    )
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    model_off = build(use_h109=False).eval()
+    torch.manual_seed(0)
+    model_on = build(use_h109=True).eval()
+
+    n_off = sum(p.numel() for p in model_off.parameters())
+    n_on = sum(p.numel() for p in model_on.parameters())
+    delta = n_on - n_off
+    expected = 512 * 512 + 512
+    print(f"Canonical params (H109 off): {n_off:,}")
+    print(f"H109 on params:               {n_on:,}")
+    print(f"Delta:                        {delta:,} (expected {expected:,})")
+    assert delta == expected, f"unexpected param delta {delta}"
+
+    # Identity-at-init forward parity check.
+    bsz = 2
+    n_surf = 1024
+    n_vol = 512
+    surface_x = torch.randn(bsz, n_surf, 7)
+    surface_mask = torch.ones(bsz, n_surf, dtype=torch.bool)
+    volume_x = torch.randn(bsz, n_vol, 4)
+    volume_mask = torch.ones(bsz, n_vol, dtype=torch.bool)
+
+    # The two models were built from the same seed; copy state to be doubly safe
+    # except for the new backbone_skip_proj on the H109 model which must remain
+    # zero-initialised.
+    state_off = model_off.state_dict()
+    state_on = model_on.state_dict()
+    extra = set(state_on) - set(state_off)
+    assert extra == {
+        "backbone_skip_proj.weight",
+        "backbone_skip_proj.bias",
+    }, f"unexpected extra keys: {extra}"
+    for k in state_off:
+        state_on[k] = state_off[k].clone()
+    model_on.load_state_dict(state_on, strict=True)
+
+    # Verify zero-init guarded.
+    assert torch.all(model_on.backbone_skip_proj.weight == 0.0)
+    assert torch.all(model_on.backbone_skip_proj.bias == 0.0)
+
+    with torch.no_grad():
+        out_off = model_off(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        out_on = model_on(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+
+    for key in ("surface_preds", "volume_preds"):
+        diff = (out_on[key] - out_off[key]).abs().max().item()
+        print(f"max |H109 - canonical| on {key}: {diff:.3e}")
+        assert diff == 0.0, f"identity-at-init violated on {key}: {diff}"
+
+    # Sanity: forward also works in surface-only and volume-only modes.
+    out_surf_only = model_on(surface_x=surface_x, surface_mask=surface_mask)
+    out_vol_only = model_on(volume_x=volume_x, volume_mask=volume_mask)
+    assert out_surf_only["surface_preds"].shape == (bsz, n_surf, 4)
+    assert out_vol_only["volume_preds"].shape == (bsz, n_vol, 1)
+
+    print("OK: identity at init AND param delta match expected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_backbone_skip_residual_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,18 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_backbone_skip_residual_decoder": (
+            "Wave 33 H109: add zero-init Linear(n_hidden, n_hidden) "
+            "projection of pre-backbone embedded surface tokens as a "
+            "residual to surface_hidden BEFORE self.surface_out. Identity "
+            "at init (weight and bias zero) so baseline is preserved at "
+            "step 0. Param cost ~263K. NEW mechanism class "
+            "(encoder-skip / backbone-bypass): tests whether the 5-layer "
+            "backbone + slice-attention compression destroys per-point "
+            "info the decoder benefits from accessing directly. "
+            "Generalizes H101 (raw xyz positions, +3K B PARTIAL) to the "
+            "full embedded feature set."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +321,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_backbone_skip_residual_decoder=config.use_backbone_skip_residual_decoder,
     )
 
 
@@ -773,7 +787,13 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # H109 backbone_skip_proj is also gated on surface tokens being
+            # present (volume-only views skip the residual injection); same
+            # DDP unused-param hazard as the surf->vol xattn block above.
+            if (
+                config.use_surf_to_vol_xattn
+                or config.use_backbone_skip_residual_decoder
+            ):
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**H109 — BACKBONE-SKIP RESIDUAL DECODER: zero-init `Linear(n_hidden, n_hidden)` projection of pre-backbone embedded surface tokens added as residual to post-backbone `surface_hidden` before `surface_out`**

NEW Wave 33 mechanism class — **ENCODER-SKIP / BACKBONE-BYPASS**. Orthogonal to all 7 in-flight Wave 33 mechanisms (width, info-at-input raw features, bidir-xattn, FiLM, self-context, parallel-MLP, depth/task-head closed). Tests whether the **5-layer backbone destroys per-point info** that the decoder benefits from accessing directly.

### Conceptual contrast with related mechanisms

- **vs H101 (info-at-input raw positions)**: H101 adds `Linear(3, n_hidden)(surface_x[..., 0:3])` — raw xyz residual. H109 adds the FULL `surface_in`-EMBEDDED features (post-embedding, pre-backbone) projected through a learned mapping. H101 = "raw geometry"; H109 = "embedded but not-backbone-processed features". Different abstraction levels — they're complementary, not redundant.
- **vs H107 (self-context global pool)**: H107 pools the SAME surface_hidden (post-backbone) globally and adds back as residual. Self-context within abstraction layer. H109 takes a DIFFERENT representation (pre-backbone) and adds. Cross-layer information injection.
- **vs H97 (bidir-xattn, just closed B PARTIAL)**: H97 adds VOLUME context to surface via attention. H109 adds PRE-BACKBONE surface context to post-backbone surface — pure same-modality skip connection.
- **vs H108 (parallel-MLP residual)**: H108 adds parallel OUTPUT-PRODUCING MLP on the same hidden. H109 adds a different INPUT representation (skip from earlier layer) into the hidden before the same output MLP. H108 = "two output paths"; H109 = "two input information levels".

### Mechanism rationale — information-theoretic

The 5-layer backbone applies massive non-linear transformations + slice-attention compression (65K→128 slice tokens per surface). Per-point per-channel features that exist immediately post-embedding (after `surface_in: Linear(SURFACE_X_DIM=7, n_hidden=512)`) MAY be partially destroyed by:

1. **Slice-attention compression** (lossy 512× compression ratio in token dimension that's then redistributed)
2. **5 layers of non-linear MLP + multi-head attention** mixing
3. **The shared backbone** processes surface AND volume tokens jointly — surface-specific per-point identity may be diluted by volume-channel interference

H109 hypothesizes that the decoder loses access to **low-abstraction per-point features** that would help downstream surface prediction. The zero-init residual lets the decoder learn to consume the pre-backbone signal alongside the post-backbone signal.

### Strong prior from H101 finding

H101 (closed B PARTIAL at +3K params) demonstrated that the decoder benefits from **raw xyz position residual access** — the slice-attention compression DOES lose per-point geometric info. H109 generalizes this finding: if RAW positions help at +3K, the FULL EMBEDDED feature set (xyz + normals + panel area, all 7 raw channels projected through `surface_in`) should help at proportionally higher param cost.

H101 used `Linear(3, n_hidden)` = 3 × 512 + 512 = 2,048 params. H109 uses `Linear(n_hidden, n_hidden)` = 512 × 512 + 512 = 262,656 params (128× more capacity, projecting the FULL embedded feature vector not just position triple).

### Wave 33 mechanism class table (with H109 slotting into new class)

| PR | Mechanism class | Params | Verdict / Status |
|----|-----------------|--------|------------------|
| H97 alphonse #1262 (closed) | bidir-xattn | +1M | **B PARTIAL** — val_WSS_z mechanism confirmed but +0.45pp val→test reverse slope |
| H102 tanjiro #1268 | width (surface MLP 1×→2×) | +266K | **🟢 GATE CRACKED val 6.122%** (LEADER) |
| H104 edward #1269 | width (volume MLP 1×→2×) | +229K | in-flight |
| H101 nezuko (closed) | info-at-input raw positions | +3K | **B PARTIAL** — test_VP cross at extreme efficiency |
| H105 fern #1271 | info-at-input raw normals | +2K | mid-cosine |
| H106 frieren #1276 | info-at-input volume xyz+sdf | +2.5K | in-flight |
| H103 askeladd #1270 | FiLM | +525K | in-flight (C NULL likely) |
| H107 thorfinn #1277 | self-context (surf-global-pool) | +262K | in-flight |
| H108 nezuko #1278 | decoder ensemble / parallel-MLP residual | +265K | in-flight |
| **H109 alphonse THIS PR** | **🟣 encoder-skip / backbone-bypass** (NEW CLASS) | **+263K** | **NEW** |

### Predicted axis impact

- **test_VP**: improvement candidate — H101 (raw position residual) cleared VP floor; H109 generalizes (full embedded features) and may strengthen VP cross.
- **test_SP**: 10-plateau-hit axis. H109 hypothesizes pre-backbone features carry per-point info that helps SP. **Plateau crack candidate if mechanism works.**
- **test_WSS_z**: H101 maintained binding axis at canonical (no regress). H109 may help if pre-backbone signal carries shear-relevant info (normals are in surface_in embedded features).
- **val→test slope**: predicted to be NEGATIVE (test amplifies val improvement) like H101 (WSS_z slope −0.603pp), in contrast to H97's val-overfit failure (+0.452pp reverse slope).

## Instructions

Implement a new flag `--use-backbone-skip-residual-decoder` (default `False`) that adds a zero-init residual from pre-backbone embedded surface tokens to post-backbone surface_hidden before surface_out.

### 1. `model.py` changes

Add constructor argument in `SurfaceTransolver.__init__`:

```python
# In __init__ args:
use_backbone_skip_residual_decoder: bool = False,
```

```python
# After other use_* attrs:
self.use_backbone_skip_residual_decoder = use_backbone_skip_residual_decoder
```

Add the projection layer (zero-init for identity-at-init):

```python
# Wave 33 H109: zero-init Linear(n_hidden, n_hidden) projection of
# pre-backbone embedded surface tokens, added as residual to
# post-backbone surface_hidden BEFORE self.surface_out. Identity at
# init via zero-init weight + bias.
# NEW mechanism class: ENCODER-SKIP / BACKBONE-BYPASS. Tests whether the
# 5-layer backbone (+ slice-attention compression) destroys per-point info
# that the decoder benefits from accessing directly. Generalizes H101
# (which added raw xyz positions, +3K params B PARTIAL) to the full embedded
# feature representation post-surface_in projection but pre-backbone.
if use_backbone_skip_residual_decoder:
    self.backbone_skip_proj = nn.Linear(n_hidden, n_hidden, bias=True)
    nn.init.zeros_(self.backbone_skip_proj.weight)
    nn.init.zeros_(self.backbone_skip_proj.bias)
else:
    self.backbone_skip_proj = None
```

In `forward`, **save the pre-backbone surface tokens immediately after `_encode_group(surface_x, ...)` produces them**, then inject as residual to `surface_hidden` after backbone but before `surface_out` (around line 624):

```python
# In forward, around line 562-580 where surface_x is encoded:
if surface_x is not None:
    surface_tokens = surface_x.shape[1]
    surface_encoded = self._encode_group(
        surface_x,
        rff=self.surface_rff,
        string_sep=self.surface_string_sep,
        project_features=self.project_surface_features,
        bias=self.surface_bias,
        placeholder=self.surface_placeholder,
    )
    tokens.append(surface_encoded)
    masks.append(surface_mask)
    # Wave 33 H109: capture pre-backbone surface tokens for skip residual.
    pre_backbone_surface = surface_encoded if self.backbone_skip_proj is not None else None
else:
    pre_backbone_surface = None
```

Then, AFTER `surface_hidden = hidden_norm[:, cursor : cursor + surface_tokens]` and BEFORE `surface_preds = self.surface_out(...)` (around line 624):

```python
if surface_x is not None:
    # Wave 33 H109: add backbone-skip residual. Zero at init via
    # zero-init proj; learns to consume pre-backbone per-point features
    # alongside post-backbone surface_hidden.
    if self.backbone_skip_proj is not None and pre_backbone_surface is not None:
        skip_residual = self.backbone_skip_proj(pre_backbone_surface)
        surface_hidden = surface_hidden + skip_residual
    surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
else:
    ...
```

**Important — DDP find_unused_parameters:** mirror H105's handling. When the flag is on AND a batch is volume-only (`N_S = 0`), the projection receives no gradient — set `find_unused_parameters=True` for that DDP wrap path. Inspect H105's `train.py` for the exact spelling.

### 2. `train.py` changes

Add the CLI argument and pass through to model construction:

```python
parser.add_argument("--use-backbone-skip-residual-decoder", action="store_true",
                    help="Wave 33 H109: zero-init residual from pre-backbone embedded surface tokens to post-backbone surface_hidden before surface_out (encoder-skip / backbone-bypass mechanism class)")
```

```python
# In model construction:
use_backbone_skip_residual_decoder=args.use_backbone_skip_residual_decoder,
```

Mirror H105's `train.py` find_unused_parameters gating.

### 3. Smoke test

Before kicking off the full run, verify identity at init: run a forward pass at step 0 with the flag on, confirm `surface_preds` is bit-identical to flag-off baseline. Specifically: `(skip_residual - 0).abs().max() == 0.0`.

### 4. Train command (DDP 8 GPUs)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-backbone-skip-residual-decoder \
  --lr 9e-5 \
  --batch-size 4 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name alphonse/h109-backbone-skip-residual-decoder \
  --wandb-group h109-backbone-skip-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

Verify exact flag spellings with `python train.py --help` before kickoff.

### Parameter count verification

Expected new params:
- `Linear(512, 512)`: 262,656 params (262,144 weight + 512 bias)
- **Total: +263K params** (matched H102 width cost +266K within 1.2%, matched H108 parallel-MLP +265K within 0.8%)

Print trainable param count at startup and confirm Δ vs canonical ≈ +263K.

## Baseline

**Single-model merge gate:** val_abupt < **6.126%** AND test_VP ≤ **3.643%** AND test_SP ≤ **3.577%** AND test_WSS ≤ **6.727%**.

**Baseline reference run (canonical):** `56bcqp3m`
- val_abupt 6.126%, test_abupt 5.844%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%
- test_WSS_x/y/z = 5.83 / 7.10 / 9.83

**Canonical val→test slope:** −0.282pp typical.

**Wave 33 fleet at H109 kickoff (8/8 WIP zero idle):**
- H102 tanjiro (surf-width +266K): **val 6.122% gate cracked, near-terminal** (LEADER)
- H104 edward (vol-width +229K): in-flight (best val_VP 3.606%)
- H103 askeladd (FiLM +525K): C NULL likely
- H105 fern (surf-normals +2K): mid-cosine
- H106 frieren (vol-info-residual +2.5K): early cosine
- H107 thorfinn (surf-global-context +262K): in-flight
- H108 nezuko (parallel-MLP residual +265K): just kicked off
- **H109 alphonse THIS PR** (backbone-skip +263K): NEW

**If H102 merges to baseline during H109 in-flight, rebase H109 onto the new baseline.** H109's mechanism is independent of H102's width axis.

## Falsifiable outcomes

| Outcome | Signal | Action |
|---|---|---|
| **A WIN** | val_abupt < 6.126% AND all test floors hold | Merge → Wave 34 compound H102+H109 (width + backbone-skip) |
| **B PARTIAL** | val_abupt < 6.20% OR ≥1 test floor cross | Wave 34 stage as compound member |
| **C NULL** | val_abupt 6.25-6.40%, all channels neutral | Close — backbone preserves per-point info adequately |
| **D NEG** | val_abupt > 6.40% OR strong regression | Close — pre-backbone signal disrupts decoder |

**Key reading: H109 vs H101 head-to-head.**
- H101 added +3K params (raw positions only) → B PARTIAL with test_VP cross −0.129pp
- H109 adds +263K params (full embedded features) — if H109 < H101 on val_abupt: pre-backbone non-position info also matters
- If H109 ≈ H101 (both ~6.20%): positions ARE the entire signal H101 captured; H109's extra capacity adds noise
- If H109 >> H101: full pre-backbone signal disrupts decoder (over-parameterized skip)

**Critical val→test slope check (vs H97 failure mode):**
H97 had +0.452pp REVERSE slope on val_WSS_z (val improvement didn't transfer to test — val-set-specific info). H109's val→test slope on test_VP and test_WSS_z is the key diagnostic — NEGATIVE slope confirms generalization, POSITIVE/REVERSE slope confirms val-overfit.

**Reproduce command (full):**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --use-backbone-skip-residual-decoder --lr 9e-5 --batch-size 4 --epochs 13 \
  --lr-warmup-epochs 1 --ema-decay 0.999 --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name alphonse/h109-backbone-skip-residual-decoder \
  --wandb-group h109-backbone-skip-residual-decoder \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```
