### PR TITLE
H183: mirror-aug + tau_y=3.0 compound — slope-preservation x slope-preservation factorial

### DIFF
--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import DrivAerMLSurfaceDataset, SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
     debug: bool = False
 
 
@@ -238,6 +239,14 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "mirror_augmentation": (
+            "H148: Train-time y=0 yaw-mirror augmentation. DrivAerML is "
+            "bilaterally symmetric (symmetry-plane BC at y=0); every case "
+            "has an exact physically valid mirror twin. Per-sample flip "
+            "with prob 0.5: negate y/normal_y in surface_x, y in volume_x, "
+            "tau_y in surface_y; cp, tau_x, tau_z, sdf, volume_pressure "
+            "are invariant. Off for val/test. Zero parameter cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -283,6 +292,41 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def apply_mirror_augmentation(batch: SurfaceBatch) -> tuple[SurfaceBatch, float]:
+    """H148 y=0 yaw mirror augmentation, per-sample with prob 0.5.
+
+    Returns the augmented batch and the empirical flip fraction for logging.
+    Operates on CPU tensors before .to(device) for parity with H148 dataloader
+    augmentation. surface_x cols [x, y, z, nx, ny, nz, area]: negate y(1)/ny(4).
+    surface_y cols [cp, tau_x, tau_y, tau_z]: negate tau_y(2).
+    volume_x cols [x, y, z, sdf]: negate y(1); sdf invariant.
+    volume_y (pressure) invariant.
+    """
+    B = batch.surface_x.shape[0]
+    flip = torch.rand(B) < 0.5
+    if not flip.any():
+        return batch, 0.0
+    sign = torch.where(flip, -1.0, 1.0).to(batch.surface_x.dtype)
+    sign_col = sign[:, None]
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = surface_x[..., 1] * sign_col
+    surface_x[..., 4] = surface_x[..., 4] * sign_col
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = surface_y[..., 2] * sign_col
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = volume_x[..., 1] * sign_col
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), float(flip.float().mean().item())
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -958,6 +1002,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mirror_flip_fraction = 0.0
+                if config.mirror_augmentation:
+                    batch, mirror_flip_fraction = apply_mirror_augmentation(batch)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1078,6 +1125,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/mirror_flip_fraction": mirror_flip_fraction,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis

**H183: mirror-aug + tau_y=3.0 compound** — first slope-preservation × slope-preservation factorial test on the y-axis.

The slope-preservation cohort is now locked at 4 independent axes (H145 y-axis loss-weight ESCALATE, H148 y-axis data invariance mirror-aug, H149 optimizer AdamW, H157 scheduler SGDR). All preserve val→test slope on WSS aggregate by ~−0.04 to −0.08pp.

**Question**: Do two y-axis slope-preservation interventions COMPOUND when stacked?

**Mechanism**: Mirror-aug (H148) and tau_y=3.0 ESCALATE (H145) target the SAME mechanism axis (y-channel gradient allocation) via DIFFERENT mechanisms:
- H148 mirror-aug forces y-channel invariance via data augmentation (left-right flip with sign-flip on y-targets)
- H145 tau_y=3.0 ESCALATE increases y-channel loss weight by 2× → 2× larger gradient signal on y-channel residuals

If the gradient reallocation mechanism is the same upstream cause, then compound slope-steepening should be approximately additive: H148 −0.081pp + H145 −0.048pp = ~−0.129pp WSS aggregate (vs H112 −0.215pp = total −0.344pp).

If terminal val_abupt clears 6.1358 AND slope steepens to ~−0.30pp+ on WSS aggregate, **H183 would be the first single-model SOTA path** combining two known-validated slope-preservation interventions.

**Risk**: Compound interventions on the same axis may saturate or anti-compound (gradient reallocation can only steepen slope by so much before overfitting). The H183 result determines whether the cohort framework supports compounding on the same axis (HIGH-EV) or only across orthogonal axes (LOW-EV for stacking).

## Instructions

**Single-flag-delta** from H148 (mirror-aug baseline): add `--tau-y-loss-weight 3.0`.

Verify against canonical H148 W&B run config — NOT against the BASELINE.md reproduce-command (which has 6+ stale flags including `--volume-loss-weight 0.5` instead of canonical 1.0). Use the methodology from H167 audit: cross-check every flag against H148's actual config.

**Critical**: This is a 2-flag delta from H112 SOTA:
1. `--tau-y-loss-weight 3.0` (was 1.5 in H112, was 1.5 in H148)
2. mirror-aug flag (was disabled in H112, enabled in H148)

ALL other flags must match H112's canonical config `u9ue2ryb` exactly:
- `--surface-loss-weight 2.0`, `--volume-loss-weight 1.0`
- `--tau-z-loss-weight 2.0` (UNCHANGED — z-axis is permanently locked per H165 closure)
- `--grad-clip-norm 0.5`, `--drop-path-max 0.10`, `--no-compile-model`
- `--use-ema --ema-decay 0.999 --ema-start-step 50` (standard, NOT 0.9999)
- All other flags from H112 PR #1283 reproduce command

**Channel-decomposition reporting required** at EP3 / EP6 / EP9 / terminal:

| Channel | EP-N value | Δ vs H112 same step | Δ vs H148 same step | Δ vs H145 same step |
|---|---:|---:|---:|---:|
| val_abupt | | | | |
| WSS aggregate | | | | |
| WSS_x (orthogonal-axis bowl-floor indicator) | | | | |
| WSS_y (target — both interventions) | | | | |
| WSS_z (orthogonal — must stay near H112) | | | | |
| VP | | | | |
| SP | | | | |

**Critical mid-train diagnostic**: WSS_x val→test slope. Per the new H165 finding (just banked), every z-axis perturbation showed positive WSS_x slope as a basin-disruption indicator. H148 and H145 individually should show negative WSS_x slope (matching H112). If compound H183 shows positive WSS_x slope at EP6/EP9 boundary, that's a basin-disruption warning even if val_abupt looks clean.

**Kill thresholds** (using PASS condition operator `<`):
```
--kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<33.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0,70664:val_primary/abupt_axis_mean_rel_l2_pct<6.1358"
```

**WandB group**: `--wandb-group fern-h183-mirror-tau-y-3p0-compound`

## Baseline

Current best (H112, PR #1283, W&B `u9ue2ryb`):
- val_abupt: 6.1358%
- val_WSS: 6.967%
- test_WSS: **6.752%** (primary objective per Morgan)
- test_WSS_z: 8.720%
- val→test WSS slope: −0.215pp

H148 (mirror-aug alone, PRESERVATION cohort member #2):
- val_abupt: 6.215% (PASS gate)
- val_WSS: ~7.04%
- test_WSS: ~6.835% (+0.083pp vs H112)
- val→test WSS slope: −0.296pp (STEEPER by −0.081pp)

H145 (tau_y=3.0 alone, PRESERVATION cohort member #1):
- val_abupt: 6.388% (MISS gate)
- val_WSS: 7.18%
- test_WSS: 6.905% (+0.153pp vs H112)
- val→test WSS slope: −0.263pp (STEEPER by −0.048pp)

**Target for H183**:
- val_abupt: ≤ 6.1358% (clears merge gate via slope-preservation compound noise floor closure)
- test_WSS: ≤ 6.671% (FIRST single-model SOTA via additive slope-steepening compound)
- val→test WSS slope: ~−0.30pp or steeper (additive compound of H145 + H148 individual steepenings)
- WSS_x val→test slope: negative (matching H112 basin neighborhood)

**Reproduce command** (build from H148 canonical config; verify against W&B before launch):
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent fern --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 3.0 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 1.0 \
  --use-surf-to-vol-xattn --drop-path-max 0.10 \
  --use-mirror-augmentation \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 16384 --eval-volume-points 65536 \
  --vol-points-schedule 0:16384:3:32768:6:49152:9:65536 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --epochs 13 --lr-warmup-epochs 1 --lr-cosine-t-max 13 --lr-min 1e-6 \
  --grad-clip-norm 0.5 --amp-mode bf16 --no-compile-model \
  --wandb-name fern/h183-mirror-aug-tau-y-3p0-compound \
  --wandb-group fern-h183-mirror-tau-y-3p0-compound \
  --kill-thresholds "10864:val_primary/abupt_axis_mean_rel_l2_pct<33.0,32592:val_primary/abupt_axis_mean_rel_l2_pct<8.5,48897:val_primary/abupt_axis_mean_rel_l2_pct<7.0,70664:val_primary/abupt_axis_mean_rel_l2_pct<6.1358"
```

**Cross-check the `--use-mirror-augmentation` flag spelling against H148's actual W&B config** — that flag name is my best guess; verify before launching. Also confirm the H148 canonical recipe has no other surprises (drop-path schedule, vol-points-schedule, etc).

H165's closure also banked: "DO NOT use late-cosine descent rate as a prognostic for val→test slope on z-axis perturbations." This is z-axis-specific; the y-axis analog is not yet validated, so for H183 the descent-rate diagnostic is still permitted as one of several mid-train signals.
