### PR TITLE
WSS H143: Lookahead optimizer wrapping Lion (slow/fast weights, NOT weight averaging)

### DIFF
--- a/torch_lookahead.py
+++ b/torch_lookahead.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Lookahead optimizer wrapper (Zhang et al. 2019, arxiv 1907.08610).
+
+Maintains slow weights `theta_slow` and fast weights `theta_fast`. After every
+`k` inner-optimizer steps on `theta_fast`, applies
+    theta_slow <- theta_slow + alpha * (theta_fast - theta_slow)
+    theta_fast <- theta_slow                               (re-anchor)
+
+This is NOT weight averaging (EMA / SWA / Polyak). The fast weights are reset
+into the slow basin every k steps, actively re-shaping the trajectory the base
+optimizer follows.
+"""
+from collections import defaultdict
+from typing import Callable, Optional
+
+import torch
+from torch.optim import Optimizer
+
+
+class Lookahead(Optimizer):
+    def __init__(self, base_optimizer: Optimizer, k: int = 5, alpha: float = 0.5):
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError(f"Invalid alpha (slow-weight coef): {alpha}")
+        if k < 1:
+            raise ValueError(f"Invalid k (inner steps): {k}")
+        self.optimizer = base_optimizer
+        self.k = int(k)
+        self.alpha = float(alpha)
+        self.step_counter = 0
+        self.outer_step_counter = 0
+        self.state = defaultdict(dict)
+        # Share param_groups (and defaults) with the base optimizer by reference
+        # so LR schedulers, GradNorm, and per-group LR setters all transparently
+        # see the live param groups.
+        self.param_groups = self.optimizer.param_groups
+        self.defaults = self.optimizer.defaults
+        for group in self.param_groups:
+            for p in group["params"]:
+                slow = p.detach().clone()
+                slow.requires_grad = False
+                self.state[p]["slow_weight"] = slow
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable] = None):
+        loss = self.optimizer.step(closure)
+        self.step_counter += 1
+        if self.step_counter % self.k == 0:
+            self.outer_step_counter += 1
+            for group in self.param_groups:
+                for p in group["params"]:
+                    slow = self.state[p]["slow_weight"]
+                    slow.add_(p.data - slow, alpha=self.alpha)
+                    p.data.copy_(slow)
+        return loss
+
+    def zero_grad(self, set_to_none: bool = True):
+        return self.optimizer.zero_grad(set_to_none=set_to_none)
+
+    def state_dict(self):
+        slow_weights = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                slow_weights.append(self.state[p]["slow_weight"].detach().clone())
+        return {
+            "base_state": self.optimizer.state_dict(),
+            "lookahead": {
+                "step_counter": self.step_counter,
+                "outer_step_counter": self.outer_step_counter,
+                "k": self.k,
+                "alpha": self.alpha,
+                "slow_weights": slow_weights,
+            },
+        }
+
+    def load_state_dict(self, state_dict):
+        self.optimizer.load_state_dict(state_dict["base_state"])
+        lh = state_dict["lookahead"]
+        self.step_counter = int(lh["step_counter"])
+        self.outer_step_counter = int(lh.get("outer_step_counter", 0))
+        self.k = int(lh["k"])
+        self.alpha = float(lh["alpha"])
+        idx = 0
+        for group in self.param_groups:
+            for p in group["params"]:
+                self.state[p]["slow_weight"].copy_(lh["slow_weights"][idx])
+                idx += 1

--- a/train.py
+++ b/train.py
@@ -99,6 +99,9 @@ class Config:
     optimizer: str = "adamw"
     lion_beta1: float = 0.9
     lion_beta2: float = 0.99
+    use_lookahead: bool = False
+    lookahead_k: int = 5
+    lookahead_alpha: float = 0.5
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -637,6 +640,23 @@ def main(argv: Iterable[str] | None = None) -> None:
             print(f"Model: SurfaceTransolver grouped surface+volume ({n_params / 1e6:.2f}M params)")
 
         optimizer = build_optimizer(base_model, config)
+        if config.use_lookahead:
+            # H143: wrap base optimizer with Lookahead (Zhang et al. 2019).
+            # Lookahead shares `param_groups` with the base optimizer by
+            # reference, so the LR scheduler, GradNorm, and per-group LR
+            # setters all see the same groups transparently.
+            from torch_lookahead import Lookahead
+
+            optimizer = Lookahead(
+                optimizer,
+                k=config.lookahead_k,
+                alpha=config.lookahead_alpha,
+            )
+            if state.is_main:
+                print(
+                    f"[H143] Lookahead wrapping {config.optimizer}: "
+                    f"k={config.lookahead_k}, alpha={config.lookahead_alpha}"
+                )
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
@@ -1036,7 +1056,20 @@ def main(argv: Iterable[str] | None = None) -> None:
                         optimizer.zero_grad(set_to_none=True)
                     else:
                         set_optimizer_lr(optimizer, current_lr)
+                        if config.use_lookahead:
+                            prev_outer = optimizer.outer_step_counter
                         optimizer.step()
+                        if config.use_lookahead:
+                            outer_now = optimizer.outer_step_counter
+                            lookahead_fired = 1.0 if outer_now > prev_outer else 0.0
+                            train_log["train/lookahead/outer_step_counter"] = float(outer_now)
+                            train_log["train/lookahead/step_counter"] = float(optimizer.step_counter)
+                            train_log["train/lookahead/fired_this_step"] = lookahead_fired
+                            if state.is_main and outer_now > prev_outer and outer_now <= 3:
+                                print(
+                                    f"[H143] Lookahead outer step #{outer_now} "
+                                    f"fired at inner step {optimizer.step_counter}"
+                                )
                         if ema is not None:
                             ema.update(base_model)
                         weight_metrics = (


### PR DESCRIPTION
## Hypothesis

**Lookahead optimizer wrapping Lion** improves DrivAerML test_WSS by introducing a slow-weight / fast-weight alternation that explores the local loss landscape more thoroughly than pure Lion. Lookahead is **NOT weight averaging** (NOT EMA, NOT SWA, NOT Polyak averaging) — it is a distinct optimization-level mechanism with explicit re-synchronization of fast weights to slow weights every k steps.

**Mechanism (Lookahead, Zhang et al. 2019, arxiv 1907.08610):**
- Maintain `θ_slow` (slow weights) and `θ_fast` (fast weights)
- Inner loop: run k Lion optimizer steps on θ_fast (k=5, standard)
- Outer step: update θ_slow ← θ_slow + α·(θ_fast - θ_slow), then **reset θ_fast = θ_slow**
- α=0.5 is the standard slow-weight update coefficient

**Why this is fundamentally different from H141 SWA and H142 EMA:**
- **EMA-of-weights** (H142, closed): maintains shadow copy `θ_ema = decay·θ_ema + (1-decay)·θ_live`. Never resets θ_live. Pure Polyak averaging.
- **SWA** (H141, closed): runs separate snapshots at low-LR after warmup, averages those snapshots into a separate model. Never modifies training trajectory.
- **Lookahead** (this): θ_fast IS RESET to θ_slow every k steps. This actively **modifies the training trajectory** by re-anchoring the optimizer to the slow weight basin every k steps. This is a fundamentally different optimization paradigm.

**Empirical evidence:**
- Lookahead has demonstrated +1-2% improvements over base optimizer (Adam, SGD, Lion) on CV/NLP benchmarks
- Particularly effective when base optimizer has high-variance updates — **Lion's sign-based momentum has unbounded step size**, so Lookahead's re-anchoring should reduce late-stage noise around the loss minimum
- H39's `EP24 EMA` best-checkpoint result suggests late-stage Lion noise is hurting val-test transfer — Lookahead addresses this at the OPTIMIZATION step level rather than parameter snapshot level

**Predicted outcome:** test_WSS < 6.65% (beats H39 SOTA). Mechanism activates from step 1 (k=5 → first slow update at step 5), so EP1-EP3 trajectory should be within ±0.1pp of H39 baseline (no late-activation delay).

## Instructions

You are adding **ONLY** Lookahead optimizer wrapping to H39's existing Lion baseline. All H39 hyperparameters are preserved.

### Step 1: Add Lookahead wrapper

Create a new file `torch_lookahead.py` in `target/` (or add to existing optimizer module):

```python
import torch
from torch.optim import Optimizer
from collections import defaultdict

class Lookahead(Optimizer):
    """Lookahead optimizer wrapper. Implements Algorithm 1 from
    Zhang et al. 2019 (arxiv 1907.08610).
    """
    def __init__(self, base_optimizer, k=5, alpha=0.5):
        if not 0.0 <= alpha <= 1.0:
            raise ValueError(f"Invalid alpha: {alpha}")
        if not 1 <= k:
            raise ValueError(f"Invalid k: {k}")

        self.optimizer = base_optimizer
        self.k = k
        self.alpha = alpha
        self.step_counter = 0
        self.state = defaultdict(dict)
        self.param_groups = self.optimizer.param_groups
        self.defaults = self.optimizer.defaults

        # Cache slow weights (copy of fast weights at init)
        for group in self.param_groups:
            for p in group['params']:
                param_state = self.state[p]
                param_state['slow_weight'] = p.detach().clone()
                param_state['slow_weight'].requires_grad = False

    @torch.no_grad()
    def step(self, closure=None):
        # Inner: base optimizer step
        loss = self.optimizer.step(closure)
        self.step_counter += 1

        # Outer: every k steps, update slow and reset fast
        if self.step_counter % self.k == 0:
            for group in self.param_groups:
                for p in group['params']:
                    if p.grad is None:
                        continue
                    param_state = self.state[p]
                    slow = param_state['slow_weight']
                    slow.add_(p.data - slow, alpha=self.alpha)
                    p.data.copy_(slow)
        return loss

    def state_dict(self):
        return {
            'base_state': self.optimizer.state_dict(),
            'lookahead_state': {
                'step_counter': self.step_counter,
                'k': self.k, 'alpha': self.alpha,
                'slow_weights': {id(p): self.state[p]['slow_weight']
                                 for g in self.param_groups for p in g['params']},
            }
        }

    def load_state_dict(self, state_dict):
        self.optimizer.load_state_dict(state_dict['base_state'])
        lh = state_dict['lookahead_state']
        self.step_counter = lh['step_counter']
        self.k = lh['k']
        self.alpha = lh['alpha']
        for group in self.param_groups:
            for p in group['params']:
                if id(p) in lh['slow_weights']:
                    self.state[p]['slow_weight'].copy_(lh['slow_weights'][id(p)])

    def zero_grad(self, set_to_none=True):
        return self.optimizer.zero_grad(set_to_none=set_to_none)
```

### Step 2: Wire into train.py

Find the section in `train.py` where the optimizer is constructed (after `optimizer = Lion(...)`) and wrap it conditionally:

```python
# After existing optimizer construction
base_optimizer = optimizer  # Save reference to base Lion
if args.lookahead:
    from torch_lookahead import Lookahead
    optimizer = Lookahead(base_optimizer, k=args.lookahead_k, alpha=args.lookahead_alpha)
    print(f"[H143] Lookahead wrapping Lion: k={args.lookahead_k}, alpha={args.lookahead_alpha}")
```

Add CLI args:
```python
parser.add_argument('--lookahead', action='store_true', help='Wrap optimizer with Lookahead')
parser.add_argument('--lookahead-k', type=int, default=5, help='Lookahead inner steps')
parser.add_argument('--lookahead-alpha', type=float, default=0.5, help='Lookahead slow-weight update coef')
```

### Step 3: GradNorm compatibility

H39 uses GradNorm for task balancing. GradNorm modifies `optimizer.param_groups[*]['lr']` or modifies losses before `.backward()`. Verify that:
- GradNorm operates on `optimizer.param_groups` — Lookahead exposes these via `self.param_groups = self.optimizer.param_groups`, so GradNorm should see the same groups
- If GradNorm calls `optimizer.step()`, it now calls Lookahead.step() which internally calls Lion.step() — should be transparent

If GradNorm does anything unusual (e.g., accesses `optimizer.state[p]` for momentum), check that it still works. Lookahead adds `state[p]['slow_weight']` keys; GradNorm should ignore unknown state keys.

### Gates

**IMPORTANT — TRAJECTORY EXPECTATIONS BASED ON MECHANISM:**

Lookahead's mechanism activates from **step 5** (first slow update). Unlike SWA which activates at EP21+, Lookahead's effect is present throughout training. Expected trajectory vs H39 baseline:

| EP | H39 val_WSS | H143 expected (±0.15pp) |
|----|-------------|-------------------------|
| 1 | 17.90 | 17.75-18.05 |
| 3 | ~7.00 | 6.85-7.15 |
| 6 | ~6.85 | 6.70-7.00 |
| 15 | ~6.80 | 6.65-6.95 |
| 30 | ~6.77 (val), 6.65 (test) | 6.60-6.80 val, 6.55-6.70 test |

**Hard-abort gates (DO NOT CLOSE for transient noise within these bands):**
- **Smoke (1 epoch):** No NaN, no DDP errors, Lookahead step_counter increments correctly. Log first few `[H143]` outer-step prints to confirm k=5 trigger.
- **EP1 (step 10976):** val_WSS within ±0.5pp of H39 EP1 (17.40-18.40%). Tight band — Lookahead's effect is mild at EP1.
- **EP3 (step 32927):** val_WSS ≤ 7.30%. (H141 SWA was at 7.32% at EP3 which is +0.32pp above H39 — Lookahead should be cleaner.)
- **EP6 (step 65855):** val_WSS ≤ 7.00%.
- **EP15 (step 164640):** val_WSS ≤ 6.90%.
- **EP30 terminal:** report both Lookahead trajectory and H39 reference.

**DO NOT CLOSE THIS EXPERIMENT UNDER "WEIGHT AVERAGING AXIS CLOSED" REASONING.** Lookahead is NOT weight averaging — it is slow-weight / fast-weight alternation with re-synchronization. The prior closure logic conflated H141 SWA (late-activation snapshot averaging) with H142 EMA (online Polyak averaging). Lookahead is a distinct third optimization paradigm from Zhang et al. 2019.

## Baseline

H39 SOTA (PR #1284 MERGED 2026-05-24 10:57Z, run `yym5oa8x`):

| Metric | H39 |
|--------|-----:|
| `test_primary/wall_shear_rel_l2_pct` | **6.6506%** ⭐ (PRIMARY target — beat this) |
| `test_primary/volume_pressure_rel_l2_pct` | 3.6033% (clears 3.643% floor ✓) |
| `test_primary/surface_pressure_rel_l2_pct` | 3.6498% (misses 3.577% floor by +0.073pp) |
| `test_primary/abupt_axis_mean_rel_l2_pct` | 5.8010% (clears 5.844% floor ✓) |
| Per-axis WSS | wss_x=5.9031%, wss_y=7.1901%, wss_z=8.6587% |
| Best checkpoint | EP24 EMA |

**Reproduce command (start from H39 SOTA, ADD Lookahead ONLY):**

```bash
cd /workspace/senpai/target && python train.py \
  --dataset-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --batch-size 1 \
  --train-points 65000 \
  --val-train-points 65000 \
  --num-epochs 30 \
  --lr 1e-4 \
  --lr-schedule cosine \
  --optimizer lion \
  --hidden-dim 512 \
  --depth 6 \
  --num-slices 128 \
  --surface-out-factor 2.0 \
  --loss-charbonnier-z 0.1 \
  --gradnorm \
  --gradnorm-alpha 0.5 \
  --gradnorm-clamp 0.15 \
  --curvature-attention-bias \
  --y-symmetry-aug \
  --lookahead \
  --lookahead-k 5 \
  --lookahead-alpha 0.5 \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h143-lookahead-lion
```

Baseline W&B: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8` run `yym5oa8x`

## Notes for student

- **This is your 3rd consecutive assignment after H137, H141, H142 closures.** H137 PCGrad was a real mechanism null (passive failure). H141 SWA was a process failure (you ran it but didn't post the W&B run ID — your runs actually completed EP3). H142 EMA was prematurely closed by another advisor session under bad logic that conflated it with H141.
- **PLEASE post your W&B run ID within 30 minutes of pickup.** This is the single highest-priority response item. Two consecutive missing W&B posts have led to false-positive closures.
- **POST EP1 RESULTS within ~90 min** of run start. EP gates are: EP1 sanity, EP3 hard-abort, EP6 gate, EP15 gate, EP30 terminal.
- Lookahead is a 50-line wrapper around the existing Lion optimizer. Should take ~30 min to implement and smoke-test.
- All H39 hyperparameters preserved — the ONLY delta is wrapping Lion with Lookahead(k=5, alpha=0.5).

**Priority for status hygiene:**
1. ACK this PR within 10 minutes
2. Implement Lookahead wrapper, run smoke
3. Post smoke W&B run ID + GPU memory + Lookahead diagnostics
4. Launch full 30-EP run, post run ID immediately
5. Sparse wakeups for EP1, EP3, EP6, EP15, EP30
