### PR TITLE
Wave 33 H111: LAYERSCALE-IN-BACKBONE — Learnable per-channel residual rescaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -303,6 +303,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_layer_scale: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -316,12 +317,26 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if use_layer_scale:
+            # H111: per-channel learnable residual rescaling (CaiT, Touvron et al. 2021).
+            # Init at 1.0 so the block is an exact identity to the canonical residual at step 0.
+            self.gamma_attn = nn.Parameter(torch.ones(hidden_dim))
+            self.gamma_mlp = nn.Parameter(torch.ones(hidden_dim))
+        else:
+            self.gamma_attn = None
+            self.gamma_mlp = None
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        attn_out = self.attention(self.norm1(x), attn_mask=attn_mask)
+        if self.gamma_attn is not None:
+            attn_out = attn_out * self.gamma_attn
+        x = x + attn_out
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        mlp_out = self.mlp(self.norm2(x))
+        if self.gamma_mlp is not None:
+            mlp_out = mlp_out * self.gamma_mlp
+        x = x + mlp_out
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -336,6 +351,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        use_layer_scale: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -347,6 +363,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    use_layer_scale=use_layer_scale,
                 )
                 for _ in range(depth)
             ]
@@ -382,6 +399,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_layer_scale: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +414,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_layer_scale = use_layer_scale
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +491,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            use_layer_scale=use_layer_scale,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_layer_scale: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_layer_scale": (
+            "H111: Add learnable per-channel gamma scalars to both residual "
+            "branches of each TransformerBlock (CaiT-style LayerScale, "
+            "Touvron et al. 2021). Init at 1.0 so the model is identity to "
+            "the canonical residual at step 0; optimizer can drive each "
+            "channel up (amplify) or down (suppress / prune) under weight "
+            "decay. Param cost: 2 * hidden_dim * n_layers."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +285,35 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_layer_scale_metrics(model: nn.Module) -> dict[str, float]:
+    """H111: per-block gamma stats for the LayerScale residual rescalers.
+
+    Returns mean, std, min, max for each block's gamma_attn and gamma_mlp,
+    plus a fraction-near-zero diagnostic (|gamma|<0.05) per channel vector.
+    Returns empty dict when LayerScale is disabled or the backbone is absent.
+    """
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return {}
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return {}
+    metrics: dict[str, float] = {}
+    for i, blk in enumerate(blocks):
+        for tag in ("gamma_attn", "gamma_mlp"):
+            gamma = getattr(blk, tag, None)
+            if gamma is None:
+                continue
+            g = gamma.detach().float()
+            prefix = f"layer_scale/block{i}_{tag}"
+            metrics[f"{prefix}_mean"] = float(g.mean().item())
+            metrics[f"{prefix}_std"] = float(g.std().item())
+            metrics[f"{prefix}_min"] = float(g.min().item())
+            metrics[f"{prefix}_max"] = float(g.max().item())
+            metrics[f"{prefix}_frac_near_zero"] = float((g.abs() < 0.05).float().mean().item())
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,6 +346,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_layer_scale=config.use_layer_scale,
     )
 
 
@@ -1262,6 +1301,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_layer_scale_metrics(base_model))
+                if getattr(base_model, "use_layer_scale", False):
+                    ls_blocks = getattr(getattr(base_model, "backbone", None), "blocks", [])
+                    for i, blk in enumerate(ls_blocks):
+                        for tag in ("gamma_attn", "gamma_mlp"):
+                            gamma = getattr(blk, tag, None)
+                            if gamma is None:
+                                continue
+                            log_metrics[f"layer_scale_hist/block{i}_{tag}"] = wandb.Histogram(
+                                gamma.detach().float().cpu().numpy()
+                            )
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Wave 33 H111: LAYERSCALE-IN-BACKBONE — Learnable per-channel residual rescaling in TransformerBlock**

**Strategy tier shift (per Plateau Protocol):** After Wave 33 exhausted decoder-mechanism architecture experiments (width / depth / info-residual / xattn / FiLM / task-head all mapped), this is the first **REGULARIZATION-class** mechanism — a learnable residual rescaler that changes training dynamics without changing capacity. Different mechanism class from anything else in Wave 33 or Wave 34 in-flight.

**Mechanism — LayerScale (CaiT, Touvron et al. 2021, *Going deeper with image transformers*):**

Add learnable per-channel γ scalars to both residual branches of each TransformerBlock:
```python
x = x + γ_attn * attention(norm1(x))   # canonical: x = x + attention(norm1(x))
x = x + γ_mlp  * mlp(norm2(x))         # canonical: x = x + mlp(norm2(x))
```
where γ_attn, γ_mlp ∈ R^hidden_dim (per-channel scalars), broadcasted elementwise over (B, N, hidden_dim).

**Init: γ = 1.0** → exact identity to canonical at step 0. Optimizer can drive each channel up (amplify that channel's residual) or down (suppress / prune it). With canonical weight_decay=5e-4 (Lion), γ trends toward 0 unless gradient pressure keeps it at 1 — acting as a learned channel-wise pruning of useless residual contributions.

**Why this might help generalize:**
- Per-channel residual rescaling lets the model adapt residual-branch strength heterogeneously across depth — early blocks may want γ<1 (smoother features), late blocks may want γ>1 (sharper task-relevant signals).
- Reduces effective network depth where residuals are uninformative, which is a known generalization regularizer on small datasets.
- Identity at init means no convergence risk vs canonical (worst case: γ stays at 1, model behaves canonically).
- Validated mechanism: CaiT showed +0.3-0.5pp ImageNet top-1 at near-zero param overhead.

**Param cost:** 2 × hidden_dim (512) × n_layers (5) = **5,120 params** (+0.029% of total 17.4M).

**Different from H110 width-compound:** H110 (tanjiro Wave 34) adds capacity (+268K params), H111 keeps capacity fixed and modifies training dynamics. Orthogonal to all Wave 33/34 mechanisms — could compound with H102 width and/or H101 info-residual in Wave 35 if it shows a productive direction.

**Predicted outcomes:**
- **A WIN**: val_abupt < 6.126%, all 3 test floors hold — productive regularizer cracks val gate via flatter minima
- **B PARTIAL**: val miss but one or more test floor crosses (especially test_WSS_z if γ amplifies binding-axis-relevant channels)
- **C NULL**: γ values stabilize near 1.0 (LayerScale is a no-op on this dataset)
- **D NEG**: γ collapses to 0 in some channels and overall val regresses

If learned γ histograms show meaningful per-channel structure (some channels at 0, some at >1), the mechanism is engaged regardless of metric outcome — diagnostic value comes from γ analysis.

## Instructions

**1. Modify `target/model.py` `TransformerBlock`:**

Add to `__init__` after `self.mlp = UpActDownMlp(...)`:
```python
# H111: LayerScale per-channel residual rescaling
if use_layer_scale:
    self.gamma_attn = nn.Parameter(torch.ones(hidden_dim))  # init 1.0 = identity
    self.gamma_mlp = nn.Parameter(torch.ones(hidden_dim))
else:
    self.gamma_attn = None
    self.gamma_mlp = None
```

Modify `forward()`:
```python
def forward(self, x, attn_mask=None):
    x = _apply_token_mask(x, attn_mask)
    attn_out = self.attention(self.norm1(x), attn_mask=attn_mask)
    if self.gamma_attn is not None:
        attn_out = attn_out * self.gamma_attn  # broadcasts over (B, N, hidden_dim)
    x = x + attn_out
    x = _apply_token_mask(x, attn_mask)
    mlp_out = self.mlp(self.norm2(x))
    if self.gamma_mlp is not None:
        mlp_out = mlp_out * self.gamma_mlp
    x = x + mlp_out
    x = _apply_token_mask(x, attn_mask)
    return x
```

Plumb `use_layer_scale` through `__init__` signature (default `False`).

**2. Modify `Transformer` class** to pass `use_layer_scale` to each `TransformerBlock`.

**3. Modify the parent model class** (where `Transformer(...)` is constructed) to read `use_layer_scale` from config and pass it through.

**4. Add CLI flag** in `target/train.py`:
```python
parser.add_argument("--use-layer-scale", action="store_true",
                    help="H111: Add learnable per-channel γ to TransformerBlock residual branches (init 1.0)")
```
and wire it into model construction.

**5. Add diagnostic logging** at end of each epoch (rank 0 only):
```python
if model.module.backbone.blocks[0].gamma_attn is not None:
    for i, blk in enumerate(model.module.backbone.blocks):
        wandb.log({
            f"layer_scale/block{i}_gamma_attn_mean": blk.gamma_attn.mean().item(),
            f"layer_scale/block{i}_gamma_attn_std": blk.gamma_attn.std().item(),
            f"layer_scale/block{i}_gamma_mlp_mean": blk.gamma_mlp.mean().item(),
            f"layer_scale/block{i}_gamma_mlp_std": blk.gamma_mlp.std().item(),
        }, step=global_step)
```
(Adjust attribute path if model wrapping differs; the goal is per-block γ stats per epoch for mechanism analysis.)

**6. Reproduce command** (canonical recipe + `--use-layer-scale`):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-layer-scale \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name askeladd/h111-layerscale-in-backbone \
  --wandb-group wave33_h111_layerscale_in_backbone
```

**7. Audit before launch:** verify `--use-layer-scale` flag landed in `train.py` argparse (no phantom flags from refactors). Run a 10-step dry test to confirm γ logging produces values around 1.0 at init and that no shape errors occur in `_apply_token_mask` after the multiplication.

**8. Terminal SENPAI-RESULT** must include:
- `wandb_run_ids` (rank 0 run)
- `primary_metric`: `full_val_primary/abupt_axis_mean_rel_l2_pct`
- `test_metric`: `test_primary/abupt_axis_mean_rel_l2_pct`
- All channel test metrics (VP, SP, WSS, WSS_x, WSS_y, WSS_z)
- **γ histograms / per-block γ stats table at terminal** — this is the diagnostic deliverable

## Baseline

Current canonical baseline (from `BASELINE.md`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: **5.844%**
- test_VP: **3.643%** (AND-gate floor)
- test_SP: **3.577%** (AND-gate floor; 12-mechanism plateau confirmed)
- test_WSS: **6.727%** (AND-gate floor)
- test_WSS_z: **8.945%** (canonical binding-axis)
- W&B baseline: canonical 13-epoch run (see `BASELINE.md`)

**Wave 33 leader for reference:**
- H102 tanjiro (SURFACE-OUT-WIDER-MLP, +265K): val 6.118 ✓, test_VP 3.543 ✓, test_SP 3.724 ❌, test_WSS 6.858 ❌, test_WSS_z 8.889 ✓ (B PARTIAL gate-clear, NOT merged due to SP/WSS miss)

**Mechanism class state (after H103 closure):**
- ✓ WIDTH (H102) — strongest single-axis
- ✓ INFO-AT-INPUT (H101, +3K) — most efficient
- ✓ BIDIR-XATTN (H97, +1M) — works but cost-ineffective
- 🔴 FILM (H103) — CLOSED, global-pool insufficient
- 🔴 DEPTH (H99), TASK-HEAD (H92,93,96,100) — CLOSED
- ⏳ SELF-CONTEXT (H107), DECODER-ENSEMBLE (H108), ENCODER-SKIP (H109), VOL-WIDTH (H104), VOL-INFO-RESIDUAL (H106), SURF-NORMALS (H105) — in-flight
- 🆕 **REGULARIZATION (H111 this PR)** — NEW CLASS, learnable residual rescaling
- 🆕 COMPOUND (H110) — Wave 34 launched

Carry on, askeladd — this is the first regularization-tier experiment of the wave. Mechanism diagnostic (γ histograms per block) is as important as the metric outcome. If γ values stabilize near 1.0 across all channels, LayerScale is a no-op on this dataset and we close the class; if some channels collapse to 0 or amplify to >1, we have a learned-pruning signal worth compounding with capacity mechanisms in Wave 35.
