### PR TITLE
Wave 33 H113: HETEROSCEDASTIC-UNCERTAINTY-WEIGHTING — Kendall+Gal 2018 multi-task loss rebalancing

### DIFF
--- a/model.py
+++ b/model.py
@@ -382,6 +382,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_heteroscedastic_loss: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -396,6 +397,19 @@ class SurfaceTransolver(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
+        self.use_heteroscedastic_loss = use_heteroscedastic_loss
+        if use_heteroscedastic_loss:
+            # Kendall, Gal & Cipolla 2018 — learnable per-task observation
+            # log-variance for the 3 regression tasks {SP, WSS, VP}. log_sigma_sq=0
+            # gives sigma=1, precision_weight=exp(0)=1, regularization=0 → identity
+            # at init when the per-task losses sum to the baseline composition.
+            self.log_sigma_sq_sp = nn.Parameter(torch.zeros(1))
+            self.log_sigma_sq_wss = nn.Parameter(torch.zeros(1))
+            self.log_sigma_sq_vp = nn.Parameter(torch.zeros(1))
+        else:
+            self.log_sigma_sq_sp = None
+            self.log_sigma_sq_wss = None
+            self.log_sigma_sq_vp = None
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -632,6 +646,22 @@ class SurfaceTransolver(nn.Module):
         else:
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
+
+        if self.use_heteroscedastic_loss:
+            # Anchor the log_sigma_sq parameters into the forward autograd
+            # graph so DDP's find_unused_parameters tracer (enabled by the
+            # surf->vol xattn) sees them as "used in forward". Without this,
+            # the heteroscedastic combination in train_loss() fires gradient
+            # hooks for params that DDP already marked ready as unused -> the
+            # "marked ready twice" crash. The contribution is identically
+            # zero so model outputs are unchanged.
+            anchor = (
+                self.log_sigma_sq_sp.sum()
+                + self.log_sigma_sq_wss.sum()
+                + self.log_sigma_sq_vp.sum()
+            ) * 0.0
+            surface_preds = surface_preds + anchor.to(surface_preds.dtype)
+            volume_preds = volume_preds + anchor.to(volume_preds.dtype)
 
         return {
             "surface_preds": surface_preds,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_heteroscedastic_loss: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -229,6 +230,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
         ),
+        "use_heteroscedastic_loss": (
+            "Wave 33 H113: Kendall, Gal & Cipolla 2018 heteroscedastic "
+            "uncertainty weighting on the 3 regression tasks {SP, WSS, VP}. "
+            "Adds 3 learnable scalar log_sigma_sq parameters; total loss "
+            "becomes sum_k exp(-log_sigma_sq_k) * L_k + 0.5 * log_sigma_sq_k. "
+            "Identity at init: log_sigma_sq=0 -> precision=1, regularization=0, "
+            "so the total matches the static-weighted baseline composition. "
+            "log_sigma_sq is clamped to [-8, +8] for numerical stability."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -276,6 +286,33 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_heteroscedastic_metrics(model: nn.Module) -> dict[str, float]:
+    """H113 diagnostic — current value of each learnable log_sigma_sq scalar
+    plus the derived sigma and precision-weight, for tasks {SP, WSS, VP}.
+
+    The precision weight is `exp(-log_sigma_sq)` clamped to the same range as
+    the loss path (clamp=[-8, +8]) so the W&B trace matches what the
+    optimiser actually sees during the heteroscedastic combination.
+    """
+    metrics: dict[str, float] = {}
+    if not getattr(model, "use_heteroscedastic_loss", False):
+        return metrics
+    clamp = HETEROSCEDASTIC_LOG_SIGMA_CLAMP
+    for task in ("sp", "wss", "vp"):
+        param = getattr(model, f"log_sigma_sq_{task}", None)
+        if param is None:
+            continue
+        ls = float(param.detach().float().clamp(-clamp, clamp).item())
+        ls_raw = float(param.detach().float().item())
+        sigma = math.exp(0.5 * ls)
+        precision = math.exp(-ls)
+        metrics[f"train/log_sigma_sq/{task}"] = ls
+        metrics[f"train/log_sigma_sq_raw/{task}"] = ls_raw
+        metrics[f"train/sigma/{task}"] = sigma
+        metrics[f"train/precision_weight/{task}"] = precision
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -308,7 +345,11 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_heteroscedastic_loss=config.use_heteroscedastic_loss,
     )
+
+
+HETEROSCEDASTIC_LOG_SIGMA_CLAMP = 8.0
 
 
 def train_loss(
@@ -321,6 +362,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    heteroscedastic_params: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,27 +374,89 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
+        # Per-channel masked MSE diagnostics (used by both paths and by the
+        # heteroscedastic split).
+        surface_preds = out["surface_preds"]
+        sp_mse = masked_mse(surface_preds[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
+        taux_mse = masked_mse(surface_preds[..., 1:2], surface_target[..., 1:2], batch.surface_mask)
+        tauy_mse = masked_mse(surface_preds[..., 2:3], surface_target[..., 2:3], batch.surface_mask)
+        tauz_mse = masked_mse(surface_preds[..., 3:4], surface_target[..., 3:4], batch.surface_mask)
+        vp_mse = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+
         if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
-                batch.surface_mask,
-                surface_channel_weights,
-            )
+            chan_w = surface_channel_weights.to(device=sp_mse.device, dtype=sp_mse.dtype)
+            w_sp = chan_w[0]
+            w_taux = chan_w[1]
+            w_tauy = chan_w[2]
+            w_tauz = chan_w[3]
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
-        volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
+            w_sp = w_taux = w_tauy = w_tauz = sp_mse.new_tensor(1.0)
+        # Baseline surface_loss = mean over (B,N,C) of w_c * sq_err_c
+        #   = (w_sp*sp + w_taux*taux + w_tauy*tauy + w_tauz*tauz) / 4
+        # so each per-channel contribution to weighted_surface_loss is
+        #   surface_loss_weight * w_c * c_mse / 4.
+        surface_loss = (
+            w_sp * sp_mse
+            + w_taux * taux_mse
+            + w_tauy * tauy_mse
+            + w_tauz * tauz_mse
+        ) / 4.0
+        volume_loss = vp_mse
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
-        loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
-        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
-        "surface_loss": float(surface_loss.detach().cpu().item()),
-        "volume_loss": float(volume_loss.detach().cpu().item()),
-        "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
-        "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
-    }
+
+        metrics: dict[str, float] = {
+            "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
+            "surface_loss": float(surface_loss.detach().cpu().item()),
+            "volume_loss": float(volume_loss.detach().cpu().item()),
+            "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
+            "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+            "loss_sp_unweighted": float(sp_mse.detach().cpu().item()),
+            "loss_tau_x_unweighted": float(taux_mse.detach().cpu().item()),
+            "loss_tau_y_unweighted": float(tauy_mse.detach().cpu().item()),
+            "loss_tau_z_unweighted": float(tauz_mse.detach().cpu().item()),
+            "loss_vp_unweighted": float(vp_mse.detach().cpu().item()),
+        }
+
+        if heteroscedastic_params is None:
+            loss = weighted_surface_loss + weighted_volume_loss
+        else:
+            # H113 Kendall, Gal & Cipolla 2018 heteroscedastic uncertainty
+            # weighting on K=3 regression tasks. The per-task partial losses
+            # are scaled so that their sum equals weighted_surface_loss +
+            # weighted_volume_loss; at log_sigma_sq=0 the heteroscedastic
+            # formula reduces to that sum exactly (identity at init).
+            ls_sp_p, ls_wss_p, ls_vp_p = heteroscedastic_params
+            ls_sp = ls_sp_p.clamp(
+                -HETEROSCEDASTIC_LOG_SIGMA_CLAMP, HETEROSCEDASTIC_LOG_SIGMA_CLAMP
+            ).float()
+            ls_wss = ls_wss_p.clamp(
+                -HETEROSCEDASTIC_LOG_SIGMA_CLAMP, HETEROSCEDASTIC_LOG_SIGMA_CLAMP
+            ).float()
+            ls_vp = ls_vp_p.clamp(
+                -HETEROSCEDASTIC_LOG_SIGMA_CLAMP, HETEROSCEDASTIC_LOG_SIGMA_CLAMP
+            ).float()
+
+            l_sp = (surface_loss_weight * w_sp * sp_mse / 4.0).float()
+            l_wss = (
+                surface_loss_weight
+                * (w_taux * taux_mse + w_tauy * tauy_mse + w_tauz * tauz_mse)
+                / 4.0
+            ).float()
+            l_vp = (volume_loss_weight * vp_mse).float()
+
+            weighted_sp = (-ls_sp).exp() * l_sp + 0.5 * ls_sp
+            weighted_wss = (-ls_wss).exp() * l_wss + 0.5 * ls_wss
+            weighted_vp = (-ls_vp).exp() * l_vp + 0.5 * ls_vp
+            loss = (weighted_sp + weighted_wss + weighted_vp).reshape(())
+            metrics["het/L_sp_partial"] = float(l_sp.detach().cpu().item())
+            metrics["het/L_wss_partial"] = float(l_wss.detach().cpu().item())
+            metrics["het/L_vp_partial"] = float(l_vp.detach().cpu().item())
+            metrics["het/loss_weighted_sp"] = float(weighted_sp.detach().cpu().item())
+            metrics["het/loss_weighted_wss"] = float(weighted_wss.detach().cpu().item())
+            metrics["het/loss_weighted_vp"] = float(weighted_vp.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -777,8 +881,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
+        heteroscedastic_params: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
+        if config.use_heteroscedastic_loss:
+            ls_sp = getattr(base_model, "log_sigma_sq_sp", None)
+            ls_wss = getattr(base_model, "log_sigma_sq_wss", None)
+            ls_vp = getattr(base_model, "log_sigma_sq_vp", None)
+            if ls_sp is None or ls_wss is None or ls_vp is None:
+                raise RuntimeError(
+                    "--use-heteroscedastic-loss requires model.log_sigma_sq_{sp,wss,vp} "
+                    "parameters; the SurfaceTransolver does not expose them."
+                )
+            heteroscedastic_params = (ls_sp, ls_wss, ls_vp)
         if state.is_main:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
+            if config.use_heteroscedastic_loss:
+                print(
+                    "Heteroscedastic uncertainty weighting ENABLED (Kendall, Gal & "
+                    "Cipolla 2018): 3 learnable log_sigma_sq scalars on tasks "
+                    "{SP, WSS, VP}; clamp=[-8, +8]; identity at log_sigma_sq=0."
+                )
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
@@ -786,6 +907,11 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
+        if config.use_gradnorm and config.use_heteroscedastic_loss:
+            raise ValueError(
+                "--use-gradnorm and --use-heteroscedastic-loss both balance "
+                "the multi-task loss and cannot be combined."
+            )
         if config.use_gradnorm:
             if config.gradnorm_mode == "full" and config.compile_model:
                 raise ValueError(
@@ -1030,6 +1156,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        heteroscedastic_params=heteroscedastic_params,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1197,27 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for key in (
+                        "loss_sp_unweighted",
+                        "loss_tau_x_unweighted",
+                        "loss_tau_y_unweighted",
+                        "loss_tau_z_unweighted",
+                        "loss_vp_unweighted",
+                    ):
+                        if key in batch_loss_metrics:
+                            train_log[f"train/{key}"] = batch_loss_metrics[key]
+                    for key in (
+                        "het/L_sp_partial",
+                        "het/L_wss_partial",
+                        "het/L_vp_partial",
+                        "het/loss_weighted_sp",
+                        "het/loss_weighted_wss",
+                        "het/loss_weighted_vp",
+                    ):
+                        if key in batch_loss_metrics:
+                            train_log[f"train/{key}"] = batch_loss_metrics[key]
+                if config.use_heteroscedastic_loss:
+                    train_log.update(collect_heteroscedastic_metrics(base_model))
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1262,6 +1410,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_heteroscedastic_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Heteroscedastic Multi-task Uncertainty Weighting** (Kendall, Gal & Cipolla 2018) for the DrivAerML multi-task surface-volume regression loss.

After 14 consecutive Wave 32+33 architecture mechanisms have missed the **test_SP plateau** (floor 3.577%, all mechanisms land in 3.70-3.95% range), the **Plateau Protocol strategy-tier shift to LOSS REFORMULATION** is now triggered. Architecture-class exhaustion is essentially confirmed on test_SP.

**Falsifiable question**: Is the persistent test_SP plateau driven by an **undertrained SP loss term** (loss-balancing issue) OR **Bayes-optimal hardness** (data/representation-bound)? Heteroscedastic uncertainty weighting reformulates the multi-task loss to dynamically rebalance attention across surface_pressure, volume_pressure, and wall_shear tasks — if the SP plateau cracks (test_SP < 3.577%), the plateau was undertrained; if it doesn't, hardness is genuine.

**Mechanism specification** (Kendall, Gal & Cipolla 2018 "Multi-Task Learning Using Uncertainty to Weigh Losses for Scene Geometry and Semantics", CVPR 2018):

For regression tasks with K outputs, replace the current uniform-weight loss:
```
L_current = L_sp + L_vp + L_wss   # or equivalent linear combination
```
with the heteroscedastic-uncertainty-weighted loss:
```
L_new = Σ_k [ exp(-log_sigma_sq_k) * L_k  +  0.5 * log_sigma_sq_k ]
```
where:
- `log_sigma_sq_k ∈ R` is a learnable scalar parameter per task k ∈ {SP, VP, WSS}
- `exp(-log_sigma_sq_k)` is the inverse-variance precision weight (auto-decreases for tasks with high observation noise)
- `0.5 * log_sigma_sq_k` is the regularization term (prevents collapse to log_sigma → -∞)
- Initialize `log_sigma_sq_k = 0.0` → `sigma_k = 1.0` → **identity at step 0** (same as current uniform-weight loss)

This is the standard "log_sigma_sq" parameterization for numerical stability (avoids division by sigma directly).

**Param cost**: +3 learnable scalar parameters (one per task). Effectively zero overhead.

**Why this is THE right next experiment:**

1. **Plateau Protocol compliance**: 14 architecture mechanisms have failed to crack test_SP. Per CLAUDE.md: "When you observe 5 or more consecutive experiments with no improvement, escalate — do not stop. Change strategy tier." Architecture → loss reformulation is the canonical Plateau Protocol move.

2. **Highly cost-efficient**: +3 params vs the +250K-+1M cost of recent architecture mechanisms. If it works, it's the strongest cost-efficiency result of the entire research program.

3. **Identity-at-init**: log_sigma_sq=0 means initial loss is IDENTICAL to baseline. The mechanism cannot harm; it can only either engage productively (cracking SP plateau) or stay near-identity (replicating baseline). **There is no failure mode that loses to baseline by mechanism.**

4. **Diagnostic value regardless of outcome**:
   - If H113 cracks SP plateau → loss balance is the bottleneck; Wave 35 can explore GradNorm, focal loss, per-channel loss weighting, etc.
   - If H113 fails to crack SP plateau → loss balance is NOT the issue; Wave 35 must go to data representation tier (CDF-normalize SP targets, log-transform, augmentation, etc.).

5. **Well-cited reference**: Kendall, Gal & Cipolla 2018 has 7000+ citations; this is canonical multi-task learning technology, not speculative.

**Predicted outcome**:
- Most likely: H113 increases the SP loss weight via lower sigma_sp (since SP has lower noise than VP/WSS in DrivAerML) → marginal test_SP improvement (~0.05-0.10pp) but not enough to cross the floor
- Best case: SP loss reweighting CRACKS plateau → test_SP < 3.577% = **strong A WIN signal** (would be the first crack of the 14-run SP plateau)
- Worst case: identity-near behavior (log_sigma stays near 0) → confirms loss balance not bottleneck → directs Wave 35 to data tier

## Instructions

### Implementation specification

1. **Add to `model.py`** (in `SurfaceTransolver.__init__`):

   ```python
   def __init__(self, ..., use_heteroscedastic_loss: bool = False, ...):
       ...
       self.use_heteroscedastic_loss = use_heteroscedastic_loss
       if use_heteroscedastic_loss:
           # log_sigma_sq for each task: SP, VP, WSS
           # Identity at init: log_sigma_sq=0 → sigma=1 → exp(-log_sigma_sq)=1 (uniform weight)
           self.log_sigma_sq_sp = nn.Parameter(torch.zeros(1))
           self.log_sigma_sq_vp = nn.Parameter(torch.zeros(1))
           self.log_sigma_sq_wss = nn.Parameter(torch.zeros(1))
       ...
   ```

2. **Modify `train.py`** (in the loss computation):

   Find the current multi-task loss combination point. It probably looks like:
   ```python
   total_loss = loss_sp + loss_vp + loss_wss  # or with fixed weights
   ```
   Replace with:
   ```python
   if model.use_heteroscedastic_loss:
       total_loss = (
           torch.exp(-model.log_sigma_sq_sp) * loss_sp + 0.5 * model.log_sigma_sq_sp +
           torch.exp(-model.log_sigma_sq_vp) * loss_vp + 0.5 * model.log_sigma_sq_vp +
           torch.exp(-model.log_sigma_sq_wss) * loss_wss + 0.5 * model.log_sigma_sq_wss
       )
   else:
       total_loss = loss_sp + loss_vp + loss_wss  # baseline path unchanged
   ```

   IMPORTANT: Ensure the three log_sigma_sq parameters are wrapped consistently with DDP (they should automatically be picked up by DDP if added to the model module; if the model uses `find_unused_parameters=True`, no issue).

3. **Add CLI flag** to `train.py` argparse:
   ```python
   parser.add_argument("--use-heteroscedastic-loss", action="store_true",
                       help="Enable Kendall+Gal 2018 heteroscedastic uncertainty weighting on multi-task loss")
   ```
   Pass to model constructor.

4. **Diagnostic logging** (CRITICAL — same level of importance as the metric):

   At each val publish boundary, log to W&B:
   - `train/log_sigma_sq/sp` (raw learnable param)
   - `train/log_sigma_sq/vp`
   - `train/log_sigma_sq/wss`
   - `train/sigma/sp` (= exp(0.5 * log_sigma_sq))
   - `train/sigma/vp`
   - `train/sigma/wss`
   - `train/precision_weight/sp` (= exp(-log_sigma_sq))
   - `train/precision_weight/vp`
   - `train/precision_weight/wss`
   - `train/loss_weighted/sp` (= precision_weight_sp × loss_sp; the actual contribution to total loss)
   - `train/loss_weighted/vp`
   - `train/loss_weighted/wss`

   These diagnostics let us see EXACTLY how the optimizer rebalances task attention over training. If sigma_sp DROPS over time (precision_weight_sp INCREASES), the optimizer is paying more attention to SP — and we should see SP metrics improve. If sigma_sp stays near 1, the mechanism is near-identity. **This logging is non-negotiable.**

5. **Smoke test** (at step 0, before training):
   - Confirm `total_loss` is bit-identical to baseline path when log_sigma_sq=0
   - Verify per-channel loss values are unchanged at step 0
   - This is the identity-at-init verification

### Run command

Submit the following on 8× H100s (DDP):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --lr 9e-5 --lr-warmup-epochs 1 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slice-num 128 \
  --use-aux-decoder-heads \
  --use-heteroscedastic-loss \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group wave33_h113_heteroscedastic_loss \
  --wandb-run-name "fern/h113-heteroscedastic-uncertainty-weighting"
```

Note: same recipe as H105 (your previous experiment), except:
- `--use-normal-residual-decoder` removed
- `--use-heteroscedastic-loss` added

### Expected diagnostic milestones

- **EP1 (step 10,864)**: log_sigma_sq should still be ~0 (warmup phase, very little gradient signal on auxiliary parameters). Loss should track baseline within ~1% noise.
- **EP3 (step 21,729)**: log_sigma_sq starts to differentiate by task. Likely log_sigma_sq_sp < log_sigma_sq_vp < log_sigma_sq_wss (SP has lower noise so gets higher precision weight).
- **EP6 (step 32,594)**: clear pattern in sigmas; per-channel loss_weighted contributions visible.
- **EP10+**: terminal sigma values; per-channel test metric improvement (especially SP) should reflect the loss rebalancing.

### Validation criteria

Standard merge gate: `val_abupt < 6.126%` (current baseline). AND-gate test floors: `test_VP ≤ 3.643% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%`.

**The KEY METRIC for this experiment is test_SP** — if the heteroscedastic mechanism is engaging, SP test should improve. Even a NEAR-MISS (test_SP in 3.60-3.65%) would be a strong signal — it would be the first time any mechanism has approached the SP floor.

## Baseline

Current best (from BASELINE.md):
- **val/abupt_axis_mean_rel_l2_pct**: 6.126% (gate to beat)
- **test/abupt_axis_mean_rel_l2_pct**: 5.844% (canonical)
- **test/surface_pressure_rel_l2_pct**: 3.577% (floor — PLATEAU at 14 consecutive misses 3.70-3.95% range)
- **test/volume_pressure_rel_l2_pct**: 3.643% (floor — multiple mechanisms cross, ~1% below floor possible)
- **test/wall_shear_rel_l2_pct**: 6.727% (goal — multiple mechanisms approach but miss)
- **test/wall_shear_z_rel_l2_pct**: 8.945% (canonical — Wave 33 mechanisms variously above and below)
- Baseline W&B run: `pn09rqv4` (canonical)

Compare your results against your own previous H105 too for tracking (W&B run `t6b1i2yk`):
- H105 val_abupt 6.349%, test_SP 3.7245%, test_VP 3.534% (CROSS), test_WSS 6.832%

## Mechanism class context

H113 is the **first Wave 33+ LOSS REFORMULATION** mechanism. Following Plateau Protocol after 14 consecutive SP plateau misses. Wave 35 will depend on H113 outcome:
- A WIN → Wave 35 explores more loss-tier mechanisms (GradNorm, focal loss, per-component sigmas)
- B PARTIAL via SP near-miss → variant with longer warmup or per-component sigmas (5 sigmas instead of 3)
- C NULL → Wave 35 shifts to data representation tier (CDF normalize SP, log-transform, geometric augmentations on hardest cases)

Good luck, fern! This is a clean Plateau Protocol move with strong diagnostic value regardless of outcome.
