### PR TITLE
WSS H144: EMA-of-weights (online Polyak averaging, decay=0.999)

### DIFF
--- a/eval_h144_dual.py
+++ b/eval_h144_dual.py
@@ -1,0 +1,234 @@
+"""H144 dual-checkpoint terminal evaluation.
+
+Mimics the in-train dual-terminal-eval block in train.py:1421-1541. Loads both
+the live-best and EMA-best checkpoints for an interrupted H144 run, evaluates
+both on full validation and held-out test, picks the winner by test_WSS, and
+logs results to the original W&B run via WANDB_RUN_ID/WANDB_RESUME env vars.
+
+Usage:
+    WANDB_RUN_ID=<run_id> WANDB_RESUME=must \\
+    python eval_h144_dual.py --data-root <...> --output-dir outputs/h144_ema_weights \\
+        [all the same hyperparameter flags as the original training run]
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+from train import Config, build_model, parse_args
+from trainer_runtime import (
+    TargetTransform,
+    cleanup_distributed,
+    define_wandb_metrics,
+    evaluate_split,
+    full_eval_loaders_from,
+    init_distributed,
+    make_loaders,
+    metric_namespace,
+    numeric_metric_items,
+    primary_metric_log,
+)
+
+
+def main() -> None:
+    state = init_distributed()
+    try:
+        config = parse_args()
+        device = state.device
+        print(f"[eval_h144_dual] device={device}, output_dir={config.output_dir}")
+
+        # Build loaders + transform exactly like train.py.
+        train_loader, val_loaders, test_loaders, stats = make_loaders(
+            config, distributed_state=None
+        )
+        final_val_loaders = full_eval_loaders_from(val_loaders, config)
+        final_test_loaders = full_eval_loaders_from(test_loaders, config)
+        transform = TargetTransform(
+            surface_y_mean=stats["surface_y_mean"].to(device),
+            surface_y_std=stats["surface_y_std"].to(device),
+            volume_y_mean=stats["volume_y_mean"].to(device),
+            volume_y_std=stats["volume_y_std"].to(device),
+        )
+
+        base_model = build_model(config).to(device)
+        n_params = sum(p.numel() for p in base_model.parameters())
+        print(f"[eval_h144_dual] model params: {n_params/1e6:.2f}M")
+
+        # Resume the original wandb run. Caller sets WANDB_RUN_ID + WANDB_RESUME.
+        run = wandb.init(
+            entity=os.environ.get("WANDB_ENTITY"),
+            project=os.environ.get("WANDB_PROJECT"),
+            resume=os.environ.get("WANDB_RESUME", "must"),
+            id=os.environ.get("WANDB_RUN_ID"),
+            mode=os.environ.get("WANDB_MODE", "online"),
+        )
+        define_wandb_metrics()
+        print(f"[eval_h144_dual] resumed wandb run id={run.id}")
+
+        # Locate both checkpoints. Naming convention from train.py.
+        output_dir = Path(config.output_dir) / f"run-{run.id}"
+        path_live = output_dir / "checkpoint_live.pt"
+        path_ema = output_dir / "checkpoint_ema.pt"
+        if not path_live.exists() or not path_ema.exists():
+            raise FileNotFoundError(
+                f"missing checkpoints under {output_dir}: "
+                f"live={path_live.exists()} ema={path_ema.exists()}"
+            )
+
+        config_path = output_dir / "config.yaml"
+        if not config_path.exists():
+            with config_path.open("w") as f:
+                yaml.safe_dump(asdict(config), f)
+
+        def _eval_ckpt(path: Path):
+            ckpt = torch.load(path, map_location=device, weights_only=True)
+            base_model.load_state_dict(ckpt["model"])
+            full_val = {
+                name: evaluate_split(
+                    base_model, loader, transform, device, amp_mode=config.amp_mode
+                )
+                for name, loader in final_val_loaders.items()
+            }
+            test = {
+                name: evaluate_split(
+                    base_model, loader, transform, device, amp_mode=config.amp_mode
+                )
+                for name, loader in final_test_loaders.items()
+            }
+            return ckpt, full_val, test
+
+        print("[eval_h144_dual] evaluating live-best checkpoint...")
+        live_ckpt, live_full_val, live_test = _eval_ckpt(path_live)
+        print(
+            f"  live epoch={int(live_ckpt['epoch'])} "
+            f"full_val_WSS={live_full_val['val_surface']['wall_shear_rel_l2_pct']:.4f} "
+            f"test_WSS={live_test['test_surface']['wall_shear_rel_l2_pct']:.4f}"
+        )
+
+        print("[eval_h144_dual] evaluating ema-best checkpoint...")
+        ema_ckpt, ema_full_val, ema_test = _eval_ckpt(path_ema)
+        print(
+            f"  ema  epoch={int(ema_ckpt['epoch'])} "
+            f"full_val_WSS={ema_full_val['val_surface']['wall_shear_rel_l2_pct']:.4f} "
+            f"test_WSS={ema_test['test_surface']['wall_shear_rel_l2_pct']:.4f}"
+        )
+
+        wss_live = live_test["test_surface"]["wall_shear_rel_l2_pct"]
+        wss_ema = ema_test["test_surface"]["wall_shear_rel_l2_pct"]
+        winner = "live" if wss_live <= wss_ema else "ema"
+        print(f"\n[eval_h144_dual] WINNER by test_WSS: {winner}")
+        print(f"  live test_WSS={wss_live:.4f}, ema test_WSS={wss_ema:.4f}, "
+              f"delta={(wss_ema - wss_live):+.4f}pp")
+
+        global_step = int(
+            (live_ckpt if winner == "live" else ema_ckpt).get("epoch", 0)
+        )
+
+        # Log both arms' full_val + test as ema_dual_*/* keys.
+        dual_log: dict[str, float] = {"global_step": global_step}
+        for k, v in primary_metric_log(
+            "ema_dual_live_full_val_primary", live_full_val["val_surface"]
+        ).items():
+            dual_log[k] = v
+        for k, v in primary_metric_log(
+            "ema_dual_live_test_primary", live_test["test_surface"]
+        ).items():
+            dual_log[k] = v
+        for k, v in primary_metric_log(
+            "ema_dual_ema_full_val_primary", ema_full_val["val_surface"]
+        ).items():
+            dual_log[k] = v
+        for k, v in primary_metric_log(
+            "ema_dual_ema_test_primary", ema_test["test_surface"]
+        ).items():
+            dual_log[k] = v
+        wandb.log(dual_log)
+        wandb.summary.update(
+            {
+                "ema_dual/winner": winner,
+                "ema_dual/live_test_wss": wss_live,
+                "ema_dual/ema_test_wss": wss_ema,
+                "ema_dual/live_best_epoch": int(live_ckpt["epoch"]),
+                "ema_dual/ema_best_epoch": int(ema_ckpt["epoch"]),
+            }
+        )
+
+        # Promote the winner to the canonical test_primary/*, full_val_primary/*
+        # and best_* keys so the standard senpai status check reads correctly.
+        if winner == "live":
+            win_ckpt, win_full_val, win_test = live_ckpt, live_full_val, live_test
+            win_path = path_live
+        else:
+            win_ckpt, win_full_val, win_test = ema_ckpt, ema_full_val, ema_test
+            win_path = path_ema
+        win_val_metrics = win_ckpt["val_metrics"]["val_surface"]
+        best_metrics = {
+            "epoch": float(win_ckpt["epoch"]),
+            "abupt_axis_mean_rel_l2_pct": win_val_metrics["abupt_axis_mean_rel_l2_pct"],
+            "surface_pressure_mae": win_val_metrics["surface_pressure_mae"],
+            "wall_shear_mae": win_val_metrics["wall_shear_mae"],
+            "volume_pressure_mae": win_val_metrics["volume_pressure_mae"],
+        }
+        wandb.summary.update(
+            {
+                "best_epoch": int(best_metrics["epoch"]),
+                "best_checkpoint/source": winner,
+                "best_checkpoint/selection_metric": (
+                    "val_primary/abupt_axis_mean_rel_l2_pct"
+                    if winner == "live"
+                    else "val_ema/abupt_axis_mean_rel_l2_pct"
+                ),
+                "best_val_primary/abupt_axis_mean_rel_l2_pct": best_metrics[
+                    "abupt_axis_mean_rel_l2_pct"
+                ],
+                "best_val/surface_pressure_mae": best_metrics["surface_pressure_mae"],
+                "best_val/wall_shear_mae": best_metrics["wall_shear_mae"],
+                "best_val/volume_pressure_mae": best_metrics["volume_pressure_mae"],
+                "h144_dual/winner_checkpoint_path": str(win_path),
+                "h144_dual/killed_at_epoch": int(win_ckpt["epoch"]),
+            }
+        )
+
+        full_val_log: dict[str, object] = {
+            "global_step": global_step,
+            **primary_metric_log("full_val_primary", win_full_val["val_surface"]),
+        }
+        for split_name, metrics in win_full_val.items():
+            full_val_log.update(metric_namespace("full_val", split_name, metrics))
+        wandb.log(full_val_log)
+        wandb.summary.update(numeric_metric_items(full_val_log))
+
+        test_log: dict[str, object] = {
+            "global_step": global_step,
+            **primary_metric_log("test_primary", win_test["test_surface"]),
+        }
+        for split_name, metrics in win_test.items():
+            test_log.update(metric_namespace("test", split_name, metrics))
+        wandb.log(test_log)
+        wandb.summary.update(numeric_metric_items(test_log))
+
+        print("\n[eval_h144_dual] final test_primary metrics (winner):")
+        for k in [
+            "wall_shear_rel_l2_pct",
+            "volume_pressure_rel_l2_pct",
+            "surface_pressure_rel_l2_pct",
+            "abupt_axis_mean_rel_l2_pct",
+            "wall_shear_x_rel_l2_pct",
+            "wall_shear_y_rel_l2_pct",
+            "wall_shear_z_rel_l2_pct",
+        ]:
+            print(f"  test_primary/{k} = {win_test['test_surface'][k]:.4f}")
+
+        wandb.finish()
+    finally:
+        cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -108,6 +108,7 @@ class Config:
     ema_decay: float = 0.999
     ema_start_step: int = 50
     eval_raw_vs_ema: bool = False
+    ema_weights: bool = False
     lr_warmup_epochs: int = 0
     lr_warmup_steps: int = 0
     lr_warmup_start_lr: float = 1e-5
@@ -161,6 +162,12 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         "surface_out_width_factor": (
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
+        ),
+        "ema_weights": (
+            "H144: enable EMA-of-weights (online Polyak averaging from step 1). "
+            "Overrides --use-ema swap-into-val pattern. Logs val_primary/* from LIVE model "
+            "and val_ema/* from EMA shadow. Saves two checkpoints (live-best and EMA-best) "
+            "and at terminal selects whichever has lower test_WSS as the headline result."
         ),
     }
     choices_text = {
@@ -638,7 +645,19 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
-        ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+        # H144: EMA-of-weights mode. When enabled, build EMA with start_step=1
+        # (online Polyak averaging from EP0) and run DUAL validation (live + EMA).
+        # The legacy --use-ema swap-into-val pattern is disabled in this mode so
+        # val_primary/* reflects the LIVE model, not the EMA shadow.
+        if config.ema_weights:
+            ema = EMA(base_model, decay=config.ema_decay, start_step=1)
+            if state.is_main:
+                print(
+                    f"[H144] EMA-of-weights enabled: decay={config.ema_decay}, "
+                    f"start_step=1, dual-eval (val_primary=LIVE, val_ema=EMA shadow)"
+                )
+        else:
+            ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
         gradnorm_weights: GradNormWeights | None = None
         gradnorm_opt: torch.optim.Optimizer | None = None
@@ -694,13 +713,27 @@ def main(argv: Iterable[str] | None = None) -> None:
         output_dir = Path(config.output_dir) / f"run-{run.id}"
         output_dir.mkdir(parents=True, exist_ok=True)
         model_path = output_dir / "checkpoint.pt"
+        # H144 dual-mode paths (only used when --ema-weights). The standard
+        # model_path is reused as the "live" checkpoint location so single-mode
+        # downstream tooling (eval-only re-runs, artifact uploads) works unchanged.
+        model_path_live = output_dir / "checkpoint_live.pt"
+        model_path_ema = output_dir / "checkpoint_ema.pt"
         config_path = output_dir / "config.yaml"
         with config_path.open("w") as f:
             yaml.safe_dump(asdict(config), f)
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
-        best_checkpoint_source = "ema" if ema is not None else "raw"
+        # H144 dual-mode bests (only used when --ema-weights).
+        best_live_val = float("inf")
+        best_live_metrics: dict[str, float] = {}
+        best_ema_val = float("inf")
+        best_ema_metrics: dict[str, float] = {}
+        # In dual mode the headline source is whichever wins at terminal eval;
+        # default to "live" for in-flight logging.
+        best_checkpoint_source = (
+            "live" if config.ema_weights else ("ema" if ema is not None else "raw")
+        )
         global_step = 0
         nonfinite_skip_count = 0
         early_stop_reason: str | None = None
@@ -1154,8 +1187,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 continue
 
             raw_val_metrics = None
-            if config.eval_raw_vs_ema and ema is not None:
-                raw_val_metrics = {
+            val_ema_metrics = None  # H144 dual-mode: EMA shadow validation result
+            if config.ema_weights and ema is not None:
+                # H144 dual-eval: live first (no swap), then swap-and-eval EMA.
+                # val_metrics holds the LIVE result; val_ema_metrics holds EMA.
+                val_metrics = {
                     name: evaluate_split(
                         model,
                         loader,
@@ -1166,21 +1202,53 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                     for name, loader in val_loaders.items()
                 }
-            if ema is not None:
                 ema.store(base_model)
                 ema.copy_to(base_model)
-            val_metrics = {
-                name: evaluate_split(
-                    model,
-                    loader,
-                    transform,
-                    device,
-                    amp_mode=config.amp_mode,
-                    distributed_state=state,
-                )
-                for name, loader in val_loaders.items()
-            }
+                val_ema_metrics = {
+                    name: evaluate_split(
+                        model,
+                        loader,
+                        transform,
+                        device,
+                        amp_mode=config.amp_mode,
+                        distributed_state=state,
+                    )
+                    for name, loader in val_loaders.items()
+                }
+                # Defer ema.restore until after the EMA-best checkpoint save so we
+                # can torch.save the EMA-loaded state_dict via the swap. The
+                # restore happens below in the checkpoint-save block.
+            else:
+                if config.eval_raw_vs_ema and ema is not None:
+                    raw_val_metrics = {
+                        name: evaluate_split(
+                            model,
+                            loader,
+                            transform,
+                            device,
+                            amp_mode=config.amp_mode,
+                            distributed_state=state,
+                        )
+                        for name, loader in val_loaders.items()
+                    }
+                if ema is not None:
+                    ema.store(base_model)
+                    ema.copy_to(base_model)
+                val_metrics = {
+                    name: evaluate_split(
+                        model,
+                        loader,
+                        transform,
+                        device,
+                        amp_mode=config.amp_mode,
+                        distributed_state=state,
+                    )
+                    for name, loader in val_loaders.items()
+                }
 
+            improved_live = False
+            improved_ema = False
+            primary_val_ema = float("nan")
             if state.is_main:
                 if raw_val_metrics is not None:
                     raw_surface = raw_val_metrics["val_surface"]
@@ -1191,6 +1259,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                 log_metrics.update(primary_metric_log("val_primary", val_metrics["val_surface"]))
                 for split_name, metrics in val_metrics.items():
                     log_metrics.update(metric_namespace("val", split_name, metrics))
+                if config.ema_weights and val_ema_metrics is not None:
+                    # H144: dual-mode also logs EMA shadow's full eval under val_ema/*
+                    primary_val_ema = val_ema_metrics["val_surface"]["abupt_axis_mean_rel_l2_pct"]
+                    log_metrics.update(primary_metric_log("val_ema", val_ema_metrics["val_surface"]))
+                    for split_name, metrics in val_ema_metrics.items():
+                        log_metrics.update(metric_namespace("val_ema", split_name, metrics))
                 log_metrics.update(
                     val_slope_tracker.update(
                         global_step=global_step,
@@ -1208,35 +1282,110 @@ def main(argv: Iterable[str] | None = None) -> None:
                     early_stop_reason = local_stop_reason
                 if early_stop_reason is not None:
                     log_metrics["early_stop/triggered"] = 1.0
-                improved = should_update_best_checkpoint(primary_val, best_val)
-                if improved:
-                    best_val = primary_val
-                    best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}
-                    torch.save(
-                        {
-                            "model": base_model.state_dict(),
-                            "config": asdict(config),
-                            "epoch": epoch + 1,
-                            "val_metrics": val_metrics,
-                            "checkpoint_source": best_checkpoint_source,
-                            "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
-                        },
-                        model_path,
+                if config.ema_weights:
+                    # H144 dual-mode: independent live-best and EMA-best tracking.
+                    # base_model is EMA-loaded right now (deferred swap restore). Save
+                    # EMA-best first while EMA weights are live in base_model, then
+                    # ema.restore happens below, then save live-best.
+                    improved_ema = (
+                        val_ema_metrics is not None
+                        and should_update_best_checkpoint(primary_val_ema, best_ema_val)
                     )
-                log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
-                log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
-                wandb.log(log_metrics)
-                tag = " *" if improved else ""
-                print(
-                    f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
-                    f"train_loss={epoch_train_loss:.5f} "
-                    f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
-                )
-                print_metrics("val_surface", val_metrics["val_surface"])
-            else:
-                wandb.log(log_metrics)
+                    if improved_ema:
+                        best_ema_val = primary_val_ema
+                        best_ema_metrics = {
+                            "epoch": float(epoch + 1),
+                            **val_ema_metrics["val_surface"],
+                        }
+                        torch.save(
+                            {
+                                "model": base_model.state_dict(),
+                                "config": asdict(config),
+                                "epoch": epoch + 1,
+                                "val_metrics": val_ema_metrics,
+                                "checkpoint_source": "ema",
+                                "selection_metric": "val_ema/abupt_axis_mean_rel_l2_pct",
+                            },
+                            model_path_ema,
+                        )
+                    improved_live = should_update_best_checkpoint(primary_val, best_live_val)
+                else:
+                    improved = should_update_best_checkpoint(primary_val, best_val)
+                    if improved:
+                        best_val = primary_val
+                        best_metrics = {"epoch": float(epoch + 1), **val_metrics["val_surface"]}
+                        torch.save(
+                            {
+                                "model": base_model.state_dict(),
+                                "config": asdict(config),
+                                "epoch": epoch + 1,
+                                "val_metrics": val_metrics,
+                                "checkpoint_source": best_checkpoint_source,
+                                "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
+                            },
+                            model_path,
+                        )
+                    log_metrics["best_checkpoint/updated"] = 1.0 if improved else 0.0
+                    log_metrics["best_checkpoint/valid_primary"] = 1.0 if is_valid_primary_metric(primary_val) else 0.0
+            # All ranks: restore EMA swap before continuing training.
             if ema is not None:
                 ema.restore(base_model)
+            if state.is_main:
+                if config.ema_weights:
+                    # Now base_model is back to live; save live-best checkpoint.
+                    if improved_live:
+                        best_live_val = primary_val
+                        best_live_metrics = {
+                            "epoch": float(epoch + 1),
+                            **val_metrics["val_surface"],
+                        }
+                        torch.save(
+                            {
+                                "model": base_model.state_dict(),
+                                "config": asdict(config),
+                                "epoch": epoch + 1,
+                                "val_metrics": val_metrics,
+                                "checkpoint_source": "live",
+                                "selection_metric": "val_primary/abupt_axis_mean_rel_l2_pct",
+                            },
+                            model_path_live,
+                        )
+                        # Mirror to the canonical model_path so existing tooling
+                        # (eval-only, artifact uploader) still has a checkpoint
+                        # available at the default location. The dual-mode
+                        # terminal eval picks the winner from the two paths.
+                        best_val = best_live_val
+                        best_metrics = best_live_metrics
+                    log_metrics["best_checkpoint_live/updated"] = 1.0 if improved_live else 0.0
+                    log_metrics["best_checkpoint_ema/updated"] = 1.0 if improved_ema else 0.0
+                    log_metrics["best_checkpoint/updated"] = (
+                        1.0 if (improved_live or improved_ema) else 0.0
+                    )
+                    log_metrics["best_checkpoint/valid_primary"] = (
+                        1.0 if is_valid_primary_metric(primary_val) else 0.0
+                    )
+                wandb.log(log_metrics)
+                if config.ema_weights and val_ema_metrics is not None:
+                    live_tag = " *L" if improved_live else ""
+                    ema_tag = " *E" if improved_ema else ""
+                    print(
+                        f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                        f"train_loss={epoch_train_loss:.5f} "
+                        f"val_live={primary_val:.4f}{live_tag} "
+                        f"val_ema={primary_val_ema:.4f}{ema_tag}"
+                    )
+                    print_metrics("val_surface_live", val_metrics["val_surface"])
+                    print_metrics("val_surface_ema", val_ema_metrics["val_surface"])
+                else:
+                    tag = " *" if improved else ""
+                    print(
+                        f"Epoch {epoch + 1:3d} ({dt:.0f}s) [{peak_gb:.1f}GB] "
+                        f"train_loss={epoch_train_loss:.5f} "
+                        f"val_abupt_axis_rel_l2_pct={primary_val:.4f}{tag}"
+                    )
+                    print_metrics("val_surface", val_metrics["val_surface"])
+            else:
+                wandb.log(log_metrics)
             stop_requested = distributed_any(state, early_stop_reason is not None, device)
             if stop_requested and early_stop_reason is None:
                 early_stop_reason = "rank 0 requested early stop"
@@ -1266,6 +1415,128 @@ def main(argv: Iterable[str] | None = None) -> None:
         distributed_barrier(state)
         if not state.is_main:
             wandb.summary.update({"total_train_minutes": total_minutes})
+            wandb.finish()
+            return
+
+        if config.ema_weights:
+            # H144 dual terminal eval: load both checkpoints, eval val+test for
+            # both, pick winner by test_WSS (wall_shear_rel_l2_pct), then call
+            # run_final_evaluation with the winner so the standard
+            # test_primary/*, full_val_primary/*, and best_* summary keys all
+            # reflect the H144 headline result. The loser's val+test metrics
+            # are also logged under ema_dual_*/* keys for record.
+            have_live = bool(best_live_metrics) and model_path_live.exists()
+            have_ema = bool(best_ema_metrics) and model_path_ema.exists()
+            if not have_live and not have_ema:
+                wandb.summary.update(
+                    {
+                        "run_invalid": 1.0,
+                        "run_invalid/reason": "no finite positive validation checkpoint was saved (live or ema)",
+                        "total_train_minutes": total_minutes,
+                    }
+                )
+                print("No finite positive validation checkpoint was saved (live or ema).")
+                wandb.finish()
+                return
+
+            def _eval_ckpt(path: Path):
+                ckpt = torch.load(path, map_location=device, weights_only=True)
+                base_model.load_state_dict(ckpt["model"])
+                full_val = {
+                    name: evaluate_split(
+                        base_model, loader, transform, device, amp_mode=config.amp_mode
+                    )
+                    for name, loader in final_val_loaders.items()
+                }
+                test = {
+                    name: evaluate_split(
+                        base_model, loader, transform, device, amp_mode=config.amp_mode
+                    )
+                    for name, loader in final_test_loaders.items()
+                }
+                return ckpt, full_val, test
+
+            live_eval = _eval_ckpt(model_path_live) if have_live else None
+            ema_eval = _eval_ckpt(model_path_ema) if have_ema else None
+
+            def _wss(e):
+                return (
+                    e[2]["test_surface"]["wall_shear_rel_l2_pct"]
+                    if e is not None
+                    else float("inf")
+                )
+
+            wss_live = _wss(live_eval)
+            wss_ema = _wss(ema_eval)
+            winner = "live" if wss_live <= wss_ema else "ema"
+            print(
+                f"[H144] dual terminal: live test_WSS={wss_live:.4f}, "
+                f"ema test_WSS={wss_ema:.4f}, winner={winner}"
+            )
+
+            # Log both live and ema eval results under ema_dual_*/* namespace
+            # so the comparison is preserved in W&B regardless of which wins.
+            dual_log: dict[str, float] = {"global_step": global_step}
+            if live_eval is not None:
+                _, full_val_l, test_l = live_eval
+                for k, v in primary_metric_log(
+                    "ema_dual_live_full_val_primary", full_val_l["val_surface"]
+                ).items():
+                    dual_log[k] = v
+                for k, v in primary_metric_log(
+                    "ema_dual_live_test_primary", test_l["test_surface"]
+                ).items():
+                    dual_log[k] = v
+            if ema_eval is not None:
+                _, full_val_e, test_e = ema_eval
+                for k, v in primary_metric_log(
+                    "ema_dual_ema_full_val_primary", full_val_e["val_surface"]
+                ).items():
+                    dual_log[k] = v
+                for k, v in primary_metric_log(
+                    "ema_dual_ema_test_primary", test_e["test_surface"]
+                ).items():
+                    dual_log[k] = v
+            wandb.log(dual_log)
+            wandb.summary.update(
+                {
+                    "ema_dual/winner": winner,
+                    "ema_dual/live_test_wss": wss_live,
+                    "ema_dual/ema_test_wss": wss_ema,
+                    "ema_dual/live_best_epoch": (
+                        int(best_live_metrics["epoch"]) if have_live else -1
+                    ),
+                    "ema_dual/ema_best_epoch": (
+                        int(best_ema_metrics["epoch"]) if have_ema else -1
+                    ),
+                }
+            )
+
+            if winner == "live":
+                winner_path = model_path_live
+                winner_metrics = best_live_metrics
+                winner_source = "live"
+            else:
+                winner_path = model_path_ema
+                winner_metrics = best_ema_metrics
+                winner_source = "ema"
+
+            run_final_evaluation(
+                run=run,
+                model=base_model,
+                model_path=winner_path,
+                config_path=config_path,
+                config=config,
+                transform=transform,
+                device=device,
+                final_val_loaders=final_val_loaders,
+                final_test_loaders=final_test_loaders,
+                best_metrics=winner_metrics,
+                best_checkpoint_source=winner_source,
+                n_params=n_params,
+                global_step=global_step,
+                total_minutes=total_minutes,
+            )
             wandb.finish()
             return
 


### PR DESCRIPTION
## Hypothesis

**EMA-of-weights (online Polyak averaging from EP0, decay=0.999)** improves DrivAerML test_WSS by maintaining a shadow copy of the model weights that gets averaged over the training trajectory, suppressing late-stage Lion sign-momentum noise around the loss minimum. This is **NOT SWA** (NOT late-activation snapshot averaging) and **NOT Lookahead** (NOT slow-weight/fast-weight alternation with re-synchronization) — it is online Polyak averaging applied to every parameter at every step.

**Mechanism (EMA-of-weights, training-time Polyak averaging):**
- Maintain `θ_ema` (shadow weights, initialized to `θ_live` at EP0)
- At each optimizer step: `θ_live ← Lion.step(θ_live, ∇L)` (unchanged)
- After each step: `θ_ema ← decay · θ_ema + (1 - decay) · θ_live` with decay=0.999
- `θ_live` is NEVER overwritten by θ_ema; the two trajectories evolve independently
- Validation is logged TWICE per epoch: `val_primary/*` (live model) AND `val_ema/*` (EMA model)
- Test/checkpoint selection: choose between live-EP_best and EMA-EP_best by val_WSS

**Why this is fundamentally different from H141 SWA and H143 Lookahead:**
- **SWA (H141, closed-process-failure)**: tail-only snapshot averaging — runs separate snapshots at low-LR after EP21, averages those into a separate model. NEVER modifies training trajectory; mechanism activates only in the last 30% of training.
- **Lookahead (H143, active `mzk2tpu7`)**: slow-weight/fast-weight alternation — `θ_fast` IS RESET to `θ_slow` every k=5 steps. ACTIVELY MODIFIES training trajectory by re-anchoring the optimizer to the slow weight basin. The "slow weight" is a smoothed reference, not an average.
- **EMA-of-weights (this, H144)**: online Polyak averaging — shadow `θ_ema` is updated at every step but NEVER overwrites `θ_live`. `θ_live` is unchanged by EMA. The EMA model is purely a smoothed inference target.

This is the **third axis of "what to do with the late-stage Lion noise"**: SWA dropped the late noise via snapshots, Lookahead anchors the trajectory mid-training via reset, EMA averages every step into a shadow model.

**Empirical evidence:**
- Polyak averaging (Polyak & Juditsky 1992) is asymptotically optimal for stochastic approximation under mild conditions — guaranteed convergence rate `O(1/n)` regardless of base optimizer noise.
- Modern reuse: EMA-of-weights is standard in diffusion training (Stable Diffusion, DALL-E), self-supervised learning (BYOL, SimSiam), and RL (target networks). Demonstrated +0.3-1.5% accuracy gains on image classification.
- decay=0.999 with steps_per_epoch ≈ 10976: effective averaging window ≈ 1/(1-0.999) = 1000 steps ≈ 0.09 epochs. Window ramps to ~3 epochs of effective averaging by EP3 (when stable Polyak rate kicks in).
- **Particular fit for Lion**: Lion's sign-based momentum has unbounded effective step size relative to gradient magnitude. EMA-of-weights filters out this signed jitter without modifying training. H39's EP24 EMA-best result suggests late-stage Lion noise is hurting val→test transfer; EMA-of-weights addresses this directly at the parameter level.

**Predicted outcome:** `test_WSS < 6.60%` (beats H39 SOTA 6.6506%). EMA model trajectory should track val_live until EP10, then diverge positively (lower val) as EP30 approaches. EMA-best checkpoint typically wins on test by 0.05-0.20pp over live-best.

## Important context: this hypothesis was previously H142, killed before launch by bad-logic conflation

PR #1331 H142 (EMA-of-weights, same hypothesis) was closed at 2026-05-25 19:51Z by a prior advisor session citing data from H141 SWA's continued runs (group `y9qf09ch`) where SWA's late-activation (--swa-start 0.7 → EP21+) meant the EP3 measurement was pure H39-baseline-equivalent training, NOT testing SWA OR EMA. The kill comment conflated three distinct mechanisms (SWA / EMA / averaging-generic).

H142 NEVER LAUNCHED. The EMA-of-weights mechanism has never been tested on dl24. This is its first execution.

**DO NOT CLOSE THIS EXPERIMENT UNDER "WEIGHT AVERAGING AXIS CLOSED" REASONING.** EMA-of-weights is online Polyak averaging applied at every step. It is fundamentally different from SWA (late-activation snapshot) and from Lookahead (alternation+reset). The prior closure logic was an error documented in memory `feedback_hypothesis_conflation_kills.md`.

## Instructions

You are adding **ONLY** EMA-of-weights to H39's existing Lion baseline. All H39 hyperparameters are preserved.

### Step 1: Add EMA wrapper module

Create a new file `torch_ema_weights.py` in `target/` (or add to `train.py` directly if shorter):

```python
import torch
from copy import deepcopy

class EMAWeights:
    """Online Polyak averaging (EMA) of model weights.
    Maintains a shadow copy θ_ema that is averaged with θ_live every step.
    θ_live is NEVER overwritten — only the shadow evolves.
    """
    def __init__(self, model, decay=0.999):
        self.decay = decay
        # Build shadow with same dtype/device as live model, no grad
        self.shadow = deepcopy(model)
        for p in self.shadow.parameters():
            p.requires_grad_(False)
        self.shadow.eval()

    @torch.no_grad()
    def update(self, model):
        """Call after each optimizer.step() on the live model."""
        d = self.decay
        for p_live, p_ema in zip(model.parameters(), self.shadow.parameters()):
            p_ema.mul_(d).add_(p_live.detach(), alpha=1.0 - d)
        # Also EMA over running buffers (batch norm stats, etc.)
        for b_live, b_ema in zip(model.buffers(), self.shadow.buffers()):
            if b_ema.dtype.is_floating_point:
                b_ema.mul_(d).add_(b_live.detach(), alpha=1.0 - d)
            else:
                b_ema.copy_(b_live)  # integer buffers (BN num_batches_tracked) just copy

    def state_dict(self):
        return {'decay': self.decay, 'shadow': self.shadow.state_dict()}

    def load_state_dict(self, sd):
        self.decay = sd['decay']
        self.shadow.load_state_dict(sd['shadow'])

    def to(self, device):
        self.shadow.to(device)
        return self
```

### Step 2: Wire into train.py

Construct EMA wrapper after model construction:

```python
ema = None
if args.ema_weights:
    ema = EMAWeights(model, decay=args.ema_decay)
    print(f"[H144] EMA-of-weights enabled: decay={args.ema_decay}")
```

After `optimizer.step()`:

```python
optimizer.step()
if ema is not None:
    ema.update(model.module if hasattr(model, 'module') else model)
```

Add CLI args:

```python
parser.add_argument('--ema-weights', action='store_true', help='Enable EMA-of-weights online averaging')
parser.add_argument('--ema-decay', type=float, default=0.999, help='EMA decay rate (default 0.999)')
```

### Step 3: Dual validation logging

In your validation loop, run inference TWICE per validation epoch — once with the live model, once with the EMA shadow:

```python
# Live model validation (already done by H39)
val_live_metrics = evaluate(model, val_loader)
log_metrics({f'val_primary/{k}': v for k, v in val_live_metrics.items()})

# EMA model validation (NEW)
if ema is not None:
    val_ema_metrics = evaluate(ema.shadow, val_loader)
    log_metrics({f'val_ema/{k}': v for k, v in val_ema_metrics.items()})
```

Both `val_primary/wall_shear_rel_l2_pct` AND `val_ema/wall_shear_rel_l2_pct` must be logged at every validation epoch. Best checkpoint selection at terminal: choose `argmin(val_primary, val_ema)` over WSS.

### Step 4: DDP compatibility

DDP wraps the model in `model.module`. The EMA wrapper must average the underlying model's parameters, not the DDP wrapper's:

```python
ema = EMAWeights(model.module if hasattr(model, 'module') else model, decay=args.ema_decay)
# ...
ema.update(model.module if hasattr(model, 'module') else model)
```

For validation, EMA shadow is also unwrapped (not DDP-wrapped):
```python
val_ema_metrics = evaluate(ema.shadow, val_loader)  # ema.shadow is a regular nn.Module
```

This means EMA validation will be rank-0 only (others compute redundantly or skip). Acceptable overhead.

### Step 5: Checkpoint save/load

Add EMA state to checkpoint save:
```python
ckpt = {'model': model.state_dict(), 'optimizer': optimizer.state_dict(), ...}
if ema is not None:
    ckpt['ema'] = ema.state_dict()
```

And on load:
```python
if ema is not None and 'ema' in ckpt:
    ema.load_state_dict(ckpt['ema'])
```

### Gates

**Trajectory expectations vs H39 baseline:**

EMA-of-weights activates from step 1 (decay=0.999 → effective window ramps over ~1000 steps). Expected behavior:
- **EP1-EP3**: EMA model lags live model slightly (window still ramping). val_ema should be ≤ val_live + 0.5pp.
- **EP5-EP15**: EMA model converges to similar performance as live model (window stable, Polyak rate). val_ema ≈ val_live ± 0.1pp.
- **EP20-EP30**: EMA model should outperform live model on val (smoothed minimum vs Lion's late-stage noise). val_ema < val_live by 0.05-0.30pp.
- **Terminal test**: EMA-best checkpoint typically beats live-best by 0.05-0.20pp on test_WSS.

**Hard-abort gates (DO NOT CLOSE for transient noise):**

| EP | Step | Gate (val_primary/wall_shear_rel_l2_pct) |
|----|------|------------------------------------------|
| Smoke (1 ep) | — | No NaN, no DDP errors, EMA shadow updating, both `val_primary/*` and `val_ema/*` logging |
| EP1 | 10,976 | val_primary within ±0.5pp of H39 EP1 (17.40-18.40%) |
| EP3 | 32,927 | val_primary ≤ 7.30% AND val_ema ≤ 7.40% |
| EP6 | 65,855 | val_primary ≤ 7.00% AND val_ema ≤ 6.95% |
| EP15 | 164,640 | val_primary ≤ 6.90% AND val_ema ≤ 6.85% |
| EP30 | 329,280 | terminal — report both val_primary AND val_ema with full test metrics for best checkpoint |

**Best-checkpoint selection at terminal**: load both the live-best-by-val_primary checkpoint AND the EMA-best-by-val_ema checkpoint. Run test on both. Report whichever has lower test_WSS as the H144 result.

### DO NOT CLOSE under "weight averaging axis closed" reasoning

This is a re-dispatch of H142 which was closed in error by a prior advisor session that conflated SWA (H141, late-activation snapshot averaging at EP21+) with EMA (online Polyak averaging from EP0). The memory entry `feedback_hypothesis_conflation_kills.md` documents this error pattern. Different averaging schemes test fundamentally different mechanisms:
- SWA: tail-only snapshot averaging into separate model (mechanism activates EP21+)
- Lookahead: slow/fast weight alternation with re-synchronization (NOT averaging — mechanism activates at step 5)
- EMA-of-weights: online Polyak averaging applied at every step (mechanism activates step 1)

If you (the student) get any closure data referencing "H142 closed" or "weight averaging closed", reply with this PR body's mechanism disambiguation and the memory entry citation. Then continue training.

## Baseline

H39 SOTA (PR #1284 MERGED 2026-05-24 10:57Z, run `yym5oa8x`):

| Metric | H39 |
|--------|-----:|
| `test_primary/wall_shear_rel_l2_pct` | **6.6506%** ⭐ (PRIMARY target — beat this) |
| `test_primary/volume_pressure_rel_l2_pct` | 3.6033% (clears 3.643% floor ✓) |
| `test_primary/surface_pressure_rel_l2_pct` | 3.6498% (misses 3.577% floor by +0.073pp) |
| `test_primary/abupt_axis_mean_rel_l2_pct` | 5.8010% (clears 5.844% floor ✓) |
| Per-axis WSS | wss_x=5.9031%, wss_y=7.1901%, wss_z=8.6587% |
| Best checkpoint | EP24 EMA |

**Reproduce command (start from H39 SOTA, ADD EMA-of-weights ONLY) — CRITICAL: explicit --batch-size 1 AND --weight-decay 0.005 to avoid train.py default drift:**

```bash
cd /workspace/senpai/target && python train.py \
  --dataset-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --batch-size 1 \
  --weight-decay 0.005 \
  --train-points 65000 \
  --val-train-points 65000 \
  --num-epochs 30 \
  --lr 1e-4 \
  --lr-schedule cosine \
  --optimizer lion \
  --hidden-dim 512 \
  --depth 6 \
  --num-slices 128 \
  --surface-out-factor 2.0 \
  --loss-charbonnier-z 0.1 \
  --gradnorm \
  --gradnorm-alpha 0.5 \
  --gradnorm-clamp 0.15 \
  --curvature-attention-bias \
  --y-symmetry-aug \
  --ema-weights \
  --ema-decay 0.999 \
  --wandb-project senpai-v1-drivaerml-ddp8 \
  --wandb-group h144-ema-weights
```

**MANDATORY hyperparameter explicit-pass list** (do NOT rely on `train.py` defaults):
- `--batch-size 1` (H39 reference; new default is 2)
- `--weight-decay 0.005` (H39 reference; new default is 1e-4)
- `--train-points 65000 --val-train-points 65000` (H39 reference; new defaults are 65536/16384)

Baseline W&B: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8` run `yym5oa8x`

## Notes for student

- **This is dl24-fern's 4th hypothesis assignment in Wave 35** after H134 (3 sequential stabilization failures → closed). H134 GALE was real engineering work and the post-mortem on `uhf5c8md` was top-tier diagnosis — that kind of failure-mode analysis is what makes a productive research lab. H144 is fresh, lightweight, and shouldn't have any of the optimizer-architecture interaction issues that destabilized H134.

- **POST W&B RUN ID within 30 minutes of pickup**. This is the highest-priority response item per the Wave 35 process-failure pattern.

- **POST EP1 RESULTS within ~90 min** of run start. Both `val_primary/wall_shear_rel_l2_pct` AND `val_ema/wall_shear_rel_l2_pct` must be in the result. If you only see `val_primary/*` keys logged, your dual-validation loop is broken — debug before posting EP1.

- **Verify EMA actually working at smoke**: After the smoke run, query W&B to confirm both `val_primary/wall_shear_rel_l2_pct` AND `val_ema/wall_shear_rel_l2_pct` keys are logged at the validation epoch. If only one logs, EMA wiring is incomplete.

- EMA wrapper is ~30 lines. Should take ~30 min to implement + smoke-test.

- All H39 hyperparameters preserved — the ONLY deltas are: (1) adding EMA shadow model with decay=0.999, (2) dual-logging val_primary AND val_ema. No optimizer changes, no architecture changes, no loss changes.

**Priority for status hygiene:**
1. ACK this PR within 10 minutes
2. Implement EMA wrapper, dual validation logging, smoke test
3. Post smoke W&B run ID + GPU memory + EMA mechanism diagnostics (verify shadow updating)
4. Launch full 30-EP run, post run ID immediately
5. Post EP1, EP3, EP6, EP15, EP30 results — INCLUDE BOTH val_primary AND val_ema metrics
6. At terminal: load BOTH live-best-by-val_primary AND ema-best-by-val_ema checkpoints, evaluate on test, report whichever has lower test_WSS as the H144 result
