### PR TITLE
H138 askeladd: split WSS_z decoder head (dedicated wider head for tau_z)

### DIFF
--- a/model.py
+++ b/model.py
@@ -419,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_split_wss_z_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +435,16 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_split_wss_z_decoder = use_split_wss_z_decoder
+        if use_split_wss_z_decoder and self.surface_output_dim != 4:
+            raise ValueError(
+                "use_split_wss_z_decoder requires surface_output_dim=4 "
+                "(cp, tau_x, tau_y, tau_z)"
+            )
+        # Surface main-head output dim (3 channels when split, else full).
+        main_surface_out_dim = (
+            self.surface_output_dim - 1 if use_split_wss_z_decoder else self.surface_output_dim
+        )
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -523,7 +534,7 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(n_hidden, main_surface_out_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -535,8 +546,22 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_out = LinearProjection(n_hidden, main_surface_out_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        if use_split_wss_z_decoder:
+            # H138: dedicated wider 2-layer MLP for tau_z (wall-shear z component).
+            # n_hidden -> n_hidden*2 -> 1 with SiLU. Output concatenated with the
+            # 3-channel surface_out [cp, tau_x, tau_y] to restore the 4-channel
+            # contract expected by the loss / eval code.
+            self.wss_z_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden * 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden * 2, 1),
+            )
+            self.wss_z_out.apply(_init_linear)
+        else:
+            self.wss_z_out = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -661,7 +686,11 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            if self.wss_z_out is not None:
+                wss_z_preds = self.wss_z_out(surface_hidden)
+                surface_preds = torch.cat([surface_preds, wss_z_preds], dim=-1)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_split_wss_z_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -318,6 +319,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_split_wss_z_decoder=config.use_split_wss_z_decoder,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H138 — Split WSS_z decoder head**: A dedicated, wider decoder for the tau_z channel (wall shear stress in the z/vertical direction) should improve WSS_z prediction without harming the other surface channels.

**Rationale**: WSS_z is the hardest channel in the DrivAerML task. H112 achieves test_WSS_z=8.720% vs test_WSS_x=5.999% and test_WSS_y=7.360%. WSS_z captures vertical boundary-layer gradients and near-wake separation physics that are geometrically distinct from the streamwise (x) and spanwise (y) components. By splitting tau_z into its own dedicated wider head, we give the model independent capacity to learn the z-shear pattern without representation pressure from the [cp, tau_x, tau_y] signals that share the existing surface_out MLP. This is architecturally analogous to multi-task learning head specialization — a proven technique when output subtasks differ substantially in geometric structure.

**Prior evidence**: On the dl24 branch, H41 (Charbonnier loss on WSS_y+z) improved WSS_z slope by >0.3pp. That experiment changed the loss form; this experiment changes the model capacity allocation. The two hypotheses are orthogonal — both may stack.

**Mechanism**: The base `surface_out` head predicts [cp, tau_x, tau_y] (3 channels). A new `wss_z_out` head (wider: n_hidden → n_hidden×2 → 1) predicts tau_z independently. Outputs are concatenated at forward time to reconstruct the full 4-channel prediction. Zero change to the backbone; only the final decoder is split. Parameter overhead: ~+262K (+1.5%).

**Falsifiable prediction**: val_abupt ≤ 6.1358%, test_WSS ≤ 6.727%, test_WSS_z ≤ 8.720% (i.e., improvement on tau_z without regressing overall).

---

## Instructions

**Step 1 — Add flag to `target/model.py`**

In `SurfaceTransolver.__init__`, add `use_split_wss_z_decoder: bool = False` to the signature.

When `use_split_wss_z_decoder=True`:
- Change `self.surface_output_dim` effective output for `surface_out` to 3 (predicts [cp, tau_x, tau_y])
- Add a dedicated wider head:
```python
self.wss_z_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden * 2),
    nn.SiLU(),
    nn.Linear(n_hidden * 2, 1),
)
self.wss_z_out.apply(_init_linear)
```
- Store `self.use_split_wss_z_decoder = use_split_wss_z_decoder`

The existing `surface_out` head should produce only 3 channels when the flag is True. Update the construction block to use `out_dim=3` for the surface_out when split mode is enabled.

In the `forward` method, after computing `surface_pred` from the shared backbone features, if `use_split_wss_z_decoder`:
```python
wss_z_pred = self.wss_z_out(surface_features)  # [B*N, 1]
surface_pred = torch.cat([surface_pred, wss_z_pred], dim=-1)  # [B*N, 4]
```
This restores the 4-channel output contract expected by the loss and eval code.

**Step 2 — Add flag to `target/train.py`**

In the `Config` dataclass, add:
```python
use_split_wss_z_decoder: bool = False
```

Pass this through to `SurfaceTransolver(...)`:
```python
use_split_wss_z_decoder=cfg.use_split_wss_z_decoder,
```

**Step 3 — Training recipe**

Use the full H112 baseline recipe with only the split decoder flag added. No other changes.

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent askeladd --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --use-split-wss-z-decoder \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --wandb-name askeladd/h138-split-wss-z-decoder \
  --wandb-group wss_h138_split_wss_z_decoder \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct>35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0"
```

**Kill gates:**
- EP1 (step ≥ 10,862): val_abupt ≥ 35.0% → kill
- EP3 (step ≥ 32,592): val_abupt ≥ 8.5% → kill
- EP6 (step ≥ 48,897): val_abupt ≥ 7.0% → kill

**EP1 progress reporting** (step ~10,862): Post val_abupt value as a PR comment.

**Terminal result**: When training completes at EP13 or is killed, run full eval against test set from best checkpoint and report all metrics. Post a `SENPAI-RESULT` marker.

---

## Baseline

**Current single-model SOTA:** PR #1283 H112 DropPath

| Metric | val | test |
|---|---|---|
| abupt | 6.1358% | 5.839% |
| VP | 3.5478% | 3.421% |
| SP | 4.0553% | 3.695% |
| WSS | 6.9670% | 6.752% |
| WSS_x | 6.0923% | 5.999% |
| WSS_y | 7.6084% | 7.360% |
| WSS_z | 9.3750% | 8.720% |

**W&B baseline run:** `u9ue2ryb`  
**Merge gate:** val_abupt < 6.1358% AND test_abupt < 5.839%  
**Test floors (AND-gate):** test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%  
**Primary objective:** test_WSS < 5.85% (Transolver-3 SOTA gap: 0.902pp)

**H138 specific success criteria:** test_WSS_z ≤ 8.720% (improve or match H112 WSS_z without regressing WSS overall)
