### PR TITLE
H231: Mesh point subsampling TTA — random N-point subset per pass

### DIFF
--- a/eval_tta_h231.py
+++ b/eval_tta_h231.py
@@ -1,0 +1,622 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H231: Mesh-subsample TTA eval on H185 EP13 checkpoint (eval-only, no training).
+
+For each batch we forward the model multiple times and average predictions in
+normalized space, exactly like H209 but with the y-mirror swapped/augmented by
+random point subsampling.
+
+Modes (all share the same per-batch forward passes — selection is bookkeeping only):
+    * original                  : forward on the unmodified inputs (Pass A)
+    * mirror_only               : un-mirrored forward on the y-mirrored geometry (Pass B)
+    * mirror_tta                : (orig + mirror) / 2 — the H209 SOTA baseline (no subsample)
+    * subsample_only_naive      : mean of 4 subsample passes, /num_passes (PR strategy a)
+    * subsample_only_mc         : Monte-Carlo coverage mean over 4 subsample passes (strategy b)
+    * mirror_subsample_naive    : mean of 5 passes (orig + mirror + 3 subsamples)
+    * mirror_subsample_mc       : MC-coverage mean of the same 5 passes
+
+Subsampling: per pass we draw an i.i.d. Bernoulli(keep_rate=0.8) keep-mask over
+valid surface and volume points (independent of each other). The model's
+``surface_mask`` and ``volume_mask`` are set to the subset mask, so suppressed
+points contribute nothing to slice attention. The model zeros the output at
+suppressed positions (``surface_preds *= surface_mask``); the naive mean
+therefore shrinks predictions toward zero at uncovered positions, while the MC
+variant averages only over the passes where each point was active.
+
+Original H209 mirror convention (kept for the mirror passes):
+    surface_x [x, y, z, nx, ny, nz, area] -> negate y(1) and ny(4)
+    volume_x  [x, y, z, sdf]              -> negate y(1)
+    surface_y predictions [cp, tau_x, tau_y, tau_z] -> un-mirror by negating tau_y(2)
+    volume_y predictions [volume_pressure] -> invariant
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import asdict, dataclass, field, fields
+from typing import Iterable
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import wandb
+
+from data import SurfaceBatch
+from model import SurfaceTransolver
+from trainer_runtime import (
+    EvalAccumulator,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    finalize_eval_accumulator,
+    init_distributed,
+    make_loaders,
+    merge_eval_accumulators,
+    primary_metric_log,
+    print_metrics,
+    unwrap_model,
+)
+
+
+# Modes in the order they appear in the summary table.
+ALL_MODES = (
+    "original",
+    "mirror_only",
+    "mirror_tta",
+    "subsample_only_naive",
+    "subsample_only_mc",
+    "mirror_subsample_naive",
+    "mirror_subsample_mc",
+)
+
+
+@dataclass
+class EvalConfig:
+    """Minimal eval-only config — mirrors EvalConfig from eval_tta_h209.py."""
+
+    checkpoint: str = ""
+    manifest: str = "data/split_manifest.json"
+    data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+    output_dir: str = "outputs/h231_eval"
+    wandb_group: str = "h231-askeladd-mesh-subsample-tta"
+    wandb_name: str = ""
+    agent: str = "askeladd"
+
+    eval_modes: str = ",".join(ALL_MODES)
+    subsample_rate: float = 0.8
+    num_subsample_passes: int = 4
+    subsample_seed: int = 20260529
+
+    batch_size: int = 2
+    eval_surface_points: int = 65536
+    eval_volume_points: int = 65536
+    train_surface_points: int = 65536
+    train_volume_points: int = 65536
+    num_workers: int = -1
+    pin_memory: bool = True
+    persistent_workers: bool = True
+    prefetch_factor: int = 2
+
+    model_layers: int = 5
+    model_hidden_dim: int = 512
+    model_heads: int = 4
+    model_mlp_ratio: int = 4
+    model_slices: int = 128
+    model_dropout: float = 0.0
+    rff_num_features: int = 16
+    rff_sigma: float = 1.0
+    rff_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    pos_encoding_mode: str = "string_separable"
+    use_qk_norm: bool = True
+    use_surf_to_vol_xattn: bool = True
+    drop_path_max: float = 0.1
+
+    amp_mode: str = "bf16"
+    debug: bool = False
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H231 mesh-subsample TTA eval")
+    defaults = EvalConfig()
+    for f in fields(EvalConfig):
+        v = getattr(defaults, f.name)
+        cli = f"--{f.name.replace('_', '-')}"
+        if isinstance(v, bool):
+            parser.add_argument(cli, action="store_true", default=v, dest=f.name)
+            parser.add_argument(
+                f"--no-{f.name.replace('_', '-')}",
+                action="store_false",
+                dest=f.name,
+            )
+        else:
+            parser.add_argument(cli, type=type(v), default=v)
+    ns = parser.parse_args(argv)
+    cfg = EvalConfig(**{f.name: getattr(ns, f.name) for f in fields(EvalConfig)})
+    return cfg
+
+
+def parse_rff_init_sigmas(spec: str) -> list[float] | None:
+    if not spec:
+        return None
+    return [float(x) for x in spec.split(",") if x.strip()]
+
+
+def build_model(cfg: EvalConfig) -> SurfaceTransolver:
+    return SurfaceTransolver(
+        n_layers=cfg.model_layers,
+        n_hidden=cfg.model_hidden_dim,
+        dropout=cfg.model_dropout,
+        n_head=cfg.model_heads,
+        mlp_ratio=cfg.model_mlp_ratio,
+        slice_num=cfg.model_slices,
+        rff_num_features=cfg.rff_num_features,
+        rff_sigma=cfg.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(cfg.rff_init_sigmas),
+        pos_encoding_mode=cfg.pos_encoding_mode,
+        use_qk_norm=cfg.use_qk_norm,
+        use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
+        drop_path_max=cfg.drop_path_max,
+    )
+
+
+# --- TTA helpers ---------------------------------------------------------
+
+
+def mirror_inputs(batch: SurfaceBatch) -> SurfaceBatch:
+    """Negate y/normal_y in surface_x, y in volume_x. Keep masks/targets unchanged."""
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1].neg_()
+    surface_x[..., 4].neg_()
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1].neg_()
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+
+
+def unmirror_surface_pred(pred: torch.Tensor) -> torch.Tensor:
+    out = pred.clone()
+    out[..., 2].neg_()
+    return out
+
+
+def unmirror_volume_pred(pred: torch.Tensor) -> torch.Tensor:
+    return pred
+
+
+def subset_mask(
+    mask: torch.Tensor, keep_rate: float, generator: torch.Generator
+) -> torch.Tensor:
+    """Bernoulli-keep a fraction of the True positions of ``mask``.
+
+    The returned tensor is False wherever ``mask`` was False (padding stays
+    masked) and False at a random ``1 - keep_rate`` fraction of the True
+    positions.
+    """
+    keep = torch.rand(
+        mask.shape, generator=generator, device=mask.device
+    ) < keep_rate
+    return mask & keep
+
+
+# --- Eval accumulation --------------------------------------------------
+
+
+def _accumulate_outputs(
+    acc: EvalAccumulator,
+    batch: SurfaceBatch,
+    surface_pred_norm: torch.Tensor,
+    volume_pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    """Mirror eval_tta_h209._accumulate_outputs — accumulate one mode for one batch."""
+    surface_target_norm = transform.apply_surface(batch.surface_y)
+    volume_target_norm = transform.apply_volume(batch.volume_y)
+
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, batch.surface_mask
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, batch.volume_mask
+    )
+    acc.surface_loss_sse += surface_sse
+    acc.surface_loss_count += surface_count
+    acc.volume_loss_sse += volume_sse
+    acc.volume_loss_count += volume_count
+
+    surface_pred = transform.invert_surface(surface_pred_norm)
+    volume_pred = transform.invert_volume(volume_pred_norm)
+
+    if bool(batch.surface_mask.any()):
+        surface_abs = (surface_pred - batch.surface_y).abs()
+        valid_surface_abs = surface_abs[batch.surface_mask]
+        acc.abs_sums["surface_pressure"] += float(
+            valid_surface_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["surface_pressure"] += int(valid_surface_abs[:, 0].numel())
+        wall_abs = valid_surface_abs[:, 1:4]
+        acc.abs_sums["wall_shear"] += float(wall_abs.sum().detach().cpu().item())
+        acc.abs_counts["wall_shear"] += int(wall_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = wall_abs[:, offset]
+            acc.abs_sums[f"wall_shear_{axis}"] += float(channel.sum().detach().cpu().item())
+            acc.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+        wall_vector_error = torch.linalg.vector_norm(
+            surface_pred[batch.surface_mask][:, 1:4]
+            - batch.surface_y[batch.surface_mask][:, 1:4],
+            dim=-1,
+        )
+        acc.wall_shear_vector_abs_sum += float(
+            wall_vector_error.sum().detach().cpu().item()
+        )
+        acc.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    if bool(batch.volume_mask.any()):
+        volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
+        acc.abs_sums["volume_pressure"] += float(
+            volume_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    for case_idx, case_id in enumerate(batch.case_ids):
+        surface_valid = batch.surface_mask[case_idx].bool()
+        if bool(surface_valid.any()):
+            surface_pred_valid = surface_pred[case_idx][surface_valid]
+            surface_target_valid = batch.surface_y[case_idx][surface_valid]
+            _accumulate_case_rel_l2(
+                acc.case_sums["surface_pressure"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 0:1],
+                target=surface_target_valid[:, 0:1],
+            )
+            _accumulate_case_rel_l2(
+                acc.case_sums["wall_shear"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 1:4],
+                target=surface_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    acc.case_sums[f"wall_shear_{axis}"],
+                    case_id=case_id,
+                    pred=surface_pred_valid[:, channel : channel + 1],
+                    target=surface_target_valid[:, channel : channel + 1],
+                )
+        volume_valid = batch.volume_mask[case_idx].bool()
+        if bool(volume_valid.any()):
+            _accumulate_case_rel_l2(
+                acc.case_sums["volume_pressure"],
+                case_id=case_id,
+                pred=volume_pred[case_idx][volume_valid],
+                target=batch.volume_y[case_idx][volume_valid],
+            )
+
+
+# --- Main TTA driver ----------------------------------------------------
+
+
+def evaluate_tta_split(
+    *,
+    model: nn.Module,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    distributed_state,
+    cfg: EvalConfig,
+    modes: list[str],
+) -> dict[str, dict[str, float]]:
+    """Run all requested modes in a single pass through the loader.
+
+    Returns ``{mode: metrics}`` on rank 0; non-rank-0 ranks return empty dicts.
+    """
+    accs: dict[str, EvalAccumulator] = {m: EvalAccumulator() for m in modes}
+
+    # Decide once per call which physical passes are needed.
+    need_orig = any(
+        m in modes
+        for m in ("original", "mirror_tta", "mirror_subsample_naive", "mirror_subsample_mc")
+    )
+    need_mirror = any(
+        m in modes
+        for m in ("mirror_only", "mirror_tta", "mirror_subsample_naive", "mirror_subsample_mc")
+    )
+    need_subsample = any(
+        m in modes
+        for m in (
+            "subsample_only_naive",
+            "subsample_only_mc",
+            "mirror_subsample_naive",
+            "mirror_subsample_mc",
+        )
+    )
+
+    n_sub = cfg.num_subsample_passes if need_subsample else 0
+    # mirror_subsample uses orig + mirror + (n_sub - 1) subsample passes per PR spec.
+    # We reuse the first n_sub - 1 subsample passes (and the n_sub'th when standalone).
+    n_sub_for_mirror = max(0, n_sub - 1)
+
+    rank = distributed_state.rank if distributed_state is not None else 0
+    base_seed = cfg.subsample_seed + rank * 100003
+
+    model.eval()
+    eval_module = unwrap_model(model)
+
+    with torch.no_grad():
+        for batch_idx, batch in enumerate(loader):
+            batch = batch.to(device)
+
+            generator = torch.Generator(device=device)
+            generator.manual_seed(base_seed + batch_idx * 9973)
+
+            # Pass A: original
+            surface_pred_a = None
+            volume_pred_a = None
+            if need_orig:
+                with autocast_context(device, amp_mode):
+                    out_a = eval_module(
+                        surface_x=batch.surface_x,
+                        surface_mask=batch.surface_mask,
+                        volume_x=batch.volume_x,
+                        volume_mask=batch.volume_mask,
+                    )
+                surface_pred_a = out_a["surface_preds"].float()
+                volume_pred_a = out_a["volume_preds"].float()
+
+            # Pass B: mirror (un-mirrored)
+            surface_pred_b = None
+            volume_pred_b = None
+            if need_mirror:
+                mirrored = mirror_inputs(batch)
+                with autocast_context(device, amp_mode):
+                    out_b = eval_module(
+                        surface_x=mirrored.surface_x,
+                        surface_mask=mirrored.surface_mask,
+                        volume_x=mirrored.volume_x,
+                        volume_mask=mirrored.volume_mask,
+                    )
+                surface_pred_b = unmirror_surface_pred(out_b["surface_preds"].float())
+                volume_pred_b = unmirror_volume_pred(out_b["volume_preds"].float())
+
+            # Passes C_i: subsample (i = 0..n_sub-1)
+            sub_surface_preds: list[torch.Tensor] = []
+            sub_volume_preds: list[torch.Tensor] = []
+            sub_surface_masks: list[torch.Tensor] = []
+            sub_volume_masks: list[torch.Tensor] = []
+            for _ in range(n_sub):
+                sm = subset_mask(batch.surface_mask, cfg.subsample_rate, generator)
+                vm = subset_mask(batch.volume_mask, cfg.subsample_rate, generator)
+                with autocast_context(device, amp_mode):
+                    out_c = eval_module(
+                        surface_x=batch.surface_x,
+                        surface_mask=sm,
+                        volume_x=batch.volume_x,
+                        volume_mask=vm,
+                    )
+                sub_surface_preds.append(out_c["surface_preds"].float())
+                sub_volume_preds.append(out_c["volume_preds"].float())
+                sub_surface_masks.append(sm)
+                sub_volume_masks.append(vm)
+
+            # ---- Compose per-mode predictions ---------------------------------
+            for mode in modes:
+                if mode == "original":
+                    sp = surface_pred_a
+                    vp = volume_pred_a
+                elif mode == "mirror_only":
+                    sp = surface_pred_b
+                    vp = volume_pred_b
+                elif mode == "mirror_tta":
+                    sp = (surface_pred_a + surface_pred_b) * 0.5
+                    vp = (volume_pred_a + volume_pred_b) * 0.5
+                elif mode == "subsample_only_naive":
+                    sp = sum(sub_surface_preds) / float(n_sub)
+                    vp = sum(sub_volume_preds) / float(n_sub)
+                elif mode == "subsample_only_mc":
+                    sp_sum = sum(sub_surface_preds)
+                    vp_sum = sum(sub_volume_preds)
+                    sm_count = sum(m.float() for m in sub_surface_masks)
+                    vm_count = sum(m.float() for m in sub_volume_masks)
+                    # Where coverage is 0 (rare with 4 passes at p=0.8) fall back to /1
+                    # so the prediction stays 0 — the eval mask will exclude these padding
+                    # rows for padded points; for non-padded points this is a tiny bias.
+                    sm_safe = sm_count.clamp_min(1.0).unsqueeze(-1)
+                    vm_safe = vm_count.clamp_min(1.0).unsqueeze(-1)
+                    sp = sp_sum / sm_safe
+                    vp = vp_sum / vm_safe
+                elif mode == "mirror_subsample_naive":
+                    sub_used_s = sub_surface_preds[:n_sub_for_mirror]
+                    sub_used_v = sub_volume_preds[:n_sub_for_mirror]
+                    n_total = 2 + len(sub_used_s)
+                    sp = (surface_pred_a + surface_pred_b + sum(sub_used_s)) / float(n_total)
+                    vp = (volume_pred_a + volume_pred_b + sum(sub_used_v)) / float(n_total)
+                elif mode == "mirror_subsample_mc":
+                    sub_used_s = sub_surface_preds[:n_sub_for_mirror]
+                    sub_used_v = sub_volume_preds[:n_sub_for_mirror]
+                    sub_used_sm = sub_surface_masks[:n_sub_for_mirror]
+                    sub_used_vm = sub_volume_masks[:n_sub_for_mirror]
+                    # orig + mirror have full coverage (each contributes 1 to every valid pt)
+                    full_count_s = 2.0 * batch.surface_mask.float()
+                    full_count_v = 2.0 * batch.volume_mask.float()
+                    sm_count = full_count_s + sum(m.float() for m in sub_used_sm)
+                    vm_count = full_count_v + sum(m.float() for m in sub_used_vm)
+                    sm_safe = sm_count.clamp_min(1.0).unsqueeze(-1)
+                    vm_safe = vm_count.clamp_min(1.0).unsqueeze(-1)
+                    sp = (surface_pred_a + surface_pred_b + sum(sub_used_s)) / sm_safe
+                    vp = (volume_pred_a + volume_pred_b + sum(sub_used_v)) / vm_safe
+                else:
+                    raise ValueError(f"Unknown mode: {mode}")
+
+                _accumulate_outputs(accs[mode], batch, sp, vp, transform)
+
+    # Reduce per-mode accumulators across ranks.
+    finalized: dict[str, dict[str, float]] = {}
+    for mode in modes:
+        acc = accs[mode]
+        if distributed_state is not None and distributed_state.enabled:
+            gathered = [None for _ in range(distributed_state.world_size)]
+            dist.all_gather_object(gathered, acc)
+            if distributed_state.is_main:
+                merged = merge_eval_accumulators(g for g in gathered if g is not None)
+                finalized[mode] = finalize_eval_accumulator(merged)
+            else:
+                finalized[mode] = {}
+        else:
+            finalized[mode] = finalize_eval_accumulator(acc)
+
+    return finalized
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+
+    modes = [m.strip() for m in cfg.eval_modes.split(",") if m.strip()]
+    unknown = [m for m in modes if m not in ALL_MODES]
+    if unknown:
+        raise ValueError(f"Unknown eval modes: {unknown}; allowed={ALL_MODES}")
+
+    if state.is_main:
+        ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
+        print(f"Device: {device}{ddp_suffix}")
+        print(f"Checkpoint: {cfg.checkpoint}")
+        print(f"Modes: {modes}")
+        print(
+            f"Subsample: keep_rate={cfg.subsample_rate} num_passes={cfg.num_subsample_passes}"
+        )
+
+    _, val_loaders, test_loaders, stats = make_loaders(cfg, distributed_state=state)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(cfg).to(device)
+    ck = torch.load(cfg.checkpoint, map_location="cpu", weights_only=False)
+    state_dict = ck["model"]
+    state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if state.is_main:
+        print(
+            f"Loaded checkpoint epoch={ck.get('epoch')} source={ck.get('checkpoint_source')}"
+        )
+        print(f"  missing={len(missing)} unexpected={len(unexpected)}")
+        if missing:
+            print(f"  missing[:5]={missing[:5]}")
+        if unexpected:
+            print(f"  unexpected[:5]={unexpected[:5]}")
+    model.eval()
+
+    run = None
+    if state.is_main:
+        run_name = cfg.wandb_name or f"{cfg.agent}/h231-mesh-subsample-tta"
+        run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8"),
+            entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
+            group=cfg.wandb_group,
+            name=run_name,
+            config={
+                **asdict(cfg),
+                "modes": modes,
+                "checkpoint_run_id": "yw2a5dyl",
+                "checkpoint_epoch": ck.get("epoch"),
+            },
+            tags=[
+                "h231",
+                "tta",
+                "mesh-subsample",
+                "eval-only",
+                cfg.agent,
+            ],
+            reinit="finish_previous",
+        )
+
+    splits = [
+        ("val_surface", val_loaders["val_surface"], "full_val"),
+        ("test_surface", test_loaders["test_surface"], "test"),
+    ]
+
+    summary: dict[str, dict[str, dict[str, float]]] = {}
+    for name, loader, log_prefix in splits:
+        if state.is_main:
+            print(f"\n=== Evaluating split={name} ===")
+        t0 = time.time()
+        per_mode = evaluate_tta_split(
+            model=model,
+            loader=loader,
+            transform=transform,
+            device=device,
+            amp_mode=cfg.amp_mode,
+            distributed_state=state,
+            cfg=cfg,
+            modes=modes,
+        )
+        dt = time.time() - t0
+        if state.is_main:
+            print(f"  done in {dt:.1f}s")
+            for mode in modes:
+                print(f"  -- {mode} --")
+                print_metrics(name, per_mode[mode])
+            summary[name] = per_mode
+
+            log_obj: dict[str, float] = {}
+            for mode in modes:
+                metrics = per_mode[mode]
+                log_obj.update(primary_metric_log(f"{log_prefix}_primary/{mode}", metrics))
+                if "loss" in metrics:
+                    log_obj[f"{log_prefix}_extra/{mode}/loss"] = metrics["loss"]
+            if run is not None:
+                wandb.log(log_obj)
+
+    if state.is_main and summary:
+        print("\n=== Summary (rel_l2_pct lower-is-better) ===")
+        for split, modes_metrics in summary.items():
+            print(f"\n[{split}]")
+            keys = (
+                "abupt_axis_mean_rel_l2_pct",
+                "surface_pressure_rel_l2_pct",
+                "wall_shear_rel_l2_pct",
+                "wall_shear_x_rel_l2_pct",
+                "wall_shear_y_rel_l2_pct",
+                "wall_shear_z_rel_l2_pct",
+                "volume_pressure_rel_l2_pct",
+            )
+            header = f"  {'metric':<36s}" + "".join(f" {m:>22s}" for m in modes)
+            print(header)
+            for k in keys:
+                row = f"  {k:<36s}"
+                for m in modes:
+                    v = modes_metrics[m].get(k, float("nan"))
+                    row += f" {v:>22.4f}"
+                print(row)
+
+        if run is not None:
+            for split, modes_metrics in summary.items():
+                for mode, metrics in modes_metrics.items():
+                    for k, v in metrics.items():
+                        try:
+                            run.summary[f"{split}/{mode}/{k}"] = float(v)
+                        except Exception:
+                            pass
+            run.finish()
+
+    cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Current SOTA (PR #1382 H209)**: val_abupt=5.9755, test_abupt=5.8221, test_WSS=6.7214, test_VP=3.4400, test_SP=3.6806
**Source checkpoint**: W&B run `yw2a5dyl` EP13 EMA (`epoch-13`/`best`)
**TTA infra**: `target/eval_tta_h209.py` (read this — it has the mirror_inputs / unmirror_surface_pred / unmirror_volume_pred working baseline; copy and extend)
**Merge gate**: val_abupt < 5.9755 AND test_abupt < 5.8221
**Paper floor**: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS ≤ 6.727
**DDP**: 8 GPUs every run
**Budget**: ~45-60min each (eval-only, NO training)

**Context findings just banked (2026-05-29 05:50-06:00Z)**:
- Finding V (askeladd H223): Rotation TTA falsified — H185 has zero rotational invariance at any angle θ ≥ 0.1°
- Finding W (alphonse H224): Coordinate scale TTA falsified — ε=±2% destroys predictions
- Mirror y remains the SOLE validated TTA augmentation for H185

Terminal marker required:
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}

## Hypothesis

Findings V + W just falsified geometric perturbation TTA (rotation, scale). All geometric input perturbations destroy because they change the underlying physics problem the model needs to solve. **What hasn't been tested**: input perturbations that DON'T change physics. Mesh point subsampling is one such candidate — different point subsets express the same flow problem at different mesh densities.

**Prediction**: For each TTA pass, randomly subsample 80% of surface_x points and 80% of volume_x points (independent uniform random selection per pass). Average 4 passes. The model has been trained on a fixed mesh density; if it has implicit point-density invariance, the averaged prediction may have reduced variance, gaining 2-5bp like mirror TTA.

If H231 succeeds, stacking with H209 mirror TTA gives orig+mirror+4×subsample = 6-pass TTA — potential SOTA.

## Instructions

Write `target/eval_tta_h231.py` (copy eval_tta_h209.py as starting point). Replace the mirror_inputs/unmirror logic with subsample_inputs:

- For each pass i, randomly select 80% of surface_x indices, 80% of volume_x indices (independent, uniform random)
- Run forward pass on the subset
- The output predictions are at the subset locations — need to evaluate on the FULL eval set for fair comparison
- **Two reasonable strategies for averaging**:
  a) Predict on the full input each pass but ZERO OUT 20% of attention contributions (mask 20% of input points as inactive, predict full output). This keeps output points consistent across passes.
  b) Predict on each subset, then for each full-eval target point, average predictions from passes where it was included (Monte Carlo coverage).

  Use strategy (a) since it gives complete prediction at all output points every pass.

Run modes:
1. orig (no augmentation) — sanity, should match 6.0172/5.8613
2. subsample_only — 4 passes of 80%-masked inputs, 0.25 average
3. mirror + subsample_combined — 5 passes: orig + mirror + 3×subsample, mean

```bash
torchrun --standalone --nproc-per-node=8 target/eval_tta_h231.py \
  --checkpoint outputs/h185_ep13/checkpoint.pt \
  --eval-modes original,subsample_only,mirror_subsample \
  --subsample-rate 0.8 \
  --num-subsample-passes 4 \
  --output-dir outputs/h231_eval \
  --wandb-group h231-askeladd-mesh-subsample-tta \
  --wandb-name "askeladd/h231-mesh-subsample-tta" \
  --batch-size 2
```

If subsample fails catastrophically (val > 7%), bonus arm: try 95% retention (smaller perturbation). If still fails → another "Finding X" landed: mesh sampling not invariant either, mirror is uniquely preserved.
