### PR TITLE
H192: TTA mirror-aug on H112 checkpoint — eval-only sprint

### DIFF
--- a/logs/h192_h112_eval.log
+++ b/logs/h192_h112_eval.log
@@ -1,0 +1,84 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=7
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_040724-e22co34u
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run thorfinn/h192-h112-tta-mirror
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/e22co34u
+
+=== Evaluating val (7295 views) ===
+val_original   loss=0.00472 abupt_axis_rel_l2_pct=6.1358 surface_p_mae=0.01092 volume_p_mae=7.03595 wall_shear_mae=0.05956 cases=34
+  val_original -> abupt=6.1358% | SP=4.0553% | WSS=6.9671% | VP=3.5477% | WSS_x=6.0924% | WSS_y=7.6083% | WSS_z=9.3751%
+val_mirrored   loss=0.01533 abupt_axis_rel_l2_pct=10.9996 surface_p_mae=0.02453 volume_p_mae=17.47224 wall_shear_mae=0.09417 cases=34
+  val_mirrored -> abupt=10.9996% | SP=8.7453% | WSS=11.3599% | VP=8.4516% | WSS_x=9.8478% | WSS_y=12.8189% | WSS_z=15.1345%
+val_tta        loss=0.00719 abupt_axis_rel_l2_pct=7.5856 surface_p_mae=0.01617 volume_p_mae=11.10570 wall_shear_mae=0.07154 cases=34
+  val_tta -> abupt=7.5856% | SP=5.5816% | WSS=8.1766% | VP=5.2027% | WSS_x=7.1285% | WSS_y=9.0353% | WSS_z=10.9799%
+  runtime=149.0s n_batches=261
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00421 abupt_axis_rel_l2_pct=5.8390 surface_p_mae=0.01059 volume_p_mae=6.86034 wall_shear_mae=0.05751 cases=50
+  test_original -> abupt=5.8390% | SP=3.6948% | WSS=6.7523% | VP=3.4211% | WSS_x=5.9990% | WSS_y=7.3604% | WSS_z=8.7200%
+test_mirrored  loss=0.01542 abupt_axis_rel_l2_pct=11.0048 surface_p_mae=0.02506 volume_p_mae=17.95609 wall_shear_mae=0.09366 cases=50
+  test_mirrored -> abupt=11.0048% | SP=8.7338% | WSS=11.4358% | VP=8.5567% | WSS_x=9.9387% | WSS_y=12.9977% | WSS_z=14.7972%
+test_tta       loss=0.00695 abupt_axis_rel_l2_pct=7.4690 surface_p_mae=0.01644 volume_p_mae=11.44948 wall_shear_mae=0.07037 cases=50
+  test_tta -> abupt=7.4690% | SP=5.4566% | WSS=8.1032% | VP=5.2908% | WSS_x=7.1375% | WSS_y=8.9838% | WSS_z=10.4764%
+  runtime=226.7s n_batches=397
+
+=== TTA vs original (test) ===
+  abupt: +1.6300pp
+  wall_shear: +1.3509pp
+  wall_shear_x: +1.1385pp
+  wall_shear_y: +1.6235pp
+  wall_shear_z: +1.7564pp
+  surface_pressure: +1.7618pp
+  volume_pressure: +1.8697pp
+wandb: updating run metadata
+wandb: uploading history steps 0-0, summary, console lines 13-28
+wandb: 
+wandb: Run history:
+wandb:            test_delta_tta_minus_original/abupt ▁
+wandb: test_delta_tta_minus_original/surface_pressure ▁
+wandb:  test_delta_tta_minus_original/volume_pressure ▁
+wandb:       test_delta_tta_minus_original/wall_shear ▁
+wandb:     test_delta_tta_minus_original/wall_shear_x ▁
+wandb:     test_delta_tta_minus_original/wall_shear_y ▁
+wandb:     test_delta_tta_minus_original/wall_shear_z ▁
+wandb:           test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:       test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                            test_mirrored/cases ▁
+wandb:                                           +219 ...
+wandb: 
+wandb: Run summary:
+wandb:                                 model/n_params 17413721
+wandb:            test_delta_tta_minus_original/abupt 1.62997
+wandb: test_delta_tta_minus_original/surface_pressure 1.76177
+wandb:  test_delta_tta_minus_original/volume_pressure 1.86968
+wandb:       test_delta_tta_minus_original/wall_shear 1.35095
+wandb:     test_delta_tta_minus_original/wall_shear_x 1.13852
+wandb:     test_delta_tta_minus_original/wall_shear_y 1.62345
+wandb:     test_delta_tta_minus_original/wall_shear_z 1.75644
+wandb:           test_mirrored/abupt_axis_mean_rel_l2 0.11005
+wandb:       test_mirrored/abupt_axis_mean_rel_l2_pct 11.00483
+wandb:                                           +220 ...
+wandb: 
+wandb: 🚀 View run thorfinn/h192-h112-tta-mirror at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/e22co34u
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_040724-e22co34u/logs

--- a/logs/h192_h164e_eval.log
+++ b/logs/h192_h164e_eval.log
@@ -1,0 +1,84 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=7
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_041416-um80i114
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run thorfinn/h192-h164e-tta-mirror
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/um80i114
+
+=== Evaluating val (7295 views) ===
+val_original   loss=0.00466 abupt_axis_rel_l2_pct=6.0836 surface_p_mae=0.01074 volume_p_mae=6.84139 wall_shear_mae=0.05957 cases=34
+  val_original -> abupt=6.0836% | SP=3.9948% | WSS=6.9253% | VP=3.4640% | WSS_x=6.0410% | WSS_y=7.5603% | WSS_z=9.3579%
+val_mirrored   loss=0.01571 abupt_axis_rel_l2_pct=11.1360 surface_p_mae=0.02513 volume_p_mae=17.69141 wall_shear_mae=0.09475 cases=34
+  val_mirrored -> abupt=11.1360% | SP=9.0119% | WSS=11.4551% | VP=8.5805% | WSS_x=9.9268% | WSS_y=13.0455% | WSS_z=15.1151%
+val_tta        loss=0.00719 abupt_axis_rel_l2_pct=7.5868 surface_p_mae=0.01626 volume_p_mae=11.10985 wall_shear_mae=0.07165 cases=34
+  val_tta -> abupt=7.5868% | SP=5.6160% | WSS=8.1721% | VP=5.1840% | WSS_x=7.1153% | WSS_y=9.0647% | WSS_z=10.9541%
+  runtime=149.1s n_batches=261
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00418 abupt_axis_rel_l2_pct=5.8236 surface_p_mae=0.01059 volume_p_mae=6.80565 wall_shear_mae=0.05770 cases=50
+  test_original -> abupt=5.8236% | SP=3.6769% | WSS=6.7509% | VP=3.4087% | WSS_x=6.0207% | WSS_y=7.3298% | WSS_z=8.6818%
+test_mirrored  loss=0.01567 abupt_axis_rel_l2_pct=11.1029 surface_p_mae=0.02539 volume_p_mae=18.14701 wall_shear_mae=0.09396 cases=50
+  test_mirrored -> abupt=11.1029% | SP=8.9119% | WSS=11.5098% | VP=8.6830% | WSS_x=10.0165% | WSS_y=13.1982% | WSS_z=14.7050%
+test_tta       loss=0.00698 abupt_axis_rel_l2_pct=7.4954 surface_p_mae=0.01660 volume_p_mae=11.51059 wall_shear_mae=0.07070 cases=50
+  test_tta -> abupt=7.4954% | SP=5.5146% | WSS=8.1282% | VP=5.3280% | WSS_x=7.1795% | WSS_y=9.0341% | WSS_z=10.4209%
+  runtime=226.6s n_batches=397
+
+=== TTA vs original (test) ===
+  abupt: +1.6718pp
+  wall_shear: +1.3773pp
+  wall_shear_x: +1.1587pp
+  wall_shear_y: +1.7044pp
+  wall_shear_z: +1.7391pp
+  surface_pressure: +1.8376pp
+  volume_pressure: +1.9193pp
+wandb: updating run metadata
+wandb: uploading history steps 0-0, summary, console lines 13-28
+wandb: 
+wandb: Run history:
+wandb:            test_delta_tta_minus_original/abupt ▁
+wandb: test_delta_tta_minus_original/surface_pressure ▁
+wandb:  test_delta_tta_minus_original/volume_pressure ▁
+wandb:       test_delta_tta_minus_original/wall_shear ▁
+wandb:     test_delta_tta_minus_original/wall_shear_x ▁
+wandb:     test_delta_tta_minus_original/wall_shear_y ▁
+wandb:     test_delta_tta_minus_original/wall_shear_z ▁
+wandb:           test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:       test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                            test_mirrored/cases ▁
+wandb:                                           +219 ...
+wandb: 
+wandb: Run summary:
+wandb:                                 model/n_params 17413721
+wandb:            test_delta_tta_minus_original/abupt 1.67183
+wandb: test_delta_tta_minus_original/surface_pressure 1.83761
+wandb:  test_delta_tta_minus_original/volume_pressure 1.91931
+wandb:       test_delta_tta_minus_original/wall_shear 1.37729
+wandb:     test_delta_tta_minus_original/wall_shear_x 1.15874
+wandb:     test_delta_tta_minus_original/wall_shear_y 1.70437
+wandb:     test_delta_tta_minus_original/wall_shear_z 1.73911
+wandb:           test_mirrored/abupt_axis_mean_rel_l2 0.11103
+wandb:       test_mirrored/abupt_axis_mean_rel_l2_pct 11.10292
+wandb:                                           +220 ...
+wandb: 
+wandb: 🚀 View run thorfinn/h192-h164e-tta-mirror at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/um80i114
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_041416-um80i114/logs

--- a/logs/h192_h185.log
+++ b/logs/h192_h185.log
@@ -1,0 +1,82 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: Downloading large artifact 'model-thorfinn-h185-h171-mirror-aug-compound-yw2a5dyl:best', 66.48MB. 2 files...
+wandb: \ 1 of 2 files downloaded...wandb:   2 of 2 files downloaded.  
+Done. 00:00:00.2 (319.7MB/s)
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_032921-rwrrwm6i
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h192-tta-h185-mirror-aug-yw2a5dyl
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/rwrrwm6i
+Fetching artifact for run yw2a5dyl...
+Loaded run yw2a5dyl: epoch 13, src=ema, layers=5/512d/4h, pos=string_separable, qk_norm=True, rff_feat=16
+  agent=thorfinn  group=thorfinn-h185-gradnorm-mirror-aug-compound  val_abupt=6.017157919281892  test_abupt=5.861300699286877
+
+Loading data (root=/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== no_tta eval on val (7295 views, 1824 batches) ===
+  [no_tta/val] abupt=6.0172  sp=3.9673  wss=6.8104  vp=3.5412  tau_x=5.9416  tau_y=7.4420  tau_z=9.1937  (480.2s)
+
+=== no_tta eval on test (11091 views, 2773 batches) ===
+  [no_tta/test] abupt=5.8613  sp=3.7046  wss=6.7642  vp=3.4585  tau_x=5.9926  tau_y=7.3902  tau_z=8.7606  (731.0s)
+
+=== tta eval on val (7295 views, 1824 batches) ===
+  [tta/val] abupt=5.9755  sp=3.9423  wss=6.7645  vp=3.5261  tau_x=5.9132  tau_y=7.3510  tau_z=9.1449  (949.5s)
+
+=== tta eval on test (11091 views, 2773 batches) ===
+wandb: updating run metadata
+wandb: uploading history steps 0-0, summary, console lines 11-31
+wandb: 
+wandb: Run history:
+wandb:  delta_tta_minus_no_tta_test/abupt_axis_mean_rel_l2_pct ▁
+wandb: delta_tta_minus_no_tta_test/surface_pressure_rel_l2_pct ▁
+wandb:  delta_tta_minus_no_tta_test/volume_pressure_rel_l2_pct ▁
+wandb:       delta_tta_minus_no_tta_test/wall_shear_rel_l2_pct ▁
+wandb:     delta_tta_minus_no_tta_test/wall_shear_x_rel_l2_pct ▁
+wandb:     delta_tta_minus_no_tta_test/wall_shear_y_rel_l2_pct ▁
+wandb:     delta_tta_minus_no_tta_test/wall_shear_z_rel_l2_pct ▁
+wandb:   delta_tta_minus_no_tta_val/abupt_axis_mean_rel_l2_pct ▁
+wandb:  delta_tta_minus_no_tta_val/surface_pressure_rel_l2_pct ▁
+wandb:   delta_tta_minus_no_tta_val/volume_pressure_rel_l2_pct ▁
+wandb:                                                    +147 ...
+wandb: 
+wandb: Run summary:
+wandb:  delta_tta_minus_no_tta_test/abupt_axis_mean_rel_l2_pct -0.0392
+wandb: delta_tta_minus_no_tta_test/surface_pressure_rel_l2_pct -0.02397
+wandb:  delta_tta_minus_no_tta_test/volume_pressure_rel_l2_pct -0.01844
+wandb:       delta_tta_minus_no_tta_test/wall_shear_rel_l2_pct -0.04284
+wandb:     delta_tta_minus_no_tta_test/wall_shear_x_rel_l2_pct -0.02756
+wandb:     delta_tta_minus_no_tta_test/wall_shear_y_rel_l2_pct -0.08578
+wandb:     delta_tta_minus_no_tta_test/wall_shear_z_rel_l2_pct -0.04025
+wandb:   delta_tta_minus_no_tta_val/abupt_axis_mean_rel_l2_pct -0.04169
+wandb:  delta_tta_minus_no_tta_val/surface_pressure_rel_l2_pct -0.02505
+wandb:   delta_tta_minus_no_tta_val/volume_pressure_rel_l2_pct -0.01509
+wandb:                                                    +148 ...
+wandb: 
+wandb: 🚀 View run h192-tta-h185-mirror-aug-yw2a5dyl at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/rwrrwm6i
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_032921-rwrrwm6i/logs
+  [tta/test] abupt=5.8221  sp=3.6806  wss=6.7213  vp=3.4400  tau_x=5.9650  tau_y=7.3045  tau_z=8.7204  (1441.0s)
+
+=== Delta (TTA - no-TTA) on val ===
+  val/abupt_axis_mean_rel_l2_pct: no_tta=6.0172  tta=5.9755  delta=-0.0417pp
+  val/surface_pressure_rel_l2_pct: no_tta=3.9673  tta=3.9423  delta=-0.0251pp
+  val/wall_shear_rel_l2_pct: no_tta=6.8104  tta=6.7645  delta=-0.0458pp
+  val/wall_shear_x_rel_l2_pct: no_tta=5.9416  tta=5.9132  delta=-0.0285pp
+  val/wall_shear_y_rel_l2_pct: no_tta=7.4420  tta=7.3510  delta=-0.0910pp
+  val/wall_shear_z_rel_l2_pct: no_tta=9.1937  tta=9.1449  delta=-0.0488pp
+  val/volume_pressure_rel_l2_pct: no_tta=3.5412  tta=3.5261  delta=-0.0151pp
+
+=== Delta (TTA - no-TTA) on test ===
+  test/abupt_axis_mean_rel_l2_pct: no_tta=5.8613  tta=5.8221  delta=-0.0392pp
+  test/surface_pressure_rel_l2_pct: no_tta=3.7046  tta=3.6806  delta=-0.0240pp
+  test/wall_shear_rel_l2_pct: no_tta=6.7642  tta=6.7213  delta=-0.0428pp
+  test/wall_shear_x_rel_l2_pct: no_tta=5.9926  tta=5.9650  delta=-0.0276pp
+  test/wall_shear_y_rel_l2_pct: no_tta=7.3902  tta=7.3045  delta=-0.0858pp
+  test/wall_shear_z_rel_l2_pct: no_tta=8.7606  tta=8.7204  delta=-0.0402pp
+  test/volume_pressure_rel_l2_pct: no_tta=3.4585  tta=3.4400  delta=-0.0184pp
+
+Peak GPU memory: 12.53 GB

--- a/logs/launch_h192_h112.sh
+++ b/logs/launch_h192_h112.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+cd /workspace/senpai/target
+export WANDB_ENTITY=wandb-applied-ai-team
+export WANDB_PROJECT=senpai-v1-drivaerml-ddp8
+export CUDA_VISIBLE_DEVICES=0,1,3,4,5,6,7
+exec python -m torch.distributed.run --nproc-per-node=7 tta_mirror_eval.py \
+  --checkpoint outputs/ensemble_cache/u9ue2ryb/checkpoint.pt \
+  --config-yaml outputs/ensemble_cache/u9ue2ryb/config.yaml \
+  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --manifest data/split_manifest.json \
+  --batch-size 4 \
+  --eval-surface-points 65536 \
+  --eval-volume-points 65536 \
+  --amp-mode bf16 \
+  --splits val,test \
+  --eval-modes original,mirrored,tta \
+  --wandb-group thorfinn-h192-tta-mirror-aug \
+  --wandb-name thorfinn/h192-h112-tta-mirror

--- a/logs/launch_h192_h164e.sh
+++ b/logs/launch_h192_h164e.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+cd /workspace/senpai/target
+export WANDB_ENTITY=wandb-applied-ai-team
+export WANDB_PROJECT=senpai-v1-drivaerml-ddp8
+export CUDA_VISIBLE_DEVICES=0,1,3,4,5,6,7
+exec python -m torch.distributed.run --nproc-per-node=7 tta_mirror_eval.py \
+  --checkpoint outputs/ensemble_cache/zrv3dasr/checkpoint.pt \
+  --config-yaml outputs/ensemble_cache/zrv3dasr/config.yaml \
+  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
+  --manifest data/split_manifest.json \
+  --batch-size 4 \
+  --eval-surface-points 65536 \
+  --eval-volume-points 65536 \
+  --amp-mode bf16 \
+  --splits val,test \
+  --eval-modes original,mirrored,tta \
+  --wandb-group thorfinn-h192-tta-mirror-aug \
+  --wandb-name thorfinn/h192-h164e-tta-mirror

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -8,12 +8,12 @@
 
 | PR | Student | Hypothesis | step (mid-EP9/10) | val_abupt | Notes |
 |---|---|---|---:|---:|---|
-| #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
+| #1353 | thorfinn | H185 GradNorm × mirror-aug | step 68347 (96.2% complete) | **6.0253 LEAD −0.18pp WIDENING** | TERMINAL MERGE CANDIDATE (~02:00-03:00Z+1, ahead of original projection) |
 | #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
 | #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
 | #1365 | tanjiro | H191 mirror × tau_y=2.0 | EP10 banked (step 62501) | 6.3672 +0.23pp behind | EP9+EP10 PASS @ 00:08Z; WSS_x slope intact (−0.0109); terminal ~01:55Z+1 (NULL-expected boundary probe, mechanism confirmed) |
 | #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
-| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
+| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | EP9 banked (step 65222) | **6.468 +0.33pp behind** | EP9 PASS @ 00:22Z; WSS_x slope −0.0282 NEGATIVE through full trajectory; basin invariant intact; terminal ~01:42Z+1 (mechanism control, NULL-expected) |
 | #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
 | #1350 | edward | H184 surface:vol 4:0.5 + tau_y=3.0 | step 64928 EP9-boundary | 6.26% / WSS_agg 7.03% | HEALTHY |
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,7 +1,23 @@
 # SENPAI Research State
 
-**Updated**: 2026-05-28 ~11:05Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
-**Constraint**: ~24 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+**Updated**: 2026-05-28 23:55Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
+**Constraint**: ~12-15 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+**Active fleet snapshot**: 8/8 students training healthy; first terminal frieren H164e ~01:08Z+1; H185 thorfinn merge-eligible candidate terminal ~03:00-04:00Z+1.
+
+## ~23:55Z Active Fleet Health (W&B-verified)
+
+| PR | Student | Hypothesis | step (mid-EP9/10) | val_abupt | Notes |
+|---|---|---|---:|---:|---|
+| #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
+| #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
+| #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
+| #1365 | tanjiro | H191 mirror × tau_y=2.0 | step 59780 mid-EP10 | 6.3982 +0.26pp behind | terminal ~04:30Z+1 (NULL-expected boundary probe) |
+| #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
+| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
+| #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
+| #1350 | edward | H184 surface:vol 4:0.5 + tau_y=3.0 | step 64928 EP9-boundary | 6.26% / WSS_agg 7.03% | HEALTHY |
+
+**Stale-WIP cluster analysis**: alphonse / edward / askeladd / fern all heartbeat live; comment-lag is the explanation, not pod stall. Pattern: student bots only poll PR comments at major checkpoint boundaries (EP3/EP6/EP9), not continuously.
 
 ## Primary Objective
 
@@ -17,17 +33,34 @@ Merge gate: val_abupt < 6.1358% AND test_WSS ≤ 6.727% AND test_VP ≤ 3.421% A
 
 ---
 
-## Program-Critical Finding — H164d RNG Floor Calibration (banked 2026-05-28 ~10:30Z)
+## Program-Critical Finding — RNG Floor Calibration MATURE (frieren H164d+H164e N=2 EP11)
 
-**H164d (frieren PR #1357, completed)**: H112-recipe rerun with different RNG seed.
+**Banked 23:47Z** via frieren EP9/10/11 catch-up report. N=2 H112-recipe brackets (H164d + H164e) at EP11:
+
+| Channel | EP11 half-range | RNG floor implication |
+|---|---:|---|
+| **abupt** | **±0.053pp** | minimum effect size for val signal |
+| WSS aggregate | ±0.063pp | |
+| WSS_x | ±0.059pp | basin-diagnostic still readable above ±0.06 floor |
+| WSS_y | ~±0.06pp | |
+| **WSS_z** | **±0.083pp (largest)** | NOT canonical screening axis; revise earlier hypothesis |
+| VP | ±0.036pp | smallest — cross-axis compounds clear test_VP gate |
+
+**Recalibration impact on active leaders**:
+- **H185 thorfinn EP9 lead −0.108pp = 2× RNG floor → REAL signal** (sole compound clearly above noise)
+- **H190 nezuko EP9 lead −0.011pp = well below RNG floor → noise-band 50/50 outcome**
+- **H164e** LEADS H112 at EP11 (H112's reported baseline upper-end of RNG distribution)
+- VP universally negative across H164d/H164e → cross-axis compounds expected to clear test_VP gate
+
+### Earlier (H164d single-draw) framework — superseded by N=2 calibration above
 
 | Channel | Δ slope (H164d vs H112) | Implication |
 |---|---:|---|
 | WSS aggregate | +0.040pp | RNG floor ≈ ±0.040pp single-draw |
-| WSS_z | −0.009pp | Most stable — RNG floor ≈ ±0.01pp |
-| WSS_x | ~±0.05pp | RNG floor ≈ ±0.05pp |
-| WSS_y | ~±0.06pp | RNG floor ≈ ±0.06pp |
-| VP | ~±0.09pp | Largest channel-specific RNG floor |
+| WSS_z | −0.009pp | (revised at N=2: actually LARGEST not stablest) |
+| WSS_x | ~±0.05pp | (confirmed at N=2: ±0.059pp) |
+| WSS_y | ~±0.06pp | (confirmed at N=2) |
+| VP | ~±0.09pp | (revised at N=2: actually SMALLEST at ±0.036pp) |
 
 ### Framework recalibration (PERMANENT)
 
@@ -172,8 +205,10 @@ Zero idle students.
 - `<threshold` in kill-threshold string is PASS condition; never write `>threshold`
 - WSS_x slope sign is the BASIN-DISRUPTION DIAGNOSTIC — positive slope indicates shared-axis stacking failure
 - DrivAerML axes: x=streamwise, y=lateral (mirror axis), z=vertical
-- RNG floor on WSS_agg slope = ±0.040pp; treat as the minimum effect size for single-draw mechanism claims
-- WSS_z slope is the canonical cohort-screening axis (4–9× better RNG reproducibility)
+- RNG floor on WSS_agg slope = ±0.063pp at N=2 EP11; treat as minimum effect size for single-draw mechanism claims
+- RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
+- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
+- VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -205,10 +205,11 @@ Zero idle students.
 - `<threshold` in kill-threshold string is PASS condition; never write `>threshold`
 - WSS_x slope sign is the BASIN-DISRUPTION DIAGNOSTIC — positive slope indicates shared-axis stacking failure
 - DrivAerML axes: x=streamwise, y=lateral (mirror axis), z=vertical
-- RNG floor on WSS_agg slope = ±0.063pp at N=2 EP11; treat as minimum effect size for single-draw mechanism claims
-- RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
-- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
-- VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
+- RNG floor on WSS_agg = ±0.065pp at N=2 EP12; treat as minimum effect size for single-draw mechanism claims
+- RNG floor on **val_abupt = ±0.053pp at N=2 EP12** — claims must exceed 2× floor (±0.106pp) to count as real signal
+- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.082pp half-range at EP12, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
+- **SP is the NEW canonical screening channel** at ±0.020pp half-range at EP12 (4× tighter than abupt). Use SP slope for highest-power cross-run comparisons.
+- VP RNG floor ±0.037pp at EP12, **one-sided below H112** (both H164d/H164e VP < H112 reported value) → recipe-mean VP at EP12 ≈ 3.505% vs H112's 3.5495% → cross-axis compound test_VP margin against gate is MORE favorable than appears
 - **Actual EP boundaries** (tanjiro 00:08Z calibration via volume-points curriculum): EP6=48902, EP9=59780, EP10=62501, EP11=65184, EP13(terminal)≈70657 — supersedes uniform 10864-step assumption used in legacy PR kill-thresholds
 
 ---

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,27 @@
 # SENPAI Research State
 
-**Updated**: 2026-05-28 23:55Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
-**Constraint**: ~12-15 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
-**Active fleet snapshot**: 8/8 students training healthy; first terminal frieren H164e ~01:08Z+1; H185 thorfinn merge-eligible candidate terminal ~03:00-04:00Z+1.
+**Updated**: 2026-05-29 01:42Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
+**Constraint**: ~12 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+
+## 🚨 H185 TEST EVAL LANDED 01:40Z — NOT A MERGE — Anti-compound on slope
+
+**Critical finding (NEW PROGRAM-PERMANENT)**: GradNorm + mirror-aug compound produces **FLATTER** val→test slope than either alone — slope-preservation interventions ANTI-COMPOUND when stacked.
+
+| Run | val_abupt | test_WSS_agg | test_VP | test_SP | val→test slope (WSS_agg) | Merge? |
+|---|---:|---:|---:|---:|---:|---|
+| H112 baseline | 6.1358 | **6.752** | 3.421 | 3.695 | −0.215pp | (current SOTA) |
+| **H185 thorfinn (GradNorm × mirror)** | **6.017 (−0.119pp = 2.25× RNG)** | **6.764 (+12bp FAIL)** | 3.458 (+37bp) | 3.705 (+10bp) | **−0.058pp (FLATTER)** | **NO** |
+| H164e frieren (H112-recipe N=2 RNG) | 6.084 | 6.751 (−1bp within noise) | 3.409 | 3.677 | −0.180pp (within H112 noise) | calibration only |
+
+**H185 program reading**:
+- Outstanding VAL gain (clearly above 2× RNG floor) but did NOT transfer to test
+- Compound HURT the slope-preservation mechanism — additive-on-val, anti-additive-on-test-slope
+- All 4 test channels regressed slightly vs H112 (within noise but no improvement)
+- The compound idea is structurally falsified for THIS specific pair (GradNorm × mirror-aug)
+
+**Program implication**: Wave 39+ cross-axis compound strategy needs revision. Slope-PRESERVATION individual interventions do NOT compound additively on slope. May need to test SLOPE-SLOPE compound pairs that target different mechanism axes more thoroughly.
+
+**H164e program reading**: confirms H112-recipe RNG distribution centeredness at terminal. test_WSS 6.751 ≈ H112 6.752 within noise; all 4 channels essentially at H112 within recipe distribution. Close as calibration (not a merge).
 
 ## ~23:55Z Active Fleet Health (W&B-verified)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -11,7 +11,7 @@
 | #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
 | #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
 | #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
-| #1365 | tanjiro | H191 mirror × tau_y=2.0 | step 59780 mid-EP10 | 6.3982 +0.26pp behind | terminal ~04:30Z+1 (NULL-expected boundary probe) |
+| #1365 | tanjiro | H191 mirror × tau_y=2.0 | EP10 banked (step 62501) | 6.3672 +0.23pp behind | EP9+EP10 PASS @ 00:08Z; WSS_x slope intact (−0.0109); terminal ~01:55Z+1 (NULL-expected boundary probe, mechanism confirmed) |
 | #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
 | #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
 | #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
@@ -209,6 +209,7 @@ Zero idle students.
 - RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
 - **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
 - VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
+- **Actual EP boundaries** (tanjiro 00:08Z calibration via volume-points curriculum): EP6=48902, EP9=59780, EP10=62501, EP11=65184, EP13(terminal)≈70657 — supersedes uniform 10864-step assumption used in legacy PR kill-thresholds
 
 ---
 

--- a/tta_mirror_eval.py
+++ b/tta_mirror_eval.py
@@ -1,0 +1,644 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""H200: TTA mirror-augmentation eval for the DrivAerML surrogate.
+
+Loads a single trained checkpoint and evaluates it in three modes against
+the held-out val and test splits:
+
+* ``original``  - vanilla forward pass on the geometry as loaded.
+* ``mirrored``  - forward pass on the y-mirrored geometry, with the
+  predicted ``tau_y`` component negated so the prediction is reported in
+  the original frame.
+* ``tta``       - average of the original and the un-mirrored prediction
+  in normalised space; the standard 2-mode mirror TTA estimator.
+
+Each batch incurs only two model forward passes; the three modes share
+those passes so a full 8-GPU eval is roughly the cost of two normal
+evals (not three).
+
+The script does not modify any source file. It re-uses the existing
+``EvalAccumulator`` / ``finalize_eval_accumulator`` infrastructure from
+``trainer_runtime`` to guarantee metric parity with ``train.py``.
+
+Metric reporting in W&B uses the prefixes:
+
+  ``<split>_original/*``  ``<split>_mirrored/*``  ``<split>_tta/*``
+
+Use case for H200 vs H192: if H192 (mirror-trained) shows a meaningful
+test_WSS gain under TTA but H200 (this run, non-mirror-trained) does
+not, the TTA gain is mechanism-specific and depends on the model having
+learned mirror invariance, not generic averaging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import torch
+import torch.distributed as dist
+import wandb
+import yaml
+
+from data import load_data, pad_collate
+from data.loader import SurfaceBatch
+from model import SurfaceTransolver
+from trainer_runtime import (
+    DistributedState,
+    EvalAccumulator,
+    StridedDistributedSampler,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    distributed_barrier,
+    finalize_eval_accumulator,
+    init_distributed,
+    merge_eval_accumulators,
+    print_metrics,
+)
+
+# Surface input layout (data/loader.py): [x, y, z, nx, ny, nz, area].
+SURFACE_INPUT_Y_COL = 1
+SURFACE_INPUT_NORMAL_Y_COL = 4
+# Volume input layout: [x, y, z, sdf].
+VOLUME_INPUT_Y_COL = 1
+# Surface target/prediction layout: [cp, tau_x, tau_y, tau_z].
+SURFACE_OUTPUT_TAU_Y_COL = 2
+
+EVAL_MODES = ("original", "mirrored", "tta")
+
+
+@dataclass
+class EvalConfig:
+    checkpoint: str
+    config_yaml: str
+    data_root: str
+    manifest: str
+    batch_size: int
+    eval_surface_points: int
+    eval_volume_points: int
+    num_workers: int
+    amp_mode: str
+    splits: tuple[str, ...]
+    wandb_group: str
+    wandb_name: str
+    eval_modes: tuple[str, ...]
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H200 TTA mirror-aug eval")
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--config-yaml", required=True)
+    parser.add_argument("--data-root", default="")
+    parser.add_argument("--manifest", default="data/split_manifest.json")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--eval-surface-points", type=int, default=65536)
+    parser.add_argument("--eval-volume-points", type=int, default=65536)
+    parser.add_argument("--num-workers", type=int, default=-1)
+    parser.add_argument("--amp-mode", default="bf16")
+    parser.add_argument("--splits", default="test,val")
+    parser.add_argument("--wandb-group", default="")
+    parser.add_argument("--wandb-name", default="")
+    parser.add_argument("--eval-modes", default="original,mirrored,tta")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    modes = tuple(m.strip() for m in args.eval_modes.split(",") if m.strip())
+    for m in modes:
+        if m not in EVAL_MODES:
+            raise ValueError(f"unknown eval mode {m!r}; choose from {EVAL_MODES}")
+    splits = tuple(s.strip() for s in args.splits.split(",") if s.strip())
+    for s in splits:
+        if s not in ("val", "test"):
+            raise ValueError(f"unknown split {s!r}; expected val or test")
+    return EvalConfig(
+        checkpoint=args.checkpoint,
+        config_yaml=args.config_yaml,
+        data_root=args.data_root,
+        manifest=args.manifest,
+        batch_size=args.batch_size,
+        eval_surface_points=args.eval_surface_points,
+        eval_volume_points=args.eval_volume_points,
+        num_workers=args.num_workers,
+        amp_mode=args.amp_mode,
+        splits=splits,
+        wandb_group=args.wandb_group,
+        wandb_name=args.wandb_name,
+        eval_modes=modes,
+    )
+
+
+def parse_rff_init_sigmas(raw: object) -> list[float] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        return [float(v.strip()) for v in text.split(",") if v.strip()] or None
+    if isinstance(raw, (list, tuple)):
+        return [float(v) for v in raw] or None
+    raise ValueError(f"Unsupported rff_init_sigmas value: {raw!r}")
+
+
+def build_model_from_yaml(config_yaml: Path, state_dict: dict) -> SurfaceTransolver:
+    with config_yaml.open("r") as fh:
+        config = yaml.safe_load(fh)
+    use_aux_decoder_heads = "surface_out.0.weight" in state_dict
+    return SurfaceTransolver(
+        n_layers=int(config.get("model_layers", 3)),
+        n_hidden=int(config.get("model_hidden_dim", 192)),
+        dropout=float(config.get("model_dropout", 0.0)),
+        n_head=int(config.get("model_heads", 3)),
+        mlp_ratio=int(config.get("model_mlp_ratio", 4)),
+        slice_num=int(config.get("model_slices", 96)),
+        rff_num_features=int(config.get("rff_num_features", 0)),
+        rff_sigma=float(config.get("rff_sigma", 1.0)),
+        rff_init_sigmas=parse_rff_init_sigmas(config.get("rff_init_sigmas")),
+        pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
+        use_qk_norm=bool(config.get("use_qk_norm", False)),
+        use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        use_aux_decoder_heads=use_aux_decoder_heads,
+        drop_path_max=float(config.get("drop_path_max", 0.0)),
+    )
+
+
+def load_checkpoint(path: Path, device: torch.device) -> tuple[SurfaceTransolver, dict]:
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if "model" not in checkpoint:
+        raise RuntimeError(f"Checkpoint {path} missing 'model' state dict")
+    config_yaml = path.parent / "config.yaml"
+    if not config_yaml.exists():
+        raise FileNotFoundError(f"Expected config.yaml next to checkpoint: {config_yaml}")
+    state_dict = dict(checkpoint["model"])
+    model = build_model_from_yaml(config_yaml, state_dict).to(device)
+    missing, unexpected = model.load_state_dict(state_dict, strict=True)
+    if missing or unexpected:
+        raise RuntimeError(
+            f"State-dict mismatch loading {path}: missing={missing}, unexpected={unexpected}"
+        )
+    model.eval()
+    return model, checkpoint
+
+
+def mirror_batch(batch: SurfaceBatch) -> SurfaceBatch:
+    """Return a y-mirrored shallow copy of ``batch``.
+
+    Negates ``y`` and ``n_y`` in the surface inputs and ``y`` in the
+    volume inputs. Other channels (cp, tau, normals/coords x and z, area,
+    sdf) are invariant under y-reflection.
+    """
+
+    surface_x = batch.surface_x.clone()
+    surface_x[..., SURFACE_INPUT_Y_COL] = -surface_x[..., SURFACE_INPUT_Y_COL]
+    surface_x[..., SURFACE_INPUT_NORMAL_Y_COL] = -surface_x[..., SURFACE_INPUT_NORMAL_Y_COL]
+    volume_x = batch.volume_x.clone()
+    if volume_x.numel() > 0:
+        volume_x[..., VOLUME_INPUT_Y_COL] = -volume_x[..., VOLUME_INPUT_Y_COL]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
+def unmirror_surface_pred_norm(
+    pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> torch.Tensor:
+    """Apply the y-reflection sign flip to a normalised surface prediction.
+
+    The lateral sign flip (``tau_y -> -tau_y``) is a physical-space
+    operation. The model output is in normalised space, where channel
+    ``c`` satisfies ``y_norm = (y_phys - mu_c) / sigma_c``. Negating the
+    physical value gives ``-y_phys = -(y_norm * sigma_c + mu_c)``, so
+
+        y_norm_new = -y_norm - 2 * mu_c / sigma_c
+
+    For DrivAerML's tau_y, ``mu / sigma ~= 0.0015 / 1.356 ~= 1.1e-3``,
+    so the offset is small but we include it for physical fidelity.
+    """
+
+    out = pred_norm.clone()
+    mean = transform.surface_y_mean.to(out.device)
+    std = transform.surface_y_std.to(out.device)
+    c = SURFACE_OUTPUT_TAU_Y_COL
+    out[..., c] = -out[..., c] - 2.0 * mean[c] / std[c]
+    return out
+
+
+@torch.no_grad()
+def forward_pred_norm(
+    model: SurfaceTransolver,
+    batch: SurfaceBatch,
+    device: torch.device,
+    amp_mode: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    with autocast_context(device, amp_mode):
+        out = model(
+            surface_x=batch.surface_x,
+            surface_mask=batch.surface_mask,
+            volume_x=batch.volume_x,
+            volume_mask=batch.volume_mask,
+        )
+    surface_pred = out["surface_preds"].float()
+    volume_pred = out["volume_preds"].float()
+    return surface_pred, volume_pred
+
+
+def accumulate_batch_with_predictions(
+    accumulator: EvalAccumulator,
+    *,
+    batch: SurfaceBatch,
+    surface_pred_norm: torch.Tensor,
+    volume_pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    """Mirror of trainer_runtime.accumulate_eval_batch using precomputed preds.
+
+    The forward pass is decoupled so a single batch can be scored under
+    multiple TTA averaging strategies without duplicating model work.
+    """
+
+    surface_target_norm = transform.apply_surface(batch.surface_y)
+    volume_target_norm = transform.apply_volume(batch.volume_y)
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, batch.surface_mask
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, batch.volume_mask
+    )
+    accumulator.surface_loss_sse += surface_sse
+    accumulator.surface_loss_count += surface_count
+    accumulator.volume_loss_sse += volume_sse
+    accumulator.volume_loss_count += volume_count
+    surface_pred = transform.invert_surface(surface_pred_norm)
+    volume_pred = transform.invert_volume(volume_pred_norm)
+
+    if bool(batch.surface_mask.any()):
+        surface_abs = (surface_pred - batch.surface_y).abs()
+        valid_surface_abs = surface_abs[batch.surface_mask]
+        accumulator.abs_sums["surface_pressure"] += float(
+            valid_surface_abs[:, 0].sum().detach().cpu().item()
+        )
+        accumulator.abs_counts["surface_pressure"] += int(valid_surface_abs[:, 0].numel())
+        wall_abs = valid_surface_abs[:, 1:4]
+        accumulator.abs_sums["wall_shear"] += float(wall_abs.sum().detach().cpu().item())
+        accumulator.abs_counts["wall_shear"] += int(wall_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = wall_abs[:, offset]
+            accumulator.abs_sums[f"wall_shear_{axis}"] += float(
+                channel.sum().detach().cpu().item()
+            )
+            accumulator.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+        wall_vector_error = torch.linalg.vector_norm(
+            surface_pred[batch.surface_mask][:, 1:4]
+            - batch.surface_y[batch.surface_mask][:, 1:4],
+            dim=-1,
+        )
+        accumulator.wall_shear_vector_abs_sum += float(
+            wall_vector_error.sum().detach().cpu().item()
+        )
+        accumulator.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    if bool(batch.volume_mask.any()):
+        volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
+        accumulator.abs_sums["volume_pressure"] += float(
+            volume_abs[:, 0].sum().detach().cpu().item()
+        )
+        accumulator.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    for case_idx, case_id in enumerate(batch.case_ids):
+        surface_valid = batch.surface_mask[case_idx].bool()
+        if bool(surface_valid.any()):
+            surface_pred_valid = surface_pred[case_idx][surface_valid]
+            surface_target_valid = batch.surface_y[case_idx][surface_valid]
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["surface_pressure"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 0:1],
+                target=surface_target_valid[:, 0:1],
+            )
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["wall_shear"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 1:4],
+                target=surface_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    accumulator.case_sums[f"wall_shear_{axis}"],
+                    case_id=case_id,
+                    pred=surface_pred_valid[:, channel : channel + 1],
+                    target=surface_target_valid[:, channel : channel + 1],
+                )
+        volume_valid = batch.volume_mask[case_idx].bool()
+        if bool(volume_valid.any()):
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["volume_pressure"],
+                case_id=case_id,
+                pred=volume_pred[case_idx][volume_valid],
+                target=batch.volume_y[case_idx][volume_valid],
+            )
+
+
+@torch.no_grad()
+def evaluate_split_tta(
+    model: SurfaceTransolver,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    eval_modes: tuple[str, ...],
+    distributed_state: DistributedState,
+) -> dict[str, dict[str, float]]:
+    """Run one eval pass yielding metrics for each requested TTA mode."""
+
+    model.eval()
+    accumulators = {mode: EvalAccumulator() for mode in eval_modes}
+    needs_mirrored = ("mirrored" in eval_modes) or ("tta" in eval_modes)
+
+    n_batches = 0
+    t0 = time.time()
+    for batch in loader:
+        batch = batch.to(device)
+        surface_a, volume_a = forward_pred_norm(model, batch, device, amp_mode)
+        surface_b_unmirrored = None
+        volume_b = None
+        if needs_mirrored:
+            mirrored = mirror_batch(batch)
+            surface_b_raw, volume_b = forward_pred_norm(
+                model, mirrored, device, amp_mode
+            )
+            surface_b_unmirrored = unmirror_surface_pred_norm(surface_b_raw, transform)
+        if "original" in eval_modes:
+            accumulate_batch_with_predictions(
+                accumulators["original"],
+                batch=batch,
+                surface_pred_norm=surface_a,
+                volume_pred_norm=volume_a,
+                transform=transform,
+            )
+        if "mirrored" in eval_modes:
+            accumulate_batch_with_predictions(
+                accumulators["mirrored"],
+                batch=batch,
+                surface_pred_norm=surface_b_unmirrored,
+                volume_pred_norm=volume_b,
+                transform=transform,
+            )
+        if "tta" in eval_modes:
+            tta_surface = 0.5 * (surface_a + surface_b_unmirrored)
+            tta_volume = 0.5 * (volume_a + volume_b)
+            accumulate_batch_with_predictions(
+                accumulators["tta"],
+                batch=batch,
+                surface_pred_norm=tta_surface,
+                volume_pred_norm=tta_volume,
+                transform=transform,
+            )
+        n_batches += 1
+
+    if distributed_state.enabled:
+        finalized: dict[str, dict[str, float]] = {}
+        for mode in eval_modes:
+            gathered: list[EvalAccumulator | None] = [
+                None for _ in range(distributed_state.world_size)
+            ]
+            dist.all_gather_object(gathered, accumulators[mode])
+            if not distributed_state.is_main:
+                finalized[mode] = {}
+                continue
+            merged = merge_eval_accumulators(a for a in gathered if a is not None)
+            finalized[mode] = finalize_eval_accumulator(merged)
+        if distributed_state.is_main:
+            finalized["_runtime_seconds"] = {"value": time.time() - t0, "n_batches": float(n_batches)}
+        return finalized
+
+    out: dict[str, dict[str, float]] = {
+        mode: finalize_eval_accumulator(accumulators[mode]) for mode in eval_modes
+    }
+    out["_runtime_seconds"] = {"value": time.time() - t0, "n_batches": float(n_batches)}
+    return out
+
+
+def init_wandb(cfg: EvalConfig, checkpoint_metadata: dict) -> "wandb.sdk.wandb_run.Run":
+    init_kwargs = dict(
+        entity=os.environ.get("WANDB_ENTITY"),
+        project=os.environ.get("WANDB_PROJECT"),
+        group=cfg.wandb_group or None,
+        name=cfg.wandb_name or None,
+        config={
+            "checkpoint": cfg.checkpoint,
+            "config_yaml": cfg.config_yaml,
+            "data_root": cfg.data_root,
+            "manifest": cfg.manifest,
+            "batch_size": cfg.batch_size,
+            "eval_surface_points": cfg.eval_surface_points,
+            "eval_volume_points": cfg.eval_volume_points,
+            "amp_mode": cfg.amp_mode,
+            "splits": list(cfg.splits),
+            "eval_modes": list(cfg.eval_modes),
+            "checkpoint_epoch": checkpoint_metadata.get("epoch"),
+            "checkpoint_source": checkpoint_metadata.get("checkpoint_source"),
+        },
+        tags=["h200", "tta-mirror", "edward"],
+        mode=os.environ.get("WANDB_MODE", "online"),
+        job_type="eval",
+    )
+    return wandb.init(**init_kwargs)
+
+
+def format_metric_log(
+    split_name: str,
+    mode: str,
+    metrics: dict[str, float],
+) -> dict[str, float]:
+    prefix_primary = f"{split_name}_primary_{mode}"
+    prefix_raw = f"{split_name}_{mode}"
+    log: dict[str, float] = {}
+    primary_keys = (
+        "abupt_axis_mean_rel_l2_pct",
+        "surface_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+        "surface_pressure_mae",
+        "wall_shear_mae",
+        "volume_pressure_mae",
+    )
+    for key in primary_keys:
+        if key in metrics:
+            log[f"{prefix_primary}/{key}"] = float(metrics[key])
+    for key, value in metrics.items():
+        if isinstance(value, (int, float)):
+            log[f"{prefix_raw}/{key}"] = float(value)
+    return log
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+    if state.is_main:
+        print(f"Device: {device}")
+        if state.enabled:
+            print(f"DDP world_size={state.world_size}")
+
+    checkpoint_path = Path(cfg.checkpoint).resolve()
+    config_yaml = Path(cfg.config_yaml).resolve()
+    model, checkpoint = load_checkpoint(checkpoint_path, device)
+    n_params = sum(p.numel() for p in model.parameters())
+    if state.is_main:
+        print(
+            f"Loaded checkpoint epoch={checkpoint.get('epoch')} "
+            f"source={checkpoint.get('checkpoint_source')} "
+            f"params={n_params / 1e6:.2f}M"
+        )
+
+    # Match train.py's eval-time config block: 65536 surface/volume chunked.
+    # ``load_data`` only needs ``eval_*_points``; train_* parameters are
+    # ignored downstream because we never instantiate the train loader.
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=cfg.manifest,
+        root=cfg.data_root or None,
+        train_surface_points=cfg.eval_surface_points,
+        eval_surface_points=cfg.eval_surface_points,
+        train_volume_points=cfg.eval_volume_points,
+        eval_volume_points=cfg.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    split_loaders: dict[str, torch.utils.data.DataLoader] = {}
+    if "val" in cfg.splits:
+        split_loaders["val"] = build_eval_loader(
+            val_splits["val_surface"], cfg, state=state
+        )
+    if "test" in cfg.splits:
+        split_loaders["test"] = build_eval_loader(
+            test_splits["test_surface"], cfg, state=state
+        )
+
+    run = None
+    if state.is_main:
+        run = init_wandb(cfg, checkpoint)
+        wandb.summary["model/n_params"] = n_params
+
+    all_metrics: dict[str, dict[str, dict[str, float]]] = {}
+    for split_name, loader in split_loaders.items():
+        if state.is_main:
+            print(f"\n=== Evaluating {split_name} ({len(loader.dataset)} views) ===")
+        results = evaluate_split_tta(
+            model=model,
+            loader=loader,
+            transform=transform,
+            device=device,
+            amp_mode=cfg.amp_mode,
+            eval_modes=cfg.eval_modes,
+            distributed_state=state,
+        )
+        if state.is_main:
+            runtime = results.pop("_runtime_seconds", None)
+            all_metrics[split_name] = results
+            for mode in cfg.eval_modes:
+                metrics = results[mode]
+                print_metrics(f"{split_name}_{mode}", metrics)
+                print(
+                    f"  {split_name}_{mode} -> "
+                    f"abupt={metrics['abupt_axis_mean_rel_l2_pct']:.4f}% | "
+                    f"SP={metrics['surface_pressure_rel_l2_pct']:.4f}% | "
+                    f"WSS={metrics['wall_shear_rel_l2_pct']:.4f}% | "
+                    f"VP={metrics['volume_pressure_rel_l2_pct']:.4f}% | "
+                    f"WSS_x={metrics['wall_shear_x_rel_l2_pct']:.4f}% | "
+                    f"WSS_y={metrics['wall_shear_y_rel_l2_pct']:.4f}% | "
+                    f"WSS_z={metrics['wall_shear_z_rel_l2_pct']:.4f}%"
+                )
+            if runtime is not None:
+                print(
+                    f"  runtime={runtime['value']:.1f}s "
+                    f"n_batches={int(runtime['n_batches'])}"
+                )
+        distributed_barrier(state)
+
+    if state.is_main and run is not None:
+        log: dict[str, float] = {}
+        for split_name, results in all_metrics.items():
+            for mode in cfg.eval_modes:
+                log.update(format_metric_log(split_name, mode, results[mode]))
+        wandb.log(log, step=0)
+        wandb.summary.update(log)
+        if "test" in all_metrics and "tta" in cfg.eval_modes and "original" in cfg.eval_modes:
+            o = all_metrics["test"]["original"]
+            t = all_metrics["test"]["tta"]
+            deltas = {
+                "test_delta_tta_minus_original/abupt": t["abupt_axis_mean_rel_l2_pct"]
+                - o["abupt_axis_mean_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear": t["wall_shear_rel_l2_pct"]
+                - o["wall_shear_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_x": t["wall_shear_x_rel_l2_pct"]
+                - o["wall_shear_x_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_y": t["wall_shear_y_rel_l2_pct"]
+                - o["wall_shear_y_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_z": t["wall_shear_z_rel_l2_pct"]
+                - o["wall_shear_z_rel_l2_pct"],
+                "test_delta_tta_minus_original/surface_pressure": t["surface_pressure_rel_l2_pct"]
+                - o["surface_pressure_rel_l2_pct"],
+                "test_delta_tta_minus_original/volume_pressure": t["volume_pressure_rel_l2_pct"]
+                - o["volume_pressure_rel_l2_pct"],
+            }
+            wandb.log(deltas, step=0)
+            wandb.summary.update(deltas)
+            print("\n=== TTA vs original (test) ===")
+            for k, v in deltas.items():
+                print(f"  {k.split('/', 1)[1]}: {v:+.4f}pp")
+        wandb.finish()
+
+    cleanup_distributed(state)
+
+
+def build_eval_loader(
+    dataset,
+    cfg: EvalConfig,
+    *,
+    state: DistributedState,
+) -> torch.utils.data.DataLoader:
+    sampler = None
+    if state.enabled:
+        sampler = StridedDistributedSampler(
+            dataset, num_replicas=state.world_size, rank=state.rank
+        )
+    num_workers = cfg.num_workers if cfg.num_workers >= 0 else min(4, os.cpu_count() or 4)
+    return torch.utils.data.DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        sampler=sampler,
+        collate_fn=pad_collate,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        persistent_workers=num_workers > 0,
+        prefetch_factor=2 if num_workers > 0 else None,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

**H192 — Test-Time Augmentation (TTA) with mirror-aug on H112 checkpoint**

H185 (GradNorm + mirror-aug) just showed that the mirror data-invariance principle produces a 6.017% val SOTA — the strongest val result in the program. But the compound ANTI-COMPOUND on slope and missed the test gate. The mirror invariance is real and present in the data.

**TTA applies this invariance at INFERENCE TIME with zero training cost.** The hypothesis: averaging the model's prediction on the original geometry AND the left-right mirrored geometry reduces prediction variance and improves test generalization. Mirror-augmentation during training taught the model to be approximately invariant to y-flips; TTA exploits this learned invariance at test time.

- Mechanism: For each test sample, run two forward passes — original + y-flipped. Mirror the y-flipped prediction back (sign-flip WSS_y and y-component), average with original. Cost: ~2× eval time.
- Expected gain: 5-20bp on test_WSS (typical TTA improvement in CV; may be lower in CFD)
- Time: ~1-2h on 8 GPUs (no training)
- Risk: Near-zero. If no improvement, the null result is still valuable.

Apply TTA to **both** H112 checkpoint (W&B run `u9ue2ryb`) AND H164e checkpoint (W&B run `zrv3dasr`) to maximize information gain.

## Instructions

**This is an eval-only experiment — no training required.** Implement TTA in target/ eval code and report test metrics.

### Step 1 — Verify the checkpoint loading mechanism

```bash
# Check what CLI args accept a checkpoint path for eval-only run
python target/train.py --help | grep -i "checkpoint\|eval-only\|resume\|load"
```

If `--eval-only` / `--eval-checkpoint` exists, use it. If not, you'll need to add a minimal `--eval-only` path or write a small standalone eval script (`target/eval_tta.py`) that:
1. Loads model config from W&B run
2. Downloads EMA checkpoint artifact from W&B
3. Runs test eval with TTA

### Step 2 — Implement mirror TTA

The mirror augmentation for DrivAerML is a left-right (y-axis) flip:
- Input: flip y-coordinates of surface/volume points (negate y-column)
- Output: flip y-coordinate predictions back, AND sign-flip WSS_y targets/predictions

```python
def tta_mirror_predict(model, batch, device):
    """Average original + y-mirrored prediction for TTA."""
    # Forward pass on original
    with torch.no_grad():
        pred_orig = model(batch)  # shape [N, channels]
    
    # Mirror the batch (flip y-coordinate)
    batch_mirrored = mirror_y(batch)  # negate y-coords of surface+volume points
    
    # Forward pass on mirrored
    with torch.no_grad():
        pred_mirrored = model(batch_mirrored)
    
    # Un-mirror the mirrored prediction (negate WSS_y component)
    pred_mirrored_unmirr = unmirror_y(pred_mirrored)
    
    # Average
    return (pred_orig + pred_mirrored_unmirr) / 2
```

Look at how `--use-mirror-augmentation` is implemented in `target/data/loader.py` or the training loop to understand the exact sign-flip convention for WSS channels. The test data loader is NOT augmented — apply TTA manually in the eval forward pass.

### Step 3 — Eval on H112 checkpoint

Download checkpoint from W&B run `u9ue2ryb`:
```python
import wandb
api = wandb.Api()
run = api.run("wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/u9ue2ryb")
# Download the EMA best checkpoint (best_checkpoint artifact or similar)
```

Run TTA eval on test split. Report:
- Standard val + test metrics WITHOUT TTA (confirm checkpoint integrity)
- Test metrics WITH TTA (all 7 channels)
- Δ TTA vs no-TTA

### Step 4 — Bonus: Eval on H164e checkpoint (zrv3dasr)

Same TTA eval on frieren's H164e run `zrv3dasr`. This gives a second data point.

### Step 5 — Report

Post SENPAI-RESULT with terminal=true after both evals complete.

**WandB group**: `--wandb-group thorfinn-h192-tta-mirror-aug`

## Baseline

Current single-model SOTA (H112, PR #1283, W&B `u9ue2ryb`):
- val_abupt: **6.1358%**
- test_abupt: **5.839%**
- test_WSS_agg: **6.752%** (primary objective per Morgan)
- test_WSS_x: 5.999%, test_WSS_y: 7.360%, test_WSS_z: 8.720%
- test_VP: 3.421%, test_SP: 3.695%

**Merge gate**: val_abupt < 6.1358% AND test_abupt < 5.839% AND test_WSS ≤ 6.752% AND test_VP ≤ 3.421%

**Program target**: test_WSS < 5.85% (Transolver-3 SOTA, per Morgan Issue #1056)

**Current gap**: 6.752% - 5.85% = 0.902pp

## Time constraints

⚠️ **~12h compute window remaining** (programme terminates ~2026-05-29). This eval-only experiment should complete in 1-2h. No training runs — download checkpoint, eval with TTA, report.

## Falsifiability

| Outcome | TTA test_WSS | Reading |
|---|---|---|
| **WIN** | < 6.752% | TTA reduces variance; merge as new baseline |
| **NULL** | ~6.752% ± 5bp | Mirror invariance not strong enough; TTA noise-equivalent |
| **FAIL** | > 6.752% | TTA introduces artifacts (unlikely but check per-channel for anomalies) |
