### PR TITLE
H193: SWA of H164e+H112 checkpoints — weight-avg eval sprint

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -8,12 +8,12 @@
 
 | PR | Student | Hypothesis | step (mid-EP9/10) | val_abupt | Notes |
 |---|---|---|---:|---:|---|
-| #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
+| #1353 | thorfinn | H185 GradNorm × mirror-aug | step 68347 (96.2% complete) | **6.0253 LEAD −0.18pp WIDENING** | TERMINAL MERGE CANDIDATE (~02:00-03:00Z+1, ahead of original projection) |
 | #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
 | #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
 | #1365 | tanjiro | H191 mirror × tau_y=2.0 | EP10 banked (step 62501) | 6.3672 +0.23pp behind | EP9+EP10 PASS @ 00:08Z; WSS_x slope intact (−0.0109); terminal ~01:55Z+1 (NULL-expected boundary probe, mechanism confirmed) |
 | #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
-| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
+| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | EP9 banked (step 65222) | **6.468 +0.33pp behind** | EP9 PASS @ 00:22Z; WSS_x slope −0.0282 NEGATIVE through full trajectory; basin invariant intact; terminal ~01:42Z+1 (mechanism control, NULL-expected) |
 | #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
 | #1350 | edward | H184 surface:vol 4:0.5 + tau_y=3.0 | step 64928 EP9-boundary | 6.26% / WSS_agg 7.03% | HEALTHY |
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,7 +1,23 @@
 # SENPAI Research State
 
-**Updated**: 2026-05-28 ~11:05Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
-**Constraint**: ~24 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+**Updated**: 2026-05-28 23:55Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
+**Constraint**: ~12-15 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+**Active fleet snapshot**: 8/8 students training healthy; first terminal frieren H164e ~01:08Z+1; H185 thorfinn merge-eligible candidate terminal ~03:00-04:00Z+1.
+
+## ~23:55Z Active Fleet Health (W&B-verified)
+
+| PR | Student | Hypothesis | step (mid-EP9/10) | val_abupt | Notes |
+|---|---|---|---:|---:|---|
+| #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
+| #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
+| #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
+| #1365 | tanjiro | H191 mirror × tau_y=2.0 | step 59780 mid-EP10 | 6.3982 +0.26pp behind | terminal ~04:30Z+1 (NULL-expected boundary probe) |
+| #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
+| #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
+| #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
+| #1350 | edward | H184 surface:vol 4:0.5 + tau_y=3.0 | step 64928 EP9-boundary | 6.26% / WSS_agg 7.03% | HEALTHY |
+
+**Stale-WIP cluster analysis**: alphonse / edward / askeladd / fern all heartbeat live; comment-lag is the explanation, not pod stall. Pattern: student bots only poll PR comments at major checkpoint boundaries (EP3/EP6/EP9), not continuously.
 
 ## Primary Objective
 
@@ -17,17 +33,34 @@ Merge gate: val_abupt < 6.1358% AND test_WSS ≤ 6.727% AND test_VP ≤ 3.421% A
 
 ---
 
-## Program-Critical Finding — H164d RNG Floor Calibration (banked 2026-05-28 ~10:30Z)
+## Program-Critical Finding — RNG Floor Calibration MATURE (frieren H164d+H164e N=2 EP11)
 
-**H164d (frieren PR #1357, completed)**: H112-recipe rerun with different RNG seed.
+**Banked 23:47Z** via frieren EP9/10/11 catch-up report. N=2 H112-recipe brackets (H164d + H164e) at EP11:
+
+| Channel | EP11 half-range | RNG floor implication |
+|---|---:|---|
+| **abupt** | **±0.053pp** | minimum effect size for val signal |
+| WSS aggregate | ±0.063pp | |
+| WSS_x | ±0.059pp | basin-diagnostic still readable above ±0.06 floor |
+| WSS_y | ~±0.06pp | |
+| **WSS_z** | **±0.083pp (largest)** | NOT canonical screening axis; revise earlier hypothesis |
+| VP | ±0.036pp | smallest — cross-axis compounds clear test_VP gate |
+
+**Recalibration impact on active leaders**:
+- **H185 thorfinn EP9 lead −0.108pp = 2× RNG floor → REAL signal** (sole compound clearly above noise)
+- **H190 nezuko EP9 lead −0.011pp = well below RNG floor → noise-band 50/50 outcome**
+- **H164e** LEADS H112 at EP11 (H112's reported baseline upper-end of RNG distribution)
+- VP universally negative across H164d/H164e → cross-axis compounds expected to clear test_VP gate
+
+### Earlier (H164d single-draw) framework — superseded by N=2 calibration above
 
 | Channel | Δ slope (H164d vs H112) | Implication |
 |---|---:|---|
 | WSS aggregate | +0.040pp | RNG floor ≈ ±0.040pp single-draw |
-| WSS_z | −0.009pp | Most stable — RNG floor ≈ ±0.01pp |
-| WSS_x | ~±0.05pp | RNG floor ≈ ±0.05pp |
-| WSS_y | ~±0.06pp | RNG floor ≈ ±0.06pp |
-| VP | ~±0.09pp | Largest channel-specific RNG floor |
+| WSS_z | −0.009pp | (revised at N=2: actually LARGEST not stablest) |
+| WSS_x | ~±0.05pp | (confirmed at N=2: ±0.059pp) |
+| WSS_y | ~±0.06pp | (confirmed at N=2) |
+| VP | ~±0.09pp | (revised at N=2: actually SMALLEST at ±0.036pp) |
 
 ### Framework recalibration (PERMANENT)
 
@@ -172,8 +205,10 @@ Zero idle students.
 - `<threshold` in kill-threshold string is PASS condition; never write `>threshold`
 - WSS_x slope sign is the BASIN-DISRUPTION DIAGNOSTIC — positive slope indicates shared-axis stacking failure
 - DrivAerML axes: x=streamwise, y=lateral (mirror axis), z=vertical
-- RNG floor on WSS_agg slope = ±0.040pp; treat as the minimum effect size for single-draw mechanism claims
-- WSS_z slope is the canonical cohort-screening axis (4–9× better RNG reproducibility)
+- RNG floor on WSS_agg slope = ±0.063pp at N=2 EP11; treat as minimum effect size for single-draw mechanism claims
+- RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
+- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
+- VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
 
 ---
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -205,10 +205,11 @@ Zero idle students.
 - `<threshold` in kill-threshold string is PASS condition; never write `>threshold`
 - WSS_x slope sign is the BASIN-DISRUPTION DIAGNOSTIC — positive slope indicates shared-axis stacking failure
 - DrivAerML axes: x=streamwise, y=lateral (mirror axis), z=vertical
-- RNG floor on WSS_agg slope = ±0.063pp at N=2 EP11; treat as minimum effect size for single-draw mechanism claims
-- RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
-- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
-- VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
+- RNG floor on WSS_agg = ±0.065pp at N=2 EP12; treat as minimum effect size for single-draw mechanism claims
+- RNG floor on **val_abupt = ±0.053pp at N=2 EP12** — claims must exceed 2× floor (±0.106pp) to count as real signal
+- **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.082pp half-range at EP12, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
+- **SP is the NEW canonical screening channel** at ±0.020pp half-range at EP12 (4× tighter than abupt). Use SP slope for highest-power cross-run comparisons.
+- VP RNG floor ±0.037pp at EP12, **one-sided below H112** (both H164d/H164e VP < H112 reported value) → recipe-mean VP at EP12 ≈ 3.505% vs H112's 3.5495% → cross-axis compound test_VP margin against gate is MORE favorable than appears
 - **Actual EP boundaries** (tanjiro 00:08Z calibration via volume-points curriculum): EP6=48902, EP9=59780, EP10=62501, EP11=65184, EP13(terminal)≈70657 — supersedes uniform 10864-step assumption used in legacy PR kill-thresholds
 
 ---

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,27 @@
 # SENPAI Research State
 
-**Updated**: 2026-05-28 23:55Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
-**Constraint**: ~12-15 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
-**Active fleet snapshot**: 8/8 students training healthy; first terminal frieren H164e ~01:08Z+1; H185 thorfinn merge-eligible candidate terminal ~03:00-04:00Z+1.
+**Updated**: 2026-05-29 01:42Z | Branch: `tay` | SOTA: H112 PR #1283 (single-model) / PR #1102 (K=8 ensemble)
+**Constraint**: ~12 hours of training compute remain (Issue #1056 human directive, 2026-05-27)
+
+## 🚨 H185 TEST EVAL LANDED 01:40Z — NOT A MERGE — Anti-compound on slope
+
+**Critical finding (NEW PROGRAM-PERMANENT)**: GradNorm + mirror-aug compound produces **FLATTER** val→test slope than either alone — slope-preservation interventions ANTI-COMPOUND when stacked.
+
+| Run | val_abupt | test_WSS_agg | test_VP | test_SP | val→test slope (WSS_agg) | Merge? |
+|---|---:|---:|---:|---:|---:|---|
+| H112 baseline | 6.1358 | **6.752** | 3.421 | 3.695 | −0.215pp | (current SOTA) |
+| **H185 thorfinn (GradNorm × mirror)** | **6.017 (−0.119pp = 2.25× RNG)** | **6.764 (+12bp FAIL)** | 3.458 (+37bp) | 3.705 (+10bp) | **−0.058pp (FLATTER)** | **NO** |
+| H164e frieren (H112-recipe N=2 RNG) | 6.084 | 6.751 (−1bp within noise) | 3.409 | 3.677 | −0.180pp (within H112 noise) | calibration only |
+
+**H185 program reading**:
+- Outstanding VAL gain (clearly above 2× RNG floor) but did NOT transfer to test
+- Compound HURT the slope-preservation mechanism — additive-on-val, anti-additive-on-test-slope
+- All 4 test channels regressed slightly vs H112 (within noise but no improvement)
+- The compound idea is structurally falsified for THIS specific pair (GradNorm × mirror-aug)
+
+**Program implication**: Wave 39+ cross-axis compound strategy needs revision. Slope-PRESERVATION individual interventions do NOT compound additively on slope. May need to test SLOPE-SLOPE compound pairs that target different mechanism axes more thoroughly.
+
+**H164e program reading**: confirms H112-recipe RNG distribution centeredness at terminal. test_WSS 6.751 ≈ H112 6.752 within noise; all 4 channels essentially at H112 within recipe distribution. Close as calibration (not a merge).
 
 ## ~23:55Z Active Fleet Health (W&B-verified)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -11,7 +11,7 @@
 | #1353 | thorfinn | H185 GradNorm × mirror-aug | EP9 banked (step 59780) | **6.0948 LEAD −0.108pp** | TERMINAL MERGE CANDIDATE (~03:00-04:00Z+1) |
 | #1357 | frieren | H164e RNG calibration | step ~65875 mid-EP12 | 6.05% trajectory | terminal ~01:08Z+1; test eval ~02:35Z+1 |
 | #1364 | nezuko | H190 mirror p=0.25 | EP9 (step 59833) | **6.1386 LEAD −0.011pp (within noise)** | terminal ~03:00Z+1 (50/50 within RNG floor) |
-| #1365 | tanjiro | H191 mirror × tau_y=2.0 | step 59780 mid-EP10 | 6.3982 +0.26pp behind | terminal ~04:30Z+1 (NULL-expected boundary probe) |
+| #1365 | tanjiro | H191 mirror × tau_y=2.0 | EP10 banked (step 62501) | 6.3672 +0.23pp behind | EP9+EP10 PASS @ 00:08Z; WSS_x slope intact (−0.0109); terminal ~01:55Z+1 (NULL-expected boundary probe, mechanism confirmed) |
 | #1362 | alphonse | H188 mirror × DropPath=0.15 | step 64690 mid-EP9 | 6.20% / WSS_agg 7.05% | HEALTHY heartbeat live; in band with H112 EP9 |
 | #1363 | askeladd | H189 AdamW × tau_y=3.0 no-mirror | step 65221 EP9-boundary | 6.50% / WSS_agg 7.36% | HEALTHY |
 | #1356 | fern | H186 mirror × AdamW (kill+restart cancelled 19:05Z) | step 64504 mid-EP9 | EP9 boundary pending | HEALTHY |
@@ -209,6 +209,7 @@ Zero idle students.
 - RNG floor on **val_abupt = ±0.053pp at N=2 EP11** — claims must exceed 2× floor (±0.106pp) to count as real signal
 - **WSS_z slope is NOT the canonical cohort-screening axis** (N=2 finding: ±0.083pp half-range, LARGEST not smallest) — supersedes earlier H164d single-draw hypothesis
 - VP smallest RNG floor at ±0.036pp → cross-axis compounds clear test_VP gate
+- **Actual EP boundaries** (tanjiro 00:08Z calibration via volume-points curriculum): EP6=48902, EP9=59780, EP10=62501, EP11=65184, EP13(terminal)≈70657 — supersedes uniform 10864-step assumption used in legacy PR kill-thresholds
 
 ---
 


### PR DESCRIPTION
## Hypothesis

**H193 — Stochastic Weight Averaging (SWA) of H164e EMA checkpoints + multi-recipe weight ensemble**

SWA averages model weights across checkpoints during training to find flatter minima with better test generalization (Izmailov et al. 2018, "Averaging Weights Leads to Wider Optima and Better Generalization"). H185 just demonstrated that the H112-recipe model achieves strong val but ANTI-COMPOUNDS on slope (val→test gap). SWA directly addresses flatter-minima generalization by averaging weight trajectories — NOT averaging predictions (NOT an ensemble).

**Key scientific motivation**: The N=2 RNG calibration (H164d + H164e) showed val→test WSS_agg slope deviations of ±0.001pp across recipe draws — the slope is highly reproducible. BUT H112's reported slope is on the STEEP END of the recipe distribution (recipe-mean slope −0.187pp vs H112 −0.215pp). SWA may find the recipe-mean basin geometry rather than H112's lucky steep-slope draw — producing a model with test metrics closer to recipe-mean (test_WSS ~6.813% → worse) OR with genuinely flatter minima (test_WSS < 6.752% → better).

Two arms:

**Arm A** — SWA over H164e EMA checkpoints (EP10 → EP13):
Average the last 4 EMA checkpoint state_dicts from H164e training run `zrv3dasr`.

**Arm B** — Cross-recipe SWA (H112 + H164e weight average):
Average H112's best-EMA checkpoint (run `u9ue2ryb`) with H164e's best-EMA checkpoint (run `zrv3dasr`). This is **single-model weight averaging** across two different RNG draws of the same recipe — NOT an ensemble. The averaged model has ONE set of weights, evaluated in a single forward pass.

Report both arms; both can complete in 30-60min total (no training).

## Instructions

### Step 1 — Download EMA checkpoints from W&B

```python
import wandb, torch
api = wandb.Api()

# H164e run
run_164e = api.run("wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/zrv3dasr")
# H112 run  
run_h112 = api.run("wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/u9ue2ryb")

# Download checkpoint artifacts or use run.summary to find best checkpoint paths
```

Check what checkpoint artifacts exist by looking at `run.logged_artifacts()` or `run.summary["best_checkpoint"]`.

### Step 2 — Arm A: SWA over H164e EP10-EP13 checkpoints

```python
def simple_swa(state_dicts):
    """Average parameter tensors across K checkpoints."""
    avg_state = {}
    for key in state_dicts[0].keys():
        avg_state[key] = torch.stack([sd[key].float() for sd in state_dicts]).mean(0)
    return avg_state

# Load EP10, EP11, EP12, EP13 EMA state_dicts from zrv3dasr artifacts
ckpts = [load_ema_checkpoint(epoch) for epoch in [10, 11, 12, 13]]
swa_state = simple_swa(ckpts)

# Load into model and evaluate on val + test
model.load_state_dict(swa_state)
```

### Step 3 — Arm B: Cross-recipe H112+H164e weight average

```python
ckpt_h112 = load_ema_best_checkpoint("u9ue2ryb")  # H112 best EMA
ckpt_h164e = load_ema_best_checkpoint("zrv3dasr")  # H164e best EMA

# Simple equal-weight average
swa_cross = simple_swa([ckpt_h112, ckpt_h164e])

model.load_state_dict(swa_cross)
# eval on val + test
```

### Step 4 — Run eval on test split

For each averaged model, run the standard val+test eval using the same eval infrastructure as H112. Use `--data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 --manifest data/split_manifest.json`.

### Step 5 — Report full channel decomposition

For both arms, report:
- val_abupt, val_WSS_agg, val_WSS_x, val_WSS_y, val_WSS_z, val_VP, val_SP
- test_abupt, test_WSS_agg, test_WSS_x, test_WSS_y, test_WSS_z, test_VP, test_SP
- Δ vs H112 for each channel
- val→test slope on WSS_agg (the binding diagnostic)

**WandB group**: `--wandb-group frieren-h193-swa-checkpoint-averaging`

## Baseline

Current single-model SOTA (H112, PR #1283, W&B `u9ue2ryb`):
- val_abupt: **6.1358%**
- test_abupt: **5.839%**
- test_WSS_agg: **6.752%** (primary objective)
- test_WSS_x: 5.999%, test_WSS_y: 7.360%, test_WSS_z: 8.720%
- test_VP: 3.421%, test_SP: 3.695%

H164e terminal (W&B `zrv3dasr`, just closed PR #1357):
- val_abupt: 6.084%, test_WSS_agg: 6.7509%, test_VP: 3.409%, test_SP: 3.677%

**N=3 recipe-mean** (H112 + H164d + H164e at terminal):
- val_WSS_agg: ~6.980%, test_WSS_agg: ~6.793% (H112 reported value is on FAVORABLE end by 0.061pp)

**Merge gate**: val_abupt < 6.1358% AND test_abupt < 5.839% AND test_WSS ≤ 6.752% AND test_VP ≤ 3.421%

## Time constraints

⚠️ **~12h compute window remaining**. This is eval-only — target 30-60min for both arms. No training.

## Falsifiability

| Outcome | Arm A/B test_WSS | Reading |
|---|---|---|
| **WIN** | < 6.752% | SWA finds flatter minima with better val→test transfer; merge |
| **NULL** | ~6.752% ± 5bp | SWA noise-equivalent to best EMA checkpoint selection |
| **FAIL** | > 6.752% | SWA averages toward recipe-mean basin (test_WSS ~6.81) — worse than lucky H112 draw |

The "FAIL" outcome is also scientifically valuable: it would confirm H112's test result IS a favorable RNG draw and recipe-mean test_WSS is ~6.81%. That would shift strategy toward finding genuinely new recipe improvements rather than averaging.
