### PR TITLE
H135: SwiGLU decoder-only surface head — isolate gating to prediction

### DIFF
--- a/model.py
+++ b/model.py
@@ -252,6 +252,22 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SwiGluMlpDecoder(nn.Module):
+    """SwiGLU decoder head: down_proj(SiLU(gate_proj(x)) * value_proj(x)).
+    Drop-in for surface_out Sequential. Same interface: Linear(in_dim -> out_dim)."""
+
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(in_dim, hidden_dim, bias=False)
+        self.value_proj = nn.Linear(in_dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, out_dim)
+        self.act = nn.SiLU()
+        self.apply(_init_linear)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act(self.gate_proj(x)) * self.value_proj(x))
+
+
 class TransolverAttention(nn.Module):
     def __init__(
         self,
@@ -418,6 +434,7 @@ class SurfaceTransolver(nn.Module):
         use_qk_norm: bool = False,
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
+        use_swiglu_surface_decoder: bool = False,
         drop_path_max: float = 0.0,
     ):
         super().__init__()
@@ -520,12 +537,21 @@ class SurfaceTransolver(nn.Module):
             # n_hidden -> n_hidden//2 -> n_hidden//4 -> volume_output_dim with SiLU.
             # Default for current training; older checkpoints (PR #823 era,
             # e.g. ghh0s4ne) set this False to load LinearProjection heads.
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, n_hidden),
-                nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
-            )
-            self.surface_out.apply(_init_linear)
+            if use_swiglu_surface_decoder:
+                # H135: SwiGLU gating in the surface decoder head only.
+                # +1.5% param overhead vs baseline (+262K / ~17.4M total).
+                self.surface_out = SwiGluMlpDecoder(
+                    in_dim=n_hidden,
+                    hidden_dim=n_hidden,
+                    out_dim=self.surface_output_dim,
+                )
+            else:
+                self.surface_out = nn.Sequential(
+                    nn.Linear(n_hidden, n_hidden),
+                    nn.SiLU(),
+                    nn.Linear(n_hidden, self.surface_output_dim),
+                )
+                self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden // 2),
                 nn.SiLU(),

--- a/train.py
+++ b/train.py
@@ -95,6 +95,7 @@ class Config:
     model_hidden_dim: int = 192
     model_heads: int = 3
     model_mlp_ratio: int = 4
+    use_swiglu_surface_decoder: bool = False
     model_slices: int = 96
     model_dropout: float = 0.0
     rff_num_features: int = 0
@@ -317,6 +318,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pos_encoding_mode=config.pos_encoding_mode,
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
+        use_swiglu_surface_decoder=config.use_swiglu_surface_decoder,
         drop_path_max=config.drop_path_max,
     )
 


### PR DESCRIPTION
## Hypothesis

H128 (SwiGLU in all transformer MLP blocks) showed WSS_z val→test slope of **−0.634pp** (~3× H112's −0.200pp), but overall test_WSS regressed due to the +30% capacity increase confounding the gating mechanism. H134 (concurrent, edward) tests param-parity with mlp_ratio=3 in all blocks.

H135 takes a complementary approach: apply SwiGLU gating **only in the surface decoder head** (`self.surface_out`), leaving the backbone transformer blocks unchanged (GELU). The rationale:

1. **The decoder head directly predicts WSS channels** (tau_x, tau_y, tau_z). It is the final transformation before loss computation. If SwiGLU's multiplicative gating helps WSS_z, the surface head is the most targeted site.
2. **Near-zero param overhead**: Current `surface_out` is `Linear(512, 512) → SiLU → Linear(512, 4)` = 512×512 + 512×4 = 264,192 params. Replacing with SwiGLU `[gate(512→512) + value(512→512)] → down(512→4)` = 512×512 × 2 + 512×4 = 526,336 params. **+262K / ~17.4M total = +1.5% overhead**.
3. **Clean isolation**: If this wins and H134 also wins, the combination (both backbone and head) becomes the natural next step. If only one wins, we know which site carries the mechanism.

Falsifiable prediction: val_abupt ≤ 6.1358% AND test_WSS ≤ 6.727%, with WSS_z slope ≥ −0.300pp (above H112's −0.200pp). If slope is flat like H128's WSS_x → gating benefit is not decoder-head-localizable.

## Instructions

This requires adding a new `--use-swiglu-surface-decoder` flag. The changes are minimal and surgical:

### 1. Add `SwiGluMlpDecoder` class to `target/model.py` (after the `UpActDownMlp` class, around line 253):

```python
class SwiGluMlpDecoder(nn.Module):
    """SwiGLU decoder head: down_proj(SiLU(gate_proj(x)) * value_proj(x)).
    Drop-in for surface_out Sequential. Same interface: Linear(in_dim -> out_dim)."""

    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int):
        super().__init__()
        self.gate_proj = nn.Linear(in_dim, hidden_dim, bias=False)
        self.value_proj = nn.Linear(in_dim, hidden_dim, bias=False)
        self.down_proj = nn.Linear(hidden_dim, out_dim)
        self.act = nn.SiLU()
        self.apply(_init_linear)

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        return self.down_proj(self.act(self.gate_proj(x)) * self.value_proj(x))
```

### 2. Add `use_swiglu_surface_decoder: bool = False` to `SurfaceTransolver.__init__` signature (around line 421):

```python
def __init__(
    self,
    *,
    ...
    use_aux_decoder_heads: bool = True,
    use_swiglu_surface_decoder: bool = False,   # <-- add this
    drop_path_max: float = 0.0,
):
```

### 3. Replace the `self.surface_out` construction in `SurfaceTransolver.__init__` (around lines 523-528). Find this block:

```python
if use_aux_decoder_heads:
    ...
    self.surface_out = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.SiLU(),
        nn.Linear(n_hidden, self.surface_output_dim),
    )
    self.surface_out.apply(_init_linear)
```

Replace with:

```python
if use_aux_decoder_heads:
    ...
    if use_swiglu_surface_decoder:
        self.surface_out = SwiGluMlpDecoder(
            in_dim=n_hidden,
            hidden_dim=n_hidden,
            out_dim=self.surface_output_dim,
        )
    else:
        self.surface_out = nn.Sequential(
            nn.Linear(n_hidden, n_hidden),
            nn.SiLU(),
            nn.Linear(n_hidden, self.surface_output_dim),
        )
        self.surface_out.apply(_init_linear)
```

### 4. Add `use_swiglu_surface_decoder: bool = False` to Config dataclass in `target/train.py` (after `model_mlp_ratio`, around line 97):

```python
model_mlp_ratio: int = 4
use_swiglu_surface_decoder: bool = False   # <-- add this
```

### 5. Pass the flag in `build_model()` in `target/train.py` (around line 320):

```python
def build_model(config: Config) -> SurfaceTransolver:
    return SurfaceTransolver(
        ...
        use_qk_norm=config.use_qk_norm,
        use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
        use_swiglu_surface_decoder=config.use_swiglu_surface_decoder,  # <-- add this
        drop_path_max=config.drop_path_max,
    )
```

### 6. Run with this command (H112 recipe + `--use-swiglu-surface-decoder`):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --use-swiglu-surface-decoder \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  --wandb-name thorfinn/h135-swiglu-decoder-only \
  --wandb-group tay-wave38-swiglu-parity
```

**Important**: The backbone uses GELU (mlp_ratio=4, no SwiGLU in transformer blocks). Only `surface_out` uses SwiGLU. This is the isolation test.

**In your results comment, please report per-channel WSS slopes**:
- val_WSS_z, test_WSS_z, slope (val−test)
- val_WSS_x, test_WSS_x, slope
- val_WSS_y, test_WSS_y, slope
This decomposition lets us determine if WSS_z improvement localizes to the decoder head.

## Kill gates

- **EP1** (step ≥ 10862): kill if `val_primary/abupt_axis_mean_rel_l2_pct` ≥ 35.0%
- **EP3** (step ≥ 32592): kill if ≥ 8.5%
- **EP6** (step ≥ 48897): kill if ≥ 7.0%

## Baseline

Current single-model SOTA: **PR #1283 H112 DropPath** (W&B run: `u9ue2ryb`)

| Metric | H112 (baseline) | H128 (SwiGLU all blocks ratio=4) |
|---|---|---|
| val_abupt | 6.1358% | ~6.17% (C NULL, gate miss) |
| val_WSS_z | 9.3750% | ~9.352% |
| test_WSS | 6.752% | ~6.8xx% (regression) |
| test_WSS_z | 8.720% | 8.986% |
| test_WSS_z slope | ~−0.200pp | **−0.634pp** (~3× better) |
| test_VP | 3.421% | — |
| test_SP | 3.695% | — |

Merge gate: val_abupt < **6.1358%** AND test_abupt < **5.839%**
Test floors: test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ **6.727%**

H112 reproduce:
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint
```
