### PR TITLE
H148: y=0 yaw-mirror augmentation — data invariance injection

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -367,6 +367,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        mirror_augmentation: bool = False,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +377,7 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.mirror_augmentation = bool(mirror_augmentation)
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -457,12 +459,33 @@ class DrivAerMLSurfaceDataset(Dataset):
         metadata["volume_view_count"] = int(view.volume_view_count)
         metadata["volume_sampling_mode"] = view.sampling_mode
         metadata["joint_view_count"] = int(view.view_count)
+        surface_x = case.surface_x
+        surface_y = case.surface_y
+        volume_x = case.volume_x
+        volume_y = case.volume_y
+        mirrored = False
+        if self.mirror_augmentation and torch.rand(1).item() < 0.5:
+            # y=0 yaw mirror: bilateral symmetry of DrivAerML geometry.
+            # surface_x cols: [x, y, z, nx, ny, nz, area]; negate y(1) and ny(4).
+            # surface_y cols: [cp, tau_x, tau_y, tau_z]; negate tau_y(2) only.
+            # volume_x cols: [x, y, z, sdf]; negate y(1); sdf invariant.
+            # volume_y: pressure scalar; invariant.
+            surface_x = surface_x.clone()
+            surface_x[..., 1] *= -1
+            surface_x[..., 4] *= -1
+            surface_y = surface_y.clone()
+            surface_y[..., 2] *= -1
+            volume_x = volume_x.clone()
+            volume_x[..., 1] *= -1
+            mirrored = True
+        metadata["mirror_augmentation"] = self.mirror_augmentation
+        metadata["mirrored"] = mirrored
         return DrivAerMLCase(
             case_id=case.case_id,
-            surface_x=case.surface_x,
-            surface_y=case.surface_y,
-            volume_x=case.volume_x,
-            volume_y=case.volume_y,
+            surface_x=surface_x,
+            surface_y=surface_y,
+            volume_x=volume_x,
+            volume_y=volume_y,
             metadata=metadata,
         )
 
@@ -543,6 +566,7 @@ def load_data(
     eval_surface_points: int = 40_000,
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
+    train_mirror_augmentation: bool = False,
     debug: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
@@ -568,6 +592,7 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        mirror_augmentation=train_mirror_augmentation,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
     debug: bool = False
 
 
@@ -237,6 +238,17 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the attention and MLP branches with a linear schedule from "
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
+        ),
+        "mirror_augmentation": (
+            "H148: Train-time y=0 yaw-mirror augmentation. DrivAerML is "
+            "bilaterally symmetric (symmetry-plane BC at y=0), so every case "
+            "has an exact physically valid mirror twin. Each train sample is "
+            "independently flipped with prob 0.5: negate y/normal_y in "
+            "surface_x and y in volume_x; negate tau_y in surface_y; cp, "
+            "tau_x, tau_z, panel_area, sdf, volume_pressure are invariant. "
+            "Off for val/test. Tests whether the val-overfit slope-flattening "
+            "pathology is a data-memorization artifact addressable by zero-"
+            "parameter data invariance injection."
         ),
     }
     for field in fields(Config):
@@ -693,6 +705,7 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        mirror_augmentation=config.mirror_augmentation,
     )
     train_sampler = None
     train_shuffle = True

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -285,6 +285,7 @@ def make_loaders(
         eval_surface_points=config.eval_surface_points,
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
+        train_mirror_augmentation=getattr(config, "mirror_augmentation", False),
         debug=config.debug,
     )
     train_sampler = None


### PR DESCRIPTION
## Hypothesis

Train-time **yaw-mirror augmentation** about the y=0 plane (car symmetry axis) with probability 0.5 per sample. The DrivAerML geometry is yaw-symmetric by construction — the body is a mirrored sedan. Every training case has an exact geometric mirror that produces valid physics. Injecting this symmetry as a data augmentation doubles the effective dataset size at zero parameter cost and teaches the model that left↔right reflections are equivalent, which should close the val→test slope catastrophe.

**Mechanism**: The slope-flattening pathology we observe across all Wave 38 capacity-adding experiments (H120/H121/H125/H132/H134/H135/H138) is consistent with the model memorising val-set-specific patterns that don't generalize. Mirror augmentation injects the strongest possible inductive bias available from the geometry without adding any parameters. If slope catastrophe is a data-memorisation artifact, mirror augmentation is the cleanest test of that hypothesis.

**Falsifiable test**: If alive → data invariance injection closes the slope catastrophe. If closed → val-overfit pathology is not a data-memorisation artifact; it is optimizer or architecture driven (H149 AdamW swap tests the optimizer axis).

**Key constraint**: This is a NON-capacity-adding intervention. Zero parameter overhead. Pure training dynamics change.

## Instructions

Implement train-time yaw-mirror augmentation in `target/data/loader.py` in the `DrivAerMLSurfaceDataset.__getitem__` method.

### Coordinate conventions (DrivAerML)

- x = streamwise, y = lateral (mirror axis), z = vertical
- Yaw flip = reflect about y=0: negate all y-coordinates and y-components of vectors
- `surface_x` shape: `[N, 7]` — columns: `[x(0), y(1), z(2), normal_x(3), normal_y(4), normal_z(5), panel_area(6)]`
- `surface_y` shape: `[N, 4]` — columns: `[cp(0), tau_x(1), tau_y(2), tau_z(3)]`
- `volume_x` shape: `[M, 4]` — columns: `[x(0), y(1), z(2), sdf(3)]`
- `volume_y` shape: `[M, 1]` — pressure (scalar, invariant under yaw flip)

### Implementation

Add a `--mirror-augmentation` boolean flag to `target/train.py` and pass it through to the dataset/dataloader. Apply the augmentation **only during training** (not validation or test).

In `DrivAerMLSurfaceDataset.__getitem__`, after loading the case and before returning, apply the mirror with prob 0.5 when `self.mirror_augmentation=True` and `self.split == 'train'`:

```python
if self.mirror_augmentation and self.split == 'train' and torch.rand(1).item() < 0.5:
    # Surface points: negate y-coordinate and y-normal
    surface_x = surface_x.clone()
    surface_x[..., 1] *= -1   # y coordinate
    surface_x[..., 4] *= -1   # normal_y
    # Surface targets: negate tau_y (index 2); cp/tau_x/tau_z are invariant
    surface_y = surface_y.clone()
    surface_y[..., 2] *= -1   # tau_y
    # Volume points: negate y-coordinate
    volume_x = volume_x.clone()
    volume_x[..., 1] *= -1   # y coordinate
    # volume_y (pressure) is invariant — do NOT negate
```

Note: `sdf` (volume_x[...,3]) is a scalar distance field — it is invariant under yaw flip (distance is unsigned, and the mirrored geometry is itself valid).

### Training recipe

Use the H112 canonical recipe exactly, plus `--mirror-augmentation`:

```bash
cd target && python train.py \
  --wandb-project wandb-applied-ai-team/senpai-v1-drivaerml-ddp8 \
  --wandb-run-name h148-mirror-aug \
  --wandb_group h148-mirror-augmentation \
  --lr 9e-5 \
  --weight-decay 5e-4 \
  --batch-size 4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn \
  --enable-residual-positions \
  --use-drop-path \
  --drop-path-rate 0.10 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --lr-schedule cosine \
  --ema-decay 0.999 \
  --grad-clip 1.0 \
  --mirror-augmentation
```

### Kill thresholds (EP1/EP3/EP6)

Use standard H112-recipe thresholds (warmup=1, ema=0.999):
- EP1 gate (step ~10864): val_abupt < 33.0%
- EP3 gate (step ~32592): val_abupt < 10.0%
- EP6 gate (step ~48897): val_abupt < 7.5%

These are soft gates — mirror augmentation makes EP1 noisier (samples vary per-pass), so do not kill before EP3 unless diverged.

### What to measure

Primary: does the val→test slope on WSS improve vs H112?

- H112 val→test slope (WSS): −0.215pp (val 6.967% → test 6.752%)
- H112 val→test slope (WSS_z): −0.655pp (val 9.375% → test 8.720%)
- H112 val→test slope (WSS_x): −0.093pp

If mirror augmentation is working, we expect **steeper** (more negative) val→test slopes — the model generalizes better, so the val-test gap stays wide while both improve. The smoking gun for failure would be slopes as flat or flatter than H112.

Report per-channel slopes in your results comment.

## Baseline

H112 (PR #1283, W&B run `pznm3tgz`) — current tay SOTA:

| Metric | val | test |
|---|---:|---:|
| abupt | 6.1358% | 5.839% |
| WSS | 6.967% | 6.752% |
| WSS_x | 6.092% | 5.999% |
| WSS_y | 7.608% | 7.360% |
| WSS_z | 9.375% | 8.720% |
| VP | — | 3.421% |
| SP | — | 3.695% |

Merge gates: val_abupt < 6.1358%, test_WSS ≤ 6.727%, test_VP ≤ 3.421%, test_SP ≤ 3.577%

**Primary target: test_WSS < 5.85%** (Transolver-3 SOTA, per Morgan Issue #1056)
