### PR TITLE
H143 frieren: tau_z loss weight escalation 2.0→4.0

### DIFF
--- a/research/h143_tau_z_escalation.md
+++ b/research/h143_tau_z_escalation.md
@@ -1,0 +1,5 @@
+# H143: tau_z loss weight escalation 2.0→4.0
+
+Hypothesis: Double tau_z loss weight from 2.0 to 4.0 to directly target
+the largest residual error component (test_WSS_z=8.720% in H112).
+Single-variable change over H112 DropPath SOTA baseline.


### PR DESCRIPTION
## Hypothesis

H143: Double tau_z loss weight from 2.0 to 4.0 to directly target the largest residual error component.

In H112 SOTA, **test_WSS_z = 8.720%** — the z-component of wall shear stress is the single largest error term, and it is the dominant contributor to test_WSS overall. H112 uses `--tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0`, meaning tau_y already receives 1.5× the base weight. Escalating tau_z from 2.0→4.0 doubles the gradient signal on the z-shear component without touching any other aspect of architecture, optimizer, schedule, or regularization.

This is a direct, single-variable intervention on the loss weighting axis — orthogonal to all capacity, regularization, and architectural experiments already run.

**Mechanism:** Higher loss weight on tau_z forces the model to devote more representational bandwidth to predicting z-shear accurately. If the current val_abupt≈6.14% partly reflects underfitting on tau_z due to competition with SP/VP/tau_y in the total loss, upweighting tau_z should shift the optimization focus and reduce test_WSS_z, which is the WSS dominant component.

**Falsification criteria:**
- PASS: test_WSS ≤ 6.752% (beats H112 baseline) with val_abupt < 6.1358%
- KILL at EP6 (step≥32,592): val_abupt ≥ 8.5%
- KILL at EP9 (step≥48,897): val_abupt ≥ 7.0%
- KILL at EP13 (step≥70,664): val_abupt ≥ 6.1358%

## Baseline (H112 DropPath SOTA)

| Metric | H112 value |
|--------|-----------|
| val_abupt | 6.1358% |
| test_abupt | 5.839% |
| test_WSS | 6.752% |
| test_VP | 3.421% |
| test_SP | 3.695% |

W&B run: `u9ue2ryb`, PR #1283

## Single change vs H112

`--tau-z-loss-weight 2.0` → `--tau-z-loss-weight 4.0`

All other flags identical to H112 reproduce command.

## Training command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent frieren --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 4.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint
```

## Kill-fence thresholds

```
--kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<35.0" \
  "32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5" \
  "48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0" \
  "70664:val_primary/abupt_axis_mean_rel_l2_pct<6.1358"
```

## Expected outcome

If tau_z upweighting reduces test_WSS_z by 5–10% relative (~0.44–0.87pp), test_WSS should improve by 0.10–0.25pp → range 6.50–6.65%. Primary objective target is test_WSS ≤ 5.85% (Transolver-3 SOTA); this experiment probes whether the loss-weighting axis has headroom that has been left on the table.

**Note:** If val_abupt improves but test_WSS does not, this would indicate the tau_z upweighting causes overfitting to the training distribution rather than genuine generalization improvement — that pattern would be useful diagnostic information.

## Context

- Axis: loss weighting (orthogonal to capacity, regularization, architecture)
- Prior WSS-z targeted experiments: none on loss-weight axis
- test_WSS_z is the largest single error component in H112 (8.720%)
- tau_y already has 1.5× weight vs base; tau_z has 2.0× — this escalates z to 4.0×
- Ensembles are BANNED — single-model result only