### PR TITLE
Wave 33 H112: STOCHASTIC-DEPTH-IN-BACKBONE — Linearly-scheduled DropPath on residuals

### DIFF
--- a/model.py
+++ b/model.py
@@ -33,6 +33,32 @@ def _apply_token_mask(x: torch.Tensor, mask: torch.Tensor | None) -> torch.Tenso
     return x * mask.unsqueeze(-1).to(device=x.device, dtype=x.dtype)
 
 
+class DropPath(nn.Module):
+    """Per-sample Stochastic Depth (Huang et al. 2016).
+
+    Drops entire residual branches with probability ``drop_prob`` during
+    training, with 1/keep_prob rescaling so expected magnitude is preserved.
+    Identity at eval, so adds zero inference cost. Broadcasting over the
+    sample dimension means each sample in a batch is independently kept/dropped.
+    """
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def extra_repr(self) -> str:
+        return f"drop_prob={self.drop_prob:.4f}"
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+        random_tensor.floor_()
+        return x.div(keep_prob) * random_tensor
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -303,6 +329,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_prob: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -316,12 +343,14 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path_attn = DropPath(drop_path_prob)
+        self.drop_path_mlp = DropPath(drop_path_prob)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.drop_path_attn(self.attention(self.norm1(x), attn_mask=attn_mask))
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.drop_path_mlp(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
         return x
 
@@ -336,8 +365,14 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        drop_path_max: float = 0.0,
     ):
         super().__init__()
+        if depth > 1:
+            drop_path_probs = [drop_path_max * i / (depth - 1) for i in range(depth)]
+        else:
+            drop_path_probs = [0.0]
+        self.drop_path_probs = drop_path_probs
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -347,8 +382,9 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
+                    drop_path_prob=drop_path_probs[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -382,6 +418,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        drop_path_max: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +433,7 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.drop_path_max = drop_path_max
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -472,6 +510,7 @@ class SurfaceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            drop_path_max=drop_path_max,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "drop_path_max": (
+            "H112: Maximum DropPath (stochastic depth, Huang et al. 2016) "
+            "probability applied to the final backbone block's residual "
+            "branches. Each TransformerBlock has independent DropPath on "
+            "the attention and MLP branches with a linear schedule from "
+            "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
+            "at eval so adds zero inference cost. 0.0 disables (default)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -308,6 +317,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        drop_path_max=config.drop_path_max,
     )
 
 
@@ -883,6 +893,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            backbone = getattr(base_model, "backbone", None)
+            if backbone is not None and hasattr(backbone, "blocks"):
+                drop_path_schedule = [
+                    float(blk.drop_path_attn.drop_prob) for blk in backbone.blocks
+                ]
+                wandb.summary["drop_path/max"] = config.drop_path_max
+                wandb.summary["drop_path/schedule"] = drop_path_schedule
+                if config.drop_path_max > 0.0:
+                    print(
+                        f"DropPath (H112): per-block schedule "
+                        f"(attn=mlp) = {drop_path_schedule}"
+                    )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

**Wave 33 H112: STOCHASTIC-DEPTH-IN-BACKBONE — Linearly-scheduled DropPath on TransformerBlock residual branches**

**Strategy tier shift (per Plateau Protocol):** After Wave 33 exhausted decoder-mechanism architecture experiments (width/depth/info-residual/xattn/FiLM/task-head/vol-width all mapped), this is the second **regularization-class** mechanism (paired with H111 LayerScale-in-backbone). Mechanistically distinct from H111: H111 = deterministic learnable γ rescale; H112 = stochastic per-step branch drop.

**Mechanism — Stochastic Depth / DropPath (Huang et al. 2016, *Deep Networks with Stochastic Depth*; refined for Transformers in DeiT-3, Swin, ConvNeXt):**

During training, each TransformerBlock's residual branch (attention + MLP) is independently dropped with probability `p_block`. When dropped, the residual contribution is zero, leaving identity through the skip connection. At eval, all branches active (full residuals).

```python
# canonical:
x = x + attention(norm1(x))
# H112 DropPath:
x = x + drop_path(attention(norm1(x)), p=p_attn)  # 1/keep_prob scaling when kept; 0 when dropped
```

**Linearly-increasing schedule** across the 5-block backbone (per ConvNeXt/Swin standard):
| Block | p_attn | p_mlp |
|---|---:|---:|
| 0 | 0.0000 | 0.0000 |
| 1 | 0.0250 | 0.0250 |
| 2 | 0.0500 | 0.0500 |
| 3 | 0.0750 | 0.0750 |
| 4 | **0.1000** | **0.1000** |

(max p = 0.10 is conservative for our 5-block backbone; literature uses 0.1-0.3 for 12-24 block ViTs and proportionally smaller for shallow nets.)

**Why this might help generalize:**
- Each training step uses a stochastically shallower sub-network → forces redundancy across blocks
- Effectively trains an ensemble of 2^(2*depth) sub-networks (each branch can be on or off independently)
- Acts as a strong implicit regularizer on small-dataset transformers — proven to improve val→test generalization
- Identity at eval (zero inference cost or risk) — worst case the model trains slightly slower and val tracks canonical
- 0 added params

**Different from H111 LayerScale:**
- H111: deterministic per-channel γ scaling, init γ=1.0 identity, optimizer-driven adjustment
- H112: stochastic per-step branch drop, no learnable params, identity at eval
- H111 modifies the optimizer's gradient landscape; H112 modifies the forward computation noise
- The two mechanisms are orthogonal — could compound in Wave 35 if one or both validate

**Predicted outcomes:**
- **A WIN**: val_abupt < 6.126%, all 3 test floors hold — stochastic regularization flattens minima
- **B PARTIAL**: val gate near-miss + test floor cross (especially WSS_z if regularization improves binding-axis generalization)
- **C NULL**: train/val curves match canonical — DropPath at p_max=0.10 too gentle for our shallow 5-block backbone
- **D NEG**: train regresses noticeably (DropPath too aggressive for short 13-epoch budget)

**Key falsifiable**: if H111 wins and H112 wins, regularization class is productive (compound candidate). If H111 wins but H112 fails, deterministic > stochastic on this task. If H112 wins but H111 fails, stochastic > deterministic. If both fail, regularization class CLOSED.

## Instructions

**1. Add DropPath module in `target/model.py`:**

```python
class DropPath(nn.Module):
    """Stochastic Depth per sample. Identity at eval; rescaling at train ensures expected magnitude is preserved."""
    def __init__(self, drop_prob: float = 0.0):
        super().__init__()
        self.drop_prob = drop_prob

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        if not self.training or self.drop_prob == 0.0:
            return x
        keep_prob = 1.0 - self.drop_prob
        # broadcast over batch dim: shape (B, 1, 1) for (B, N, C) input
        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
        random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
        random_tensor.floor_()  # 0 or 1
        return x.div(keep_prob) * random_tensor
```

**2. Modify `TransformerBlock` `__init__` signature** to accept `drop_path_prob: float = 0.0`:

```python
def __init__(self, ..., drop_path_prob: float = 0.0):
    super().__init__()
    ...  # existing init
    self.drop_path_attn = DropPath(drop_path_prob)
    self.drop_path_mlp = DropPath(drop_path_prob)
```

**3. Modify `TransformerBlock.forward()`:**

```python
def forward(self, x, attn_mask=None):
    x = _apply_token_mask(x, attn_mask)
    x = x + self.drop_path_attn(self.attention(self.norm1(x), attn_mask=attn_mask))
    x = _apply_token_mask(x, attn_mask)
    x = x + self.drop_path_mlp(self.mlp(self.norm2(x)))
    x = _apply_token_mask(x, attn_mask)
    return x
```

**4. Modify `Transformer.__init__`** to accept `drop_path_max: float = 0.0` and compute per-block schedule:

```python
def __init__(self, depth, hidden_dim, ..., drop_path_max: float = 0.0):
    super().__init__()
    # Linear schedule from 0 (block 0) to drop_path_max (final block)
    drop_path_probs = (
        [drop_path_max * i / max(depth - 1, 1) for i in range(depth)]
        if depth > 1 else [0.0]
    )
    self.blocks = nn.ModuleList([
        TransformerBlock(..., drop_path_prob=drop_path_probs[i])
        for i in range(depth)
    ])
```

**5. Plumb `drop_path_max` through the parent model class** and add CLI flag in `target/train.py`:

```python
parser.add_argument("--drop-path-max", type=float, default=0.0,
                    help="H112: Max DropPath probability for last backbone block (linear schedule from 0 at block 0)")
```

**6. Verify flag landed in argparse** (audit per memory rule — phantom flags from refactors crash at startup).

**7. Add diagnostic logging at epoch end (rank 0)** to verify schedule is active:

```python
if hasattr(model.module.backbone, 'blocks'):
    block_drop_probs = [blk.drop_path_attn.drop_prob for blk in model.module.backbone.blocks]
    wandb.log({"drop_path/schedule": str(block_drop_probs)}, step=global_step)
```

(One-time log per epoch is sufficient — values are fixed across training.)

**8. Reproduce command** (canonical + `--drop-path-max 0.10`):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name edward/h112-stochastic-depth-in-backbone \
  --wandb-group wave33_h112_stochastic_depth_in_backbone
```

**9. Terminal SENPAI-RESULT** must include:
- `wandb_run_ids` (rank 0)
- `primary_metric`: `full_val_primary/abupt_axis_mean_rel_l2_pct`
- `test_metric`: `test_primary/abupt_axis_mean_rel_l2_pct`
- All channel test metrics (VP, SP, WSS, WSS_x, WSS_y, WSS_z)
- Train-loss vs val-loss gap at terminal (diagnostic for whether DropPath reduced overfit)
- Per-block DropPath schedule actually applied (sanity check)

## Baseline

Current canonical baseline (from `BASELINE.md`):
- val_abupt: **6.126%** (merge gate)
- test_abupt: **5.844%**
- test_VP: **3.643%** (AND-gate floor)
- test_SP: **3.577%** (AND-gate floor; **13-mechanism plateau confirmed**)
- test_WSS: **6.727%** (AND-gate floor)
- test_WSS_z: **8.945%** (canonical binding-axis)

**Wave 33 mechanism class state (after H103 + H104 closures):**
- ✓ WIDTH SURFACE (H102, +266K) — gate-clearing leader, NOT merged due to SP/WSS miss
- ✓ WIDTH VOLUME (H104, +229K, this run's predecessor on your slot) — test_VP −0.108pp cross, val gate near-miss
- ✓ INFO-AT-INPUT (H101, +3K) — deepest test_VP cross, most efficient
- ✓ BIDIR-XATTN (H97, +1M) — val-overfit on binding axis, cost-ineffective
- 🔴 FILM (H103) — CLOSED, global-pool insufficient
- 🔴 DEPTH (H99), TASK-HEAD (H92/93/96/100) — CLOSED
- ⏳ SELF-CONTEXT (H107), DECODER-ENSEMBLE (H108), ENCODER-SKIP (H109), VOL-INFO-RESIDUAL (H106), SURF-NORMALS (H105) — in-flight
- 🆕 COMPOUND (H110 H102+H101) — Wave 34 launched
- 🆕 REGULARIZATION-DETERMINISTIC (H111 LayerScale) — askeladd, just launched
- 🆕 **REGULARIZATION-STOCHASTIC (H112 this PR)** — NEW CLASS, paired diagnostic with H111

Carry on, edward — this is the second regularization-tier experiment of the wave (paired with H111). Mechanistic complementarity with H111 means the H111+H112 outcomes together answer "is regularization productive on this task?" If both succeed independently, expect a Wave 35 H111+H112 compound. If both fail, regularization class CLOSED.
