### PR TITLE
H-B2: Detached aux log-magnitude WSS head — gradient stop on backbone

### DIFF
--- a/model.py
+++ b/model.py
@@ -538,6 +538,22 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
+        # H-B2 (PR #1320): Auxiliary log-magnitude WSS head with DETACHED
+        # gradient. Predicts log(1 + ||tau||) per surface point. The detach
+        # at the input (in forward) prevents aux-loss gradients from flowing
+        # into the backbone, so the backbone remains shaped only by the
+        # primary rel_l2 loss (preserving H112's OOD generalization). The
+        # head itself still trains end-to-end as a diagnostic probe.
+        # Final layer zero-ish-init so aux loss is small at step 0 and
+        # train-start trajectory matches H112.
+        self.aux_log_mag_head = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden // 2),
+            nn.SiLU(),
+            nn.Linear(n_hidden // 2, 1),
+        )
+        nn.init.normal_(self.aux_log_mag_head[-1].weight, std=1e-3)
+        nn.init.zeros_(self.aux_log_mag_head[-1].bias)
+
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
         # Bridges geometry-aware surface features into the volume decoder
@@ -662,9 +678,16 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            # H-B2: aux head consumes a DETACHED copy of surface_hidden so its
+            # gradient cannot flow back into the backbone. The aux head's own
+            # weights still receive gradients from the aux loss term.
+            aux_log_mag_preds = self.aux_log_mag_head(
+                surface_hidden.detach()
+            ) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
+            aux_log_mag_preds = volume_hidden.new_zeros(batch_size, 0, 1)
 
         if volume_x is not None:
             volume_preds = self.volume_out(volume_hidden) * volume_mask.unsqueeze(-1)
@@ -675,6 +698,7 @@ class SurfaceTransolver(nn.Module):
         return {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
+            "aux_log_mag_preds": aux_log_mag_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,

--- a/train.py
+++ b/train.py
@@ -356,12 +356,28 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
+        # H-B2 (PR #1320): detached auxiliary log-magnitude WSS loss. The model
+        # already detaches surface_hidden before this head, so the gradient
+        # only updates the aux head itself — the backbone stays purely shaped
+        # by the primary rel_l2 loss. lambda=0.1 so the primary loss
+        # dominates the scalar `loss` at every step.
+        aux_log_mag_loss = surface_target.new_zeros(())
+        if "aux_log_mag_preds" in out and out["aux_log_mag_preds"].shape[1] > 0:
+            tau_target = surface_target[..., 1:4]
+            log_mag_target = torch.log1p(
+                torch.linalg.norm(tau_target, dim=-1, keepdim=True)
+            )
+            aux_log_mag_loss = masked_mse(
+                out["aux_log_mag_preds"], log_mag_target, batch.surface_mask
+            )
+            loss = loss + 0.1 * aux_log_mag_loss
     return loss, {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
+        "aux_log_mag_loss": float(aux_log_mag_loss.detach().cpu().item()),
     }
 
 
@@ -1092,6 +1108,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "aux_log_mag_loss" in batch_loss_metrics:
+                        train_log["train/aux_log_mag_loss"] = batch_loss_metrics["aux_log_mag_loss"]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**H-B2: Detached auxiliary log-magnitude WSS head — gradient stop on backbone, aux head trains independently.**

H-B (PR #1307) added an auxiliary `log(1 + ||τ||)` head that achieved **val_abupt=6.1288%** (BEAT merge gate by 0.007pp), but **test_WSS=6.7974%** (+0.045pp REGRESSION vs H112 6.752%). The same val→test catastrophe pattern seen in H120, H121, H125, H128.

**Root cause analysis (H-B):** The auxiliary loss gradient propagated into the backbone, adding a training-distribution-specific magnitude calibration signal. This reshaped backbone features to better predict in-distribution magnitude patterns, but hurt OOD (test) generalization — the backbone learned to rely on ID magnitude cues that don't transfer.

**H-B2 fix — gradient stop (detach):** The aux head still predicts `log(1 + ||τ||)`, still gets trained, but the loss does **NOT** propagate into the backbone:

```python
# H-B: aux head learned from backbone gradients (FAILED — val→test catastrophe)
aux_log_mag = self.aux_log_mag_head(surface_hidden)

# H-B2: gradient stop — backbone is frozen w.r.t. aux loss
aux_log_mag = self.aux_log_mag_head(surface_hidden.detach())
```

The aux head now acts as a **diagnostic probe** — it trains to predict WSS magnitude, but the backbone features remain shaped only by the primary rel_l2 loss. This preserves H112's proven OOD generalization while answering the scientific question: can a detached magnitude head provide implicit regularization benefits?

**Mechanism hypothesis:** Even with detached gradients, the aux head's presence may provide training-time benefits via:
1. Shared optimizer state (Lion β momentum) — the optimizer tracks the `surface_hidden.detach()` activation patterns, providing soft implicit smoothing
2. The detached probe still computes `log_mag_target` from the same ground-truth labels, so it provides a numerical sanity check on the training run
3. Most importantly: the backbone is now **purely primary-loss-driven** — removing any risk of ID calibration signal

**Falsifiable prediction:**
- If detached: val_abupt ≈ H112 (±0.02pp) AND test_WSS ≈ H112 (±0.02pp) → aux head is inert, close C NULL
- If detached AND val/test improves: the aux head provides implicit regularization through a mechanism we haven't identified (worth following up on)
- If detached AND val improves but test still regresses: the improvement is from init-variance noise, not mechanism → close C NULL

**This is a single character change** (`surface_hidden` → `surface_hidden.detach()`) vs H-B. Single experimental flag, canonical H112 recipe otherwise.

**Why this is NOT in any exhausted class:**
- NOT capacity-axis (no hidden/depth change)
- NOT loss-form on primary decoder (only aux head is modified)
- NOT target reparameterization (primary target unchanged)
- NOT SP-axis (H113-H117 exhausted SP; this tests WSS magnitude probe)

---

## Instructions

### Step 1: Implement the H-B aux head (same as PR #1307, with ONE modification)

Add a parallel log-magnitude prediction head to `target/model.py`:

In the `__init__` of the Transolver model (after `self.surface_out` is defined, around line 528):

```python
# H-B2: Auxiliary log-magnitude WSS head (DETACHED gradient)
# Predicts log(1 + ||tau||) per surface point.
# Gradient is STOPPED at surface_hidden.detach() — backbone not affected.
self.aux_log_mag_head = nn.Sequential(
    nn.Linear(n_hidden, n_hidden // 2),
    nn.SiLU(),
    nn.Linear(n_hidden // 2, 1),
)
# Zero-init final layer: aux loss is near-zero at init → train-start behavior identical to H112
nn.init.normal_(self.aux_log_mag_head[-1].weight, std=1e-3)
nn.init.zeros_(self.aux_log_mag_head[-1].bias)
```

In `target/model.py` forward pass, after line 664 (`surface_preds = self.surface_out(surface_hidden) * ...`):

```python
# Detached aux head: gradient stop prevents backbone contamination (H-B2)
aux_log_mag_preds = self.aux_log_mag_head(surface_hidden.detach()) * surface_mask.unsqueeze(-1)
```

Add `aux_log_mag_preds` to the return dict:
```python
return {
    "surface_preds": surface_preds,
    "volume_preds": volume_preds,
    "aux_log_mag_preds": aux_log_mag_preds,  # NEW: (B, N, 1) detached probe
    "hidden": hidden,
    "surface_hidden": surface_hidden,
    "volume_hidden": volume_hidden,
}
```

### Step 2: Add aux loss in `target/train.py`

In the `compute_loss` function (or wherever `out["surface_preds"]` is used), add:

```python
# H-B2 auxiliary log-magnitude loss (DETACHED — no backbone gradient)
if "aux_log_mag_preds" in out:
    tau_target = surface_target[..., 1:4]  # tau_x, tau_y, tau_z channels
    log_mag_target = torch.log1p(
        torch.norm(tau_target, dim=-1, keepdim=True)
    )  # (B, N, 1)
    aux_loss_val = masked_mse(
        out["aux_log_mag_preds"], log_mag_target, batch.surface_mask
    )
    # aux_loss_weight=0.1: small, so primary loss dominates at all steps
    loss = loss + 0.1 * aux_loss_val
    loss_metrics["aux_log_mag_loss"] = float(aux_loss_val.detach().cpu().item())
```

Log `train/aux_log_mag_loss` to W&B alongside the other per-batch metrics.

### Step 3: No CLI flags needed

The aux head is **always on** for this experiment (single arm). No CLI flag plumbing required — simpler implementation, no risk of flag typos. The detach is hardcoded.

**IMPORTANT**: Verify `masked_mse` is importable from the same module or copy the pattern from the existing tau_z loss computation.

### Step 4: Recipe

Use **exactly H112's canonical recipe** with **NO changes** except the model code above:

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name alphonse/h-b2-detached-aux-log-mag \
  --wandb-group tay-wave38-detached-aux-probe
```

Kill thresholds (global_step indexed, NOT epoch):
- Step 10862 (EP1): val_abupt < 35.0% — cold-start fence (aux head zero-init should clear this easily)
- Step 32592 (EP3): val_abupt < 8.5% — binding gate
- Step 48897 (EP6): val_abupt < 7.0% — confirmation gate

---

## Baseline

**Current single-model SOTA (`tay`):** PR #1283 H112 DropPath (W&B run `u9ue2ryb`, EMA EP13)

| Metric | H112 baseline | Target |
|---|---:|---:|
| val_abupt | **6.1358%** | < 6.1358% (merge gate) |
| test_abupt | 5.839% | — |
| val_WSS | 6.9670% | — |
| val_WSS_x | 6.0923% | — |
| val_WSS_z | 9.3750% | — |
| **test_WSS** | **6.752%** | **≤ 6.727%** (paper floor) |
| test_VP | 3.421% | ≤ 3.643% |
| test_SP | 3.695% | ≤ 3.577% |

**H-B comparison (PR #1307, CLOSED C NULL):**

| Metric | H-B (aux head, NO detach) | Delta vs H112 |
|---|---:|---:|
| val_abupt | 6.1288% | −0.007pp (A WIN val) |
| **test_WSS** | **6.7974%** | **+0.045pp REGRESSION** |
| test_VP | 3.452% | +0.031pp |
| test_SP | 3.580% | −0.115pp |

H-B's val WIN was a val→test catastrophe. H-B2's detach aims to reproduce H112's test generalization while probing whether the aux head adds any benefit.

**Primary objective:** test_WSS < 5.85% (Transolver-3 SOTA, per Morgan Issue #1056). Single-model gap = 0.902pp from H112.

---

## Required diagnostics in PR comment

Post these at each check-in (EP3, EP6, EP10, EP13):

1. **val_WSS_x / val_WSS_z delta vs H112** — mechanism probe: is the detached head shifting directional WSS representation?
2. **aux_log_mag_loss trajectory** — should decrease monotonically; spike = training instability
3. **val_abupt vs H112 EP-by-EP** — early divergence from H112 baseline indicates backbone contamination (detach failed or wrong code path)
4. **Final test breakdown: test_WSS_x / test_WSS_y / test_WSS_z**

**Expected outcome:** val_abupt ≈ H112 (±0.02pp at each EP gate) and test_WSS ≈ H112. If this is confirmed, the aux head is inert under detach — that is scientifically informative (proves H-B's regression was backbone contamination, not coincidence).

---

**Owner:** alphonse
**Wave:** 38 (WSS-axis — detached gradient probe)
**Effort estimate:** ~25 lines (model aux head + detach + train.py aux loss)
**Wall-clock estimate:** ~14-15h (canonical 13ep at DDP 8×H100)
**Group:** `tay-wave38-detached-aux-probe`
