### PR TITLE
H230: TTA-mirror on H183 / H190 / H148 — N=5 cross-checkpoint Finding Q extension

### DIFF
--- a/eval_tta_h209.py
+++ b/eval_tta_h209.py
@@ -62,6 +62,7 @@ class EvalConfig:
     """
 
     checkpoint: str = ""
+    run_id: str = "yw2a5dyl"
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
     output_dir: str = "outputs/h209_eval"
@@ -396,7 +397,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
             group=cfg.wandb_group,
             name=run_name,
-            config={**asdict(cfg), "checkpoint_run_id": "yw2a5dyl", "checkpoint_epoch": ck.get("epoch")},
+            config={**asdict(cfg), "checkpoint_run_id": cfg.run_id, "checkpoint_epoch": ck.get("epoch")},
             tags=["h209", "tta", "mirror-aug", "eval-only", cfg.agent],
             reinit="finish_previous",
         )


### PR DESCRIPTION
## H230: TTA-mirror on H183 / H190 / H148 — N=5 cross-checkpoint Finding Q extension

### Hypothesis
Finding Q established that TTA gives +4-5bp on the H185 mirror-aug checkpoint. H183, H190, and H148 are other mirror-aug trained checkpoints that were not tested with TTA. If TTA gain is consistent across mirror-aug checkpoints (+4-5bp each), this extends Finding Q and may reveal whether the TTA benefit is checkpoint-specific or a general property of mirror-aug training.

### Context

**Current SOTA (PR #1382 H209)**: val_abupt=5.9755, test_abupt=5.8221, test_WSS=6.7214, test_VP=3.4400, test_SP=3.6806
**Source checkpoint**: W&B run `yw2a5dyl` EP13 EMA (`epoch-13`/`best`)
**TTA infra**: `eval_tta_h209.py` is on tay (read it before extending — has mirror_inputs, unmirror_surface_pred, unmirror_volume_pred)
**Merge gate**: val_abupt < 5.9755 AND test_abupt < 5.8221
**Paper floor**: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS ≤ 6.727
**DDP**: 8 GPUs every run
**Budget**: ~45-60min each (eval-only, NO training)
**Coordination**: askeladd is running H223 in parallel (rotational TTA ±2° around x-axis). If askeladd's H223 shows a gain, your variant may stack additively on top.

### Background

The TTA story so far:
- Finding N: TTA on NON-mirror-trained checkpoints → +1.27-1.38pp degradation (bad)
- Finding Q: TTA on H185 (mirror-aug) → +4-5bp improvement (good, but small)
- H209: merged the H185+TTA result as new SOTA

The open question: is the +4-5bp gain locked to H185 specifically, or is it general across all mirror-aug checkpoints? If other mirror-aug checkpoints also benefit, TTA is a reliable post-hoc boost we can apply to any future mirror-aug model. If the gain varies a lot (e.g., some checkpoints get +10bp, some get nothing), that tells us TTA interacts with specific training dynamics.

**Target checkpoints to evaluate:**
- H183: see PR comments/body for its W&B run ID and best checkpoint epoch
- H190: see PR for its W&B run ID and best checkpoint epoch  
- H148: see PR for its W&B run ID and best checkpoint epoch

Look up each PR to find the run IDs and best checkpoint epochs before running.

### Student Instructions

You only need to run `eval_tta_h209.py` exactly as-is — NO code modifications. Apply it to three checkpoints:

**Step 1: Find run IDs and best epochs**
Look at PRs for H183, H190, H148. Get each checkpoint's W&B run ID and best epoch. Also note each checkpoint's no-TTA baseline val_abupt.

**Step 2: Run TTA on each checkpoint**

```bash
# H183
torchrun --nproc_per_node=8 eval_tta_h209.py \
  --run_id <H183_RUN_ID> \
  --checkpoint <H183_BEST_EPOCH> \
  --use_ema \
  --wandb_group h230-thorfinn-tta-cross \
  --wandb_run_name "h230-mirror-tta-h183"

# H190
torchrun --nproc_per_node=8 eval_tta_h209.py \
  --run_id <H190_RUN_ID> \
  --checkpoint <H190_BEST_EPOCH> \
  --use_ema \
  --wandb_group h230-thorfinn-tta-cross \
  --wandb_run_name "h230-mirror-tta-h190"

# H148
torchrun --nproc_per_node=8 eval_tta_h209.py \
  --run_id <H148_RUN_ID> \
  --checkpoint <H148_BEST_EPOCH> \
  --use_ema \
  --wandb_group h230-thorfinn-tta-cross \
  --wandb_run_name "h230-mirror-tta-h148"
```

### Results Table

| Checkpoint | no-TTA val_abupt | TTA val_abupt | delta | TTA test_abupt | test_WSS | W&B Run ID |
|------------|-----------------|---------------|-------|----------------|----------|------------|
| H183 | (from PR) | | | | | |
| H190 | (from PR) | | | | | |
| H148 | (from PR) | | | | | |
| H185/H209 (reference) | 5.9840 | 5.9755 | -0.0085 | 5.8221 | 6.7214 | yw2a5dyl |

Include the no-TTA baseline for each checkpoint so we can compute the delta precisely.

### Merge Criteria

- **Merge**: any checkpoint reaches val_abupt < 5.9755 AND test_abupt < 5.8221 with TTA
- **Request changes**: if TTA benefit is consistent (+3-10bp) across checkpoints — confirms Finding Q generalizes, I'll direct further extension
- **Close**: if all checkpoints show TTA degradation (confirms TTA is H185-specific)

### Terminal Result Marker

Report the best-performing checkpoint+TTA combination:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<h183-run-id>","<h190-run-id>","<h148-run-id>"],"primary_metric":{"name":"val_abupt","value":<best_val>},"test_metric":{"name":"test_abupt","value":<best_test>}}
```
