### PR TITLE
H-A: Surface-Intrinsic Tangent-Frame Input Encoding — WSS-axis representation attack

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -269,12 +269,60 @@ def _three_column(value: np.ndarray, name: str) -> np.ndarray:
     return arr
 
 
+_TANGENT_FRAME_DEBUG_PRINTS_REMAINING = 3
+
+
+def _tangent_frame_local_xyz(xyz: np.ndarray, normals: np.ndarray, case_id: str) -> np.ndarray:
+    # Surface-Intrinsic Tangent-Frame Input Encoding (PR #1302 / H-A).
+    # Replace world (x, y, z) with offset-from-centroid projected onto the
+    # per-point local tangent frame {t_hat_1, t_hat_2, n_hat} built from the
+    # existing surface normal. Output frame is unchanged.
+    global _TANGENT_FRAME_DEBUG_PRINTS_REMAINING
+    # Eval-time chunked views can produce an empty surface slice for the
+    # extra views that exist only to cover the larger volume view count;
+    # short-circuit so xyz.mean does not emit a noisy NaN warning.
+    if xyz.shape[0] == 0:
+        return np.zeros((0, 3), dtype=np.float32)
+    n_hat = normals.astype(np.float32, copy=False)
+    ref = np.tile(np.array([0.0, 0.0, 1.0], dtype=np.float32), (n_hat.shape[0], 1))
+    align_dot = np.einsum("ij,ij->i", n_hat, ref)
+    align_mask = np.abs(align_dot) > 0.95
+    ref[align_mask] = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    t1 = np.cross(n_hat, ref)
+    t1 /= np.linalg.norm(t1, axis=1, keepdims=True) + 1e-9
+    t2 = np.cross(n_hat, t1)
+    centroid = xyz.mean(axis=0, keepdims=True)
+    dp = xyz - centroid
+    xyz_local = np.stack(
+        [
+            np.einsum("ij,ij->i", dp, t1),
+            np.einsum("ij,ij->i", dp, t2),
+            np.einsum("ij,ij->i", dp, n_hat),
+        ],
+        axis=1,
+    ).astype(np.float32, copy=False)
+    if _TANGENT_FRAME_DEBUG_PRINTS_REMAINING > 0:
+        align_frac = float(align_mask.mean())
+        print(
+            f"[tangent-frame] case={case_id} N={xyz.shape[0]} "
+            f"centroid.shape={tuple(centroid.shape)} "
+            f"centroid={centroid.ravel().tolist()} "
+            f"align_mask_frac={align_frac:.4f} "
+            f"dp_t1_range=[{xyz_local[:, 0].min():.3f},{xyz_local[:, 0].max():.3f}] "
+            f"dp_n_range=[{xyz_local[:, 2].min():.3f},{xyz_local[:, 2].max():.3f}]",
+            flush=True,
+        )
+        _TANGENT_FRAME_DEBUG_PRINTS_REMAINING -= 1
+    return xyz_local
+
+
 def load_case(
     root: str | Path,
     case_id: str,
     *,
     surface_rows: np.ndarray | None = None,
     volume_rows: np.ndarray | None = None,
+    use_tangent_frame_input: bool = False,
 ) -> DrivAerMLCase:
     case_dir = _case_dir(Path(root), case_id)
     xyz = _load_npy_rows(case_dir / "surface_xyz.npy", surface_rows)
@@ -285,7 +333,11 @@ def load_case(
         _load_npy_rows(case_dir / "surface_wallshearstress.npy", surface_rows),
         "surface_wallshearstress.npy",
     )
-    surface_x = np.concatenate([xyz, normals, area], axis=1)
+    if use_tangent_frame_input:
+        xyz_input = _tangent_frame_local_xyz(xyz, normals, case_id)
+    else:
+        xyz_input = xyz
+    surface_x = np.concatenate([xyz_input, normals, area], axis=1)
     surface_y = np.concatenate([cp, wall_shear], axis=1)
     volume_x = np.concatenate(
         [
@@ -307,6 +359,17 @@ def load_case(
             "n_volume": int(volume_x.shape[0]),
         },
     )
+
+
+def reset_tangent_frame_debug_prints(remaining: int = 3) -> None:
+    """Re-enable the one-shot tangent-frame diagnostic prints.
+
+    Useful when a test wants to assert the print fires; production training
+    relies on the default 3-print quota set at module-import time.
+    """
+
+    global _TANGENT_FRAME_DEBUG_PRINTS_REMAINING
+    _TANGENT_FRAME_DEBUG_PRINTS_REMAINING = remaining
 
 
 def load_case_point_counts(root: str | Path, case_id: str) -> dict[str, int]:
@@ -338,8 +401,15 @@ class DrivAerMLCaseStore:
         *,
         surface_rows: np.ndarray | None = None,
         volume_rows: np.ndarray | None = None,
+        use_tangent_frame_input: bool = False,
     ) -> DrivAerMLCase:
-        return load_case(self.root, case_id, surface_rows=surface_rows, volume_rows=volume_rows)
+        return load_case(
+            self.root,
+            case_id,
+            surface_rows=surface_rows,
+            volume_rows=volume_rows,
+            use_tangent_frame_input=use_tangent_frame_input,
+        )
 
     def case_point_counts(self, case_id: str) -> dict[str, int]:
         cached = self._point_count_cache.get(case_id)
@@ -367,6 +437,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_tangent_frame_input: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +447,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_tangent_frame_input = use_tangent_frame_input
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -444,6 +516,7 @@ class DrivAerMLSurfaceDataset(Dataset):
             view.case_id,
             surface_rows=None if surface_idx is None else surface_idx.numpy(),
             volume_rows=None if volume_idx is None else volume_idx.numpy(),
+            use_tangent_frame_input=self.use_tangent_frame_input,
         )
         metadata = dict(case.metadata)
         metadata["n_surface_full"] = int(counts["n_surface"])
@@ -544,6 +617,7 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_tangent_frame_input: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +642,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_tangent_frame_input=use_tangent_frame_input,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(
@@ -576,6 +651,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_tangent_frame_input=use_tangent_frame_input,
         )
     }
     test_splits = {
@@ -585,6 +661,7 @@ def load_data(
             max_surface_points=eval_surface_points,
             max_volume_points=eval_volume_points,
             sampling_mode=eval_sampling,
+            use_tangent_frame_input=use_tangent_frame_input,
         )
     }
     stats = target_stats_from_normalizers(store)

--- a/train.py
+++ b/train.py
@@ -103,6 +103,7 @@ class Config:
     pos_encoding_mode: str = "sincos"
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
+    use_tangent_frame_input: bool = False
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
@@ -237,6 +238,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the attention and MLP branches with a linear schedule from "
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
+        ),
+        "use_tangent_frame_input": (
+            "H-A (PR #1302): Surface-Intrinsic Tangent-Frame Input Encoding. "
+            "Replace the three world (x, y, z) position channels in the "
+            "surface input with the per-case centroid offset projected onto "
+            "the local frame {t_hat_1, t_hat_2, n_hat} built from the existing "
+            "surface normal. Output frame is unchanged; the model still "
+            "predicts (tau_x, tau_y, tau_z) in world frame and loss is in "
+            "world frame. Shape (N, 7) is preserved. Reference axis is world-z "
+            "with world-y fallback where |n_hat . z| > 0.95. 0 added params."
         ),
     }
     for field in fields(Config):
@@ -693,6 +704,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        use_tangent_frame_input=getattr(old_ds, "use_tangent_frame_input", False),
     )
     train_sampler = None
     train_shuffle = True

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -286,6 +286,7 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_tangent_frame_input=getattr(config, "use_tangent_frame_input", False),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**Surface-Intrinsic Tangent-Frame Input Encoding will close ≥ 0.15pp of the test_WSS gap to Transolver-3 SOTA (5.85%).**

WSS τ is, by construction, a **tangential** vector field — τ·n̂ = 0 at every wall point. Yet the model currently predicts in **world (x, y, z) frame** where the relationship between τ_z, τ_x and the local panel normal is entangled with panel orientation. On a near-horizontal roof panel (n̂ ≈ [0,0,1]), the model must implicitly learn that τ_z ≈ 0; on a near-vertical side panel (n̂ ≈ [0,±1,0]), the model must learn that τ_y ≈ 0. This is an **implicit geometric invariant** that the model currently must rediscover from data instead of being given as a representation.

This hypothesis attacks the WSS-axis representation gap from the **input-representation tier** — orthogonal to the (now-exhausted) tangency-imposition class which attempted to enforce τ·n̂ = 0 as a hard constraint at the **output**:

| # | PR | Class | Mechanism | Outcome |
|---|---|---|---|---|
| 1 | #351 | hard projection | output τ_pred − (τ_pred·n̂)·n̂ | C NULL — gradients zeroed on normal component |
| 2 | #680 | hard projection | same | C NULL — same pathology |
| 3 | #713 | soft penalty | `λ·\|τ·n̂\|²` loss term | C NULL — model sacrifices τ_y/τ_z to satisfy constraint |
| 4 | #1299 | hard projection | per-point `τ_tangent = τ − (τ·n̂)·n̂` | C NULL — `pre_proj_normal_rel` 0.34 flat throughout |

H-A is **not in this class**. It is a change to the **input representation**, not an output constraint. Gradients flow freely through a linear basis change. The model still predicts raw (τ_x, τ_y, τ_z) in world frame and is supervised on all three. What changes is only the **basis of the position input** — replacing world (x, y, z) offset with surface-intrinsic (δp·t̂₁, δp·t̂₂, δp·n̂).

**Literature support**:
- Dalton et al. (arXiv 2212.05023, 2022): SE(3)-equivariant graph convolution on triangular meshes achieves **7.6%** relative WSS error vs **34%** for a non-equivariant baseline on hemodynamic surfaces — frame alignment is a load-bearing inductive bias for surface vector fields.
- Sharp et al. (arXiv 2406.09648, 2024, Intrinsic Vector Heat Networks): basis-invariant manifold operations systematically outperform frame-dependent baselines for vector fields on surfaces.

**Why this attacks WSS specifically and not VP/SP**: VP and SP are scalar fields; their values are basis-invariant. WSS is a vector field on the surface — its **representation** depends on the frame. Tangent-frame encoding should mostly leave VP / SP unchanged (within noise) and concentrate gains on test_WSS, with the largest effect on `test_WSS_z` (the channel whose world-frame value most strongly correlates with panel orientation).

**Falsifiable prediction**:
- Primary: test_WSS improves ≥ **0.15pp** vs H112 baseline (6.752% → ≤ **6.60%**).
- Mechanism observable: `val_WSS_z` improves more than `val_WSS_x` (because τ_z on near-horizontal panels is the channel whose world-frame value is most entangled with normal direction).
- Falsifying signature: if `val_WSS_z` regresses or improves less than `val_WSS_x`, the frame-alignment explanation is wrong and the rep change is structurally inert (close C NULL).

---

## Instructions

**Single change: replace the 3 position channels (x, y, z) in the surface input with their projection onto a per-point local tangent frame {t̂₁, t̂₂, n̂} constructed from the existing surface normal.**

### Code path (exact)

`target/data/loader.py`, inside `load_case()` (currently lines 280-288):

Current code path:
```python
xyz = np.load(...surface_xyz.npy)           # (N, 3) world position
normals = np.load(...surface_normals.npy)   # (N, 3) outward unit normal
area = np.load(...surface_area.npy)         # (N, 1)
surface_x = np.concatenate([xyz, normals, area], axis=1)   # (N, 7)
```

Replace with **conditional** tangent-frame transformation behind a new CLI flag `--use-tangent-frame-input` (default off):

```python
xyz = np.load(...surface_xyz.npy)
normals = np.load(...surface_normals.npy)
area = np.load(...surface_area.npy)

if args.use_tangent_frame_input:
    n_hat = normals  # already unit-length per drivaerml preprocessor
    # Reference direction: world z-axis, fallback to world y-axis where n_hat aligns with z.
    ref = np.tile([0.0, 0.0, 1.0], (n_hat.shape[0], 1))
    align_mask = np.abs(np.einsum("ij,ij->i", n_hat, ref)) > 0.95   # near-parallel
    ref[align_mask] = np.array([0.0, 1.0, 0.0])
    # t1 = normalize(cross(n_hat, ref))
    t1 = np.cross(n_hat, ref)
    t1 /= np.linalg.norm(t1, axis=1, keepdims=True) + 1e-9
    # t2 = cross(n_hat, t1) — already unit-length since n_hat ⟂ t1 and unit-length.
    t2 = np.cross(n_hat, t1)

    # Project the position OFFSET (not absolute position) into the local frame.
    centroid = xyz.mean(axis=0, keepdims=True)
    dp = xyz - centroid                              # (N, 3) offset from centroid
    xyz_local = np.stack([
        np.einsum("ij,ij->i", dp, t1),               # δp·t̂₁
        np.einsum("ij,ij->i", dp, t2),               # δp·t̂₂
        np.einsum("ij,ij->i", dp, n_hat),            # δp·n̂
    ], axis=1)                                       # (N, 3)

    surface_x = np.concatenate([xyz_local, normals, area], axis=1)   # (N, 7), same shape
else:
    surface_x = np.concatenate([xyz, normals, area], axis=1)
```

### CLI flag plumbing

1. Add `--use-tangent-frame-input` to `target/train.py` argparse (boolean flag, default False).
2. Thread it into `Dataset` construction so `load_case()` can see it (either via dataset `__init__` arg or a global module-level config). Match the existing pattern for other dataset-level boolean flags (e.g. how `--enable-residual-positions` is threaded if present).
3. **Do NOT change the model architecture, output head, or loss.** The shape `(N, 7)` is preserved; only the meaning of channels 0..2 changes.

### Implementation guardrails

- **Output frame is unchanged.** Model still predicts (τ_x, τ_y, τ_z) in world frame; loss is computed in world frame; this is a pure input-representation change.
- **Use the position OFFSET from per-case centroid**, not absolute xyz, so the projection onto the local frame is bounded and translation-invariant per case. (Absolute xyz projected onto t̂₁ would carry large case-scale offsets that the existing model is not trained for.)
- **t̂₁ direction degeneracy guard**: where `|n̂ · ẑ| > 0.95` (near-horizontal panels — roof, floor, ground plane), fall back to ŷ as reference. This keeps t̂₁ smooth across the mesh.
- **No yaw-augmentation interaction issue**: yaw-aug rotates n̂ together with positions; the tangent frame rotates with it. The representation is yaw-equivariant by construction (good — this is exactly why we expect the change to help).
- **Existing volume-side inputs are NOT changed** — volume points don't have surface normals.

### Single arm only

This is a **single experimental arm**: tangent-frame ON vs canonical (the existing baseline H112 is the OFF reference). Do not sweep variants in this PR.

If H-A succeeds, follow-up PR H-A2 will add output-frame change (decode τ in local frame, project back to world for loss). Do **NOT** combine input + output frame change in this PR — we need to isolate the representation effect first.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor (paper claim) |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | — |
| val_WSS | 6.9670% | — |
| val_WSS_x | 6.0923% | — |
| val_WSS_y | 7.6084% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **6.727%** ← floor; gap to SOTA 5.85% = **0.902pp** |
| test_WSS_x | 5.999% | — |
| test_WSS_y | 7.360% | — |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | 3.643% |
| test_SP | 3.695% | 3.577% |

**Gate (this PR):** A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism is judged by `val_WSS_z` vs `val_WSS_x` Δ.

**Primary objective**: per Morgan Issue #1056, **test_WSS is the primary objective** — gap = 0.902pp to Transolver-3 SOTA 5.85%. Mech-confirmed input-rep change targeting WSS specifically is exactly the kind of attack this directive calls for.

**Reproduce command** (single arm, copy verbatim and set group as shown):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-tangent-frame-input \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name thorfinn/h-a-tangent-frame-input \
  --wandb-group tay-wave36-wss-representation
```

**Kill threshold gates** (computed from **actual** end-of-EP × `steps_per_epoch` for vol-points-schedule; uses **global_step** not W&B `_step`):

- **EP1 (step 10862)** cold-start fence: < 35.0% — catches catastrophic init failure only
- **EP3 (step 32592)** binding gate: < 8.5% — anything weaker is structurally broken vs H112's 7.03% canonical EP3
- **EP6 (step 48897)** confirmation gate: < 7.0% — anything weaker won't make a A WIN at EP13

**Note**: vol-points-schedule halves steps/epoch at the EP3 and EP6 boundaries. EP6 lands near global_step 48,897 (NOT 65,184). Don't quote stale EP6+ step values from non-vol-schedule recipes.

---

## Diagnostic instrumentation (REQUIRED in PR comment)

When you post terminal results, include these mechanism-checks so we can falsify cleanly:

1. **Frame Δ table** — val_WSS_x / val_WSS_y / val_WSS_z at each EP gate (EP3, EP6, EP10, EP13) vs H112's canonical values. The hypothesis predicts: `val_WSS_z` improves more than `val_WSS_x`.
2. **Test breakdown** — final test_WSS_x / test_WSS_y / test_WSS_z. The hypothesis predicts: largest improvement on test_WSS_z.
3. **Confirm centroid is per-case, not global**: log a one-time print at epoch 0 step 0 confirming `centroid.shape == (1, 3)` and that values differ across the first 2-3 cases logged.
4. **Confirm fallback mask hits roof/floor panels**: log the fraction of points where `align_mask=True` for the first case (should be ~5–15% — roof, hood, floor of a sedan).

These are 4 cheap one-shot prints during training initialization; no W&B logging change needed beyond the canonical metrics.

---

## Mechanism notes for self-review

If your terminal result shows test_WSS improvement but `val_WSS_z` did NOT improve more than `val_WSS_x`, the win is **probably coincidental** (variance in init / data order). Flag this honestly in the PR comment; the advisor will treat it as a mechanism-unconfirmed win and may request a single seed re-run before merge.

If the run regresses on test_VP or test_SP by > 0.10pp, that means changing the positional input frame disrupted volume / pressure learning — a representation-bottleneck failure. Flag it; we'd then explore augmenting (concat both frames) rather than replacing.

If `val_WSS` is flat (within ±0.05pp of canonical) at EP6, the rep change is structurally inert at this depth; we'd close C NULL without finishing the run.

---

**Owner:** thorfinn
**Wave:** 36 (WSS-axis representation)
**Effort estimate:** ~50 lines (data loader edit + CLI flag plumbing)
**Wall-clock estimate:** ~14h (canonical 13ep at DDP 8×H100)
**Group:** `tay-wave36-wss-representation`