### PR TITLE
H207: weight interpolation H112 EP13 ↔ H183 EP13

### DIFF
--- a/interp_eval.py
+++ b/interp_eval.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Linear weight-interpolation eval for DrivAerML (PR #1380, H207).
+
+Loads two checkpoints (H112 EP13 and H183 EP13 best artifacts), builds
+``w_alpha = (1 - alpha) * w_a + alpha * w_b`` for each requested alpha,
+runs full val+test eval per alpha, and logs metrics to W&B. No training,
+no source-file modifications.
+
+Run a single alpha:
+
+    python interp_eval.py --alphas 0.5 --wandb-name h207-alpha-0.5
+
+Or run a sweep sequentially on one GPU:
+
+    python interp_eval.py --alphas 0.0,0.25,0.5,0.75,1.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+from data import load_data
+from ensemble_eval import (
+    build_model_from_config,
+    download_checkpoint,
+    evaluate_ensemble_split,
+    make_eval_loader,
+    primary_log_payload,
+)
+from trainer_runtime import TargetTransform
+
+
+ARCH_KEYS = (
+    "model_layers",
+    "model_hidden_dim",
+    "model_heads",
+    "model_mlp_ratio",
+    "model_slices",
+    "rff_num_features",
+    "rff_sigma",
+    "rff_init_sigmas",
+    "pos_encoding_mode",
+    "use_qk_norm",
+    "use_surf_to_vol_xattn",
+    "enable_residual_positions",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--alphas", default="0.0,0.25,0.5,0.75,1.0",
+                   help="Comma-separated alphas in [0,1] (w_a@alpha=0, w_b@alpha=1).")
+    p.add_argument("--run-id-a", default="u9ue2ryb",
+                   help="W&B run id contributing weights at alpha=0 (H112 EP13).")
+    p.add_argument("--run-id-b", default="5k58uzqc",
+                   help="W&B run id contributing weights at alpha=1 (H183 EP13).")
+    p.add_argument("--eval-surface-points", type=int, default=65536)
+    p.add_argument("--eval-volume-points", type=int, default=65536)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--num-workers", type=int, default=4)
+    p.add_argument("--amp-mode", default="bf16", choices=["bf16", "none"])
+    p.add_argument("--manifest", default="data/split_manifest.json")
+    p.add_argument("--data-root", default="")
+    p.add_argument("--cache-root", default="outputs/ensemble_cache",
+                   help="Where to cache downloaded W&B artifacts.")
+    p.add_argument("--wandb-group", default="h207-askeladd-interp-h112-h183")
+    p.add_argument("--wandb-name-prefix", default="h207-alpha")
+    p.add_argument("--no-wandb", action="store_true")
+    p.add_argument("--limit-batches", type=int, default=0,
+                   help="Optional cap on batches per split (debug).")
+    return p.parse_args()
+
+
+def _verify_architecture_match(cfg_a: dict, cfg_b: dict) -> None:
+    diffs = []
+    for k in ARCH_KEYS:
+        if cfg_a.get(k) != cfg_b.get(k):
+            diffs.append(f"  {k}: A={cfg_a.get(k)!r} vs B={cfg_b.get(k)!r}")
+    if diffs:
+        raise RuntimeError(
+            "Architecture mismatch between A and B checkpoints — interpolation "
+            "is not well-defined:\n" + "\n".join(diffs)
+        )
+
+
+def _load_state_dict(checkpoint_path: Path) -> dict:
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if "model" not in ckpt:
+        raise RuntimeError(f"Checkpoint {checkpoint_path} missing 'model' key")
+    state = {k: v for k, v in ckpt["model"].items()}
+    src = ckpt.get("checkpoint_source")
+    if src != "ema":
+        print(f"WARNING: {checkpoint_path} checkpoint_source={src!r} (expected 'ema')")
+    return state
+
+
+def _verify_state_dicts_compatible(state_a: dict, state_b: dict) -> None:
+    keys_a = set(state_a.keys())
+    keys_b = set(state_b.keys())
+    if keys_a != keys_b:
+        only_a = sorted(keys_a - keys_b)
+        only_b = sorted(keys_b - keys_a)
+        raise RuntimeError(
+            "State-dict key mismatch.\n"
+            f"  Only in A ({len(only_a)}): {only_a[:10]}{'...' if len(only_a) > 10 else ''}\n"
+            f"  Only in B ({len(only_b)}): {only_b[:10]}{'...' if len(only_b) > 10 else ''}"
+        )
+    for k in keys_a:
+        if state_a[k].shape != state_b[k].shape:
+            raise RuntimeError(
+                f"Shape mismatch for {k}: A={tuple(state_a[k].shape)} "
+                f"vs B={tuple(state_b[k].shape)}"
+            )
+
+
+def _interpolate(state_a: dict, state_b: dict, alpha: float) -> dict:
+    if alpha == 0.0:
+        return {k: v.clone() for k, v in state_a.items()}
+    if alpha == 1.0:
+        return {k: v.clone() for k, v in state_b.items()}
+    interp: dict[str, torch.Tensor] = {}
+    for k in state_a:
+        a = state_a[k]
+        b = state_b[k]
+        # Float interpolation; cast back to the original dtype to match the
+        # checkpoint precision used during training (typically float32 for
+        # the SurfaceTransolver backbone).
+        v = (1.0 - alpha) * a.float() + alpha * b.float()
+        interp[k] = v.to(a.dtype)
+    return interp
+
+
+def main() -> None:
+    args = parse_args()
+
+    entity = os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    project = os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+
+    alphas = [float(a) for a in args.alphas.split(",") if a.strip()]
+    if not alphas:
+        raise ValueError("--alphas parsed to empty list")
+    for a in alphas:
+        if not (0.0 <= a <= 1.0):
+            raise ValueError(f"alpha must be in [0, 1]; got {a}")
+
+    cache_root = Path(args.cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading A checkpoint (run {args.run_id_a})...")
+    api = wandb.Api()
+    dir_a = download_checkpoint(api, entity, project, args.run_id_a, cache_root)
+    print(f"Downloading B checkpoint (run {args.run_id_b})...")
+    dir_b = download_checkpoint(api, entity, project, args.run_id_b, cache_root)
+
+    cfg_a = yaml.safe_load((dir_a / "config.yaml").open())
+    cfg_b = yaml.safe_load((dir_b / "config.yaml").open())
+    _verify_architecture_match(cfg_a, cfg_b)
+
+    state_a = _load_state_dict(dir_a / "checkpoint.pt")
+    state_b = _load_state_dict(dir_b / "checkpoint.pt")
+    _verify_state_dicts_compatible(state_a, state_b)
+    print(f"State dicts compatible: {len(state_a)} tensors, total params "
+          f"{sum(v.numel() for v in state_a.values()):,}")
+
+    use_aux_decoder_heads = "surface_out.0.weight" in state_a
+    model = build_model_from_config(
+        cfg_a, use_aux_decoder_heads=use_aux_decoder_heads
+    ).to(device)
+
+    print("Loading data splits (val + test)...")
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=args.manifest,
+        root=args.data_root or None,
+        train_surface_points=args.eval_surface_points,
+        eval_surface_points=args.eval_surface_points,
+        train_volume_points=args.eval_volume_points,
+        eval_volume_points=args.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+    val_loader = make_eval_loader(val_splits["val_surface"], args.batch_size, args.num_workers)
+    test_loader = make_eval_loader(test_splits["test_surface"], args.batch_size, args.num_workers)
+
+    for alpha in alphas:
+        print(f"\n=== alpha = {alpha} ===")
+        t0 = time.time()
+        interp_state = _interpolate(state_a, state_b, alpha)
+        missing, unexpected = model.load_state_dict(interp_state, strict=True)
+        if missing or unexpected:
+            raise RuntimeError(
+                f"State-dict load issue at alpha={alpha}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+        model.eval()
+
+        val_metrics = evaluate_ensemble_split(
+            [model], val_loader, transform, device, args.amp_mode
+        )
+        test_metrics = evaluate_ensemble_split(
+            [model], test_loader, transform, device, args.amp_mode
+        )
+
+        peak_mem_gb = (
+            torch.cuda.max_memory_allocated(device) / (1024 ** 3)
+            if torch.cuda.is_available() else 0.0
+        )
+        elapsed = time.time() - t0
+
+        run_name = f"{args.wandb_name_prefix}-{alpha}"
+        print(f"  val_abupt = {val_metrics['abupt_axis_mean_rel_l2_pct']:.4f}")
+        print(f"  test_abupt = {test_metrics['abupt_axis_mean_rel_l2_pct']:.4f}")
+        print(f"  test_WSS = {test_metrics['wall_shear_rel_l2_pct']:.4f}  "
+              f"test_VP = {test_metrics['volume_pressure_rel_l2_pct']:.4f}  "
+              f"test_SP = {test_metrics['surface_pressure_rel_l2_pct']:.4f}")
+        print(f"  elapsed = {elapsed:.1f}s  peak_mem = {peak_mem_gb:.1f} GiB")
+
+        if not args.no_wandb:
+            run = wandb.init(
+                entity=entity,
+                project=project,
+                group=args.wandb_group,
+                name=run_name,
+                tags=["h207", "interp", "askeladd", "eval-only"],
+                config={
+                    "alpha": alpha,
+                    "run_id_a": args.run_id_a,
+                    "run_id_b": args.run_id_b,
+                    "agent": "askeladd",
+                    "pr": 1380,
+                    "hypothesis": "H207-weight-interp-H112-H183",
+                    "eval_surface_points": args.eval_surface_points,
+                    "eval_volume_points": args.eval_volume_points,
+                    "batch_size": args.batch_size,
+                    "amp_mode": args.amp_mode,
+                    "data_root": args.data_root,
+                },
+                reinit=True,
+                mode=os.environ.get("WANDB_MODE", "online"),
+            )
+            payload = {
+                "alpha": alpha,
+                "elapsed_seconds": elapsed,
+                "peak_memory_gib": peak_mem_gb,
+            }
+            payload.update(primary_log_payload("full_val_primary", val_metrics))
+            payload.update(primary_log_payload("test_primary", test_metrics))
+            wandb.log(payload)
+            for k, v in payload.items():
+                wandb.run.summary[k] = v
+            wandb.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_logs/h207/alpha_0.0.log
+++ b/run_logs/h207/alpha_0.0.log
@@ -1,0 +1,52 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+Downloading A checkpoint (run u9ue2ryb)...
+Downloading B checkpoint (run 5k58uzqc)...
+State dicts compatible: 137 tensors, total params 17,413,806
+Loading data splits (val + test)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== alpha = 0.0 ===
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: WARNING Using a boolean value for 'reinit' is deprecated. Use 'return_previous' or 'finish_previous' instead.
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_033636-69ul5jj7
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h207-alpha-0.0
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/69ul5jj7
+wandb: updating run metadata; uploading summary
+wandb: 
+wandb: Run history:
+wandb:                                        alpha ▁
+wandb:                              elapsed_seconds ▁
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct ▁
+wandb:        full_val_primary/surface_pressure_mae ▁
+wandb: full_val_primary/surface_pressure_rel_l2_pct ▁
+wandb:         full_val_primary/volume_pressure_mae ▁
+wandb:  full_val_primary/volume_pressure_rel_l2_pct ▁
+wandb:              full_val_primary/wall_shear_mae ▁
+wandb:       full_val_primary/wall_shear_rel_l2_pct ▁
+wandb:            full_val_primary/wall_shear_x_mae ▁
+wandb:                                          +19 ...
+wandb: 
+wandb: Run summary:
+wandb:                                        alpha 0
+wandb:                              elapsed_seconds 1210.40339
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct 6.13577
+wandb:        full_val_primary/surface_pressure_mae 0.01092
+wandb: full_val_primary/surface_pressure_rel_l2_pct 4.05535
+wandb:         full_val_primary/volume_pressure_mae 7.03636
+wandb:  full_val_primary/volume_pressure_rel_l2_pct 3.54775
+wandb:              full_val_primary/wall_shear_mae 0.05956
+wandb:       full_val_primary/wall_shear_rel_l2_pct 6.96706
+wandb:            full_val_primary/wall_shear_x_mae 0.07764
+wandb:                                          +19 ...
+wandb: 
+wandb: 🚀 View run h207-alpha-0.0 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/69ul5jj7
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_033636-69ul5jj7/logs
+  val_abupt = 6.1358
+  test_abupt = 5.8391
+  test_WSS = 6.7523  test_VP = 3.4213  test_SP = 3.6948
+  elapsed = 1210.4s  peak_mem = 9.1 GiB

--- a/run_logs/h207/alpha_0.25.log
+++ b/run_logs/h207/alpha_0.25.log
@@ -1,0 +1,53 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+Downloading A checkpoint (run u9ue2ryb)...
+Downloading B checkpoint (run 5k58uzqc)...
+State dicts compatible: 137 tensors, total params 17,413,806
+Loading data splits (val + test)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== alpha = 0.25 ===
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: WARNING Using a boolean value for 'reinit' is deprecated. Use 'return_previous' or 'finish_previous' instead.
+wandb: setting up run u4mttmbd
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_033638-u4mttmbd
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h207-alpha-0.25
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/u4mttmbd
+wandb: updating run metadata; uploading summary
+wandb: 
+wandb: Run history:
+wandb:                                        alpha ▁
+wandb:                              elapsed_seconds ▁
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct ▁
+wandb:        full_val_primary/surface_pressure_mae ▁
+wandb: full_val_primary/surface_pressure_rel_l2_pct ▁
+wandb:         full_val_primary/volume_pressure_mae ▁
+wandb:  full_val_primary/volume_pressure_rel_l2_pct ▁
+wandb:              full_val_primary/wall_shear_mae ▁
+wandb:       full_val_primary/wall_shear_rel_l2_pct ▁
+wandb:            full_val_primary/wall_shear_x_mae ▁
+wandb:                                          +19 ...
+wandb: 
+wandb: Run summary:
+wandb:                                        alpha 0.25
+wandb:                              elapsed_seconds 1210.95287
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct 66.60142
+wandb:        full_val_primary/surface_pressure_mae 0.16103
+wandb: full_val_primary/surface_pressure_rel_l2_pct 54.2887
+wandb:         full_val_primary/volume_pressure_mae 110.46683
+wandb:  full_val_primary/volume_pressure_rel_l2_pct 49.68749
+wandb:              full_val_primary/wall_shear_mae 0.6983
+wandb:       full_val_primary/wall_shear_rel_l2_pct 71.40916
+wandb:            full_val_primary/wall_shear_x_mae 1.06953
+wandb:                                          +19 ...
+wandb: 
+wandb: 🚀 View run h207-alpha-0.25 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/u4mttmbd
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_033638-u4mttmbd/logs
+  val_abupt = 66.6014
+  test_abupt = 66.7094
+  test_WSS = 72.0293  test_VP = 49.8612  test_SP = 54.1304
+  elapsed = 1211.0s  peak_mem = 9.1 GiB

--- a/run_logs/h207/alpha_0.5.log
+++ b/run_logs/h207/alpha_0.5.log
@@ -1,0 +1,52 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+Downloading A checkpoint (run u9ue2ryb)...
+Downloading B checkpoint (run 5k58uzqc)...
+State dicts compatible: 137 tensors, total params 17,413,806
+Loading data splits (val + test)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== alpha = 0.5 ===
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: WARNING Using a boolean value for 'reinit' is deprecated. Use 'return_previous' or 'finish_previous' instead.
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_033640-5w1mo8zj
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h207-alpha-0.5
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/5w1mo8zj
+wandb: updating run metadata; uploading summary
+wandb: 
+wandb: Run history:
+wandb:                                        alpha ▁
+wandb:                              elapsed_seconds ▁
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct ▁
+wandb:        full_val_primary/surface_pressure_mae ▁
+wandb: full_val_primary/surface_pressure_rel_l2_pct ▁
+wandb:         full_val_primary/volume_pressure_mae ▁
+wandb:  full_val_primary/volume_pressure_rel_l2_pct ▁
+wandb:              full_val_primary/wall_shear_mae ▁
+wandb:       full_val_primary/wall_shear_rel_l2_pct ▁
+wandb:            full_val_primary/wall_shear_x_mae ▁
+wandb:                                          +19 ...
+wandb: 
+wandb: Run summary:
+wandb:                                        alpha 0.5
+wandb:                              elapsed_seconds 1210.88018
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct 88.77245
+wandb:        full_val_primary/surface_pressure_mae 0.23866
+wandb: full_val_primary/surface_pressure_rel_l2_pct 76.19773
+wandb:         full_val_primary/volume_pressure_mae 187.8835
+wandb:  full_val_primary/volume_pressure_rel_l2_pct 79.04143
+wandb:              full_val_primary/wall_shear_mae 0.92715
+wandb:       full_val_primary/wall_shear_rel_l2_pct 91.54572
+wandb:            full_val_primary/wall_shear_x_mae 1.48175
+wandb:                                          +19 ...
+wandb: 
+wandb: 🚀 View run h207-alpha-0.5 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/5w1mo8zj
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_033640-5w1mo8zj/logs
+  val_abupt = 88.7724
+  test_abupt = 88.8888
+  test_WSS = 91.9248  test_VP = 79.1347  test_SP = 76.2672
+  elapsed = 1210.9s  peak_mem = 9.1 GiB

--- a/run_logs/h207/alpha_0.75.log
+++ b/run_logs/h207/alpha_0.75.log
@@ -1,0 +1,54 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+Downloading A checkpoint (run u9ue2ryb)...
+Downloading B checkpoint (run 5k58uzqc)...
+State dicts compatible: 137 tensors, total params 17,413,806
+Loading data splits (val + test)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== alpha = 0.75 ===
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: WARNING Using a boolean value for 'reinit' is deprecated. Use 'return_previous' or 'finish_previous' instead.
+wandb: setting up run ynkwv226
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_033642-ynkwv226
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h207-alpha-0.75
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ynkwv226
+wandb: updating run metadata; uploading summary
+wandb: uploading wandb-summary.json; uploading config.yaml; uploading code/interp_eval.py; uploading wandb-metadata.json; uploading requirements.txt
+wandb: 
+wandb: Run history:
+wandb:                                        alpha ▁
+wandb:                              elapsed_seconds ▁
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct ▁
+wandb:        full_val_primary/surface_pressure_mae ▁
+wandb: full_val_primary/surface_pressure_rel_l2_pct ▁
+wandb:         full_val_primary/volume_pressure_mae ▁
+wandb:  full_val_primary/volume_pressure_rel_l2_pct ▁
+wandb:              full_val_primary/wall_shear_mae ▁
+wandb:       full_val_primary/wall_shear_rel_l2_pct ▁
+wandb:            full_val_primary/wall_shear_x_mae ▁
+wandb:                                          +19 ...
+wandb: 
+wandb: Run summary:
+wandb:                                        alpha 0.75
+wandb:                              elapsed_seconds 1211.04247
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct 62.54437
+wandb:        full_val_primary/surface_pressure_mae 0.15258
+wandb: full_val_primary/surface_pressure_rel_l2_pct 50.09816
+wandb:         full_val_primary/volume_pressure_mae 107.27882
+wandb:  full_val_primary/volume_pressure_rel_l2_pct 49.53738
+wandb:              full_val_primary/wall_shear_mae 0.63975
+wandb:       full_val_primary/wall_shear_rel_l2_pct 65.93148
+wandb:            full_val_primary/wall_shear_x_mae 0.93602
+wandb:                                          +19 ...
+wandb: 
+wandb: 🚀 View run h207-alpha-0.75 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/ynkwv226
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_033642-ynkwv226/logs
+  val_abupt = 62.5444
+  test_abupt = 63.1741
+  test_WSS = 66.9319  test_VP = 50.1080  test_SP = 50.3099
+  elapsed = 1211.0s  peak_mem = 9.1 GiB

--- a/run_logs/h207/alpha_1.0.log
+++ b/run_logs/h207/alpha_1.0.log
@@ -1,0 +1,54 @@
+wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+Downloading A checkpoint (run u9ue2ryb)...
+Downloading B checkpoint (run 5k58uzqc)...
+State dicts compatible: 137 tensors, total params 17,413,806
+Loading data splits (val + test)...
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+=== alpha = 1.0 ===
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: WARNING Using a boolean value for 'reinit' is deprecated. Use 'return_previous' or 'finish_previous' instead.
+wandb: setting up run vuj4sqpi
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_033642-vuj4sqpi
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run h207-alpha-1.0
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/vuj4sqpi
+wandb: updating run metadata; uploading summary
+wandb: uploading config.yaml; uploading code/interp_eval.py; uploading wandb-metadata.json; uploading requirements.txt; uploading wandb-summary.json
+wandb: 
+wandb: Run history:
+wandb:                                        alpha ▁
+wandb:                              elapsed_seconds ▁
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct ▁
+wandb:        full_val_primary/surface_pressure_mae ▁
+wandb: full_val_primary/surface_pressure_rel_l2_pct ▁
+wandb:         full_val_primary/volume_pressure_mae ▁
+wandb:  full_val_primary/volume_pressure_rel_l2_pct ▁
+wandb:              full_val_primary/wall_shear_mae ▁
+wandb:       full_val_primary/wall_shear_rel_l2_pct ▁
+wandb:            full_val_primary/wall_shear_x_mae ▁
+wandb:                                          +19 ...
+wandb: 
+wandb: Run summary:
+wandb:                                        alpha 1
+wandb:                              elapsed_seconds 1209.7447
+wandb:  full_val_primary/abupt_axis_mean_rel_l2_pct 6.03884
+wandb:        full_val_primary/surface_pressure_mae 0.0109
+wandb: full_val_primary/surface_pressure_rel_l2_pct 4.02571
+wandb:         full_val_primary/volume_pressure_mae 6.9111
+wandb:  full_val_primary/volume_pressure_rel_l2_pct 3.50455
+wandb:              full_val_primary/wall_shear_mae 0.05945
+wandb:       full_val_primary/wall_shear_rel_l2_pct 6.86427
+wandb:            full_val_primary/wall_shear_x_mae 0.07843
+wandb:                                          +19 ...
+wandb: 
+wandb: 🚀 View run h207-alpha-1.0 at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/vuj4sqpi
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_033642-vuj4sqpi/logs
+  val_abupt = 6.0388
+  test_abupt = 5.9136
+  test_WSS = 6.8287  test_VP = 3.5277  test_SP = 3.7833
+  elapsed = 1209.7s  peak_mem = 9.1 GiB


### PR DESCRIPTION
## Hypothesis

H112 EP13 has the basin-intact slope (val 6.1358%, test 6.752%, WSS_x slope −0.215pp). H183 EP13 has the program val SOTA (val 6.039%) but basin-disrupted terminal (test 6.829%, WSS_x slope +0.064pp). These are two checkpoints on the **same problem manifold**.

**Hypothesis**: Linear interpolation of the two state_dicts at intermediate alpha produces a checkpoint with PARTIAL val gain from H183 AND PARTIAL basin integrity from H112. If a sweet spot exists where val < 6.1358 AND WSS_x slope < −0.020pp AND test_WSS < 6.752 → SOTA candidate at zero training cost.

```
W_alpha = (1 − alpha) × W_H112 + alpha × W_H183
```

- alpha = 0.0 → pure H112 (current SOTA)
- alpha = 1.0 → pure H183 (val SOTA, test fails)
- alpha ∈ (0, 1) → unexplored manifold

## Instructions

**This is a pure eval sprint — NO training. No source file modifications.**

### Step 1: Locate both EP13 best checkpoints
- H112: W&B run `u9ue2ryb`, artifact `model-*-u9ue2ryb:v0` (alias `best`)
- H183: W&B run `5k58uzqc`, artifact `model-fern-h183-mirror-aug-tau-y-3p0-compound-5k58uzqc:v0` (alias `best`)
- Download both to local disk

### Step 2: Linear interpolation pipeline

```python
import torch

w_h112 = torch.load("h112_ep13.pt")  # state_dict (or full ckpt — extract state_dict if nested)
w_h183 = torch.load("h183_ep13.pt")

# IMPORTANT: ensure both have IDENTICAL keys and tensor shapes.
# H112 and H183 used same architecture (depth=5, hidden=512, etc.), so this should hold.
# If keys differ (e.g. EMA wrapper artifacts), strip prefixes consistently before interpolation.

for alpha in [0.0, 0.25, 0.5, 0.75, 1.0]:
    w_alpha = {k: (1 - alpha) * w_h112[k] + alpha * w_h183[k] for k in w_h112}
    torch.save(w_alpha, f"interp_alpha_{alpha}.pt")
```

### Step 3: Eval each interpolated checkpoint (DDP=8 GPUs)

```bash
for alpha in 0.0 0.25 0.5 0.75 1.0; do
  python -m torch.distributed.run --nproc-per-node=8 \
    train.py --eval_only \
    --checkpoint interp_alpha_${alpha}.pt \
    --wandb_group h207-askeladd-interp-h112-h183 \
    --run_name h207-alpha-${alpha}
done
```

### Step 4: Report

Table per alpha:
- val_abupt, val_WSS, val_WSS_x, val_WSS_y, val_WSS_z, val_VP, val_SP
- test_WSS, test_WSS_x, test_WSS_y, test_WSS_z, test_VP, test_SP
- WSS_x slope sign (key basin diagnostic)
- val→test slope on WSS aggregate

### Step 5: SOTA candidate check

Criterion: val_abupt < 6.1358% AND test_WSS ≤ 6.752% AND test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND WSS_x slope ≤ −0.020pp.

If any alpha passes all 5 gates → SOTA candidate. Report the SOTA-candidate alpha + per-channel decomposition. Tag advisor for merge.

**Bonus arm — find optimum alpha**:
After the initial 5-point sweep, if alpha=0.25 or 0.5 looks promising (basin intact + val gain), do a refinement sweep at alpha=0.1, 0.2, 0.3, 0.4. Total ~9 evals ≈ 2.5h on 8 GPUs.

## Baseline

Current best (H112, PR #1283, W&B run `u9ue2ryb`):
- val_abupt: **6.1358%**
- test_WSS: **6.752%**
- test_VP: **3.421%**
- test_SP: **3.695%** (strict gate ≤ 3.577%)

All 4 gates + WSS_x basin must pass for merge.

## Coordination

- fern H208 = same logic, H112 ↔ H190 interpolation
- tanjiro H210 = cross-recipe SWA of all 5 EP13 best artifacts (the full-cohort consensus variant)
- These 3 weight-arithmetic experiments together test whether the val-SOTA recipes can be partially recovered via parameter-space averaging

## Background

The original H198 (cohort-wide checkpoint search) was blocked by the same checkpoint-persistence issue that blocked H204 — mid-EP EMAs were never saved. H207 PIVOTS to weight interpolation between TWO EP13 best artifacts, which is fully executable.

Expected runtime: ~1.5-2h on 8 GPUs (5-9 evals × ~20-25min each).
