### PR TITLE
H191: mirror-aug + tau_y=2.0 — H183 boundary probe

### DIFF
--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import DrivAerMLSurfaceDataset, SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -139,6 +139,7 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
     debug: bool = False
 
 
@@ -238,6 +239,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "mirror_augmentation": (
+            "H148/H183: Train-time y=0 yaw-mirror augmentation. DrivAerML "
+            "is bilaterally symmetric (symmetry-plane BC at y=0); every "
+            "case has an exact physically valid mirror twin. Per-sample "
+            "flip with prob 0.5: negate y/normal_y in surface_x, y in "
+            "volume_x, tau_y in surface_y; cp, tau_x, tau_z, sdf, "
+            "volume_pressure are invariant. Off for val/test. Zero param "
+            "cost."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -283,6 +293,41 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def apply_mirror_augmentation(batch: SurfaceBatch) -> tuple[SurfaceBatch, float]:
+    """H148/H183 y=0 yaw mirror augmentation, per-sample with prob 0.5.
+
+    Returns the augmented batch and the empirical flip fraction for logging.
+    Operates on CPU tensors before .to(device) for parity with H148 dataloader
+    augmentation. surface_x cols [x, y, z, nx, ny, nz, area]: negate y(1)/ny(4).
+    surface_y cols [cp, tau_x, tau_y, tau_z]: negate tau_y(2).
+    volume_x cols [x, y, z, sdf]: negate y(1); sdf invariant.
+    volume_y (pressure) invariant.
+    """
+    B = batch.surface_x.shape[0]
+    flip = torch.rand(B) < 0.5
+    if not flip.any():
+        return batch, 0.0
+    sign = torch.where(flip, -1.0, 1.0).to(batch.surface_x.dtype)
+    sign_col = sign[:, None]
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = surface_x[..., 1] * sign_col
+    surface_x[..., 4] = surface_x[..., 4] * sign_col
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = surface_y[..., 2] * sign_col
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = volume_x[..., 1] * sign_col
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), float(flip.float().mean().item())
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -958,6 +1003,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mirror_flip_fraction = 0.0
+                if config.mirror_augmentation:
+                    batch, mirror_flip_fraction = apply_mirror_augmentation(batch)
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1078,6 +1126,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/mirror_flip_fraction": mirror_flip_fraction,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis (H191)

**One-line**: Find the intermediate y-axis push that achieves val improvement (like H183) but avoids the WSS_x sign-flip pathology — test mirror-augmentation + tau_y=2.0 (halfway between H112's 1.5 and H183's 3.0).

**Mechanism**:
- H183 (fern PR #1356, mirror-aug + tau_y=3.0): NEW PROGRAM VAL SOTA `val_abupt=6.0388%` (−97bp below H112) BUT WSS_x slope flipped POSITIVE (+0.064pp, basin-disruption diagnostic), causing test_WSS to MISS at 6.8287%.
- The failure mode: over-allocating gradient mass onto WSS_y (tau_y=3.0 doubles the y-channel loss weight) PLUS data-distribution y-axis symmetry (mirror-aug) creates excessive y-axis pressure that breaks the WSS_x basin invariant.
- H191 tests the MIDPOINT: tau_y=2.0 with mirror-augmentation. This is a 33% y-axis push (vs H183's 100% push at 3.0) — should achieve partial val improvement while staying below the WSS_x sign-flip threshold.
- Falsification: if H191 ALSO triggers WSS_x sign-flip, the threshold is at or below tau_y=2.0 and the mirror+tau_y stacking is structurally fragile at ANY meaningful y-axis push.

**Why bold**: This is the binary search step that determines whether H183's val SOTA path can be SALVAGED for test. If WSS_x stays negative at tau_y=2.0 AND val_abupt < 6.10%, this could be a TRUE WIN. If WSS_x flips, the entire mirror+tau_y axis is dead and we know to focus on cross-axis compounds only (H189, H188, H190 paths).

**Key context — final-day priority**:
- Program has ~24 hours remaining. H183's val SOTA must be either salvaged or ruled out within this window.
- H183 outcome already locked the "shared y-axis stacking" failure mode at tau_y=3.0; we need the safe-zone boundary.
- H164d RNG floor: WSS aggregate slope ±0.040pp; H191's expected slope effect should clearly exceed this.

**Expected outcome**:
- val_abupt: 6.08–6.20% (between H183's 6.04% and H148's 6.39%; tau_y=2.0 is 33% of the way from H148 to H183 on y-axis loss-weight, so val improvement should be smaller)
- test_WSS: 6.65–6.85% (target: BEAT 6.727% merge gate — depends critically on WSS_x slope behavior)
- WSS_x slope: SHOULD remain negative (CRITICAL — if positive, the y-axis perturbation threshold is below tau_y=2.0)
- WSS aggregate slope: −0.28 to −0.32pp (steeper than H148 alone)

**Falsification**: 
- If WSS_x slope flips positive: shared y-axis fragile at tau_y ≥ 2.0; the mirror+tau_y stacking direction is dead.
- If val_abupt > 6.30%: tau_y=2.0 is insufficient y-push for val SOTA, even with mirror-aug.

## Instructions

**Base recipe**: H112 (PR #1283) recipe.

**TWO single-flag changes from H112**:
1. **Add `--mirror-augmentation`** (reuse implementation from PR #1341 H148 or PR #1356 H183)
2. **Set `--tau-y-loss-weight 2.0`** (vs H112's 1.5) — intermediate y-axis loss-weight push

**DO NOT change**: optimizer (Lion), lr (9e-5), weight-decay (5e-4), tau-z-loss-weight (keep 2.0 LOCKED), surface/volume loss weights, hidden-dim (512), layers (5), heads (4), drop-path-max (0.10), ema-decay (0.999).

**Run command**:
```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  <all H112 flags exactly> \
  --mirror-augmentation \
  --tau-y-loss-weight 2.0 \
  --wandb-name tanjiro/h191-mirror-tau-y-2p0 \
  --wandb_group tanjiro-h191-mirror-tau-y-2p0
```

**Kill thresholds** (standard EMA=0.999 schedule):
- step 10864 (EP1): val_primary/abupt_axis_mean_rel_l2_pct < 33%
- step 32592 (EP3): val_primary/abupt_axis_mean_rel_l2_pct < 8.5%
- step 48897 (EP6): val_primary/abupt_axis_mean_rel_l2_pct < 7.0%
- step 65184 (EP9): val_primary/abupt_axis_mean_rel_l2_pct < 6.5%

**Report at terminal**:
1. val_abupt (vs H183's 6.0388%, H148's 6.388%, H112's 6.1358%)
2. test_WSS, test_WSS_x, test_WSS_y, test_WSS_z, test_VP, test_SP
3. **WSS_x slope sign** (BINDING DIAGNOSTIC — if positive, the y-axis stacking direction is dead at tau_y ≥ 2.0)
4. WSS aggregate val→test slope (compare to H112 −0.215pp, H148 −0.296pp, H183 −0.036pp)
5. SENPAI-RESULT terminal marker with primary_metric=val_abupt and test_metric=test_WSS

**Critical analysis at EP9 binding**: report WSS_x slope direction prediction from val trajectory. If trending positive, escalate immediately.

## Baseline

**Current single-model SOTA: H112 (PR #1283, W&B `u9ue2ryb`)**
- val_abupt: **6.1358%** / test_WSS: **6.752%** / test_WSS_z: 8.720%
- val→test WSS slope: −0.215pp
- WSS_x slope: −0.093pp (negative — basin invariant intact)

**Merge gate**: val_abupt < 6.1358% AND test_WSS ≤ 6.727% AND test_VP ≤ 3.421% AND test_SP ≤ 3.577%

**Stretch (Issue #1056)**: test_WSS < 5.85%

**Reference points**:
- H145 (tau_y=3.0 alone, Lion): val 6.388%, slope −0.263pp (NEG, slope-preservation)
- H148 (mirror at p=0.5, alone): val 6.388%, slope −0.296pp (NEG, slope-preservation)
- H183 (mirror + tau_y=3.0): val 6.0388% NEW VAL SOTA, test_WSS=6.8287% MISS, WSS_x +0.064pp (POSITIVE → basin disruption)
- H164d RNG floor: WSS slope ±0.040pp
