### PR TITLE
H214: sub-alpha sweep H112↔H183 — basin radius probe

### DIFF
--- a/interp_eval.py
+++ b/interp_eval.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Linear weight-interpolation eval for DrivAerML (PR #1388, H214).
+
+Loads two checkpoints (H112 EP13 and H183 EP13 best artifacts), builds
+``w_alpha = (1 - alpha) * w_a + alpha * w_b`` for each requested alpha,
+runs full val+test eval per alpha, and logs metrics to W&B. No training,
+no source-file modifications.
+
+Originally introduced for H207 (PR #1380); H214 reuses unchanged and
+runs a finer-grained sub-alpha sweep to measure H112's basin radius in
+the H183 direction.
+
+Run a single alpha:
+
+    python interp_eval.py --alphas 0.05 --wandb-name-prefix h214-alpha
+
+Or run a sweep sequentially on one GPU:
+
+    python interp_eval.py --alphas 0.005,0.01,0.025,0.05,0.1,0.15,0.2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import torch
+import wandb
+import yaml
+
+from data import load_data
+from ensemble_eval import (
+    build_model_from_config,
+    download_checkpoint,
+    evaluate_ensemble_split,
+    make_eval_loader,
+    primary_log_payload,
+)
+from trainer_runtime import TargetTransform
+
+
+ARCH_KEYS = (
+    "model_layers",
+    "model_hidden_dim",
+    "model_heads",
+    "model_mlp_ratio",
+    "model_slices",
+    "rff_num_features",
+    "rff_sigma",
+    "rff_init_sigmas",
+    "pos_encoding_mode",
+    "use_qk_norm",
+    "use_surf_to_vol_xattn",
+    "enable_residual_positions",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--alphas", default="0.0,0.25,0.5,0.75,1.0",
+                   help="Comma-separated alphas in [0,1] (w_a@alpha=0, w_b@alpha=1).")
+    p.add_argument("--run-id-a", default="u9ue2ryb",
+                   help="W&B run id contributing weights at alpha=0 (H112 EP13).")
+    p.add_argument("--run-id-b", default="5k58uzqc",
+                   help="W&B run id contributing weights at alpha=1 (H183 EP13).")
+    p.add_argument("--eval-surface-points", type=int, default=65536)
+    p.add_argument("--eval-volume-points", type=int, default=65536)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--num-workers", type=int, default=4)
+    p.add_argument("--amp-mode", default="bf16", choices=["bf16", "none"])
+    p.add_argument("--manifest", default="data/split_manifest.json")
+    p.add_argument("--data-root", default="")
+    p.add_argument("--cache-root", default="outputs/ensemble_cache",
+                   help="Where to cache downloaded W&B artifacts.")
+    p.add_argument("--wandb-group", default="h214-askeladd-sub-alpha-h112-h183")
+    p.add_argument("--wandb-name-prefix", default="h214-alpha")
+    p.add_argument("--no-wandb", action="store_true")
+    p.add_argument("--limit-batches", type=int, default=0,
+                   help="Optional cap on batches per split (debug).")
+    return p.parse_args()
+
+
+def _verify_architecture_match(cfg_a: dict, cfg_b: dict) -> None:
+    diffs = []
+    for k in ARCH_KEYS:
+        if cfg_a.get(k) != cfg_b.get(k):
+            diffs.append(f"  {k}: A={cfg_a.get(k)!r} vs B={cfg_b.get(k)!r}")
+    if diffs:
+        raise RuntimeError(
+            "Architecture mismatch between A and B checkpoints — interpolation "
+            "is not well-defined:\n" + "\n".join(diffs)
+        )
+
+
+def _load_state_dict(checkpoint_path: Path) -> dict:
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if "model" not in ckpt:
+        raise RuntimeError(f"Checkpoint {checkpoint_path} missing 'model' key")
+    state = {k: v for k, v in ckpt["model"].items()}
+    src = ckpt.get("checkpoint_source")
+    if src != "ema":
+        print(f"WARNING: {checkpoint_path} checkpoint_source={src!r} (expected 'ema')")
+    return state
+
+
+def _verify_state_dicts_compatible(state_a: dict, state_b: dict) -> None:
+    keys_a = set(state_a.keys())
+    keys_b = set(state_b.keys())
+    if keys_a != keys_b:
+        only_a = sorted(keys_a - keys_b)
+        only_b = sorted(keys_b - keys_a)
+        raise RuntimeError(
+            "State-dict key mismatch.\n"
+            f"  Only in A ({len(only_a)}): {only_a[:10]}{'...' if len(only_a) > 10 else ''}\n"
+            f"  Only in B ({len(only_b)}): {only_b[:10]}{'...' if len(only_b) > 10 else ''}"
+        )
+    for k in keys_a:
+        if state_a[k].shape != state_b[k].shape:
+            raise RuntimeError(
+                f"Shape mismatch for {k}: A={tuple(state_a[k].shape)} "
+                f"vs B={tuple(state_b[k].shape)}"
+            )
+
+
+def _interpolate(state_a: dict, state_b: dict, alpha: float) -> dict:
+    if alpha == 0.0:
+        return {k: v.clone() for k, v in state_a.items()}
+    if alpha == 1.0:
+        return {k: v.clone() for k, v in state_b.items()}
+    interp: dict[str, torch.Tensor] = {}
+    for k in state_a:
+        a = state_a[k]
+        b = state_b[k]
+        # Float interpolation; cast back to the original dtype to match the
+        # checkpoint precision used during training (typically float32 for
+        # the SurfaceTransolver backbone).
+        v = (1.0 - alpha) * a.float() + alpha * b.float()
+        interp[k] = v.to(a.dtype)
+    return interp
+
+
+def main() -> None:
+    args = parse_args()
+
+    entity = os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team")
+    project = os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+
+    alphas = [float(a) for a in args.alphas.split(",") if a.strip()]
+    if not alphas:
+        raise ValueError("--alphas parsed to empty list")
+    for a in alphas:
+        if not (0.0 <= a <= 1.0):
+            raise ValueError(f"alpha must be in [0, 1]; got {a}")
+
+    cache_root = Path(args.cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading A checkpoint (run {args.run_id_a})...")
+    api = wandb.Api()
+    dir_a = download_checkpoint(api, entity, project, args.run_id_a, cache_root)
+    print(f"Downloading B checkpoint (run {args.run_id_b})...")
+    dir_b = download_checkpoint(api, entity, project, args.run_id_b, cache_root)
+
+    cfg_a = yaml.safe_load((dir_a / "config.yaml").open())
+    cfg_b = yaml.safe_load((dir_b / "config.yaml").open())
+    _verify_architecture_match(cfg_a, cfg_b)
+
+    state_a = _load_state_dict(dir_a / "checkpoint.pt")
+    state_b = _load_state_dict(dir_b / "checkpoint.pt")
+    _verify_state_dicts_compatible(state_a, state_b)
+    print(f"State dicts compatible: {len(state_a)} tensors, total params "
+          f"{sum(v.numel() for v in state_a.values()):,}")
+
+    use_aux_decoder_heads = "surface_out.0.weight" in state_a
+    model = build_model_from_config(
+        cfg_a, use_aux_decoder_heads=use_aux_decoder_heads
+    ).to(device)
+
+    print("Loading data splits (val + test)...")
+    _, val_splits, test_splits, stats = load_data(
+        manifest_path=args.manifest,
+        root=args.data_root or None,
+        train_surface_points=args.eval_surface_points,
+        eval_surface_points=args.eval_surface_points,
+        train_volume_points=args.eval_volume_points,
+        eval_volume_points=args.eval_volume_points,
+        debug=False,
+    )
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+    val_loader = make_eval_loader(val_splits["val_surface"], args.batch_size, args.num_workers)
+    test_loader = make_eval_loader(test_splits["test_surface"], args.batch_size, args.num_workers)
+
+    for alpha in alphas:
+        print(f"\n=== alpha = {alpha} ===")
+        t0 = time.time()
+        interp_state = _interpolate(state_a, state_b, alpha)
+        missing, unexpected = model.load_state_dict(interp_state, strict=True)
+        if missing or unexpected:
+            raise RuntimeError(
+                f"State-dict load issue at alpha={alpha}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+        model.eval()
+
+        val_metrics = evaluate_ensemble_split(
+            [model], val_loader, transform, device, args.amp_mode
+        )
+        test_metrics = evaluate_ensemble_split(
+            [model], test_loader, transform, device, args.amp_mode
+        )
+
+        peak_mem_gb = (
+            torch.cuda.max_memory_allocated(device) / (1024 ** 3)
+            if torch.cuda.is_available() else 0.0
+        )
+        elapsed = time.time() - t0
+
+        run_name = f"{args.wandb_name_prefix}-{alpha}"
+        print(f"  val_abupt = {val_metrics['abupt_axis_mean_rel_l2_pct']:.4f}")
+        print(f"  test_abupt = {test_metrics['abupt_axis_mean_rel_l2_pct']:.4f}")
+        print(f"  test_WSS = {test_metrics['wall_shear_rel_l2_pct']:.4f}  "
+              f"test_VP = {test_metrics['volume_pressure_rel_l2_pct']:.4f}  "
+              f"test_SP = {test_metrics['surface_pressure_rel_l2_pct']:.4f}")
+        print(f"  elapsed = {elapsed:.1f}s  peak_mem = {peak_mem_gb:.1f} GiB")
+
+        if not args.no_wandb:
+            run = wandb.init(
+                entity=entity,
+                project=project,
+                group=args.wandb_group,
+                name=run_name,
+                tags=["h214", "interp", "sub-alpha", "askeladd", "eval-only"],
+                config={
+                    "alpha": alpha,
+                    "run_id_a": args.run_id_a,
+                    "run_id_b": args.run_id_b,
+                    "agent": "askeladd",
+                    "pr": 1388,
+                    "hypothesis": "H214-sub-alpha-H112-H183-basin-radius",
+                    "eval_surface_points": args.eval_surface_points,
+                    "eval_volume_points": args.eval_volume_points,
+                    "batch_size": args.batch_size,
+                    "amp_mode": args.amp_mode,
+                    "data_root": args.data_root,
+                },
+                reinit=True,
+                mode=os.environ.get("WANDB_MODE", "online"),
+            )
+            payload = {
+                "alpha": alpha,
+                "elapsed_seconds": elapsed,
+                "peak_memory_gib": peak_mem_gb,
+            }
+            payload.update(primary_log_payload("full_val_primary", val_metrics))
+            payload.update(primary_log_payload("test_primary", test_metrics))
+            wandb.log(payload)
+            for k, v in payload.items():
+                wandb.run.summary[k] = v
+            wandb.finish()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

Your H207 (Finding P) established that H112 and H183 EP13 are NOT linearly mode-connected — even alpha=0.25 collapses val_abupt from 6.14 to 66.6 (10× degradation in a single step). The basin boundary lies somewhere in (0, 0.25).

**H214 question**: What is the **basin radius** of H112 in the H183 direction? Is there any sub-0.25 alpha where the model stays functional AND gains some of H183's val improvement?

**Hypothesis**: Three outcomes possible:
1. **Sharp basin** (most likely): alpha ≤ 0.025 already collapses → basins are completely disjoint, no linear blend at any meaningful weight.
2. **Soft basin**: alpha ∈ (0, 0.05) stays functional but val doesn't improve → tiny workable region but zero H183 transfer.
3. **Sweet spot** (low probability): some alpha ∈ (0, 0.2) has val_abupt < 6.1358 AND test_WSS ≤ 6.752 AND slope ≤ −0.020 → SOTA candidate.

This definitively closes the linear interpolation arm for H112↔H183. Combined with tanjiro's H213 (block splice, orthogonal approach), we exhaust the parameter-space alternatives.

## Instructions

**Pure eval sprint — NO training. Reuse your H207 `interp_eval.py` infrastructure exactly.**

### Step 1: Pull H112 and H183 EP13 best checkpoints (same artifacts as H207)
- H112: W&B run `u9ue2ryb`, alias `best`/`epoch-13`
- H183: W&B run `5k58uzqc`, alias `best`/`epoch-13`

### Step 2: Sub-alpha sweep (7 fine-grained alphas)

```bash
cd /workspace/senpai/target
for alpha in 0.005 0.01 0.025 0.05 0.1 0.15 0.2; do
  python interp_eval.py --alphas $alpha \
    --wandb-name-prefix h214-alpha \
    --wandb-group h214-askeladd-sub-alpha-h112-h183 \
    2>&1 | tee run_logs/h214/alpha_${alpha}.log
done
```

**Preferred (parallelized)**: run 7 GPUs simultaneously if your infrastructure supports `CUDA_VISIBLE_DEVICES` per-job — reduces runtime from ~140min to ~25min.

### Step 3: Report

Fill this table (alpha=0.0 H112 from H207 is the anchor):

| alpha | val_abupt | test_WSS | test_VP | test_SP | WSS_x slope | Functional? |
|---|---:|---:|---:|---:|---:|---|
| 0.0 (H112, H207 anchor) | 6.1358 | 6.752 | 3.421 | 3.695 | −0.093pp | ✓ canonical |
| 0.005 | ? | ? | ? | ? | ? | ? |
| 0.01 | ? | ? | ? | ? | ? | ? |
| 0.025 | ? | ? | ? | ? | ? | ? |
| 0.05 | ? | ? | ? | ? | ? | ? |
| 0.1 | ? | ? | ? | ? | ? | ? |
| 0.15 | ? | ? | ? | ? | ? | ? |
| 0.2 | ? | ? | ? | ? | ? | ? |

Key diagnostics:
- At which alpha does val_abupt FIRST exceed 6.25% (beyond H112 + 1× RNG floor of ±0.053pp)?
- At which alpha does WSS_x slope first flip to positive?
- Is there ANY alpha with val_abupt < 6.1358 AND test_WSS ≤ 6.752 AND WSS_x slope ≤ −0.020?

Report the empirical **basin radius** as the largest alpha where val_abupt < 10% (model still functional).

### Step 4: SOTA candidate

Criterion: val_abupt < 6.1358% AND test_WSS ≤ 6.752% AND test_VP ≤ 3.421% AND test_SP ≤ 3.577% AND WSS_x slope ≤ −0.020pp.

If any alpha passes → IMMEDIATE SOTA candidate, tag advisor.

## Baseline

Current best (H112, PR #1283, W&B run `u9ue2ryb`):
- val_abupt: **6.1358%**
- test_WSS: **6.752%** (merge gate: ≤ 6.752%)
- test_VP: **3.421%** (merge gate: ≤ 3.421%)
- test_SP: **3.695%** (strict gate: ≤ 3.577%)

H207 results (your prior sprint):
- alpha=0.0: val 6.1358, test_WSS 6.752 ✓
- alpha=0.25: val 66.60 (DESTROYED — basin boundary lies in (0, 0.25))
- alpha=0.5: val 88.77 (deepest mountain pass)

## Coordination

- tanjiro H213 = block-wise splice H112↔H183 at k=0..5 (active, complements this)
- fern H208 = H112↔H190 interpolation (active, will confirm same collapse pattern)
- **askeladd H214 (THIS)** = sub-alpha sweep — quantifies H112 basin radius in H183 direction

Expected runtime: ~25-30min if parallelized across 7 GPUs; ~140min serial.
