### PR TITLE
H157: Cosine Warm Restarts (SGDR T0=4) — basin-escape scheduler

### DIFF
--- a/train.py
+++ b/train.py
@@ -117,6 +117,7 @@ class Config:
     eval_raw_vs_ema: bool = False
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
+    lr_cosine_t_mult: int = 1  # T_mult for CosineAnnealingWarmRestarts; 1 = fixed-period restarts, 2 = doubling periods
     lr_min: float = 1e-6
     grad_clip_norm: float = 1.0
     gradient_log_every: int = 250

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1291,9 +1291,10 @@ def build_lr_scheduler(
     max_epochs: int,
 ) -> torch.optim.lr_scheduler.LRScheduler:
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
-    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
         optimizer,
-        T_max=max(1, t_max),
+        T_0=max(1, t_max),
+        T_mult=config.lr_cosine_t_mult,
         eta_min=config.lr_min,
     )
     if config.lr_warmup_epochs <= 0:


### PR DESCRIPTION
## Hypothesis

The current recipe uses a **single cosine LR decay cycle** (`CosineAnnealingLR`, T_max=13 epochs). After the cosine tail reaches `lr_min ≈ 1e-6` around EP6-8, the remaining epochs are effectively frozen — the optimizer cannot escape whatever basin it has entered. This matches the **slope-flattening pathology** observed across the entire Wave 38 cohort (H120/H121/H125/H132/H134/H135/H138): every mechanism class produced progressively shallower val→test slopes in late training, consistently converging to sharp minima that generalise poorly.

**Cosine Annealing Warm Restarts** (SGDR — Loshchilov & Hutter 2017) periodically resets the LR to its maximum value. With T_0=4 and T_mult=1, restarts fire at EP5, EP9, EP13 — twice during the productive late-train window when the H112 baseline is frozen at `lr_min`. Each restart forces the optimizer through a basin escape attempt before the LR decays again. The key question: **does flat-basin entrapment explain the slope-flattening pathology, and do periodic restarts produce flatter/deeper minima with better val→test generalisation?**

This is a pure optimisation-trajectory change:
- **Zero parameter overhead** (same architecture as H112)
- **Zero data change** (no augmentation)
- **Single mechanism** (scheduler only — cannot interact adversarially with ESCALATE loss weights; LR schedule is orthogonal to loss reweighting)
- **First time tested** in this programme

Paper: Loshchilov & Hutter (2017) "SGDR: Stochastic Gradient Descent with Warm Restarts" — https://arxiv.org/abs/1608.03983

## Instructions

**This experiment requires two small code changes + one new flag.** They are contained to two files and total ~10 lines.

### Step 1 — Add `lr_cosine_t_mult` field to TrainConfig

In `target/train.py`, find the `TrainConfig` dataclass (around line 119 where `lr_cosine_t_max` is defined). Add immediately after `lr_cosine_t_max`:

```python
lr_cosine_t_mult: int = 1  # T_mult for CosineAnnealingWarmRestarts; 1 = fixed-period restarts, 2 = doubling periods
```

The dataclass-to-argparse system in `train.py` will automatically expose `--lr-cosine-t-mult` as a CLI flag.

### Step 2 — Switch from CosineAnnealingLR to CosineAnnealingWarmRestarts

In `target/trainer_runtime.py`, find `build_lr_scheduler` (line ~1288). Replace the `cosine_scheduler` assignment:

**Before:**
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
    optimizer,
    T_max=max(1, t_max),
    eta_min=config.lr_min,
)
```

**After:**
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
    optimizer,
    T_0=max(1, t_max),
    T_mult=config.lr_cosine_t_mult,
    eta_min=config.lr_min,
)
```

`CosineAnnealingWarmRestarts` is a PyTorch built-in (`torch.optim.lr_scheduler`) — no new dependencies.

### Step 3 — Run with T_0=4

Use the following training command (H112 base + scheduler change only, zero other changes):

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --tau-y-loss-weight 1.5 --tau-z-loss-weight 2.0 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn \
  --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 4 --lr-cosine-t-mult 1 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "32592:val_primary/abupt_axis_mean_rel_l2_pct<9.0,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.5" \
  --wandb-name nezuko/h157-cosine-warm-restarts \
  --wandb-group h157-cosine-warm-restarts \
  --save-best-checkpoint
```

**Key flag difference from H112**: `--lr-cosine-t-max 4 --lr-cosine-t-mult 1` (T_0=4, T_mult=1 → fixed 4-epoch cycles, restarts at EP5/EP9/EP13).

**LR schedule with warmup=1**:
- EP1: linear warmup 0.05×lr → lr
- EP1-5: cosine decay lr → lr_min (first cycle)
- EP5: restart → lr
- EP5-9: cosine decay lr → lr_min (second cycle)
- EP9: restart → lr
- EP9-13: cosine decay lr → lr_min (third cycle)

### Kill threshold notes

- **EP3 (step 32592)**: kill if val_abupt ≥ 9.0% — run is mid-first-cosine-cycle (between warmup end at EP1 and first restart at EP5). val should be tracking H112 raw class at EP3 (~6.98%). Threshold 9.0% is 2pp looser than H112 EP3 to account for warm-restart overhead.
- **EP9 (step 48897)**: kill if val_abupt ≥ 7.5% — just AFTER second restart at EP9. val may briefly spike from restart LR, so gate is looser than H112 EP9. EMA will smooth the spike.
- **EP1 (step 10864): PASS** — warmup=1 recipe lands val_abupt ~33% at EP1 (composition artifact). Do NOT kill at EP1.

### What to report at each epoch publish

1. **val_primary/abupt + val_primary/wall_shear_z_rel_l2_pct** vs H112 raw same-step (run `u9ue2ryb`)
2. **train/lr** — confirm warm restarts are firing (LR should spike back toward 9e-5 at EP5, EP9, EP13)
3. **val→test slope** at terminal — this is the diagnostic. H112 slope: 0.215pp (val_WSS 6.967% → test_WSS 6.752%). If H157 has a steeper slope (better test generalisation), warm restarts are escaping flat basins.

## Baseline

Current single-model SOTA: **H112 PR #1283** (`u9ue2ryb`)

| Metric | H112 val | H112 test |
|---|---:|---:|
| abupt | 6.1358% | 5.839% |
| WSS | 6.9670% | 6.752% |
| WSS_x | 6.0923% | 5.999% |
| WSS_y | 7.6084% | 7.360% |
| WSS_z | 9.3750% | 8.720% |
| VP | 3.5478% | 3.421% |
| SP | 4.0553% | 3.695% |

**Merge gate**: val_abupt < 6.1358%, test_WSS ≤ 6.727%, test_VP ≤ 3.421%, test_SP ≤ 3.577%

**Primary objective (Morgan Issue #1056)**: test_WSS < 5.85% — gap = 0.902pp

