### PR TITLE
H-B: Auxiliary log-magnitude head for WSS — non-destructive magnitude/direction decoupling

### DIFF
--- a/model.py
+++ b/model.py
@@ -419,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_aux_log_magnitude_head: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +435,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_aux_log_magnitude_head = use_aux_log_magnitude_head
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -537,6 +539,23 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # H-B (PR #1307): auxiliary log-magnitude head on WSS.
+        # Parallel 1-channel head predicts log(1 + ||tau||) per surface point;
+        # supervised by a separate aux loss term in train.py. Non-destructive:
+        # final linear initialised with small std so aux gradients ramp in
+        # smoothly without perturbing primary decoder at step 0.
+        if use_aux_log_magnitude_head:
+            self.aux_log_mag_head = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 2, 1),
+            )
+            self.aux_log_mag_head.apply(_init_linear)
+            nn.init.normal_(self.aux_log_mag_head[-1].weight, std=1e-3)
+            nn.init.zeros_(self.aux_log_mag_head[-1].bias)
+        else:
+            self.aux_log_mag_head = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -662,9 +681,20 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.aux_log_mag_head is not None:
+                aux_log_mag = (
+                    self.aux_log_mag_head(surface_hidden) * surface_mask.unsqueeze(-1)
+                )
+            else:
+                aux_log_mag = None
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+            aux_log_mag = (
+                volume_hidden.new_zeros(batch_size, 0, 1)
+                if self.aux_log_mag_head is not None
+                else None
+            )
 
         if volume_x is not None:
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
@@ -672,10 +702,13 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        out: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if aux_log_mag is not None:
+            out["aux_log_mag"] = aux_log_mag
+        return out

--- a/train.py
+++ b/train.py
@@ -104,6 +104,8 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_aux_log_magnitude_head: bool = False
+    aux_log_magnitude_loss_weight: float = 0.1
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +240,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_aux_log_magnitude_head": (
+            "H-B (PR #1307): enable an auxiliary log-magnitude prediction "
+            "head on the surface decoder. The head is a 2-layer MLP "
+            "(n_hidden -> n_hidden//2 -> 1) supervised by MSE on "
+            "log(1 + ||tau||) per surface point, weighted by "
+            "--aux-log-magnitude-loss-weight. Non-destructive: final "
+            "linear is initialised with std=1e-3 so aux gradients ramp "
+            "in smoothly and the primary 4-channel decoder is unchanged "
+            "at step 0. Hypothesis: decouples magnitude from direction "
+            "for the shared backbone features, helping WSS_z disproportionately."
+        ),
+        "aux_log_magnitude_loss_weight": (
+            "H-B (PR #1307): scalar weight on the auxiliary log-magnitude "
+            "loss term added to the total training loss. Default 0.1 is "
+            "small enough to keep the primary decoder gradient dominant. "
+            "Unused unless --use-aux-log-magnitude-head is set."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -318,6 +337,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_aux_log_magnitude_head=config.use_aux_log_magnitude_head,
     )
 
 
@@ -331,6 +351,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    aux_log_magnitude_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -356,13 +377,33 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        aux_log_mag_loss: torch.Tensor | None = None
+        if aux_log_magnitude_loss_weight > 0.0 and "aux_log_mag" in out:
+            # H-B (PR #1307): auxiliary log-magnitude head loss.
+            # Target = log(1 + ||tau||) in NORMALISED tau space (matches
+            # how the primary surface loss is computed). The decoupling
+            # thesis is on shared backbone features, so the operating
+            # space is the normalised regression space.
+            tau_target = surface_target[..., 1:4]
+            log_mag_target = torch.log1p(torch.norm(tau_target, dim=-1, keepdim=True))
+            aux_log_mag_loss = masked_mse(
+                out["aux_log_mag"], log_mag_target, batch.surface_mask
+            )
+            loss = loss + aux_log_magnitude_loss_weight * aux_log_mag_loss
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if aux_log_mag_loss is not None:
+        aux_loss_value = float(aux_log_mag_loss.detach().cpu().item())
+        metrics["aux_log_mag_loss"] = aux_loss_value
+        metrics["aux_log_mag_loss_weighted"] = (
+            aux_log_magnitude_loss_weight * aux_loss_value
+        )
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -905,6 +946,24 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"DropPath (H112): per-block schedule "
                         f"(attn=mlp) = {drop_path_schedule}"
                     )
+            wandb.summary["aux_log_magnitude_head/enabled"] = bool(
+                config.use_aux_log_magnitude_head
+            )
+            wandb.summary["aux_log_magnitude_head/loss_weight"] = (
+                config.aux_log_magnitude_loss_weight
+                if config.use_aux_log_magnitude_head
+                else 0.0
+            )
+            if config.use_aux_log_magnitude_head:
+                aux_head = getattr(base_model, "aux_log_mag_head", None)
+                if aux_head is not None:
+                    aux_params = sum(p.numel() for p in aux_head.parameters())
+                    wandb.summary["aux_log_magnitude_head/n_params"] = aux_params
+                    print(
+                        f"H-B aux log-magnitude head enabled: "
+                        f"{aux_params:,d} params, "
+                        f"loss_weight={config.aux_log_magnitude_loss_weight}"
+                    )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1052,6 +1111,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        aux_log_magnitude_loss_weight=(
+                            config.aux_log_magnitude_loss_weight
+                            if config.use_aux_log_magnitude_head
+                            else 0.0
+                        ),
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1092,6 +1156,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "aux_log_mag_loss" in batch_loss_metrics:
+                        train_log["train/aux_log_mag_loss"] = batch_loss_metrics[
+                            "aux_log_mag_loss"
+                        ]
+                        train_log["train/aux_log_mag_loss_weighted"] = batch_loss_metrics[
+                            "aux_log_mag_loss_weighted"
+                        ]
+                        train_log["train/aux_log_magnitude_loss_weight"] = (
+                            config.aux_log_magnitude_loss_weight
+                        )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Adding an auxiliary log-magnitude prediction head on WSS, supervised in parallel with the existing 3-channel τ regression, will close ≥ 0.10pp of the test_WSS gap to Transolver-3 SOTA (5.85%).**

WSS τ is a 3-channel vector field with strongly heterogeneous magnitude — high at separation/reattachment, near-zero in low-velocity regions. The current decoder predicts (τ_x, τ_y, τ_z) directly in world frame, requiring the model to implicitly learn that all three components are coupled by a shared scalar magnitude `||τ||`.

**H-B decouples this scalar magnitude as an explicit auxiliary prediction target.** The model gains a second head that predicts `log(1 + ||τ||)` per surface point, supervised by an auxiliary loss term. The primary 3-channel τ regression and reconstruction loss is unchanged. This is a **non-destructive auxiliary regularization** — at λ_aux=0 it reduces to canonical H112 exactly.

### Why this attacks WSS specifically and is NOT in any exhausted class

This is NOT:
- A loss-form change on the existing decoder (loss-form class CLOSED for SP per H113/H114/H115)
- An output-tier tangency-imposition (CLOSED — 4 failures: PRs #351/#680/#713/#1299)
- An input-tier rep change (PR #1302 H-A C NULL, PR #1299 H-A2 in flight as parallel concat-tangent attack)
- A target reparameterization replacing the existing decoder (PR #1292 H117 alphonse already runs signed-sqrt on SP)

It IS:
- An **auxiliary regularization head**: separate prediction head + separate loss term added in parallel
- Mechanistically interpretable: decouples "where is shear high" from "which direction shear flows"
- **Non-destructive at init**: with auxiliary loss weight λ_aux = 0.1, the primary decoder behavior is preserved; the auxiliary head provides a feature-shaping gradient signal through the shared backbone

### Why decoupling magnitude from direction should help WSS_z specifically

WSS_z (vertical shear) is the worst-performing channel: H112 val_WSS_z 9.375% vs val_WSS_x 6.092% — a 1.5× ratio. The mechanism hypothesis is that **vertical shear magnitude is geometrically constrained** (proportional to vertical velocity gradient near floor/roof panels), but its DIRECTION in world frame depends sensitively on panel orientation. If the model can learn magnitude prediction independently — using surface curvature and panel normal as the dominant features — it removes a learning-signal entanglement that currently hurts τ_z accuracy.

### Literature support

- **Magnitude/direction decomposition for surface vector fields** is canonical in 3D scene flow (Yang et al., 2021), normal estimation networks (Boulch & Marlet, 2016), and surface curvature prediction. The decoupling principle: regress magnitude as a positive scalar field and direction as a unit-vector field separately.
- **Auxiliary regression heads** are a standard regularization technique in multi-task learning (Liebel & Körner, 2018; Caruana, 1997). Adding a parallel head supervised by a related target shapes the backbone features to be more useful for the primary task.
- **Log-magnitude regression** (rather than raw magnitude) is well-conditioned for positive heavy-tailed targets and is the basis of the signed-power transform that H117 is testing on SP.

### Falsifiable prediction

- **Primary**: test_WSS improves ≥ 0.10pp vs H112 baseline (6.752% → ≤ 6.65%).
- **Mechanism observable**: val_WSS_z improves more than val_WSS_x at EP6 and EP13. The mechanism predicts magnitude-prediction is differentially load-bearing for WSS_z.
- **Falsifying signature**: if val_WSS_z gain ≤ val_WSS_x gain (or no gain), the magnitude-decoupling explanation is wrong and the head is structurally inert. Close C NULL.

---

## Instructions

**Single change: add a parallel log-magnitude prediction head on the surface decoder, supervised by an auxiliary loss term.**

### Code path — `target/model.py` (surface decoder, ~lines 523-528)

Current surface decoder:
```python
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),  # output: (p, τ_x, τ_y, τ_z)
)
```

Add a parallel auxiliary head behind new CLI flag `--use-aux-log-magnitude-head` (default False):

```python
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden),
    nn.SiLU(),
    nn.Linear(n_hidden, self.surface_output_dim),
)
if config.use_aux_log_magnitude_head:
    # 1-channel auxiliary head: predicts log(1 + ||τ||)
    self.aux_log_mag_head = nn.Sequential(
        nn.Linear(n_hidden, n_hidden // 2),
        nn.SiLU(),
        nn.Linear(n_hidden // 2, 1),
    )
```

In the forward pass, after `surface_hidden` is computed:

```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
if self.config.use_aux_log_magnitude_head:
    aux_log_mag = self.aux_log_mag_head(surface_hidden) * surface_mask.unsqueeze(-1)
    return surface_preds, aux_log_mag
return surface_preds
```

### Code path — `target/train.py` (loss computation)

Locate the surface loss computation block. After the standard rel_l2 loss on (p, τ_x, τ_y, τ_z), add the auxiliary log-magnitude loss:

```python
# Standard surface loss (unchanged)
surface_loss = ...  # existing rel_l2 on (p, τ_x, τ_y, τ_z)

# Auxiliary log-magnitude head loss (if enabled)
if args.use_aux_log_magnitude_head:
    # Targets: log(1 + ||τ_target||) per surface point
    tau_target = surface_target[..., 1:4]  # τ_x, τ_y, τ_z
    log_mag_target = torch.log1p(torch.norm(tau_target, dim=-1, keepdim=True))  # (B, N, 1)
    log_mag_pred = aux_log_mag  # model's auxiliary head output
    aux_loss = F.mse_loss(log_mag_pred, log_mag_target, reduction='none')
    aux_loss = (aux_loss * surface_mask.unsqueeze(-1)).sum() / (surface_mask.sum() + 1e-6)
    total_surface_loss = surface_loss + args.aux_log_magnitude_loss_weight * aux_loss
```

### CLI flag plumbing

1. Add `--use-aux-log-magnitude-head` (bool, default False) to `target/train.py` Config + argparse
2. Add `--aux-log-magnitude-loss-weight` (float, default 0.1) to Config + argparse — chosen to be small enough that primary loss dominates at init
3. Thread `use_aux_log_magnitude_head` flag into Model construction
4. **No change to data loader** — supervision target is computed from existing `surface_target[..., 1:4]`

### Implementation guardrails

- **Zero-init aux head's final linear layer** (`nn.init.normal_(self.aux_log_mag_head[-1].weight, std=1e-3)`) so the auxiliary loss term is small at init — model behaves like H112 at step 0.
- **MSE on log(1+|τ|) is well-conditioned** at zero (gradient is bounded) and compresses tail behavior — exactly the property we want.
- **Use `surface_mask` correctly** — padded surface points contribute zero to aux loss (avoid biasing via padding).
- **DDP-friendly**: the aux head's parameters are auto-included in DDP backward; no manual sync needed.
- **Recipe parity with H112**: ALL other flags match H112's actual recipe (DropPath 0.10, hidden 512, etc.) so the only experimental variable is the aux head.

### Single arm only

Single experimental arm: aux-log-magnitude head ON (λ_aux=0.1) vs canonical (H112 OFF reference). Do not sweep λ in this PR.

If H-B succeeds, follow-up could sweep λ ∈ {0.05, 0.1, 0.2, 0.5} or extend to direction-head prediction.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor (paper claim) |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | — |
| val_WSS | 6.9670% | — |
| val_WSS_x | 6.0923% | — |
| val_WSS_y | 7.6084% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **6.727%** ← floor; gap to SOTA 5.85% = **0.902pp** |
| test_WSS_x | 5.999% | — |
| test_WSS_y | 7.360% | — |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | 3.643% |
| test_SP | 3.695% | 3.577% |

**Gate (this PR)**: A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism judged by `val_WSS_z` vs `val_WSS_x` Δ.

**Primary objective**: per Morgan Issue #1056, **test_WSS is the primary objective** — gap = 0.902pp to Transolver-3 SOTA 5.85%.

**Reproduce command** (single arm, copy verbatim and set group as shown):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --use-aux-log-magnitude-head \
  --aux-log-magnitude-loss-weight 0.1 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name edward/h-b-aux-log-magnitude-head \
  --wandb-group tay-wave36-wss-magnitude-direction
```

**Kill threshold gates** (vol-points-schedule active, uses **global_step**):

- EP1 (step 10862): < 35.0% — cold-start fence; aux head with zero-init final linear should clear easily
- EP3 (step 32592): < 8.5% — binding gate
- EP6 (step 48897): < 7.0% — confirmation gate

---

## Diagnostic instrumentation (REQUIRED in PR comment)

1. **Frame Δ table** — val_WSS_x / val_WSS_y / val_WSS_z at each EP gate (EP3, EP6, EP10, EP13) vs H112 canonical. Predicts: val_WSS_z improves more than val_WSS_x.
2. **Test breakdown** — final test_WSS_x / test_WSS_y / test_WSS_z.
3. **Aux loss trajectory** — log `aux_loss_value` at each W&B publish step. Predicts: aux_loss decreases monotonically; if it spikes mid-training, magnitude prediction destabilizes.
4. **Aux head activation magnitude**: at EP13 best, log the per-token mean activation magnitude in the aux head's penultimate layer vs the primary decoder's penultimate layer. Tells us how much backbone capacity the aux head consumes.

---

## Mechanism notes for self-review

- If test_WSS improvement happens but val_WSS_z did NOT improve more than val_WSS_x, the win is **probably coincidental** (init variance / data order). Flag honestly.
- If test_VP or test_SP regresses by > 0.10pp, the aux head is competing with primary decoder gradients for backbone capacity. Flag — could explore freezing aux head's first linear layer or reducing λ_aux.
- If val_WSS lands within ±0.05pp of H112 canonical at EP6, the aux head is structurally inert. Close C NULL early.
- If aux_loss plateaus near zero very quickly (within EP2), the magnitude prediction is too easy → backbone features already encode magnitude → aux head doesn't add useful signal. Honest signal that the decoupling thesis is wrong for this model.

---

**Owner:** edward
**Wave:** 36 (WSS-axis magnitude-direction decoupling, non-destructive)
**Effort estimate:** ~40 lines (model aux head + train.py aux loss + CLI flag plumbing)
**Wall-clock estimate:** ~14h (canonical 13ep at DDP 8×H100)
**Group:** `tay-wave36-wss-magnitude-direction`
