### PR TITLE
H150: Lion β-sweep high neighbor (β1=0.97, β2=0.985)

### DIFF
--- a/curvature_proxy_stats_k16_v1.json
+++ b/curvature_proxy_stats_k16_v1.json
@@ -1,0 +1,16 @@
+{
+  "mean": [
+    0.02856144342125595,
+    0.01238992213118092,
+    0.032225027457385653
+  ],
+  "std": [
+    0.08759301544863994,
+    0.06059323902318705,
+    0.10618328877785052
+  ],
+  "count": 3434177441,
+  "num_cases": 400,
+  "filename_npy": "surface_curvature_proxy_k16_v1.npy",
+  "case_root": "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+}

--- a/scripts/precompute_curvature_proxy.py
+++ b/scripts/precompute_curvature_proxy.py
@@ -1,0 +1,87 @@
+"""Compute train-split mean/std of the per-vertex curvature proxy.
+
+Reads ``surface_curvature_proxy_k16_v1.npy`` from each train case in the
+pinned split manifest and writes ``curvature_proxy_stats_k16_v1.json`` next
+to ``trainer_runtime.py`` so ``load_curvature_stats`` can find it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "data" / "split_manifest.json"
+DEFAULT_STATS_PATH = REPO_ROOT / "curvature_proxy_stats_k16_v1.json"
+CURVATURE_FILENAME = "surface_curvature_proxy_k16_v1.npy"
+CURVATURE_DIM = 3
+
+
+def _resolve_root(manifest: dict, override: str | None) -> Path:
+    if override:
+        return Path(override)
+    candidates = [manifest.get("case_root", "")] + list(manifest.get("case_root_candidates", []))
+    for cand in candidates:
+        if cand and Path(cand).is_dir():
+            return Path(cand)
+    raise FileNotFoundError(f"No case_root candidate exists. Tried: {candidates}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--data-root", type=str, default=None,
+                        help="Override case_root in the manifest (e.g. /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511)")
+    parser.add_argument("--output", type=Path, default=DEFAULT_STATS_PATH)
+    args = parser.parse_args()
+
+    with args.manifest.open() as f:
+        manifest = json.load(f)
+    root = _resolve_root(manifest, args.data_root)
+    train_cases = manifest["surface_splits"]["train"]
+    print(f"Computing curvature stats over {len(train_cases)} train cases under {root}")
+
+    count = 0
+    sum_x = np.zeros(CURVATURE_DIM, dtype=np.float64)
+    sum_x2 = np.zeros(CURVATURE_DIM, dtype=np.float64)
+
+    for i, case_id in enumerate(train_cases):
+        path = root / case_id / CURVATURE_FILENAME
+        if not path.exists():
+            raise FileNotFoundError(f"Missing curvature file for {case_id}: {path}")
+        arr = np.load(path).astype(np.float64, copy=False)
+        if arr.ndim != 2 or arr.shape[1] != CURVATURE_DIM:
+            raise ValueError(f"{path}: expected (V, {CURVATURE_DIM}); got {arr.shape}")
+        count += arr.shape[0]
+        sum_x += arr.sum(axis=0)
+        sum_x2 += (arr * arr).sum(axis=0)
+        if (i + 1) % 50 == 0:
+            print(f"  processed {i + 1}/{len(train_cases)} cases; running count={count:,}")
+
+    mean = sum_x / count
+    var = sum_x2 / count - mean * mean
+    var = np.maximum(var, 0.0)
+    std = np.sqrt(var)
+
+    stats = {
+        "mean": [float(x) for x in mean],
+        "std": [float(x) for x in std],
+        "count": int(count),
+        "num_cases": int(len(train_cases)),
+        "filename_npy": CURVATURE_FILENAME,
+        "case_root": str(root),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as f:
+        json.dump(stats, f, indent=2)
+    print(f"Wrote {args.output}")
+    print(f"  mean = {stats['mean']}")
+    print(f"  std  = {stats['std']}")
+    print(f"  total surface points = {count:,}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

H150: Lion β-sweep high neighbor — can test_WSS improve further by shifting β1 up to 0.97 and β2 up to 0.985?

Wave 36 (H147, PR #1344) confirmed Lion β1=0.95/β2=0.98 as the single driver of our new SOTA test_WSS=6.5409%. The optimal has been found at one point but the landscape above it has not been explored. The shift from canonical 0.9/0.99 to 0.95/0.98 is a non-trivial move toward higher β1 and lower β2 simultaneously — it is plausible that the optimal valley continues in the same direction.

This arm tests the **above-optimal neighbor**: β1=0.97 (+0.02), β2=0.985 (+0.005). If the improvement came from β1 increasing (faster first-moment forgetting) the trend may not saturate at 0.95.

## Instructions

Run on the **full canonical H39 stack + Lion β1=0.95/β2=0.98 base**, with only the β values changed:

```bash
cd target/ && python train.py \
  --hidden-dim 512 --layers 6 --heads 4 --slices 128 \
  --surface-out-width-factor 2.0 \
  --pe-type string_multisigma \
  --lion-beta1 0.97 --lion-beta2 0.985 \
  --ema-decay 0.999 --ema-start-step 500 \
  --epochs 30 \
  --wandb_group h150-lion-beta-sweep
```

**Exact changes from baseline:**
- `--lion-beta1 0.97` (was 0.95)
- `--lion-beta2 0.985` (was 0.98)
- All other flags identical to the canonical reproduce command

**Optional second arm** (if time permits within the 2-day window): also run `--lion-beta1 0.98 --lion-beta2 0.99` in the same `wandb_group` to test how close to degenerate-momentum the benefit persists.

Report all four metrics: test_WSS, test_ABUPT, test_VP (vol_p), test_SP. Use best-val checkpoint for test evaluation.

## Baseline (PR #1344, run k6q4c3on)

| Metric | Current SOTA | Hard Floor |
|--------|-------------|-----------|
| test_WSS | 6.5409% | < 5.85% (Transolver-3) |
| test_ABUPT | 5.6648% | ≤ 5.844% ✅ |
| test_VP | 3.6033% | ≤ 3.643% ✅ |
| test_SP | 3.6498% | ≤ 3.577% ✗ |

Reproduce command (canonical):
```bash
cd target/ && python train.py --hidden-dim 512 --layers 6 --heads 4 --slices 128 --surface-out-width-factor 2.0 --pe-type string_multisigma --lion-beta1 0.95 --lion-beta2 0.98 --ema-decay 0.999 --ema-start-step 500 --epochs 30
```
