### PR TITLE
H229: TTA with input coordinate Gaussian noise σ=0.001 on H185 EP13

### DIFF
--- a/eval_tta_h229.py
+++ b/eval_tta_h229.py
@@ -1,0 +1,543 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H229: TTA with Gaussian coordinate noise on H185 EP13 (eval-only).
+
+Extends H209 mirror TTA by adding K Gaussian-noise passes on top of the
+y-mirror pass. The 5-pass TTA averages 1 mirror pass and K=4 noise passes
+in normalized prediction space (equal weights 1/(1+K)).
+
+Noise model:
+  Isotropic Gaussian noise ε ~ N(0, σ²) added per node coordinate, applied
+  only to the (x, y, z) channels of surface_x (channels 0,1,2) and volume_x
+  (channels 0,1,2). Normals (surface_x channels 3,4,5), area (channel 6),
+  and sdf (volume_x channel 3) are NOT perturbed — they are geometric
+  attributes derived from the original mesh and would be inconsistent if
+  noised independently of the coords.
+
+Per-pass numpy RNG seeding uses `42 + pass_idx` mixed with a stable
+batch counter (`pass_idx * 100003 + batch_idx`) so the noise applied in
+each (pass, batch) is reproducible and distinct across passes.
+
+Diagnostic accumulators tracked per split:
+    orig    : original geometry only (matches H209 Pass A — sanity check)
+    mirror  : y-mirror only (matches H209 Pass B — sanity check)
+    noise   : average of K noise passes (no mirror)
+    tta     : 5-pass weighted average (mirror + K noise, weight 1/(1+K) each)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import asdict, dataclass, fields
+from typing import Iterable
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import wandb
+
+from data import SurfaceBatch
+from model import SurfaceTransolver
+from trainer_runtime import (
+    EvalAccumulator,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    finalize_eval_accumulator,
+    init_distributed,
+    make_loaders,
+    merge_eval_accumulators,
+    primary_metric_log,
+    print_metrics,
+    unwrap_model,
+)
+
+
+@dataclass
+class EvalConfig:
+    """Minimal config mirroring train.Config for eval. Defaults match H185 yw2a5dyl."""
+
+    checkpoint: str = ""
+    manifest: str = "data/split_manifest.json"
+    data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+    output_dir: str = "outputs/h229_eval"
+    wandb_group: str = "h229-tanjiro-noise-tta"
+    wandb_name: str = ""
+    agent: str = "tanjiro"
+
+    # Noise TTA params
+    noise_sigma: float = 0.001
+    noise_passes: int = 4
+
+    # Eval-only loader params
+    batch_size: int = 2
+    eval_surface_points: int = 65536
+    eval_volume_points: int = 65536
+    train_surface_points: int = 65536
+    train_volume_points: int = 65536
+    num_workers: int = -1
+    pin_memory: bool = True
+    persistent_workers: bool = True
+    prefetch_factor: int = 2
+
+    # Model arch (must match H185 yw2a5dyl exactly)
+    model_layers: int = 5
+    model_hidden_dim: int = 512
+    model_heads: int = 4
+    model_mlp_ratio: int = 4
+    model_slices: int = 128
+    model_dropout: float = 0.0
+    rff_num_features: int = 16
+    rff_sigma: float = 1.0
+    rff_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    pos_encoding_mode: str = "string_separable"
+    use_qk_norm: bool = True
+    use_surf_to_vol_xattn: bool = True
+    drop_path_max: float = 0.1
+
+    amp_mode: str = "bf16"
+    debug: bool = False
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H229 noise TTA eval")
+    defaults = EvalConfig()
+    for f in fields(EvalConfig):
+        v = getattr(defaults, f.name)
+        cli = f"--{f.name.replace('_', '-')}"
+        if isinstance(v, bool):
+            parser.add_argument(cli, action="store_true", default=v, dest=f.name)
+            parser.add_argument(
+                f"--no-{f.name.replace('_', '-')}",
+                action="store_false",
+                dest=f.name,
+            )
+        else:
+            parser.add_argument(cli, type=type(v), default=v)
+    ns = parser.parse_args(argv)
+    cfg = EvalConfig(**{f.name: getattr(ns, f.name) for f in fields(EvalConfig)})
+    return cfg
+
+
+def parse_rff_init_sigmas(spec: str) -> list[float] | None:
+    if not spec:
+        return None
+    return [float(x) for x in spec.split(",") if x.strip()]
+
+
+def build_model(cfg: EvalConfig) -> SurfaceTransolver:
+    return SurfaceTransolver(
+        n_layers=cfg.model_layers,
+        n_hidden=cfg.model_hidden_dim,
+        dropout=cfg.model_dropout,
+        n_head=cfg.model_heads,
+        mlp_ratio=cfg.model_mlp_ratio,
+        slice_num=cfg.model_slices,
+        rff_num_features=cfg.rff_num_features,
+        rff_sigma=cfg.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(cfg.rff_init_sigmas),
+        pos_encoding_mode=cfg.pos_encoding_mode,
+        use_qk_norm=cfg.use_qk_norm,
+        use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
+        drop_path_max=cfg.drop_path_max,
+    )
+
+
+# --- Mirror helpers (H148 convention, lifted from eval_tta_h209) ---
+
+
+def mirror_inputs(batch: SurfaceBatch) -> SurfaceBatch:
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1].neg_()  # y
+    surface_x[..., 4].neg_()  # normal_y
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1].neg_()  # y
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+
+
+def unmirror_surface_pred(pred: torch.Tensor) -> torch.Tensor:
+    out = pred.clone()
+    out[..., 2].neg_()  # tau_y
+    return out
+
+
+def unmirror_volume_pred(pred: torch.Tensor) -> torch.Tensor:
+    return pred  # volume pressure is invariant
+
+
+# --- Noise helpers ---
+
+
+def noisy_inputs(
+    batch: SurfaceBatch,
+    sigma: float,
+    seed: int,
+) -> SurfaceBatch:
+    """Add isotropic Gaussian noise to (x, y, z) channels of surface_x and volume_x.
+
+    Normals, area, and sdf are NOT noised (they describe the un-perturbed mesh
+    and would be incoherent if perturbed independently of coords).
+    """
+    rng = np.random.RandomState(seed)
+
+    surface_x = batch.surface_x.clone()
+    surf_coords = surface_x[..., :3]
+    surf_noise = torch.from_numpy(
+        rng.standard_normal(size=tuple(surf_coords.shape)).astype(np.float32) * sigma
+    ).to(device=surf_coords.device, dtype=surf_coords.dtype)
+    surface_x[..., :3] = surf_coords + surf_noise
+
+    volume_x = batch.volume_x.clone()
+    vol_coords = volume_x[..., :3]
+    vol_noise = torch.from_numpy(
+        rng.standard_normal(size=tuple(vol_coords.shape)).astype(np.float32) * sigma
+    ).to(device=vol_coords.device, dtype=vol_coords.dtype)
+    volume_x[..., :3] = vol_coords + vol_noise
+
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+
+
+# --- Accumulation helper (lifted verbatim from eval_tta_h209) ---
+
+
+def _accumulate_outputs(
+    acc: EvalAccumulator,
+    batch: SurfaceBatch,
+    surface_pred_norm: torch.Tensor,
+    volume_pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    surface_target_norm = transform.apply_surface(batch.surface_y)
+    volume_target_norm = transform.apply_volume(batch.volume_y)
+
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, batch.surface_mask
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, batch.volume_mask
+    )
+    acc.surface_loss_sse += surface_sse
+    acc.surface_loss_count += surface_count
+    acc.volume_loss_sse += volume_sse
+    acc.volume_loss_count += volume_count
+
+    surface_pred = transform.invert_surface(surface_pred_norm)
+    volume_pred = transform.invert_volume(volume_pred_norm)
+
+    if bool(batch.surface_mask.any()):
+        surface_abs = (surface_pred - batch.surface_y).abs()
+        valid_surface_abs = surface_abs[batch.surface_mask]
+        acc.abs_sums["surface_pressure"] += float(
+            valid_surface_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["surface_pressure"] += int(valid_surface_abs[:, 0].numel())
+        wall_abs = valid_surface_abs[:, 1:4]
+        acc.abs_sums["wall_shear"] += float(wall_abs.sum().detach().cpu().item())
+        acc.abs_counts["wall_shear"] += int(wall_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = wall_abs[:, offset]
+            acc.abs_sums[f"wall_shear_{axis}"] += float(channel.sum().detach().cpu().item())
+            acc.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+        wall_vector_error = torch.linalg.vector_norm(
+            surface_pred[batch.surface_mask][:, 1:4]
+            - batch.surface_y[batch.surface_mask][:, 1:4],
+            dim=-1,
+        )
+        acc.wall_shear_vector_abs_sum += float(
+            wall_vector_error.sum().detach().cpu().item()
+        )
+        acc.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    if bool(batch.volume_mask.any()):
+        volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
+        acc.abs_sums["volume_pressure"] += float(
+            volume_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    for case_idx, case_id in enumerate(batch.case_ids):
+        surface_valid = batch.surface_mask[case_idx].bool()
+        if bool(surface_valid.any()):
+            surface_pred_valid = surface_pred[case_idx][surface_valid]
+            surface_target_valid = batch.surface_y[case_idx][surface_valid]
+            _accumulate_case_rel_l2(
+                acc.case_sums["surface_pressure"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 0:1],
+                target=surface_target_valid[:, 0:1],
+            )
+            _accumulate_case_rel_l2(
+                acc.case_sums["wall_shear"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 1:4],
+                target=surface_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    acc.case_sums[f"wall_shear_{axis}"],
+                    case_id=case_id,
+                    pred=surface_pred_valid[:, channel : channel + 1],
+                    target=surface_target_valid[:, channel : channel + 1],
+                )
+        volume_valid = batch.volume_mask[case_idx].bool()
+        if bool(volume_valid.any()):
+            _accumulate_case_rel_l2(
+                acc.case_sums["volume_pressure"],
+                case_id=case_id,
+                pred=volume_pred[case_idx][volume_valid],
+                target=batch.volume_y[case_idx][volume_valid],
+            )
+
+
+def evaluate_tta_split(
+    *,
+    model: nn.Module,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    noise_sigma: float,
+    noise_passes: int,
+    rank: int,
+    distributed_state,
+) -> dict[str, dict[str, float]]:
+    """Single pass over loader; per batch run orig + mirror + K noise forwards.
+
+    Returns dict keyed by mode in {orig, mirror, noise, tta}.
+    """
+    acc_orig = EvalAccumulator()
+    acc_mirror = EvalAccumulator()
+    acc_noise = EvalAccumulator()
+    acc_tta = EvalAccumulator()
+
+    model.eval()
+    eval_module = unwrap_model(model)
+
+    # tta weight: equal-weight average of (1 mirror + K noise) passes.
+    n_tta = 1 + noise_passes
+    w = 1.0 / float(n_tta)
+
+    with torch.no_grad():
+        for batch_idx, batch in enumerate(loader):
+            batch = batch.to(device)
+            mirrored = mirror_inputs(batch)
+
+            with autocast_context(device, amp_mode):
+                out_orig = eval_module(
+                    surface_x=batch.surface_x,
+                    surface_mask=batch.surface_mask,
+                    volume_x=batch.volume_x,
+                    volume_mask=batch.volume_mask,
+                )
+                out_mirror = eval_module(
+                    surface_x=mirrored.surface_x,
+                    surface_mask=mirrored.surface_mask,
+                    volume_x=mirrored.volume_x,
+                    volume_mask=mirrored.volume_mask,
+                )
+
+            surface_pred_orig = out_orig["surface_preds"].float()
+            volume_pred_orig = out_orig["volume_preds"].float()
+
+            surface_pred_mirror_raw = out_mirror["surface_preds"].float()
+            volume_pred_mirror_raw = out_mirror["volume_preds"].float()
+            surface_pred_mirror = unmirror_surface_pred(surface_pred_mirror_raw)
+            volume_pred_mirror = unmirror_volume_pred(volume_pred_mirror_raw)
+
+            surface_pred_noise_sum = torch.zeros_like(surface_pred_orig)
+            volume_pred_noise_sum = torch.zeros_like(volume_pred_orig)
+
+            for pass_idx in range(noise_passes):
+                # Distinct seed per (pass, rank, batch) so noise differs across all axes
+                # but stays reproducible. Mixes 42+pass_idx (advisor scheme) with
+                # rank and a stable batch counter.
+                seed = ((42 + pass_idx) * 100003) ^ (rank * 1009 + batch_idx)
+                seed = seed & 0xFFFFFFFF  # numpy seed must fit in uint32
+                noisy = noisy_inputs(batch, sigma=noise_sigma, seed=seed)
+                with autocast_context(device, amp_mode):
+                    out_k = eval_module(
+                        surface_x=noisy.surface_x,
+                        surface_mask=noisy.surface_mask,
+                        volume_x=noisy.volume_x,
+                        volume_mask=noisy.volume_mask,
+                    )
+                surface_pred_noise_sum += out_k["surface_preds"].float()
+                volume_pred_noise_sum += out_k["volume_preds"].float()
+
+            # Equal-weight average over the K noise passes (diagnostic mode)
+            surface_pred_noise_avg = surface_pred_noise_sum / float(noise_passes)
+            volume_pred_noise_avg = volume_pred_noise_sum / float(noise_passes)
+
+            # 5-pass TTA: w * (mirror + sum_k noise_k)
+            surface_pred_tta = w * (surface_pred_mirror + surface_pred_noise_sum)
+            volume_pred_tta = w * (volume_pred_mirror + volume_pred_noise_sum)
+
+            _accumulate_outputs(acc_orig, batch, surface_pred_orig, volume_pred_orig, transform)
+            _accumulate_outputs(acc_mirror, batch, surface_pred_mirror, volume_pred_mirror, transform)
+            _accumulate_outputs(acc_noise, batch, surface_pred_noise_avg, volume_pred_noise_avg, transform)
+            _accumulate_outputs(acc_tta, batch, surface_pred_tta, volume_pred_tta, transform)
+
+    out_metrics: dict[str, dict[str, float]] = {}
+    for mode_name, acc in (("orig", acc_orig), ("mirror", acc_mirror), ("noise", acc_noise), ("tta", acc_tta)):
+        if distributed_state is not None and distributed_state.enabled:
+            gathered = [None for _ in range(distributed_state.world_size)]
+            dist.all_gather_object(gathered, acc)
+            if distributed_state.is_main:
+                merged = merge_eval_accumulators(g for g in gathered if g is not None)
+                out_metrics[mode_name] = finalize_eval_accumulator(merged)
+            else:
+                out_metrics[mode_name] = {}
+        else:
+            out_metrics[mode_name] = finalize_eval_accumulator(acc)
+    return out_metrics
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+    if state.is_main:
+        ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
+        print(f"Device: {device}{ddp_suffix}")
+        print(f"Checkpoint: {cfg.checkpoint}")
+        print(f"Noise TTA: sigma={cfg.noise_sigma}, K={cfg.noise_passes} (+1 mirror = {1+cfg.noise_passes}-pass)")
+
+    train_loader, val_loaders, test_loaders, stats = make_loaders(cfg, distributed_state=state)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(cfg).to(device)
+    ck = torch.load(cfg.checkpoint, map_location="cpu", weights_only=False)
+    state_dict = ck["model"]
+    state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if state.is_main:
+        print(f"Loaded checkpoint epoch={ck.get('epoch')} source={ck.get('checkpoint_source')}")
+        print(f"  missing={len(missing)} unexpected={len(unexpected)}")
+        if missing:
+            print(f"  missing[:5]={missing[:5]}")
+        if unexpected:
+            print(f"  unexpected[:5]={unexpected[:5]}")
+    model.eval()
+
+    run = None
+    if state.is_main:
+        run_name = cfg.wandb_name or f"{cfg.agent}/h229-noise-sigma{cfg.noise_sigma}-K{cfg.noise_passes}"
+        run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8"),
+            entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
+            group=cfg.wandb_group,
+            name=run_name,
+            config={
+                **asdict(cfg),
+                "checkpoint_run_id": "yw2a5dyl",
+                "checkpoint_epoch": ck.get("epoch"),
+                "checkpoint_source": ck.get("checkpoint_source"),
+                "tta_total_passes": 1 + cfg.noise_passes,
+                "tta_weight_per_pass": 1.0 / float(1 + cfg.noise_passes),
+            },
+            tags=["h229", "tta", "noise-aug", "mirror-aug", "eval-only", cfg.agent],
+            reinit="finish_previous",
+        )
+
+    splits = [
+        ("val_surface", val_loaders["val_surface"], "full_val"),
+        ("test_surface", test_loaders["test_surface"], "test"),
+    ]
+
+    summary: dict[str, dict[str, dict[str, float]]] = {}
+    for name, loader, log_prefix in splits:
+        if state.is_main:
+            print(f"\n=== Evaluating split={name} ===")
+        t0 = time.time()
+        modes = evaluate_tta_split(
+            model=model,
+            loader=loader,
+            transform=transform,
+            device=device,
+            amp_mode=cfg.amp_mode,
+            noise_sigma=cfg.noise_sigma,
+            noise_passes=cfg.noise_passes,
+            rank=state.rank,
+            distributed_state=state,
+        )
+        dt = time.time() - t0
+        if state.is_main:
+            print(f"  done in {dt:.1f}s")
+            for mode_name, metrics in modes.items():
+                print(f"  -- {mode_name} --")
+                print_metrics(name, metrics)
+            summary[name] = modes
+
+            log_obj: dict[str, float] = {}
+            for mode_name, metrics in modes.items():
+                log_obj.update(primary_metric_log(f"{log_prefix}_primary/{mode_name}", metrics))
+                log_obj.update({f"{log_prefix}_extra/{mode_name}/loss": metrics["loss"]})
+            if run is not None:
+                wandb.log(log_obj)
+
+    if state.is_main and summary:
+        # Compact comparison table
+        print("\n=== Summary (rel_l2_pct lower-is-better) ===")
+        for split, modes in summary.items():
+            print(f"\n[{split}]")
+            keys = (
+                "abupt_axis_mean_rel_l2_pct",
+                "surface_pressure_rel_l2_pct",
+                "wall_shear_rel_l2_pct",
+                "wall_shear_x_rel_l2_pct",
+                "wall_shear_y_rel_l2_pct",
+                "wall_shear_z_rel_l2_pct",
+                "volume_pressure_rel_l2_pct",
+            )
+            header = f"  {'metric':<36s}" + "".join(f" {m:>10s}" for m in modes) + f" {'tta_vs_orig':>12s}"
+            print(header)
+            for k in keys:
+                vals = {m: modes[m][k] for m in modes}
+                d = vals["tta"] - vals["orig"]
+                row = f"  {k:<36s}" + "".join(f" {vals[m]:>10.4f}" for m in modes) + f" {d:>+12.4f}"
+                print(row)
+
+        if run is not None:
+            for split, modes in summary.items():
+                for mode_name, metrics in modes.items():
+                    for k, v in metrics.items():
+                        try:
+                            run.summary[f"{split}/{mode_name}/{k}"] = float(v)
+                        except Exception:
+                            pass
+            run.finish()
+
+    cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## H229: TTA with input coordinate Gaussian noise σ=0.001 on H185 EP13

### Hypothesis
Mirror and rotational TTA exploit geometric symmetries. Gaussian coordinate noise is a different augmentation strategy: instead of symmetry, we exploit the fact that small perturbations to input node positions should produce similar outputs (the solution field is continuous w.r.t. mesh position). Averaging predictions over several noise realizations can cancel high-frequency prediction errors. This tests whether noise-based TTA is complementary or redundant with geometric TTA.

### Context

**Current SOTA (PR #1382 H209)**: val_abupt=5.9755, test_abupt=5.8221, test_WSS=6.7214, test_VP=3.4400, test_SP=3.6806
**Source checkpoint**: W&B run `yw2a5dyl` EP13 EMA (`epoch-13`/`best`)
**TTA infra**: `eval_tta_h209.py` is on tay (read it before extending — has mirror_inputs, unmirror_surface_pred, unmirror_volume_pred)
**Merge gate**: val_abupt < 5.9755 AND test_abupt < 5.8221
**Paper floor**: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS ≤ 6.727
**DDP**: 8 GPUs every run
**Budget**: ~45-60min each (eval-only, NO training)
**Coordination**: askeladd is running H223 in parallel (rotational TTA ±2° around x-axis). If askeladd's H223 shows a gain, your variant may stack additively on top.

### Background

Noise-based TTA is used widely in point-cloud and mesh models. The idea: the model sees slightly jittered node positions and must predict the same physics. By averaging K noisy predictions, we cancel random errors while keeping the systematic prediction. Key questions:
- σ=0.001 in mesh coordinate units: is this physically reasonable? Mesh node spacing in DrivAerML is typically 0.001-0.01m, so σ=0.001 is a 10-100% perturbation at the finest resolution — this may be too large. If it degrades, try σ=0.0001.
- How many noise passes? 4-5 passes takes the same wall time as 4 geometric passes.

The experiment design: 1 mirror pass + 4 noise passes (total 5 passes, weights 0.2 each). Mirror is included because we know it helps.

### Student Instructions

Create `eval_tta_h229.py` by extending `eval_tta_h209.py`. Add `--noise_sigma` (float, default 0.001) and `--noise_passes` (int, default 4) arguments.

**5-pass TTA:**
- Pass 1: mirror (y → -y) — weight 0.2, use existing `mirror_inputs`, `unmirror_surface_pred`, `unmirror_volume_pred`
- Passes 2–5: original coordinates + Gaussian noise ε ~ N(0, σ²) per node coordinate — weight 0.2 each, NO unrotation needed (noise is symmetric so no inverse transform required)

**Noise application:**
```python
def add_coordinate_noise(coords, sigma):
    """Add isotropic Gaussian noise to node coordinates."""
    noise = np.random.randn(*coords.shape) * sigma
    return coords + noise
```

Note: set a fixed numpy seed per-pass for reproducibility (`np.random.seed(42 + pass_idx)`).

**Run command (primary: σ=0.001, 4 noise passes):**
```bash
torchrun --nproc_per_node=8 eval_tta_h229.py \
  --run_id yw2a5dyl \
  --checkpoint epoch-13 \
  --use_ema \
  --noise_sigma 0.001 \
  --noise_passes 4 \
  --wandb_group h229-tanjiro-noise-tta \
  --wandb_run_name "h229-noise-sigma1e-3-4pass"
```

**Secondary run (σ=0.0001, finer perturbation):**
```bash
torchrun --nproc_per_node=8 eval_tta_h229.py \
  --run_id yw2a5dyl \
  --checkpoint epoch-13 \
  --use_ema \
  --noise_sigma 0.0001 \
  --noise_passes 4 \
  --wandb_group h229-tanjiro-noise-tta \
  --wandb_run_name "h229-noise-sigma1e-4-4pass"
```

### Results Table

| Run | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B Run ID |
|-----|-----------|------------|----------|---------|---------|------------|
| H229 σ=0.001, 4 noise + mirror | | | | | | |
| H229 σ=0.0001, 4 noise + mirror | | | | | | |
| H209 SOTA (mirror TTA only) | 5.9755 | 5.8221 | 6.7214 | 3.4400 | 3.6806 | yw2a5dyl |

### Merge Criteria

- **Merge**: val_abupt < 5.9755 AND test_abupt < 5.8221
- **Request changes**: if one σ level is promising, sweep a narrower range
- **Close**: if both runs degrade beyond +0.05pp

### Terminal Result Marker

Report the best-performing σ configuration:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<sigma1e-3-run-id>","<sigma1e-4-run-id>"],"primary_metric":{"name":"val_abupt","value":<best_val>},"test_metric":{"name":"test_abupt","value":<best_test>}}
```
