### PR TITLE
H146 edward: split WSS_y decoder head (dedicated wider head for tau_y)

### DIFF
--- a/model.py
+++ b/model.py
@@ -419,6 +419,7 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_split_wss_y_decoder: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +435,7 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_split_wss_y_decoder = use_split_wss_y_decoder
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -513,6 +515,14 @@ class SurfaceTransolver(nn.Module):
             drop_path_max=drop_path_max,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
+        # When split_wss_y is on, the shared surface_out predicts only 3 channels
+        # [sp, tau_x, tau_z]; the dedicated wss_y_out head predicts tau_y.
+        # The 4-channel output [sp, tau_x, tau_y, tau_z] is reconstructed in forward.
+        main_surface_output_dim = (
+            self.surface_output_dim - 1
+            if use_split_wss_y_decoder
+            else self.surface_output_dim
+        )
         if use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
             # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
@@ -523,7 +533,7 @@ class SurfaceTransolver(nn.Module):
             self.surface_out = nn.Sequential(
                 nn.Linear(n_hidden, n_hidden),
                 nn.SiLU(),
-                nn.Linear(n_hidden, self.surface_output_dim),
+                nn.Linear(n_hidden, main_surface_output_dim),
             )
             self.surface_out.apply(_init_linear)
             self.volume_out = nn.Sequential(
@@ -535,8 +545,22 @@ class SurfaceTransolver(nn.Module):
             )
             self.volume_out.apply(_init_linear)
         else:
-            self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
+            self.surface_out = LinearProjection(n_hidden, main_surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        if use_split_wss_y_decoder:
+            # H146: dedicated wider head for tau_y (wall shear in spanwise/y direction).
+            # Mirrors H138's wss_z_out pattern but applied to channel index 2.
+            # The shared surface_out drops tau_y so [sp, tau_x, tau_z] flow through it;
+            # wss_y_out predicts tau_y independently from the same post-norm hidden.
+            self.wss_y_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden * 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden * 2, 1),
+            )
+            self.wss_y_out.apply(_init_linear)
+        else:
+            self.wss_y_out = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -661,7 +685,21 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            if self.use_split_wss_y_decoder:
+                # surface_preds here is [B, N, 3] = [sp, tau_x, tau_z].
+                # Reconstruct [sp, tau_x, tau_y, tau_z] by splicing in the
+                # dedicated tau_y prediction at channel index 2.
+                wss_y_pred = self.wss_y_out(surface_hidden)
+                surface_preds = torch.cat(
+                    [
+                        surface_preds[..., 0:2],  # sp, tau_x
+                        wss_y_pred,                # tau_y from dedicated head
+                        surface_preds[..., 2:3],  # tau_z from main head
+                    ],
+                    dim=-1,
+                )
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    use_split_wss_y_decoder: bool = False
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -238,6 +239,16 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "use_split_wss_y_decoder": (
+            "H146: Split out tau_y (channel index 2 in [sp, tau_x, tau_y, "
+            "tau_z]) into a dedicated wider decoder head. The shared "
+            "surface_out drops tau_y and predicts only [sp, tau_x, tau_z]; "
+            "a new wss_y_out = Linear(n_hidden, 2*n_hidden) -> SiLU -> "
+            "Linear(2*n_hidden, 1) head produces tau_y. Outputs are "
+            "concatenated to restore the 4-channel contract. Mirrors the "
+            "H138 split-wss-z-decoder mechanism for the tau_y channel. "
+            "~+262K params (+1.5 pct). Disabled by default."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -318,6 +329,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_split_wss_y_decoder=config.use_split_wss_y_decoder,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H146 — Split WSS_y decoder head**: A dedicated wider decoder for the tau_y channel (wall shear stress in the spanwise/y direction) should improve WSS_y prediction without harming other channels.

**Rationale**: WSS_y is the second-hardest WSS channel on DrivAerML: H112 achieves test_WSS_y=7.360% vs test_WSS_x=5.999%. H138 (askeladd, currently in flight) tests a split decoder on tau_z — the hardest channel. H146 applies the same architectural mechanism to tau_y, completing the factorial design:

| Architectural mechanism | tau_z | tau_y |
|---|---|---|
| Split dedicated decoder | **H138 askeladd** (alive, −0.054pp WSS_z LEAD) | **H146 edward ← this PR** |
| Loss-weight escalation | H143 frieren (4.0), H144 fern (6.0) | H145 alphonse (3.0) |

Both H138 and H146 are the ARCHITECTURAL class of tau mechanism: separate capacity allocation by channel rather than gradient pressure or loss rescaling. By testing tau_z (H138) and tau_y (H146) in parallel, we determine whether dedicated decoder capacity generalizes across high-residual WSS channels or is WSS_z-specific.

**Expected mechanism**: The shared surface_out head learns a joint representation for [sp, tau_x, tau_y, tau_z]. When tau_y and tau_z are competing for decoder capacity, the harder z-channel may dominate gradient signal and under-train the y-channel prediction. Splitting tau_y into its own wider head gives it independent capacity without contending with the z-shear pattern.

**Falsifiable prediction**:
- val_abupt ≤ 6.1358% (merge gate)
- test_WSS ≤ 6.727% (test floor)
- test_WSS_y ≤ 7.360% (improve or match H112 WSS_y — the mechanism-specific success criterion)
- No regression vs H112 on test_WSS_x or test_WSS_z

**Parameter overhead**: ~+262K (+1.5%) — same as H138.

---

## Instructions

This is an architectural change to `target/model.py` and `target/train.py`. Mirror the H138 split WSS_z pattern, but apply it to tau_y (channel index 2 in the 4-channel surface output `[sp, tau_x, tau_y, tau_z]`).

**Channel ordering reference**: Surface targets are always `[sp(cp), tau_x, tau_y, tau_z]` — indices 0, 1, 2, 3. Loss code in `train.py` confirms: `surface_pred[..., 2:3]` is `tauy_loss`, `surface_pred[..., 3:4]` is `tauz_loss`.

### Step 1 — Add `use_split_wss_y_decoder` flag to `target/model.py`

In `SurfaceTransolver.__init__`, add `use_split_wss_y_decoder: bool = False` to the signature (after `use_split_wss_z_decoder` if that flag exists from a prior merge, or after `surface_output_dim`).

When `use_split_wss_y_decoder=True`:
- Change the `surface_out` head to predict only 3 channels: `[sp, tau_x, tau_z]` (indices 0, 1, 3 of the full 4-channel output)
- Add a dedicated wider head:

```python
self.wss_y_out = nn.Sequential(
    nn.Linear(n_hidden, n_hidden * 2),
    nn.SiLU(),
    nn.Linear(n_hidden * 2, 1),
)
self.wss_y_out.apply(_init_linear)
self.use_split_wss_y_decoder = use_split_wss_y_decoder
```

In the surface head construction block, when `use_split_wss_y_decoder=True`, change `surface_output_dim` for `surface_out` to 3 (drop tau_y from the main head).

In the `forward` method, after computing `surface_pred` from `surface_out` (which now predicts 3 channels `[sp, tau_x, tau_z]`), if `use_split_wss_y_decoder`:
```python
wss_y_pred = self.wss_y_out(surface_hidden)  # [B*N, 1]
# Reconstruct full 4-channel output: [sp, tau_x, tau_y, tau_z]
surface_pred = torch.cat([
    surface_pred[..., 0:2],   # sp, tau_x
    wss_y_pred,                # tau_y from dedicated head
    surface_pred[..., 2:3],   # tau_z from main head
], dim=-1)
```
This restores the 4-channel output contract `[sp, tau_x, tau_y, tau_z]` expected by the loss and eval code.

Store `self.use_split_wss_y_decoder = use_split_wss_y_decoder` on the module.

### Step 2 — Add flag to `target/train.py`

In the `Config` dataclass, add:
```python
use_split_wss_y_decoder: bool = False
```

Pass it through to `SurfaceTransolver(...)` in `build_model()`:
```python
use_split_wss_y_decoder=cfg.use_split_wss_y_decoder,
```

Add a CLI arg (follow the pattern of other `use_*` flags in `target/train.py`):
```python
parser.add_argument("--use-split-wss-y-decoder", action="store_true", ...)
```

### Step 3 — Training recipe

Use the full H112 baseline recipe with only the split decoder flag added. No other changes.

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent edward --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --use-drop-path --drop-path-rate 0.10 \
  --use-split-wss-y-decoder \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --wandb-name edward/h146-split-wss-y-decoder \
  --wandb-group wss_h146_split_wss_y_decoder \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>35.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0"
```

**Kill gates** (step-indexed, NOT epoch-indexed):
- EP1 (step ≥ 10,864): val_abupt ≥ 35.0% → kill (warmup=1, expect ~30-35% at EP1)
- EP3 (step ≥ 32,592): val_abupt ≥ 8.5% → kill
- EP6 (step ≥ 48,897): val_abupt ≥ 7.0% → kill

**EP1 progress report** (~step 10,864): Post val_abupt as a PR comment, along with val_WSS_y vs val_WSS_z — the per-channel split is the primary diagnostic.

**EP3 binding diagnostic** (~step 32,592): Post val_WSS_y vs H112 raw at same step. If val_WSS_y is LEADING H112 raw at EP3, this is the primary mechanism confirmation.

**Terminal result**: When training completes at EP13 or is killed, run full eval against the test set from best-checkpoint and report all metrics including per-channel WSS. Post a `SENPAI-RESULT` marker.

**Mechanism diagnostic** at terminal:
- Per-channel val→test slope table (val_WSS_x/y/z vs test_WSS_x/y/z)
- Cross-cohort comparison vs H138 askeladd (split tau_z) and H112: does splitting tau_y produce a comparable channel-specific LEAD as splitting tau_z?
- wss_y_out head weight norms vs surface_out norms at terminal — confirm the dedicated head specializes

---

## Baseline

**Current single-model SOTA:** PR #1283 H112 DropPath

| Metric | val | test |
|---|---|---|
| abupt | 6.1358% | 5.839% |
| VP | 3.5478% | 3.421% |
| SP | 4.0553% | 3.695% |
| WSS | 6.9670% | 6.752% |
| WSS_x | 6.0923% | 5.999% |
| WSS_y | 7.6084% | 7.360% |
| WSS_z | 9.3750% | 8.720% |

**W&B baseline run:** `u9ue2ryb`
**Merge gate:** val_abupt < 6.1358% AND test_abupt < 5.839%
**Test floors (AND-gate):** test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND test_WSS ≤ 6.727%
**Primary objective:** test_WSS < 5.85% (Transolver-3 SOTA gap: 0.902pp)

**H146 specific success criterion:** test_WSS_y ≤ 7.360% without regressing test_WSS overall
