### PR TITLE
H164: Stochastic Weight Averaging (SWA) — averaging-axis flat-basin discovery

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,7 @@ from trainer_runtime import (
     TargetTransform,
     autocast_context,
     build_lr_scheduler,
+    build_swa_components,
     check_kill_thresholds,
     cleanup_distributed,
     collect_gradient_metrics,
@@ -61,6 +62,7 @@ from trainer_runtime import (
     primary_metric_log,
     print_metrics,
     run_final_evaluation,
+    run_swa_evaluation,
     should_update_best_checkpoint,
     timeout_budget_minutes,
     unwrap_model,
@@ -115,6 +117,13 @@ class Config:
     ema_decay: float = 0.999
     ema_start_step: int = 50
     eval_raw_vs_ema: bool = False
+    # SWA (Izmailov et al. 2018, https://arxiv.org/abs/1803.05407): after
+    # swa_start_epoch, switch the LR schedule to a constant swa_lr and average
+    # the model weights uniformly at the end of each remaining epoch.
+    use_swa: bool = False
+    swa_start_epoch: int = 9
+    swa_lr: float = 1e-5
+    swa_anneal_epochs: int = 1
     lr_warmup_epochs: int = 0
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
@@ -793,6 +802,15 @@ def main(argv: Iterable[str] | None = None) -> None:
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
+        swa_model, swa_scheduler = build_swa_components(base_model, optimizer, config)
+        swa_active_epochs = 0
+        if swa_model is not None and state.is_main:
+            print(
+                f"SWA enabled: start_epoch={config.swa_start_epoch} "
+                f"swa_lr={config.swa_lr:g} anneal_epochs={config.swa_anneal_epochs} "
+                f"(uniform-mean averaging at end of each SWA-active epoch; "
+                f"DDP keeps params synced so per-rank averaging produces identical weights)"
+            )
 
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
@@ -1055,7 +1073,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
-                current_lr = scheduler.get_last_lr()[0]
+                # Read LR from the optimizer directly so SWA-active epochs (where
+                # swa_scheduler controls the LR and cosine `scheduler` is no
+                # longer stepped) still report the correct value.
+                current_lr = optimizer.param_groups[0]["lr"]
                 loss_is_nonfinite = not bool(torch.isfinite(loss.detach()).item())
                 skip_step = distributed_any(state, loss_is_nonfinite, device)
                 should_log_model_telemetry = (
@@ -1186,7 +1207,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                         )
                     break
 
-            scheduler.step()
+            # SWA replaces the cosine scheduler from swa_start_epoch onward and
+            # snapshots the current weights into the running uniform mean once
+            # per epoch, after the last optimizer step.
+            if swa_model is not None and epoch >= config.swa_start_epoch:
+                swa_model.update_parameters(base_model)
+                swa_scheduler.step()
+                swa_active_epochs += 1
+            else:
+                scheduler.step()
             epoch_train_loss = train_loss_sum / max(n_batches, 1)
             dt = time.time() - t0
             peak_gb = torch.cuda.max_memory_allocated(device) / 1e9 if torch.cuda.is_available() else 0.0
@@ -1199,10 +1228,13 @@ def main(argv: Iterable[str] | None = None) -> None:
 
             log_metrics: dict[str, object] = {
                 "train/epoch_loss": epoch_train_loss,
-                "train/lr": scheduler.get_last_lr()[0],
-                "lr": scheduler.get_last_lr()[0],
+                "train/lr": optimizer.param_groups[0]["lr"],
+                "lr": optimizer.param_groups[0]["lr"],
                 "epoch_time_s": dt,
                 "global_step": global_step,
+                "swa/active": 1.0 if (swa_model is not None and epoch >= config.swa_start_epoch) else 0.0,
+                "swa/active_epochs": float(swa_active_epochs),
+                "swa/n_averaged": float(int(swa_model.n_averaged.item())) if swa_model is not None else 0.0,
             }
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
@@ -1390,6 +1422,20 @@ def main(argv: Iterable[str] | None = None) -> None:
             global_step=global_step,
             total_minutes=total_minutes,
         )
+        if swa_model is not None:
+            run_swa_evaluation(
+                run=run,
+                swa_model=swa_model,
+                train_loader=train_loader,
+                config=config,
+                transform=transform,
+                device=device,
+                final_val_loaders=final_val_loaders,
+                final_test_loaders=final_test_loaders,
+                global_step=global_step,
+                output_dir=output_dir,
+                swa_active_epochs=swa_active_epochs,
+            )
         wandb.finish()
     finally:
         cleanup_distributed(state)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1311,6 +1311,36 @@ def build_lr_scheduler(
     )
 
 
+def build_swa_components(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    config,
+) -> tuple[nn.Module | None, torch.optim.lr_scheduler.LRScheduler | None]:
+    """Construct an AveragedModel + SWALR pair for Stochastic Weight Averaging.
+
+    Izmailov et al. 2018 (https://arxiv.org/abs/1803.05407): after a burn-in,
+    switch to a constant low LR and uniformly average the model weights over
+    the remaining epochs. The averaged model lands in a flatter region of the
+    loss landscape than any single snapshot.
+
+    Wrapping convention: pass the *unwrapped* base model (no DDP, no compile).
+    DDP keeps base_model.parameters() synchronized across ranks via gradient
+    allreduce, so per-rank `update_parameters` produces identical SWA weights
+    on every rank. AveragedModel deepcopies the module, so its parameters are
+    independent storage from the live training weights.
+    """
+    if not getattr(config, "use_swa", False):
+        return None, None
+    swa_model = torch.optim.swa_utils.AveragedModel(model)
+    swa_scheduler = torch.optim.swa_utils.SWALR(
+        optimizer,
+        anneal_strategy="linear",
+        anneal_epochs=max(1, int(getattr(config, "swa_anneal_epochs", 1))),
+        swa_lr=float(getattr(config, "swa_lr", 1e-5)),
+    )
+    return swa_model, swa_scheduler
+
+
 def global_grad_norm(parameters: Iterable[torch.nn.Parameter], device: torch.device) -> torch.Tensor:
     total = torch.zeros((), device=device, dtype=torch.float32)
     for param in parameters:
@@ -1355,6 +1385,11 @@ def define_wandb_metrics() -> None:
         "full_val_primary/*",
         "test/*",
         "test_primary/*",
+        "full_val_swa/*",
+        "full_val_swa_primary/*",
+        "test_swa/*",
+        "test_swa_primary/*",
+        "swa/*",
         "train/slope/*",
         "val/slope/*",
         "full_val/slope/*",
@@ -1519,3 +1554,115 @@ def run_final_evaluation(
         test_metrics=test_metrics,
         n_params=n_params,
     )
+
+
+def run_swa_evaluation(
+    *,
+    run,
+    swa_model: nn.Module,
+    train_loader: DataLoader,
+    config,
+    transform: TargetTransform,
+    device: torch.device,
+    final_val_loaders: dict[str, DataLoader],
+    final_test_loaders: dict[str, DataLoader],
+    global_step: int,
+    output_dir: Path,
+    swa_active_epochs: int,
+) -> None:
+    """Final evaluation cohort for the SWA-averaged model.
+
+    Logs full_val_swa/* and test_swa/* in parallel to the EMA cohort
+    (full_val/* and test/*), so SWA-vs-EMA basin-geometry comparisons can
+    be read directly off W&B without rerunning training.
+
+    DrivAerML uses GroupNorm only, so `torch.optim.swa_utils.update_bn` has
+    no momenta to refresh and returns early before iterating the loader; we
+    still skip the call defensively because the loader yields SurfaceBatch
+    objects rather than the (input, target) tuples update_bn expects.
+    """
+    if swa_active_epochs <= 0 or int(swa_model.n_averaged.item()) == 0:
+        print("SWA: no SWA-active epochs completed; skipping SWA evaluation.")
+        wandb.summary.update(
+            {
+                "swa/active_epochs": float(swa_active_epochs),
+                "swa/n_averaged": float(int(swa_model.n_averaged.item())),
+                "swa/skipped": 1.0,
+            }
+        )
+        return
+
+    bn_modules = [
+        m for m in swa_model.modules() if isinstance(m, torch.nn.modules.batchnorm._BatchNorm)
+    ]
+    if bn_modules:
+        torch.optim.swa_utils.update_bn(train_loader, swa_model, device=device)
+        print(f"SWA: refreshed BN running stats over {len(bn_modules)} BN modules.")
+    else:
+        print("SWA: no BatchNorm modules detected; skipping update_bn (GroupNorm-only model).")
+
+    swa_path = output_dir / f"swa_{run.id}.pt"
+    torch.save(
+        {
+            "swa_model": swa_model.module.state_dict(),
+            "n_averaged": int(swa_model.n_averaged.item()),
+            "swa_active_epochs": int(swa_active_epochs),
+            "swa_start_epoch": int(getattr(config, "swa_start_epoch", -1)),
+            "swa_lr": float(getattr(config, "swa_lr", 0.0)),
+            "swa_anneal_epochs": int(getattr(config, "swa_anneal_epochs", 0)),
+            "config": asdict(config),
+        },
+        swa_path,
+    )
+    print(
+        f"SWA: averaged {swa_active_epochs} epoch(s) "
+        f"(n_averaged={int(swa_model.n_averaged.item())}); saved to {swa_path}"
+    )
+
+    full_val_metrics = {
+        name: evaluate_split(swa_model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in final_val_loaders.items()
+    }
+    full_val_log: dict[str, object] = {
+        "global_step": global_step,
+        "swa/active_epochs": float(swa_active_epochs),
+        "swa/n_averaged": float(int(swa_model.n_averaged.item())),
+        **{
+            f"full_val_swa_primary/{key}": full_val_metrics["val_surface"][key]
+            for key in PRIMARY_METRIC_KEYS
+        },
+    }
+    for split_name, metrics in full_val_metrics.items():
+        full_val_log.update(metric_namespace("full_val_swa", split_name, metrics))
+    try:
+        assert_required_finite_metrics(full_val_log, "full_val_swa_primary")
+    except RuntimeError as exc:
+        wandb.summary.update({"swa/invalid": 1.0, "swa/invalid_reason": str(exc)})
+        raise
+    wandb.log(full_val_log)
+    wandb.summary.update(numeric_metric_items(full_val_log))
+    print_metrics("full_val_swa", full_val_metrics["val_surface"])
+
+    test_metrics = {
+        name: evaluate_split(swa_model, loader, transform, device, amp_mode=config.amp_mode)
+        for name, loader in final_test_loaders.items()
+    }
+    test_log: dict[str, object] = {
+        "global_step": global_step,
+        "swa/active_epochs": float(swa_active_epochs),
+        "swa/n_averaged": float(int(swa_model.n_averaged.item())),
+        **{
+            f"test_swa_primary/{key}": test_metrics["test_surface"][key]
+            for key in PRIMARY_METRIC_KEYS
+        },
+    }
+    for split_name, metrics in test_metrics.items():
+        test_log.update(metric_namespace("test_swa", split_name, metrics))
+    try:
+        assert_required_finite_metrics(test_log, "test_swa_primary")
+    except RuntimeError as exc:
+        wandb.summary.update({"swa/invalid": 1.0, "swa/invalid_reason": str(exc)})
+        raise
+    wandb.log(test_log)
+    wandb.summary.update(numeric_metric_items(test_log))
+    print_metrics("test_swa", test_metrics["test_surface"])


### PR DESCRIPTION
## Hypothesis

**Stochastic Weight Averaging (SWA, Izmailov et al. 2018) for flat-basin discovery.**

The H143 closure (2026-05-26 10:55Z, test_WSS_z +0.175pp REGRESSION) was the program's first NON-CAPACITY-ADDING slope-flattening — zero parameter overhead, yet val→test slope on the target channel flattened 33%. ALL channels' slopes flattened, not just the escalated one. This contradicts the Wave 38 hypothesis that slope-flattening correlates with parameter overhead.

**Working hypothesis post-H143**: The pathology is basin-geometry-driven, not overhead-driven. H112 converges to a relatively sharp minimum in the loss landscape — small perturbations (loss-weight, capacity, architecture) shift trajectories into different basins with WORSE generalization (steeper val→test transfer).

**SWA mechanism (Izmailov et al. 2018, "Averaging Weights Leads to Wider Optima and Better Generalization")**: After a "burn-in" period of standard training, switch to constant low learning rate and average model weights uniformly over the remaining epochs. The averaged model lands in a flatter region of the loss landscape than any single snapshot, with empirically better test generalization. This is theoretically and empirically distinct from EMA (geometric decay weighting recent steps heavily).

**Why this targets the H143 finding**: 
- EMA (geometric decay 0.999) heavily weights the last ~1-2 epochs → tracks the sharp basin H112 finds
- SWA (uniform mean over last K epochs at constant LR) explicitly targets flat minima → tests whether the "sharp basin" hypothesis is right
- If H143's slope-flattening signature is basin-geometry, SWA should DECREASE val→test slope (LARGER negative slope = better test improvement over val)

**Compounds with H157 cosine warm restarts** (nezuko, parallel assignment): SWA over warm-restart cycles is the canonical basin-discovery combination — restarts explore basins, SWA averages over the flat regions discovered.

Reference: https://arxiv.org/abs/1803.05407 (Izmailov, Podoprikhin, Garipov, Vetrov, Wilson 2018)

## Instructions

**Goal**: Add Stochastic Weight Averaging to the training pipeline, activated post-burn-in for the last 4 epochs.

### Implementation (target/train.py + target/trainer_runtime.py)

**1) Add CLI flags via TrainConfig in target/train.py** (around line ~119 with other LR fields):

```python
# In TrainConfig dataclass
use_swa: bool = False
swa_start_epoch: int = 9
swa_lr: float = 1e-5
swa_anneal_epochs: int = 1
```

**2) Modify the training loop in target/trainer_runtime.py**:

In `build_lr_scheduler` (around line 1288) — leave the existing scheduler logic in place. SWA replaces the LR scheduler when active. Add a separate `build_swa_components` helper:

```python
def build_swa_components(model, optimizer, config):
    """Returns (swa_model, swa_scheduler) when use_swa, else (None, None)."""
    if not config.use_swa:
        return None, None
    swa_model = torch.optim.swa_utils.AveragedModel(model)
    swa_scheduler = torch.optim.swa_utils.SWALR(
        optimizer,
        anneal_strategy="linear",
        anneal_epochs=config.swa_anneal_epochs,
        swa_lr=config.swa_lr,
    )
    return swa_model, swa_scheduler
```

In the training loop epoch boundary:
- For `epoch < swa_start_epoch`: use existing cosine scheduler (unchanged)
- For `epoch >= swa_start_epoch`: use `swa_scheduler.step()` instead of cosine scheduler.step(), and call `swa_model.update_parameters(model)` ONCE per epoch (after the last optimizer.step of that epoch)

At training END (after final epoch):
- Update BN statistics for the SWA model: `torch.optim.swa_utils.update_bn(train_loader, swa_model)` — DrivAerML uses GroupNorm not BN, so this may be a no-op, but include the call defensively
- Run `evaluate()` on the SWA model in addition to the EMA model
- Save SWA model checkpoint with same naming convention as EMA: `swa_<run_id>.pt`
- W&B log: `val_swa/*` and `test_swa/*` metrics for direct cohort comparison

### Important DDP/compile considerations

- `AveragedModel` should wrap the model AFTER `torch.compile` and AFTER DDP, OR wrap before compile + DDP and pass `device=...`. Test before full run. If issues arise with compile, add `--no-compile-model` to the reproduce command and accept the throughput hit.
- For DDP: SWA's `update_parameters` is local to each rank; the parameters are already synchronized via DDP gradient communication, so per-rank averaging produces identical weights across ranks. Verify by checking rank 0 and rank 4 produce identical val metrics in early epochs.

### Reproduce command (DDP 8 GPUs, full 13-epoch run)

```bash
cd target && torchrun --nproc_per_node=8 train.py \
    --dataset drivaerml --task surface_tau_vp \
    --batch-size 1 --grad-accum-steps 1 \
    --epochs 13 --lr 5e-4 --lr-min 1e-6 --lr-warmup-epochs 1 \
    --lr-cosine-t-max 13 \
    --optimizer lion --weight-decay 0.05 \
    --ema-decay 0.999 \
    --loss-weight-tau-z 2.0 --loss-weight-tau-y 1.0 --loss-weight-tau-x 1.0 \
    --loss-weight-vp 1.0 --loss-weight-sp 1.0 \
    --volume-loss-weight 1.0 \
    --eval-train-points 49152 --eval-volume-points 32768 \
    --kill-thresholds 10864:val_abupt<33.0 32592:val_abupt<10.5 48897:val_abupt<8.0 \
    --use-swa --swa-start-epoch 9 --swa-lr 1e-5 --swa-anneal-epochs 1 \
    --wandb-group h164-swa --wandb-name h164-swa-start9-lr1e-5 \
    --output-dir /workspace/output_h164
```

### Expected behavior

- EP1-9: training proceeds exactly as H112 (cosine LR schedule active, EMA accumulating)
- EP10-13: LR drops to constant `1e-5` (or anneals over 1 epoch to it), SWA model accumulates uniform average of weights at end of each epoch
- Terminal: compare `val_swa/abupt`, `val_swa/WSS`, `val_swa/WSS_z` vs `val_ema/abupt` etc. The interesting question: does SWA outperform EMA on val→test slope?

### Kill thresholds & gates

Apply the standard step-indexed thresholds — SWA only kicks in at EP9, so EP1/EP3 kill gates target the same trajectory as H112:
- 10864:val_abupt<33.0 (EP1) — WAIVED (warmup epoch)
- 32592:val_abupt<10.5 (EP3)
- 48897:val_abupt<8.0 (EP6 with vol-points-schedule)

### Verification (BEFORE full run)

Spend 5 min running a 2-epoch debug job with `--use-swa --swa-start-epoch 1` to verify:
- SWA model state_dict size matches model
- `swa_model(batch)` runs without compile/DDP errors  
- val_swa/* metrics appear in W&B

If anything breaks, post a comment with the error before launching the full run.

## Baseline

H112 (W&B run `u9ue2ryb`, PR #1283 merged) — current SOTA on `tay`:

| Metric | val | test |
|---|---:|---:|
| abupt | 6.1358% | 5.839% |
| WSS | 6.967% | 6.752% |
| WSS_x | 6.187% | 5.999% |
| WSS_y | 7.480% | 7.360% |
| **WSS_z** | **9.375%** | **8.720%** |
| VP | 3.548% | 3.421% |
| SP | 4.055% | 3.695% |

**Merge gates**: val_abupt < 6.1358%, test_WSS ≤ 6.727%, test_VP ≤ 3.421%, test_SP ≤ 3.577%.
**PRIMARY OBJECTIVE (Morgan Issue #1056)**: test_WSS < 5.85%. Current gap: −0.90pp.

**A WIN criterion for H164**: val_swa OR val_ema beats H112 val_abupt AND test_swa OR test_ema beats H112 test_WSS by any margin.

**Diagnostic of interest** (banked even on C NULL): val→test slope on WSS_z for SWA vs EMA. If SWA slope is markedly LESS flattened than EMA's (−0.655pp baseline), that's program-positive evidence for basin-geometry hypothesis — even if the absolute metrics don't pass merge gates.

## Why this is a high-priority Wave 40 assignment

This is **frieren's reassignment after H143 closure** (frieren's H143 analysis was exemplary — clean run-to-completion, mechanism-rooted suggestions in closure including the τy/τz joint sweep idea, banked for Wave 41). 

H164 directly tests the basin-geometry hypothesis that emerged from H143:
- H143 showed slope-flattening is overhead-INdependent
- H157 (nezuko) tests basin escape via warm restarts
- H164 (frieren) tests basin discovery via uniform weight averaging
- Both H157 + H164 alive → compound mechanism (SWA over restart cycles, canonical combination)

This is the AVERAGING-axis frontier of Wave 40. The OPTIMIZER-axis is H149 (AdamW, in flight). The SCHEDULER-axis is H157 (warm restarts, just assigned). The DATA-axis is H148 (mirror aug, in flight). Together these cover the four major non-capacity mechanism classes.

Run it cleanly, frieren. We're counting on the basin-geometry hypothesis being right — and SWA is the textbook test of it.
