### PR TITLE
H139 tanjiro: Charbonnier loss on tau_z channel (robust M-estimator)

### DIFF
--- a/launch_h139.sh
+++ b/launch_h139.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+export SENPAI_TIMEOUT_MINUTES=1100
+exec torchrun --standalone --nproc-per-node=8 train.py \
+    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+    --manifest data/split_manifest.json \
+    --epochs 13 --batch-size 4 \
+    --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
+    --model-slices 128 --model-dropout 0.0 \
+    --drop-path-max 0.10 \
+    --train-surface-points 65536 --eval-surface-points 65536 \
+    --train-volume-points 16384 --eval-volume-points 65536 \
+    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
+    --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
+    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
+    --use-charb-tau-z --charb-tau-z-eps 1e-3 \
+    --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
+    --use-ema --ema-decay 0.999 --ema-start-step 50 \
+    --use-surf-to-vol-xattn \
+    --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
+    --weight-decay 5e-4 --grad-clip-norm 0.5 \
+    --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
+    --amp-mode bf16 --no-compile-model \
+    --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
+    --wandb-name tanjiro/h139-charb-tau-z \
+    --wandb-group wss_h139_charb_tau_z \
+    --agent tanjiro

--- a/launch_h139.sh
+++ b/launch_h139.sh
@@ -21,7 +21,7 @@ exec torchrun --standalone --nproc-per-node=8 train.py \
     --weight-decay 5e-4 --grad-clip-norm 0.5 \
     --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
     --amp-mode bf16 --no-compile-model \
-    --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35,32594:val_primary/abupt_axis_mean_rel_l2_pct<8.5,65228:val_primary/abupt_axis_mean_rel_l2_pct<6.7" \
+    --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct<35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
     --wandb-name tanjiro/h139-charb-tau-z \
     --wandb-group wss_h139_charb_tau_z \
     --agent tanjiro

--- a/train.py
+++ b/train.py
@@ -106,6 +106,8 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    use_charb_tau_z: bool = False
+    charb_tau_z_eps: float = 1e-3
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -331,6 +333,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    charb_tau_z_eps: float | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -348,6 +351,7 @@ def train_loss(
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
+                charb_tau_z_eps=charb_tau_z_eps,
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
@@ -766,7 +770,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             dtype=torch.float32,
         )
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
+            or config.use_charb_tau_z
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -893,6 +899,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_charb_tau_z"] = config.use_charb_tau_z
+            wandb.summary["loss/charb_tau_z_eps"] = config.charb_tau_z_eps
+            if config.use_charb_tau_z:
+                print(
+                    f"H139 Charbonnier tau_z: eps={config.charb_tau_z_eps} "
+                    f"(replaces squared error on channel 3 within "
+                    f"weighted_channel_mse; tau_z_loss_weight="
+                    f"{config.tau_z_loss_weight} preserved)"
+                )
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1052,6 +1067,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        charb_tau_z_eps=(
+                            config.charb_tau_z_eps if config.use_charb_tau_z else None
+                        ),
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -842,6 +842,7 @@ def weighted_channel_mse(
     target: torch.Tensor,
     mask: torch.Tensor,
     weights: torch.Tensor,
+    charb_tau_z_eps: float | None = None,
 ) -> torch.Tensor:
     """Per-channel weighted masked MSE with a single mean over all entries.
 
@@ -852,6 +853,13 @@ def weighted_channel_mse(
     and only changes the relative gradient budget across channels — it does NOT
     decompose into per-channel means (which would double-weight the smaller
     channels and was the failure mode of PR #353).
+
+    H139: when ``charb_tau_z_eps`` is not None, the per-element error on the
+    last channel (tau_z, index 3 for the 4-channel surface output) is replaced
+    by the Charbonnier residual ``sqrt(r**2 + eps**2) - eps`` instead of
+    squared error. All other channels and the weighting/denominator structure
+    are unchanged so the relative gradient budget across channels stays at the
+    weighted level set by ``weights``.
     """
     if pred.numel() == 0:
         return pred.sum() * 0.0
@@ -860,9 +868,22 @@ def weighted_channel_mse(
         raise ValueError(
             f"weights last-dim {weights_dev.shape[-1]} must equal pred last-dim {pred.shape[-1]}"
         )
-    sq_err = (pred - target).square()
+    residual = pred - target
+    if charb_tau_z_eps is not None:
+        if pred.shape[-1] < 4:
+            raise ValueError(
+                f"Charbonnier tau_z requires last-dim >= 4, got {pred.shape[-1]}"
+            )
+        eps = float(charb_tau_z_eps)
+        eps_sq = eps * eps
+        sq_err_base = residual[..., :3].square()
+        z_res = residual[..., 3:]
+        charb_z = torch.sqrt(z_res.square() + eps_sq) - eps
+        elem_err = torch.cat([sq_err_base, charb_z], dim=-1)
+    else:
+        elem_err = residual.square()
     mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
-    weighted = sq_err * weights_dev * mask_dev
+    weighted = elem_err * weights_dev * mask_dev
     valid_points = mask_dev.sum()
     denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
     if bool(valid_points.detach().cpu().item() > 0):


### PR DESCRIPTION
## Hypothesis

**H139 — Charbonnier loss on tau_z channel**: Replace MSE loss on the tau_z (WSS_z / vertical wall shear stress) channel with a Charbonnier robust M-estimator loss, keeping all other channels on MSE. This should improve WSS_z prediction — the hardest channel in the DrivAerML task.

**Rationale**: WSS_z is the weakest channel: H112 achieves test_WSS_z=8.720% vs test_WSS_x=5.999% and test_WSS_y=7.360%. The WSS_z distribution has heavy tails from near-wake separation and wheel-arch vortex regions. MSE over-weights large residuals and under-weights small background values. Charbonnier loss `L = sqrt((pred - target)^2 + eps^2) - eps` is a smooth L1-L2 hybrid: quadratic near zero (like MSE), linear in tails (robustness to outliers). This de-emphasizes catastrophic over-correction on rare extreme tau_z values while still learning the background field accurately.

**Prior evidence (dl24 H41)**: On the dl24 branch, H41 applied Charbonnier to both WSS_y and WSS_z channels. Result: WSS_z slope improved by >0.3pp. That experiment bundled two channels; this experiment isolates tau_z only, on the tay H112 baseline (which already uses `tau_z_loss_weight=2.0` as an independent amplitude amplifier). The Charbonnier and amplitude-weighting mechanisms are orthogonal — both may apply simultaneously.

**Mechanism**: Zero architectural change. Pure loss-form modification on one output channel (index 3 of the 4-channel surface output [cp, tau_x, tau_y, tau_z]). The `tau_z_loss_weight=2.0` from the H112 recipe is preserved — the Charbonnier replaces the squared error within the weighted term.

**Charbonnier loss formula**: `L_charb(r, eps) = sqrt(r^2 + eps^2) - eps` where `r = pred - target`. Default `eps=1e-3`.

**Falsifiable prediction**: val_abupt ≤ 6.1358%, test_WSS ≤ 6.727%, test_WSS_z ≤ 8.720% (improvement on tau_z without regressing overall WSS).

---

## Instructions

**Step 1 — Add flags to `target/train.py` Config dataclass**

Add two new fields:
```python
use_charb_tau_z: bool = False
charb_tau_z_eps: float = 1e-3
```

**Step 2 — Modify the surface loss computation in `target/train.py`**

Locate the training loss computation for surface outputs. The loss currently applies `tau_z_loss_weight` to channel index 3 (tau_z) of the 4-channel surface prediction. Replace the MSE for channel index 3 with Charbonnier when the flag is set.

Find the surface loss block (likely in a function like `compute_loss` or `train_step`). It should look something like:
```python
surface_loss = F.mse_loss(surface_pred, surface_target, ...)
# or with per-channel weighting applied after
```

Restructure to apply Charbonnier selectively on tau_z (channel index 3):

```python
if cfg.use_charb_tau_z:
    # Split channels: [cp, tau_x, tau_y] use MSE; tau_z uses Charbonnier
    # surface_pred and surface_target are [B*N, 4] or [B, N, 4]
    pred_base = surface_pred[..., :3]    # [cp, tau_x, tau_y]
    pred_z = surface_pred[..., 3:4]      # [tau_z]
    tgt_base = surface_target[..., :3]
    tgt_z = surface_target[..., 3:4]

    eps = cfg.charb_tau_z_eps
    loss_base = F.mse_loss(pred_base, tgt_base)
    # Charbonnier: sqrt((pred - target)^2 + eps^2) - eps
    residual_z = pred_z - tgt_z
    loss_z = (torch.sqrt(residual_z ** 2 + eps ** 2) - eps).mean()

    # Combine with the same weighting as H112
    # tau_z_loss_weight=2.0 amplifies the z term
    surface_loss = (loss_base * 3 + loss_z * cfg.tau_z_loss_weight) / (3 + cfg.tau_z_loss_weight)
else:
    surface_loss = F.mse_loss(surface_pred, surface_target)
```

**Important**: Look at how the existing loss weighting for `tau_y_loss_weight` and `tau_z_loss_weight` is currently applied before modifying — match the existing weighting convention precisely. The goal is to swap only the loss *form* for tau_z, not to change the relative weight between channels. Study the actual loss code before implementing.

**Step 3 — Pass flags through to training**

Ensure `cfg.use_charb_tau_z` and `cfg.charb_tau_z_eps` are properly parsed from CLI flags:
- `--use-charb-tau-z` (boolean flag)
- `--charb-tau-z-eps 1e-3`

**Step 4 — Training recipe**

Use the full H112 baseline recipe with only the Charbonnier flag added:

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent tanjiro --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --use-charb-tau-z --charb-tau-z-eps 1e-3 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --wandb-name tanjiro/h139-charb-tau-z \
  --wandb-group wss_h139_charb_tau_z \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct>35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0"
```

**Kill gates:**
- EP1 (step ≥ 10,862): val_abupt ≥ 35.0% → kill
- EP3 (step ≥ 32,592): val_abupt ≥ 8.5% → kill
- EP6 (step ≥ 48,897): val_abupt ≥ 7.0% → kill

**EP1 progress reporting** (step ~10,862): Post val_abupt value as a PR comment.

**Terminal result**: When training completes at EP13 or is killed, run full eval against test set from best checkpoint and report all metrics (including per-channel WSS breakdown). Post a `SENPAI-RESULT` marker.

---

## Baseline

**Current single-model SOTA:** PR #1283 H112 DropPath

| Metric | val | test |
|---|---|---|
| abupt | 6.1358% | 5.839% |
| VP | 3.5478% | 3.421% |
| SP | 4.0553% | 3.695% |
| WSS | 6.9670% | 6.752% |
| WSS_x | 6.0923% | 5.999% |
| WSS_y | 7.6084% | 7.360% |
| WSS_z | 9.3750% | 8.720% |

**W&B baseline run:** `u9ue2ryb`  
**Merge gate:** val_abupt < 6.1358% AND test_abupt < 5.839%  
**Test floors (AND-gate):** test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%  
**Primary objective:** test_WSS < 5.85% (Transolver-3 SOTA gap: 0.902pp)

**H139 specific success criteria:** test_WSS_z ≤ 8.720% (improve or match H112 WSS_z without regressing WSS overall)

**dl24 H41 reference**: Charbonnier on WSS_y+z (dl24 branch, bundled) achieved WSS_z slope >0.3pp improvement. H139 isolates tau_z only to cleanly attribute the mechanism.
