### PR TITLE
WSS H39: Wider surface_out MLP — port tay H102 (hidden 512→1024) onto H21 base

### DIFF
--- a/model.py
+++ b/model.py
@@ -172,6 +172,31 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+class CurvatureAttentionBias(nn.Module):
+    """Zero-init projection of curvature features to an additive token bias.
+
+    WSS H5 (PR #1132). Surface input channels stay at 7; curvature is injected
+    AFTER the input projection so the GradNorm task-share budget per token is
+    unchanged. The final linear is zero-initialised, so at step 0 the bias
+    contributes exactly 0 and the model is functionally identical to the
+    no-curvature SOTA baseline.
+    """
+
+    def __init__(self, hidden_dim: int, curvature_dim: int = 3):
+        super().__init__()
+        mid = max(hidden_dim // 8, 16)
+        self.net = nn.Sequential(
+            nn.Linear(curvature_dim, mid),
+            nn.SiLU(),
+            nn.Linear(mid, hidden_dim),
+        )
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, curvature: torch.Tensor) -> torch.Tensor:
+        return self.net(curvature)
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -315,6 +340,9 @@ class SurfaceTransolver(nn.Module):
         pe_kind: str = "sincos",
         pe_num_features: int = 16,
         pe_init_sigmas: list[float] | None = None,
+        use_curvature_attention_bias: bool = False,
+        curvature_dim: int = 3,
+        surface_out_width_factor: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -325,6 +353,9 @@ class SurfaceTransolver(nn.Module):
         self.pe_kind = pe_kind
         self.pe_num_features = pe_num_features
         self.pe_init_sigmas = list(pe_init_sigmas) if pe_init_sigmas else None
+        self.use_curvature_attention_bias = use_curvature_attention_bias
+        self.curvature_dim = curvature_dim
+        self.surface_out_width_factor = float(surface_out_width_factor)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -353,6 +384,12 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        self.curvature_attn_bias: CurvatureAttentionBias | None = None
+        if use_curvature_attention_bias:
+            self.curvature_attn_bias = CurvatureAttentionBias(
+                hidden_dim=n_hidden,
+                curvature_dim=curvature_dim,
+            )
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -362,7 +399,20 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+        # H39 (PR #1284): widened 2-layer surface_out head (Linear-GELU-Linear)
+        # with hidden width = int(n_hidden * surface_out_width_factor). At
+        # factor=2.0 this matches tay H102's wider-head mechanism on top of
+        # H21 base. Note: at factor=1.0 this is NOT byte-identical to the
+        # pre-H39 single-Linear canonical (it adds an extra Linear+GELU);
+        # this is documented in the PR and is acceptable as the H39 test
+        # explicitly uses factor=2.0.
+        surf_hidden_width = max(1, int(n_hidden * self.surface_out_width_factor))
+        self.surface_out_hidden_width = surf_hidden_width
+        self.surface_out = nn.Sequential(
+            nn.Linear(n_hidden, surf_hidden_width),
+            nn.GELU(),
+            nn.Linear(surf_hidden_width, self.surface_output_dim),
+        )
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -386,6 +436,7 @@ class SurfaceTransolver(nn.Module):
         surface_mask: torch.Tensor | None = None,
         volume_x: torch.Tensor | None = None,
         volume_mask: torch.Tensor | None = None,
+        surface_curvature: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         if surface_x is None and volume_x is None:
             raise ValueError("SurfaceTransolver requires surface_x or volume_x")
@@ -401,14 +452,22 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_tokens = surface_x.shape[1]
-            tokens.append(
-                self._encode_group(
-                    surface_x,
-                    project_features=self.project_surface_features,
-                    bias=self.surface_bias,
-                    placeholder=self.surface_placeholder,
-                )
+            surface_encoded = self._encode_group(
+                surface_x,
+                project_features=self.project_surface_features,
+                bias=self.surface_bias,
+                placeholder=self.surface_placeholder,
             )
+            if self.curvature_attn_bias is not None and surface_curvature is not None:
+                curv = surface_curvature.to(
+                    device=surface_encoded.device,
+                    dtype=surface_encoded.dtype,
+                )
+                bias = self.curvature_attn_bias(curv)
+                if surface_mask is not None:
+                    bias = bias * surface_mask.unsqueeze(-1).to(dtype=bias.dtype)
+                surface_encoded = surface_encoded + bias
+            tokens.append(surface_encoded)
             masks.append(surface_mask)
 
         if volume_x is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "wandb",
     "pyyaml",
     "lion-pytorch",
+    "scipy",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -132,6 +132,15 @@ class Config:
     use_gradnorm: bool = False
     gradnorm_alpha: float = 1.0
     gradnorm_lr: float = 1e-3
+    gradnorm_min_w_vol_p: float = 0.0
+    use_curvature_attention_bias: bool = False
+    wss_charbonnier_weight: float = 0.0
+    wss_charbonnier_eps: float = 1e-3
+    wss_charbonnier_axes: str = "all"
+    vol_p_charbonnier_weight: float = 0.0
+    vol_p_charbonnier_eps: float = 1e-3
+    tau_z_loss_weight: float = 1.0
+    surface_out_width_factor: float = 1.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -145,16 +154,34 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "a logged W&B key exactly, for example "
             "'500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25'."
         ),
+        "wss_charbonnier_axes": (
+            "Which WSS channels the supplementary Charbonnier loss applies to. "
+            "'all' = tau_x, tau_y, tau_z (H10 default). 'z' = tau_z only (H10b)."
+        ),
+        "surface_out_width_factor": (
+            "Width multiplier for surface_out hidden layer (H39 PR #1284). "
+            "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
+        ),
+    }
+    choices_text = {
+        "wss_charbonnier_axes": ["all", "z"],
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
         arg_name = f"--{field.name.replace('_', '-')}"
         help_value = help_text.get(field.name)
+        choices = choices_text.get(field.name)
         if isinstance(value, bool):
             parser.add_argument(arg_name, action="store_true", default=value, help=help_value)
             parser.add_argument(f"--no-{field.name.replace('_', '-')}", action="store_false", dest=field.name)
         else:
-            parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
+            parser.add_argument(
+                arg_name,
+                type=type(value),
+                default=value,
+                help=help_value,
+                choices=choices,
+            )
     namespace = parser.parse_args(argv)
     return Config(**vars(namespace))
 
@@ -224,6 +251,27 @@ def per_channel_masked_mse(
     return weighted.sum(dim=(0, 1)) / denom  # [C]
 
 
+def masked_charbonnier(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Masked Charbonnier (pseudo-Huber) loss: ``sqrt(eps^2 + (pred-target)^2) - eps``.
+
+    Averaged over masked spatial points and channels, matching the convention
+    used by :func:`masked_mse`. Differentiable everywhere, gradient bounded by 1
+    in magnitude — robust to outliers compared with squared error.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    delta = pred - target
+    values = torch.sqrt(eps * eps + delta * delta) - eps  # [B, N, C]
+    weighted = values * mask_f
+    n_pts = mask_f.sum().clamp_min(1.0)
+    n_ch = float(pred.shape[-1])
+    return weighted.sum() / (n_pts * n_ch)
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -235,6 +283,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_kind=config.model_pe,
         pe_num_features=config.pe_num_features,
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
+        use_curvature_attention_bias=config.use_curvature_attention_bias,
+        surface_out_width_factor=config.surface_out_width_factor,
     )
 
 
@@ -301,8 +351,18 @@ def train_loss(
     y_symmetry_aug_prob: float = 0.5,
     aug_log: dict | None = None,
     gradnorm_weights: GradNormWeights | None = None,
+    wss_charbonnier_weight: float = 0.0,
+    wss_charbonnier_eps: float = 1e-3,
+    wss_charbonnier_axes: str = "all",
+    vol_p_charbonnier_weight: float = 0.0,
+    vol_p_charbonnier_eps: float = 1e-3,
+    tau_z_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
+    surface_curvature = getattr(batch, "surface_curvature", None)
     batch = batch.to(device)
+    if surface_curvature is not None:
+        surface_curvature = surface_curvature.to(device)
+        setattr(batch, "surface_curvature", surface_curvature)
     if use_y_symmetry_aug:
         flip_mask = apply_y_symmetry_aug(batch, y_symmetry_aug_prob)
         if aug_log is not None:
@@ -310,22 +370,68 @@ def train_loss(
             aug_log["batch_size"] = int(flip_mask.shape[0])
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    forward_kwargs: dict[str, torch.Tensor] = dict(
+        surface_x=batch.surface_x,
+        surface_mask=batch.surface_mask,
+        volume_x=batch.volume_x,
+        volume_mask=batch.volume_mask,
+    )
+    if surface_curvature is not None:
+        forward_kwargs["surface_curvature"] = surface_curvature
     with autocast_context(device, amp_mode):
-        out = model(
-            surface_x=batch.surface_x,
-            surface_mask=batch.surface_mask,
-            volume_x=batch.volume_x,
-            volume_mask=batch.volume_mask,
-        )
+        out = model(**forward_kwargs)
         surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+        # H19 advisor fix: pre-compute Charbonnier on vol_p so it can be
+        # passed to GradNorm as the vol_p task signal (the L0 anchor and
+        # per-task gradient norms need to reflect the reshaped Charb
+        # landscape, otherwise the H19 mechanism is invisible to the
+        # dynamic-weight balancing — root cause flagged in run i4zt1zrl).
+        if vol_p_charbonnier_weight > 0.0:
+            pred_vol_p = out["volume_preds"]  # [B, N_vol, 1]
+            target_vol_p = volume_target
+            loss_vol_p_charb = masked_charbonnier(
+                pred_vol_p,
+                target_vol_p,
+                batch.volume_mask,
+                eps=vol_p_charbonnier_eps,
+            )
+            loss_vol_p_mse_diag = masked_mse(
+                pred_vol_p, target_vol_p, batch.volume_mask
+            )
+        else:
+            loss_vol_p_charb = None
+            loss_vol_p_mse_diag = None
         if gradnorm_weights is not None:
+            # H26: scale per-task losses by surface_loss_weight / volume_loss_weight
+            # BEFORE concatenation. L0 (captured from task_losses on the first
+            # step) absorbs the scaling so r-ratios cancel; the lever then acts
+            # through gradient magnitudes (c_per_task / G_bar) and the total
+            # backward signal, not through r-renormalisation.
             surface_per_ch = per_channel_masked_mse(
                 out["surface_preds"], surface_target, batch.surface_mask
-            )  # [4]: cp, tau_x, tau_y, tau_z
-            volume_per_ch = per_channel_masked_mse(
-                out["volume_preds"], volume_target, batch.volume_mask
-            )  # [1]: vol_p
+            ) * surface_loss_weight  # [4]: cp, tau_x, tau_y, tau_z
+            # H36: Asymmetric tau_z boost. Multiply ONLY index 3 (tau_z) by
+            # tau_z_loss_weight. Same pre-GradNorm injection point as H26 —
+            # L0 absorbs the scaling so the lever acts through gradient
+            # magnitudes (c_tau_z / G_bar) and the total backward signal,
+            # without disturbing cp/tau_x/tau_y budgets.
+            tau_z_scale = surface_per_ch.new_tensor(
+                [1.0, 1.0, 1.0, tau_z_loss_weight]
+            )
+            surface_per_ch = surface_per_ch * tau_z_scale
+            if loss_vol_p_charb is not None:
+                # H19 advisor fix: vol_p slot carries the Charbonnier tensor
+                # so GradNorm's L0 anchor and per-task gradient norms reflect
+                # the reshape. The Charb contribution to the total loss is
+                # now w_vol_p * Charb_vol_p via the weighted sum below —
+                # adding a separate `vol_p_charb_weight * Charb` term would
+                # double-count.
+                volume_per_ch = loss_vol_p_charb.unsqueeze(0) * volume_loss_weight  # [1]
+            else:
+                volume_per_ch = per_channel_masked_mse(
+                    out["volume_preds"], volume_target, batch.volume_mask
+                ) * volume_loss_weight  # [1]: vol_p MSE
             task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
             w_detached = gradnorm_weights.weights.detach()
             loss = (w_detached * task_losses).sum()
@@ -337,13 +443,70 @@ def train_loss(
             weighted_volume_loss = volume_loss_weight * volume_loss
             loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        # H10b: Supplementary Charbonnier (pseudo-Huber) on WSS channels.
+        # Channels 1-3 of surface_preds/target are tau_x, tau_y, tau_z (idx 0 is cp).
+        # With axes="z", restrict to channel 3 (tau_z) — the axis with the
+        # largest val→test gap in H10, while letting τ_x/τ_y keep H9's MSE.
+        if wss_charbonnier_weight > 0.0:
+            if wss_charbonnier_axes == "z":
+                pred_wss = out["surface_preds"][..., 3:4]
+                target_wss = surface_target[..., 3:4]
+            elif wss_charbonnier_axes == "all":
+                pred_wss = out["surface_preds"][..., 1:4]
+                target_wss = surface_target[..., 1:4]
+            else:
+                raise ValueError(
+                    f"Unknown wss_charbonnier_axes={wss_charbonnier_axes}"
+                )
+            loss_wss_charb = masked_charbonnier(
+                pred_wss, target_wss, batch.surface_mask, eps=wss_charbonnier_eps
+            )
+            loss_wss_mse_diag = masked_mse(pred_wss, target_wss, batch.surface_mask)
+            loss = loss + wss_charbonnier_weight * loss_wss_charb
+            charb_metrics = {
+                "loss_wss_charb_unweighted": float(
+                    loss_wss_charb.detach().cpu().item()
+                ),
+                "loss_wss_charb_weighted": float(
+                    (wss_charbonnier_weight * loss_wss_charb).detach().cpu().item()
+                ),
+                "loss_wss_charb_target_mse": float(
+                    loss_wss_mse_diag.detach().cpu().item()
+                ),
+            }
+        else:
+            charb_metrics = {}
+        # H19: vol_p Charbonnier — under GradNorm, the Charb tensor is already
+        # in task_losses[4] above, contributing w_vol_p * Charb_vol_p to the
+        # weighted sum. Adding an extra additive term would double-count.
+        # Without GradNorm we fall back to the additive form (loss += w * Charb)
+        # so the mechanism still fires.
+        if loss_vol_p_charb is not None:
+            if gradnorm_weights is None:
+                loss = loss + vol_p_charbonnier_weight * loss_vol_p_charb
+            vol_p_charb_metrics = {
+                "loss_vol_p_charb_unweighted": float(
+                    loss_vol_p_charb.detach().cpu().item()
+                ),
+                "loss_vol_p_charb_weighted": float(
+                    (vol_p_charbonnier_weight * loss_vol_p_charb).detach().cpu().item()
+                ),
+                "loss_vol_p_charb_target_mse": float(
+                    loss_vol_p_mse_diag.detach().cpu().item()
+                ),
+            }
+        else:
+            vol_p_charb_metrics = {}
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }, task_losses
+    }
+    metrics.update(charb_metrics)
+    metrics.update(vol_p_charb_metrics)
+    return loss, metrics, task_losses
 
 
 def run_eval_only(config: Config, state) -> None:
@@ -583,6 +746,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     y_symmetry_aug_prob=config.y_symmetry_aug_prob,
                     aug_log=aug_log,
                     gradnorm_weights=gradnorm_weights,
+                    wss_charbonnier_weight=config.wss_charbonnier_weight,
+                    wss_charbonnier_eps=config.wss_charbonnier_eps,
+                    wss_charbonnier_axes=config.wss_charbonnier_axes,
+                    vol_p_charbonnier_weight=config.vol_p_charbonnier_weight,
+                    vol_p_charbonnier_eps=config.vol_p_charbonnier_eps,
+                    tau_z_loss_weight=config.tau_z_loss_weight,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -632,8 +801,62 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "loss_wss_charb_unweighted" in batch_loss_metrics:
+                        # H10b diagnostics: key suffix follows --wss-charbonnier-axes
+                        # so dashboards can compare "wss" (all-axes) vs "tau_z" (z-only).
+                        wss_axes_label = (
+                            "tau_z"
+                            if config.wss_charbonnier_axes == "z"
+                            else "wss"
+                        )
+                        target_mse = batch_loss_metrics["loss_wss_charb_target_mse"]
+                        charb_unw = batch_loss_metrics["loss_wss_charb_unweighted"]
+                        charb_w = batch_loss_metrics["loss_wss_charb_weighted"]
+                        ratio_to_mse = (
+                            charb_unw / target_mse
+                            if target_mse > 1e-12
+                            else float("nan")
+                        )
+                        weighted_ratio = (
+                            charb_w / target_mse
+                            if target_mse > 1e-12
+                            else float("nan")
+                        )
+                        train_log.update(
+                            {
+                                f"train/loss_{wss_axes_label}_mse": target_mse,
+                                f"train/loss_{wss_axes_label}_charb_unweighted": charb_unw,
+                                f"train/loss_{wss_axes_label}_charb_weighted": charb_w,
+                                f"train/loss_{wss_axes_label}_charb_to_mse_ratio": ratio_to_mse,
+                                f"train/loss_{wss_axes_label}_charb_weighted_to_mse_ratio": weighted_ratio,
+                            }
+                        )
+                    if "loss_vol_p_charb_unweighted" in batch_loss_metrics:
+                        vol_p_target_mse = batch_loss_metrics["loss_vol_p_charb_target_mse"]
+                        vol_p_charb_unw = batch_loss_metrics["loss_vol_p_charb_unweighted"]
+                        vol_p_charb_w = batch_loss_metrics["loss_vol_p_charb_weighted"]
+                        vol_p_ratio_to_mse = (
+                            vol_p_charb_unw / vol_p_target_mse
+                            if vol_p_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        vol_p_weighted_ratio = (
+                            vol_p_charb_w / vol_p_target_mse
+                            if vol_p_target_mse > 1e-12
+                            else float("nan")
+                        )
+                        train_log.update(
+                            {
+                                "train/loss_vol_p_mse": vol_p_target_mse,
+                                "train/loss_vol_p_charb_unweighted": vol_p_charb_unw,
+                                "train/loss_vol_p_charb_weighted": vol_p_charb_w,
+                                "train/loss_vol_p_charb_to_mse_ratio": vol_p_ratio_to_mse,
+                                "train/loss_vol_p_charb_weighted_to_mse_ratio": vol_p_weighted_ratio,
+                            }
+                        )
                 if config.use_y_symmetry_aug and aug_log:
                     bs = max(1, aug_log.get("batch_size", 0))
                     train_log["train/aug/y_symmetry_flip_rate"] = (
@@ -706,6 +929,32 @@ def main(argv: Iterable[str] | None = None) -> None:
                                     float(gradnorm_n_tasks)
                                 )
                                 gradnorm_weights.log_weights.data.copy_(lw_norm)
+                                # H9: hard floor on vol_p task weight to prevent
+                                # GradNorm starvation (root cause of vol_p breach
+                                # in H1/H2/H3/H5). Indices: cp, tau_x, tau_y,
+                                # tau_z, vol_p.
+                                w_vol_p_clamp_active = False
+                                if config.gradnorm_min_w_vol_p > 0.0:
+                                    w_curr = gradnorm_weights.weights.detach()
+                                    vol_p_idx = 4
+                                    min_w = config.gradnorm_min_w_vol_p
+                                    if w_curr[vol_p_idx].item() < min_w:
+                                        w_vol_p_clamp_active = True
+                                        other_idx = torch.tensor(
+                                            [0, 1, 2, 3], device=w_curr.device
+                                        )
+                                        deficit = min_w - w_curr[vol_p_idx].item()
+                                        other_sum = w_curr[other_idx].sum().item()
+                                        scale = max(
+                                            (other_sum - deficit) / max(other_sum, 1e-12),
+                                            0.01,
+                                        )
+                                        new_w = w_curr.clone()
+                                        new_w[vol_p_idx] = min_w
+                                        new_w[other_idx] = w_curr[other_idx] * scale
+                                        gradnorm_weights.log_weights.data.copy_(
+                                            new_w.clamp_min(1e-12).log()
+                                        )
                                 # DDP: average log_weights across ranks for sync
                                 if state.enabled:
                                     torch.distributed.all_reduce(
@@ -739,6 +988,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                                 gradnorm_log["gradnorm/G_bar"] = float(
                                     G_bar.detach().cpu().item()
                                 )
+                                if config.gradnorm_min_w_vol_p > 0.0:
+                                    gradnorm_log["gradnorm/w_vol_p_clamp_active"] = float(
+                                        w_vol_p_clamp_active
+                                    )
+                                    gradnorm_log["gradnorm/min_w_vol_p"] = float(
+                                        config.gradnorm_min_w_vol_p
+                                    )
                     if gradnorm_log:
                         train_log.update(gradnorm_log)
                     loss.backward()

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import re
@@ -15,6 +16,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -30,6 +32,13 @@ from data import (
     VOLUME_Y_DIM,
     load_data,
     pad_collate,
+)
+from data.loader import (
+    DEFAULT_MANIFEST,
+    DrivAerMLCase,
+    DrivAerMLCaseStore,
+    DrivAerMLSurfaceDataset,
+    _load_npy_rows,
 )
 
 
@@ -229,10 +238,134 @@ def resolve_num_workers(config) -> int:
     return min(4, os.cpu_count() or 4)
 
 
+CURVATURE_CACHE_FILENAME = "surface_curvature_proxy_k16_v1.npy"
+CURVATURE_STATS_FILENAME = "curvature_proxy_stats_k16_v1.json"
+CURVATURE_DIM = 3
+
+
+def load_curvature_stats(stats_path: str | Path | None = None) -> dict[str, list[float]]:
+    """Load train-split curvature mean/std for z-score normalisation."""
+
+    if stats_path is None:
+        stats_path = Path(__file__).resolve().parent / CURVATURE_STATS_FILENAME
+    stats_path = Path(stats_path)
+    if not stats_path.exists():
+        raise FileNotFoundError(
+            f"Curvature stats missing: {stats_path}. Run "
+            f"`python -m scripts.precompute_curvature_proxy` before training."
+        )
+    with stats_path.open() as f:
+        stats = json.load(f)
+    return stats
+
+
+class CurvatureAugmentedCaseStore(DrivAerMLCaseStore):
+    """Case store that loads pre-computed curvature proxy alongside each case.
+
+    Reads ``surface_curvature_proxy_k16_v1.npy`` of shape ``(V, 3)`` from each
+    case directory and z-scores it with the dataset-level mean/std cached in
+    ``curvature_proxy_stats_k16_v1.json``. The normalised curvature is stored
+    in ``case.metadata["surface_curvature"]`` as a ``torch.Tensor`` of shape
+    ``(N_loaded_surface, 3)`` so the collate function can pad and attach it
+    to the batch without changing ``SurfaceBatch``'s schema.
+    """
+
+    def __init__(
+        self,
+        manifest_path: str | Path = DEFAULT_MANIFEST,
+        root: str | Path | None = None,
+        *,
+        stats: dict[str, list[float]] | None = None,
+    ):
+        super().__init__(manifest_path=manifest_path, root=root)
+        if stats is None:
+            stats = load_curvature_stats()
+        mean = np.asarray(stats["mean"], dtype=np.float32)
+        std = np.asarray(stats["std"], dtype=np.float32)
+        if mean.shape != (CURVATURE_DIM,) or std.shape != (CURVATURE_DIM,):
+            raise ValueError(
+                f"Curvature stats must have {CURVATURE_DIM} channels; got "
+                f"mean={mean.shape}, std={std.shape}"
+            )
+        self._curv_mean = mean
+        self._curv_std = np.maximum(std, 1e-6).astype(np.float32)
+        self.curvature_stats = stats
+
+    def load_case(
+        self,
+        case_id: str,
+        *,
+        surface_rows: np.ndarray | None = None,
+        volume_rows: np.ndarray | None = None,
+    ) -> DrivAerMLCase:
+        case = super().load_case(
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+        )
+        case_dir = self.root / case_id
+        cache_path = case_dir / CURVATURE_CACHE_FILENAME
+        if not cache_path.exists():
+            raise FileNotFoundError(
+                f"Curvature cache missing for {case_id}: {cache_path}. Run "
+                "`python -m scripts.precompute_curvature_proxy` first."
+            )
+        curv = _load_npy_rows(cache_path, surface_rows)
+        if curv.shape[0] != case.surface_x.shape[0]:
+            raise RuntimeError(
+                f"Curvature row count mismatch for {case_id}: curv={curv.shape[0]} "
+                f"vs surface={case.surface_x.shape[0]}"
+            )
+        if curv.shape[-1] != CURVATURE_DIM:
+            raise RuntimeError(
+                f"Curvature channel count mismatch for {case_id}: {curv.shape[-1]} "
+                f"vs expected {CURVATURE_DIM}"
+            )
+        curv_norm = (curv - self._curv_mean) / self._curv_std
+        metadata = dict(case.metadata)
+        metadata["surface_curvature"] = torch.from_numpy(
+            np.ascontiguousarray(curv_norm.astype(np.float32))
+        )
+        metadata["surface_curvature_dim"] = int(CURVATURE_DIM)
+        return DrivAerMLCase(
+            case_id=case.case_id,
+            surface_x=case.surface_x,
+            surface_y=case.surface_y,
+            volume_x=case.volume_x,
+            volume_y=case.volume_y,
+            metadata=metadata,
+        )
+
+
+def curvature_pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
+    """Variant of ``pad_collate`` that also pads and attaches surface curvature.
+
+    The curvature tensor is attached as a new ``surface_curvature`` attribute on
+    the returned ``SurfaceBatch`` (the dataclass is not frozen, so attribute
+    assignment works). Padded rows are zero — which is the post-normalisation
+    "neutral" value because the dataset mean is subtracted.
+    """
+
+    batch = pad_collate(samples)
+    if not samples or "surface_curvature" not in samples[0].metadata:
+        return batch
+    batch_size = len(samples)
+    max_surface_n = batch.surface_x.shape[1]
+    curv_dim = int(samples[0].metadata.get("surface_curvature_dim", CURVATURE_DIM))
+    curvature = torch.zeros(batch_size, max_surface_n, curv_dim, dtype=torch.float32)
+    for i, sample in enumerate(samples):
+        c = sample.metadata["surface_curvature"]
+        n = c.shape[0]
+        curvature[i, :n] = c
+    setattr(batch, "surface_curvature", curvature)
+    return batch
+
+
 def loader_kwargs(config) -> dict[str, object]:
     num_workers = resolve_num_workers(config)
+    use_curvature = getattr(config, "use_curvature_attention_bias", False)
     kwargs: dict[str, object] = {
-        "collate_fn": pad_collate,
+        "collate_fn": curvature_pad_collate if use_curvature else pad_collate,
         "num_workers": num_workers,
         "pin_memory": config.pin_memory and torch.cuda.is_available(),
     }
@@ -274,6 +407,12 @@ def full_eval_loaders_from(
     }
 
 
+def _swap_dataset_store(ds, store: DrivAerMLCaseStore) -> None:
+    """Replace the case store on a ``DrivAerMLSurfaceDataset`` in place."""
+
+    ds.store = store
+
+
 def make_loaders(
     config,
     distributed_state: DistributedState | None = None,
@@ -287,6 +426,18 @@ def make_loaders(
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
     )
+    if getattr(config, "use_curvature_attention_bias", False):
+        curv_stats = load_curvature_stats()
+        curv_store = CurvatureAugmentedCaseStore(
+            manifest_path=config.manifest,
+            root=config.data_root or None,
+            stats=curv_stats,
+        )
+        _swap_dataset_store(train_ds, curv_store)
+        for ds in val_splits.values():
+            _swap_dataset_store(ds, curv_store)
+        for ds in test_splits.values():
+            _swap_dataset_store(ds, curv_store)
     train_sampler = None
     train_shuffle = True
     if distributed_state is not None and distributed_state.enabled:
@@ -927,17 +1078,24 @@ def accumulate_eval_batch(
     device: torch.device,
     amp_mode: str,
 ) -> None:
+    surface_curvature = getattr(batch, "surface_curvature", None)
     batch = batch.to(device)
+    if surface_curvature is not None:
+        surface_curvature = surface_curvature.to(device)
+        setattr(batch, "surface_curvature", surface_curvature)
     surface_target_norm = transform.apply_surface(batch.surface_y)
     volume_target_norm = transform.apply_volume(batch.volume_y)
     eval_module = unwrap_model(model)
+    forward_kwargs: dict[str, torch.Tensor] = dict(
+        surface_x=batch.surface_x,
+        surface_mask=batch.surface_mask,
+        volume_x=batch.volume_x,
+        volume_mask=batch.volume_mask,
+    )
+    if surface_curvature is not None:
+        forward_kwargs["surface_curvature"] = surface_curvature
     with autocast_context(device, amp_mode):
-        out = eval_module(
-            surface_x=batch.surface_x,
-            surface_mask=batch.surface_mask,
-            volume_x=batch.volume_x,
-            volume_mask=batch.volume_mask,
-        )
+        out = eval_module(**forward_kwargs)
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)


### PR DESCRIPTION
## Hypothesis

**WSS H39: Wider surface_out MLP — port of tay's H102 finding to dl24 long-form (H21 base + decoder width 1× → 2×).**

Wave 33 dl24 architectural arms (H33 GALE, H34 Ada-Temp, H35 slice-xattn, H36 τ_z asymmetric, H37 GeoTransolver-true, H38 surf-p Charbonnier) have all attacked encoder-side or loss-shape mechanisms. NONE have attacked decoder capacity directly. Meanwhile, tay fleet's H102 (PR #1268, CLOSED 2026-05-23 10:37Z B-PARTIAL) showed **width dominates depth on every channel** at matched param cost:

| tay channel | H99 depth (+132K) | H102 width (+265K) | Δ |
|---|---:|---:|---:|
| val_abupt | 6.331 | **6.118** | −0.213pp |
| test_abupt | 6.249 | **6.118** | −0.131pp |
| test_VP | 3.637 | **3.543** | −0.094pp ⭐ SUB-FLOOR |
| test_SP | 3.804 | 3.724 | −0.080pp (still plateau) |
| test_WSS | 7.008 | 6.858 | −0.150pp |
| test_WSS_z | 9.088 | 8.889 | −0.199pp |

**tay H102 CRACKED the test_VP floor (3.543 < 3.643) on the corrected dataset** — first single-model architectural mechanism in either fleet to do so without H21's clamp+Charb stack. Combined with H21 base mechanisms (clamp_w_vol_p=0.15 + vol_p Charb + curvature attention + y-symmetry aug), the H39 prediction is that the WIDTH mechanism compounds with H21's existing stack to deliver a sub-floor VP + sub-floor SP outcome.

## Why width and not depth on dl24

tay H99 (depth 2→3 layers) added +132K params, H102 (width 1→2×) added +265K params. At nearly 2× the param cost, H102 beat H99 on **every** channel by 0.08-0.20pp. The mechanism interpretation: width-expansion in the surface_out hidden layer captures more cross-feature interactions in a single non-linear transformation, which is more useful than sequential composition for the 4-channel surface output (τ_x, τ_y, τ_z, cp).

For dl24's H21 base, the GradNorm budget is already balanced via clamp+Charb on the loss-shape axis. Adding decoder WIDTH gives the model more representational capacity to differentiate the 4 surface channels under that loss landscape — directly orthogonal to all six Wave 33 architectural arms in flight.

## Instructions

### Code changes — `target/model.py`

1. **Modify `SurfaceTransolver.__init__`** in the section where `self.surface_out` is constructed (search for `self.surface_out = nn.Sequential`). Parameterize the hidden dim:
   ```python
   surf_hidden_width = int(n_hidden * surface_out_width_factor)
   self.surface_out = nn.Sequential(
       nn.Linear(n_hidden, surf_hidden_width),
       nn.GELU(),
       nn.Linear(surf_hidden_width, self.surface_output_dim),
   )
   ```
   At `surface_out_width_factor=1.0`, this is byte-identical to canonical.

2. **Add constructor arg** `surface_out_width_factor: float = 1.0` to `SurfaceTransolver.__init__`.

3. **No changes to forward pass**.

### Code changes — `target/train.py`

1. **Add CLI flag** in argparse:
   ```python
   parser.add_argument(
       "--surface-out-width-factor",
       type=float,
       default=1.0,
       help="Width multiplier for surface_out hidden layer (1.0=canonical, 2.0=H39 wider MLP)",
   )
   ```

2. **Pass through to model**:
   ```python
   model = SurfaceTransolver(
       ...
       surface_out_width_factor=args.surface_out_width_factor,
       ...
   )
   ```

### H21 base cherry-pick

H21 mechanisms (`829e3a9` from earlier wave) must be on the branch. If your branch is from `drivaerml-long-20260504` and doesn't already have H21, cherry-pick `829e3a9` before applying H39 changes.

### Training command (DDP 8 GPUs, 30 EPs)

```bash
SENPAI_TIMEOUT_MINUTES=1300 SENPAI_MAX_EPOCHS=30 \
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --lr-warmup-epochs 1 --lr-cosine-t-max 30 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --gradnorm-min-w-vol-p 0.15 --gradnorm-alpha 0.5 \
  --use-curvature-attention-bias \
  --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --epochs 30 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-start-step 500 \
  --wandb_group wss_h39_surface_out_wider
```

## Engagement check (post EP1)

Confirm in W&B summary:
- Parameter count: H21 base ~18.87M → H39 ~19.13M (+265K from wider surface_out)
- `surface_out` layer dims: Linear(512→1024) → Linear(1024→4) instead of Linear(512→512) → Linear(512→4)
- No NaN/skipped steps in EP1
- gradnorm/w_vol_p approaches 0.15 clamp by EP1.5-2.0 (H21 pattern preserved)

## Falsification ladder

| Gate | Cadence | Criterion | Action on miss |
|---|---|---|---|
| EP1 engagement | ~12 min in | param count = 19.13M, surface_out wider | abort + report |
| EP3 hard-abort | step 32927 (~13 min EP3) | val_wss<7.50 AND val_sp<4.45 AND val_vp<4.70 | close if 2/3 miss |
| EP10 soft signal | step 109760 | val_wss ≤ 7.04 AND val_sp ≤ 4.05 AND val_vp ≤ 3.85 | continue to terminal regardless |
| Terminal | EP30 ~22h | test_abupt ≤ 5.844 AND test_vol_p ≤ 3.643 AND test_surf_p ≤ 3.577 AND test_wss ≤ 6.727 | merge if all 4 clear |

## Predicted outcomes

| Channel | H21 base | tay H102 | H39 prediction | Source |
|---|---:|---:|---:|---|
| test_abupt | 5.832 | 6.118 | **5.78-5.85** | width capacity bonus |
| test_vol_p | **3.579** (sub-floor) | **3.543** (sub-floor) | **3.50-3.60** ⭐ | H21 clamp + width compounds |
| test_surf_p | 3.679 (+0.102 breach) | 3.724 (+0.147 breach) | **3.65-3.75** | width didn't crack SP plateau in tay |
| test_wss | 6.730 (≈SOTA tie) | 6.858 (+0.131 miss) | **6.68-6.78** | width helps differentiate channels |

**Best case (40% prob)**: 4 floors clear → FIRST contract winner of Wave 33.
**Most likely (50%)**: vol_p + abupt + wss clear; surf_p remains in 3.65-3.75 plateau → 3 of 4 floors clear (A-PARTIAL).
**Worst case (10%)**: width adds noise without help → close as wave-noise variant.

## Baseline

| Metric | PR #972 SOTA | H21 reference (`xcj9749y`) |
|---|---:|---:|
| test_abupt | **5.844%** | 5.832% (⭐ SOTA beat by −0.012pp) |
| test_vol_p | **3.643%** | 3.579% (⭐ FIRST sub-floor by −0.064pp) |
| test_surf_p | **3.577%** | 3.679% (+0.102pp breach) |
| test_wss | **6.727%** | 6.730% (+0.003pp ≈ tie) |

H21 base run for reproducibility: `xcj9749y`. Wave 33 baseline assignments: H32-H38 already attempted on 7 orthogonal mechanisms.