### PR TITLE
H212: mirror invariance profile across 5 cohort EP13 checkpoints

### DIFF
--- a/logs/h212/h112.log
+++ b/logs/h212/h112.log
@@ -1,0 +1,64 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=8
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_035128-89jj6f3d
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run edward/h212-h112-mirror-profile
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/89jj6f3d
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00421 abupt_axis_rel_l2_pct=5.8390 surface_p_mae=0.01059 volume_p_mae=6.86038 wall_shear_mae=0.05751 cases=50
+  test_original -> abupt=5.8390% | SP=3.6948% | WSS=6.7523% | VP=3.4211% | WSS_x=5.9990% | WSS_y=7.3604% | WSS_z=8.7199%
+test_mirrored  loss=0.01542 abupt_axis_rel_l2_pct=11.0048 surface_p_mae=0.02506 volume_p_mae=17.95607 wall_shear_mae=0.09366 cases=50
+  test_mirrored -> abupt=11.0048% | SP=8.7338% | WSS=11.4358% | VP=8.5567% | WSS_x=9.9387% | WSS_y=12.9977% | WSS_z=14.7972%
+  runtime=198.9s n_batches=347
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: updating run metadata
+wandb: 
+wandb: Run history:
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                       test_mirrored/cases ▁
+wandb:                        test_mirrored/loss ▁
+wandb:               test_mirrored/surface_cases ▁
+wandb:                test_mirrored/surface_loss ▁
+wandb:        test_mirrored/surface_pressure_mae ▁
+wandb:     test_mirrored/surface_pressure_rel_l2 ▁
+wandb: test_mirrored/surface_pressure_rel_l2_pct ▁
+wandb:                test_mirrored/volume_cases ▁
+wandb:                                       +64 ...
+wandb: 
+wandb: Run summary:
+wandb:                            model/n_params 17413721
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 0.11005
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct 11.00483
+wandb:                       test_mirrored/cases 50
+wandb:                        test_mirrored/loss 0.01542
+wandb:               test_mirrored/surface_cases 50
+wandb:                test_mirrored/surface_loss 0.01645
+wandb:        test_mirrored/surface_pressure_mae 0.02506
+wandb:     test_mirrored/surface_pressure_rel_l2 0.08734
+wandb: test_mirrored/surface_pressure_rel_l2_pct 8.73384
+wandb:                                       +65 ...
+wandb: 
+wandb: 🚀 View run edward/h212-h112-mirror-profile at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/89jj6f3d
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_035128-89jj6f3d/logs

--- a/logs/h212/h148.log
+++ b/logs/h212/h148.log
@@ -1,0 +1,65 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=8
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run wu0avbzr
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_035456-wu0avbzr
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run edward/h212-h148-mirror-profile
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/wu0avbzr
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00423 abupt_axis_rel_l2_pct=5.8508 surface_p_mae=0.01062 volume_p_mae=6.85920 wall_shear_mae=0.05766 cases=50
+  test_original -> abupt=5.8508% | SP=3.6955% | WSS=6.7750% | VP=3.4164% | WSS_x=6.0191% | WSS_y=7.3891% | WSS_z=8.7337%
+test_mirrored  loss=0.00422 abupt_axis_rel_l2_pct=5.8497 surface_p_mae=0.01063 volume_p_mae=6.85073 wall_shear_mae=0.05764 cases=50
+  test_mirrored -> abupt=5.8497% | SP=3.6970% | WSS=6.7731% | VP=3.4152% | WSS_x=6.0173% | WSS_y=7.3865% | WSS_z=8.7322%
+  runtime=198.7s n_batches=347
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: updating run metadata
+wandb: 
+wandb: Run history:
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                       test_mirrored/cases ▁
+wandb:                        test_mirrored/loss ▁
+wandb:               test_mirrored/surface_cases ▁
+wandb:                test_mirrored/surface_loss ▁
+wandb:        test_mirrored/surface_pressure_mae ▁
+wandb:     test_mirrored/surface_pressure_rel_l2 ▁
+wandb: test_mirrored/surface_pressure_rel_l2_pct ▁
+wandb:                test_mirrored/volume_cases ▁
+wandb:                                       +64 ...
+wandb: 
+wandb: Run summary:
+wandb:                            model/n_params 17413721
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 0.0585
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct 5.84965
+wandb:                       test_mirrored/cases 50
+wandb:                        test_mirrored/loss 0.00422
+wandb:               test_mirrored/surface_cases 50
+wandb:                test_mirrored/surface_loss 0.00516
+wandb:        test_mirrored/surface_pressure_mae 0.01063
+wandb:     test_mirrored/surface_pressure_rel_l2 0.03697
+wandb: test_mirrored/surface_pressure_rel_l2_pct 3.697
+wandb:                                       +65 ...
+wandb: 
+wandb: 🚀 View run edward/h212-h148-mirror-profile at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/wu0avbzr
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_035456-wu0avbzr/logs

--- a/logs/h212/h183.log
+++ b/logs/h212/h183.log
@@ -1,0 +1,66 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=8
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run cab3gi27
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_035825-cab3gi27
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run edward/h212-h183-mirror-profile
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/cab3gi27
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00433 abupt_axis_rel_l2_pct=5.9135 surface_p_mae=0.01092 volume_p_mae=7.02232 wall_shear_mae=0.05819 cases=50
+  test_original -> abupt=5.9135% | SP=3.7833% | WSS=6.8287% | VP=3.5275% | WSS_x=6.1121% | WSS_y=7.3295% | WSS_z=8.8154%
+test_mirrored  loss=0.00433 abupt_axis_rel_l2_pct=5.9144 surface_p_mae=0.01093 volume_p_mae=7.02648 wall_shear_mae=0.05820 cases=50
+  test_mirrored -> abupt=5.9144% | SP=3.7848% | WSS=6.8301% | VP=3.5280% | WSS_x=6.1144% | WSS_y=7.3301% | WSS_z=8.8149%
+  runtime=198.9s n_batches=347
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: updating run metadata
+wandb: uploading history steps 0-0, summary, console lines 2-8
+wandb: 
+wandb: Run history:
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                       test_mirrored/cases ▁
+wandb:                        test_mirrored/loss ▁
+wandb:               test_mirrored/surface_cases ▁
+wandb:                test_mirrored/surface_loss ▁
+wandb:        test_mirrored/surface_pressure_mae ▁
+wandb:     test_mirrored/surface_pressure_rel_l2 ▁
+wandb: test_mirrored/surface_pressure_rel_l2_pct ▁
+wandb:                test_mirrored/volume_cases ▁
+wandb:                                       +64 ...
+wandb: 
+wandb: Run summary:
+wandb:                            model/n_params 17413721
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 0.05914
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct 5.91444
+wandb:                       test_mirrored/cases 50
+wandb:                        test_mirrored/loss 0.00433
+wandb:               test_mirrored/surface_cases 50
+wandb:                test_mirrored/surface_loss 0.00525
+wandb:        test_mirrored/surface_pressure_mae 0.01093
+wandb:     test_mirrored/surface_pressure_rel_l2 0.03785
+wandb: test_mirrored/surface_pressure_rel_l2_pct 3.78482
+wandb:                                       +65 ...
+wandb: 
+wandb: 🚀 View run edward/h212-h183-mirror-profile at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/cab3gi27
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_035825-cab3gi27/logs

--- a/logs/h212/h185.log
+++ b/logs/h212/h185.log
@@ -1,0 +1,65 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=8
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: setting up run d4a8tq6u
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_040153-d4a8tq6u
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run edward/h212-h185-mirror-profile
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/d4a8tq6u
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00424 abupt_axis_rel_l2_pct=5.8613 surface_p_mae=0.01064 volume_p_mae=6.97024 wall_shear_mae=0.05758 cases=50
+  test_original -> abupt=5.8613% | SP=3.7046% | WSS=6.7642% | VP=3.4583% | WSS_x=5.9926% | WSS_y=7.3902% | WSS_z=8.7606%
+test_mirrored  loss=0.00425 abupt_axis_rel_l2_pct=5.8630 surface_p_mae=0.01065 volume_p_mae=6.96813 wall_shear_mae=0.05758 cases=50
+  test_mirrored -> abupt=5.8630% | SP=3.7067% | WSS=6.7662% | VP=3.4572% | WSS_x=5.9945% | WSS_y=7.3894% | WSS_z=8.7670%
+  runtime=198.9s n_batches=347
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: updating run metadata
+wandb: 
+wandb: Run history:
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                       test_mirrored/cases ▁
+wandb:                        test_mirrored/loss ▁
+wandb:               test_mirrored/surface_cases ▁
+wandb:                test_mirrored/surface_loss ▁
+wandb:        test_mirrored/surface_pressure_mae ▁
+wandb:     test_mirrored/surface_pressure_rel_l2 ▁
+wandb: test_mirrored/surface_pressure_rel_l2_pct ▁
+wandb:                test_mirrored/volume_cases ▁
+wandb:                                       +64 ...
+wandb: 
+wandb: Run summary:
+wandb:                            model/n_params 17413721
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 0.05863
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct 5.86297
+wandb:                       test_mirrored/cases 50
+wandb:                        test_mirrored/loss 0.00425
+wandb:               test_mirrored/surface_cases 50
+wandb:                test_mirrored/surface_loss 0.00517
+wandb:        test_mirrored/surface_pressure_mae 0.01065
+wandb:     test_mirrored/surface_pressure_rel_l2 0.03707
+wandb: test_mirrored/surface_pressure_rel_l2_pct 3.70668
+wandb:                                       +65 ...
+wandb: 
+wandb: 🚀 View run edward/h212-h185-mirror-profile at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/d4a8tq6u
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_040153-d4a8tq6u/logs

--- a/logs/h212/h190.log
+++ b/logs/h212/h190.log
@@ -1,0 +1,64 @@
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Device: cuda:0
+DDP world_size=8
+Loaded checkpoint epoch=13 source=ema params=17.41M
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 casesDrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+
+
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+DrivAerML: train=87064 views/400 cases, val=7295 views/34 cases, test=11091 views/50 cases
+wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from WANDB_API_KEY.
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+wandb: Tracking run with wandb version 0.27.0
+wandb: Run data is saved locally in /workspace/senpai/target/wandb/run-20260529_040521-9qffxckg
+wandb: Run `wandb offline` to turn off syncing.
+wandb: Syncing run edward/h212-h190-mirror-profile
+wandb: ⭐️ View project at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: 🚀 View run at https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/9qffxckg
+
+=== Evaluating test (11091 views) ===
+test_original  loss=0.00429 abupt_axis_rel_l2_pct=5.8994 surface_p_mae=0.01080 volume_p_mae=6.96469 wall_shear_mae=0.05802 cases=50
+  test_original -> abupt=5.8994% | SP=3.7399% | WSS=6.8198% | VP=3.4713% | WSS_x=6.0691% | WSS_y=7.3899% | WSS_z=8.8266%
+test_mirrored  loss=0.00432 abupt_axis_rel_l2_pct=5.9188 surface_p_mae=0.01088 volume_p_mae=7.02448 wall_shear_mae=0.05845 cases=50
+  test_mirrored -> abupt=5.9188% | SP=3.7553% | WSS=6.8407% | VP=3.4862% | WSS_x=6.0870% | WSS_y=7.4322% | WSS_z=8.8331%
+  runtime=198.9s n_batches=347
+/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+  return func(*args, **kwargs)
+wandb: updating run metadata
+wandb: 
+wandb: Run history:
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 ▁
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct ▁
+wandb:                       test_mirrored/cases ▁
+wandb:                        test_mirrored/loss ▁
+wandb:               test_mirrored/surface_cases ▁
+wandb:                test_mirrored/surface_loss ▁
+wandb:        test_mirrored/surface_pressure_mae ▁
+wandb:     test_mirrored/surface_pressure_rel_l2 ▁
+wandb: test_mirrored/surface_pressure_rel_l2_pct ▁
+wandb:                test_mirrored/volume_cases ▁
+wandb:                                       +64 ...
+wandb: 
+wandb: Run summary:
+wandb:                            model/n_params 17413721
+wandb:      test_mirrored/abupt_axis_mean_rel_l2 0.05919
+wandb:  test_mirrored/abupt_axis_mean_rel_l2_pct 5.91876
+wandb:                       test_mirrored/cases 50
+wandb:                        test_mirrored/loss 0.00432
+wandb:               test_mirrored/surface_cases 50
+wandb:                test_mirrored/surface_loss 0.00526
+wandb:        test_mirrored/surface_pressure_mae 0.01088
+wandb:     test_mirrored/surface_pressure_rel_l2 0.03755
+wandb: test_mirrored/surface_pressure_rel_l2_pct 3.75533
+wandb:                                       +65 ...
+wandb: 
+wandb: 🚀 View run edward/h212-h190-mirror-profile at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/9qffxckg
+wandb: ⭐️ View project at: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8
+wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
+wandb: Find logs at: ./wandb/run-20260529_040521-9qffxckg/logs

--- a/run_h212_evals.sh
+++ b/run_h212_evals.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# H212 mirror-invariance profile across 5 EP13 cohort checkpoints.
+# Note: --data-root deviated from PR ("drivaerml_processed") to
+#   "drivaerml_processed_rawcanon_20260511" because:
+#   1) All 5 models were trained on rawcanon (per their config.yaml data_root).
+#   2) H200 control (H189) was run on rawcanon — keeping the comparison
+#      apples-to-apples vs the published delta_mirror = +4.532pp.
+set -e
+DATA_ROOT="/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+LOGDIR="/workspace/senpai/target/logs/h212"
+mkdir -p "$LOGDIR"
+
+for model in h112 h148 h183 h185 h190; do
+  echo "=== Running $model ==="
+  python -m torch.distributed.run --standalone --nproc-per-node=8 tta_mirror_eval.py \
+    --checkpoint "outputs/${model}/checkpoint.pt" \
+    --config-yaml "outputs/${model}/config.yaml" \
+    --data-root "$DATA_ROOT" \
+    --manifest data/split_manifest.json \
+    --batch-size 4 \
+    --eval-surface-points 65536 \
+    --eval-volume-points 65536 \
+    --amp-mode bf16 \
+    --splits test \
+    --eval-modes original,mirrored \
+    --wandb-group h212-edward-mirror-invariance-profile \
+    --wandb-name "edward/h212-${model}-mirror-profile" \
+    2>&1 | tee "$LOGDIR/${model}.log"
+  echo "=== $model done ==="
+done

--- a/tta_mirror_eval.py
+++ b/tta_mirror_eval.py
@@ -1,0 +1,644 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""H200: TTA mirror-augmentation eval for the DrivAerML surrogate.
+
+Loads a single trained checkpoint and evaluates it in three modes against
+the held-out val and test splits:
+
+* ``original``  - vanilla forward pass on the geometry as loaded.
+* ``mirrored``  - forward pass on the y-mirrored geometry, with the
+  predicted ``tau_y`` component negated so the prediction is reported in
+  the original frame.
+* ``tta``       - average of the original and the un-mirrored prediction
+  in normalised space; the standard 2-mode mirror TTA estimator.
+
+Each batch incurs only two model forward passes; the three modes share
+those passes so a full 8-GPU eval is roughly the cost of two normal
+evals (not three).
+
+The script does not modify any source file. It re-uses the existing
+``EvalAccumulator`` / ``finalize_eval_accumulator`` infrastructure from
+``trainer_runtime`` to guarantee metric parity with ``train.py``.
+
+Metric reporting in W&B uses the prefixes:
+
+  ``<split>_original/*``  ``<split>_mirrored/*``  ``<split>_tta/*``
+
+Use case for H200 vs H192: if H192 (mirror-trained) shows a meaningful
+test_WSS gain under TTA but H200 (this run, non-mirror-trained) does
+not, the TTA gain is mechanism-specific and depends on the model having
+learned mirror invariance, not generic averaging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import torch
+import torch.distributed as dist
+import wandb
+import yaml
+
+from data import load_data, pad_collate
+from data.loader import SurfaceBatch
+from model import SurfaceTransolver
+from trainer_runtime import (
+    DistributedState,
+    EvalAccumulator,
+    StridedDistributedSampler,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    distributed_barrier,
+    finalize_eval_accumulator,
+    init_distributed,
+    merge_eval_accumulators,
+    print_metrics,
+)
+
+# Surface input layout (data/loader.py): [x, y, z, nx, ny, nz, area].
+SURFACE_INPUT_Y_COL = 1
+SURFACE_INPUT_NORMAL_Y_COL = 4
+# Volume input layout: [x, y, z, sdf].
+VOLUME_INPUT_Y_COL = 1
+# Surface target/prediction layout: [cp, tau_x, tau_y, tau_z].
+SURFACE_OUTPUT_TAU_Y_COL = 2
+
+EVAL_MODES = ("original", "mirrored", "tta")
+
+
+@dataclass
+class EvalConfig:
+    checkpoint: str
+    config_yaml: str
+    data_root: str
+    manifest: str
+    batch_size: int
+    eval_surface_points: int
+    eval_volume_points: int
+    num_workers: int
+    amp_mode: str
+    splits: tuple[str, ...]
+    wandb_group: str
+    wandb_name: str
+    eval_modes: tuple[str, ...]
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H200 TTA mirror-aug eval")
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--config-yaml", required=True)
+    parser.add_argument("--data-root", default="")
+    parser.add_argument("--manifest", default="data/split_manifest.json")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--eval-surface-points", type=int, default=65536)
+    parser.add_argument("--eval-volume-points", type=int, default=65536)
+    parser.add_argument("--num-workers", type=int, default=-1)
+    parser.add_argument("--amp-mode", default="bf16")
+    parser.add_argument("--splits", default="test,val")
+    parser.add_argument("--wandb-group", default="")
+    parser.add_argument("--wandb-name", default="")
+    parser.add_argument("--eval-modes", default="original,mirrored,tta")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    modes = tuple(m.strip() for m in args.eval_modes.split(",") if m.strip())
+    for m in modes:
+        if m not in EVAL_MODES:
+            raise ValueError(f"unknown eval mode {m!r}; choose from {EVAL_MODES}")
+    splits = tuple(s.strip() for s in args.splits.split(",") if s.strip())
+    for s in splits:
+        if s not in ("val", "test"):
+            raise ValueError(f"unknown split {s!r}; expected val or test")
+    return EvalConfig(
+        checkpoint=args.checkpoint,
+        config_yaml=args.config_yaml,
+        data_root=args.data_root,
+        manifest=args.manifest,
+        batch_size=args.batch_size,
+        eval_surface_points=args.eval_surface_points,
+        eval_volume_points=args.eval_volume_points,
+        num_workers=args.num_workers,
+        amp_mode=args.amp_mode,
+        splits=splits,
+        wandb_group=args.wandb_group,
+        wandb_name=args.wandb_name,
+        eval_modes=modes,
+    )
+
+
+def parse_rff_init_sigmas(raw: object) -> list[float] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        return [float(v.strip()) for v in text.split(",") if v.strip()] or None
+    if isinstance(raw, (list, tuple)):
+        return [float(v) for v in raw] or None
+    raise ValueError(f"Unsupported rff_init_sigmas value: {raw!r}")
+
+
+def build_model_from_yaml(config_yaml: Path, state_dict: dict) -> SurfaceTransolver:
+    with config_yaml.open("r") as fh:
+        config = yaml.safe_load(fh)
+    use_aux_decoder_heads = "surface_out.0.weight" in state_dict
+    return SurfaceTransolver(
+        n_layers=int(config.get("model_layers", 3)),
+        n_hidden=int(config.get("model_hidden_dim", 192)),
+        dropout=float(config.get("model_dropout", 0.0)),
+        n_head=int(config.get("model_heads", 3)),
+        mlp_ratio=int(config.get("model_mlp_ratio", 4)),
+        slice_num=int(config.get("model_slices", 96)),
+        rff_num_features=int(config.get("rff_num_features", 0)),
+        rff_sigma=float(config.get("rff_sigma", 1.0)),
+        rff_init_sigmas=parse_rff_init_sigmas(config.get("rff_init_sigmas")),
+        pos_encoding_mode=str(config.get("pos_encoding_mode", "sincos")),
+        use_qk_norm=bool(config.get("use_qk_norm", False)),
+        use_surf_to_vol_xattn=bool(config.get("use_surf_to_vol_xattn", False)),
+        use_aux_decoder_heads=use_aux_decoder_heads,
+        drop_path_max=float(config.get("drop_path_max", 0.0)),
+    )
+
+
+def load_checkpoint(path: Path, device: torch.device) -> tuple[SurfaceTransolver, dict]:
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if "model" not in checkpoint:
+        raise RuntimeError(f"Checkpoint {path} missing 'model' state dict")
+    config_yaml = path.parent / "config.yaml"
+    if not config_yaml.exists():
+        raise FileNotFoundError(f"Expected config.yaml next to checkpoint: {config_yaml}")
+    state_dict = dict(checkpoint["model"])
+    model = build_model_from_yaml(config_yaml, state_dict).to(device)
+    missing, unexpected = model.load_state_dict(state_dict, strict=True)
+    if missing or unexpected:
+        raise RuntimeError(
+            f"State-dict mismatch loading {path}: missing={missing}, unexpected={unexpected}"
+        )
+    model.eval()
+    return model, checkpoint
+
+
+def mirror_batch(batch: SurfaceBatch) -> SurfaceBatch:
+    """Return a y-mirrored shallow copy of ``batch``.
+
+    Negates ``y`` and ``n_y`` in the surface inputs and ``y`` in the
+    volume inputs. Other channels (cp, tau, normals/coords x and z, area,
+    sdf) are invariant under y-reflection.
+    """
+
+    surface_x = batch.surface_x.clone()
+    surface_x[..., SURFACE_INPUT_Y_COL] = -surface_x[..., SURFACE_INPUT_Y_COL]
+    surface_x[..., SURFACE_INPUT_NORMAL_Y_COL] = -surface_x[..., SURFACE_INPUT_NORMAL_Y_COL]
+    volume_x = batch.volume_x.clone()
+    if volume_x.numel() > 0:
+        volume_x[..., VOLUME_INPUT_Y_COL] = -volume_x[..., VOLUME_INPUT_Y_COL]
+    return SurfaceBatch(
+        case_ids=list(batch.case_ids),
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=list(batch.metadata),
+    )
+
+
+def unmirror_surface_pred_norm(
+    pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> torch.Tensor:
+    """Apply the y-reflection sign flip to a normalised surface prediction.
+
+    The lateral sign flip (``tau_y -> -tau_y``) is a physical-space
+    operation. The model output is in normalised space, where channel
+    ``c`` satisfies ``y_norm = (y_phys - mu_c) / sigma_c``. Negating the
+    physical value gives ``-y_phys = -(y_norm * sigma_c + mu_c)``, so
+
+        y_norm_new = -y_norm - 2 * mu_c / sigma_c
+
+    For DrivAerML's tau_y, ``mu / sigma ~= 0.0015 / 1.356 ~= 1.1e-3``,
+    so the offset is small but we include it for physical fidelity.
+    """
+
+    out = pred_norm.clone()
+    mean = transform.surface_y_mean.to(out.device)
+    std = transform.surface_y_std.to(out.device)
+    c = SURFACE_OUTPUT_TAU_Y_COL
+    out[..., c] = -out[..., c] - 2.0 * mean[c] / std[c]
+    return out
+
+
+@torch.no_grad()
+def forward_pred_norm(
+    model: SurfaceTransolver,
+    batch: SurfaceBatch,
+    device: torch.device,
+    amp_mode: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    with autocast_context(device, amp_mode):
+        out = model(
+            surface_x=batch.surface_x,
+            surface_mask=batch.surface_mask,
+            volume_x=batch.volume_x,
+            volume_mask=batch.volume_mask,
+        )
+    surface_pred = out["surface_preds"].float()
+    volume_pred = out["volume_preds"].float()
+    return surface_pred, volume_pred
+
+
+def accumulate_batch_with_predictions(
+    accumulator: EvalAccumulator,
+    *,
+    batch: SurfaceBatch,
+    surface_pred_norm: torch.Tensor,
+    volume_pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    """Mirror of trainer_runtime.accumulate_eval_batch using precomputed preds.
+
+    The forward pass is decoupled so a single batch can be scored under
+    multiple TTA averaging strategies without duplicating model work.
+    """
+
+    surface_target_norm = transform.apply_surface(batch.surface_y)
+    volume_target_norm = transform.apply_volume(batch.volume_y)
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, batch.surface_mask
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, batch.volume_mask
+    )
+    accumulator.surface_loss_sse += surface_sse
+    accumulator.surface_loss_count += surface_count
+    accumulator.volume_loss_sse += volume_sse
+    accumulator.volume_loss_count += volume_count
+    surface_pred = transform.invert_surface(surface_pred_norm)
+    volume_pred = transform.invert_volume(volume_pred_norm)
+
+    if bool(batch.surface_mask.any()):
+        surface_abs = (surface_pred - batch.surface_y).abs()
+        valid_surface_abs = surface_abs[batch.surface_mask]
+        accumulator.abs_sums["surface_pressure"] += float(
+            valid_surface_abs[:, 0].sum().detach().cpu().item()
+        )
+        accumulator.abs_counts["surface_pressure"] += int(valid_surface_abs[:, 0].numel())
+        wall_abs = valid_surface_abs[:, 1:4]
+        accumulator.abs_sums["wall_shear"] += float(wall_abs.sum().detach().cpu().item())
+        accumulator.abs_counts["wall_shear"] += int(wall_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = wall_abs[:, offset]
+            accumulator.abs_sums[f"wall_shear_{axis}"] += float(
+                channel.sum().detach().cpu().item()
+            )
+            accumulator.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+        wall_vector_error = torch.linalg.vector_norm(
+            surface_pred[batch.surface_mask][:, 1:4]
+            - batch.surface_y[batch.surface_mask][:, 1:4],
+            dim=-1,
+        )
+        accumulator.wall_shear_vector_abs_sum += float(
+            wall_vector_error.sum().detach().cpu().item()
+        )
+        accumulator.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    if bool(batch.volume_mask.any()):
+        volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
+        accumulator.abs_sums["volume_pressure"] += float(
+            volume_abs[:, 0].sum().detach().cpu().item()
+        )
+        accumulator.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    for case_idx, case_id in enumerate(batch.case_ids):
+        surface_valid = batch.surface_mask[case_idx].bool()
+        if bool(surface_valid.any()):
+            surface_pred_valid = surface_pred[case_idx][surface_valid]
+            surface_target_valid = batch.surface_y[case_idx][surface_valid]
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["surface_pressure"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 0:1],
+                target=surface_target_valid[:, 0:1],
+            )
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["wall_shear"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 1:4],
+                target=surface_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    accumulator.case_sums[f"wall_shear_{axis}"],
+                    case_id=case_id,
+                    pred=surface_pred_valid[:, channel : channel + 1],
+                    target=surface_target_valid[:, channel : channel + 1],
+                )
+        volume_valid = batch.volume_mask[case_idx].bool()
+        if bool(volume_valid.any()):
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["volume_pressure"],
+                case_id=case_id,
+                pred=volume_pred[case_idx][volume_valid],
+                target=batch.volume_y[case_idx][volume_valid],
+            )
+
+
+@torch.no_grad()
+def evaluate_split_tta(
+    model: SurfaceTransolver,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    eval_modes: tuple[str, ...],
+    distributed_state: DistributedState,
+) -> dict[str, dict[str, float]]:
+    """Run one eval pass yielding metrics for each requested TTA mode."""
+
+    model.eval()
+    accumulators = {mode: EvalAccumulator() for mode in eval_modes}
+    needs_mirrored = ("mirrored" in eval_modes) or ("tta" in eval_modes)
+
+    n_batches = 0
+    t0 = time.time()
+    for batch in loader:
+        batch = batch.to(device)
+        surface_a, volume_a = forward_pred_norm(model, batch, device, amp_mode)
+        surface_b_unmirrored = None
+        volume_b = None
+        if needs_mirrored:
+            mirrored = mirror_batch(batch)
+            surface_b_raw, volume_b = forward_pred_norm(
+                model, mirrored, device, amp_mode
+            )
+            surface_b_unmirrored = unmirror_surface_pred_norm(surface_b_raw, transform)
+        if "original" in eval_modes:
+            accumulate_batch_with_predictions(
+                accumulators["original"],
+                batch=batch,
+                surface_pred_norm=surface_a,
+                volume_pred_norm=volume_a,
+                transform=transform,
+            )
+        if "mirrored" in eval_modes:
+            accumulate_batch_with_predictions(
+                accumulators["mirrored"],
+                batch=batch,
+                surface_pred_norm=surface_b_unmirrored,
+                volume_pred_norm=volume_b,
+                transform=transform,
+            )
+        if "tta" in eval_modes:
+            tta_surface = 0.5 * (surface_a + surface_b_unmirrored)
+            tta_volume = 0.5 * (volume_a + volume_b)
+            accumulate_batch_with_predictions(
+                accumulators["tta"],
+                batch=batch,
+                surface_pred_norm=tta_surface,
+                volume_pred_norm=tta_volume,
+                transform=transform,
+            )
+        n_batches += 1
+
+    if distributed_state.enabled:
+        finalized: dict[str, dict[str, float]] = {}
+        for mode in eval_modes:
+            gathered: list[EvalAccumulator | None] = [
+                None for _ in range(distributed_state.world_size)
+            ]
+            dist.all_gather_object(gathered, accumulators[mode])
+            if not distributed_state.is_main:
+                finalized[mode] = {}
+                continue
+            merged = merge_eval_accumulators(a for a in gathered if a is not None)
+            finalized[mode] = finalize_eval_accumulator(merged)
+        if distributed_state.is_main:
+            finalized["_runtime_seconds"] = {"value": time.time() - t0, "n_batches": float(n_batches)}
+        return finalized
+
+    out: dict[str, dict[str, float]] = {
+        mode: finalize_eval_accumulator(accumulators[mode]) for mode in eval_modes
+    }
+    out["_runtime_seconds"] = {"value": time.time() - t0, "n_batches": float(n_batches)}
+    return out
+
+
+def init_wandb(cfg: EvalConfig, checkpoint_metadata: dict) -> "wandb.sdk.wandb_run.Run":
+    init_kwargs = dict(
+        entity=os.environ.get("WANDB_ENTITY"),
+        project=os.environ.get("WANDB_PROJECT"),
+        group=cfg.wandb_group or None,
+        name=cfg.wandb_name or None,
+        config={
+            "checkpoint": cfg.checkpoint,
+            "config_yaml": cfg.config_yaml,
+            "data_root": cfg.data_root,
+            "manifest": cfg.manifest,
+            "batch_size": cfg.batch_size,
+            "eval_surface_points": cfg.eval_surface_points,
+            "eval_volume_points": cfg.eval_volume_points,
+            "amp_mode": cfg.amp_mode,
+            "splits": list(cfg.splits),
+            "eval_modes": list(cfg.eval_modes),
+            "checkpoint_epoch": checkpoint_metadata.get("epoch"),
+            "checkpoint_source": checkpoint_metadata.get("checkpoint_source"),
+        },
+        tags=["h200", "tta-mirror", "edward"],
+        mode=os.environ.get("WANDB_MODE", "online"),
+        job_type="eval",
+    )
+    return wandb.init(**init_kwargs)
+
+
+def format_metric_log(
+    split_name: str,
+    mode: str,
+    metrics: dict[str, float],
+) -> dict[str, float]:
+    prefix_primary = f"{split_name}_primary_{mode}"
+    prefix_raw = f"{split_name}_{mode}"
+    log: dict[str, float] = {}
+    primary_keys = (
+        "abupt_axis_mean_rel_l2_pct",
+        "surface_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+        "surface_pressure_mae",
+        "wall_shear_mae",
+        "volume_pressure_mae",
+    )
+    for key in primary_keys:
+        if key in metrics:
+            log[f"{prefix_primary}/{key}"] = float(metrics[key])
+    for key, value in metrics.items():
+        if isinstance(value, (int, float)):
+            log[f"{prefix_raw}/{key}"] = float(value)
+    return log
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+    if state.is_main:
+        print(f"Device: {device}")
+        if state.enabled:
+            print(f"DDP world_size={state.world_size}")
+
+    checkpoint_path = Path(cfg.checkpoint).resolve()
+    config_yaml = Path(cfg.config_yaml).resolve()
+    model, checkpoint = load_checkpoint(checkpoint_path, device)
+    n_params = sum(p.numel() for p in model.parameters())
+    if state.is_main:
+        print(
+            f"Loaded checkpoint epoch={checkpoint.get('epoch')} "
+            f"source={checkpoint.get('checkpoint_source')} "
+            f"params={n_params / 1e6:.2f}M"
+        )
+
+    # Match train.py's eval-time config block: 65536 surface/volume chunked.
+    # ``load_data`` only needs ``eval_*_points``; train_* parameters are
+    # ignored downstream because we never instantiate the train loader.
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=cfg.manifest,
+        root=cfg.data_root or None,
+        train_surface_points=cfg.eval_surface_points,
+        eval_surface_points=cfg.eval_surface_points,
+        train_volume_points=cfg.eval_volume_points,
+        eval_volume_points=cfg.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    split_loaders: dict[str, torch.utils.data.DataLoader] = {}
+    if "val" in cfg.splits:
+        split_loaders["val"] = build_eval_loader(
+            val_splits["val_surface"], cfg, state=state
+        )
+    if "test" in cfg.splits:
+        split_loaders["test"] = build_eval_loader(
+            test_splits["test_surface"], cfg, state=state
+        )
+
+    run = None
+    if state.is_main:
+        run = init_wandb(cfg, checkpoint)
+        wandb.summary["model/n_params"] = n_params
+
+    all_metrics: dict[str, dict[str, dict[str, float]]] = {}
+    for split_name, loader in split_loaders.items():
+        if state.is_main:
+            print(f"\n=== Evaluating {split_name} ({len(loader.dataset)} views) ===")
+        results = evaluate_split_tta(
+            model=model,
+            loader=loader,
+            transform=transform,
+            device=device,
+            amp_mode=cfg.amp_mode,
+            eval_modes=cfg.eval_modes,
+            distributed_state=state,
+        )
+        if state.is_main:
+            runtime = results.pop("_runtime_seconds", None)
+            all_metrics[split_name] = results
+            for mode in cfg.eval_modes:
+                metrics = results[mode]
+                print_metrics(f"{split_name}_{mode}", metrics)
+                print(
+                    f"  {split_name}_{mode} -> "
+                    f"abupt={metrics['abupt_axis_mean_rel_l2_pct']:.4f}% | "
+                    f"SP={metrics['surface_pressure_rel_l2_pct']:.4f}% | "
+                    f"WSS={metrics['wall_shear_rel_l2_pct']:.4f}% | "
+                    f"VP={metrics['volume_pressure_rel_l2_pct']:.4f}% | "
+                    f"WSS_x={metrics['wall_shear_x_rel_l2_pct']:.4f}% | "
+                    f"WSS_y={metrics['wall_shear_y_rel_l2_pct']:.4f}% | "
+                    f"WSS_z={metrics['wall_shear_z_rel_l2_pct']:.4f}%"
+                )
+            if runtime is not None:
+                print(
+                    f"  runtime={runtime['value']:.1f}s "
+                    f"n_batches={int(runtime['n_batches'])}"
+                )
+        distributed_barrier(state)
+
+    if state.is_main and run is not None:
+        log: dict[str, float] = {}
+        for split_name, results in all_metrics.items():
+            for mode in cfg.eval_modes:
+                log.update(format_metric_log(split_name, mode, results[mode]))
+        wandb.log(log, step=0)
+        wandb.summary.update(log)
+        if "test" in all_metrics and "tta" in cfg.eval_modes and "original" in cfg.eval_modes:
+            o = all_metrics["test"]["original"]
+            t = all_metrics["test"]["tta"]
+            deltas = {
+                "test_delta_tta_minus_original/abupt": t["abupt_axis_mean_rel_l2_pct"]
+                - o["abupt_axis_mean_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear": t["wall_shear_rel_l2_pct"]
+                - o["wall_shear_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_x": t["wall_shear_x_rel_l2_pct"]
+                - o["wall_shear_x_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_y": t["wall_shear_y_rel_l2_pct"]
+                - o["wall_shear_y_rel_l2_pct"],
+                "test_delta_tta_minus_original/wall_shear_z": t["wall_shear_z_rel_l2_pct"]
+                - o["wall_shear_z_rel_l2_pct"],
+                "test_delta_tta_minus_original/surface_pressure": t["surface_pressure_rel_l2_pct"]
+                - o["surface_pressure_rel_l2_pct"],
+                "test_delta_tta_minus_original/volume_pressure": t["volume_pressure_rel_l2_pct"]
+                - o["volume_pressure_rel_l2_pct"],
+            }
+            wandb.log(deltas, step=0)
+            wandb.summary.update(deltas)
+            print("\n=== TTA vs original (test) ===")
+            for k, v in deltas.items():
+                print(f"  {k.split('/', 1)[1]}: {v:+.4f}pp")
+        wandb.finish()
+
+    cleanup_distributed(state)
+
+
+def build_eval_loader(
+    dataset,
+    cfg: EvalConfig,
+    *,
+    state: DistributedState,
+) -> torch.utils.data.DataLoader:
+    sampler = None
+    if state.enabled:
+        sampler = StridedDistributedSampler(
+            dataset, num_replicas=state.world_size, rank=state.rank
+        )
+    num_workers = cfg.num_workers if cfg.num_workers >= 0 else min(4, os.cpu_count() or 4)
+    return torch.utils.data.DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        sampler=sampler,
+        collate_fn=pad_collate,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        persistent_workers=num_workers > 0,
+        prefetch_factor=2 if num_workers > 0 else None,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

Your H200 control established the **CONTROL FLOOR**: TTA mirror-aug on a non-mirror-trained model (H189) hurts test_WSS by +1.27pp. The mirrored-only eval for H189 was catastrophically bad (+4.53pp WSS). This anchors mechanism attribution for the 4 active TTA recovery sprints (H192 H112, H206 H183, H209 H185, H211 H190).

**H212 question**: How much mirror invariance has each cohort model actually learned? The metric `delta_mirror = test_WSS_mirrored − test_WSS_original` directly quantifies this. A model with full mirror invariance would show delta_mirror ≈ 0. H189 (no mirror-aug training) shows +4.53pp.

**Hypothesis**: Models trained with mirror-aug (H148 p=0.5, H183 p=0.5+tau_y, H185 GradNorm+p=0.5, H190 p=0.25) will show smaller delta_mirror than H112/H189 (no aug). The ranking by delta_mirror should predict which models benefit most from TTA averaging in H192/H206/H209/H211. This test is cross-predictive — run before those sprints terminate, register predictions, validate afterward.

## Instructions

**Pure eval sprint — NO training. Use the existing `tta_mirror_eval.py` you wrote for H200.**

### Step 1: Identify the 5 EP13 best checkpoints

| Model | W&B run | mirror-aug training |
|---|---|---|
| H112 | `u9ue2ryb` | NONE (baseline) |
| H148 | find H148 run in W&B project `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8` | p=0.5 |
| H183 | `5k58uzqc` | p=0.5 + tau_y=3.0 |
| H185 | `yw2a5dyl` | GradNorm + p=0.5 |
| H190 | `9f2jtrg2` | p=0.25 |

Add H189 (`bp12b1cc`) as the control reference (you already have this result: delta_mirror = +4.532pp).

### Step 2: Run original + mirrored modes only

Drop the TTA mode (save time — we have 4 dedicated TTA sprints). Just `original,mirrored`:

```bash
for model in h112 h148 h183 h185 h190; do
  python -m torch.distributed.run --nproc-per-node=8 tta_mirror_eval.py \
    --checkpoint outputs/${model}/checkpoint.pt \
    --config-yaml outputs/${model}/config.yaml \
    --data-root /mnt/new-pvc/Processed/drivaerml_processed \
    --manifest data/split_manifest.json \
    --batch-size 4 \
    --eval-surface-points 65536 \
    --eval-volume-points 65536 \
    --amp-mode bf16 \
    --splits test \
    --eval-modes original,mirrored \
    --wandb-group h212-edward-mirror-invariance-profile \
    --wandb-name edward/h212-${model}-mirror-profile
done
```

Runtime: ~5min per model × 5 = ~25min total.

### Step 3: Report mirror invariance profile

Fill this table (include H189 from H200 as reference):

| Model | test_WSS_orig | test_WSS_mirrored | delta_mirror (pp) | mirror-aug recipe | val_abupt |
|---|---:|---:|---:|---|---:|
| H189 (H200) | 7.120 | 11.652 | **+4.532** | NONE | 6.448 |
| H112 | 6.752 | ? | ? | NONE | 6.136 |
| H148 | 6.775 | ? | ? | p=0.5 | 6.219 |
| H183 | 6.829 | ? | ? | p=0.5+tau_y | 6.039 |
| H185 | 6.764 | ? | ? | GradNorm+p=0.5 | 6.017 |
| H190 | 6.820 | ? | ? | p=0.25 | 6.077 |

Also report:
- Per-channel deltas: WSS_x, WSS_y, WSS_z, SP, VP — which channel is MOST / LEAST mirror-affected
- Does H148 (p=0.5, slope intact at test) have smaller delta than H190 (p=0.25, slope collapsed)? This cross-checks the bimodal mirror-regime finding (Finding L)
- Rank models by smallest delta_mirror (most invariance)

### Step 4: Pre-register predictions for active TTA sprints

Before any of the active TTA sprints (H192/H206/H209/H211) terminate, post a prediction comment naming which model should benefit most from TTA (smallest delta_mirror), and whether any will clear the test_WSS ≤ 6.752 gate under TTA. This makes the cross-sprint comparison rigorous.

### Step 5: Flag any original-mode metric drift

If any model's `original` mode result differs > 0.5pp from its published baseline test_WSS, flag immediately — that would mean checkpoint loading or eval setup has drifted.

## Baseline

Current best (H112, PR #1283, W&B run `u9ue2ryb`):
- val_abupt: **6.1358%**
- test_WSS: **6.752%** (merge gate: ≤ 6.752%)
- test_VP: **3.421%** (merge gate: ≤ 3.421%)
- test_SP: **3.695%** (merge gate: ≤ 3.577%)

Your H200 reference: H189 delta_mirror = **+4.532pp** (control floor, no mirror-aug training).

Cohort mirror-aug runs: H148 (p=0.5, slope intact), H183 (val SOTA 6.039%, basin flipped terminal), H185 (val SOTA 6.017%, basin flipped terminal), H190 (p=0.25, slope collapsed — bimodal finding).

## Coordination

- thorfinn H192 = TTA on H112 (in flight)
- alphonse H206 = TTA on H183 (in flight)
- frieren H209 = TTA on H185 (in flight)
- nezuko H211 = TTA on H190 (in flight)
- **edward H212 (THIS)** = mirror invariance PROFILE — diagnostic spine for interpreting all 4 TTA sprints

Expected runtime: ~25-30min on 8 GPUs (5 models × ~5min each).
