### PR TITLE
H119: COMPOUND H112+H102 — DropPath + wider surface_out 2× (orthogonal-class compound)

### DIFF
--- a/model.py
+++ b/model.py
@@ -419,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        surface_out_width_factor: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +435,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.surface_out_width_factor = surface_out_width_factor
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -520,10 +522,11 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
+            surf_hidden_width = int(round(n_hidden * surface_out_width_factor))
             self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
+                nn.Linear(n_hidden, surf_hidden_width),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(surf_hidden_width, self.surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    surface_out_width_factor: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +239,13 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "surface_out_width_factor": (
+            "H119: Width multiplier for the surface_out MLP hidden layer "
+            "(n_hidden -> int(n_hidden * factor) -> surface_output_dim). "
+            "1.0 = canonical (byte-identical to baseline); 2.0 = H102 wider "
+            "surface decoder (+266K params at n_hidden=512). Activation "
+            "(SiLU) and depth (2 layers) preserved at all factors."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -318,6 +326,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        surface_out_width_factor=config.surface_out_width_factor,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Wave 36 H119: COMPOUND H112+H102 — DropPath regularization + wider surface_out MLP (orthogonal-class compound)**

H112 (DropPath, zero params) became our new single-model SOTA (test_abupt=5.839%, test_VP=3.421% deepest program cross). H102 (surface_out 2×, +266K params) was the strongest decoder-capacity signal in Wave 33 — narrowly missed the old gate by +0.008pp AND violated the test_VP floor (3.650% > 3.643%), which was attributed to insufficient regularization.

**The compound additivity diagnostic (H110 result) mandates exactly this experiment:**
- H110 tested H102+H101 (two decoder-capacity mechanisms). Result: ANTI-ADDITIVE on VP/SP (decoder-capacity × decoder-capacity = competition). BUT ADDITIVE+ on WSS_z (best program result at the time).
- H112 is a **regularization** mechanism, H102 is a **decoder-capacity** mechanism — these are **orthogonal classes**.
- The program's strategic implication (locked at H110 close): *"compound across orthogonal mechanism classes: decoder × regularization."* H119 is exactly that compound.

**Why H102's VP floor breach should be fixed by DropPath:**
H102's VP floor breach (3.650% vs 3.643% floor) occurred on a model without regularization. DropPath imposes stochastic training pressure on backbone residuals — this acts as an implicit ensemble at train time, improving generalization of upstream features before they reach the decoder. The wider surface_out MLP (larger expressivity) compounded with DropPath's regularization is expected to eliminate the VP over-fit signature. H112 alone achieved test_VP=3.421% (−0.222pp below floor) — the regularization budget is ample.

**Mechanism:**
- H112 base: `--use-drop-path --drop-path-rate 0.10` (zero params, linear schedule 0→0.10 across 5 backbone blocks)
- H102 addition: `--surface-out-width-factor 2.0` → surface_out hidden dim 512→1024, +266K params
  - surface_out before: `Linear(512, 512) → GELU → Linear(512, 4)`
  - surface_out after: `Linear(512, 1024) → GELU → Linear(1024, 4)`

**Falsifiable predictions:**
- If val_abupt < 6.1358% AND test_VP ≤ 3.421% → orthogonal-class additivity confirmed; decoder-capacity unlock with regularization stabilization
- If val_abupt < 6.1358% BUT test_VP > 3.421% (VP floor breach) → DropPath rate 0.10 insufficient for +266K decoder; could retry with drop-path-rate 0.15
- If val_abupt ≥ 6.1358% → wider decoder does not help even with regularization; decoder-capacity axis is exhausted at n_hidden=512 family

**WSS/WSS_z secondary target:**
H112 already achieved test_WSS_z=8.720% (new program best). H102 showed additive WSS_z improvement in H110 analysis. H119 is the strongest expected vehicle for approaching the test_WSS < 6.727% floor.

**Param cost:** +266K (H102 width only) + 0 (H112 DropPath) = +266K total vs H112 base.

---

## Instructions

### Code changes — `target/train.py`

Add the CLI flag:
```python
parser.add_argument(
    "--surface-out-width-factor",
    type=float,
    default=1.0,
    help="Width multiplier for surface_out hidden layer (1.0=canonical, 2.0=H119 wider MLP)",
)
```

Pass it through to the model constructor:
```python
model = SurfaceTransolver(
    ...,
    surface_out_width_factor=args.surface_out_width_factor,
)
```

### Code changes — `target/model.py`

In `SurfaceTransolver.__init__`, parameterize the surface_out hidden dim (around line 484–489, where `self.surface_out` is constructed):

```python
# Add surface_out_width_factor param to __init__ signature (default=1.0)
surf_hidden_width = int(n_hidden * surface_out_width_factor)
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, surf_hidden_width),
    nn.GELU(),
    nn.Linear(surf_hidden_width, self.surface_output_dim),
)
```

This keeps 2 layers (canonical depth) but widens the intermediate dim. At `surface_out_width_factor=1.0` this is byte-identical to canonical behavior — safe default.

**No other changes needed.** The DropPath code is already merged on the `tay` branch from H112 (PR #1283). You only need to add the width-factor flag on top.

### Training command (DDP 8 GPUs)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --surface-out-width-factor 2.0 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
  --wandb-name edward/h119-compound-droppath-wider-surface-decoder \
  --wandb-group wave36_h119_compound_h112_h102
```

**Key flags vs H112 base:**
- `--surface-out-width-factor 2.0` — THE ONLY CHANGE from H112 reproduce command
- All other flags are identical to H112 (DropPath already included)

### Kill thresholds (step-indexed, NOT epoch-indexed)

- Step 10864 (EP1 end): val_abupt < 35.0% (early crash kill)
- Step 32594 (EP3 end): val_abupt < 8.5% (divergence kill)
- Step 65228 (EP6 end): val_abupt < 6.7% (underperformance kill)

### What to report

Post a terminal `SENPAI-RESULT` comment with:

1. **Full per-channel val + test table** (val_abupt, val_SP, val_VP, val_WSS, val_WSS_x/y/z + matching test_ values)
2. **Param count delta** vs H112 baseline: should be +266K params
3. **Direct comparison to H112** (new baseline) and H102 (prior decoder-width attempt)
4. **val→test slope per channel** — are we generalizing better or worse on VP vs H112?
5. **EP3/EP6 gate commentary** — any early signal on VP channel specifically

Terminal result marker format:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_primary/abupt_axis_mean_rel_l2_pct","value":<number>}}
```

---

## Baseline

**Current single-model SOTA: PR #1283 H112 DropPath (edward)**

| Metric | H112 (baseline) | H102 (ref, not merged) |
|--------|-----------------|------------------------|
| val_abupt | **6.1358%** ← merge gate | 6.118% (old gate) |
| test_abupt | **5.839%** | N/A |
| test_VP | **3.421%** (floor) | 3.650% (VP BREACH) |
| test_SP | 3.695% (MISS 3.577% floor) | — |
| test_WSS | 6.752% (MISS 6.727% floor) | — |
| test_WSS_z | **8.720%** (program best) | — |

**H112 W&B run:** `u9ue2ryb`

**Merge gate (strict):** val_abupt < **6.1358%** AND test_abupt < **5.839%**
**Test floors (AND-gate for paper claims):** test_VP ≤ **3.421%** AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%

**H112 reproduce (your base):**
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint
```
