### PR TITLE
H115: Huber loss for SP (Plateau Protocol loss-form data-tier)

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_huber,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -138,6 +139,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_huber_sp_loss: bool = False
+    huber_delta_sp: float = 1.0
     debug: bool = False
 
 
@@ -228,6 +231,25 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_huber_sp_loss": (
+            "Replace MSE with Huber loss for the SP (surface_pressure) channel "
+            "only. Huber transitions from L2 to L1 at |r|=delta, bounding the "
+            "gradient contribution of outlier residuals. Falsifiable Plateau "
+            "Protocol intervention: if test_SP < 3.577%, MSE's quadratic outlier "
+            "amplification was the missing bottleneck for the 16-mechanism SP "
+            "plateau. Zero added params; SP only -- tau_x/tau_y/tau_z/VP loss "
+            "computation unchanged. Surface loss is recombined as "
+            "(sp_huber + 3*tau_weighted_mse)/4 to preserve the original "
+            "4-channel-average normalisation when Huber degenerates to MSE."
+        ),
+        "huber_delta_sp": (
+            "Transition threshold for Huber SP loss. Below |r|=delta the loss "
+            "is 0.5*r^2 (canonical Huber, half of MSE in the quadratic regime); "
+            "above delta it is delta*(|r|-0.5*delta). For normalised SP targets, "
+            "default 1.0 treats roughly the top 30% of error magnitudes as "
+            "outliers (linear regime). Smaller delta = more aggressive outlier "
+            "dampening. Unused if --use-huber-sp-loss is off."
         ),
     }
     for field in fields(Config):
@@ -321,6 +343,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_huber_sp_loss: bool = False,
+    huber_delta_sp: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -332,27 +356,82 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
-            surface_loss = weighted_channel_mse(
-                out["surface_preds"],
-                surface_target,
+        huber_diagnostics: dict[str, float] = {}
+        if use_huber_sp_loss:
+            # Split surface loss: Huber on SP (channel 0), existing MSE on tau (1:4).
+            # Combine as (sp + 3*tau)/4 to preserve the 4-channel-average
+            # normalisation of weighted_channel_mse when Huber degenerates to MSE.
+            surface_pred = out["surface_preds"]
+            sp_pred = surface_pred[..., 0:1]
+            sp_target = surface_target[..., 0:1]
+            sp_loss = masked_huber(
+                sp_pred,
+                sp_target,
                 batch.surface_mask,
-                surface_channel_weights,
+                delta=huber_delta_sp,
             )
+            tau_pred = surface_pred[..., 1:4]
+            tau_target = surface_target[..., 1:4]
+            if surface_channel_weights is not None:
+                tau_weights = surface_channel_weights[1:].to(
+                    device=tau_pred.device, dtype=tau_pred.dtype
+                )
+                tau_loss = weighted_channel_mse(
+                    tau_pred, tau_target, batch.surface_mask, tau_weights
+                )
+            else:
+                tau_loss = masked_mse(tau_pred, tau_target, batch.surface_mask)
+            surface_loss = (sp_loss + 3.0 * tau_loss) / 4.0
+            # MSE-equivalent SP loss for direct A/B comparison vs the canonical baseline.
+            sp_loss_mse_equiv = masked_mse(sp_pred, sp_target, batch.surface_mask).detach()
+            # Fraction of SP residuals in the Huber linear regime (|r| > delta).
+            sp_diff = (sp_pred - sp_target).detach()
+            sp_abs = sp_diff.abs()
+            sp_mask_expanded = batch.surface_mask.to(
+                device=sp_abs.device, dtype=sp_abs.dtype
+            ).unsqueeze(-1)
+            valid_points = sp_mask_expanded.sum().clamp_min(1.0)
+            linear_regime_frac = (
+                (sp_abs > huber_delta_sp).to(dtype=sp_abs.dtype) * sp_mask_expanded
+            ).sum() / valid_points
+            masked_abs = sp_abs * sp_mask_expanded
+            sp_abs_mean = masked_abs.sum() / valid_points
+            if masked_abs.numel() > 0:
+                sp_abs_max = masked_abs.max()
+            else:
+                sp_abs_max = torch.zeros((), device=sp_abs.device, dtype=sp_abs.dtype)
+            huber_diagnostics = {
+                "huber/sp_loss_raw": float(sp_loss.detach().cpu().item()),
+                "huber/sp_loss_mse_equiv": float(sp_loss_mse_equiv.cpu().item()),
+                "huber/tau_loss_raw": float(tau_loss.detach().cpu().item()),
+                "huber/sp_linear_regime_frac": float(linear_regime_frac.detach().cpu().item()),
+                "huber/sp_abs_residual_mean": float(sp_abs_mean.detach().cpu().item()),
+                "huber/sp_abs_residual_max": float(sp_abs_max.detach().cpu().item()),
+            }
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            if surface_channel_weights is not None:
+                surface_loss = weighted_channel_mse(
+                    out["surface_preds"],
+                    surface_target,
+                    batch.surface_mask,
+                    surface_channel_weights,
+                )
+            else:
+                surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(huber_diagnostics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -852,6 +931,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_huber_sp_loss:
+                print(
+                    f"Huber SP loss enabled: delta={config.huber_delta_sp} "
+                    f"(canonical 0.5*r^2 in quadratic regime, delta*(|r|-0.5*delta) "
+                    f"in linear regime). Surface loss = (sp_huber + 3*tau_mse)/4."
+                )
 
         run = init_wandb_run(
             config=config,
@@ -883,6 +968,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_huber_sp_loss"] = bool(config.use_huber_sp_loss)
+            wandb.summary["loss/huber_delta_sp"] = float(config.huber_delta_sp)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1030,6 +1117,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_huber_sp_loss=config.use_huber_sp_loss,
+                        huber_delta_sp=config.huber_delta_sp,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1070,6 +1159,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for huber_key in (
+                        "huber/sp_loss_raw",
+                        "huber/sp_loss_mse_equiv",
+                        "huber/tau_loss_raw",
+                        "huber/sp_linear_regime_frac",
+                        "huber/sp_abs_residual_mean",
+                        "huber/sp_abs_residual_max",
+                    ):
+                        if huber_key in batch_loss_metrics:
+                            train_log[f"train/{huber_key}"] = batch_loss_metrics[huber_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,31 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def masked_huber(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    delta: float = 1.0,
+) -> torch.Tensor:
+    """Huber (smooth-L1) loss reduced over a mask. Mirrors masked_mse signature.
+
+    For |r| <= delta: 0.5 * r^2  (canonical Huber, half of MSE in the quadratic regime)
+    For |r| >  delta: delta * (|r| - 0.5*delta)  (linear tail; gradient capped at +/- delta)
+
+    pred / target: [B, N, C]; mask: [B, N]. Returns a scalar mean over valid
+    (point x channel) entries, matching masked_mean's normalisation so balance
+    weights against other tasks stay on the same scale as masked_mse(per-channel).
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    diff = pred - target
+    abs_diff = diff.abs()
+    quadratic = 0.5 * diff * diff
+    linear = delta * (abs_diff - 0.5 * delta)
+    elementwise = torch.where(abs_diff <= delta, quadratic, linear)
+    return masked_mean(elementwise, mask)
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**HUBER LOSS FOR SP TARGETS — Plateau Protocol loss-form data-tier intervention to crack the 16-mechanism test_SP plateau.**

After 16 consecutive experiments failing to crack the test_SP=3.577% floor, H113 has empirically falsified the loss-balance hypothesis (log_σ² drifted to −2.3 with only 2.1% relative per-task differential — the optimizer found ZERO meaningful task differential, confirming DrivAerML per-task aleatoric noise is small). The SP plateau is **HARDNESS-BOUND, not balance-bound**. H114 (frieren, panel-area-weighted SP) is testing the **per-point gradient distribution** hypothesis. H115 tests the **loss-form** hypothesis: is the SP plateau caused by **MSE's quadratic outlier amplification**?

The current `compute_per_task_losses()` SP head uses **uniform per-point MSE**:
```python
sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
```

After surface-target normalization (`transform.apply_surface`), SP targets sit roughly in N(0, σ²) space, but the spatial distribution of error magnitude is decidedly non-Gaussian: hard outlier regions (separation zones, vortex cores at A-pillars / wheel arches / underbody splitter, sharp pressure gradients near rear taillights) generate residuals 5-20× larger than the bulk. **MSE penalizes these quadratically**, which has two effects:

1. **Gradient amplification**: a single point with ||error||=5 contributes 25 to the loss, vs 1.0 from 25 typical points. The optimizer chases impossible-to-fit hard outliers instead of the bulk SP signal.
2. **Plateau lock-in**: once the model has minimized MSE on the bulk, the residual gradient signal is dominated by these tail outliers — but those outliers may be irreducible (sharp physical phenomena under-resolved by the surface mesh).

**Huber loss** transitions from L2 (quadratic, near zero) to L1 (linear, beyond a threshold δ):
```
L_huber(r, δ) = 0.5 * r²              if |r| ≤ δ
              = δ * (|r| - 0.5*δ)      otherwise
```

For r > δ, Huber's gradient w.r.t. r is constant (sign(r)·δ) rather than 2r — outliers contribute **bounded** gradient signal. The model focuses on bulk-distribution residuals rather than chasing tails.

**Why this might crack the SP plateau when 16 prior mechanisms didn't**: every prior SP-targeted experiment changed the **representational capacity** at decoder (volume info, surface info, normals, depth, self-context, parallel MLP, encoder-skip) OR the **balance** of SP loss vs other tasks (heteroscedastic, GradNorm). **None changed the per-point loss curvature**. Huber directly addresses the hypothesis that **MSE's outlier amplification is the wall the SP error keeps hitting**.

**Falsifiable predictions**:
- **PASS**: `test_SP < 3.577%` → 16-mechanism plateau cracked, MSE's quadratic tail penalty was the bottleneck. **Definitively loss-form mechanism**.
- **PARTIAL**: `val_abupt < 6.126%` OR another test floor crossed (likely WSS via redistributed gradient budget) → mechanism reshapes gradient distribution productively; plateau remains but compound unlocked.
- **NULL**: `val_abupt ≥ 6.126%` AND `test_SP ≥ 3.577%` → confirms SP plateau is independent of per-point loss curvature. Forces further data-tier escalation (target transformation, sample augmentation).

**Zero added parameters.** Pure loss-form reformulation. One-line swap of `masked_mse` → `masked_huber` for SP only (other channels unchanged).

**Why Huber on SP only, not other channels**: tau_y, tau_z, and WSS axes have already been improved by prior mechanisms (test_WSS_z dropped from 9.83% → 8.89% via H107). Volume pressure is already near floor. Only SP shows the persistent 16-mechanism plateau pattern characteristic of an irreducible-tail-outlier problem.

**Related work**:
- Huber (1964) — original robust statistics paper
- Faster R-CNN / Mask R-CNN — smooth L1 widely used in object detection for bounding-box regression precisely to handle outlier-prone targets
- PINN robust losses literature — Huber + scaling for irreducible PDE residuals

**Choice of δ**: For normalized targets (post `transform.apply_surface`), residuals are roughly in [-3, +3] for typical points. δ = 1.0 catches roughly the top 30% of error magnitudes as "tail" (L1 regime). **Default δ = 1.0**, register as `--huber-delta-sp` so it's tunable.

---

## Instructions

Implement an **opt-in Huber SP loss** in `target/train.py`. The Huber transition is gated by a new boolean Config flag and the threshold δ is a separate hyperparameter, so it can be cleanly compared against the baseline and swept.

### Step 1: Add Config fields

In `target/train.py`, in the `Config` dataclass (line 75-141), add the following fields. Place them near the other loss-balance flags (e.g. after `use_gradnorm` and friends):

```python
use_huber_sp_loss: bool = False
huber_delta_sp: float = 1.0
```

The dataclass-to-argparse plumbing at line 233-241 will **automatically** register `--use-huber-sp-loss`, `--no-use-huber-sp-loss`, and `--huber-delta-sp` CLI flags.

Add help entries in the `help_text` dict (around line 147):

```python
"use_huber_sp_loss": (
    "Replace MSE with Huber loss for the SP (surface_pressure) channel "
    "only. Huber transitions from L2 to L1 at |r|=delta, bounding the "
    "gradient contribution of outlier residuals. Falsifiable Plateau "
    "Protocol intervention: if test_SP < 3.577%, MSE's quadratic outlier "
    "amplification was the missing bottleneck for the 16-mechanism SP "
    "plateau. Zero added params; SP only — tau_x/tau_y/tau_z/VP loss "
    "computation unchanged."
),
"huber_delta_sp": (
    "Transition threshold for Huber SP loss. Below |r|=delta the loss "
    "is 0.5*r^2 (matches MSE up to a factor); above delta it's "
    "delta*(|r|-0.5*delta). For normalized SP targets, default 1.0 "
    "treats roughly the top 30% of error magnitudes as outliers. "
    "Smaller delta = more aggressive outlier dampening. Unused if "
    "--use-huber-sp-loss is off."
),
```

### Step 2: Add masked_huber helper

In `target/trainer_runtime.py`, add the following helper near `masked_mse` (line 836). Place it directly after `masked_mse`:

```python
def masked_huber(
    pred: torch.Tensor,
    target: torch.Tensor,
    mask: torch.Tensor,
    delta: float = 1.0,
) -> torch.Tensor:
    """Huber loss reduced over a mask. Mirrors masked_mse signature.

    For |r| <= delta: 0.5 * r^2  (matches MSE)
    For |r| >  delta: delta * (|r| - 0.5*delta)  (linear tail)

    pred / target: [B, N, C]; mask: [B, N].
    Returns a scalar mean over valid (point x channel) entries, matching
    masked_mse's normalisation so balance weights against other tasks
    remain on the same scale as before.
    """
    if pred.numel() == 0:
        return pred.sum() * 0.0
    diff = pred - target
    abs_diff = diff.abs()
    quadratic = 0.5 * diff * diff
    linear = delta * (abs_diff - 0.5 * delta)
    elementwise = torch.where(abs_diff <= delta, quadratic, linear)
    return masked_mean(elementwise, mask)
```

Export it alongside `masked_mse` (mirror the existing export pattern in trainer_runtime.py).

### Step 3: Wire into `compute_per_task_losses`

In `target/train.py`, modify the function at line ~365 (`compute_per_task_losses`). The relevant block is line 387:

```python
# Before:
sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
```

Change to:

```python
# After:
if config.use_huber_sp_loss:
    sp_loss = masked_huber(
        surface_pred[..., 0:1],
        surface_target[..., 0:1],
        batch.surface_mask,
        delta=config.huber_delta_sp,
    )
else:
    sp_loss = masked_mse(surface_pred[..., 0:1], surface_target[..., 0:1], batch.surface_mask)
```

**Important — pass `config` to `compute_per_task_losses` if it's not already a parameter.** Check the function signature; if not, add `config: Config` as the last argument and update the caller.

**IMPORTANT — verify SP target value range at step 0**: log the per-batch min/max/mean of `(surface_pred[..., 0:1] - surface_target[..., 0:1])` once on rank 0 to confirm |r| values are in the expected range (roughly [-3, +3]). If residuals are systematically <0.1 at step 0, δ=1.0 is too high and the Huber will degenerate to pure MSE; if systematically >>3, δ should scale up. Confirm before launching full run.

### Step 4: Verify mechanism engages on a 1-epoch debug

Before launching the full 13-epoch run:
1. Run a 1-epoch debug with `--debug --use-huber-sp-loss --huber-delta-sp 1.0` to ensure no NaNs, no crashes.
2. Check `loss/sp` magnitude vs the baseline equivalent: Huber should be lower (the tail residuals are linearized down).
3. Spot-check: ratio of `loss/sp` Huber vs MSE at step 100 should be ~0.5-0.85 (more aggressive tail dampening if smaller δ).

### Step 5: Launch the full run

Use the canonical 13-epoch DDP recipe with `--use-huber-sp-loss --huber-delta-sp 1.0`. **Do not change any other hyperparameter**. This is a clean A/B comparison against the H101-merged baseline.

### Reproduce command

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-huber-sp-loss --huber-delta-sp 1.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name thorfinn/h115-sp-huber-loss \
  --wandb-group h115-sp-huber-loss
```

### Diagnostic to report

In addition to terminal metrics, **post the SP loss vs MSE-equivalent trajectory** (step 10864, 32594, 65222, 70664) and the val_SP / test_SP delta vs H101 baseline. Also log the **fraction of SP residuals in the linear regime** (|r| > δ) over training — if this stays >50% throughout, δ should be smaller; if it's <5%, Huber is effectively MSE and δ should be larger. This will help calibrate any follow-up sweep.

---

## Baseline

**Single-model SOTA target (PR #972, run `56bcqp3m`):**
- **val_abupt: 6.126%** (gate)
- **test_abupt: 5.844%**
- **test_vol_p: 3.643%** (floor)
- **test_SP: 3.577%** (16-mechanism plateau floor — this experiment's primary target)
- **test_WSS: 6.727%** (goal)
- Source W&B run: `56bcqp3m`; eval run: `zxnhtagj`

**Merge gates (any one triggers merge):**
- A WIN: `val_abupt < 6.126%`
- B PARTIAL: any test floor cross — `test_vol_p ≤ 3.643%` OR `test_SP ≤ 3.577%` OR `test_WSS ≤ 6.727%`

**Falsifiable Plateau Protocol claim:**
- This experiment is designed to **either** crack `test_SP < 3.577%` (definitively loss-form intervention wins) **or** definitively show test_SP plateau is independent of per-point loss curvature. Combined with H114 (panel-area-weighted SP loss), Wave 35 will isolate which axis of the data-tier intervention space is the real bottleneck.

**Reproduce baseline:** see PR #972; source run `56bcqp3m`.
