### PR TITLE
H126b: Inverse-area sampling T=4.0 (softer reweighting after H126 EP1 catastrophe)

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -255,6 +255,30 @@ def _npy_row_count(path: Path) -> int:
     return int(arr.shape[0])
 
 
+def _compute_inverse_area_weights(area_arr: np.ndarray, temperature: float) -> np.ndarray:
+    """Compute inverse-panel-area sampling weights normalized to sum to 1.
+
+    H126: weight_i ∝ (1 / area_i)^(1/T). Small panels (auto-mesh refined at
+    high-curvature regions) get higher probability than large flat panels.
+
+    Fast path for T=1.0 skips log/exp (weights = 1/area, normalized). For
+    other T we use the log/exp formulation with max-subtraction for
+    numerical stability. 1e-12 floor on area protects against log(0).
+    """
+    area_safe = np.maximum(area_arr.astype(np.float32, copy=False), 1e-12)
+    if abs(float(temperature) - 1.0) < 1e-6:
+        weights = (1.0 / area_safe).astype(np.float32)
+    else:
+        temp_safe = max(float(temperature), 1e-9)
+        log_w = -np.log(area_safe) / temp_safe
+        log_w = log_w - log_w.max()
+        weights = np.exp(log_w).astype(np.float32)
+    total = float(weights.sum())
+    if not np.isfinite(total) or total <= 0.0:
+        return np.full_like(area_safe, 1.0 / area_safe.shape[0], dtype=np.float32)
+    return (weights / total).astype(np.float32)
+
+
 def _column(value: np.ndarray) -> np.ndarray:
     arr = np.asarray(value, dtype=np.float32)
     return arr[:, None] if arr.ndim == 1 else arr
@@ -367,6 +391,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        use_area_weighted_sampling: bool = False,
+        area_sampling_temperature: float = 1.0,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +402,12 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.use_area_weighted_sampling = bool(use_area_weighted_sampling)
+        self.area_sampling_temperature = float(area_sampling_temperature)
+        # H126: per-case cumulative distribution cache for inverse-area sampling.
+        # Built lazily on first access per (case_id, N). float32 tensor of size N.
+        # ~33MB per case * ~50 cases/rank = ~1.65GB per worker; cleared on fork copy.
+        self._cdf_cache: dict[str, torch.Tensor] = {}
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -414,25 +446,69 @@ class DrivAerMLSurfaceDataset(Dataset):
         view: PointView,
         *,
         group_view_count: int,
+        cdf: torch.Tensor | None = None,
     ) -> torch.Tensor | None:
         if view.view_index >= group_view_count:
             return torch.empty(0, dtype=torch.long)
         if count <= 0 or total <= count:
             return None if view.view_index == 0 else torch.empty(0, dtype=torch.long)
         if view.sampling_mode == "train_random":
+            if cdf is not None:
+                u = torch.rand(count, dtype=cdf.dtype)
+                idx = torch.searchsorted(cdf, u)
+                idx.clamp_(max=cdf.numel() - 1)
+                return idx.to(torch.long).sort().values
             return torch.randint(total, (count,), dtype=torch.long).sort().values
         if view.sampling_mode == "eval_chunk":
             return torch.arange(view.view_index, total, group_view_count, dtype=torch.long)
         return None
 
+    def _get_inverse_area_cdf(self, case_id: str, expected_total: int) -> torch.Tensor:
+        """Cached cumulative distribution for inverse-area sampling.
+
+        Loads `surface_area.npy` and builds an inverse-area CDF once per case
+        per dataset instance (per DataLoader worker, since workers fork the
+        dataset). Subsequent calls return the cached tensor. float32 keeps
+        memory at ~4*N bytes (~33MB for a 8M-point case) while preserving
+        enough precision for searchsorted at K=65536 samples per call.
+        """
+        cdf = self._cdf_cache.get(case_id)
+        if cdf is None or cdf.numel() != expected_total:
+            case_dir = _case_dir(self.store.root, case_id)
+            area_arr = np.asarray(
+                np.load(_resolve_artifact_path(case_dir / "surface_area.npy")),
+                dtype=np.float32,
+            ).reshape(-1)
+            if area_arr.shape[0] != expected_total:
+                raise ValueError(
+                    f"surface_area.npy length {area_arr.shape[0]} does not match "
+                    f"surface_xyz row count {expected_total} for case {case_id!r}"
+                )
+            weights = _compute_inverse_area_weights(area_arr, self.area_sampling_temperature)
+            cdf_np = np.cumsum(weights, dtype=np.float32)
+            cdf_np[-1] = np.float32(1.0)
+            cdf = torch.from_numpy(cdf_np)
+            self._cdf_cache[case_id] = cdf
+        return cdf
+
     def __getitem__(self, idx: int) -> DrivAerMLCase:
         view = self.views[idx]
         counts = self.store.case_point_counts(view.case_id)
+        surface_cdf: torch.Tensor | None = None
+        if (
+            self.use_area_weighted_sampling
+            and view.sampling_mode == "train_random"
+            and self.max_surface_points > 0
+            and counts["n_surface"] > self.max_surface_points
+            and view.view_index < view.surface_view_count
+        ):
+            surface_cdf = self._get_inverse_area_cdf(view.case_id, counts["n_surface"])
         surface_idx = self._indices(
             counts["n_surface"],
             self.max_surface_points,
             view,
             group_view_count=view.surface_view_count,
+            cdf=surface_cdf,
         )
         volume_idx = self._indices(
             counts["n_volume"],
@@ -544,6 +620,8 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    use_area_weighted_sampling: bool = False,
+    area_sampling_temperature: float = 1.0,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -568,6 +646,8 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        use_area_weighted_sampling=use_area_weighted_sampling,
+        area_sampling_temperature=area_sampling_temperature,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -33,6 +34,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
 from data import DrivAerMLSurfaceDataset
+from data.loader import _compute_inverse_area_weights, _resolve_artifact_path, _case_dir
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -131,6 +133,8 @@ class Config:
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
     vol_points_schedule: str = ""
+    use_area_weighted_sampling: bool = False
+    area_sampling_temperature: float = 1.0
     use_gradnorm: bool = False
     gradnorm_mode: str = "ema_proxy"
     gradnorm_alpha: float = 1.5
@@ -161,6 +165,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "epoch onwards (inclusive) until the next breakpoint. Empty "
             "string disables the curriculum and `--train-volume-points` is "
             "used unchanged. Example: '0:16384:3:32768:6:49152:9:65536'."
+        ),
+        "use_area_weighted_sampling": (
+            "H126: Replace uniform train surface point sampling with inverse "
+            "panel-area weighted sampling. Probability per point is "
+            "(1 / area_i)^(1/T), normalized per case. Small auto-meshed "
+            "panels (high-curvature regions: wheel arches, A-pillar, hood-roof "
+            "junction) get oversampled relative to large flat panels. Only "
+            "applies during training (`train_random` mode); eval is unchanged. "
+            "Volume sampling is unchanged. Surface area is read from "
+            "surface_area.npy per case (no new data dependency). Default off."
+        ),
+        "area_sampling_temperature": (
+            "H126: Sharpness temperature T for inverse-area weights. "
+            "weight_i ∝ (1/area_i)^(1/T). T=1.0 (default) is the canonical "
+            "inverse-area. T<1.0 sharpens (more oversampling of small panels); "
+            "T>1.0 softens (closer to uniform). Only applies when "
+            "--use-area-weighted-sampling is enabled."
         ),
         "use_gradnorm": (
             "Enable GradNorm dynamic per-task loss balancing (Chen et al., "
@@ -669,6 +690,84 @@ def vol_points_for_epoch(
     return current
 
 
+def compute_area_sampling_diagnostics(
+    train_dataset: DrivAerMLSurfaceDataset,
+    *,
+    n_cases: int | None = None,
+) -> dict[str, float | list[float]]:
+    """H126: aggregate inverse-area sampling diagnostics across training cases.
+
+    Returns per-case-averaged statistics on:
+      * panel area distribution (min / median / max)
+      * effective sampling ratio (weight_i / (1/N_i)) — i.e. how many times
+        more likely each point is sampled vs uniform.
+      * extreme ratio: max_weight_ratio (most-oversampled point per case)
+        and min_weight_ratio (least-oversampled point per case).
+    """
+    if not getattr(train_dataset, "use_area_weighted_sampling", False):
+        return {}
+    case_ids = list(train_dataset.case_ids)
+    if n_cases is not None:
+        case_ids = case_ids[:n_cases]
+    temperature = float(train_dataset.area_sampling_temperature)
+    area_min: list[float] = []
+    area_p25: list[float] = []
+    area_p50: list[float] = []
+    area_p75: list[float] = []
+    area_max: list[float] = []
+    ratio_min: list[float] = []
+    ratio_p25: list[float] = []
+    ratio_p50: list[float] = []
+    ratio_p75: list[float] = []
+    ratio_max: list[float] = []
+    point_counts: list[int] = []
+    for case_id in case_ids:
+        case_dir = _case_dir(train_dataset.store.root, case_id)
+        area_arr = np.asarray(
+            np.load(_resolve_artifact_path(case_dir / "surface_area.npy")),
+            dtype=np.float32,
+        ).reshape(-1)
+        n = int(area_arr.shape[0])
+        point_counts.append(n)
+        area_min.append(float(area_arr.min()))
+        area_p25.append(float(np.percentile(area_arr, 25)))
+        area_p50.append(float(np.percentile(area_arr, 50)))
+        area_p75.append(float(np.percentile(area_arr, 75)))
+        area_max.append(float(area_arr.max()))
+        weights = _compute_inverse_area_weights(area_arr, temperature)
+        ratio = weights * float(n)
+        ratio_min.append(float(ratio.min()))
+        ratio_p25.append(float(np.percentile(ratio, 25)))
+        ratio_p50.append(float(np.percentile(ratio, 50)))
+        ratio_p75.append(float(np.percentile(ratio, 75)))
+        ratio_max.append(float(ratio.max()))
+
+    def _mean(values: list[float]) -> float:
+        return float(np.mean(values)) if values else float("nan")
+
+    return {
+        "n_cases_analyzed": len(case_ids),
+        "n_points_min": int(min(point_counts)) if point_counts else 0,
+        "n_points_median": int(np.median(point_counts)) if point_counts else 0,
+        "n_points_max": int(max(point_counts)) if point_counts else 0,
+        "area/min_mean": _mean(area_min),
+        "area/p25_mean": _mean(area_p25),
+        "area/p50_mean": _mean(area_p50),
+        "area/p75_mean": _mean(area_p75),
+        "area/max_mean": _mean(area_max),
+        "ratio/min_mean": _mean(ratio_min),
+        "ratio/p25_mean": _mean(ratio_p25),
+        "ratio/p50_mean": _mean(ratio_p50),
+        "ratio/p75_mean": _mean(ratio_p75),
+        "ratio/max_mean": _mean(ratio_max),
+        "ratio/max_p99_acrosscases": float(np.percentile(ratio_max, 99)) if ratio_max else float("nan"),
+        "ratio/skew_max_over_p50": _mean(
+            [r_max / max(r_p50, 1e-12) for r_max, r_p50 in zip(ratio_max, ratio_p50)]
+        ),
+        "temperature": temperature,
+    }
+
+
 def rebuild_train_loader_with_vol_points(
     config: Config,
     old_train_loader: DataLoader,
@@ -693,6 +792,8 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        use_area_weighted_sampling=config.use_area_weighted_sampling,
+        area_sampling_temperature=config.area_sampling_temperature,
     )
     train_sampler = None
     train_shuffle = True
@@ -893,6 +994,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            if config.use_area_weighted_sampling:
+                diag = compute_area_sampling_diagnostics(train_loader.dataset, n_cases=20)
+                if diag:
+                    print(
+                        f"H126 inverse-area sampling: T={diag['temperature']:.3f}, "
+                        f"n_cases={diag['n_cases_analyzed']}, "
+                        f"area_p50_mean={diag['area/p50_mean']:.4g}, "
+                        f"ratio_p50_mean={diag['ratio/p50_mean']:.4f}, "
+                        f"ratio_max_mean={diag['ratio/max_mean']:.4f}, "
+                        f"ratio_skew(max/p50)={diag['ratio/skew_max_over_p50']:.2f}"
+                    )
+                    for key, value in diag.items():
+                        wandb.summary[f"data/area_weighted_sampling/{key}"] = value
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -286,6 +286,8 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        use_area_weighted_sampling=getattr(config, "use_area_weighted_sampling", False),
+        area_sampling_temperature=getattr(config, "area_sampling_temperature", 1.0),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**Softer temperature (T=4.0) on inverse-panel-area stratified surface sampling will clear the EP1 cold-start fence AND test the WSS-sampling mechanism cleanly.**

H126 (PR #1303) C NULL'd at EP1 with val_abupt 43.84% vs gate <35% (missed by 8.84pp). Your diagnostic identified the root cause: at T=1.0, DrivAerML's 5-order-of-magnitude panel-area range produces **95× max/median oversampling** (vs the PR's projected 2-3×) — a "softmax over log-area" pathology where unit-temperature softmax collapses onto extremes when σ_log is large.

**H126b uses your recommended fix**: T=4.0 reduces the max/median skew from 95× to ~3× (`95^(1/4) ≈ 3.1×`) — within the original PR's projected "moderate reweighting" zone. This isolates the *mechanism* (does inverse-area-aware sampling help WSS?) from the *parameter pathology* (T=1.0 catastrophe).

### Why this is mechanism-distinct from H126

- **H126 (T=1.0)**: extreme distribution shift; ~50% of batch concentrates on <1% of surface area → model never learns dominant large-panel regions → EP1 catastrophe
- **H126b (T=4.0)**: moderate distribution shift; small/curvy panels get ~3× uniform rate, large panels get ~0.3× uniform rate → bounded shift, model still sees adequate coverage of all regions

### Decision-tree predictions

- **If H126b clears EP1 (val_abupt < 35% at step 10862)**: mechanism is workable at moderate T. Continue to terminal for full eval. If test_WSS improves ≥0.08pp, sampling mechanism is load-bearing.
- **If H126b ALSO fails EP1 cold-start**: mechanism is structurally fragile at any aggressive reweighting; data-tier sampling class CLOSES (joins H-A in "training-distribution-shift" anti-pattern).
- **If H126b clears EP1 but doesn't move test_WSS terminal**: mechanism is benign-but-inert; sampling-distribution tier closes on this dataset; pivot to other Wave 36+ axes.

### Literature support (same as H126)

- Weng et al. 2022 (PINN collocation point selection): residual-weighted sampling improves convergence on heterogeneous PDE domains.
- DoMINO 2024 (Nvidia CFD): adaptive sampling near separation/reattachment regions improves surface field prediction.
- Deshpande 2024 (adaptive collocation): curvature-weighted sampling improves PDE accuracy on irregular geometries.

### Falsifiable prediction

- **Primary**: test_WSS improves ≥ 0.08pp vs H112 baseline (6.752% → ≤ 6.67%).
- **Mechanism observable**: val_WSS_z improves more than val_WSS_x (small/curvy panels concentrate where τ_z dominates, e.g., roof/floor edges).
- **EP1 sanity check**: val_abupt ≤ 30% (clearing 35% fence with comfortable margin) — predicts the mechanism doesn't break cold-start learning at this T.

---

## Instructions

**Single recipe change relative to H126**: `--area-sampling-temperature 4.0` (was 1.0). The H126 loader implementation is re-used; no code changes are required.

### Code path — re-use H126 implementation

You implemented the area-weighted sampling correctly in H126; the failure was parameter calibration, not implementation. Re-apply your H126 loader changes to this new branch:

```bash
# Cherry-pick or re-apply your H126 loader changes:
# git cherry-pick <H126-commit-sha-on-nezuko/h126-area-weighted-sampling>
# OR re-implement using the exact pattern from H126
```

Files to re-introduce on this branch (from H126):
- `target/data/loader.py` — `area`-aware sampler with searchsorted-on-cached-CDF fast path; T=1.0 fast path stays as-is (canonical recipe untouched)
- `target/train.py` Config — `use_area_weighted_sampling: bool = False`, `area_sampling_temperature: float = 1.0`
- Diagnostic logging — `data/area_weighted_sampling/*` keys preserved (area distribution, ratio distribution, skew, n_points)

**No new code; only re-applying H126 implementation.** All the hard work (CDF caching, searchsorted equivalence to multinomial, DDP safety, fast path for T=1.0) is already done.

### Implementation guardrails

- **Default-off behavior preserved**: canonical recipe without `--use-area-weighted-sampling` flag behaves identically to H112.
- **Cache memory check**: per-case CDF cache (~33 MB/case × ~50/rank ≈ 1.65 GB/worker per H126's instrumentation) was within budget. No change at T=4.0.
- **DDP safety**: per-rank stochastic sampler with seeded RNG; verified in H126.
- **Volume sampling unchanged**: surface sampler only.
- **Eval/val/test sampling unchanged**: `view.sampling_mode == "train_random"` guard prevents distribution shift at evaluation.

### Single arm only

Single experimental arm: T=4.0 (H126b) vs canonical (T=∞ effectively, no reweighting). Do not sweep T in this PR — that's H126c if H126b clears EP1 but doesn't move terminal.

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Floor (paper claim) |
|---|---:|---:|
| val_abupt | **6.1358%** | gate |
| test_abupt | 5.839% | — |
| val_WSS | 6.9670% | — |
| val_WSS_x | 6.0923% | — |
| val_WSS_y | 7.6084% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **6.727%** ← floor; gap to SOTA 5.85% = **0.902pp** |
| test_WSS_x | 5.999% | — |
| test_WSS_y | 7.360% | — |
| test_WSS_z | 8.720% | — |
| test_VP | 3.421% | 3.643% |
| test_SP | 3.695% | 3.577% |

**Gate (this PR)**: A WIN if val_abupt < 6.1358%; B PARTIAL test_WSS if test_WSS < 6.727%. Mechanism judged by `val_WSS_z` vs `val_WSS_x` Δ.

**Primary objective**: per Morgan Issue #1056, **test_WSS is the primary objective** — gap = 0.902pp to Transolver-3 SOTA 5.85%.

**Reproduce command** (single arm, copy verbatim and set group as shown):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --use-area-weighted-sampling --area-sampling-temperature 4.0 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name nezuko/h126b-area-sampling-t4 \
  --wandb-group tay-wave36-wss-sampling
```

**Note**: includes `--drop-path-max 0.10` to match H112 canonical recipe (the actual single-model SOTA includes DropPath — H126 omitted this, which is OK for cold-start fence diagnostic but for a clean comparison the baseline-matching recipe is preferred). If you want to test strict H126-parity (no DropPath), make a follow-up arm; this PR is the WSS-axis attack.

**Kill threshold gates** (vol-points-schedule active, uses **global_step**):

- EP1 (step 10862): < 35.0% — cold-start fence; T=4.0 should clear easily per your diagnostic (predicted val_abupt ~28-30% at EP1)
- EP3 (step 32592): < 8.5% — binding gate
- EP6 (step 48897): < 7.0% — confirmation gate

If EP1 still trips (val_abupt > 35%), the mechanism class is structurally fragile and we'll close the sampling-distribution tier joined with H-A.

---

## Diagnostic instrumentation (REQUIRED in PR comment)

1. **Area-weighted sampling diagnostics** — re-log `data/area_weighted_sampling/{area/min_mean, area/p50_mean, area/max_mean, ratio/max_mean, ratio/skew_max_over_p50, ratio/max_p99_acrosscases, n_points}` at training start. Predicts: `ratio/max_mean ≈ 3-5×` (vs T=1.0's 24.5×), `ratio/skew_max_over_p50 ≈ 3-5×` (vs T=1.0's 94.9×).
2. **Frame Δ table** — val_WSS_x / val_WSS_y / val_WSS_z at each EP gate (EP3, EP6, EP10, EP13) vs H112 canonical. Predicts: val_WSS_z improves more than val_WSS_x.
3. **Test breakdown** — final test_WSS_x / test_WSS_y / test_WSS_z. Predicts: largest improvement on test_WSS_z.
4. **EP1 cold-start trajectory** — val_abupt at step 10862 + comparison to H112 canonical (25.87%). Predicts: val_abupt ≤ 30% (within ~5pp of H112 baseline).

---

## Mechanism notes for self-review

- If EP1 val_abupt > 35% (kill-fence trip): T=4.0 is still too aggressive for this mesh. Mechanism class closes; pivot to quantile-rank or capped-ratio sampling for any future area-aware attempt.
- If EP1 val_abupt clears 35% but is >30%: T=4.0 is borderline; consider H126c at T=8.0.
- If test_WSS improvement happens but val_WSS_z did NOT improve more than val_WSS_x: win is likely coincidental (sampling stochasticity / init variance). Flag honestly.
- If test_VP or test_SP regresses by > 0.10pp: area-weighted sampling is degrading pressure prediction through over-emphasis on small panels. Flag — could test SP-only or VP-only area weighting separately.

---

**Owner:** nezuko
**Wave:** 36 (WSS-sampling tier, refined H126)
**Effort estimate:** ~15 lines (re-apply H126 loader changes; only recipe parameter changes vs H126 — virtually no new code)
**Wall-clock estimate:** ~14h (canonical 13ep at DDP 8×H100)
**Group:** `tay-wave36-wss-sampling`
