### PR TITLE
H128: SwiGLU MLP — drop-in replacement of dense GELU feedforward in Transolver blocks

### DIFF
--- a/model.py
+++ b/model.py
@@ -252,6 +252,55 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SwiGluMlp(nn.Module):
+    """SwiGLU gated MLP: Down(SiLU(Gate(x)) * Value(x)).
+
+    Llama-style three-projection feedforward replacing the dense
+    Up->GELU->Down pattern. Gate/value share the same hidden dim; the
+    elementwise product is then projected back to hidden_dim by down_proj.
+
+    Init: gate/value follow the standard trunc-normal (std=0.02) used
+    elsewhere in this model; down_proj.weight is zero-initialised so the
+    MLP contributes zero at step 0 (residual-stream identity, mirrors the
+    cross-attention out_proj zero-init pattern). bias=False on all three
+    projections per Llama/Mistral convention.
+
+    Records gate-activation diagnostics in self._last_stats during eval()
+    forwards so the trainer can log per-block gate utilisation.
+    """
+
+    def __init__(self, hidden_dim: int, mlp_hidden_dim: int, dropout: float = 0.0):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_dim, mlp_hidden_dim, bias=False)
+        self.value_proj = nn.Linear(hidden_dim, mlp_hidden_dim, bias=False)
+        self.down_proj = nn.Linear(mlp_hidden_dim, hidden_dim, bias=False)
+        self.act = nn.SiLU()
+        self.dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+        nn.init.trunc_normal_(self.gate_proj.weight, std=0.02)
+        nn.init.trunc_normal_(self.value_proj.weight, std=0.02)
+        nn.init.zeros_(self.down_proj.weight)
+        self._last_stats: dict[str, float] = {}
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_pre = self.gate_proj(x)
+        gate = self.act(gate_pre)
+        value = self.value_proj(x)
+        if not self.training:
+            with torch.no_grad():
+                g_pre = gate_pre.detach().float()
+                g = gate.detach().float()
+                self._last_stats = {
+                    "gate_pre_mean": float(g_pre.mean().item()),
+                    "gate_pre_std": float(g_pre.std().item()),
+                    "gate_pre_absmax": float(g_pre.abs().max().item()),
+                    "gate_silu_mean": float(g.mean().item()),
+                    "gate_silu_std": float(g.std().item()),
+                    "gate_silu_abs_mean": float(g.abs().mean().item()),
+                    "gate_silu_sat_frac": float((g.abs() > 3.0).float().mean().item()),
+                }
+        return self.dropout(self.down_proj(gate * value))
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -330,6 +379,7 @@ class TransformerBlock(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_prob: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -342,7 +392,12 @@ class TransformerBlock(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if use_swiglu_mlp:
+            self.mlp = SwiGluMlp(
+                hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim, dropout=dropout
+            )
+        else:
+            self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
         self.drop_path_attn = DropPath(drop_path_prob)
         self.drop_path_mlp = DropPath(drop_path_prob)
 
@@ -366,6 +421,7 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_max: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         if depth > 1:
@@ -383,6 +439,7 @@ class Transformer(nn.Module):
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
                     drop_path_prob=drop_path_probs[i],
+                    use_swiglu_mlp=use_swiglu_mlp,
                 )
                 for i in range(depth)
             ]
@@ -419,6 +476,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +492,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_swiglu_mlp = use_swiglu_mlp
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -511,6 +570,7 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
             drop_path_max=drop_path_max,
+            use_swiglu_mlp=use_swiglu_mlp,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_swiglu_mlp: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +239,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_swiglu_mlp": (
+            "H128: Replace each TransformerBlock's dense Up->GELU->Down "
+            "MLP (UpActDownMlp) with a Llama-style SwiGLU gated MLP "
+            "(SwiGluMlp): Down(SiLU(Gate(x)) * Value(x)). Three bias-free "
+            "Linear projections (gate, value, down). down_proj.weight is "
+            "zero-initialised so the block is residual-stream identity "
+            "at step 0. Keeps mlp_ratio unchanged, adding ~30% MLP params "
+            "(~5M for 5 blocks at hidden=512, mlp_ratio=4)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -285,6 +295,31 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     return sigmas
 
 
+def collect_swiglu_gate_metrics(model: nn.Module) -> dict[str, float]:
+    """Aggregate per-block SwiGLU gate diagnostics recorded during eval()."""
+    from model import SwiGluMlp
+
+    metrics: dict[str, float] = {}
+    block_stats: list[dict[str, float]] = []
+    for idx, module in enumerate(model.modules()):
+        if not isinstance(module, SwiGluMlp):
+            continue
+        stats = dict(getattr(module, "_last_stats", {}) or {})
+        if not stats:
+            continue
+        block_idx = len(block_stats)
+        block_stats.append(stats)
+        for key, value in stats.items():
+            metrics[f"swiglu/block_{block_idx}/{key}"] = value
+    if block_stats:
+        keys = block_stats[0].keys()
+        for key in keys:
+            values = [bs[key] for bs in block_stats if key in bs]
+            if values:
+                metrics[f"swiglu/mean/{key}"] = float(sum(values) / len(values))
+    return metrics
+
+
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for attr in ("surface_string_sep", "volume_string_sep"):
@@ -318,6 +353,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_swiglu_mlp=config.use_swiglu_mlp,
     )
 
 
@@ -905,6 +941,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"DropPath (H112): per-block schedule "
                         f"(attn=mlp) = {drop_path_schedule}"
                     )
+            total_params = sum(p.numel() for p in base_model.parameters())
+            trainable_params = sum(
+                p.numel() for p in base_model.parameters() if p.requires_grad
+            )
+            wandb.summary["model/total_params"] = total_params
+            wandb.summary["model/trainable_params"] = trainable_params
+            wandb.summary["model/use_swiglu_mlp"] = bool(config.use_swiglu_mlp)
+            print(
+                f"Model param count: total={total_params:,d} "
+                f"trainable={trainable_params:,d} "
+                f"use_swiglu_mlp={config.use_swiglu_mlp}"
+            )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1284,6 +1332,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
                 log_metrics.update(collect_string_sep_metrics(base_model))
+                log_metrics.update(collect_swiglu_gate_metrics(base_model))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,


### PR DESCRIPTION
## Hypothesis

**Replacing the Transolver block's dense `UpActDownMlp` (GELU activation) with a SwiGLU gated MLP will close ≥ 0.05pp of the test_WSS gap to Transolver-3 SOTA (5.85%).**

SwiGLU `(Swish-Gated Linear Unit)` is the canonical activation choice in modern large transformers (Llama family, Gemma, PaLM, Mistral, DeepSeek, GPT-OSS) — empirically shown by Shazeer (2020) and confirmed across hundreds of subsequent papers to consistently outperform dense GELU/SiLU/ReLU MLPs at matched or near-matched parameter count. The current Transolver block uses a 1990s-era dense Up→GELU→Down feedforward; this is the lowest-hanging architectural primitive in the entire model that hasn't been modernized.

### Mechanism

A SwiGLU MLP is `Down(SiLU(Gate(x)) ⊙ Value(x))` — two parallel up-projections (one gated, one ungated) elementwise-multiplied before the down-projection. The multiplicative gating is what differentiates SwiGLU from dense MLPs:
1. The gate `SiLU(Gate(x))` learns a per-channel soft mask
2. The value `Value(x)` provides the content to be selectively passed through
3. Output `Down(gate * value)` is multiplicatively conditioned

This is mechanistically distinct from any in-flight hypothesis:
- NOT a capacity-axis change (H120 depth, H121 hidden, H127 decoder-width all touch model size only — same activation)
- NOT a WSS-rep tier (H-A2 input, H-B output mag/dir decoupling, H126 sampling)
- NOT a loss-form / target-reparam (CLOSED for SP per H117 closure)
- IS an architectural primitive — the inner workings of the transformer block itself

### Why this could move test_WSS specifically

WSS prediction requires the model to learn:
1. **Where** on the surface shear is high (curvature, separation lines, stagnation)
2. **What direction** shear flows (tangent vector field constrained by τ·n̂ = 0)
3. **How magnitudes scale** across vehicle features

A gated MLP's multiplicative structure is well-suited for "select-then-aggregate" computations — exactly the pattern needed to predict tangent vector fields from surface curvature features. The gated path can learn "is this a high-shear region" (gate) and the value path can learn "in which direction does shear flow here" (value), then multiply for the WSS prediction. This is a stronger inductive bias for tangential vector field regression than dense GELU.

### Literature support

- Shazeer (2020), "GLU Variants Improve Transformer" — original SwiGLU paper, shows consistent improvements across multiple benchmarks
- Llama 1/2/3 (Touvron 2023, 2024), Gemma 1/2 (Google 2024), Mistral 7B (Jiang 2023), DeepSeek (2024), GPT-OSS (2024) — all production transformers use SwiGLU
- In CFD-surrogate context specifically: no published Transolver variant uses SwiGLU yet — this is the first SwiGLU-Transolver experiment.

### Falsifiable prediction

- **Primary**: test_WSS improves ≥ 0.05pp vs H112 baseline (6.752% → ≤ 6.70%).
- **Secondary**: val_abupt improves ≥ 0.02pp (architectural primitive should help slightly across all heads).
- **Falsifying signature**: if val_abupt or val_WSS land within ±0.02pp of H112 canonical, the gating mechanism is structurally inert at our scale (17M params).
- **Anti-prediction (sanity check)**: if H128 wildly regresses (val_WSS > 7.5%), the SwiGLU init may need a learning-rate tuning revisit. With current `--lr 9e-5` and SiLU gating, the modal failure mode is mid-cosine instability.

---

## Instructions

**Single change**: add a SwiGLU MLP variant of `UpActDownMlp`, instantiate it in `TransformerBlock` behind a Config flag `--use-swiglu-mlp` (default False).

### Code path 1 — `target/model.py` (new class at ~line 240, adjacent to `UpActDownMlp`)

```python
class SwiGluMlp(nn.Module):
    """SwiGLU gated MLP: Down(SiLU(Gate(x)) ⊙ Value(x)). Llama-style."""
    def __init__(self, dim, hidden_dim, dropout=0.0):
        super().__init__()
        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
        self.value_proj = nn.Linear(dim, hidden_dim, bias=False)
        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
        self.act = nn.SiLU()
        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()

    def forward(self, x):
        gate = self.act(self.gate_proj(x))
        value = self.value_proj(x)
        return self.dropout(self.down_proj(gate * value))
```

### Code path 2 — `target/model.py` (`TransformerBlock.__init__`, ~line 345)

Replace:
```python
self.mlp = UpActDownMlp(...)
```

With:
```python
if config.use_swiglu_mlp:
    self.mlp = SwiGluMlp(dim, hidden_dim=mlp_ratio * dim, dropout=dropout)
else:
    self.mlp = UpActDownMlp(...)
```

Where `dim` and `mlp_ratio` are the existing constructor args (model_hidden_dim and model_mlp_ratio).

### Code path 3 — `target/train.py` Config dataclass

Add:
```python
use_swiglu_mlp: bool = False
```

Plus the auto-generated `--use-swiglu-mlp` argparse flag.

### Important — keep mlp_ratio=4 (drop-in test)

Do NOT also change `--model-mlp-ratio` for this experiment. Keep `mlp_ratio=4` (H112 canonical) to isolate the activation/gating mechanism as the only variable. This means SwiGLU will have:
- 3 linear layers (Gate, Value, Down) instead of 2 (Up, Down)
- Intermediate dim 2048 (same as dense at mlp_ratio=4)
- **Total MLP params: 3 * 512 * 2048 ≈ 3.15M per block** vs dense `2 * 512 * 2048 ≈ 2.10M` per block
- **Across 5 transformer blocks**: ~+5.25M params on the model (17.4M → ~22.7M, +30%)

This is a confounded test (activation × capacity), but it's the canonical drop-in pattern. If H128 succeeds, a follow-up (H129) could test param-parity SwiGLU at mlp_ratio=3 for clean mechanism attribution.

### Implementation guardrails

- **Zero-init `down_proj.weight`** to keep step-1 model behavior near canonical: `nn.init.zeros_(self.down_proj.weight)` makes the MLP contribution near-zero at init, preserving residual stream identity. Note: this is more conservative than Llama's default; safer for cold-start.
- **Use bias=False** for all three Linear layers (canonical Llama / Gemma convention; matches `UpActDownMlp` likely also bias=False — verify in code).
- **NO change** to normalization (LayerNorm in TransformerBlock unchanged), attention (TransolverAttention unchanged), surface_out / volume_out decoders unchanged.
- **VRAM**: +30% model params at BF16 = +10MB per GPU at most. Activations may increase slightly but dominate over weights — expect 80-85GB peak (was 78GB) — within 96GB headroom.
- **Wall-clock**: expect +5-10% wall-clock (~15-16h instead of 14.3h). Within SENPAI_TIMEOUT_MINUTES=1100 budget.

### Single arm only

Single experimental arm: `--use-swiglu-mlp` ON vs H112 canonical (OFF). Do not sweep mlp_ratio or hidden_dim in this PR.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor (paper claim) |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | — |
| val_WSS | 6.9670% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **6.727%** ← floor; gap to SOTA 5.85% = **0.902pp** |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | 3.643% |
| test_SP | 3.695% | 3.577% |

**Gate (this PR)**: A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism judged by whether all channels improve approximately uniformly (gating mechanism should help all heads, not just WSS).

**Primary objective**: per Morgan Issue #1056, **test_WSS is the primary objective** — gap = 0.902pp to Transolver-3 SOTA 5.85%.

**Reproduce command** (single arm, copy verbatim and set group as shown):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --use-swiglu-mlp \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name alphonse/h128-swiglu-mlp \
  --wandb-group tay-wave36-swiglu-mlp
```

**Kill threshold gates** (vol-points-schedule active, uses **global_step**):

- EP1 (step 10862): < 35.0% — cold-start fence; with `down_proj.weight` zero-init, MLP contributes near-zero at step 0 → behaves like H112 at init → fence cleared easily
- EP3 (step 32592): < 8.5% — binding gate
- EP6 (step 48897): < 7.0% — confirmation gate

---

## Diagnostic instrumentation (REQUIRED in PR comment)

1. **Frame Δ table** — val_abupt / val_WSS / val_WSS_x / val_WSS_y / val_WSS_z at EP3, EP6, EP10, EP13 vs H112 canonical. Predicts: all channels improve approximately uniformly (gated MLP is a per-token primitive, not WSS-specific).
2. **Test breakdown** — final test_VP / test_SP / test_WSS_x / test_WSS_y / test_WSS_z.
3. **Param count log** — final model param count at startup; expect ~22.7M (+30% vs H112's 17.4M).
4. **Gate utilization** — at EP13 best EMA, log per-block mean of `sigmoid(gate_proj(x) * SiLU)` activation across surface tokens (should be ~0.4-0.6; if all-saturated near 0 or 1, the gating isn't being used).
5. **Peak VRAM** — should be ~80-85GB/GPU.
6. **Wall-clock per epoch** — expect ~1.10-1.15× H112's per-epoch wall-clock.

---

## Mechanism notes for self-review

- **If test_WSS improves by ≥ 0.05pp** with proportional improvements across all channels, the architectural primitive change is mechanism-load-bearing → success.
- **If test_WSS improves but ONLY on one channel (e.g., only WSS_z)**, the per-channel pattern is suspicious and may indicate gating is exploiting a specific signal — flag for follow-up.
- **If val_abupt or val_WSS lands within ±0.02pp of H112**, gating mechanism is structurally inert at 17M-class scale. Honest signal — banks negative result. Suggests SwiGLU's empirical wins on LLMs require different scale / training data.
- **If wall-clock balloons > 1.25× H112**, profile the SwiGLU forward; the 3-Linear pattern should still be efficient at this size.
- **If `gate_proj` weights collapse to near-uniform** (gate is always-on or always-off), the gating signal isn't being learned → consider initializing differently or extending training.

---

**Owner:** alphonse
**Wave:** 36 (architectural primitive — feedforward modernization)
**Effort estimate:** ~50 lines (new SwiGluMlp class + TransformerBlock branch + Config flag + argparse)
**Wall-clock estimate:** ~15-16h (canonical 13ep at DDP 8×H100, +5-10% vs H112)
**Group:** `tay-wave36-swiglu-mlp`
