### PR TITLE
H134: SwiGLU param-parity (mlp_ratio=3) — isolate gating vs capacity

### DIFF
--- a/model.py
+++ b/model.py
@@ -252,6 +252,30 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SwiGluMlp(nn.Module):
+    """SwiGLU MLP: down_proj(SiLU(gate_proj(x)) * value_proj(x)).
+
+    Drop-in for UpActDownMlp matching its (hidden_dim, mlp_hidden_dim) signature.
+    Per-block param count is 3 * hidden_dim * mlp_hidden_dim, so use mlp_ratio=3
+    for near-parity with the GELU mlp_ratio=4 baseline (8 -> 9 d_model**2).
+    down_proj weight is zero-initialised so the residual stream is identity at
+    init, matching the safe cold-start pattern used elsewhere in this model.
+    """
+
+    def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_dim, mlp_hidden_dim, bias=False)
+        self.value_proj = nn.Linear(hidden_dim, mlp_hidden_dim, bias=False)
+        self.down_proj = nn.Linear(mlp_hidden_dim, hidden_dim, bias=False)
+        self.act = nn.SiLU()
+        _init_linear(self.gate_proj)
+        _init_linear(self.value_proj)
+        nn.init.zeros_(self.down_proj.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act(self.gate_proj(x)) * self.value_proj(x))
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -330,6 +354,7 @@ class TransformerBlock(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_prob: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -342,7 +367,10 @@ class TransformerBlock(nn.Module):
             use_qk_norm=use_qk_norm,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if use_swiglu_mlp:
+            self.mlp = SwiGluMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        else:
+            self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
         self.drop_path_attn = DropPath(drop_path_prob)
         self.drop_path_mlp = DropPath(drop_path_prob)
 
@@ -366,6 +394,7 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_max: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         if depth > 1:
@@ -383,6 +412,7 @@ class Transformer(nn.Module):
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
                     drop_path_prob=drop_path_probs[i],
+                    use_swiglu_mlp=use_swiglu_mlp,
                 )
                 for i in range(depth)
             ]
@@ -419,6 +449,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_swiglu_mlp: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +465,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_swiglu_mlp = use_swiglu_mlp
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -511,6 +543,7 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
             drop_path_max=drop_path_max,
+            use_swiglu_mlp=use_swiglu_mlp,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -95,6 +95,7 @@ class Config:
     model_hidden_dim: int = 192
     model_heads: int = 3
     model_mlp_ratio: int = 4
+    use_swiglu_mlp: bool = False
     model_slices: int = 96
     model_dropout: float = 0.0
     rff_num_features: int = 0
@@ -238,6 +239,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_swiglu_mlp": (
+            "H134: Replace the GELU UpActDownMlp in each TransformerBlock "
+            "with a SwiGLU MLP (down(SiLU(gate(x)) * value(x))). Per-block "
+            "param count becomes 3 * d_model * mlp_hidden_dim (vs 2 * d * h "
+            "for GELU), so pair with --model-mlp-ratio 3 for near-parity "
+            "with the GELU mlp_ratio=4 baseline. down_proj is zero-initialised "
+            "so the residual stream is identity at step 0."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -318,6 +327,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_swiglu_mlp=config.use_swiglu_mlp,
     )
 
 
@@ -893,6 +903,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["model/use_swiglu_mlp"] = config.use_swiglu_mlp
+            wandb.summary["model/mlp_ratio"] = config.model_mlp_ratio
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [


### PR DESCRIPTION
## Hypothesis

H128 (SwiGLU at mlp_ratio=4) showed a striking per-channel finding: WSS_z val→test slope was **−0.634pp** (~3× H112's ~−0.200pp), but overall test_WSS **regressed** (+30% param count created a generalization deficit that overwhelmed the gating benefit). The mechanism — multiplicative gating helping high-shear WSS_z prediction — appears real but was confounded by the capacity increase.

H134 tests whether the WSS_z slope benefit persists at **H112-equivalent parameter count** using mlp_ratio=3 with SwiGLU. Param math:
- GELU mlp_ratio=4: 2 × d × (4d) = **8d²** params per MLP block (H112 baseline)
- SwiGLU mlp_ratio=3: (gate + value + down) × d × (3d) = **9d²** (+12% per block, vs +50% at mlp_ratio=4)
- Exact parity requires mlp_ratio=2.67; mlp_ratio=3 is the nearest integer — minimal capacity overhead

Falsifiable prediction: val_abupt ≤ 6.1358% (merge gate) and test_WSS ≤ 6.727% (beat H112) within H112 capacity class. If WSS_z slope remains −0.600pp+ while test_WSS improves → mechanism confirmed, proceed to mlp_ratio=2 for tighter parity. If WSS_z slope collapses → gating benefit was capacity-dependent, not architectural.

## Instructions

This is a **single-flag change** from H128. The `SwiGluMlp` class and `--use-swiglu-mlp` flag already exist in `target/model.py` and `target/train.py` from H128. Only change: `--model-mlp-ratio 4` → `--model-mlp-ratio 3`.

No code changes needed — run the following command directly:

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 3 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --use-swiglu-mlp \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name edward/h134-swiglu-param-parity \
  --wandb-group tay-wave38-swiglu-parity
```

**Key difference vs H128**: `--model-mlp-ratio 3` (was 4). Everything else is identical.

**Approximate model size**: ~19.5M params vs H112's ~17.4M params (~+12% overhead, down from +50% in H128).

**In your results comment, please report per-channel WSS slopes**:
- val_WSS_z, test_WSS_z, slope (val−test)
- val_WSS_x, test_WSS_x, slope
- val_WSS_y, test_WSS_y, slope
This decomposition is critical for understanding whether the SwiGLU gating mechanism is genuinely helping WSS_z.

## Kill gates

- **EP1** (step ≥ 10862): kill if `val_primary/abupt_axis_mean_rel_l2_pct` ≥ 35.0%
- **EP3** (step ≥ 32592): kill if ≥ 8.5%
- **EP6** (step ≥ 48897): kill if ≥ 7.0%

## Baseline

Current single-model SOTA: **PR #1283 H112 DropPath** (W&B run: `u9ue2ryb`)

| Metric | H112 (baseline) | H128 (SwiGLU ratio=4) |
|---|---|---|
| val_abupt | 6.1358% | ~6.17% (C NULL) |
| val_WSS_z | 9.3750% | ~9.352% |
| test_WSS | 6.752% | ~6.8xx% (regression) |
| test_WSS_z | 8.720% | 8.986% |
| test_WSS_z slope | ~−0.200pp | **−0.634pp** |
| test_VP | 3.421% | — |
| test_SP | 3.695% | — |

Merge gate: val_abupt < **6.1358%** AND test_abupt < **5.839%**
Test floors: test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ **6.727%**

H112 reproduce:
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint
```
