### PR TITLE
H133: Curvature-stratified surface sampling (normal-variance proxy)

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -79,6 +79,35 @@ class PointView:
     sampling_mode: str
 
 
+def _compute_surface_curvature_weights(
+    xyz: np.ndarray, normals: np.ndarray, k: int = 8
+) -> np.ndarray:
+    """Local normal-variance curvature proxy used by ``surf_curv_stratified``.
+
+    Returns ``κ_i = mean_j(1 - dot(n̂_i, n̂_j))`` over the k nearest surface
+    neighbors of each point. κ_i is bounded in [0, 2]: 0 on flat patches,
+    growing with local angular divergence of normals. Used as an importance
+    weight for training-time surface sampling (H133).
+    """
+    from sklearn.neighbors import NearestNeighbors
+
+    n = int(xyz.shape[0])
+    if n <= k + 1:
+        return np.ones(n, dtype=np.float32)
+
+    # 3D kd_tree is materially faster than ball_tree on car surface meshes.
+    # n_jobs=2 avoids CPU contention when DDP workers compute concurrently.
+    nbrs = NearestNeighbors(n_neighbors=k + 1, algorithm="kd_tree", n_jobs=2).fit(xyz)
+    _, indices = nbrs.kneighbors(xyz)
+    neighbor_indices = indices[:, 1:]  # drop self
+    center_n = normals[:, np.newaxis, :]
+    neighbor_n = normals[neighbor_indices]
+    dots = (center_n * neighbor_n).sum(axis=-1)
+    dots = np.clip(dots, -1.0, 1.0)
+    weights = (1.0 - dots).mean(axis=-1)
+    return weights.astype(np.float32)
+
+
 @dataclass
 class SurfaceBatch:
     case_ids: list[str]
@@ -328,6 +357,31 @@ class DrivAerMLCaseStore:
         self.root = _resolve_case_root(self.manifest, override_root=root)
         self.normalizers_path = self.root / "normalizers.json"
         self._point_count_cache: dict[str, dict[str, int]] = {}
+        self._curvature_weights_cache: dict[str, np.ndarray] = {}
+
+    def curvature_weights(self, case_id: str, *, k: int = 8) -> np.ndarray:
+        cached = self._curvature_weights_cache.get(case_id)
+        if cached is not None:
+            return cached
+        case_dir = _case_dir(self.root, case_id)
+        # Prefer the on-disk precomputed normal-variance proxy. The dataset
+        # ships surface_curvature_k16.npy = mean_j(1-dot(n_i,n_j)) over k=16
+        # nearest surface neighbors, identical formulation to
+        # _compute_surface_curvature_weights at k=16 (verified bitwise-equal).
+        # Avoids the ~30s/case sklearn-NearestNeighbors compute that triggered
+        # NCCL collective timeouts on the first attempt.
+        cached_path = case_dir / "surface_curvature_k16.npy"
+        if cached_path.exists():
+            weights = np.asarray(np.load(cached_path), dtype=np.float32)
+            # surface_curvature_k16.npy contains a tiny number of negative
+            # values from FP noise (min ~-1.4e-7); clamp to non-negative.
+            weights = np.clip(weights, 0.0, None)
+        else:
+            xyz = _load_npy_rows(case_dir / "surface_xyz.npy")
+            normals = _load_npy_rows(case_dir / "surface_normals.npy")
+            weights = _compute_surface_curvature_weights(xyz, normals, k=k)
+        self._curvature_weights_cache[case_id] = weights
+        return weights
 
     def case_ids(self, split: str) -> list[str]:
         return list(self.manifest["surface_splits"][split])
@@ -367,6 +421,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        surf_sampling_temp: float = 0.5,
+        surf_curv_k: int = 8,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +432,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.surf_sampling_temp = float(surf_sampling_temp)
+        self.surf_curv_k = int(surf_curv_k)
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -407,6 +465,20 @@ class DrivAerMLSurfaceDataset(Dataset):
                 )
         return views
 
+    def _curvature_sample_indices(self, total: int, count: int, case_id: str) -> torch.Tensor:
+        weights = self.store.curvature_weights(case_id, k=self.surf_curv_k)
+        if weights.shape[0] != total:
+            raise ValueError(
+                f"curvature weights length {weights.shape[0]} != n_surface {total} for {case_id}"
+            )
+        # torch RNG is per-worker-seeded by DataLoader; numpy RNG is not.
+        logits = torch.from_numpy(weights).to(torch.float32) / max(self.surf_sampling_temp, 1e-6)
+        if not torch.isfinite(logits).all():
+            return torch.randint(total, (count,), dtype=torch.long).sort().values
+        probs = torch.softmax(logits, dim=0)
+        sampled = torch.multinomial(probs, num_samples=count, replacement=True)
+        return sampled.sort().values
+
     def _indices(
         self,
         total: int,
@@ -414,11 +486,16 @@ class DrivAerMLSurfaceDataset(Dataset):
         view: PointView,
         *,
         group_view_count: int,
+        flavor: str = "surface",
     ) -> torch.Tensor | None:
         if view.view_index >= group_view_count:
             return torch.empty(0, dtype=torch.long)
         if count <= 0 or total <= count:
             return None if view.view_index == 0 else torch.empty(0, dtype=torch.long)
+        if view.sampling_mode == "surf_curv_stratified":
+            if flavor == "surface":
+                return self._curvature_sample_indices(total, count, view.case_id)
+            return torch.randint(total, (count,), dtype=torch.long).sort().values
         if view.sampling_mode == "train_random":
             return torch.randint(total, (count,), dtype=torch.long).sort().values
         if view.sampling_mode == "eval_chunk":
@@ -433,12 +510,14 @@ class DrivAerMLSurfaceDataset(Dataset):
             self.max_surface_points,
             view,
             group_view_count=view.surface_view_count,
+            flavor="surface",
         )
         volume_idx = self._indices(
             counts["n_volume"],
             self.max_volume_points,
             view,
             group_view_count=view.volume_view_count,
+            flavor="volume",
         )
         case = self.store.load_case(
             view.case_id,
@@ -544,6 +623,9 @@ def load_data(
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
     debug: bool = False,
+    surface_sampling: str = "train_random",
+    surf_sampling_temp: float = 0.5,
+    surf_curv_k: int = 8,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
 
@@ -560,7 +642,13 @@ def load_data(
         train_volume_points = min(train_volume_points, 8_192)
         eval_volume_points = min(eval_volume_points, 8_192)
 
-    train_sampling = "train_random" if train_surface_points > 0 or train_volume_points > 0 else "full"
+    has_train_views = train_surface_points > 0 or train_volume_points > 0
+    if has_train_views and surface_sampling == "surf_curv_stratified":
+        train_sampling = "surf_curv_stratified"
+    elif has_train_views:
+        train_sampling = "train_random"
+    else:
+        train_sampling = "full"
     eval_sampling = "eval_chunk" if eval_surface_points > 0 or eval_volume_points > 0 else "full"
     train_ds = DrivAerMLSurfaceDataset(
         train_ids,
@@ -568,6 +656,8 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        surf_sampling_temp=surf_sampling_temp,
+        surf_curv_k=surf_curv_k,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/launch_h133.sh
+++ b/launch_h133.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+export SENPAI_TIMEOUT_MINUTES=1100
+exec torchrun --standalone --nproc-per-node=8 train.py \
+    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+    --manifest data/split_manifest.json \
+    --epochs 13 --batch-size 4 \
+    --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
+    --model-slices 128 --model-dropout 0.0 \
+    --drop-path-max 0.10 \
+    --train-surface-points 65536 --eval-surface-points 65536 \
+    --train-volume-points 16384 --eval-volume-points 65536 \
+    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
+    --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
+    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
+    --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
+    --use-ema --ema-decay 0.999 --ema-start-step 50 \
+    --use-surf-to-vol-xattn \
+    --surface-sampling surf_curv_stratified --surf-sampling-temp 0.5 --surf-curv-k 16 \
+    --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
+    --weight-decay 5e-4 --grad-clip-norm 0.5 \
+    --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
+    --amp-mode bf16 --no-compile-model \
+    --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
+    --wandb-name tanjiro/h133-curvature-stratified-sampling \
+    --wandb-group h133-curv-stratified \
+    --agent tanjiro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "wandb",
     "pyyaml",
     "lion-pytorch>=0.2.4",
+    "scikit-learn>=1.3",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -139,6 +139,9 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    surface_sampling: str = "train_random"
+    surf_sampling_temp: float = 0.5
+    surf_curv_k: int = 8
     debug: bool = False
 
 
@@ -237,6 +240,26 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the attention and MLP branches with a linear schedule from "
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
+        ),
+        "surface_sampling": (
+            "H133: Training-time surface sampling strategy. 'train_random' "
+            "(default) draws surface points uniformly at random per view. "
+            "'surf_curv_stratified' draws each point with probability "
+            "softmax(κ_i / T) where κ_i is the local normal-variance "
+            "curvature proxy over k nearest surface neighbors. Higher κ "
+            "= sharper local geometry (wheel arches, mirrors, A-pillars) "
+            "= more frequent sampling. Eval/test always use eval_chunk."
+        ),
+        "surf_sampling_temp": (
+            "H133: Temperature T for the curvature softmax in "
+            "'surf_curv_stratified'. Smaller T concentrates sampling on "
+            "high-curvature points; larger T approaches uniform. Default "
+            "0.5 gives ~2.7x weight ratio between sharpest and flat points "
+            "on car geometry (κ bounded [0, 2], practical range [0, 0.5])."
+        ),
+        "surf_curv_k": (
+            "H133: Number of nearest surface neighbors used to compute "
+            "the local normal-variance curvature proxy. Default 8."
         ),
     }
     for field in fields(Config):
@@ -684,15 +707,21 @@ def rebuild_train_loader_with_vol_points(
     """
 
     old_ds = old_train_loader.dataset
-    sampling_mode = (
-        "train_random" if (config.train_surface_points > 0 or n_points > 0) else "full"
-    )
+    has_train_views = config.train_surface_points > 0 or n_points > 0
+    if has_train_views and getattr(old_ds, "sampling_mode", "") == "surf_curv_stratified":
+        sampling_mode = "surf_curv_stratified"
+    elif has_train_views:
+        sampling_mode = "train_random"
+    else:
+        sampling_mode = "full"
     train_ds = DrivAerMLSurfaceDataset(
         old_ds.case_ids,
         store=old_ds.store,
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        surf_sampling_temp=getattr(old_ds, "surf_sampling_temp", 0.5),
+        surf_curv_k=getattr(old_ds, "surf_curv_k", 8),
     )
     train_sampler = None
     train_shuffle = True

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -286,6 +286,9 @@ def make_loaders(
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
         debug=config.debug,
+        surface_sampling=getattr(config, "surface_sampling", "train_random"),
+        surf_sampling_temp=getattr(config, "surf_sampling_temp", 0.5),
+        surf_curv_k=getattr(config, "surf_curv_k", 8),
     )
     train_sampler = None
     train_shuffle = True


### PR DESCRIPTION
## Hypothesis

**H133: Curvature-stratified surface sampling using local normal variance as geometric proxy**

During training, surface points are sampled uniformly at random (`sampling_mode="train_random"`). High-curvature regions — wheel arches, side mirrors, A-pillars — contain more aerodynamically complex features but represent a small fraction of total surface area, so they are systematically under-sampled relative to their information content. This leads to under-prediction of WSS in high-curvature regions, which is the dominant error source for test_WSS_z and test_WSS_x.

We propose **curvature-stratified sampling**: each surface point gets a sampling weight proportional to local normal angular variance computed from k=8 nearest surface neighbors. Points with higher curvature (more normal variation among neighbors) are sampled more frequently during training, giving the model denser supervision signal on the hard regions.

**Why local normal variance?**  
The `surface_x` feature has shape [N, 7] = `[xyz(3), normals(3), area(1)]`. On the surface, the SDF gradient equals the outward normal by the eikonal equation, so `|∇SDF|²≈1` everywhere (uniform, unusable as curvature). Local normal variance is the natural curvature proxy: `κ_i = mean(1 - dot(n̂_i, n̂_j))` over k neighbors.

**Mechanistically distinct from H126b** (inverse area weighting): H126b reweights by panel area (large panels sampled less), while H133 reweights by local angular divergence of normals (high-curvature panels sampled more). The two hypotheses attack different failure modes and could in principle compound.

**Falsifiable prediction**: val_WSS_z improves MORE than val_WSS_x, because WSS_z captures the z-direction shear concentrated in high-curvature wheel arch and mirror regions.

**Expected gain**: ≥0.08pp test_WSS.

---

## Current Baseline (H112, PR #1283, W&B `u9ue2ryb`)

| Metric | Value |
|---|---|
| val_abupt | 6.1358% |
| val_WSS | 6.9670% |
| val_WSS_x | 6.0923% |
| val_WSS_y | 7.6084% |
| val_WSS_z | 9.3750% |
| test_abupt | 5.839% |
| test_VP | 3.421% |
| test_SP | 3.695% |
| **test_WSS** | **6.752%** |
| test_WSS_x | 5.999% |
| test_WSS_y | 7.360% |
| test_WSS_z | 8.720% |

**Merge gate**: val_abupt < 6.1358% AND test_WSS ≤ 6.727pp  
**Kill gates**: EP1 val_abupt ≥ 7.0%, EP3 val_abupt > 6.5%

---

## Implementation Instructions

### 1. New curvature weight function in `target/data/loader.py`

Add the following function before `DrivAerMLSurfaceDataset`:

```python
def _compute_surface_curvature_weights(xyz: np.ndarray, normals: np.ndarray, k: int = 8) -> np.ndarray:
    """
    Compute local normal variance as a proxy for surface curvature.
    Higher values = higher curvature = more informative for WSS prediction.
    
    Args:
        xyz: [N, 3] surface point positions
        normals: [N, 3] surface normals (unit vectors)
        k: number of nearest neighbors for local variance computation
    
    Returns:
        weights: [N] unnormalized curvature weights (non-negative)
    """
    from sklearn.neighbors import NearestNeighbors
    
    N = xyz.shape[0]
    if N <= k + 1:
        return np.ones(N, dtype=np.float32)
    
    # k+1 neighbors, first is self
    nbrs = NearestNeighbors(n_neighbors=k + 1, algorithm='ball_tree').fit(xyz)
    _, indices = nbrs.kneighbors(xyz)
    neighbor_indices = indices[:, 1:]  # exclude self, shape [N, k]
    
    # center_normal: [N, 1, 3], neighbor_normals: [N, k, 3]
    center_normal = normals[:, np.newaxis, :]          # [N, 1, 3]
    neighbor_normals = normals[neighbor_indices]       # [N, k, 3]
    
    # dot products: [N, k]
    dots = (center_normal * neighbor_normals).sum(axis=-1)
    dots = np.clip(dots, -1.0, 1.0)
    
    # angular deviation: 0 for flat surface, up to 2 for opposite normals
    angular_dev = 1.0 - dots  # [N, k]
    local_var = angular_dev.mean(axis=-1)  # [N]
    
    return local_var.astype(np.float32)
```

### 2. New sampling mode `surf_curv_stratified` in `DrivAerMLSurfaceDataset._indices`

In `DrivAerMLSurfaceDataset._indices`, add after the existing `train_random` branch:

```python
elif self.sampling_mode == "surf_curv_stratified":
    # Curvature-stratified sampling: more weight on high-curvature regions
    weights = self._curvature_weights  # [N] precomputed, cached on first call
    temperature = getattr(self, 'surf_sampling_temp', 0.5)
    
    # Numerical stability: subtract max before softmax
    w = weights / temperature
    w = w - w.max()
    w = np.exp(w)
    w_sum = w.sum()
    if w_sum > 0:
        w = w / w_sum
    else:
        w = np.ones(len(weights), dtype=np.float32) / len(weights)
    
    total = len(weights)
    count = self.num_surface_points
    if count >= total:
        return np.arange(total)
    return np.random.choice(total, size=count, replace=False, p=w)
```

### 3. Cache curvature weights in `DrivAerMLSurfaceDataset.__init__` or on first call

Add a lazy property to `DrivAerMLSurfaceDataset`:

```python
@property
def _curvature_weights(self):
    if not hasattr(self, '_curvature_weights_cache'):
        # Load xyz and normals from the dataset
        # surface_x shape: [N, 7] = [xyz(3), normals(3), area(1)]
        surface_x = self._load_surface_x()  # use existing load method
        xyz = surface_x[:, :3]
        normals = surface_x[:, 3:6]
        self._curvature_weights_cache = _compute_surface_curvature_weights(xyz, normals, k=8)
    return self._curvature_weights_cache
```

If the dataset loads per-case (not a single global surface), compute weights per case and store in a dict keyed by case index.

### 4. Add CLI flags

In `target/train.py` argparse, add:

```python
parser.add_argument('--surface-sampling', type=str, default='train_random',
                    choices=['train_random', 'surf_curv_stratified'],
                    help='Surface point sampling strategy during training')
parser.add_argument('--surf-sampling-temp', type=float, default=0.5,
                    help='Temperature for curvature-stratified softmax sampling')
```

Pass these through to the dataset constructor.

### 5. Eval/test views unchanged

`eval_chunk` sampling mode is unchanged. Only training sampling is affected.

---

## Run Command

```bash
python target/train.py \
  --surface-sampling surf_curv_stratified \
  --surf-sampling-temp 0.5 \
  --wandb_group h133-curv-stratified \
  [all other H112 canonical flags]
```

---

## Kill Gates

| Epoch | Metric | Kill if |
|---|---|---|
| EP1 (~step 10864) | val_abupt | ≥ 7.0% |
| EP3 (~step 32592) | val_abupt | > 6.5% |

---

## Expected Outcome

- val_abupt < 6.1358% (beat H112 merge gate)
- test_WSS ≤ 6.727% (beat current best)
- val_WSS_z improves more than val_WSS_x vs H112 (mechanism validation)
- val→test WSS slope does NOT flip sign (generalization healthy)

