### PR TITLE
WSS H38: Symmetric surf-p Charbonnier — attack the wave surf_p floor

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,15 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    gradnorm_min_w_vol_p: float = 0.0
+    use_curvature_attention_bias: bool = False
+    wss_charbonnier_weight: float = 0.0
+    wss_charbonnier_eps: float = 1e-3
+    wss_charbonnier_axes: str = "all"
+    vol_p_charbonnier_weight: float = 0.0
+    vol_p_charbonnier_eps: float = 1e-3
+    surf_p_charbonnier_weight: float = 0.0
+    surf_p_charbonnier_eps: float = 1e-3
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -145,16 +154,30 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
         ),
+        "wss_charbonnier_axes": (
+            "Which WSS channels the supplementary Charbonnier loss applies to. "
+            "'all' = tau_x, tau_y, tau_z (H10 default). 'z' = tau_z only (H10b)."
+        ),
+    }
+    choices_text = {
+        "wss_charbonnier_axes": ["all", "z"],
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
         arg_name = f"--{field.name.replace('_', '-')}"
         help_value = help_text.get(field.name)
+        choices = choices_text.get(field.name)
         if isinstance(value, bool):
             parser.add_argument(arg_name, action="store_true", default=value, help=help_value)
             parser.add_argument(f"--no-{field.name.replace('_', '-')}", action="store_false", dest=field.name)
         else:
-            parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
+            parser.add_argument(
+                arg_name,
+                type=type(value),
+                default=value,
+                help=help_value,
+                choices=choices,
+            )
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
 
@@ -224,6 +247,27 @@ def per_channel_masked_mse(
     return weighted.sum(dim=(0, 1)) / denom  # [C]
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Masked Charbonnier (pseudo-Huber) loss: ``sqrt(eps^2 + (pred-target)^2) - eps``.
+
+    Averaged over masked spatial points and channels, matching the convention
+    used by :func:`masked_mse`. Differentiable everywhere, gradient bounded by 1
+    in magnitude — robust to outliers compared with squared error.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    delta = pred - target
+    values = torch.sqrt(eps * eps + delta * delta) - eps  # [B, N, C]
+    weighted = values * mask_f
+    n_pts = mask_f.sum().clamp_min(1.0)
+    n_ch = float(pred.shape[-1])
+    return weighted.sum() / (n_pts * n_ch)
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -235,6 +279,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_curvature_attention_bias=config.use_curvature_attention_bias,
     )
 
 
@@ -301,8 +346,19 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    wss_charbonnier_weight: float = 0.0,
+    wss_charbonnier_eps: float = 1e-3,
+    wss_charbonnier_axes: str = "all",
+    vol_p_charbonnier_weight: float = 0.0,
+    vol_p_charbonnier_eps: float = 1e-3,
+    surf_p_charbonnier_weight: float = 0.0,
+    surf_p_charbonnier_eps: float = 1e-3,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
+    surface_curvature = getattr(batch, "surface_curvature", None)
     batch = batch.to(device)
+    if surface_curvature is not None:
+        surface_curvature = surface_curvature.to(device)
+        setattr(batch, "surface_curvature", surface_curvature)
     if use_y_symmetry_aug:
         flip_mask = apply_y_symmetry_aug(batch, y_symmetry_aug_prob)
         if aug_log is not None:
@@ -310,22 +366,80 @@ def train_loss(
             aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    forward_kwargs: dict[str, torch.Tensor] = dict(
+        surface_x=batch.surface_x,
+        surface_mask=batch.surface_mask,
+        volume_x=batch.volume_x,
+        volume_mask=batch.volume_mask,
+    )
+    if surface_curvature is not None:
+        forward_kwargs["surface_curvature"] = surface_curvature
     with autocast_context(device, amp_mode):
-        out = model(
-            surface_x=batch.surface_x,
-            surface_mask=batch.surface_mask,
-            volume_x=batch.volume_x,
-            volume_mask=batch.volume_mask,
-        )
+        out = model(**forward_kwargs)
         surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # H19 advisor fix: pre-compute Charbonnier on vol_p so it can be
+        # passed to GradNorm as the vol_p task signal (the L0 anchor and
+        # per-task gradient norms need to reflect the reshaped Charb
+        # landscape, otherwise the H19 mechanism is invisible to the
+        # dynamic-weight balancing — root cause flagged in run i4zt1zrl).
+        if vol_p_charbonnier_weight > 0.0:
+            pred_vol_p = out["volume_preds"]  # [B, N_vol, 1]
+            target_vol_p = volume_target
+            loss_vol_p_charb = masked_charbonnier(
+                pred_vol_p,
+                target_vol_p,
+                batch.volume_mask,
+                eps=vol_p_charbonnier_eps,
+            )
+            loss_vol_p_mse_diag = masked_mse(
+                pred_vol_p, target_vol_p, batch.volume_mask
+            )
+        else:
+            loss_vol_p_charb = None
+            loss_vol_p_mse_diag = None
+        # H38: pre-compute Charbonnier on cp (surface pressure, idx 0) so it
+        # can be passed to GradNorm as the cp task signal — mirrors the H19
+        # vol_p Charbonnier-in-task_losses pattern.
+        if surf_p_charbonnier_weight > 0.0:
+            pred_surf_p = out["surface_preds"][..., 0:1]  # cp = channel 0
+            target_surf_p = surface_target[..., 0:1]
+            loss_surf_p_charb = masked_charbonnier(
+                pred_surf_p,
+                target_surf_p,
+                batch.surface_mask,
+                eps=surf_p_charbonnier_eps,
+            )
+            loss_surf_p_mse_diag = masked_mse(
+                pred_surf_p, target_surf_p, batch.surface_mask
+            )
+        else:
+            loss_surf_p_charb = None
+            loss_surf_p_mse_diag = None
         if gradnorm_weights is not None:
             surface_per_ch = per_channel_masked_mse(
                 out["surface_preds"], surface_target, batch.surface_mask
             )  # [4]: cp, tau_x, tau_y, tau_z
-            volume_per_ch = per_channel_masked_mse(
-                out["volume_preds"], volume_target, batch.volume_mask
-            )  # [1]: vol_p
+            if loss_surf_p_charb is not None:
+                # H38: cp slot carries the Charbonnier tensor so GradNorm's L0
+                # anchor and per-task gradient norms reflect the reshape.
+                # Mirrors the H19 vol_p slot pattern below; an extra additive
+                # `surf_p_charb_weight * Charb` term would double-count.
+                surface_per_ch = torch.cat(
+                    [loss_surf_p_charb.unsqueeze(0), surface_per_ch[1:]]
+                )
+            if loss_vol_p_charb is not None:
+                # H19 advisor fix: vol_p slot carries the Charbonnier tensor
+                # so GradNorm's L0 anchor and per-task gradient norms reflect
+                # the reshape. The Charb contribution to the total loss is
+                # now w_vol_p * Charb_vol_p via the weighted sum below —
+                # adding a separate `vol_p_charb_weight * Charb` term would
+                # double-count.
+                volume_per_ch = loss_vol_p_charb.unsqueeze(0)  # [1]
+            else:
+                volume_per_ch = per_channel_masked_mse(
+                    out["volume_preds"], volume_target, batch.volume_mask
+                )  # [1]: vol_p MSE
             task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
             w_detached = gradnorm_weights.weights.detach()
             loss = (w_detached * task_losses).sum()
@@ -337,13 +451,90 @@ def train_loss(
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        # H10b: Supplementary Charbonnier (pseudo-Huber) on WSS channels.
+        # Channels 1-3 of surface_preds/target are tau_x, tau_y, tau_z (idx 0 is cp).
+        # With axes="z", restrict to channel 3 (tau_z) — the axis with the
+        # largest val→test gap in H10, while letting τ_x/τ_y keep H9's MSE.
+        if wss_charbonnier_weight > 0.0:
+            if wss_charbonnier_axes == "z":
+                pred_wss = out["surface_preds"][..., 3:4]
+                target_wss = surface_target[..., 3:4]
+            elif wss_charbonnier_axes == "all":
+                pred_wss = out["surface_preds"][..., 1:4]
+                target_wss = surface_target[..., 1:4]
+            else:
+                raise ValueError(
+                    f"Unknown wss_charbonnier_axes={wss_charbonnier_axes}"
+                )
+            loss_wss_charb = masked_charbonnier(
+                pred_wss, target_wss, batch.surface_mask, eps=wss_charbonnier_eps
+            )
+            loss_wss_mse_diag = masked_mse(pred_wss, target_wss, batch.surface_mask)
+            loss = loss + wss_charbonnier_weight * loss_wss_charb
+            charb_metrics = {
+                "loss_wss_charb_unweighted": float(
+                    loss_wss_charb.detach().cpu().item()
+                ),
+                "loss_wss_charb_weighted": float(
+                    (wss_charbonnier_weight * loss_wss_charb).detach().cpu().item()
+                ),
+                "loss_wss_charb_target_mse": float(
+                    loss_wss_mse_diag.detach().cpu().item()
+                ),
+            }
+        else:
+            charb_metrics = {}
+        # H19: vol_p Charbonnier — under GradNorm, the Charb tensor is already
+        # in task_losses[4] above, contributing w_vol_p * Charb_vol_p to the
+        # weighted sum. Adding an extra additive term would double-count.
+        # Without GradNorm we fall back to the additive form (loss += w * Charb)
+        # so the mechanism still fires.
+        if loss_vol_p_charb is not None:
+            if gradnorm_weights is None:
+                loss = loss + vol_p_charbonnier_weight * loss_vol_p_charb
+            vol_p_charb_metrics = {
+                "loss_vol_p_charb_unweighted": float(
+                    loss_vol_p_charb.detach().cpu().item()
+                ),
+                "loss_vol_p_charb_weighted": float(
+                    (vol_p_charbonnier_weight * loss_vol_p_charb).detach().cpu().item()
+                ),
+                "loss_vol_p_charb_target_mse": float(
+                    loss_vol_p_mse_diag.detach().cpu().item()
+                ),
+            }
+        else:
+            vol_p_charb_metrics = {}
+        # H38: surf_p (cp) Charbonnier — under GradNorm, the Charb tensor is
+        # already in task_losses[0] above; without GradNorm fall back to the
+        # additive form so the mechanism still fires.
+        if loss_surf_p_charb is not None:
+            if gradnorm_weights is None:
+                loss = loss + surf_p_charbonnier_weight * loss_surf_p_charb
+            surf_p_charb_metrics = {
+                "loss_surf_p_charb_unweighted": float(
+                    loss_surf_p_charb.detach().cpu().item()
+                ),
+                "loss_surf_p_charb_weighted": float(
+                    (surf_p_charbonnier_weight * loss_surf_p_charb).detach().cpu().item()
+                ),
+                "loss_surf_p_charb_target_mse": float(
+                    loss_surf_p_mse_diag.detach().cpu().item()
+                ),
+            }
+        else:
+            surf_p_charb_metrics = {}
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }, task_losses
+    }
+    metrics.update(charb_metrics)
+    metrics.update(vol_p_charb_metrics)
+    metrics.update(surf_p_charb_metrics)
+    return loss, metrics, task_losses
 
 
 def run_eval_only(config: Config, state) -> None:
@@ -583,6 +774,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    wss_charbonnier_weight=config.wss_charbonnier_weight,
+                    wss_charbonnier_eps=config.wss_charbonnier_eps,
+                    wss_charbonnier_axes=config.wss_charbonnier_axes,
+                    vol_p_charbonnier_weight=config.vol_p_charbonnier_weight,
+                    vol_p_charbonnier_eps=config.vol_p_charbonnier_eps,
+                    surf_p_charbonnier_weight=config.surf_p_charbonnier_weight,
+                    surf_p_charbonnier_eps=config.surf_p_charbonnier_eps,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -634,6 +832,82 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                         }
                     )
+                    if "loss_wss_charb_unweighted" in batch_loss_metrics:
+                        # H10b diagnostics: key suffix follows --wss-charbonnier-axes
+                        # so dashboards can compare "wss" (all-axes) vs "tau_z" (z-only).
+                        wss_axes_label = (
+                            "tau_z"
+                            if config.wss_charbonnier_axes == "z"
+                            else "wss"
+                        )
+                        target_mse = batch_loss_metrics["loss_wss_charb_target_mse"]
+                        charb_unw = batch_loss_metrics["loss_wss_charb_unweighted"]
+                        charb_w = batch_loss_metrics["loss_wss_charb_weighted"]
+                        ratio_to_mse = (
+                            charb_unw / target_mse
+                            if target_mse > 1e-12
+                            else float("nan")
+                        )
+                        weighted_ratio = (
+                            charb_w / target_mse
+                            if target_mse > 1e-12
+                            else float("nan")
+                        )
+                        train_log.update(
+                            {
+                                f"train/loss_{wss_axes_label}_mse": target_mse,
+                                f"train/loss_{wss_axes_label}_charb_unweighted": charb_unw,
+                                f"train/loss_{wss_axes_label}_charb_weighted": charb_w,
+                                f"train/loss_{wss_axes_label}_charb_to_mse_ratio": ratio_to_mse,
+                                f"train/loss_{wss_axes_label}_charb_weighted_to_mse_ratio": weighted_ratio,
+                            }
+                        )
+                    if "loss_vol_p_charb_unweighted" in batch_loss_metrics:
+                        vol_p_target_mse = batch_loss_metrics["loss_vol_p_charb_target_mse"]
+                        vol_p_charb_unw = batch_loss_metrics["loss_vol_p_charb_unweighted"]
+                        vol_p_charb_w = batch_loss_metrics["loss_vol_p_charb_weighted"]
+                        vol_p_ratio_to_mse = (
+                            vol_p_charb_unw / vol_p_target_mse
+                            if vol_p_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        vol_p_weighted_ratio = (
+                            vol_p_charb_w / vol_p_target_mse
+                            if vol_p_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        train_log.update(
+                            {
+                                "train/loss_vol_p_mse": vol_p_target_mse,
+                                "train/loss_vol_p_charb_unweighted": vol_p_charb_unw,
+                                "train/loss_vol_p_charb_weighted": vol_p_charb_w,
+                                "train/loss_vol_p_charb_to_mse_ratio": vol_p_ratio_to_mse,
+                                "train/loss_vol_p_charb_weighted_to_mse_ratio": vol_p_weighted_ratio,
+                            }
+                        )
+                    if "loss_surf_p_charb_unweighted" in batch_loss_metrics:
+                        sp_target_mse = batch_loss_metrics["loss_surf_p_charb_target_mse"]
+                        sp_charb_unw = batch_loss_metrics["loss_surf_p_charb_unweighted"]
+                        sp_charb_w = batch_loss_metrics["loss_surf_p_charb_weighted"]
+                        sp_ratio_to_mse = (
+                            sp_charb_unw / sp_target_mse
+                            if sp_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        sp_weighted_ratio = (
+                            sp_charb_w / sp_target_mse
+                            if sp_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        train_log.update(
+                            {
+                                "train/loss_surf_p_mse": sp_target_mse,
+                                "train/loss_surf_p_charb_unweighted": sp_charb_unw,
+                                "train/loss_surf_p_charb_weighted": sp_charb_w,
+                                "train/loss_surf_p_charb_to_mse_ratio": sp_ratio_to_mse,
+                                "train/loss_surf_p_charb_weighted_to_mse_ratio": sp_weighted_ratio,
+                            }
+                        )
                 if config.use_y_symmetry_aug and aug_log:
                     bs = max(1, aug_log.get("batch_size", 0))
                     train_log["train/aug/y_symmetry_flip_rate"] = (
@@ -706,6 +980,32 @@ def main(argv: Iterable[str] | None = None) -> None:
                                     float(gradnorm_n_tasks)
                                 )
                                 gradnorm_weights.log_weights.data.copy_(lw_norm)
+                                # H9: hard floor on vol_p task weight to prevent
+                                # GradNorm starvation (root cause of vol_p breach
+                                # in H1/H2/H3/H5). Indices: cp, tau_x, tau_y,
+                                # tau_z, vol_p.
+                                w_vol_p_clamp_active = False
+                                if config.gradnorm_min_w_vol_p > 0.0:
+                                    w_curr = gradnorm_weights.weights.detach()
+                                    vol_p_idx = 4
+                                    min_w = config.gradnorm_min_w_vol_p
+                                    if w_curr[vol_p_idx].item() < min_w:
+                                        w_vol_p_clamp_active = True
+                                        other_idx = torch.tensor(
+                                            [0, 1, 2, 3], device=w_curr.device
+                                        )
+                                        deficit = min_w - w_curr[vol_p_idx].item()
+                                        other_sum = w_curr[other_idx].sum().item()
+                                        scale = max(
+                                            (other_sum - deficit) / max(other_sum, 1e-12),
+                                            0.01,
+                                        )
+                                        new_w = w_curr.clone()
+                                        new_w[vol_p_idx] = min_w
+                                        new_w[other_idx] = w_curr[other_idx] * scale
+                                        gradnorm_weights.log_weights.data.copy_(
+                                            new_w.clamp_min(1e-12).log()
+                                        )
                                 # DDP: average log_weights across ranks for sync
                                 if state.enabled:
                                     torch.distributed.all_reduce(
@@ -739,6 +1039,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                                 gradnorm_log["gradnorm/G_bar"] = float(
                                     G_bar.detach().cpu().item()
                                 )
+                                if config.gradnorm_min_w_vol_p > 0.0:
+                                    gradnorm_log["gradnorm/w_vol_p_clamp_active"] = float(
+                                        w_vol_p_clamp_active
+                                    )
+                                    gradnorm_log["gradnorm/min_w_vol_p"] = float(
+                                        config.gradnorm_min_w_vol_p
+                                    )
                     if gradnorm_log:
                         train_log.update(gradnorm_log)
                     loss.backward()


### PR DESCRIPTION
## Hypothesis

**Attack the wave's structural pressure-axis floor via the symmetric Charbonnier mechanism**: apply Charbonnier loss to the surface pressure (cp) channel — mirroring the vol_p Charbonnier mechanism that already proved itself (H21 test_vol_p=3.579, sub-floor by −0.064).

### Why this is the right next experiment

**Wave 33's load-bearing finding** (across H21, H32, H33, and now H34): every wss-axis architectural arm produces test_wss < SOTA but BREACHES the surf_p floor at 3.577. The plateau is wave-wide:

| Variant | Mechanism | test_surf_p | vs floor 3.577 |
|---|---|---:|---:|
| H19 ref | curv + τz_Charb + vp_Charb | 3.627 | +0.050 (smallest miss) |
| H21 | + clamp 0.15 | 3.679 | +0.102 |
| H26 | + surf_lw=1.5 | 3.653 | +0.076 |
| H27 | + clamp 0.10 | 3.690 | +0.113 |
| H30 | + clamp 0.20 | 3.74 | +0.16 |
| H32 | + surf_lw=1.25 | 3.677 | +0.100 |
| H33 | GALE-Transolver | 3.652 | +0.075 |
| tay H102 (projected) | surface_out MLP 1×→2× | 3.85 | +0.27 (worse) |

**Mechanism analysis**: vol_p Charbonnier compresses the high-error tail (smoothed quadratic→linear), which is the exact failure mode of pressure metrics (high-magnitude outliers in low-flow regions dominate val/test gap). H19's `--vol-p-charbonnier-weight 0.1 --vol-p-charbonnier-eps 1e-3` clears the vol_p floor in H21. **The symmetric application to surf_p should be the cleanest single-lever floor crack we have.**

### Predicted outcome (vs H21 reference `xcj9749y`)

| Metric | H21 ref | H38 predicted | Δ vs floor / SOTA |
|---|---:|---:|---:|
| test_wss | 6.730 | ~6.73 (preserved) | beats SOTA by ~0.0 (within wave noise) |
| test_vol_p | **3.579** ✓ | ~3.58 (preserved) | clears floor 3.643 ✓ |
| **test_surf_p** | 3.679 (breach +0.10) | **~3.55** ⭐ | **clears floor 3.577 by ~0.03** |
| test_abupt | 5.832 | ~5.81 | beats SOTA 5.844 ✓ |

**This is the first single-mechanism shot at the surf_p floor.** If H38 lands `test_surf_p ≤ 3.577 AND test_vol_p ≤ 3.643 AND test_wss ≤ 6.727`, it satisfies all 4 floors of Issue #1056 — the first contract winner since the wave opened.

## Instructions

**Base**: H21 base (cherry-pick `829e3a9` if not already in your working tree — same H19-derived stack used by H21 → H27 → H32). Add `--surf-p-charbonnier-{weight,eps}` as a NEW mechanism, symmetric to `--vol-p-charbonnier-{weight,eps}`. Keep ALL H21 flags (incl. `--vol-p-charbonnier-weight 0.1`, `--gradnorm-min-w-vol-p 0.15`, `--wss-charbonnier-weight 0.1 --wss-charbonnier-axes z`, `--use-curvature-attention-bias`).

**Implementation** (~15-25 LoC, mirror existing vol_p Charbonnier path in 829e3a9):

In `train.py`:
1. Add CLI flags:
```python
parser.add_argument('--surf-p-charbonnier-weight', type=float, default=0.0,
                    help='Weight for Charbonnier loss on surface pressure (cp) channel. 0 = disabled.')
parser.add_argument('--surf-p-charbonnier-eps', type=float, default=1e-3,
                    help='Epsilon for Charbonnier loss on surface pressure.')
```

2. In the per-channel loss computation block (where `vol_p_charbonnier_loss` is computed; near the `surface_per_ch = per_channel_masked_mse(...)` call), add the symmetric surf_p Charbonnier path:
```python
# surf_p (cp) Charbonnier — mirrors vol_p Charbonnier mechanism
if config.surf_p_charbonnier_weight > 0:
    cp_pred = out["surface_preds"][..., 0]  # cp is index 0 of surface
    cp_target = surface_target[..., 0]
    cp_residual = cp_pred - cp_target
    # Apply same surface_mask reduction as cp MSE
    masked_residual = cp_residual * batch.surface_mask
    n_valid = batch.surface_mask.sum().clamp(min=1)
    surf_p_charb_loss = (torch.sqrt(masked_residual**2 + config.surf_p_charbonnier_eps**2) - config.surf_p_charbonnier_eps).sum() / n_valid
    surface_per_ch[0] = surface_per_ch[0] + config.surf_p_charbonnier_weight * surf_p_charb_loss
    # Log to W&B for engagement check
    wandb_log_dict["train/surf_p_charbonnier_loss"] = surf_p_charb_loss.detach()
```

Mirror EXACTLY whatever pattern the existing vol_p Charbonnier code uses in 829e3a9 — same reduction, same gradient detachment (or not), same task_losses integration point. The key invariant: cp channel of `task_losses` (index 0) should be augmented by Charb, so GradNorm sees the new task loss signal.

3. Add to W&B config: `wandb.config['surf_p_charbonnier_weight'] = config.surf_p_charbonnier_weight`.

**Engagement check at EP1**: post the median `train/surf_p_charbonnier_loss` value and median `surface_per_ch[0]` value. Sanity ratio: Charb-loss / MSE-loss should be ~0.5-2× depending on residual scale. If `surf_p_charbonnier_loss` is 0 or NaN, halt and debug the patch.

## EP3 abort gate

| Metric | Threshold | Reason |
|---|---|---|
| val_wss | < 7.50 | H21 ref EP3 was 7.40 — Charb-cp should not corrupt wss |
| val_surf_p | < 4.30 | H21 ref EP3 was 4.21; if surf_p worse than H21 → mechanism broken |
| val_vol_p | < 4.70 | H21 ref EP3 was 4.49; vol_p should be preserved |

Hard abort if any breach.

## EP10 soft gate

| Metric | Threshold | Reason |
|---|---|---|
| val_wss | ≤ 7.04 | H32-class wss retention |
| **val_surf_p** | ≤ **4.05** | **must beat H21 EP10 (~4.05)** — primary mechanism signal |
| val_vol_p | ≤ 3.90 | H21-level vol_p retained |

If `val_surf_p > 4.05 at EP10`, the Charbonnier-on-surf_p mechanism is NOT working — close as "symmetric Charbonnier fails to transfer to surf_p" (informative negative). The wave-wide surf_p plateau is then provably orthogonal to the loss-shape lever.

## Terminal gates (Issue #1056 strict AND-clause)

| Metric | Floor / Target | H38 must clear |
|---|---:|---|
| test_wss | ≤ 6.727 | beat SOTA (or tied) |
| **test_surf_p** | ≤ **3.577** | **THE wave-defining floor crack** |
| test_vol_p | ≤ 3.643 | preserved from H21 |
| test_abupt | ≤ 5.844 | preserved from H21 |

ALL 4 must clear → first wave-33 contract winner. Even 3 of 4 (with test_surf_p cleared) would be a strong directional result.

## Baseline (current best from BASELINE.md)

- PR #972 SOTA: test_wss=6.727, test_surf_p=3.577, test_vol_p=3.643, test_abupt=5.844
- H21 reference (`xcj9749y`): test_wss=6.730 (tied), test_surf_p=3.679 (+0.10 BREACH), test_vol_p=3.579 ✓, test_abupt=5.832 ✓
- H33 wave-best wss (`v4vkkr23`): test_wss=6.679 ⭐ but 3 floor breaches (closed)
- W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

## Reproduce command

```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --output-dir outputs/h38_surf_p_charb_0p1 \
  --epochs 30 --batch-size 1 \
  --train-surface-points 65000 --eval-surface-points 65536 \
  --train-volume-points 65000 --eval-volume-points 65536 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --use-ema --ema-decay 0.999 --ema-start-step 500 \
  --no-compile-model \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias \
  --wss-charbonnier-weight 0.1 --wss-charbonnier-eps 1e-3 --wss-charbonnier-axes z \
  --vol-p-charbonnier-weight 0.1 --vol-p-charbonnier-eps 1e-3 \
  --surf-p-charbonnier-weight 0.1 --surf-p-charbonnier-eps 1e-3 \
  --surface-loss-weight 1.0 --volume-loss-weight 1.0 \
  --wandb-group wss_h38_surf_p_charb_0p1 \
  --wandb-name dl24-nezuko/h38-surf-p-charb-0p1 \
  --agent dl24-nezuko
```

Train timeout: 1320 min (22h, same as H21). Expect ~21.5h walltime.

## Falsification ladder

1. **Patch engagement (EP1)**: `train/surf_p_charbonnier_loss` non-zero, finite, in range 0.001-0.05. Sanity ratio Charb/MSE ~0.5-2×. Fail → halt, debug.
2. **EP3 hard abort**: val_wss < 7.50 AND val_surf_p < 4.30 AND val_vol_p < 4.70. Fail → close.
3. **EP10 mechanism signal**: val_surf_p ≤ 4.05 (H21-level). Fail → close as "loss-shape lever doesn't transfer to surf_p".
4. **Terminal**: test_surf_p ≤ 3.577 (THE FLOOR) AND test_wss ≤ 6.727 AND test_vol_p ≤ 3.643. All 4 = contract winner. surf_p alone = strong directional.

## Wave 33 context

H32 closed (test_wss=6.691 beats SOTA), H33 closed (test_wss=6.679 new bar), **H34 just closed at EP10 (mechanism alive but ineffective for wss)** — third "alive-ineffective" architectural arm in Wave 33. All three breach pressure floors. **H38 is the wave's first explicitly pressure-axis-protection experiment**, not a wss-axis architecture. Other active arms: H35 frieren (slice-level WSS↔surf_p xattn, relaunching after Path 1 redirect), H36 tanjiro (asymmetric τ_z, EP5.6 healthy), H37 fern (GeoTransolver-true, EP0.5 alive after crash recovery).

Good luck — surf_p has been the wave's white whale. The symmetric Charbonnier mechanism is the cleanest mechanistic shot at it we have.
