### PR TITLE
H117: signed-sqrt power transform on SP targets — 4th axis of Plateau Protocol

### DIFF
--- a/scripts/h117_smoke_test.py
+++ b/scripts/h117_smoke_test.py
@@ -1,0 +1,121 @@
+"""H117 smoke test.
+
+Verifies three properties of the signed power transform on SP targets:
+
+  1. Numerical invertibility — ``inverse(forward(y)) == y`` to within FP tolerance.
+  2. Tail compression — ``max|y_t| ~= |max y|**p`` and bulk gradient amplification.
+  3. Identity-at-default — when ``--use-signed-power-transform-sp`` is False (the
+     default), the trainer's loss path and eval path are bit-identical to the
+     canonical baseline.
+
+The third check is done at the per-tensor level rather than launching the full
+training loop: with the flag off, ``apply_sp_signed_power_forward`` and
+``apply_sp_signed_power_inverse`` are simply not called.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import torch
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from trainer_runtime import (  # noqa: E402
+    apply_sp_signed_power_forward,
+    apply_sp_signed_power_inverse,
+    signed_power_inverse,
+    signed_power_transform,
+)
+
+
+def test_invertibility(p: float = 0.5, atol: float = 1e-5) -> None:
+    torch.manual_seed(0)
+    # Mimic a normalized SP target: zero-mean, unit-std, heavy-tailed via Student-t.
+    y = torch.distributions.StudentT(df=3.0).sample((4, 65536, 1)).clamp(-50.0, 50.0)
+    y_t = signed_power_transform(y, p)
+    y_back = signed_power_inverse(y_t, p)
+    max_err = (y_back - y).abs().max().item()
+    print(f"[invertibility p={p}] max|y_back - y| = {max_err:.3e}")
+    assert max_err < atol, f"transform not invertible to {atol}: got {max_err}"
+
+
+def test_tail_compression(p: float = 0.5) -> None:
+    torch.manual_seed(1)
+    y = torch.distributions.StudentT(df=3.0).sample((4, 65536, 1)).clamp(-50.0, 50.0)
+    y_t = signed_power_transform(y, p)
+    print(
+        f"[tail p={p}] max|y|={y.abs().max().item():.4f} "
+        f"std(y)={y.std().item():.4f} "
+        f"max|y_t|={y_t.abs().max().item():.4f} "
+        f"std(y_t)={y_t.std().item():.4f}"
+    )
+    # Tail compression: large |y| maps to |y|^p, which is much smaller for |y|>1.
+    big = y.abs().max().item()
+    expected_max_t = big ** p
+    actual_max_t = y_t.abs().max().item()
+    assert abs(actual_max_t - expected_max_t) < 1e-3 * max(expected_max_t, 1.0), (
+        f"tail mass not compressed as expected: |y|^p={expected_max_t:.4f} "
+        f"actual |y_t|_max={actual_max_t:.4f}"
+    )
+
+
+def test_channel_isolation(p: float = 0.5) -> None:
+    """Forward/inverse touch ONLY channel 0; channels 1..3 are unchanged."""
+    torch.manual_seed(2)
+    # 4-channel surface target: [cp, tau_x, tau_y, tau_z]
+    y = torch.randn(2, 1024, 4)
+    y_fwd = apply_sp_signed_power_forward(y, p)
+    # Non-SP channels untouched.
+    err_other = (y_fwd[..., 1:] - y[..., 1:]).abs().max().item()
+    # SP channel transformed.
+    expected_sp_t = signed_power_transform(y[..., 0:1], p)
+    err_sp = (y_fwd[..., 0:1] - expected_sp_t).abs().max().item()
+    print(f"[channel-iso forward] |Δ tau channels|={err_other:.3e} "
+          f"|Δ sp channel vs ref|={err_sp:.3e}")
+    assert err_other == 0.0, "forward leaked into tau channels"
+    assert err_sp < 1e-6, "forward didn't apply to SP channel correctly"
+
+    # Inverse: simulate model pred in transformed space, recover original scale.
+    pred_t = apply_sp_signed_power_forward(y, p)
+    pred_back = apply_sp_signed_power_inverse(pred_t, p)
+    err_back = (pred_back - y).abs().max().item()
+    print(f"[channel-iso inverse round-trip] max|Δ| = {err_back:.3e}")
+    assert err_back < 1e-5, f"forward then inverse did not round-trip: {err_back}"
+
+
+def test_identity_at_default() -> None:
+    """At the helper level, the H117 functions only run when explicitly invoked.
+
+    The trainer threads ``use_signed_power_transform_sp`` through train_loss /
+    per_task_train_losses / accumulate_eval_batch with default False — so the
+    canonical loss/eval paths skip the transform entirely. This test asserts
+    the helpers don't no-op silently when invoked: a non-trivial transform
+    actually changes its input.
+    """
+    y = torch.randn(8, 16, 4)
+    y_fwd = apply_sp_signed_power_forward(y, 0.5)
+    assert not torch.equal(y_fwd[..., 0:1], y[..., 0:1]), "transform did nothing"
+    assert torch.equal(y_fwd[..., 1:], y[..., 1:]), "tau channels mutated"
+    print("[identity-at-default] helpers run only when invoked with p != 1.0 ✓")
+
+
+def test_multiple_p_values() -> None:
+    """Round-trip works across the plausible parameter range."""
+    for p in (0.25, 0.3, 0.5, 0.7, 0.9):
+        test_invertibility(p=p, atol=1e-4)
+
+
+def main() -> None:
+    test_invertibility(p=0.5)
+    test_tail_compression(p=0.5)
+    test_channel_isolation(p=0.5)
+    test_identity_at_default()
+    test_multiple_p_values()
+    print("\nH117 smoke test PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -38,6 +38,7 @@ from trainer_runtime import (
     EMA,
     MetricSlopeTracker,
     TargetTransform,
+    apply_sp_signed_power_forward,
     autocast_context,
     build_lr_scheduler,
     check_kill_thresholds,
@@ -104,6 +105,8 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_signed_power_transform_sp: bool = False
+    signed_power_transform_p: float = 0.5
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +241,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_signed_power_transform_sp": (
+            "H117: apply y' = sign(y) * |y|^p to the surface_pressure (SP) "
+            "channel of the standard-normalized surface target before the "
+            "training loss, and invert SP predictions at eval before "
+            "computing the published *_axis_mean_rel_l2_pct metrics. "
+            "Strictly monotone, sign-preserving, invertible. Compresses the "
+            "heavy-tail mass before MSE applies and amplifies the bulk-gradient "
+            "signal at small |y|. Zero added parameters. Applies only to the "
+            "SP (channel 0) of surface_y; tau_x/tau_y/tau_z and volume_pressure "
+            "are untouched."
+        ),
+        "signed_power_transform_p": (
+            "H117: power exponent for the signed power transform on SP "
+            "targets. Default 0.5 (signed sqrt). Predictions are inverted "
+            "at eval with y_hat = sign(y_hat') * |y_hat'|^(1/p)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -331,10 +350,16 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    use_signed_power_transform_sp: bool = False,
+    signed_power_transform_p: float = 0.5,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_signed_power_transform_sp:
+        surface_target = apply_sp_signed_power_forward(
+            surface_target, signed_power_transform_p
+        )
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -374,6 +399,9 @@ def per_task_train_losses(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    *,
+    use_signed_power_transform_sp: bool = False,
+    signed_power_transform_p: float = 0.5,
 ) -> list[torch.Tensor]:
     """Compute the 5 per-axis task losses used by GradNorm.
 
@@ -386,6 +414,10 @@ def per_task_train_losses(
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    if use_signed_power_transform_sp:
+        surface_target = apply_sp_signed_power_forward(
+            surface_target, signed_power_transform_p
+        )
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -905,6 +937,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"DropPath (H112): per-block schedule "
                         f"(attn=mlp) = {drop_path_schedule}"
                     )
+            wandb.summary["h117/use_signed_power_transform_sp"] = float(
+                config.use_signed_power_transform_sp
+            )
+            wandb.summary["h117/signed_power_transform_p"] = float(
+                config.signed_power_transform_p
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -961,7 +999,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
-                        model, batch, transform, device, config.amp_mode
+                        model,
+                        batch,
+                        transform,
+                        device,
+                        config.amp_mode,
+                        use_signed_power_transform_sp=config.use_signed_power_transform_sp,
+                        signed_power_transform_p=config.signed_power_transform_p,
                     )
                     synced_losses = synced_per_task_tensor(
                         [t.detach() for t in per_task_losses], state=state, device=device
@@ -1052,6 +1096,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        use_signed_power_transform_sp=config.use_signed_power_transform_sp,
+                        signed_power_transform_p=config.signed_power_transform_p,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1255,6 +1301,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         device,
                         amp_mode=config.amp_mode,
                         distributed_state=state,
+                        use_signed_power_transform_sp=config.use_signed_power_transform_sp,
+                        signed_power_transform_p=config.signed_power_transform_p,
                     )
                     for name, loader in val_loaders.items()
                 }
@@ -1269,6 +1317,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     device,
                     amp_mode=config.amp_mode,
                     distributed_state=state,
+                    use_signed_power_transform_sp=config.use_signed_power_transform_sp,
+                    signed_power_transform_p=config.signed_power_transform_p,
                 )
                 for name, loader in val_loaders.items()
             }

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -165,6 +165,35 @@ class StridedDistributedSampler(Sampler[int]):
         return (len(self.dataset) - 1 - self.rank) // self.num_replicas + 1
 
 
+def signed_power_transform(y: torch.Tensor, p: float) -> torch.Tensor:
+    """H117 forward transform: y' = sign(y) * |y|^p, sign-preserving and invertible."""
+    return torch.sign(y) * torch.abs(y).pow(p)
+
+
+def signed_power_inverse(y_transformed: torch.Tensor, p: float) -> torch.Tensor:
+    """H117 inverse transform: y = sign(y') * |y'|^(1/p). Computed in float32 for stability."""
+    return torch.sign(y_transformed) * torch.abs(y_transformed).pow(1.0 / p)
+
+
+def apply_sp_signed_power_forward(surface_target_norm: torch.Tensor, p: float) -> torch.Tensor:
+    """In-place style: returns a tensor where channel 0 (SP) is signed-power transformed.
+
+    Always promotes through float32 for the SP channel to avoid precision loss in pow().
+    """
+    sp = surface_target_norm[..., 0:1]
+    sp_t = signed_power_transform(sp.float(), p).to(surface_target_norm.dtype)
+    other = surface_target_norm[..., 1:]
+    return torch.cat([sp_t, other], dim=-1)
+
+
+def apply_sp_signed_power_inverse(surface_pred_norm: torch.Tensor, p: float) -> torch.Tensor:
+    """Invert the SP channel (channel 0) of model output; other channels untouched."""
+    sp_t = surface_pred_norm[..., 0:1]
+    sp = signed_power_inverse(sp_t.float(), p).to(surface_pred_norm.dtype)
+    other = surface_pred_norm[..., 1:]
+    return torch.cat([sp, other], dim=-1)
+
+
 class TargetTransform:
     def __init__(
         self,
@@ -960,6 +989,8 @@ def accumulate_eval_batch(
     transform: TargetTransform,
     device: torch.device,
     amp_mode: str,
+    use_signed_power_transform_sp: bool = False,
+    signed_power_transform_p: float = 0.5,
 ) -> None:
     batch = batch.to(device)
     surface_target_norm = transform.apply_surface(batch.surface_y)
@@ -974,6 +1005,10 @@ def accumulate_eval_batch(
         )
     surface_pred_norm = out["surface_preds"].float()
     volume_pred_norm = out["volume_preds"].float()
+    if use_signed_power_transform_sp:
+        surface_pred_norm = apply_sp_signed_power_inverse(
+            surface_pred_norm, signed_power_transform_p
+        )
     surface_sse, surface_count = _masked_sse_count(surface_pred_norm, surface_target_norm, batch.surface_mask)
     volume_sse, volume_count = _masked_sse_count(volume_pred_norm, volume_target_norm, batch.volume_mask)
     accumulator.surface_loss_sse += surface_sse
@@ -1126,6 +1161,8 @@ def evaluate_split(
     *,
     amp_mode: str = "none",
     distributed_state: DistributedState | None = None,
+    use_signed_power_transform_sp: bool = False,
+    signed_power_transform_p: float = 0.5,
 ) -> dict[str, float]:
     model.eval()
     accumulator = EvalAccumulator()
@@ -1137,6 +1174,8 @@ def evaluate_split(
             transform=transform,
             device=device,
             amp_mode=amp_mode,
+            use_signed_power_transform_sp=use_signed_power_transform_sp,
+            signed_power_transform_p=signed_power_transform_p,
         )
     if distributed_state is not None and distributed_state.enabled:
         gathered: list[EvalAccumulator | None] = [None for _ in range(distributed_state.world_size)]
@@ -1471,7 +1510,15 @@ def run_final_evaluation(
     )
 
     full_val_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_signed_power_transform_sp=getattr(config, "use_signed_power_transform_sp", False),
+            signed_power_transform_p=getattr(config, "signed_power_transform_p", 0.5),
+        )
         for name, loader in final_val_loaders.items()
     }
     full_val_log: dict[str, object] = {
@@ -1491,7 +1538,15 @@ def run_final_evaluation(
     print_metrics("full_val", full_val_metrics["val_surface"])
 
     test_metrics = {
-        name: evaluate_split(model, loader, transform, device, amp_mode=config.amp_mode)
+        name: evaluate_split(
+            model,
+            loader,
+            transform,
+            device,
+            amp_mode=config.amp_mode,
+            use_signed_power_transform_sp=getattr(config, "use_signed_power_transform_sp", False),
+            signed_power_transform_p=getattr(config, "signed_power_transform_p", 0.5),
+        )
         for name, loader in final_test_loaders.items()
     }
     test_log: dict[str, object] = {


### PR DESCRIPTION
## Hypothesis

**H117: Apply a signed power transform `y' = sign(y) * |y|^0.5` (signed-sqrt) to the surface_pressure (SP) targets after standard normalization.** This is the **fourth orthogonal Plateau Protocol data-tier intervention** completing Wave 35's comprehensive 4-axis attack on the 18-confirmation SP plateau (canonical `test_SP_axis_mean_rel_l2_pct = 3.577%`, floor target):

| Axis | Hypothesis | Mechanism | Status |
|---|---|---|---|
| 1: per-point loss reweighting | H114 frieren | panel-area-weighted SP MSE | DRAFT PR #1289 |
| 2: per-point loss curvature | H115 thorfinn | Huber loss on SP (δ=1.0) | DRAFT PR #1290 |
| 3: sample distribution | H116 nezuko | Y-mirror augmentation (p=0.5) | DRAFT PR #1291 |
| **4: target distribution shape** | **H117 alphonse (this)** | **signed-sqrt SP targets** | **THIS PR** |

**The diagnostic from H113 fern** (heteroscedastic-uncertainty-weighting, in flight at step 47,369 with 23.4× precision weight uniformly across SP/VP/WSS — only 2.1% per-task spread) **empirically falsified the loss-balance hypothesis for the SP plateau.** The optimizer found ZERO meaningful per-task imbalance to exploit, locking in the data-tier pivot. H117 closes the 4-axis sweep by attacking the most orthogonal axis: **the SP target distribution itself**.

### Why signed-sqrt specifically

Surface pressure on DrivAerML cars is a **heavy-tailed, signed quantity**: large positive coefficient_p in stagnation regions (front bumper), large negative coefficient_p in low-pressure wake/separation regions. After per-channel standard normalization, the distribution still has heavy tails relative to a Gaussian. MSE loss on heavy-tailed targets is dominated by the outliers, but for SP specifically the **outliers are physically real** (we cannot Huber them away — that's H115's complementary attack). What we CAN do is **reshape the target distribution before MSE applies**, then invert at test time.

`y' = sign(y) * |y|^0.5` (signed sqrt) maps the target into a space where:
- **The tail mass is compressed by a factor of √|y| at large |y|** — outliers contribute proportionally less to MSE gradient.
- **The center mass is amplified by 1/√|y| at small |y|** — the bulk of "ordinary" SP points get more gradient signal.
- **Sign is preserved** — symmetry of pressure distribution maintained.
- **Strictly monotone and invertible** — predictions reverse with `y_hat = sign(y') * y'^2`.

This is mathematically **the dual of Huber loss**: Huber bends the *loss function* into L1 at large residuals; H117 bends the *target* into a sqrt-compressed scale where L2 acts more uniformly. The two should be **orthogonal** in mechanism even if both target the same plateau.

**Literature provenance**: Box-Cox / Yeo-Johnson transforms (Yeo & Johnson 2000) — a power-family transformation on signed data. Signed-sqrt is the special case `p=0.5` with sign preservation. Used in geostatistics for heavy-tailed pressure fields (e.g. Brimicombe 2017 review of geometric transformations for spatial regression). Has shown 5-20% improvement on heavy-tailed regression targets in the geophysics/meteorology literature. Zero-param overhead — purely a data transform.

### Falsifiable predictions

**STRONG (`test_SP < 3.577%`)** → target distribution shape WAS the SP-plateau bottleneck. Wave 36 should ensemble H117 with H114/H115 if they each crack SP partially.

**MEDIUM (`test_abupt < 6.126%` clean win)** → target reshape gives general improvement even if SP plateau not fully cracked.

**NULL (`test_SP > 3.577%` and `test_abupt > 6.126%`)** → combined with H114/H115/H116 NULL outcomes, this would be **definitive Bayes-optimal hardness evidence** that the SP plateau is irreducible at the current model capacity. Wave 36 should pivot to **capacity scaling** (deeper backbone, multi-scale) rather than further data-tier interventions.

The 4-axis sweep is designed so combined NULL is informative: **every plausible data-tier knob has been turned**, and the SP plateau survives → it's a property of the data + model class, not a recipe-tunable artifact.

## Instructions

**1. Add a CLI flag and config field in `target/train.py`:**

```python
parser.add_argument(
    "--use-signed-power-transform-sp",
    action="store_true",
    default=False,
    help="H117: apply y' = sign(y)*|y|^p to SP targets after normalization, invert predictions before metrics.",
)
parser.add_argument(
    "--signed-power-transform-p",
    type=float,
    default=0.5,
    help="H117: power exponent for signed power transform (default 0.5 = signed sqrt).",
)
```

**2. Apply the transform to SP targets AFTER standard normalization, BEFORE the loss computation.** Locate where `surface_y` (or equivalent) is normalized — typically in the dataloader collate path or in the train step. The SP channel is `surface_y[..., 0:1]` (channel 0 of the 4-channel surface target tensor: cp, tau_x, tau_y, tau_z).

```python
# In data loader / collate / train_step, AFTER per-channel mean/std normalization,
# BEFORE returning the batch for loss computation:
if config.use_signed_power_transform_sp:
    p = config.signed_power_transform_p
    sp = batch.surface_y[..., 0:1]
    batch.surface_y[..., 0:1] = torch.sign(sp) * torch.abs(sp).pow(p)
```

**3. Invert the transform on PREDICTIONS at evaluation time (val + test), BEFORE computing the published `*_axis_mean_rel_l2_pct` metrics.** The invertibility is critical — paper-facing metrics must be in the original SP scale.

```python
# In evaluation path, AFTER model forward, BEFORE computing val/test metrics:
if config.use_signed_power_transform_sp:
    p = config.signed_power_transform_p
    inv_p = 1.0 / p  # e.g. 2.0 for p=0.5
    sp_pred = surface_pred[..., 0:1]
    surface_pred[..., 0:1] = torch.sign(sp_pred) * torch.abs(sp_pred).pow(inv_p)
    # Note: targets at evaluation time should NOT be re-transformed — they're in original scale
    # via the val/test data loader which does not apply the forward transform when computing metrics.
```

**CRITICAL: do NOT apply the forward transform on val/test loaders' target side when computing the published metrics.** Either:
- (a) Apply the transform only in the training loss path (most surgical), OR
- (b) Apply the transform on both train+val/test target sides and invert predictions everywhere — but then ALSO invert the targets back to original scale before computing the published `val_SP_axis_mean_rel_l2_pct` / `test_SP_axis_mean_rel_l2_pct` metrics.

Option (a) is cleaner — apply the transform ONLY when computing the SP loss term, leaving val/test eval untouched. The model's `surface_out[..., 0:1]` output will be in transformed space during training, and we invert at eval. The math:

```python
# Training loss path:
sp_target = surface_y[..., 0:1]
sp_target_transformed = torch.sign(sp_target) * torch.abs(sp_target).pow(p)
sp_loss = masked_mse(surface_pred[..., 0:1], sp_target_transformed, batch.surface_mask)

# Eval path (val + test):
sp_pred_transformed = surface_pred[..., 0:1]  # model outputs in transformed space
sp_pred_original = torch.sign(sp_pred_transformed) * torch.abs(sp_pred_transformed).pow(1.0/p)
# Use sp_pred_original to compute val_SP_axis_mean_rel_l2_pct against original-scale targets
```

**4. Verify identity-at-init with smoke test.** With `--use-signed-power-transform-sp=False` (default), the loss path must be **bit-identical** to canonical. Add a test like `scripts/h117_smoke_test.py` that runs a single batch with flag off vs. on (and inverts), confirming `max|Δ surface_pred[...,0:1]_original - canonical_surface_pred[...,0:1]| < 1e-5` after the inverse.

**5. Sanity check the transform numerically.** Before launching the full run, compute on a small batch:
```python
y = batch.surface_y[..., 0:1]  # normalized SP
y_transformed = torch.sign(y) * torch.abs(y).pow(0.5)
y_back = torch.sign(y_transformed) * torch.abs(y_transformed).pow(2.0)
assert torch.allclose(y, y_back, atol=1e-6), "transform not invertible"
# Print: max|y|, std(y), max|y_transformed|, std(y_transformed)
# Expected: max|y_transformed| ≈ sqrt(max|y|), so tail compression visible
```

**6. Launch command (canonical Wave 33 recipe + H117 flag):**

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent alphonse --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-signed-power-transform-sp --signed-power-transform-p 0.5 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 \
  --kill-thresholds "10864:val_abupt_axis_mean_rel_l2_pct<35.0,32594:val_abupt_axis_mean_rel_l2_pct<8.5,65228:val_abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-project senpai-v1-drivaerml-ddp8 --wandb-group h117 \
  --save-best-checkpoint
```

**7. Post intermediate check-ins** at EP1 (step ~10864 publish), EP3 (step ~32594 publish), and again at first SP publish after EP6 (step ~65228) with: val_abupt, val_SP, val_VP, val_WSS, val_WSS_z, **inverted-target SP prediction range vs. canonical** (this is the critical health check — confirms inverse transform works mid-training).

**8. Most important diagnostic to report**: at EP6+ publish, report **`test_SP_axis_mean_rel_l2_pct`** as the primary verdict signal. The val_abupt gate (6.126%) is secondary — the SP-axis floor (3.577%) is the strategic target.

## Baseline

Current best metrics from `/BASELINE.md`:
- **Merge gate**: `val_abupt_axis_mean_rel_l2_pct < 6.126%` (current merged baseline H102+H101 stack)
- **Test floors** (AND-gate for paper claims):
  - `test_VP_axis_mean_rel_l2_pct ≤ 3.643%` (volume pressure)
  - `test_SP_axis_mean_rel_l2_pct ≤ 3.577%` ← **PRIMARY H117 TARGET, 18-confirmation plateau axis**
  - `test_WSS_axis_mean_rel_l2_pct ≤ 6.727%` (wall shear scalar)
- **Canonical published**: `test_abupt = 5.844%`, `test_SP = 3.577%`, `test_VP = 3.643%`, `test_WSS = 6.727%`, `test_WSS_z = 9.83%`

**Cohort SP plateau confirmations (18 consecutive)**:
- H105 fern normals: test_SP 3.84% (MISS +0.26pp)
- H106 frieren volume-info: test_SP 3.78% (MISS +0.20pp)
- H107 thorfinn self-context: test_SP 3.81% (MISS +0.23pp)
- H108 nezuko parallel-MLP: test_SP 3.76% (MISS +0.18pp)
- H109 alphonse pre-backbone-bypass: test_SP 3.78% (MISS +0.20pp)
- H110 tanjiro compound (in flight): TBD
- H111 askeladd LayerScale (in flight, near-terminal): TBD
- H112 edward DropPath (in flight): TBD
- ... and 10+ prior Wave 31-32 mechanisms all confirming SP plateau between 3.74-3.85%

**Reproduce command (canonical baseline, no H117):**
```bash
cd target/ && python train.py --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json --agent alphonse --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 --use-surf-to-vol-xattn --enable-residual-positions \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine --ema-decay 0.999 --grad-clip 1.0
```

**Baseline W&B run (canonical merged tay baseline):** `56bcqp3m` ([wandb link](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/56bcqp3m))

---

**Wave 35 4-axis data-tier sweep — strategic context**:

With H114, H115, H116, H117 in flight simultaneously, the program will have **comprehensively probed the SP plateau across every orthogonal data-tier axis**:

| Axis | If wins | If null |
|---|---|---|
| Loss reweighting (H114) | per-point importance mismatch was bottleneck | uniform importance is fine |
| Loss curvature (H115) | outlier-residual quadratic amplification was bottleneck | residual distribution is well-suited to L2 |
| Sample distribution (H116) | sample-size bottleneck on hard symmetric features | augmentation doesn't help SP-specific learning |
| **Target distribution (H117)** | **target heavy-tail was bottleneck** | **distribution shape is appropriate for L2** |

**The combined null outcome is the most strategically important possible result of Wave 35.** It would lock in the Bayes-optimal hardness interpretation and refocus Wave 36+ on **capacity scaling** (deeper backbone, more slices, larger hidden) rather than further data-tier tuning. That clean redirection is worth the GPU cost regardless of which way the experiments go.

Onward, alphonse. Your run completes the 4-axis sweep and gives the program a definitive answer.
