### PR TITLE
H126: Inverse-panel-area stratified surface sampling — WSS-variance attack (refined H-C)

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -255,6 +255,30 @@ def _npy_row_count(path: Path) -> int:
     return int(arr.shape[0])
 
 
+def _compute_inverse_area_weights(area_arr: np.ndarray, temperature: float) -> np.ndarray:
+    """Compute inverse-panel-area sampling weights normalized to sum to 1.
+
+    H126: weight_i ∝ (1 / area_i)^(1/T). Small panels (auto-mesh refined at
+    high-curvature regions) get higher probability than large flat panels.
+
+    Fast path for T=1.0 skips log/exp (weights = 1/area, normalized). For
+    other T we use the log/exp formulation with max-subtraction for
+    numerical stability. 1e-12 floor on area protects against log(0).
+    """
+    area_safe = np.maximum(area_arr.astype(np.float32, copy=False), 1e-12)
+    if abs(float(temperature) - 1.0) < 1e-6:
+        weights = (1.0 / area_safe).astype(np.float32)
+    else:
+        temp_safe = max(float(temperature), 1e-9)
+        log_w = -np.log(area_safe) / temp_safe
+        log_w = log_w - log_w.max()
+        weights = np.exp(log_w).astype(np.float32)
+    total = float(weights.sum())
+    if not np.isfinite(total) or total <= 0.0:
+        return np.full_like(area_safe, 1.0 / area_safe.shape[0], dtype=np.float32)
+    return (weights / total).astype(np.float32)
+
+
 def _column(value: np.ndarray) -> np.ndarray:
     arr = np.asarray(value, dtype=np.float32)
     return arr[:, None] if arr.ndim == 1 else arr
@@ -367,6 +391,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_area_weighted_sampling: bool = False,
+        area_sampling_temperature: float = 1.0,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +402,12 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_area_weighted_sampling = bool(use_area_weighted_sampling)
+        self.area_sampling_temperature = float(area_sampling_temperature)
+        # H126: per-case cumulative distribution cache for inverse-area sampling.
+        # Built lazily on first access per (case_id, N). float32 tensor of size N.
+        # ~33MB per case * ~50 cases/rank = ~1.65GB per worker; cleared on fork copy.
+        self._cdf_cache: dict[str, torch.Tensor] = {}
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -414,25 +446,69 @@ class DrivAerMLSurfaceDataset(Dataset):
         view: PointView,
         *,
         group_view_count: int,
+        cdf: torch.Tensor | None = None,
     ) -> torch.Tensor | None:
         if view.view_index >= group_view_count:
             return torch.empty(0, dtype=torch.long)
         if count <= 0 or total <= count:
             return None if view.view_index == 0 else torch.empty(0, dtype=torch.long)
         if view.sampling_mode == "train_random":
+            if cdf is not None:
+                u = torch.rand(count, dtype=cdf.dtype)
+                idx = torch.searchsorted(cdf, u)
+                idx.clamp_(max=cdf.numel() - 1)
+                return idx.to(torch.long).sort().values
             return torch.randint(total, (count,), dtype=torch.long).sort().values
         if view.sampling_mode == "eval_chunk":
             return torch.arange(view.view_index, total, group_view_count, dtype=torch.long)
         return None
 
+    def _get_inverse_area_cdf(self, case_id: str, expected_total: int) -> torch.Tensor:
+        """Cached cumulative distribution for inverse-area sampling.
+
+        Loads `surface_area.npy` and builds an inverse-area CDF once per case
+        per dataset instance (per DataLoader worker, since workers fork the
+        dataset). Subsequent calls return the cached tensor. float32 keeps
+        memory at ~4*N bytes (~33MB for a 8M-point case) while preserving
+        enough precision for searchsorted at K=65536 samples per call.
+        """
+        cdf = self._cdf_cache.get(case_id)
+        if cdf is None or cdf.numel() != expected_total:
+            case_dir = _case_dir(self.store.root, case_id)
+            area_arr = np.asarray(
+                np.load(_resolve_artifact_path(case_dir / "surface_area.npy")),
+                dtype=np.float32,
+            ).reshape(-1)
+            if area_arr.shape[0] != expected_total:
+                raise ValueError(
+                    f"surface_area.npy length {area_arr.shape[0]} does not match "
+                    f"surface_xyz row count {expected_total} for case {case_id!r}"
+                )
+            weights = _compute_inverse_area_weights(area_arr, self.area_sampling_temperature)
+            cdf_np = np.cumsum(weights, dtype=np.float32)
+            cdf_np[-1] = np.float32(1.0)
+            cdf = torch.from_numpy(cdf_np)
+            self._cdf_cache[case_id] = cdf
+        return cdf
+
     def __getitem__(self, idx: int) -> DrivAerMLCase:
         view = self.views[idx]
         counts = self.store.case_point_counts(view.case_id)
+        surface_cdf: torch.Tensor | None = None
+        if (
+            self.use_area_weighted_sampling
+            and view.sampling_mode == "train_random"
+            and self.max_surface_points > 0
+            and counts["n_surface"] > self.max_surface_points
+            and view.view_index < view.surface_view_count
+        ):
+            surface_cdf = self._get_inverse_area_cdf(view.case_id, counts["n_surface"])
         surface_idx = self._indices(
             counts["n_surface"],
             self.max_surface_points,
             view,
             group_view_count=view.surface_view_count,
+            cdf=surface_cdf,
         )
         volume_idx = self._indices(
             counts["n_volume"],
@@ -544,6 +620,8 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_area_weighted_sampling: bool = False,
+    area_sampling_temperature: float = 1.0,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +646,8 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_area_weighted_sampling=use_area_weighted_sampling,
+        area_sampling_temperature=area_sampling_temperature,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -33,6 +34,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
+from data.loader import _compute_inverse_area_weights, _resolve_artifact_path, _case_dir
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -131,6 +133,8 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    use_area_weighted_sampling: bool = False
+    area_sampling_temperature: float = 1.0
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -161,6 +165,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "use_area_weighted_sampling": (
+            "H126: Replace uniform train surface point sampling with inverse "
+            "panel-area weighted sampling. Probability per point is "
+            "(1 / area_i)^(1/T), normalized per case. Small auto-meshed "
+            "panels (high-curvature regions: wheel arches, A-pillar, hood-roof "
+            "junction) get oversampled relative to large flat panels. Only "
+            "applies during training (`train_random` mode); eval is unchanged. "
+            "Volume sampling is unchanged. Surface area is read from "
+            "surface_area.npy per case (no new data dependency). Default off."
+        ),
+        "area_sampling_temperature": (
+            "H126: Sharpness temperature T for inverse-area weights. "
+            "weight_i ∝ (1/area_i)^(1/T). T=1.0 (default) is the canonical "
+            "inverse-area. T<1.0 sharpens (more oversampling of small panels); "
+            "T>1.0 softens (closer to uniform). Only applies when "
+            "--use-area-weighted-sampling is enabled."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -669,6 +690,84 @@ def vol_points_for_epoch(
     return current
 
 
+def compute_area_sampling_diagnostics(
+    train_dataset: DrivAerMLSurfaceDataset,
+    *,
+    n_cases: int | None = None,
+) -> dict[str, float | list[float]]:
+    """H126: aggregate inverse-area sampling diagnostics across training cases.
+
+    Returns per-case-averaged statistics on:
+      * panel area distribution (min / median / max)
+      * effective sampling ratio (weight_i / (1/N_i)) — i.e. how many times
+        more likely each point is sampled vs uniform.
+      * extreme ratio: max_weight_ratio (most-oversampled point per case)
+        and min_weight_ratio (least-oversampled point per case).
+    """
+    if not getattr(train_dataset, "use_area_weighted_sampling", False):
+        return {}
+    case_ids = list(train_dataset.case_ids)
+    if n_cases is not None:
+        case_ids = case_ids[:n_cases]
+    temperature = float(train_dataset.area_sampling_temperature)
+    area_min: list[float] = []
+    area_p25: list[float] = []
+    area_p50: list[float] = []
+    area_p75: list[float] = []
+    area_max: list[float] = []
+    ratio_min: list[float] = []
+    ratio_p25: list[float] = []
+    ratio_p50: list[float] = []
+    ratio_p75: list[float] = []
+    ratio_max: list[float] = []
+    point_counts: list[int] = []
+    for case_id in case_ids:
+        case_dir = _case_dir(train_dataset.store.root, case_id)
+        area_arr = np.asarray(
+            np.load(_resolve_artifact_path(case_dir / "surface_area.npy")),
+            dtype=np.float32,
+        ).reshape(-1)
+        n = int(area_arr.shape[0])
+        point_counts.append(n)
+        area_min.append(float(area_arr.min()))
+        area_p25.append(float(np.percentile(area_arr, 25)))
+        area_p50.append(float(np.percentile(area_arr, 50)))
+        area_p75.append(float(np.percentile(area_arr, 75)))
+        area_max.append(float(area_arr.max()))
+        weights = _compute_inverse_area_weights(area_arr, temperature)
+        ratio = weights * float(n)
+        ratio_min.append(float(ratio.min()))
+        ratio_p25.append(float(np.percentile(ratio, 25)))
+        ratio_p50.append(float(np.percentile(ratio, 50)))
+        ratio_p75.append(float(np.percentile(ratio, 75)))
+        ratio_max.append(float(ratio.max()))
+
+    def _mean(values: list[float]) -> float:
+        return float(np.mean(values)) if values else float("nan")
+
+    return {
+        "n_cases_analyzed": len(case_ids),
+        "n_points_min": int(min(point_counts)) if point_counts else 0,
+        "n_points_median": int(np.median(point_counts)) if point_counts else 0,
+        "n_points_max": int(max(point_counts)) if point_counts else 0,
+        "area/min_mean": _mean(area_min),
+        "area/p25_mean": _mean(area_p25),
+        "area/p50_mean": _mean(area_p50),
+        "area/p75_mean": _mean(area_p75),
+        "area/max_mean": _mean(area_max),
+        "ratio/min_mean": _mean(ratio_min),
+        "ratio/p25_mean": _mean(ratio_p25),
+        "ratio/p50_mean": _mean(ratio_p50),
+        "ratio/p75_mean": _mean(ratio_p75),
+        "ratio/max_mean": _mean(ratio_max),
+        "ratio/max_p99_acrosscases": float(np.percentile(ratio_max, 99)) if ratio_max else float("nan"),
+        "ratio/skew_max_over_p50": _mean(
+            [r_max / max(r_p50, 1e-12) for r_max, r_p50 in zip(ratio_max, ratio_p50)]
+        ),
+        "temperature": temperature,
+    }
+
+
 def rebuild_train_loader_with_vol_points(
     config: Config,
     old_train_loader: DataLoader,
@@ -693,6 +792,8 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        use_area_weighted_sampling=config.use_area_weighted_sampling,
+        area_sampling_temperature=config.area_sampling_temperature,
     )
     train_sampler = None
     train_shuffle = True
@@ -893,6 +994,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.use_area_weighted_sampling:
+                diag = compute_area_sampling_diagnostics(train_loader.dataset, n_cases=20)
+                if diag:
+                    print(
+                        f"H126 inverse-area sampling: T={diag['temperature']:.3f}, "
+                        f"n_cases={diag['n_cases_analyzed']}, "
+                        f"area_p50_mean={diag['area/p50_mean']:.4g}, "
+                        f"ratio_p50_mean={diag['ratio/p50_mean']:.4f}, "
+                        f"ratio_max_mean={diag['ratio/max_mean']:.4f}, "
+                        f"ratio_skew(max/p50)={diag['ratio/skew_max_over_p50']:.2f}"
+                    )
+                    for key, value in diag.items():
+                        wandb.summary[f"data/area_weighted_sampling/{key}"] = value
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -286,6 +286,8 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_area_weighted_sampling=getattr(config, "use_area_weighted_sampling", False),
+        area_sampling_temperature=getattr(config, "area_sampling_temperature", 1.0),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**Inverse-panel-area stratified surface point sampling will close ≥ 0.08pp of the test_WSS gap to Transolver-3 SOTA.**

Current training uses **uniform** surface point sampling (`torch.randint(N_surface, (count,))` at `target/data/loader.py:423`). Each training step draws ~63% unique points per epoch from the full surface point cloud with equal probability per point. This means **large flat panels** (roof center, door faces) — which contribute very little WSS error — receive the same expected coverage as **small high-curvature panels** (wheel arches, A-pillar, door gaps, hood-roof junction, mirror bases) which drive the bulk of WSS L2 error.

This is the **first refinement of H-C from `RESEARCH_IDEAS_2026-05-24_12:30.md`** (originally SDF-gradient-based, refined to panel-area proxy because surface points have no SDF data in our dataset).

**Why inverse panel area is the right WSS-variance proxy**:
1. Drivaerml mesh has **inverse-area panel size correlation with curvature** — auto-meshing refines aggressively near high-curvature features (typical CFD pre-processor behaviour). Small panels concentrate at edges, fillets, corners, sharp transitions, and detailed components.
2. **These same regions are exactly where WSS has the largest spatial gradients** — boundary layer separation, reattachment, and sharp pressure gradient regions are mesh-refined for accurate flow capture.
3. **Panel area is already in the input vector** (channel 6 of `surface_x`). No new data to compute, no new files to load.
4. **The signal is fully label-free** — sampling weight depends only on geometry (panel area), not WSS magnitudes, so no test-time label leakage.

**Why this is NOT in a closed class**:
- NOT tangency-imposition: no output projection / constraint. Loss is unchanged.
- NOT data-augmentation: no transformation of input data (unlike H116 Y-mirror which transforms y → -y and led to inverse val→test correlation). Only the **sampling distribution** of which existing points appear in each batch is changed.
- NOT loss-balancing: per-point MSE is identical. Only the points that compute losses change.
- NOT curvature features: no new feature added to the input vector.

**Why this is NOT H116-class data-distribution-shift**:
H116 Y-mirror failed because (a) `string_separable` PE is not y-equivariant, (b) asymmetric flow-disturbing features (mirrors, exhaust) create label-consistency bias, (c) the training sampler is already stochastic so the "free 2×" framing was misleading. H126 has **none** of these failure modes:
- Same coordinate system, same PE — no equivariance friction.
- Same input data, same target labels — no asymmetric-feature reconciliation problem.
- The training sampler stochasticity is the **mechanism** being modified, not layered on top.

H126 is a clean test of: **does biasing the training sampler toward high-detail surface regions reduce WSS error on those same regions in test?**

**Falsifiable prediction**:
- Primary: test_WSS improves ≥ **0.08pp** vs H112 baseline (6.752% → ≤ **6.67%**).
- Mechanism observable: `val_WSS_z` improves more than `val_WSS_x` (wheel arch / vertical-panel patches drive the z-component error; these are the small-panel regions being oversampled).
- Falsifying signature: if `val_WSS_z` and `val_WSS_x` improve proportionally (no z-dominance), the panel-area-curvature-WSS_z correlation hypothesis is wrong → close C NULL.
- Secondary observable: `val_SP` should NOT regress significantly (sampling change is task-agnostic; SP also benefits from better coverage of high-curvature regions).

---

## Instructions

**Single change: replace uniform surface point sampling with inverse-panel-area weighted sampling, behind a new CLI flag `--use-area-weighted-sampling` (default off).**

### Code path (exact)

`target/data/loader.py`, `_indices()` (currently lines 410-426):

Current code:
```python
return torch.randint(total, (count,), dtype=torch.long).sort().values
```

Replace with **conditional** weighted sampling. The function needs access to per-case `panel_area` — pass it through from `__getitem__()` where `surface_area` is loaded.

### Suggested implementation pattern

In `__getitem__()` (around line 431-445), load `surface_area.npy` separately (before the `surface_rows` index draw) to use as sampling weights. Then call a modified `_indices_weighted()`:

```python
# Inside __getitem__, before existing _indices call:
if args.use_area_weighted_sampling and view.sampling_mode == "train_random":
    # Load per-point panel area for weight computation
    surface_area = np.load(case_dir / "surface_area.npy").squeeze()   # (N,)
    # Inverse area, with temperature T for sharpness control
    log_weights = -np.log(surface_area + 1e-12)                       # higher for smaller panels
    log_weights = log_weights / args.area_sampling_temperature        # T=1.0 default
    # Normalize: subtract max for numerical stability, then softmax
    log_weights = log_weights - log_weights.max()
    weights = np.exp(log_weights)
    weights = weights / weights.sum()                                 # (N,) sums to 1.0
    # Draw with replacement (matches current behavior)
    surface_rows = np.sort(np.random.choice(
        len(weights), size=count, replace=True, p=weights,
    )).astype(np.int64)
    surface_rows = torch.from_numpy(surface_rows)
else:
    surface_rows = _indices(view, total=counts["n_surface"], count=count)  # existing path
```

**Equivalent torch.multinomial path** (if you prefer torch over numpy):
```python
weights_t = torch.from_numpy(weights)
surface_rows = torch.multinomial(weights_t, count, replacement=True).sort().values
```

### Implementation guardrails

- **Eval/val/test path UNCHANGED**: the `if view.sampling_mode == "train_random"` guard ensures sampling weights apply ONLY during training. Eval uses the existing canonical sampling (no leakage of training-time bias into evaluation point selection).
- **DDP-safe**: `np.random.choice` and `torch.multinomial` are per-rank stochastic. Different ranks see different points, which is what we want (rank diversity = ensemble effect).
- **Temperature default T=1.0** — equivalent to `w_i ∝ 1/area_i`. The CLI flag `--area-sampling-temperature` can sweep this (T=0.5 sharper, T=2.0 softer). For THIS PR, fix T=1.0 — single arm.
- **Numerical stability**: subtract `log_weights.max()` before exp to prevent overflow on cases with extreme area outliers. Add `1e-12` to area before log to handle any degenerate zero-area panels.
- **Effective oversampling ratio**: at T=1.0, expect ~2-3× oversampling of the smallest 10% of panels relative to uniform. Log this once per epoch (mean / median / max effective probability ratio) as a sanity check.

### Required diagnostic instrumentation

In your terminal PR comment, include these mechanism-checks:

1. **Effective sampling ratio**: at step 0, log the distribution of `weights / (1/N)` — i.e. how many times more likely is each point sampled vs uniform. Histogram or 5-bucket summary (min, 25%, 50%, 75%, max).
2. **Panel area distribution**: log min / median / max panel area across all training cases to sanity-check the weight distribution.
3. **Frame Δ table** — val_WSS_x / val_WSS_y / val_WSS_z at each EP gate (EP3, EP6, EP10, EP13) vs H112's canonical values. Hypothesis predicts: val_WSS_z improves > val_WSS_x.
4. **Test breakdown**: final test_WSS_x / test_WSS_y / test_WSS_z. Hypothesis predicts: largest improvement on test_WSS_z (wheel arch / vertical panels).

### Single arm only

This is a **single arm**: area-weighted sampling at T=1.0 vs canonical baseline (existing H112). Do NOT sweep T or vary oversampling ratio in this PR — we need clean causal isolation.

If H126 succeeds, follow-up PR H126b will sweep T ∈ {0.5, 2.0} and optionally add inverse-area weighting to eval-time test rendering for ensemble effect. Do NOT combine these in this PR.

### Volume-side UNCHANGED

Only surface point sampling is modified. Volume points continue to use the existing schedule `--vol-points-schedule "0:16384:3:32768:6:49152:9:65536"`.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor / Gate |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | merge gate |
| val_WSS | 6.9670% | — |
| val_WSS_x | 6.0923% | — |
| val_WSS_y | 7.6084% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **floor 6.727%** ← gap to SOTA 5.85% = **0.902pp** |
| test_WSS_x | 5.999% | — |
| test_WSS_y | 7.360% | — |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | floor 3.643% |
| test_SP | 3.695% | floor 3.577% |

**Gate (this PR):** A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism judged by `val_WSS_z` vs `val_WSS_x` Δ.

**Primary objective**: per Morgan Issue #1056, **test_WSS is THE primary objective** — gap = 0.902pp to Transolver-3 SOTA 5.85%. Mech-confirmed sampling-distribution change targeting WSS-variance concentration is the kind of data-tier attack this directive calls for.

**Reproduce command** (single arm):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --use-area-weighted-sampling --area-sampling-temperature 1.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name nezuko/h126-inverse-area-stratified-sampling \
  --wandb-group tay-wave36-wss-sampling
```

**Kill thresholds** (computed from **actual** end-of-EP × steps_per_epoch for vol-points-schedule; uses **global_step** not W&B `_step`):
- **EP1 (step 10862)** cold-start fence: < 35.0%
- **EP3 (step 32592)** binding gate: < 8.5% — anything weaker is structurally broken
- **EP6 (step 48897)** confirmation gate: < 7.0%

---

## Mechanism notes for self-review

If your terminal result shows test_WSS improvement but `val_WSS_z` did NOT improve more than `val_WSS_x`, the win is **probably coincidental** (variance in init / data order). Flag this honestly — advisor will treat it as a mechanism-unconfirmed win and may request a single seed re-run before merge.

If `val_VP` regresses by > 0.10pp, that means the volume-side learning is hurt by surface sampling distribution shift (via the surf→vol cross-attention path). Flag it.

If `val_WSS` is flat (within ±0.05pp of canonical) at EP6, the sampling change is structurally inert at this depth; we'd close C NULL without finishing.

---

**Owner:** nezuko
**Wave:** 36 (WSS-axis sampling — refined from H-C)
**Effort estimate:** ~30 lines (sampling weight computation in data loader + 2 CLI flags)
**Wall-clock estimate:** ~14h (canonical 13ep at DDP 8×H100)
**Group:** `tay-wave36-wss-sampling`

**Note on H-C → H126 numbering**: H-C in `RESEARCH_IDEAS_2026-05-24_12:30.md` originally specified SDF-gradient-based weighting. Surface points have no SDF data in our dataset (`SURFACE_X_DIM = 7`: xyz + normals + area; no SDF). Refined to **inverse-panel-area** as the analogous geometric WSS-variance proxy. Same hypothesis class, implementable on current data.
