### PR TITLE
H116: longitudinal Y-mirror augmentation (Plateau Protocol data-tier sample aug)

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -15,6 +15,7 @@ from .loader import (
     DrivAerMLCaseStore,
     DrivAerMLSurfaceDataset,
     SurfaceBatch,
+    apply_y_mirror,
     load_data,
     pad_collate,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "DrivAerMLCaseStore",
     "DrivAerMLSurfaceDataset",
     "SurfaceBatch",
+    "apply_y_mirror",
     "load_data",
     "pad_collate",
 ]

--- a/data/loader.py
+++ b/data/loader.py
@@ -269,6 +269,46 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+def apply_y_mirror(case: DrivAerMLCase, prob: float = 0.5) -> DrivAerMLCase:
+    """Stochastic longitudinal Y-mirror augmentation for one training sample.
+
+    DrivAerML is approximately longitudinally symmetric (y -> -y). Under this
+    transformation only the y-axis quantities flip sign:
+      - surface_x[..., 1] (y coord)        -> negate
+      - surface_x[..., 4] (normal_y)       -> negate
+      - surface_y[..., 2] (tau_y target)   -> negate
+      - volume_x[..., 1] (y coord)         -> negate
+      - everything else (SP, VP, tau_x, tau_z, panel_area, sdf, normals_x/z)
+        is unchanged
+
+    `prob` is the per-sample probability of applying the mirror. With
+    probability (1 - prob) the input case is returned unchanged.
+    """
+
+    if prob <= 0.0 or torch.rand(1).item() >= prob:
+        return case
+
+    surface_x = case.surface_x.clone()
+    surface_y = case.surface_y.clone()
+    volume_x = case.volume_x.clone()
+
+    surface_x[..., 1].neg_()  # y coord
+    surface_x[..., 4].neg_()  # normal_y
+    surface_y[..., 2].neg_()  # tau_y target
+    volume_x[..., 1].neg_()  # volume y coord
+
+    metadata = dict(case.metadata)
+    metadata["y_mirror_applied"] = True
+    return DrivAerMLCase(
+        case_id=case.case_id,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        volume_x=volume_x,
+        volume_y=case.volume_y,
+        metadata=metadata,
+    )
+
+
 def load_case(
     root: str | Path,
     case_id: str,
@@ -367,6 +407,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_y_mirror_aug: bool = False,
+        y_mirror_prob: float = 0.5,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +418,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_y_mirror_aug = bool(use_y_mirror_aug)
+        self.y_mirror_prob = float(y_mirror_prob)
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -457,7 +501,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         metadata["volume_view_count"] = int(view.volume_view_count)
         metadata["volume_sampling_mode"] = view.sampling_mode
         metadata["joint_view_count"] = int(view.view_count)
-        return DrivAerMLCase(
+        metadata["y_mirror_applied"] = False
+        case_out = DrivAerMLCase(
             case_id=case.case_id,
             surface_x=case.surface_x,
             surface_y=case.surface_y,
@@ -465,6 +510,12 @@ class DrivAerMLSurfaceDataset(Dataset):
             volume_y=case.volume_y,
             metadata=metadata,
         )
+        # Y-mirror is a training-only augmentation. Defense-in-depth: guard on
+        # both the explicit opt-in flag and the train sampling mode so eval
+        # datasets cannot accidentally apply the mirror.
+        if self.use_y_mirror_aug and self.sampling_mode == "train_random":
+            case_out = apply_y_mirror(case_out, prob=self.y_mirror_prob)
+        return case_out
 
 
 def pad_collate(samples: list[DrivAerMLCase]) -> SurfaceBatch:
@@ -544,6 +595,8 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_y_mirror_aug: bool = False,
+    y_mirror_prob: float = 0.5,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +621,8 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_y_mirror_aug=use_y_mirror_aug,
+        y_mirror_prob=y_mirror_prob,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    use_y_mirror_aug: bool = False
+    y_mirror_prob: float = 0.5
     debug: bool = False
 
 
@@ -228,6 +230,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "weight and bias are zero-initialised so the layer is identity "
             "at init (preserves baseline at epoch 0). embed_dim follows "
             "--model-hidden-dim and num_heads follows --model-heads."
+        ),
+        "use_y_mirror_aug": (
+            "Enable longitudinal Y-mirror data augmentation in the training "
+            "data loader (NOT eval). With probability `y_mirror_prob`, each "
+            "training sample's y-coordinates, y-normals, and tau_y targets "
+            "are negated (y -> -y). This is a free 2x data augmentation "
+            "exploiting DrivAerML's approximate longitudinal symmetry. "
+            "Plateau Protocol data-tier intervention (H116) testing whether "
+            "the SP plateau is sample-size-bound."
+        ),
+        "y_mirror_prob": (
+            "Probability of applying Y-mirror per training sample (independent "
+            "per sample in batch). 0.5 = balanced augmentation, 1.0 = always "
+            "mirror, 0.0 = effectively disable. Default 0.5. Unused if "
+            "--use-y-mirror-aug is off."
         ),
     }
     for field in fields(Config):
@@ -683,6 +700,8 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        use_y_mirror_aug=getattr(old_ds, "use_y_mirror_aug", False),
+        y_mirror_prob=getattr(old_ds, "y_mirror_prob", 0.5),
     )
     train_sampler = None
     train_shuffle = True
@@ -851,6 +870,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print(
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                )
+            if config.use_y_mirror_aug:
+                print(
+                    f"Y-mirror augmentation: enabled on train loader only, "
+                    f"prob={config.y_mirror_prob} (negates y, normal_y, tau_y, "
+                    f"volume y)"
                 )
 
         run = init_wandb_run(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -286,6 +286,8 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_y_mirror_aug=getattr(config, "use_y_mirror_aug", False),
+        y_mirror_prob=getattr(config, "y_mirror_prob", 0.5),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**LONGITUDINAL Y-MIRROR AUGMENTATION — Plateau Protocol data-tier intervention testing whether the SP plateau (and broader train-set ceiling) is sample-size-bound.**

H113 diagnostic empirically falsified loss-balance as the SP plateau bottleneck. H114 (panel-area-weighted SP loss) and H115 (Huber SP loss) are testing two orthogonal **per-point loss reformulation** axes. H116 tests the **third orthogonal axis** of the data-tier intervention space: **sample augmentation**.

The current training pipeline sees each DrivAerML car shape exactly once per epoch with **no augmentation**. The dataset contains 484 unique geometries split into train/val/test. The model has converged to its current SP plateau across 17 consecutive mechanism interventions — none of which **changed the effective training set size**.

**Physical rationale for longitudinal mirror as a valid augmentation:**

DrivAerML cars are sedans/SUVs/hatchbacks with **approximate longitudinal (y-axis) symmetry**:
- The vehicle's principal mass axis is along x (forward/back).
- The transverse axis y (left/right) is the symmetry axis for the bulk of the surface (roof, windshield, hood, underbody floor pan).
- Asymmetric features are **second-order**: side mirrors (~0.5% of surface area), exhaust pipe (~0.1%), antenna (~0.01%), license plate (~0.05%) — total <1% asymmetric area.
- The flow is **statistically symmetric** about the y=0 plane (inflow along -x, no yaw, no crosswind).
- Therefore: under the transformation `y → -y`, the simulation result should be **approximately mirror-symmetric**:
  - `SP(x, -y, z) ≈ SP(x, y, z)` (scalar pressure, symmetric flow)
  - `VP(x, -y, z) ≈ VP(x, y, z)` (scalar volume pressure)
  - `tau_x(x, -y, z) ≈ tau_x(x, y, z)` (longitudinal shear, symmetric)
  - **`tau_y(x, -y, z) ≈ -tau_y(x, y, z)`** (transverse shear flips sign)
  - `tau_z(x, -y, z) ≈ tau_z(x, y, z)` (vertical shear, symmetric)
  - `normal_x → normal_x`, `normal_y → -normal_y`, `normal_z → normal_z`

**This is a free 2× data augmentation** with ~1% label noise from car asymmetries (smaller than the natural simulation uncertainty).

**Why this might crack the SP plateau when 17 prior mechanisms didn't**: every prior experiment changed the model's representational capacity (architecture-tier) OR the loss function (loss-tier). **None increased the effective training set size**. If the SP plateau is **sample-size-bound** (the model has saturated on the 387 train cars), Y-mirror should provide measurable improvement on test_SP. If the SP plateau is **truly Bayes-optimal hardness** (per-point irreducible aleatoric noise), Y-mirror will not improve SP because the same hard-outlier regions exist in the mirrored samples.

**Falsifiable predictions**:
- **PASS**: `test_SP < 3.577%` AND/OR `val_abupt < 6.126%` → SP plateau (or broader generalization) was sample-size-bound. Y-mirror is the data-tier mechanism that breaks it.
- **PARTIAL**: `val_abupt < 6.126%` but `test_SP ≥ 3.577%` → Y-mirror improves generalization across channels but doesn't crack SP specifically (sample augmentation helps but SP is still hardness-bound).
- **NULL**: `val_abupt ≥ 6.126%` AND `test_SP ≥ 3.577%` → SP plateau is sample-size-independent. Combined with H114+H115 NULL outcomes (if they also fail), this would be **definitive evidence that the SP plateau is Bayes-optimal hardness** at the dataset's spatial resolution. Forces further data-tier escalation: SP-specific architecture, sub-sample-mesh refinement, or full simulation augmentation.

**Zero added parameters.** Pure data augmentation. Trivial implementation. Tests the LAST viable data-tier axis before declaring SP plateau Bayes-optimal.

**Auxiliary expectation — test_tau_y improvement**: The current canonical model has test_tau_y = 7.10%, the worst surface channel by a wide margin. Y-mirror augmentation **directly targets tau_y** by training the model on ±tau_y signs simultaneously. Expect test_tau_y improvement of 0.2-0.5pp regardless of SP outcome.

**Related work**:
- Cohen & Welling (2016) — Group Equivariant CNNs (symmetry-aware augmentation)
- Yang et al. (2023) — augmentation-driven generalization in CFD surrogates
- General data augmentation literature: random flip / mirror is the standard low-hanging fruit in vision tasks

---

## Instructions

Implement **opt-in 50% Y-mirror augmentation in the training data loader only** (not eval). The transformation is gated by a Config flag.

### Step 1: Add Config field

In `target/train.py`, in the `Config` dataclass (line 75-141), add:

```python
use_y_mirror_aug: bool = False
y_mirror_prob: float = 0.5
```

The dataclass-to-argparse plumbing will register `--use-y-mirror-aug`, `--no-use-y-mirror-aug`, and `--y-mirror-prob`.

Help entries:

```python
"use_y_mirror_aug": (
    "Enable longitudinal Y-mirror data augmentation in training "
    "data loader (NOT eval). With probability `y_mirror_prob`, "
    "each training sample's y-coordinates, y-normals, and tau_y "
    "targets are negated (y -> -y). This is a free 2x data "
    "augmentation exploiting DrivAerML's approximate longitudinal "
    "symmetry. Plateau Protocol data-tier intervention testing "
    "whether SP plateau is sample-size-bound."
),
"y_mirror_prob": (
    "Probability of applying Y-mirror per training sample (independent "
    "per sample in batch). 0.5 = balanced augmentation, 1.0 = always "
    "mirror, 0.0 = effectively disable. Default 0.5. Unused if "
    "--use-y-mirror-aug is off."
),
```

### Step 2: Implement Y-mirror in the training data loader

Locate the training `DataLoader` / `Dataset` in `target/data/loader.py`. Find the `__getitem__` method or the collate function. The transformation should be applied at sample-load time (per-sample stochastic, NOT per-batch deterministic).

Add the following helper near the top of `target/data/loader.py`:

```python
def apply_y_mirror(sample, prob: float = 0.5) -> dict:
    """In-place Y-mirror augmentation for one training sample.

    DrivAerML is approximately longitudinally symmetric (y -> -y).
    Under this transformation:
      - surface_x[..., 1] (y coord)        ->  negate
      - surface_x[..., 4] (normal_y)       ->  negate
      - surface_y[..., 2] (tau_y target)   ->  negate
      - volume_x[..., 1] (y coord)         ->  negate
      - all other channels (SP, VP, tau_x, tau_z, panel_area, sdf,
        normals_x, normals_z) are unchanged

    `prob` is the per-sample probability of applying the mirror.
    Pass-through with probability (1 - prob).
    """
    if torch.rand(1).item() >= prob:
        return sample

    # Surface: 7 channels = [x, y, z, n_x, n_y, n_z, panel_area]
    sample.surface_x[..., 1] = -sample.surface_x[..., 1]  # y coord
    sample.surface_x[..., 4] = -sample.surface_x[..., 4]  # normal_y

    # Surface targets: 4 channels = [SP, tau_x, tau_y, tau_z]
    sample.surface_y[..., 2] = -sample.surface_y[..., 2]  # tau_y

    # Volume: 4 channels = [x, y, z, sdf]
    sample.volume_x[..., 1] = -sample.volume_x[..., 1]   # y coord
    # SDF (channel 3) and VP target (1 channel) are scalars, unchanged

    return sample
```

**Wire it into the training-only Dataset.__getitem__**:

Find the `__getitem__` of the training Dataset (not val/test). Add the Y-mirror call after the sample is loaded but before any normalization/transform calls:

```python
def __getitem__(self, idx):
    sample = self._load_sample(idx)  # existing
    if self.use_y_mirror_aug and self.is_training:
        sample = apply_y_mirror(sample, prob=self.y_mirror_prob)
    # ... rest of __getitem__ unchanged
    return sample
```

**Important — flag must propagate to Dataset constructor**. The Dataset class needs `use_y_mirror_aug: bool = False` and `y_mirror_prob: float = 0.5` constructor args, passed from `train.py` where the Dataset is instantiated.

**Important — eval Dataset MUST NOT use Y-mirror.** Verify the val/test Dataset constructor receives `use_y_mirror_aug=False` regardless of the flag setting.

### Step 3: Verify symmetry invariance assumption with a sanity check

Before launching the full run, post a sanity-check log on a 100-sample subset:
1. Load a sample (original).
2. Apply Y-mirror.
3. Manually verify: `surface_x[..., 1] == -original.surface_x[..., 1]`, `surface_x[..., 4] == -original.surface_x[..., 4]`, `surface_y[..., 2] == -original.surface_y[..., 2]`, `volume_x[..., 1] == -original.volume_x[..., 1]`, all other channels unchanged.
4. Confirm `surface_y[..., 0]` (SP), `surface_y[..., 1]` (tau_x), `surface_y[..., 3]` (tau_z), `volume_y` (VP) are bit-identical to original.

Optionally compute spatial statistics:
- For a single car, the mean and variance of SP at y > 0 vs y < 0 should be approximately equal (within 5%). If they differ by >20%, the car has stronger asymmetry than expected and Y-mirror introduces more noise than helps.

### Step 4: Verify mechanism engages on a 1-epoch debug

Before launching the full 13-epoch run:
1. Run a 1-epoch debug with `--debug --use-y-mirror-aug` to ensure no crashes, no shape mismatches.
2. Confirm training proceeds normally (val_abupt at EP1 should be in cohort-baseline range 25-30%; Y-mirror should not destabilize early training).
3. Check that val/test metrics are NOT computed with Y-mirror applied (verify via shape/value spot check at eval time).

### Step 5: Launch the full run

Use the canonical 13-epoch DDP recipe with `--use-y-mirror-aug --y-mirror-prob 0.5`. **Do not change any other hyperparameter**.

### Reproduce command

```bash
cd target/
SENPAI_TIMEOUT_MINUTES=1100 torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-y-mirror-aug --y-mirror-prob 0.5 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name nezuko/h116-y-mirror-augmentation \
  --wandb-group h116-y-mirror-augmentation
```

### Diagnostic to report

In addition to terminal metrics, **post the per-channel test deltas vs H101 baseline** with special emphasis on:
- **test_SP delta** (primary plateau target — does it crack 3.577%?)
- **test_tau_y delta** (secondary expectation — should improve via balanced ±tau_y training)
- **test_WSS_y delta** (should improve via balanced ±y normals exposure)

Also note: log the per-step train loss curve to verify the augmentation doesn't destabilize training (expected: train loss may be slightly higher than baseline early on as the model learns the augmented distribution, then descends below baseline late as generalization improves).

---

## Baseline

**Single-model SOTA target (PR #972, run `56bcqp3m`):**
- **val_abupt: 6.126%** (gate)
- **test_abupt: 5.844%**
- **test_vol_p: 3.643%** (floor)
- **test_SP: 3.577%** (17-mechanism plateau floor — this experiment's primary target)
- **test_WSS: 6.727%** (goal)
- test_tau_y: 7.10% (secondary expectation target — Y-mirror specifically helps this channel)
- test_WSS_y: 7.10% canonical
- Source W&B run: `56bcqp3m`; eval run: `zxnhtagj`

**Merge gates (any one triggers merge):**
- A WIN: `val_abupt < 6.126%`
- B PARTIAL: any test floor cross — `test_vol_p ≤ 3.643%` OR `test_SP ≤ 3.577%` OR `test_WSS ≤ 6.727%`

**Falsifiable Plateau Protocol claim:**
- This experiment is the **third orthogonal data-tier intervention** in the H113-diagnostic-driven Wave 35 pivot. H114 reweights per-point loss (panel-area), H115 changes per-point loss curvature (Huber), and H116 (this) augments the sample distribution (Y-mirror). Combined results across H114+H115+H116 will isolate which axis of the data-tier intervention space is the binding constraint for the SP plateau — or definitively show the plateau is Bayes-optimal hardness.

**Reproduce baseline:** see PR #972; source run `56bcqp3m`.
