### PR TITLE
WSS H140: z-coord-weighted WSS loss — spatial reweighting (parallel to H138 curvature)

### DIFF
--- a/train.py
+++ b/train.py
@@ -141,6 +141,8 @@ class Config:
     vol_p_charbonnier_eps: float = 1e-3
     tau_z_loss_weight: float = 1.0
     surface_out_width_factor: float = 1.0
+    use_z_coord_wss_weight: bool = False
+    z_coord_weight_alpha: float = 1.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -161,6 +163,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         "surface_out_width_factor": (
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
+        ),
+        "use_z_coord_wss_weight": (
+            "H140: weight WSS loss terms (tau_x/y/z) by per-point factor "
+            "w_i = 1 + alpha * |z_i / z_max| in [1.0, 1.0+alpha]. Amplifies "
+            "gradient share for high-|z| surface points (roof/A-pillar/wheel arch). "
+            "Applies to the per-channel WSS MSE used by GradNorm AND the supplementary "
+            "WSS Charbonnier; does NOT touch surface_pressure (cp) or vol_p."
+        ),
+        "z_coord_weight_alpha": (
+            "H140 strength: w_i = 1 + alpha * |z_i / z_max|. alpha=1.0 -> w in [1, 2]."
         ),
     }
     choices_text = {
@@ -272,6 +284,100 @@ def masked_charbonnier(
     return weighted.sum() / (n_pts * n_ch)
 
 
+def per_channel_masked_mse_pointweighted(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    point_weight: torch.Tensor,
+) -> torch.Tensor:
+    """Per-channel masked MSE with a per-point scalar weight (H140).
+
+    point_weight: ``[B, N]`` non-negative weights, broadcast across channels.
+    Reduces as a weighted mean over masked points:
+    ``sum(w*mask*diff^2) / sum(w*mask)`` per channel. With ``w == 1`` this
+    reduces to :func:`per_channel_masked_mse`.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    w = point_weight.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)  # [B, N, 1]
+    weighting = mask_f * w
+    diff_sq = (pred - target).square()
+    weighted = diff_sq * weighting
+    denom = weighting.sum().clamp_min(1.0)
+    return weighted.sum(dim=(0, 1)) / denom
+
+
+def masked_charbonnier_pointweighted(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    point_weight: torch.Tensor,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Masked Charbonnier with per-point weights (H140).
+
+    point_weight: ``[B, N]``. Reduces as weighted mean over masked points and
+    plain mean over channels. With ``w == 1`` this matches
+    :func:`masked_charbonnier`.
+    """
+    mask_f = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    w = point_weight.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighting = mask_f * w
+    delta = pred - target
+    values = torch.sqrt(eps * eps + delta * delta) - eps
+    weighted = values * weighting
+    n_pts = weighting.sum().clamp_min(1.0)
+    n_ch = float(pred.shape[-1])
+    return weighted.sum() / (n_pts * n_ch)
+
+
+def compute_z_coord_point_weight(
+    surface_x: torch.Tensor,
+    surface_mask: torch.Tensor,
+    alpha: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """H140 per-point WSS weight w_i = 1 + alpha * |z_i / z_max|.
+
+    ``surface_x`` has channel layout ``[x, y, z, nx, ny, nz, area]`` so the
+    z-coordinate is index 2. ``z_max`` is computed per-sample over masked
+    points only. Padded points receive zero weighting in downstream losses
+    because ``mask`` zeros them out — the value assigned here for those rows
+    therefore does not affect the weighted average.
+    """
+    z = surface_x[..., 2]  # [B, N]
+    # Multi-view batches occasionally produce zero-row surface tensors when
+    # ``surface_view_count < volume_view_count`` for a case (data loader
+    # behaviour, see DrivAerMLSurfaceDataset._indices). amax() on an empty
+    # last dim raises IndexError, so short-circuit to a ones-tensor — the
+    # downstream masked sums clamp the denominator to 1.0 and produce a
+    # zero loss for empty surfaces, matching the H39 baseline path.
+    if z.numel() == 0 or z.shape[-1] == 0:
+        w = torch.ones_like(z)
+        stats = {
+            "z_coord_weight_mean": 1.0,
+            "z_coord_weight_max": 1.0,
+            "z_coord_weight_min_nonpad": 1.0,
+            "z_max_batch": 0.0,
+        }
+        return w, stats
+    mask_f = surface_mask.to(device=z.device, dtype=z.dtype)
+    z_abs_masked = z.abs() * mask_f  # masked-out rows contribute 0 to max
+    z_max = z_abs_masked.amax(dim=-1, keepdim=True).clamp_min(1e-6)  # [B, 1]
+    w = 1.0 + alpha * (z.abs() / z_max)  # [B, N], in [1, 1+alpha] on masked rows
+    masked_w = w * mask_f  # ignore padded rows
+    n_pts = mask_f.sum().clamp_min(1.0)
+    stats = {
+        "z_coord_weight_mean": float(
+            (masked_w.sum() / n_pts).detach().cpu().item()
+        ),
+        "z_coord_weight_max": float(masked_w.max().detach().cpu().item()),
+        "z_coord_weight_min_nonpad": float(
+            (w * mask_f + (1.0 - mask_f) * 1e9).min().detach().cpu().item()
+        ),
+        "z_max_batch": float(z_max.max().detach().cpu().item()),
+    }
+    return w, stats
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -357,6 +463,8 @@ def train_loss(
     vol_p_charbonnier_weight: float = 0.0,
     vol_p_charbonnier_eps: float = 1e-3,
     tau_z_loss_weight: float = 1.0,
+    use_z_coord_wss_weight: bool = False,
+    z_coord_weight_alpha: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     surface_curvature = getattr(batch, "surface_curvature", None)
     batch = batch.to(device)
@@ -378,6 +486,15 @@ def train_loss(
     )
     if surface_curvature is not None:
         forward_kwargs["surface_curvature"] = surface_curvature
+    z_coord_weight = None
+    z_coord_weight_stats: dict[str, float] = {}
+    if use_z_coord_wss_weight:
+        # H140: per-point WSS reweighting by 1 + alpha * |z/z_max|.
+        # Computed in fp32 outside autocast to keep z_max stable; the tensor
+        # is cast inside the per-channel/Charbonnier helpers as needed.
+        z_coord_weight, z_coord_weight_stats = compute_z_coord_point_weight(
+            batch.surface_x, batch.surface_mask, z_coord_weight_alpha
+        )
     with autocast_context(device, amp_mode):
         out = model(**forward_kwargs)
         surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
@@ -408,9 +525,26 @@ def train_loss(
             # step) absorbs the scaling so r-ratios cancel; the lever then acts
             # through gradient magnitudes (c_per_task / G_bar) and the total
             # backward signal, not through r-renormalisation.
-            surface_per_ch = per_channel_masked_mse(
-                out["surface_preds"], surface_target, batch.surface_mask
-            ) * surface_loss_weight  # [4]: cp, tau_x, tau_y, tau_z
+            if z_coord_weight is not None:
+                # H140: cp (idx 0) stays unweighted; tau_x/y/z (idx 1-3) use
+                # per-point z-magnitude weighting. Concatenate them so the
+                # GradNorm task_losses tensor keeps shape [4].
+                cp_per_ch = per_channel_masked_mse(
+                    out["surface_preds"][..., :1],
+                    surface_target[..., :1],
+                    batch.surface_mask,
+                )  # [1]
+                wss_per_ch = per_channel_masked_mse_pointweighted(
+                    out["surface_preds"][..., 1:4],
+                    surface_target[..., 1:4],
+                    batch.surface_mask,
+                    z_coord_weight,
+                )  # [3]
+                surface_per_ch = torch.cat([cp_per_ch, wss_per_ch]) * surface_loss_weight
+            else:
+                surface_per_ch = per_channel_masked_mse(
+                    out["surface_preds"], surface_target, batch.surface_mask
+                ) * surface_loss_weight  # [4]: cp, tau_x, tau_y, tau_z
             # H36: Asymmetric tau_z boost. Multiply ONLY index 3 (tau_z) by
             # tau_z_loss_weight. Same pre-GradNorm injection point as H26 —
             # L0 absorbs the scaling so the lever acts through gradient
@@ -458,9 +592,18 @@ def train_loss(
                 raise ValueError(
                     f"Unknown wss_charbonnier_axes={wss_charbonnier_axes}"
                 )
-            loss_wss_charb = masked_charbonnier(
-                pred_wss, target_wss, batch.surface_mask, eps=wss_charbonnier_eps
-            )
+            if z_coord_weight is not None:
+                loss_wss_charb = masked_charbonnier_pointweighted(
+                    pred_wss,
+                    target_wss,
+                    batch.surface_mask,
+                    z_coord_weight,
+                    eps=wss_charbonnier_eps,
+                )
+            else:
+                loss_wss_charb = masked_charbonnier(
+                    pred_wss, target_wss, batch.surface_mask, eps=wss_charbonnier_eps
+                )
             loss_wss_mse_diag = masked_mse(pred_wss, target_wss, batch.surface_mask)
             loss = loss + wss_charbonnier_weight * loss_wss_charb
             charb_metrics = {
@@ -506,6 +649,7 @@ def train_loss(
     }
     metrics.update(charb_metrics)
     metrics.update(vol_p_charb_metrics)
+    metrics.update(z_coord_weight_stats)
     return loss, metrics, task_losses
 
 
@@ -752,6 +896,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     vol_p_charbonnier_weight=config.vol_p_charbonnier_weight,
                     vol_p_charbonnier_eps=config.vol_p_charbonnier_eps,
                     tau_z_loss_weight=config.tau_z_loss_weight,
+                    use_z_coord_wss_weight=config.use_z_coord_wss_weight,
+                    z_coord_weight_alpha=config.z_coord_weight_alpha,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -832,6 +978,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                                 f"train/loss_{wss_axes_label}_charb_weighted": charb_w,
                                 f"train/loss_{wss_axes_label}_charb_to_mse_ratio": ratio_to_mse,
                                 f"train/loss_{wss_axes_label}_charb_weighted_to_mse_ratio": weighted_ratio,
+                            }
+                        )
+                    if "z_coord_weight_mean" in batch_loss_metrics:
+                        # H140 diagnostics: per-point WSS reweighting by |z|/z_max.
+                        train_log.update(
+                            {
+                                "train/z_weight/mean": batch_loss_metrics[
+                                    "z_coord_weight_mean"
+                                ],
+                                "train/z_weight/max": batch_loss_metrics[
+                                    "z_coord_weight_max"
+                                ],
+                                "train/z_weight/min_nonpad": batch_loss_metrics[
+                                    "z_coord_weight_min_nonpad"
+                                ],
+                                "train/z_weight/z_max_batch": batch_loss_metrics[
+                                    "z_max_batch"
+                                ],
+                                "train/z_weight/alpha": config.z_coord_weight_alpha,
                             }
                         )
                     if "loss_vol_p_charb_unweighted" in batch_loss_metrics:


### PR DESCRIPTION
## Hypothesis

Per-axis test_WSS error is concentrated on the z axis: x=5.90%, y=7.19%, **z=8.66%** (worst, +2.76pp above x). The z-axis carries the largest residual share because:

1. **z is the surface-normal-ish direction** for the vehicle's vertical extent (roof, underbody, A-pillar peaks). Wall shear in z represents flow attachment/separation patterns that vary most strongly along z.
2. **High-|z| points are sparse** (top of A-pillars, top of roof, wheel arches) — they get less per-point gradient share under uniform-weighted Charbonnier.

**H140 hypothesis**: per-point WSS loss weighting by `w_i = 1 + α · |z_i / z_max|` (range [1.0, 2.0]) directly amplifies gradient share for high-|z| surface points. This is **orthogonal in mechanism** to H138 (which uses curvature κ as the weighting scalar) — z-magnitude and curvature correlate on some surface regions (A-pillars, mirrors, wheel arches) but disagree on others (smooth top-of-roof has low κ but high |z|; underbody seam has high κ but low |z|).

**Parallel test design with H138**: if both H138 (curvature) and H140 (z-magnitude) beat H39, the mechanism is "spatial WSS reweighting" in general → compound for W37. If only one beats H39, the SPECIFIC scalar matters. If neither beats H39, spatial reweighting is null on this architecture.

This is **orthogonal** to:
- H138 frieren (curvature-weighted Charb-z — different scalar)
- H141 SWA nezuko (post-hoc weight averaging — training axis)
- H134 fern (GALE-Transolver — architecture)

## Mechanism

```python
# Per-point z-magnitude weight: w_i = 1 + alpha * |z_i / z_max|
# Applied to WSS loss terms (all 3 axes — x/y/z), NOT to surf_p or vol_p
z_coords = surface_points[:, 2]                  # (N_surface,)
z_max = z_coords.abs().max()                     # scalar
w_i = 1.0 + alpha * (z_coords.abs() / z_max)     # (N_surface,) in [1.0, 1.0+alpha]

# Standard H39 Charb-z + MSE x/y losses, now weighted per-point:
mse_x = (pred_x - target_x) ** 2  # (N_surface,)
mse_y = (pred_y - target_y) ** 2
charb_z = sqrt((pred_z - target_z)**2 + eps**2) - eps  # bounded grad

loss_wss = ((w_i * (mse_x + mse_y)).sum() / w_i.sum() 
            + (w_i * charb_z).sum() / w_i.sum())
```

**Key difference from H138**:
- H138 uses **curvature** (geometric scalar from `curvature_proxy_stats_k16_v1.json`) — emphasizes A-pillar/mirror local geometry
- H140 uses **|z_i|** (Cartesian scalar) — emphasizes vertical extent (roof/underbody points)

Both reweight WSS loss but on **different surface regions**. Parallel evidence collection.

## Instructions

**Target file**: `train.py` (WSS loss block — ~10 lines)

**Step 1 — Add CLI flags**:
```python
parser.add_argument('--use-z-coord-wss-weight', action='store_true',
                    help='Weight WSS loss by 1 + alpha * |z/z_max| per point')
parser.add_argument('--z-coord-weight-alpha', type=float, default=1.0,
                    help='z-coordinate weighting strength: w_i = 1 + alpha * |z_i/z_max|')
```

**Step 2 — Compute per-point z-magnitude weights** (at batch construction or in the loss):
```python
# Inside the WSS loss function, with surface_points = (N, 3)
z = surface_points[:, 2]
z_max = z.abs().max().clamp(min=1e-6)  # avoid division by zero
w_i = 1.0 + args.z_coord_weight_alpha * (z.abs() / z_max)  # (N,)
```

**Step 3 — Apply weighting to ALL WSS axes (x, y, z) — NOT to surf_p, vol_p, abupt**:
```python
if args.use_z_coord_wss_weight:
    # Weighted x-axis MSE
    mse_x = (pred_wss_x - target_wss_x) ** 2
    loss_wss_x = (w_i * mse_x).sum() / w_i.sum()
    # Weighted y-axis MSE
    mse_y = (pred_wss_y - target_wss_y) ** 2
    loss_wss_y = (w_i * mse_y).sum() / w_i.sum()
    # Weighted z-axis Charbonnier (preserves H39 bounded-loss for z)
    charb_z = torch.sqrt((pred_wss_z - target_wss_z) ** 2 + eps ** 2) - eps
    loss_wss_z = args.charb_z_weight * (w_i * charb_z).sum() / w_i.sum()
else:
    loss_wss_x = mse_x.mean()
    loss_wss_y = mse_y.mean()
    loss_wss_z = args.charb_z_weight * charb_z.mean()  # H39 default
```

**Step 4 — Reproduce command** (one extra flag on H39 canonical):
```bash
cd target/ && python train.py \
    --batch-size 1 \
    --train-points 65000 --eval-volume-points 65000 \
    --depth 6 --hidden 512 --slices 128 \
    --surface-out-factor 2.0 \
    --use-charb-z --charb-z-weight 0.1 \
    --use-curvature-attention-bias \
    --use-y-symmetry-aug \
    --lr 1e-4 --lr-cosine-t-max 30 --lr-warmup-epochs 1 \
    --optimizer lion --lion-beta1 0.95 --lion-beta2 0.98 \
    --ema-decay 0.999 --ema-start-step 500 \
    --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
    --use-z-coord-wss-weight --z-coord-weight-alpha 1.0 \
    --epochs 30 \
    --wandb-group wss_h140_z_coord
```

## Predicted outcome

- **Best case**: test_WSS = 6.30-6.40% (−0.25 to −0.35pp from H39, dominant gain in test_z axis)
- **Expected case**: test_WSS = 6.40-6.50% (−0.15 to −0.25pp)
- **Null case**: z-coordinate weighting redundant with H39's curvature-attention-bias (encoder already emphasizes geometric features); no independent gain. Or — z and curvature scalars are too correlated (both peak at A-pillar tips) and H140 simply mirrors H138.
- **Probability beats H39 SOTA**: 55-65%
- **AND-contract risk**: low — only changes WSS loss weighting; doesn't touch surf_p, vol_p, abupt losses

## EP gates and abort conditions

- **EP1 sanity**: val_abupt < 25% (z-magnitude weighting could destabilize abupt — abort if breach)
- **EP3 hard-abort**: val_WSS > 7.10%
- **EP5 diagnostic**: log mean and max of `w_i`, verify range matches `[1.0, 1.0 + alpha]`. Log also `val_WSS_z` separately to verify z-axis is improving fastest.
- **EP6 gate**: val_WSS ≤ 6.95%, val_WSS_z ≤ 9.0% (must show z-axis improvement vs H39 EP6=~9.5%)
- **EP10 gate**: val_WSS ≤ 6.80%, val_WSS_z ≤ 8.5%
- **EP15 gate**: projected val_WSS ≤ 6.70%
- **EP30 terminal**: test_WSS < 6.65% (H39 SOTA) AND test_vp ≤ 3.643% AND test_surf_p ≤ 3.577%, test_z ≤ 8.0% (currently 8.66% — target -0.66pp z-axis reduction)

## Baseline (current SOTA — H39, PR #1284 merged 2026-05-24)

- **test_WSS**: 6.6506% (gap to Transolver-3 SOTA 5.85% = 0.80pp)
- **test_VP**: 3.6033% (clears 3.643 floor)
- **test_SP**: 3.6498% (misses 3.577 floor by +0.073pp)
- **test_abupt**: 5.8010% (clears 5.844 floor)
- **val_WSS** (best EMA EP24): 6.7681%
- **W&B run**: `yym5oa8x`
- **Per-axis test_WSS**: x=5.90, y=7.19, **z=8.66** (target axis)

## References

- Per-point loss reweighting on point clouds: DeepSDF (Park et al. 2019, arxiv 1901.05103)
- Charbonnier loss: Charbonnier et al. 1994; bounded gradient
- For comparison with H138 curvature-weighted variant (PR #1324): both reweight WSS loss spatially but use different scalars — parallel test of "spatial reweighting" mechanism class

## Test plan

- [ ] Add z-coord WSS weighting CLI flag and logic in train.py
- [ ] Smoke test 50-100 steps to verify no NaN, no DDP unused-params, loss decreasing
- [ ] Confirm `w_i` range in [1.0, 2.0] when alpha=1.0
- [ ] Full 30-epoch run with `--wandb-group wss_h140_z_coord`
- [ ] Post EP1 abupt result for sanity check
- [ ] Post EP3 val_WSS + val_WSS_z result
- [ ] Post EP6 + EP10 trajectory with per-axis breakdown (x/y/z)
- [ ] Terminal post: test_WSS, test_VP, test_SP, test_abupt + per-axis test_WSS (especially test_z)

## Notes

H138 frieren (curvature-weighted Charb-z) is currently EP4.60 with val_WSS=6.89 (-0.15pp ahead H39). H140 z-coord variant is a **parallel test** of the same mechanism class (spatial reweighting) with a different scalar. If both beat H39 → spatial reweighting is the lever, can compound for W37. If only H138 beats → curvature is the load-bearing scalar. If only H140 beats → z-axis structural matters more than local curvature. If neither beats → spatial reweighting null on this architecture.
