### PR TITLE
H171 thorfinn: GradNorm plateau-exact static recipe (values-vs-dynamics test)

### DIFF
--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import DrivAerMLSurfaceDataset, SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
     debug: bool = False
 
 
@@ -238,6 +239,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "mirror_augmentation": (
+            "H148: Train-time y=0 yaw-mirror augmentation. DrivAerML is "
+            "bilaterally symmetric (symmetry-plane BC at y=0); every case "
+            "has an exact physically valid mirror twin. Per-sample flip "
+            "with prob 0.5: negate y/normal_y in surface_x, y in volume_x, "
+            "tau_y in surface_y; cp, tau_x, tau_z, sdf, volume_pressure "
+            "are invariant. Off for val/test. Zero parameter cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -283,6 +292,41 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def apply_mirror_augmentation(batch: SurfaceBatch) -> tuple[SurfaceBatch, float]:
+    """H148 y=0 yaw mirror augmentation, per-sample with prob 0.5.
+
+    Returns the augmented batch and the empirical flip fraction for logging.
+    Operates on CPU tensors before .to(device) for parity with H148 dataloader
+    augmentation. surface_x cols [x, y, z, nx, ny, nz, area]: negate y(1)/ny(4).
+    surface_y cols [cp, tau_x, tau_y, tau_z]: negate tau_y(2).
+    volume_x cols [x, y, z, sdf]: negate y(1); sdf invariant.
+    volume_y (pressure) invariant.
+    """
+    B = batch.surface_x.shape[0]
+    flip = torch.rand(B) < 0.5
+    if not flip.any():
+        return batch, 0.0
+    sign = torch.where(flip, -1.0, 1.0).to(batch.surface_x.dtype)
+    sign_col = sign[:, None]
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = surface_x[..., 1] * sign_col
+    surface_x[..., 4] = surface_x[..., 4] * sign_col
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = surface_y[..., 2] * sign_col
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = volume_x[..., 1] * sign_col
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), float(flip.float().mean().item())
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -958,6 +1002,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mirror_flip_fraction = 0.0
+                if config.mirror_augmentation:
+                    batch, mirror_flip_fraction = apply_mirror_augmentation(batch)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1078,6 +1125,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/mirror_flip_fraction": mirror_flip_fraction,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis — H147 GradNorm plateau-exact static replication (values-vs-dynamics test)

H147 thorfinn closed at 21:10Z with **PROGRAM-INVERTING finding**: GradNorm dynamic balancing landed in slope-FLATTENING cohort (NOT slope-preservation), and the auto-discovered tau_z ceiling at **1.679 (EP7 peak), 1.638 (EP8), 1.669 (terminal)** sits **16.6% BELOW H112's static 2.0** — in the DE-escalate region.

**This means H143/H144's ESCALATE direction was searching the WRONG HALF of magnitude space.** The gradient-aligned optimum on z-axis is in DE-escalate region [1.65, 1.70], not ESCALATE [2.0, 6.0].

H171 hypothesis: **Static replication of GradNorm's discovered terminal plateau values produces the same slope decomposition as the dynamic adaptation.** Tests whether the H147 slope-flattening is driven by:
- **(A) Values**: the perturbation off H112's prior in gradient-aligned direction breaks basin geometry → H171 will ALSO slope-flatten
- **(B) Dynamics**: GradNorm's discrete-to-smooth weight evolution adds regularization that static replication can't recover → H171 will slope-PRESERVE

### Decomposition into 3-flag delta from H112

| Weight | H112 | GradNorm plateau (effective at terminal) | H171 (this) | Direction |
|---|---:|---:|---:|---|
| `--surface-loss-weight` | 2.0 | 2.0 × sp_dyn(0.60) = 1.20 (sp), 2.0 × tau_x_dyn(1.14) = 2.27 (tau_x) | **2.0** (default) | unchanged |
| `--volume-loss-weight` | 1.0 | 0.5 × vp_dyn(0.30) = 0.15 | **0.5** | DE-escalate −50% |
| `--tau-y-loss-weight` | 1.5 | 1.0 × tau_y_dyn(1.30) = 1.30 | **1.30** | DE-escalate −13% |
| `--tau-z-loss-weight` | 2.0 | 1.0 × tau_z_dyn(1.67) = 1.67 | **1.67** | DE-escalate −17% |

The available CLI flags (`--surface/--volume/--tau-y/--tau-z-loss-weight`) cannot replicate GradNorm's per-channel sp/tau_x/vp downweights independently (since those flags don't exist). The 3-flag delta hits **the three most-perturbed effective weights** (volume, tau_y, tau_z) while keeping surface at H112's default.

### Factorial design with H170 edward (parallel mid-flight)

H170 edward is testing `--surface-loss-weight 4.0 --volume-loss-weight 0.5` (pure surface:volume axis, 8:1 ratio). H171 tests the orthogonal axis (per-channel WSS DE-escalate, volume DE-escalate without surface ESCALATE). Together H170 + H171 form a 2×2 factorial:

| | `surface=2.0` (H112 default) | `surface=4.0` (ESCALATE) |
|---|---|---|
| `vol=1.0, tau-y=1.5, tau-z=2.0` (H112) | **H112 baseline** | (not run) |
| `vol=0.5, tau-y=1.5, tau-z=2.0` | (not run) | **H170** (this run + surface ESCALATE) |
| `vol=0.5, tau-y=1.30, tau-z=1.67` | **H171 (this PR)** | (could be Wave 40+ stack) |

Cleanly decomposes "surface ESCALATE axis" vs "per-channel WSS DE-escalate axis".

### Falsifiability matrix (binding interpretation post-H147)

| Outcome | val_abupt | test_WSS | slope WSS agg | Reading |
|---|---|---|---|---|
| **A WIN — gradient-aligned static SOTA** | < 6.1358% | ≤ 6.727% | ≤ −0.215pp preserved | **MAJOR FINDING**: DE-escalate plateau IS the gradient-aligned SOTA. Static replication of GradNorm's discovered values produces the merge-eligible result GradNorm's dynamics could not. MERGE WITH PRIORITY. Reframes Wave 40+ entirely. |
| **C NULL, slope PRESERVE** (≤ −0.215pp) | ≥ 6.1358% | regression | preserved | Dynamics matter, not values. GradNorm's smooth adaptation added regularization that static can't replicate. Reopens dynamic-loss-balancing class (PCGrad, MGDA, IMTL variants). |
| **C NULL, slope FLATTER** | ≥ 6.1358% | regression | > −0.215pp | **perturbation-itself-is-the-issue framework LOCKED**. Static + dynamic z-axis perturbation in BOTH directions all break slope. Closes dynamic-loss-balancing mechanism class permanently (paired exhaustion H147+H171). Wave 40+ must pivot to orthogonal axes only. |
| D NEGATIVE | divergent | severe regression | flat or worse | The DE-escalate-multi-axis recipe is structurally worse than H112. Banks lesson on per-channel reweighting interactions. |

Most likely outcome per H147 prediction (gradient-aligned optimum theory): **C NULL slope-FLAT** confirming perturbation framework. But A WIN is non-negligible-probability if the static operating point hits the gradient optimum.

## Instructions

Single multi-flag delta from H112's verified recipe (PR #1283, W&B `u9ue2ryb`).

Make exactly three CLI flag changes from H112:
- `--volume-loss-weight 1.0` → `--volume-loss-weight 0.5`
- `--tau-y-loss-weight 1.5` → `--tau-y-loss-weight 1.30`
- `--tau-z-loss-weight 2.0` → `--tau-z-loss-weight 1.67`

All other flags **must match H112 exactly** — including `--surface-loss-weight 2.0`, LR, optimizer (Lion), batch size, hidden dim, vol-points-schedule, ema-decay=0.999. Use `--wandb-group h171-plateau-exact`.

### Kill gates (standard H112-recipe thresholds, recipe-specific)

EP1 gate: 33% per warmup-1 recipe (`--lr-warmup-epochs 1` makes EP1 val_abupt ~25-35% normal).
EP3 gate: 8.5% (standard).
EP6 gate: 7.0% (standard).

```
--kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>33.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0"
```

## Reproduce command

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent thorfinn \
  --epochs 13 --batch-size 4 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule "0:16384:3:32768:6:49152:9:65536" \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --tau-y-loss-weight 1.30 --tau-z-loss-weight 1.67 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct>33.0,32592:val_primary/abupt_axis_mean_rel_l2_pct>8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct>7.0" \
  --wandb-name thorfinn/h171-plateau-exact --wandb-group h171-plateau-exact
```

## Baseline (H112, the cohort anchor)

H112 W&B run `u9ue2ryb`:
- val_abupt 6.1358%, val_WSS 6.967%, val_WSS_z 9.375%
- test_abupt 5.839%, test_WSS 6.752%, test_VP 3.421%, test_SP 3.695%
- WSS aggregate val→test slope: −0.215pp (the cohort discriminator)

## Cross-cohort context (H147 verified, parallel fleet)

| Cohort point | Mechanism | Slope WSS agg | Class | Status |
|---|---|---:|---|---|
| H143 | Static tau_z=4.0 (z ESCALATE) | +0.115pp FLATTER | flattening | C NULL |
| H147 | GradNorm dynamic balancing | +0.105pp FLATTER | flattening | C NULL (closed 21:10Z) |
| **H171 (this)** | **Static plateau-exact replication** | **? prediction: FLATTER** | **? class TBD** | **target A WIN OR class lock** |
| H145 | y-axis tau_y=3.0 (ESCALATE) | −0.048pp STEEPER | preservation | C NULL (val regress) |
| H148 | Mirror-aug data invariance | −0.081pp STEEPER | preservation | C NULL (val noise floor) |
| H149 | AdamW optimizer axis | −0.036pp STEEPER | preservation | C NULL (pressure regress) |
| H170 (in flight) | Surface:vol 4:0.5 (ESCALATE+DE) | ? | ? | active EP1-EP3 |
| H180 (in flight) | Lookahead(AdamW) | ? | ? | active EP1-EP3 |
| H181 (in flight) | Mirror-aug + ema=0.9999 | ? | ? | active EP1-EP3 |

## Diagnostic targets per epoch publish

Per-epoch publish targets (the H147 diagnostic methodology applies — banked permanent):
- **EP3 publish**: per-channel val Δ vs H112 raw EP3. Three signatures matter: (1) val_WSS_z LEAD ≥ −0.05pp would indicate gradient-aligned operating point hit; (2) val_VP regression (vp not GradNorm-downweighted to 0.30, so should be LESS regressed than H147); (3) WSS_x invariant Δ (cohort target ≤ −0.05pp for slope-preservation class).
- **EP6 publish**: full WSS aggregate Δ vs H112. EP6 is binding diagnostic — if WSS aggregate LEAD vs H112 raw, slope-preservation hypothesis alive; if LAG matching H147's EP6 (+0.071pp on abupt), perturbation-itself-is-issue framework strengthening.
- **EP9 publish**: terminal projection point. val_abupt and test slope-decomposition prediction.
- **Terminal**: full val + test eval + val→test slope decomposition vs H112/H147 baseline.

## Outstanding excellence

thorfinn, your H147 24k-step plateau diagnostic + tau_z auto-discovered ceiling + EP-aligned-baseline caveat at EP8 are banked as **permanent program methodology**. H171 is your natural follow-up: the cleanest test of "values vs dynamics" that the H147 finding enables. The student-driven hypothesis path (your suggestion #1 in H147 closure) is exactly the right direction.

**The deliverable at terminal is the val→test slope decomposition table** in the same format as H148, with WSS_z as the target channel and WSS_x as the invariant control, vs H112 and H147 simultaneously. If H171 lands cohort point in the slope-FLATTENING class with z-axis-peak signature matching H147's +0.194pp, the perturbation-itself-is-issue framework locks definitively.
