### PR TITLE
H140 nezuko: Signed-log reparameterization of tau_z targets

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ from trainer_runtime import (
     make_loaders,
     masked_mse,
     metric_namespace,
+    signed_log1p,
     weighted_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
@@ -106,6 +107,8 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    use_tau_z_log_reparam: bool = False
+    tau_z_log_reparam_scale: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -238,6 +241,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_tau_z_log_reparam": (
+            "H140: Apply a signed-log1p reparameterisation to the tau_z "
+            "channel when computing the training loss. The model output for "
+            "tau_z remains in normalised raw space; the loss inverts the "
+            "normalisation and computes MSE against signed_log1p(tau_z_raw, "
+            "scale). This compresses the heavy tail of tau_z so gradient "
+            "mass is not dominated by wheel-arch/underbody outliers. The "
+            "validation/test metric path is unchanged because predictions "
+            "are still inverted via the existing mean/std transform. "
+            "Requires --tau-z-log-reparam-scale > 0."
+        ),
+        "tau_z_log_reparam_scale": (
+            "Scale parameter for the signed-log1p transform on tau_z. "
+            "Recommended: p95 of |tau_z| over the training split. For the "
+            "current DrivAerML processed split, p95 of |tau_z| measured on "
+            "40 train cases is approximately 2.27 (Pa)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -249,7 +269,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         else:
             parser.add_argument(arg_name, type=type(value), default=value, help=help_value)
     namespace = parser.parse_args(argv)
-    return Config(**vars(namespace))
+    cfg = Config(**vars(namespace))
+    if cfg.use_tau_z_log_reparam and cfg.tau_z_log_reparam_scale <= 0.0:
+        raise ValueError(
+            "--use-tau-z-log-reparam requires --tau-z-log-reparam-scale > 0 "
+            "(recommended: p95 of |tau_z| over the training split; "
+            "current DrivAerML estimate ~2.27)."
+        )
+    if cfg.use_tau_z_log_reparam and cfg.use_gradnorm:
+        raise ValueError(
+            "--use-tau-z-log-reparam is not implemented for the GradNorm "
+            "per-task path (`per_task_train_losses`). Disable one of them."
+        )
+    return cfg
 
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
@@ -331,10 +363,12 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    tau_z_log_reparam_scale: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    tau_z_loss_log: torch.Tensor | None = None
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -342,27 +376,56 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        surface_pred = out["surface_preds"]
+        if tau_z_log_reparam_scale > 0.0:
+            # H140: keep cp/tau_x/tau_y in normalized-MSE space; for tau_z,
+            # invert the prediction back to raw, then compute MSE in
+            # signed-log1p space. The model output still lives in normalized
+            # raw space (eval/metric path unaffected).
+            weights = (
+                surface_channel_weights
+                if surface_channel_weights is not None
+                else torch.ones(4, device=surface_pred.device, dtype=surface_pred.dtype)
+            )
+            base_loss = weighted_channel_mse(
+                surface_pred[..., :3],
+                surface_target[..., :3],
+                batch.surface_mask,
+                weights[:3],
+            )
+            std_z = transform.surface_y_std.to(surface_pred.device)[3]
+            mean_z = transform.surface_y_mean.to(surface_pred.device)[3]
+            pred_z_raw = surface_pred[..., 3:4] * std_z + mean_z
+            target_z_raw = batch.surface_y[..., 3:4]
+            pred_z_log = signed_log1p(pred_z_raw, tau_z_log_reparam_scale)
+            target_z_log = signed_log1p(target_z_raw, tau_z_log_reparam_scale)
+            z_loss = masked_mse(pred_z_log, target_z_log, batch.surface_mask)
+            tau_z_loss_log = z_loss.detach()
+            surface_loss = (3.0 * base_loss + weights[3] * z_loss) / 4.0
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
-                out["surface_preds"],
+                surface_pred,
                 surface_target,
                 batch.surface_mask,
                 surface_channel_weights,
             )
         else:
-            surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+            surface_loss = masked_mse(surface_pred, surface_target, batch.surface_mask)
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if tau_z_loss_log is not None:
+        metrics["tau_z_loss_log"] = float(tau_z_loss_log.cpu().item())
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -862,6 +925,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.use_tau_z_log_reparam:
+                print(
+                    f"H140: signed-log1p reparam ENABLED for tau_z, "
+                    f"scale={config.tau_z_log_reparam_scale}"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -893,6 +961,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/use_tau_z_log_reparam"] = bool(config.use_tau_z_log_reparam)
+            wandb.summary["loss/tau_z_log_reparam_scale"] = float(
+                config.tau_z_log_reparam_scale if config.use_tau_z_log_reparam else 0.0
+            )
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1052,6 +1124,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        tau_z_log_reparam_scale=(
+                            config.tau_z_log_reparam_scale
+                            if config.use_tau_z_log_reparam
+                            else 0.0
+                        ),
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1092,6 +1169,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "tau_z_loss_log" in batch_loss_metrics:
+                        train_log["train/tau_z_loss_log"] = batch_loss_metrics["tau_z_loss_log"]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -837,6 +837,20 @@ def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> 
     return masked_mean((pred - target).square(), mask)
 
 
+def signed_log1p(x: torch.Tensor, scale: float) -> torch.Tensor:
+    """Variance-stabilising transform: sign(x) * log1p(|x| / scale).
+
+    Compresses heavy tails (large |x| -> ~log) while staying near-linear for
+    |x| << scale. The inverse is :func:`signed_expm1`.
+    """
+    return x.sign() * torch.log1p(x.abs() / scale)
+
+
+def signed_expm1(x: torch.Tensor, scale: float) -> torch.Tensor:
+    """Inverse of :func:`signed_log1p`: sign(x) * (exp(|x|) - 1) * scale."""
+    return x.sign() * torch.expm1(x.abs()) * scale
+
+
 def weighted_channel_mse(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
# H140 nezuko: Signed-Log Reparameterization of tau_z Targets

## Hypothesis

The tau_z (wall shear stress, vertical component) channel has the worst test error of all channels: test_WSS_z=8.720% (H112 SOTA). Examination of the tau_z target distribution reveals a heavy-tailed distribution dominated by large-curvature regions (wheel arches, underbody transitions) where tau_z values span 2–3 orders of magnitude. MSE penalizes these large-residual regions proportionally to their squared magnitude — which means a small fractional error on a large-magnitude tau_z sample can dominate the total WSS_z loss, drowning out fine-grained errors in moderate-magnitude regions.

**Prior exhausted approaches:**
- H92 per-channel loss weight tau_z=3.0: D NEGATIVE (val_WSS_z=9.601% WORSE than canonical ~9.49%; val_abupt=6.3235%). Under Lion sign-update, loss weighting only modulates gradient ratios — does not add representational capacity.
- H138 askeladd: split surface/WSS-z decoder heads (architectural separation, currently in-flight)
- H139 tanjiro: Charbonnier loss on tau_z (loss shape modification, currently in-flight)
- H137: PCGrad gradient surgery (already assigned, different student)

**New angle — target normalization:**

Apply a **signed-log transform** to the tau_z targets at training time:

```
τ_z_transformed = sign(τ_z) * log1p(|τ_z| / scale)
```

where `scale` is a dataset-level normalization constant (e.g., the 95th percentile of |tau_z| across training cases). At inference, reverse the transform:

```
τ_z = sign(τ_z_transformed) * (exp(|τ_z_transformed|) - 1) * scale
```

**Why this works:**
- Compresses the dynamic range of tau_z targets from O(3 orders of magnitude) to O(1 order of magnitude)
- MSE in log-space is equivalent to a scale-invariant relative error — exactly what WSS_z needs, since we report WSS_z as a percentage error
- The model can use its full capacity to distinguish moderate-magnitude tau_z gradients that matter for the surface integral, rather than spending most capacity matching the rare very-large peaks
- Strictly orthogonal to H138 (architectural), H139 (loss shape), and H137 (gradient surgery) — this touches only the target representation

**This is distinct from Charbonnier loss (H139):**
- Charbonnier modifies the loss function shape (MSE → Huber-like) while keeping targets in raw space
- This hypothesis keeps MSE loss but reparameterizes the target space — the optimization landscape changes completely
- The two could compose if both prove beneficial

**Key implementation:**
- Transform tau_z targets in the loss computation only (NOT as data preprocessing — keep raw targets in memory)
- Apply inverse transform before metric computation so val/test metrics remain comparable
- Use `scale = torch.quantile(|tau_z_train|, 0.95)` computed from training data, stored as a buffer
- Predicted tau_z is in log-space during training; inverse-transformed for metric evaluation

## Implementation

Add to `target/model.py` or a new `target/transforms.py`:

```python
# Signed-log transform / inverse
def signed_log1p(x: torch.Tensor, scale: float) -> torch.Tensor:
    """Transform: sign(x) * log1p(|x| / scale)"""
    return x.sign() * torch.log1p(x.abs() / scale)

def signed_exp1m(x: torch.Tensor, scale: float) -> torch.Tensor:
    """Inverse: sign(x) * (exp(|x|) - 1) * scale"""
    return x.sign() * torch.expm1(x.abs()) * scale
```

Add to `target/config.py`:

```python
use_tau_z_log_reparam: bool = False
tau_z_log_reparam_scale: float = 0.0  # 0.0 = auto-compute from training data p95
```

Modify the surface loss computation in `target/train.py` (inside the training loop):

```python
if cfg.use_tau_z_log_reparam:
    # tau_z is surface channel index 3 (cp=0, tau_x=1, tau_y=2, tau_z=3)
    scale = cfg.tau_z_log_reparam_scale  # pre-computed p95, passed as CLI arg
    pred_base = surface_pred[..., :3]        # [cp, tau_x, tau_y] — unchanged
    pred_z    = surface_pred[..., 3:4]       # [tau_z] raw model output
    tgt_base  = surface_target[..., :3]
    tgt_z_raw = surface_target[..., 3:4]
    
    # Transform target to log-space
    tgt_z_log = signed_log1p(tgt_z_raw, scale)
    # Transform prediction to log-space for MSE (pred is in raw space; transform it too)
    pred_z_log = signed_log1p(pred_z, scale)
    
    loss_base = F.mse_loss(pred_base, tgt_base)
    loss_z    = F.mse_loss(pred_z_log, tgt_z_log)
    surface_loss = (loss_base * 3 + loss_z * cfg.tau_z_loss_weight) / (3 + cfg.tau_z_loss_weight)
    
    # For metric computation, transform pred back to raw space before passing to metric fn
    surface_pred_for_metrics = torch.cat([pred_base, signed_exp1m(pred_z_log, scale)], dim=-1)
else:
    surface_loss = F.mse_loss(surface_pred, surface_target)
    surface_pred_for_metrics = surface_pred
```

**Computing scale:** Run a one-off script to compute the 95th percentile of |tau_z| across all training cases from the manifest. Based on DrivAerML tau_z distribution (0–0.3 Pa typical range with peaks ~1-2 Pa in wheel arches), expected p95 ≈ 0.08–0.15. If auto-compute is implemented, initialize as a `nn.Buffer` in the model loaded from training data stats. A simpler approach: hard-code `scale=0.10` as a reasonable prior based on the dataset.

For this experiment: use `--tau-z-log-reparam-scale 0.10` (hardcoded p95 estimate). The student can check the actual distribution from the loader in a quick diagnostic.

## Training Command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent nezuko --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --use-tau-z-log-reparam --tau-z-log-reparam-scale 0.10 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --wandb-name nezuko/h140-tau-z-log-reparam \
  --wandb-group wss_h140_tau_z_log_reparam \
  --kill-thresholds "10862:val_primary/abupt_axis_mean_rel_l2_pct>35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0"
```

**Note to student:** Before implementing, run a quick one-liner on the training data to check the actual p95 of |tau_z|:

```python
import numpy as np, json, os, glob
# Load a few training cases and compute percentile of |tau_z| surface values
# tau_z is the last surface channel in the processed .npz files
files = glob.glob("/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511/train/**/*.npz", recursive=True)[:20]
vals = []
for f in files:
    d = np.load(f)
    if 'surface_tau_z' in d or 'surface' in d:
        key = 'surface_tau_z' if 'surface_tau_z' in d else 'surface'
        arr = d[key]
        if arr.ndim > 1: arr = arr[..., -1]  # tau_z is last channel
        vals.append(np.abs(arr).ravel())
all_vals = np.concatenate(vals)
print(f"p50={np.percentile(all_vals, 50):.4f}, p95={np.percentile(all_vals, 95):.4f}, p99={np.percentile(all_vals, 99):.4f}, max={all_vals.max():.4f}")
```

If the actual p95 differs significantly from 0.10, adjust `--tau-z-log-reparam-scale` accordingly. **Use the computed p95 as the scale.** The exact value of scale determines the compression ratio and matters for the optimization landscape.

## Baseline to Beat

**H112 SOTA (W&B: u9ue2ryb, PR #1283):**
- val_abupt = 6.1358%
- test_abupt = 5.839%
- test_WSS = 6.752%
- test_WSS_z = 8.720% ← primary target to improve
- test_VP = 3.421%
- test_SP = 3.695%

**Merge gate:** val_abupt < 6.1358% AND test_abupt < 5.839%
**Test floors (AND-gate):** test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%

## Falsifiable Predictions

**Win criteria:** test_WSS_z ≤ 8.50% (≥ 0.22pp improvement over H112) AND val_abupt < 6.1358%
**Inert/benign:** test_WSS_z ≈ 8.72% ± 0.05pp with val_abupt near H112 (log-space MSE equivalent to raw MSE at small magnitudes)
**Anti-pattern (failure class):** val_abupt > 6.5% or val_WSS_z > 9.8% — log transform could hurt if scale is badly chosen (model output saturates in log-space)

## Kill Thresholds

- EP1 (step ≥ 10,862): val_abupt > 35.0% → kill (warmup normal, this gate is very conservative)
- EP3 (step ≥ 32,592): val_abupt > 8.5% → kill
- EP6 (step ≥ 48,897): val_abupt > 7.0% → kill

## Result Format

Post results as:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val>},"test_metric":{"name":"test_primary/wss_rel_l2_pct","value":<test_wss>}}
```

Report val_abupt, test_abupt, test_WSS, test_WSS_z, test_VP, test_SP from best val checkpoint.
