### PR TITLE
Wave 34 H110: COMPOUND H102+H101 (width + geom-residual)

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,8 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        surface_out_width_factor: float = 1.0,
+        use_geom_residual_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +398,8 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.surface_out_width_factor = surface_out_width_factor
+        self.use_geom_residual_decoder = use_geom_residual_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -481,10 +485,14 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
+            # Wave 34 H110 (H102 mechanism): widen surface_out hidden by factor.
+            # factor=1.0 is byte-identical to canonical; factor=2.0 doubles
+            # the hidden dim to 1024 (matching H102 closed B PARTIAL).
+            surf_hidden_width = int(round(n_hidden * surface_out_width_factor))
             self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
+                nn.Linear(n_hidden, surf_hidden_width),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(surf_hidden_width, self.surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -518,6 +526,20 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+        # Wave 34 H110 (H101 mechanism): zero-init geometric residual projection
+        # from raw xyz position into n_hidden, added to surface_hidden before
+        # surface_out, followed by LayerNorm. Identity at init (zero residual).
+        # Restores fine-grained spatial discrimination lost in the 128-slice
+        # attention bottleneck. Closed B PARTIAL in PR #1266 (nezuko).
+        if use_geom_residual_decoder:
+            self.geom_residual_proj = nn.Linear(space_dim, n_hidden)
+            nn.init.zeros_(self.geom_residual_proj.weight)
+            nn.init.zeros_(self.geom_residual_proj.bias)
+            self.geom_residual_norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        else:
+            self.geom_residual_proj = None
+            self.geom_residual_norm = None
 
     def _encode_group(
         self,
@@ -622,6 +644,15 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
+            # Wave 34 H110 (H101 mechanism): zero-init geom residual from raw
+            # xyz positions, applied to surface_hidden then post-fusion LayerNorm.
+            # Mirrors PR #1266 (nezuko H101 closure) exactly.
+            if self.use_geom_residual_decoder:
+                surface_xyz = surface_x[..., : self.space_dim]
+                geom_residual = self.geom_residual_proj(surface_xyz)
+                geom_residual = _apply_token_mask(geom_residual, surface_mask)
+                surface_hidden = self.geom_residual_norm(surface_hidden + geom_residual)
+                surface_hidden = _apply_token_mask(surface_hidden, surface_mask)
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    surface_out_width_factor: float = 1.0
+    use_geom_residual_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +231,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "surface_out_width_factor": (
+            "Width multiplier for the surface_out MLP hidden layer (Wave 33 "
+            "H102 mechanism, PR #1268). At 1.0 (canonical) the surface "
+            "decoder is Linear(n_hidden, n_hidden) -> SiLU -> "
+            "Linear(n_hidden, surf_dim). At 2.0 the hidden dim is widened "
+            "to 2*n_hidden (+264.7K params at n_hidden=512). Used together "
+            "with --use-geom-residual-decoder in H110 (PR #1280) as the "
+            "first Wave 34 compound: capacity + info-at-input."
+        ),
+        "use_geom_residual_decoder": (
+            "Enable zero-init geometric residual projection at the surface "
+            "decoder (Wave 33 H101 mechanism, PR #1266). Adds a "
+            "Linear(3, n_hidden) projection from raw surface xyz positions, "
+            "applied as a residual to surface_hidden before surface_out, "
+            "followed by LayerNorm (post-fusion). Both weight and bias of "
+            "the projection are zero-initialised so the residual is identity "
+            "at init. Restores fine-grained spatial discrimination lost in "
+            "the slice-attention bottleneck. Adds +3,072 params. Used "
+            "together with --surface-out-width-factor 2.0 in H110 (PR #1280)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +330,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        surface_out_width_factor=config.surface_out_width_factor,
+        use_geom_residual_decoder=config.use_geom_residual_decoder,
     )
 
 
@@ -748,6 +772,17 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         model: nn.Module = build_model(config).to(device)
         n_params = sum(param.numel() for param in model.parameters())
+        if config.use_geom_residual_decoder and state.is_main:
+            proj = model.geom_residual_proj
+            w_norm = float(proj.weight.detach().float().norm().item())
+            b_norm = float(proj.bias.detach().float().norm().item())
+            geom_params = sum(p.numel() for p in proj.parameters()) + sum(
+                p.numel() for p in model.geom_residual_norm.parameters()
+            )
+            print(
+                f"H110 geom_residual_proj at init: weight_norm={w_norm:.6e} "
+                f"bias_norm={b_norm:.6e} extra_params={geom_params}"
+            )
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
         surface_channel_weights = torch.tensor(
@@ -773,7 +808,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_geom_residual_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1321,6 +1356,20 @@ def main(argv: Iterable[str] | None = None) -> None:
         total_minutes = (time.time() - train_start) / 60.0
         if state.is_main:
             print(f"\nTraining done in {total_minutes:.1f} min")
+            if config.use_geom_residual_decoder:
+                proj = base_model.geom_residual_proj
+                w_norm = float(proj.weight.detach().float().norm().item())
+                b_norm = float(proj.bias.detach().float().norm().item())
+                print(
+                    f"H110 geom_residual_proj at end: weight_norm={w_norm:.6e} "
+                    f"bias_norm={b_norm:.6e}"
+                )
+                wandb.summary.update(
+                    {
+                        "geom_residual_proj/weight_norm_end": w_norm,
+                        "geom_residual_proj/bias_norm_end": b_norm,
+                    }
+                )
 
         if early_stop_reason is not None:
             wandb.summary.update(


### PR DESCRIPTION
## Hypothesis

**H110 — WAVE 34 COMPOUND: H102 (SURFACE-OUT-WIDER-MLP) + H101 (GEOM-RESIDUAL-DECODER): combine the TWO best-validated Wave 33 mechanisms — surface decoder MLP width 1×→2× AND zero-init raw xyz position residual at surface decoder input**

This is the **first Wave 34 compound launch** — combining the LEADER capacity mechanism (H102: +266K params, val gate cleared by −0.008pp) with the most parameter-efficient info-routing mechanism (H101: +3K params, test_VP cross −0.129pp at extreme efficiency).

### Wave 33 → Wave 34 logic

Both H102 and H101 closed B PARTIAL with **non-overlapping test floor crosses** and **compatible val→test slopes**:

| Mechanism | H102 width | H101 raw-positions | Compound H110 (expected) |
|---|---:|---:|---:|
| Δ params | +264.7K | +3.1K | +267.8K |
| val_abupt | 6.118% (gate clear) | 6.213% | < 6.10% projected |
| test_abupt | 5.940% | 5.956% | ~5.85% projected (if additive) |
| test_VP cross floor 3.643 | **−0.100pp** ✓ | **−0.129pp** ✓ | **−0.20pp+ projected** (both mechanisms help VP) |
| test_SP miss floor 3.577 | +0.147pp | +0.129pp (11-plateau confirm) | possibly cracks plateau (combined access) |
| test_WSS miss goal 6.727 | +0.131pp | +0.186pp | ~+0.10pp (compound may not crack) |
| test_WSS_z vs canonical 8.945 | **−0.056pp** ✓ | TIE | **−0.05pp+ projected** (width helps z-shear, positions are TIE) |
| val→test slope (abupt) | −0.179pp (shallow) | −0.258pp (canonical) | favorable |
| val→test slope (WSS_z) | **−0.510pp** (steep+) | −0.603pp (steep+) | **both mechanisms have steep-favorable WSS_z slope** |

### Compound hypothesis

The two mechanisms attack orthogonal axes:
- **H102 width** = decoder MLP CAPACITY (surface_out hidden 512 → 1024)
- **H101 positions** = decoder INPUT INFORMATION (raw xyz residual to surface_hidden before surface_out)

If the axes are truly orthogonal, the compound should:
1. Cross test_VP floor by **−0.20pp or more** (both single mechanisms cross by ~−0.10pp each)
2. Possibly crack test_SP plateau (combined width + position info attacks both MLP capacity AND input information)
3. Beat H102's val 6.118% gate clear by ~0.03-0.10pp (compound capacity)
4. Maintain steep-favorable val→test WSS_z slope (both single mechanisms had this)
5. ACHIEVE A WIN if test_SP cracks (the critical 11-plateau-broken event)

### Wave 33 mechanism class table (post-H102 closure, H110 slot in Wave 34)

| PR | Mechanism class | Status | Verdict |
|----|-----------------|--------|---------|
| **H102 #1268 (closed)** | width | LEADER closed | **B PARTIAL** val gate clear + test_VP cross + test_WSS_z improvement |
| **H101 #1266 (closed)** | info-at-input positions | extreme efficiency | **B PARTIAL** test_VP cross at +3K params |
| H97 #1262 (closed) | bidir-xattn | confirmed but cost-ineffective | B PARTIAL |
| H104 #1269 | width (volume side) | in-flight | TBD |
| H103 #1270 | FiLM | in-flight | C NULL likely |
| H105 #1271 | info-at-input normals | mid-cosine | TBD |
| H106 #1276 | info-at-input vol-xyz+sdf | in-flight | TBD |
| H107 #1277 | self-context global pool | in-flight | TBD |
| H108 #1278 | decoder ensemble / parallel-MLP | in-flight | TBD |
| H109 #1279 | encoder-skip / backbone-bypass | just kicked off | TBD |
| **H110 THIS PR** | **WAVE 34 COMPOUND H102+H101** | **NEW** | **TBD** |

## Instructions

This PR implements BOTH H102 (width) AND H101 (position residual) on top of canonical tay. **Neither mechanism is currently on tay** (both closed B PARTIAL, not merged), so both implementations are required in this PR.

### 1. `model.py` changes — H102 width factor

In `SurfaceTransolver.__init__`, add the width factor argument and modify `surface_out` construction:

```python
# In __init__ args:
surface_out_width_factor: float = 1.0,
```

```python
# In __init__ body, after other stored attrs:
self.surface_out_width_factor = surface_out_width_factor
```

In the `surface_out` construction (around line 484-489 currently):

```python
# Wave 34 H110 (H102 mechanism): widen surface_out hidden by factor.
surface_hidden_dim = int(n_hidden * surface_out_width_factor)
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, surface_hidden_dim),
    nn.SiLU(),
    nn.Linear(surface_hidden_dim, self.surface_output_dim),
)
self.surface_out.apply(_init_linear)
```

When `surface_out_width_factor=1.0` (default), this is byte-identical to canonical. When `=2.0`, the hidden dim doubles to 1024 (matching H102).

### 2. `model.py` changes — H101 position residual

Add the position residual argument:

```python
# In __init__ args:
use_geom_residual_decoder: bool = False,
```

```python
# In __init__ body:
self.use_geom_residual_decoder = use_geom_residual_decoder

# Wave 34 H110 (H101 mechanism): zero-init Linear(3, n_hidden) projecting
# raw xyz position [surface_x[..., 0:3]] as additive residual to
# surface_hidden BEFORE surface_out. Identity at init via zero-init.
# Combined with width factor 2.0: compound capacity + info-at-input.
if use_geom_residual_decoder:
    self.geom_residual_proj = nn.Linear(3, n_hidden, bias=True)
    nn.init.zeros_(self.geom_residual_proj.weight)
    nn.init.zeros_(self.geom_residual_proj.bias)
    # LayerNorm post-projection for stability (matches H101 closure spec)
    self.geom_residual_norm = nn.LayerNorm(n_hidden)
else:
    self.geom_residual_proj = None
    self.geom_residual_norm = None
```

In `forward`, inject position residual before `surface_out` (around line 624 currently):

```python
if surface_x is not None:
    # Wave 34 H110 (H101 mechanism): add raw xyz position residual.
    # Identity at init via zero-init proj; learns to consume per-point
    # raw geometry at decoder input.
    if self.geom_residual_proj is not None and surface_x.shape[1] > 0:
        position_residual = self.geom_residual_proj(surface_x[..., 0:3])
        position_residual = self.geom_residual_norm(position_residual)
        surface_hidden = surface_hidden + position_residual
    surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
else:
    ...
```

**DDP find_unused_parameters**: when `use_geom_residual_decoder=True` AND a batch is volume-only (`N_S = 0`), the projection participates in autograd but receives no gradient. Set `find_unused_parameters=True` for that DDP wrap path (mirror H105's `train.py` pattern).

### 3. `train.py` changes

Add both CLI arguments:

```python
parser.add_argument("--surface-out-width-factor", type=float, default=1.0,
                    help="Wave 34 H110 (H102 mechanism): multiplier on surface_out hidden dim. 1.0=canonical, 2.0=H102 width.")
parser.add_argument("--use-geom-residual-decoder", action="store_true",
                    help="Wave 34 H110 (H101 mechanism): zero-init residual from raw xyz positions to surface_hidden before surface_out.")
```

Pass through to model construction:

```python
surface_out_width_factor=args.surface_out_width_factor,
use_geom_residual_decoder=args.use_geom_residual_decoder,
```

Mirror H105's `train.py` find_unused_parameters gating for `use_geom_residual_decoder`.

### 4. Smoke test (CRITICAL for compound)

Before kicking off the full run, verify identity at init **with BOTH flags on**:
1. Run forward pass at step 0 with `--surface-out-width-factor 2.0 --use-geom-residual-decoder`
2. Verify `position_residual.abs().max() == 0.0` (geom residual is zero at init)
3. Verify `surface_preds` matches a flag-on width-factor-1.0-only run (no-position-residual baseline at init)
4. NOTE: width factor 2.0 itself is NOT identity-at-init (it's a different architecture) — the smoke test is for the position-residual identity, not the width identity

### 5. Train command (DDP 8 GPUs)

```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --surface-out-width-factor 2.0 \
  --use-geom-residual-decoder \
  --lr 9e-5 \
  --batch-size 4 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --ema-decay 0.999 \
  --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name tanjiro/h110-wave34-h102-plus-h101-compound \
  --wandb-group h110-wave34-h102-plus-h101-compound \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```

Verify exact flag spellings with `python train.py --help` before kickoff.

### Parameter count verification

Expected new params:
- H102 width factor (Linear 512→1024 + SiLU + Linear 1024→4): +264,704 params
- H101 position residual (Linear 3→512 + LayerNorm 512): 2,048 + 1,024 = +3,072 params
- **Total: +267,776 params (~+268K, matched H102 alone)**

Print trainable param count at startup and confirm Δ vs canonical ≈ +268K.

## Baseline

**Single-model merge gate:** val_abupt < **6.126%** AND test_VP ≤ **3.643%** AND test_SP ≤ **3.577%** AND test_WSS ≤ **6.727%**.

**Baseline reference run (canonical):** `56bcqp3m`
- val_abupt 6.126%, test_abupt 5.844%, test_VP 3.643%, test_SP 3.577%, test_WSS 6.727%
- test_WSS_x/y/z = 5.83 / 7.10 / 9.83

**Canonical val→test slope:** −0.282pp typical.

**Reference Wave 33 results being compounded:**
- H102 tanjiro `n14qwfg4`: val 6.118 / test_VP 3.543 / test_SP 3.724 / test_WSS 6.858 / test_WSS_z 8.889
- H101 nezuko `41jk1b0m`: val 6.213 / test_VP 3.514 / test_SP 3.706 / test_WSS 6.913 / test_WSS_z 8.946

**Wave 33+34 fleet at H110 kickoff (8/8 WIP zero idle):**
- H103 askeladd (FiLM +525K): C NULL likely, terminal soon
- H104 edward (vol-width +229K): in-flight, B PARTIAL likely
- H105 fern (surf-normals +2K): mid-cosine
- H106 frieren (vol-info-residual +2.5K): in-flight
- H107 thorfinn (surf-global-context +262K): in-flight
- H108 nezuko (parallel-MLP residual +265K): in-flight
- H109 alphonse (backbone-skip +263K): just kicked off
- **H110 tanjiro THIS PR** (Wave 34 H102+H101 compound +268K): NEW — first Wave 34 launch

## Falsifiable outcomes (Wave 34 compound-specific)

| Outcome | Signal | Action |
|---|---|---|
| **A WIN** | val_abupt < 6.126 AND ALL 3 test floors hold (test_VP ≤ 3.643, test_SP ≤ 3.577, test_WSS ≤ 6.727) | **MERGE → new baseline → Wave 35** |
| **B PARTIAL ADDITIVE** | val < H102's 6.118 AND test_VP cross > H102's −0.10pp OR test_SP < 3.70 (cracks plateau) | Wave 35 stage |
| **B PARTIAL SATURATED** | val ≈ H102's 6.118 (within 0.02pp) AND test_VP cross ≈ −0.10pp | Compound saturates at single-mechanism level — close, mechanism axes redundant |
| **C NULL** | val_abupt 6.20-6.40%, single mechanisms outperform compound | Close — mechanism axes anti-additive |
| **D NEG** | val_abupt > 6.40% | Close — compound destabilizes training |

**Key Wave 34 reading: ADDITIVE vs SATURATED vs ANTI-ADDITIVE.**

- ADDITIVE (best case): both single-mechanism gains stack. Predicted val < 6.05%, test_VP < 3.45%, possible SP crack.
- SATURATED (likely): compound ≈ best single mechanism (H102 width). H101 contribution masked by H102's larger capacity.
- ANTI-ADDITIVE (failure mode): width's added capacity over-fits with position-residual signal; val goes up.

If H110 lands **B PARTIAL ADDITIVE or A WIN**, Wave 35 expands to triple compounds (H102+H101+H105 etc.). If SATURATED, Wave 34 pivots to OTHER orthogonal axes (H108 ensemble + H101, H109 skip + H101, etc.).

**Critical val→test slope check:**
Both H102 and H101 had negative WSS_z val→test slopes (−0.510pp and −0.603pp respectively). Compound should preserve this — WSS_z slope ≥ −0.50pp is the expected signature of healthy mechanism stacking.

**Reproduce command (full):**
```bash
cd target/
torchrun --nproc_per_node=8 train.py \
  --surface-out-width-factor 2.0 --use-geom-residual-decoder \
  --lr 9e-5 --batch-size 4 --epochs 13 \
  --lr-warmup-epochs 1 --ema-decay 0.999 --use-aux-decoder-heads \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-name tanjiro/h110-wave34-h102-plus-h101-compound \
  --wandb-group h110-wave34-h102-plus-h101-compound \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511
```
