### PR TITLE
H149: AdamW optimizer swap — test if slope-flattening is Lion-specific

### DIFF
--- a/launch_h149.sh
+++ b/launch_h149.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# H149: AdamW optimizer swap — test if slope-flattening is Lion-specific.
+# Mirrors H112 (PR #1283, run u9ue2ryb) exactly except for optimizer+LR.
+# Verified H112 config from W&B: volume_loss_weight=1.0, grad_clip_norm=0.5.
+set -e
+export SENPAI_TIMEOUT_MINUTES=1100
+exec torchrun --standalone --nproc-per-node=8 train.py \
+    --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+    --manifest data/split_manifest.json \
+    --epochs 13 --batch-size 4 \
+    --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
+    --model-slices 128 --model-dropout 0.0 \
+    --drop-path-max 0.10 \
+    --train-surface-points 65536 --eval-surface-points 65536 \
+    --train-volume-points 16384 --eval-volume-points 65536 \
+    --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
+    --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
+    --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
+    --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pos-encoding-mode string_separable \
+    --use-ema --ema-decay 0.999 --ema-start-step 50 \
+    --use-surf-to-vol-xattn \
+    --lr 3e-4 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
+    --weight-decay 5e-4 --grad-clip-norm 0.5 \
+    --optimizer adamw \
+    --amp-mode bf16 --no-compile-model \
+    --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<33.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<10.0,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.5" \
+    --wandb-name tanjiro/h149-adamw \
+    --wandb-group h149-adamw-optimizer \
+    --agent tanjiro


### PR DESCRIPTION
## Hypothesis

**AdamW optimizer swap: replace Lion with AdamW at canonical LR=3e-4.** H112 uses Lion (LR=9e-5). This experiment tests whether the val→test slope catastrophe and cross-channel bleed we observe throughout Wave 38 is **Lion-specific**.

**Background**: The cross-channel bleed finding from H139 (Charbonnier closure) identified that Lion's sign-only update rule may be the mechanism behind observed pathologies:

> "Lion sign-only update: softening tau_z per-element gradient magnitudes shifts the shared-parameter sign accumulation across the surface decoder MLP. Lion's sign-only updates propagate the shifted direction to tau_y through shared decoder weights."

If the cross-channel bleed and slope-flattening pathology is Lion-specific, AdamW should produce steeper val→test slopes (closer to H112 baseline, or better) and eliminate the WSS_y bleed signature. If AdamW shows the same pathology at canonical LR, the pathology is optimizer-agnostic.

**This is a program-pivotal experiment.** The SOFTEN class (H139, H140) is definitively closed, but if AdamW eliminates cross-channel bleed, SOFTEN-class variants might be revisited with AdamW as the optimizer. More importantly, if AdamW fundamentally changes the slope behavior, it may open new architecture or loss territory that was previously foreclosed by Lion's sign-accumulation dynamics.

**Falsifiable**: If alive → Lion contributes to slope flattening; AdamW opens new search space. If closed → pathology is optimizer-agnostic; slope catastrophe is a data or architecture problem.

**Zero parameter overhead.** Pure training dynamics change.

## Instructions

Swap Lion for AdamW by changing the `--optimizer` flag and adjusting the learning rate. No other changes to architecture, loss weights, or schedule.

### Recipe

```bash
cd target && python train.py \
  --wandb-project wandb-applied-ai-team/senpai-v1-drivaerml-ddp8 \
  --wandb-run-name h149-adamw \
  --wandb_group h149-adamw-optimizer \
  --optimizer adamw \
  --lr 3e-4 \
  --weight-decay 5e-4 \
  --batch-size 4 \
  --tau-y-loss-weight 1.5 \
  --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 \
  --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn \
  --enable-residual-positions \
  --use-drop-path \
  --drop-path-rate 0.10 \
  --epochs 13 \
  --lr-warmup-epochs 1 \
  --lr-schedule cosine \
  --ema-decay 0.999 \
  --grad-clip 1.0
```

**Key changes vs H112**:
- `--optimizer adamw` (was Lion, default)
- `--lr 3e-4` (was 9e-5 — AdamW canonical LR is ~3-10× higher than Lion for the same architecture)

Do NOT include `--lion-beta1` or `--lion-beta2` flags (Lion-specific).

### LR rationale

AdamW and Lion operate at different effective step sizes due to the sign-only vs. gradient magnitude update rule. The canonical correspondence for Transolver-class architectures is:
- Lion: LR ~9e-5 → AdamW: LR ~3e-4 to 1e-3

Use LR=3e-4 as the first trial (conservative). If EP3 shows val_abupt well above 10%, consider bumping to 1e-3 in a follow-up PR (H149b).

### Kill thresholds

- EP1 gate (step ~10864): val_abupt < 33.0%
- EP3 gate (step ~32592): val_abupt < 10.0%
- EP6 gate (step ~48897): val_abupt < 7.5%

AdamW with warmup=1 epoch may train more aggressively early — if EP1 val_abupt is dramatically better than expected (e.g. < 20%), do NOT kill; continue.

### What to measure

Primary: val→test slope on WSS and WSS channels.

- H112 Lion slope (WSS): −0.215pp (val 6.967% → test 6.752%)
- H112 Lion slope (WSS_z): −0.655pp
- H112 Lion slope (WSS_y): −0.248pp

If AdamW eliminates the slope-flattening pathology, we expect WSS slopes at least as steep as H112. If cross-channel bleed is Lion-specific, we should see WSS_y behave normally under cross-channel perturbations.

Report per-channel val→test slopes in your results comment. Also report if the training curve is stable vs Lion (does AdamW produce smoother loss curves? Faster early convergence?).

## Baseline

H112 (PR #1283, W&B run `pznm3tgz`) — current tay SOTA:

| Metric | val | test |
|---|---:|---:|
| abupt | 6.1358% | 5.839% |
| WSS | 6.967% | 6.752% |
| WSS_x | 6.092% | 5.999% |
| WSS_y | 7.608% | 7.360% |
| WSS_z | 9.375% | 8.720% |
| VP | — | 3.421% |
| SP | — | 3.695% |

Merge gates: val_abupt < 6.1358%, test_WSS ≤ 6.727%, test_VP ≤ 3.421%, test_SP ≤ 3.577%

**Primary target: test_WSS < 5.85%** (Transolver-3 SOTA, per Morgan Issue #1056)

## Context

This PR is the direct follow-up to H139 (Charbonnier on tau_z, closed C NULL). H139's cross-channel bleed finding — tau_z-scoped loss change produces LARGER regression on tau_y than tau_z via Lion sign-accumulation — motivated this optimizer ablation. See PR #1326 for the mechanism detail.
