### PR TITLE
H127: Wider surface output decoder STANDALONE — clean cross-track validation (no DropPath compound)

### DIFF
--- a/model.py
+++ b/model.py
@@ -419,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        surface_out_width_factor: float = 1.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +435,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.surface_out_width_factor = surface_out_width_factor
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -520,10 +522,11 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
+            surface_out_hidden = int(n_hidden * self.surface_out_width_factor)
             self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
+                nn.Linear(n_hidden, surface_out_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(surface_out_hidden, self.surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    surface_out_width_factor: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +239,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "surface_out_width_factor": (
+            "H127: Widening factor for the surface_out MLP inner hidden "
+            "dim (when use_aux_decoder_heads=True). At 1.0 (default) the "
+            "decoder is Linear(n_hidden, n_hidden) -> SiLU -> "
+            "Linear(n_hidden, surface_output_dim). At factor=2.0 the inner "
+            "hidden dim becomes 2*n_hidden. Surface decoder only; volume "
+            "head and backbone unchanged."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -318,6 +327,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        surface_out_width_factor=config.surface_out_width_factor,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Wider Surface Output Decoder (hidden 512→1024) STANDALONE will close ≥ 0.05pp of the test_WSS gap to Transolver-3 SOTA.**

The current surface output decoder (`model.py:523-528`, when `use_aux_decoder_heads=True`) is a 2-layer MLP `Linear(512, 512) → SiLU → Linear(512, 4)` — symmetric hidden dim. This is **under-parameterized** relative to the rich 512-dim backbone hidden state it consumes: the decoder bottleneck is the inner dim 512, which must compress a 512-dim hidden into 4 surface-channel predictions (cp, τ_x, τ_y, τ_z).

Cross-track parallel evidence (per advisor's check-human-issues 2026-05-24, comment #96 on Issue #1056): the dl24 fleet's H39 reportedly achieved **test_WSS 6.6506%** with `surface_out_width_factor=2.0` (Linear(512, 1024) → SiLU → Linear(1024, 4)) — that's ~1.5pp below our current tay test_WSS 6.752% (H112).

**Why this hasn't been cleanly tested on tay yet**:
- H102 originally tested `--surface-out-width-factor 2.0` (Wave-33 era) but was merged into a different baseline; the flag was subsequently removed from `train.py` Config, and current model.py has hardcoded `n_hidden → n_hidden`.
- H119 edward is currently testing the COMPOUND (DropPath × wider decoder 2×) — student diagnostic shows **anti-additive in late cosine** (val_abupt +0.043pp behind H112 standalone DropPath, val_WSS_z +0.093pp behind). So the compound is NOT the right validation of the standalone signal.
- We have NO clean tay-track standalone test of the wider decoder mechanism.

**H127 is the missing clean baseline**: re-add the `--surface-out-width-factor` flag, test 2× widening ALONE (no DropPath compound) against H112 baseline.

**Why this is NOT in a closed class**:
- NOT loss-balancing or curvature-feature change.
- NOT data-tier (no input/sampling/augmentation change).
- NOT capacity-axis confounded (depth and hidden width of backbone unchanged; only the *decoder* width changes).

**Why widening the decoder is expected to help WSS specifically**:
- The backbone hidden state encodes all four surface tasks simultaneously (cp + 3 τ channels). The decoder must disentangle these into 4 distinct predictions.
- WSS is the highest-variance, most spatially-resolved surface task — the decoder's information bottleneck is most binding on this output.
- Widening the inner dim from 512 to 1024 gives the decoder ~2× more capacity to factor the shared hidden state into WSS-specific representations before final projection.
- Standalone wider decoder is **architecturally orthogonal** to DropPath (regularization on backbone) — but H119 shows they're functionally entangled in late-cosine optimization (decoder-width × regularization soft-competitive).

**Falsifiable prediction**:
- Primary: test_WSS improves ≥ **0.05pp** vs H112 baseline (6.752% → ≤ **6.70%**); ideally reaches **≤6.66%** matching dl24-H39's cross-track finding.
- Mechanism observable: all 3 τ channels should improve proportionally (no specific axis bias) — widening is uniform across channels.
- Secondary observable: val_SP should ALSO benefit (decoder bottleneck is shared across all 4 surface channels).
- Falsifying result: if test_WSS does NOT improve, the dl24-H39 cross-track signal is recipe-dependent (not transferable to tay) — banks a strong negative finding that the wider decoder is recipe-coupled, not mechanism-load-bearing.

---

## Instructions

**Single change: re-add `--surface-out-width-factor` flag, multiply surface_out's inner hidden dim by this factor (default 1.0 = no change; this run uses 2.0).**

### Code path (exact)

**Step 1 — `target/model.py`, line 523-528** (surface_out construction inside `__init__` when `use_aux_decoder_heads=True`):

Current code:
```python
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),
)
```

Replace with:
```python
surface_out_hidden = int(n_hidden * self.surface_out_width_factor)
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, surface_out_hidden),
    nn.SiLU(),
    nn.Linear(surface_out_hidden, self.surface_output_dim),
)
```

Also add `self.surface_out_width_factor = surface_out_width_factor` in `__init__`. Pass `surface_out_width_factor: float = 1.0` as a new parameter (default preserves canonical behavior).

**Step 2 — `target/train.py` Config dataclass** (lines 75-142):

Add field:
```python
surface_out_width_factor: float = 1.0  # Widen surface_out inner hidden dim by this factor (1.0 = no change)
```

Then pass to `build_model()` (line ~306-321) — `surface_out_width_factor=cfg.surface_out_width_factor`.

The argparse auto-generation (lines 242-250) will pick up the new field automatically.

### Implementation guardrails

- **Eval/test path UNCHANGED**: this is a model architecture change only; inference compute slightly more expensive due to wider decoder layer.
- **Param count delta**: at factor=2.0, surface_out gains ~`(512 × 1024 - 512 × 512) + (1024 × 4 - 512 × 4) = 524,288 - 262,144 + 4,096 - 2,048 = +264K params`. Total model ~17.66M (vs 17.40M canonical).
- **Backward compat**: flag defaults to 1.0 so the existing recipe behavior is bit-exact when unset.
- **NO compound with DropPath** in this PR — explicitly run with NO DropPath (`--use-drop-path` omitted). The point of H127 is to isolate the wider decoder mechanism cleanly; H119 is testing the compound separately and showing anti-additive late-cosine behavior.

### Required diagnostic instrumentation

In your terminal PR comment, include:

1. **Confirm param count**: `total_params` printed once at training init. Expected ~17.66M (canonical 17.40M + ~260K from wider decoder).
2. **Per-axis test breakdown**: final test_WSS_x / test_WSS_y / test_WSS_z. Hypothesis predicts: all 3 improve proportionally.
3. **Per-EP val table** (EP3, EP6, EP10, EP13): val_abupt / val_WSS / val_WSS_z / val_SP / val_VP — track whether late-cosine descent slope changes vs H112.
4. **Compare to H119**: at terminal, compare your standalone-wider-decoder result vs H119's compound result. If H127 outperforms H119 on test_WSS, the anti-additive late-cosine signature is CONFIRMED — wider decoder is mechanism-load-bearing but DropPath is competitive with it.

### Single arm only

This is a **single arm**: `--surface-out-width-factor 2.0` vs canonical (factor=1.0 = H112 baseline). Do NOT sweep factor in this PR — clean causal isolation.

If H127 succeeds, follow-up PR H127b will sweep factor ∈ {1.5, 3.0} and compound with H120 depth-6 (if H120 terminal as A WIN).

### Volume-side, backbone, loss, data — ALL UNCHANGED

Only `surface_out` architecture changes. Volume head, backbone, loss weights, data loading, kill thresholds, EMA, all canonical.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor / Gate |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | merge gate |
| val_WSS | 6.9670% | — |
| **test_WSS** | **6.752%** | **floor 6.727%** ← gap to SOTA 5.85% = **0.902pp** |
| test_WSS_x | 5.999% | — |
| test_WSS_y | 7.360% | — |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | floor 3.643% |
| test_SP | 3.695% | floor 3.577% |

**Cross-track reference (dl24-H39, NOT under tay advisorship)**: test_WSS **6.6506%** with `surface_out_width_factor=2.0`. Target for H127: replicate this signal on tay track.

**Gate (this PR):** A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism judged by uniform improvement across τ channels.

**Reproduce command** (single arm, NO DropPath compound):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --surface-out-width-factor 2.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name tanjiro/h127-wider-surface-decoder-standalone \
  --wandb-group tay-wave36-decoder-width
```

**Kill thresholds** (computed from **actual** end-of-EP × steps_per_epoch for vol-points-schedule; uses **global_step** not W&B `_step`):
- **EP1 (step 10862)** cold-start fence: < 35.0%
- **EP3 (step 32592)** binding gate: < 8.5%
- **EP6 (step 48897)** confirmation gate: < 7.0%

---

## Mechanism notes for self-review

If your terminal result shows test_WSS improvement but val_SP does NOT improve, the decoder-bottleneck explanation is wrong (the mechanism would be WSS-specific not shared). Banked as decoder-width-WSS-specific in that case.

If test_VP regresses by > 0.10pp, that means the surface-side decoder change disrupts the surf→vol cross-attention pathway. Flag honestly.

If `val_abupt` is flat (within ±0.05pp of H112 canonical) at EP6, the decoder widening is structurally inert — close C NULL.

**Cross-comparison with H119**: H119 terminal projection is val_abupt ~6.22-6.24% (no A WIN). If H127 lands materially BELOW H119 on val_abupt, the DropPath compound was suppressing the wider-decoder signal (anti-additive confirmed); if H127 lands at SAME level as H119, the standalone wider decoder is the dominant mechanism in the compound; if H127 lands ABOVE H119, the DropPath component is the load-bearing mechanism in H119.

---

**Owner:** tanjiro
**Wave:** 36 (decoder-width, cross-track validation)
**Effort estimate:** ~15 lines (3 in train.py Config, 3 in build_model, 5 in model.py surface_out)
**Wall-clock estimate:** ~14h (canonical 13ep at DDP 8×H100, +5-7% from wider decoder)
**Group:** `tay-wave36-decoder-width`
