### PR TITLE
Wave 36 H123: WSS TANGENT-FRAME PROJECTION — hard tangent-plane projection of predicted shear vector (zero added params, Morgan WSS-primary directive #1056)

### DIFF
--- a/launch_h123.sh
+++ b/launch_h123.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# H123 PR #1299: WSS tangent-frame projection (Option A — physical-space).
+# H112 DropPath SOTA recipe + --use-wss-tangent-projection.
+# Stale recipe flags in the PR body translated to actual train.py CLI:
+#   --use-drop-path --drop-path-rate 0.10 -> --drop-path-max 0.10
+#   --grad-clip 1.0                       -> --grad-clip-norm 1.0
+#   --lr-schedule cosine                  -> implicit via --lr-cosine-t-max 13
+#   --save-best-checkpoint                -> default on
+#   --wandb-run-name X                    -> --wandb-name X
+set -euo pipefail
+cd /workspace/senpai/target
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+LOG="logs/h123_${TS}.log"
+PIDFILE="logs/h123_${TS}.pid"
+
+SENPAI_TIMEOUT_MINUTES=1100 \
+nohup torchrun --standalone --nproc_per_node=8 --master_port=29500 train.py \
+  --agent fern \
+  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --manifest data/split_manifest.json \
+  --epochs 13 --batch-size 4 \
+  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
+  --model-slices 128 --model-dropout 0.0 \
+  --train-surface-points 65536 --eval-surface-points 65536 \
+  --train-volume-points 16384 --eval-volume-points 65536 \
+  --vol-points-schedule '0:16384:3:32768:6:49152:9:65536' \
+  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
+  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
+  --use-qk-norm \
+  --rff-num-features 16 \
+  --rff-init-sigmas '0.25,0.5,1.0,2.0,4.0' \
+  --pos-encoding-mode string_separable \
+  --use-ema --ema-decay 0.999 --ema-start-step 50 \
+  --use-surf-to-vol-xattn \
+  --drop-path-max 0.10 \
+  --use-wss-tangent-projection \
+  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
+  --weight-decay 5e-4 --grad-clip-norm 1.0 \
+  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
+  --amp-mode bf16 --no-compile-model \
+  --kill-thresholds '10864:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.4' \
+  --wandb-name 'fern/h123-wss-tangent-frame-projection' \
+  --wandb-group 'wave36_h123_wss_tangent_projection' \
+  > "$LOG" 2>&1 &
+
+LAUNCH_PID=$!
+echo "$LAUNCH_PID" > "$PIDFILE"
+echo "H123 launch PID: $LAUNCH_PID"
+echo "Log: $LOG"
+echo "PID file: $PIDFILE"

--- a/model.py
+++ b/model.py
@@ -419,6 +419,9 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_wss_tangent_projection: bool = False,
+        tau_phys_mean: torch.Tensor | None = None,
+        tau_phys_std: torch.Tensor | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +437,32 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_wss_tangent_projection = use_wss_tangent_projection
+        if use_wss_tangent_projection:
+            # H123 PR #1299 Option A (per advisor #1299#issuecomment 2026-05-24T08:33Z):
+            # project tau onto the tangent plane in PHYSICAL space, not
+            # normalized space. The per-channel surface_y normalizer has
+            # tau_x mean -1.20 std 2.08, tau_y mean +0.00 std 1.36, tau_z
+            # mean -0.07 std 1.11, so (tau_pred_norm * std + mean) . n = 0
+            # is the physically faithful no-penetration constraint, while
+            # tau_pred_norm . n = 0 imposes a non-physical sigma-rescaled
+            # one. Mean/std are stored as buffers so they ride checkpoints
+            # and move with the model under .to(device).
+            if tau_phys_mean is None or tau_phys_std is None:
+                raise ValueError(
+                    "use_wss_tangent_projection=True requires "
+                    "tau_phys_mean and tau_phys_std (3-element tensors "
+                    "of surface_y_mean[1:4] and surface_y_std[1:4])."
+                )
+            tau_mean_t = torch.as_tensor(tau_phys_mean, dtype=torch.float32).reshape(-1)
+            tau_std_t = torch.as_tensor(tau_phys_std, dtype=torch.float32).reshape(-1)
+            if tau_mean_t.numel() != 3 or tau_std_t.numel() != 3:
+                raise ValueError(
+                    f"tau_phys_mean/std must each have 3 elements, "
+                    f"got {tau_mean_t.numel()}/{tau_std_t.numel()}"
+                )
+            self.register_buffer("tau_phys_mean", tau_mean_t)
+            self.register_buffer("tau_phys_std", tau_std_t)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -660,8 +689,50 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        wss_tangent_diag: dict[str, torch.Tensor] | None = None
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.use_wss_tangent_projection and surface_preds.shape[-1] >= 4:
+                # H123 PR #1299 Option A: hard tangent-plane projection of
+                # predicted WSS in PHYSICAL space. surface_x layout
+                # (data/loader.py:288) is xyz(3) + normals(3) + area(1).
+                # Renormalize normals defensively — the loader can emit
+                # non-unit magnitudes due to mesh smoothing; padded rows
+                # have zero normals which stay zero after the clamp.
+                surface_normals = surface_x[:, :, 3:6]
+                surface_normals = surface_normals / (
+                    surface_normals.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+                )
+                cp_norm = surface_preds[..., 0:1]
+                tau_norm = surface_preds[..., 1:4]
+                # Denormalize → project → renormalize. Cast buffers to the
+                # autocast dtype of tau_norm so this stays mixed-precision-safe.
+                tau_phys_mean = self.tau_phys_mean.to(dtype=tau_norm.dtype)
+                tau_phys_std = self.tau_phys_std.to(dtype=tau_norm.dtype)
+                tau_phys = tau_norm * tau_phys_std + tau_phys_mean
+                tau_dot_n_pre_phys = (tau_phys * surface_normals).sum(dim=-1, keepdim=True)
+                tau_tangent_phys = tau_phys - tau_dot_n_pre_phys * surface_normals
+                tau_tangent_norm = (tau_tangent_phys - tau_phys_mean) / tau_phys_std
+                surface_preds = torch.cat([cp_norm, tau_tangent_norm], dim=-1) * surface_mask.unsqueeze(-1)
+                # Per-batch diagnostics restricted to real (non-padded) points
+                # via surface_mask. Computed in PHYSICAL space — the physically
+                # meaningful coordinates. Hoped-for trajectory: pre_proj_rel
+                # decreases over training (model learns to predict tangent tau
+                # natively); post_proj_abs stays ~0 (sanity that projection holds).
+                mask_f = surface_mask.to(dtype=tau_phys.dtype)
+                mask_sum = mask_f.sum().clamp(min=1.0)
+                tau_dot_n_pre_abs = tau_dot_n_pre_phys.squeeze(-1).abs() * mask_f
+                pre_proj_abs_mean = tau_dot_n_pre_abs.sum() / mask_sum
+                tau_phys_norm_pre = tau_phys.norm(dim=-1).clamp(min=1e-8)
+                pre_proj_rel = (tau_dot_n_pre_phys.squeeze(-1).abs() / tau_phys_norm_pre) * mask_f
+                pre_proj_rel_mean = pre_proj_rel.sum() / mask_sum
+                tau_dot_n_post = (tau_tangent_phys * surface_normals).sum(dim=-1).abs() * mask_f
+                post_proj_abs_mean = tau_dot_n_post.sum() / mask_sum
+                wss_tangent_diag = {
+                    "pre_proj_normal_component_abs_mean_phys": pre_proj_abs_mean.detach(),
+                    "pre_proj_normal_component_rel_mean_phys": pre_proj_rel_mean.detach(),
+                    "post_proj_normal_component_abs_mean_phys": post_proj_abs_mean.detach(),
+                }
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -672,10 +743,13 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if wss_tangent_diag is not None:
+            out["wss_tangent_diag"] = wss_tangent_diag
+        return out

--- a/smoke_h123_tangent.py
+++ b/smoke_h123_tangent.py
@@ -1,0 +1,188 @@
+"""H123 PR #1299 smoke test: physical-space tangent projection.
+
+Verifies:
+1. Buffer registration succeeds with use_wss_tangent_projection=True.
+2. Forward pass yields tau_pred such that (tau_pred_phys . n_hat) ~ 0
+   after projection, where tau_pred_phys = tau_pred_norm * std + mean.
+3. Diagnostic keys are emitted with the _phys suffix.
+4. Parameter count matches the off variant (buffers don't count).
+"""
+from __future__ import annotations
+
+import torch
+
+from train import Config, build_model
+
+
+_REAL_STATS = {
+    "surface_y_mean": torch.tensor(
+        [-0.3038, -1.2007, 0.0015, -0.0721], dtype=torch.float32
+    ),
+    "surface_y_std": torch.tensor(
+        [0.3563, 2.0769, 1.3564, 1.1143], dtype=torch.float32
+    ),
+    "volume_y_mean": torch.tensor([0.0], dtype=torch.float32),
+    "volume_y_std": torch.tensor([1.0], dtype=torch.float32),
+}
+
+
+def _baseline_config() -> Config:
+    cfg = Config()
+    cfg.model_layers = 2
+    cfg.model_hidden_dim = 64
+    cfg.model_heads = 2
+    cfg.model_mlp_ratio = 2
+    cfg.model_slices = 8
+    cfg.rff_num_features = 0
+    cfg.pos_encoding_mode = "sincos"
+    cfg.amp_mode = "fp32"
+    return cfg
+
+
+def _fake_batch(device, batch_size=2, n_surface=128, n_volume=128):
+    # surface_x layout: [xyz(3), normals(3), area(1)] per loader.py:288
+    xyz = torch.randn(batch_size, n_surface, 3, device=device)
+    # Random unit normals
+    raw_normals = torch.randn(batch_size, n_surface, 3, device=device)
+    normals = raw_normals / raw_normals.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+    area = torch.rand(batch_size, n_surface, 1, device=device)
+    surface_x = torch.cat([xyz, normals, area], dim=-1)
+    # volume_x layout: [xyz(3), sdf(1)]
+    volume_x = torch.randn(batch_size, n_volume, 4, device=device)
+    surface_mask = torch.ones(batch_size, n_surface, dtype=torch.bool, device=device)
+    volume_mask = torch.ones(batch_size, n_volume, dtype=torch.bool, device=device)
+    return surface_x, volume_x, surface_mask, volume_mask, normals
+
+
+def main():
+    torch.manual_seed(123)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    cfg_off = _baseline_config()
+    cfg_on = _baseline_config()
+    cfg_on.use_wss_tangent_projection = True
+
+    torch.manual_seed(7)
+    model_off = build_model(cfg_off, stats=_REAL_STATS).to(device)
+    torch.manual_seed(7)
+    model_on = build_model(cfg_on, stats=_REAL_STATS).to(device)
+
+    n_off = sum(p.numel() for p in model_off.parameters())
+    n_on = sum(p.numel() for p in model_on.parameters())
+    print(f"params off={n_off}  on={n_on}  delta={n_on - n_off}")
+    assert n_off == n_on, "tangent projection must add zero params (buffers only)"
+
+    # Verify buffers
+    assert hasattr(model_on, "tau_phys_mean")
+    assert hasattr(model_on, "tau_phys_std")
+    assert torch.allclose(
+        model_on.tau_phys_mean.cpu(), _REAL_STATS["surface_y_mean"][1:4]
+    )
+    assert torch.allclose(
+        model_on.tau_phys_std.cpu(), _REAL_STATS["surface_y_std"][1:4]
+    )
+    print(
+        f"buffers loaded: tau_phys_mean={model_on.tau_phys_mean.tolist()} "
+        f"tau_phys_std={model_on.tau_phys_std.tolist()}"
+    )
+    assert not hasattr(model_off, "tau_phys_mean")
+
+    # Forward pass on the projection-on model
+    model_on.eval()
+    surface_x, volume_x, surface_mask, volume_mask, normals = _fake_batch(device)
+    with torch.no_grad():
+        out = model_on(
+            surface_x=surface_x,
+            volume_x=volume_x,
+            surface_mask=surface_mask,
+            volume_mask=volume_mask,
+        )
+    assert "wss_tangent_diag" in out, "missing wss_tangent_diag in forward output"
+    diag = out["wss_tangent_diag"]
+    for k in (
+        "pre_proj_normal_component_abs_mean_phys",
+        "pre_proj_normal_component_rel_mean_phys",
+        "post_proj_normal_component_abs_mean_phys",
+    ):
+        assert k in diag, f"missing diag key {k}"
+        print(f"  diag[{k}] = {diag[k].item():.6e}")
+
+    # The MUST-HOLD sanity assertion: post-projection normal residual is zero
+    post = diag["post_proj_normal_component_abs_mean_phys"].item()
+    assert post < 1e-5, f"post_proj normal residual {post:.6e} should be < 1e-5"
+
+    # Independently verify by re-computing physical projection on the output
+    tau_norm = out["surface_preds"][..., 1:4]
+    mean = model_on.tau_phys_mean.to(dtype=tau_norm.dtype)
+    std = model_on.tau_phys_std.to(dtype=tau_norm.dtype)
+    tau_phys = tau_norm * std + mean
+    tau_dot_n = (tau_phys * normals).sum(dim=-1)
+    abs_mean = tau_dot_n.abs().mean().item()
+    print(f"independent (tau_phys . n).abs().mean() = {abs_mean:.6e}")
+    assert abs_mean < 1e-4, f"physical-space tangency violated: {abs_mean:.6e}"
+
+    # Now compare against off-variant: same inputs, different outputs (projection kills DoF)
+    model_off.load_state_dict(
+        {k: v for k, v in model_on.state_dict().items() if k in model_off.state_dict()},
+        strict=False,
+    )
+    model_off.eval()
+    with torch.no_grad():
+        out_off = model_off(
+            surface_x=surface_x,
+            volume_x=volume_x,
+            surface_mask=surface_mask,
+            volume_mask=volume_mask,
+        )
+    diff = (out["surface_preds"][..., 1:4] - out_off["surface_preds"][..., 1:4]).abs().mean().item()
+    print(f"|tau_pred_on - tau_pred_off|.mean() = {diff:.6e}")
+    assert diff > 0.0, "projection should produce different tau output"
+
+    # cp channel must be untouched by projection
+    cp_diff = (out["surface_preds"][..., 0:1] - out_off["surface_preds"][..., 0:1]).abs().mean().item()
+    print(f"|cp_on - cp_off|.mean() = {cp_diff:.6e}")
+    assert cp_diff < 1e-6, "cp channel should be untouched by projection"
+
+    # bf16 autocast + backward sanity (the actual training path)
+    if device.type == "cuda":
+        model_on.train()
+        for p in model_on.parameters():
+            p.grad = None
+        with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
+            out_amp = model_on(
+                surface_x=surface_x,
+                volume_x=volume_x,
+                surface_mask=surface_mask,
+                volume_mask=volume_mask,
+            )
+            tau_pred = out_amp["surface_preds"][..., 1:4]
+            loss = (tau_pred ** 2).mean()
+        loss.backward()
+        post_amp = out_amp["wss_tangent_diag"][
+            "post_proj_normal_component_abs_mean_phys"
+        ].item()
+        # bf16 has ~8-bit mantissa so post-projection residual is larger than fp32.
+        # tau_phys_mean magnitudes are O(1), normals are unit, so post_proj is
+        # at the bf16 epsilon scale (~few e-2 absolute). Sanity: < 0.1.
+        print(f"bf16 post_proj_abs_mean = {post_amp:.6e}")
+        assert post_amp < 0.1, f"bf16 post_proj should be small, got {post_amp:.6e}"
+        n_grad = sum(1 for p in model_on.parameters() if p.grad is not None)
+        n_tot = sum(1 for _ in model_on.parameters())
+        # Surface-only loss leaves the volume head with no grad — expected.
+        # Just check the projection path itself didn't break gradient flow.
+        print(f"grads populated: {n_grad}/{n_tot} params (surface-only loss)")
+        assert n_grad >= n_tot - 8, f"projection path broke grad flow ({n_grad}/{n_tot})"
+        # Verify surface_out specifically gets grads — it's the layer directly
+        # before the projection, so a broken projection backward would zero its grads.
+        surf_out_grad_norms = [
+            p.grad.norm().item() for p in model_on.surface_out.parameters()
+            if p.grad is not None
+        ]
+        print(f"surface_out grad norms: {surf_out_grad_norms}")
+        assert all(g > 0.0 for g in surf_out_grad_norms), "surface_out grad flow is broken"
+
+    print("\nH123 PHYSICAL-SPACE TANGENT PROJECTION smoke test PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_wss_tangent_projection: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +239,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_wss_tangent_projection": (
+            "H123 (PR #1299) Option A: hard tangent-plane projection of the "
+            "predicted wall-shear vector inside the surface decoder, applied "
+            "in PHYSICAL space. After surface_preds = self.surface_out(...), "
+            "tau_norm is denormalized to physical units via the surface_y "
+            "mean/std buffers (registered at build_model time from loader "
+            "stats), projected onto the local tangent plane via "
+            "tau_tangent_phys = tau_phys - (tau_phys . n_hat) n_hat, then "
+            "renormalized back. n_hat is the per-point surface normal taken "
+            "from surface_x[..., 3:6]. Zero added parameters; enforces "
+            "tau_phys . n_hat = 0 (no-penetration / boundary-layer "
+            "constraint) as a hard inductive bias instead of asking the MLP "
+            "to learn it. Physical-space projection chosen over "
+            "normalized-space because per-channel std spread (86.4 pct) and "
+            "non-zero tau_x mean make the latter geometrically non-physical."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -303,7 +320,22 @@ def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     return metrics
 
 
-def build_model(config: Config) -> SurfaceTransolver:
+def build_model(
+    config: Config,
+    stats: dict[str, torch.Tensor] | None = None,
+) -> SurfaceTransolver:
+    tau_phys_mean = None
+    tau_phys_std = None
+    if config.use_wss_tangent_projection:
+        if stats is None:
+            raise ValueError(
+                "build_model needs stats={'surface_y_mean', 'surface_y_std'} "
+                "when use_wss_tangent_projection=True (H123 Option A "
+                "physical-space projection)."
+            )
+        # surface_y layout is [cp, tau_x, tau_y, tau_z]; slice 1:4 = tau.
+        tau_phys_mean = stats["surface_y_mean"][1:4].detach().clone()
+        tau_phys_std = stats["surface_y_std"][1:4].detach().clone()
     return SurfaceTransolver(
         n_layers=config.model_layers,
         n_hidden=config.model_hidden_dim,
@@ -318,6 +350,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_wss_tangent_projection=config.use_wss_tangent_projection,
+        tau_phys_mean=tau_phys_mean,
+        tau_phys_std=tau_phys_std,
     )
 
 
@@ -356,13 +391,18 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    diag = out.get("wss_tangent_diag") if isinstance(out, dict) else None
+    if diag is not None:
+        for key, tensor in diag.items():
+            metrics[f"wss_tangent/{key}"] = float(tensor.detach().cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -756,7 +796,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             volume_y_std=stats["volume_y_std"].to(device),
         )
 
-        model: nn.Module = build_model(config).to(device)
+        model: nn.Module = build_model(config, stats=stats).to(device)
         n_params = sum(param.numel() for param in model.parameters())
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
@@ -1092,6 +1132,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for key, value in batch_loss_metrics.items():
+                        if key.startswith("wss_tangent/"):
+                            train_log[f"train/{key}"] = value
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Hard tangent-plane projection of the predicted wall-shear vector inside the surface decoder will improve test_WSS by removing the unphysical normal component as a capacity sink.**

Physically, wall shear stress is **tangent to the wall by construction** (τ · n̂ = 0 in the boundary-layer limit). However, our decoder predicts τ = (τ_x, τ_y, τ_z) as three independent scalar fields with no geometric coupling, forcing the MLP to *learn* tangency from data. This wastes capacity — especially for τ_z, which is the WSS bottleneck (test_WSS_z=8.720% under H112 vs canonical 8.945% improvement target).

**Mechanism**: After the surface decoder outputs `surface_preds = (cp, τ_x, τ_y, τ_z)`, project away the normal component using the per-point surface normal (which is **already an input feature** at `surface_x[..., 3:6]` per `data/loader.py:38`):
```
τ_tangent = τ − (τ · n̂) n̂
```
This is **zero added parameters** and **geometrically aligned** with WSS physics. It enforces the no-penetration constraint as a hard inductive bias rather than asking the model to learn it.

**Why this matters for the WSS axis specifically** (per Morgan's directive in Issue #1056, 2026-05-24T07:35Z — `test_WSS < 5.85% Transolver-3 SOTA` is now the primary objective):
- H112 (current SOTA) test_WSS = **6.752%** → gap to Transolver-3 SOTA = **0.902pp**
- Pure capacity scaling (H118 slices-192, H120 depth-6, H121 hidden-576) helps val_abupt but has not yet demonstrated strong WSS-axis gains
- Loss-balancing (H113 het-uncertainty) was null-falsified — uniform amplification, no per-task rebalancing
- A WSS-aligned **architectural** intervention is the cleanest next swing — surgical, falsifiable, no parameter cost

**Falsifiable predictions:**
1. test_WSS improves (target: cross 6.727% floor; stretch: meaningful step toward 5.85%)
2. test_WSS_z specifically improves more than τ_x/τ_y (because horizontal panels with large n_z see the biggest projection)
3. val_WSS_z trajectory shows lower variance vs free-form prediction
4. Per-point `mean(|τ · n̂| / |τ|)` collapses toward 0 (post-projection identity at every step) while pre-projection raw values monotonically decrease as model adapts

**Related work / first-principles grounding:**
- DeepONet / FNO surface-PDE literature increasingly enforces geometric constraints in the decoder (vs free MLP). Tangent-plane projection is the WSS analogue of incompressibility / divergence-free projection for velocity fields.
- This is also the simplest member of a family of decoder-side equivariance-respecting transformations (tangent-frame coordinates, surface-normal-conditioned MLPs, intrinsic-geometry attention).

## Instructions

**One arm. Single PR. Targeting `tay`.**

### Code change

**File: `model.py`** — modify the `Transolver` class to support a new flag `use_wss_tangent_projection`:

1. Add `use_wss_tangent_projection: bool = False` to `Transolver.__init__` signature. Cache as `self.use_wss_tangent_projection = use_wss_tangent_projection`.

2. In `Transolver.forward(self, surface_x, volume_x, ...)`, **before any encoding** capture the per-point surface normals:
   ```python
   if self.use_wss_tangent_projection:
       # data/loader.py:38 — surface_x = [xyz(3), normals(3), panel_area(1)]
       surface_normals = surface_x[:, :, 3:6]  # [B, N_surf, 3]
       # Renormalize defensively (loader may emit non-unit magnitudes due to mesh smoothing)
       surface_normals = surface_normals / (surface_normals.norm(dim=-1, keepdim=True).clamp(min=1e-8))
   ```

3. After `surface_preds = self.surface_out(surface_hidden)` (or equivalent — find where surface output is produced), apply the projection:
   ```python
   if self.use_wss_tangent_projection:
       # surface_preds layout: [cp(1), tau_x(1), tau_y(1), tau_z(1)]
       cp = surface_preds[..., 0:1]
       tau = surface_preds[..., 1:4]  # [B, N_surf, 3]
       tau_dot_n = (tau * surface_normals).sum(dim=-1, keepdim=True)  # [B, N_surf, 1]
       tau_tangent = tau - tau_dot_n * surface_normals
       surface_preds = torch.cat([cp, tau_tangent], dim=-1)
   ```

4. **Important: this is NOT identity at init.** The pretrained checkpoint baseline pattern has the model predicting τ with small residual normal component (mesh-noise floor of targets is ~1-3% relative |τ·n̂|/|τ|, varies by region). Projection removes this from outputs immediately. **Initial val_abupt at EP1 may show a small bump (~+0.5-1.0pp)** as the model rebalances; expected to recover by EP3.

5. **Loss / metric coordinate frame**: the projection is applied in the model's native output space (post-decoder, pre-inverse-transform). If `transform.apply_surface` is a simple per-channel standardization (subtract mean, divide by std), the projection is still meaningful because the τ components share the same normalization scale (typically). **Verify before launch**: print `transform.surface_mean` and `transform.surface_std` once — if τ_x, τ_y, τ_z have the same std (within 10%), the in-normalized-space projection is geometrically faithful. If they differ wildly, ping the advisor before launching.

### CLI plumbing

**File: `train.py`** — add the argparse flag:
```python
parser.add_argument("--use-wss-tangent-projection", action="store_true",
                    help="Hard tangent-plane projection of predicted WSS vector (zero added params)")
```

Thread it through to the `Transolver` constructor where the model is built. Match the existing convention for other `use_*` boolean flags (e.g., `use_drop_path`, `use_aux_decoder_heads`).

### Verification before full training launch

1. **Smoke test (REQUIRED, ~3 min)**: Launch single-GPU `python train.py ... --epochs 1 --max-train-steps 50 --use-wss-tangent-projection`. Verify:
   - Process doesn't crash on import / model build / forward.
   - W&B logs `train/total_loss` is finite for ≥10 steps.
   - The model param count is **unchanged** vs baseline (same as H112 DropPath: 17.41M).
2. **Sanity assertion**: Add a debug print (or W&B scalar `debug/tau_dot_n_post_proj_mean_abs`) computing `(surface_preds[..., 1:4] * surface_normals).sum(dim=-1).abs().mean()` *after* projection. This must be **< 1e-5** (numerically zero — confirms hard projection is working). Strip the debug print before full launch.

### Reproduce command (full run)

```bash
cd target && SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent fern --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --use-wss-tangent-projection \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group wave36_h123_wss_tangent_projection \
  --wandb-run-name "fern/h123-wss-tangent-frame-projection-rank0"
```

(This is the H112 DropPath SOTA recipe + the single new flag `--use-wss-tangent-projection`.)

### Kill thresholds (canonical 13-ep recipe)

```
--kill-thresholds 10864:val_primary/abupt_axis_mean_rel_l2_pct<36.0 \
                  32594:val_primary/abupt_axis_mean_rel_l2_pct<9.0 \
                  65228:val_primary/abupt_axis_mean_rel_l2_pct<6.4
```

**Note**: EP1 gate raised to 36.0% (vs canonical 35.0%) to accommodate the initial transient as the model rebalances under the new projection inductive bias. EP3 gate raised slightly to 9.0% (vs 8.5%) for the same reason. **EP6 gate at 6.4% is the real go/no-go — if val_abupt > 6.4% at step 65,228, kill.**

### Diagnostic logging requirement

Log to W&B at every val publish boundary (these are the keys you need for the closure review):
- `train/wss_tangent/pre_proj_normal_component_abs_mean` — mean(|τ·n̂|) **before** projection (model's raw prediction)
- `train/wss_tangent/pre_proj_normal_component_rel_mean` — mean(|τ·n̂| / (|τ| + ε)) **before** projection
- `train/wss_tangent/post_proj_normal_component_abs_mean` — must be near-zero (sanity check)

These let us see whether the model is *learning* to predict pre-projected tangent τ over time (the hoped-for outcome — projection becomes increasingly redundant), or just relying on the projection to clean up arbitrarily-pointed predictions (less favorable).

## Baseline

**Current SOTA (H112 DropPath, PR #1283, merged 2026-05-24):**
- W&B run: `u9ue2ryb`
- val_abupt: **6.1358%** (merge gate)
- test_abupt: **5.839%** (canonical floor)
- test_VP: **3.421%** (was floor 3.643% — now tighter)
- test_SP: **3.695%** (floor 3.577% — still above)
- **test_WSS: 6.752%** (was floor 6.727% — slight regression on this axis)
- **test_WSS_z: 8.720%** (canonical 8.945%; the worst component, biggest improvement target)

**Primary research objective (Morgan, Issue #1056, 2026-05-24T07:35Z):**
- **test_WSS < 5.85%** (Transolver-3 SOTA target)
- Gap from current best: **0.902pp**
- Hard constraints: test_VP ≤ 3.643%, test_SP ≤ 3.577% (must not regress)

**Merge / partial / null decision tree:**
- **A WIN** (merge): val_abupt < 6.1358% AND test_abupt < 5.839%
- **B PARTIAL** (merge if WSS-aligned): test_WSS < 6.752% (improves the primary metric) AND test_VP ≤ 3.643% AND test_SP ≤ 3.577% (floors hold)
- **C NULL** (close): regression on test_WSS or any floor breach
- **D STRONG WIN** (priority merge + paper update): test_WSS < 6.5%, meaningful step toward Transolver-3 SOTA

**Reproduce command for baseline (H112 reference for direct comparison):**
```bash
cd target/
# (Same recipe as above WITHOUT --use-wss-tangent-projection)
```
W&B baseline group: `wave35_h112_droppath` (run `u9ue2ryb`)

## What to report in your SENPAI-RESULT

1. Terminal metrics (val_abupt, test_abupt, test_VP, test_SP, **test_WSS**, **test_WSS_x**, **test_WSS_y**, **test_WSS_z**)
2. Verdict against merge / partial / null tree above
3. Diagnostic trajectory of the WSS tangent metric: at each val publish, `pre_proj_normal_component_rel_mean` (we want to see this *decrease* over time as model learns to predict more-tangent τ pre-projection)
4. Per-WSS-component breakdown vs H112: |Δ test_WSS_x|, |Δ test_WSS_y|, |Δ test_WSS_z| — the prediction is τ_z improves most
5. Implementation peak memory + wall time
