### PR TITLE
H216: H185 + tau_y=2.0 retrain — below stacking failure boundary

### DIFF
--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
-from data import DrivAerMLSurfaceDataset
+from data import DrivAerMLSurfaceDataset, SurfaceBatch
 from model import SurfaceTransolver
 from trainer_runtime import (
     EMA,
@@ -139,6 +139,8 @@ class Config:
     gradnorm_log_clip: float = 4.0
     gradnorm_ema_beta: float = 0.9
     gradnorm_min_weight: float = 0.0
+    mirror_augmentation: bool = False
+    mirror_augmentation_prob: float = 0.5
     debug: bool = False
 
 
@@ -238,6 +240,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "0.0 at block 0 to drop_path_max at block (depth-1). Identity "
             "at eval so adds zero inference cost. 0.0 disables (default)."
         ),
+        "mirror_augmentation": (
+            "H148/H185: Train-time y=0 yaw-mirror augmentation. DrivAerML "
+            "is bilaterally symmetric (symmetry-plane BC at y=0); every "
+            "case has an exact physically valid mirror twin. Per-sample "
+            "flip with prob --mirror-augmentation-prob (default 0.5): "
+            "negate y/normal_y in surface_x, y in volume_x, tau_y in "
+            "surface_y; cp, tau_x, tau_z, sdf, volume_pressure are "
+            "invariant. Off for val/test. Zero parameter cost."
+        ),
+        "mirror_augmentation_prob": (
+            "H190/H216: Per-sample probability of applying the y=0 yaw-"
+            "mirror augmentation when --mirror-augmentation is enabled. "
+            "0.5 is canonical H148; 0.25 halves the effective augmentation "
+            "frequency (H190/H216 boundary probe)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -283,6 +300,32 @@ def parse_rff_init_sigmas(spec: str) -> list[float] | None:
     if any(s <= 0.0 for s in sigmas):
         raise ValueError(f"--rff-init-sigmas must be positive: {spec!r}")
     return sigmas
+
+
+def apply_mirror_augmentation(batch: SurfaceBatch, prob: float) -> tuple[SurfaceBatch, float]:
+    B = batch.surface_x.shape[0]
+    flip = torch.rand(B) < float(prob)
+    if not flip.any():
+        return batch, 0.0
+    sign = torch.where(flip, -1.0, 1.0).to(batch.surface_x.dtype)
+    sign_col = sign[:, None]
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1] = surface_x[..., 1] * sign_col
+    surface_x[..., 4] = surface_x[..., 4] * sign_col
+    surface_y = batch.surface_y.clone()
+    surface_y[..., 2] = surface_y[..., 2] * sign_col
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1] = volume_x[..., 1] * sign_col
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    ), float(flip.float().mean().item())
 
 
 def collect_string_sep_metrics(model: nn.Module) -> dict[str, float]:
@@ -905,6 +948,15 @@ def main(argv: Iterable[str] | None = None) -> None:
                         f"DropPath (H112): per-block schedule "
                         f"(attn=mlp) = {drop_path_schedule}"
                     )
+            wandb.summary["mirror_augmentation/enabled"] = bool(config.mirror_augmentation)
+            wandb.summary["mirror_augmentation/prob"] = float(
+                config.mirror_augmentation_prob if config.mirror_augmentation else 0.0
+            )
+            if config.mirror_augmentation:
+                print(
+                    f"Mirror augmentation (H148/H185/H216): enabled with "
+                    f"per-sample prob = {config.mirror_augmentation_prob}"
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -958,6 +1010,11 @@ def main(argv: Iterable[str] | None = None) -> None:
                 leave=False,
                 disable=not state.is_main,
             ):
+                mirror_flip_fraction = 0.0
+                if config.mirror_augmentation:
+                    batch, mirror_flip_fraction = apply_mirror_augmentation(
+                        batch, config.mirror_augmentation_prob
+                    )
                 gradnorm_metrics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
@@ -1078,6 +1135,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/vol_points": float(current_train_vol_points),
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
+                    "train/mirror_flip_fraction": mirror_flip_fraction,
                 }
                 if not loss_is_nonfinite:
                     train_log.update(


### PR DESCRIPTION
## Hypothesis

**H216: H185 recipe + tau_y=2.0 retrain — de-escalate tau_y below Finding J failure boundary**

H185 used tau_y=3.0, which is at/above the stacking failure boundary from Finding J. Combined with Finding Q (TTA does NOT recover the WSS_x slope flip), the hypothesis is that tau_y=3.0 over-weights WSS_y at the cost of WSS_x basin integrity.

**Prediction**: Full retrain with tau_y=2.0 (everything else identical to H185) should:
- Restore WSS_x slope to negative (intact basin) at terminal EP
- Slightly weaken WSS_y improvement (less aggressive y-axis weighting)
- Net: lower test_WSS via deeper basin; TTA restores WSS_y boost at inference

## Instructions

**Training-heavy sprint. ~3.5h training + 5min TTA eval. DDP=8 GPUs.**

### Step 1: Full retrain with tau_y=2.0

```bash
SENPAI_TIMEOUT_MINUTES=240 torchrun --standalone --nproc-per-node=8 target/train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent fern \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --lr 9e-5 --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 2.0 --tau-z-loss-weight 2.0 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --use-surf-to-vol-xattn --enable-residual-positions \
  --epochs 13 --lr-warmup-epochs 1 --lr-schedule cosine \
  --ema-decay 0.999 --grad-clip 1.0 --save-best-checkpoint \
  --mirror-augment-p 0.25 \
  --wandb_group h216-fern-tau_y_2 \
  --run_name fern/h216-h185-tauy2
```

Identical to H185 except `--tau-y-loss-weight 2.0` (vs 3.0).

### Step 2: TTA eval at best EMA

```bash
torchrun --standalone --nproc-per-node=8 target/eval_tta_h209.py \
  --checkpoint outputs/<run-dir>/checkpoint_best.pt \
  --output-dir outputs/h216_eval \
  --wandb-group h216-fern-tau_y_2 \
  --wandb-name "fern/h216-h185-tauy2-tta" \
  --batch-size 2
```

### Step 3: WSS_x slope tracking at EP6, EP9, EP13 — CRITICAL

| EP | val_WSS_x | test_WSS_x | slope | basin health |
|---|---|---|---|---|
| 6 | ? | ? | ? | ? |
| 9 | ? | ? | ? | ? |
| 13 (best) | ? | ? | ? | ? |

H185 EP13: WSS_x slope = +0.0519 (FLIPPED). Target: restore to negative.

### Step 4: Full report

All metrics (val + test, orig + TTA):
- val_abupt, val_WSS, val_WSS_x/y/z, val_VP, val_SP
- test_abupt, test_WSS, test_WSS_x/y/z, test_VP, test_SP
- delta_mirror_WSS (per Finding S)

### Step 5: SOTA candidate gate

PRIMARY: val_abupt < 5.9755 AND test_abupt < 5.8221
Paper-floor: test_VP ≤ 3.421 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727

## Baseline

Current SOTA (PR #1382 H209, H185+TTA): val_abupt 5.9755, test_abupt 5.8221, test_WSS 6.7214
H185 raw EP13 (W&B `yw2a5dyl`): val_abupt 6.0172, test_abupt 5.8613, WSS_x slope +0.0519 (flipped)
W&B run: `bx3t1vdw`
