### PR TITLE
H190: mirror-aug at p=0.25 — augmentation strength sweep

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -367,6 +367,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         max_surface_points: int = 0,
         max_volume_points: int = 0,
         sampling_mode: str = "full",
+        mirror_augmentation: bool = False,
+        mirror_augmentation_prob: float = 0.5,
     ):
         self.store = store or DrivAerMLCaseStore(manifest_path=manifest_path, root=root)
         self.case_ids = list(case_ids)
@@ -376,6 +378,8 @@ class DrivAerMLSurfaceDataset(Dataset):
         self.max_surface_points = max_surface_points
         self.max_volume_points = max_volume_points
         self.sampling_mode = sampling_mode
+        self.mirror_augmentation = bool(mirror_augmentation)
+        self.mirror_augmentation_prob = float(mirror_augmentation_prob)
         self.views = self._build_views()
 
     def __len__(self) -> int:
@@ -457,12 +461,38 @@ class DrivAerMLSurfaceDataset(Dataset):
         metadata["volume_view_count"] = int(view.volume_view_count)
         metadata["volume_sampling_mode"] = view.sampling_mode
         metadata["joint_view_count"] = int(view.view_count)
+        surface_x = case.surface_x
+        surface_y = case.surface_y
+        volume_x = case.volume_x
+        volume_y = case.volume_y
+        mirrored = False
+        if (
+            self.mirror_augmentation
+            and self.mirror_augmentation_prob > 0.0
+            and torch.rand(1).item() < self.mirror_augmentation_prob
+        ):
+            # y=0 yaw mirror: bilateral symmetry of DrivAerML geometry.
+            # surface_x cols: [x, y, z, nx, ny, nz, area]; negate y(1) and ny(4).
+            # surface_y cols: [cp, tau_x, tau_y, tau_z]; negate tau_y(2) only.
+            # volume_x cols: [x, y, z, sdf]; negate y(1); sdf invariant.
+            # volume_y: pressure scalar; invariant.
+            surface_x = surface_x.clone()
+            surface_x[..., 1] *= -1
+            surface_x[..., 4] *= -1
+            surface_y = surface_y.clone()
+            surface_y[..., 2] *= -1
+            volume_x = volume_x.clone()
+            volume_x[..., 1] *= -1
+            mirrored = True
+        metadata["mirror_augmentation"] = self.mirror_augmentation
+        metadata["mirror_augmentation_prob"] = self.mirror_augmentation_prob
+        metadata["mirrored"] = mirrored
         return DrivAerMLCase(
             case_id=case.case_id,
-            surface_x=case.surface_x,
-            surface_y=case.surface_y,
-            volume_x=case.volume_x,
-            volume_y=case.volume_y,
+            surface_x=surface_x,
+            surface_y=surface_y,
+            volume_x=volume_x,
+            volume_y=volume_y,
             metadata=metadata,
         )
 
@@ -543,6 +573,8 @@ def load_data(
     eval_surface_points: int = 40_000,
     train_volume_points: int = 40_000,
     eval_volume_points: int = 40_000,
+    train_mirror_augmentation: bool = False,
+    train_mirror_augmentation_prob: float = 0.5,
     debug: bool = False,
 ) -> tuple[DrivAerMLSurfaceDataset, dict[str, DrivAerMLSurfaceDataset], dict[str, DrivAerMLSurfaceDataset], dict[str, torch.Tensor]]:
     """Return train, validation, test datasets and target normalization stats."""
@@ -568,6 +600,8 @@ def load_data(
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
         sampling_mode=train_sampling,
+        mirror_augmentation=train_mirror_augmentation,
+        mirror_augmentation_prob=train_mirror_augmentation_prob,
     )
     val_splits = {
         "val_surface": DrivAerMLSurfaceDataset(

--- a/train.py
+++ b/train.py
@@ -139,6 +139,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
+    mirror_augmentation_prob: float = 0.5
     debug: bool = False
 
 
@@ -237,6 +239,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the attention and MLP branches with a linear schedule from "
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
+        ),
+        "mirror_augmentation": (
+            "H148: Train-time y=0 yaw-mirror augmentation. DrivAerML is "
+            "bilaterally symmetric (symmetry-plane BC at y=0); every case "
+            "has an exact physically valid mirror twin. Per-sample flip "
+            "with prob --mirror-augmentation-prob (default 0.5): negate "
+            "y/normal_y in surface_x and y in volume_x; negate tau_y in "
+            "surface_y; cp, tau_x, tau_z, sdf, volume_pressure invariant. "
+            "Off for val/test. Zero parameter cost."
+        ),
+        "mirror_augmentation_prob": (
+            "H190: Per-sample probability of applying the y=0 yaw-mirror "
+            "augmentation when --mirror-augmentation is enabled. 0.5 is "
+            "the canonical H148 value; 0.25 halves the effective "
+            "augmentation frequency to test the augmentation-strength "
+            "operating point."
         ),
     }
     for field in fields(Config):
@@ -693,6 +711,8 @@ def rebuild_train_loader_with_vol_points(
         max_surface_points=config.train_surface_points,
         max_volume_points=n_points,
         sampling_mode=sampling_mode,
+        mirror_augmentation=config.mirror_augmentation,
+        mirror_augmentation_prob=config.mirror_augmentation_prob,
     )
     train_sampler = None
     train_shuffle = True
@@ -905,6 +925,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"DropPath (H112): per-block schedule "
                         f"(attn=mlp) = {drop_path_schedule}"
                     )
+            wandb.summary["mirror_augmentation/enabled"] = bool(config.mirror_augmentation)
+            wandb.summary["mirror_augmentation/prob"] = float(
+                config.mirror_augmentation_prob if config.mirror_augmentation else 0.0
+            )
+            if config.mirror_augmentation:
+                print(
+                    f"Mirror augmentation (H148): enabled with "
+                    f"per-sample prob = {config.mirror_augmentation_prob}"
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -958,6 +987,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mirror_flip_fraction = 0.0
+                if config.mirror_augmentation and getattr(batch, "metadata", None):
+                    flips = [
+                        float(m.get("mirrored", False)) for m in batch.metadata
+                    ]
+                    if flips:
+                        mirror_flip_fraction = sum(flips) / len(flips)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1078,6 +1114,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/mirror_flip_fraction": mirror_flip_fraction,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -285,6 +285,8 @@ def make_loaders(
         eval_surface_points=config.eval_surface_points,
         train_volume_points=config.train_volume_points,
         eval_volume_points=config.eval_volume_points,
+        train_mirror_augmentation=getattr(config, "mirror_augmentation", False),
+        train_mirror_augmentation_prob=getattr(config, "mirror_augmentation_prob", 0.5),
         debug=config.debug,
     )
     train_sampler = None


### PR DESCRIPTION
## Hypothesis (H190)

**One-line**: Test mirror-augmentation at HALF the default probability (p=0.25 vs p=0.50) on the H112 base recipe to find the optimal augmentation strength operating point on the strongest single slope-preservation axis BEFORE compounding.

**Mechanism**:
- H148 (mirror-aug at p=0.5, PR #1341) produced the steepest single-axis slope improvement (val→test WSS slope −0.296pp vs H112 −0.215pp; ΔWSS slope = −0.081pp). But val_abupt was 6.388% — WORSE than H112's 6.1358% — suggesting the augmentation was OVER-regularizing.
- At p=0.25, effective augmentation frequency is halved. The training distribution stays more anchored to the original data manifold:
  - **Hypothesis A**: val_abupt drops CLOSER to H112's 6.1358% (less over-regularization) while slope steepening is preserved or only modestly reduced.
  - **Hypothesis B**: slope steepening requires high augmentation coverage, so p=0.25 flattens slope back toward H112 — confirming p=0.5 is the canonical operating point.
- This is the discriminating diagnostic for augmentation-strength on the H148 mechanism.

**Why bold**: If p=0.25 gives BETTER val_abupt while preserving slope (Hypothesis A), it immediately becomes the canonical mirror-aug operating point in ALL future compounds (H184/H185/H186 should be re-evaluated with p=0.25). If val_abupt = 6.10% AND slope < −0.27pp WSS agg, this could become a SOTA candidate on its own.

**Key context — final-day priority**:
- Program has ~24 hours remaining. The mirror-aug probability sweep is explicitly banked as H185 in CURRENT_RESEARCH_STATE.md but never run.
- H183 just achieved val SOTA 6.0388% with mirror+tau_y=3.0 — the compound space is opening up but we don't know what mirror-p value optimizes it.
- H164d RNG floor: WSS aggregate slope deviations smaller than ±0.040pp may be RNG noise. H148's −0.081pp is 2x the floor and survives; we need H190's slope effect to also exceed the floor.

**Expected outcome**:
- val_abupt: 6.15–6.30% (between H112's 6.1358% and H148's 6.388%, depending on regularization)
- test_WSS: 6.72–6.85% (depending on whether slope steepening scales with p or is binary)
- WSS aggregate slope: −0.22 to −0.28pp (some steepening, less than H148's −0.296pp)

**Falsification**: If slope WSS agg is within ±0.04pp of H112's −0.215pp (RNG floor), augmentation at p=0.25 is below the effectiveness threshold — H148's slope effect requires high mirror coverage and p=0.5 is canonical.

## Instructions

**Base recipe**: H112 (PR #1283) recipe — copy all flags exactly.

**ONE addition + one parameter change**:
1. **Add `--mirror-augmentation`** — reuse the mirror-aug implementation from PR #1341 (H148) or PR #1356 (H183). Cherry-pick the data/loader.py and trainer.py changes from one of those branches.
2. **Set mirror-aug probability to 0.25**. If the implementation has a `--mirror-aug-prob` or `--mirror-augmentation-prob` flag, use that. If not, modify the implementation to expose it. The default (p=0.5) MUST be overridden.

**DO NOT change**: anything else from H112 baseline — hidden-dim (512), layers (5), heads (4), slices (128), tau-y-loss-weight (1.5), tau-z-loss-weight (2.0), optimizer (lion), lr (9e-5), weight-decay (5e-4), drop-path-max (0.10), ema-decay (0.999), lr-warmup-epochs (1), lr-cosine-t-max (13).

**Verify in W&B logs**: at training start, log the effective mirror-aug probability so we can confirm p=0.25 is active (not the default 0.5).

**Run command**:
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  <all H112 flags exactly> \
  --mirror-augmentation \
  --mirror-augmentation-prob 0.25 \
  --wandb-name nezuko/h190-mirror-aug-p025 \
  --wandb_group nezuko-h190-mirror-aug-p025
```

**Kill thresholds** (standard EMA=0.999 schedule):
- step 10864 (EP1): val_primary/abupt_axis_mean_rel_l2_pct < 33%
- step 32592 (EP3): val_primary/abupt_axis_mean_rel_l2_pct < 8.5%
- step 48897 (EP6): val_primary/abupt_axis_mean_rel_l2_pct < 7.0%
- step 65184 (EP9): val_primary/abupt_axis_mean_rel_l2_pct < 6.5%

**Report at terminal**:
1. val_abupt (vs H148's 6.388% and H112's 6.136% — where does H190 land?)
2. test_WSS, test_WSS_x, test_WSS_y, test_WSS_z, test_VP, test_SP
3. WSS aggregate val→test slope (compare to H112's −0.215pp, H148's −0.296pp)
4. **Per-channel slopes (WSS_x, WSS_y, WSS_z, abupt)** — needed for cohort analysis
5. SENPAI-RESULT terminal marker with primary_metric=val_abupt and test_metric=test_WSS

## Baseline

**Current single-model SOTA: H112 (PR #1283, W&B `u9ue2ryb`)**
- val_abupt: **6.1358%** / test_WSS: **6.752%** / test_WSS_z: 8.720%
- val→test WSS slope: −0.215pp

**Merge gate**: val_abupt < 6.1358% AND test_WSS ≤ 6.727% AND test_VP ≤ 3.421% AND test_SP ≤ 3.577%

**Stretch (Issue #1056)**: test_WSS < 5.85%

**Reference points**:
- H148 (mirror-aug at p=0.5, PR #1341, closed): val_abupt=6.388%, test_WSS=6.935%, WSS slope=−0.296pp
- H183 (mirror at p=0.5 + tau_y=3.0): val_abupt=6.0388% NEW VAL SOTA, test_WSS=6.8287% MISS
- H164d RNG floor: WSS slope ±0.040pp
