### PR TITLE
H235: TTA-mirror Finding Q extension — N≥6 cross-checkpoint sweep

### DIFF
--- a/aggregate_h235.py
+++ b/aggregate_h235.py
@@ -1,0 +1,128 @@
+"""H235: aggregate W&B summary metrics from the per-checkpoint TTA evals.
+
+Each ``frieren/h235-tta-<LABEL>-<RUNID>`` run logs ``full_val`` and ``test``
+metrics under ``{split}/{mode}/{metric}`` summary keys for mode in
+{orig, mirror, tta}. This script pulls them and renders the comparison
+table requested by the PR:
+
+  checkpoint | val_abupt orig | val_abupt TTA | test_abupt orig | test_abupt TTA | TTA_delta (bp) | WSS_x slope
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import wandb
+
+CANDIDATES = [
+    ("H185", "yw2a5dyl"),
+    ("H183", "5k58uzqc"),
+    ("H190", "9f2jtrg2"),
+    ("H188", "18t5rx2t"),
+    ("H148", "2qr5guel"),
+    ("H191", "5y5a5tgr"),
+    ("H181b", "w7w92npw"),
+    ("H186", "d15dm825"),
+]
+
+
+def _summary(api, label: str, source_run_id: str) -> dict:
+    runs = list(
+        api.runs(
+            "wandb-applied-ai-team/senpai-v1-drivaerml-ddp8",
+            {"display_name": {"$regex": f"^frieren/h235-tta-{label}-{source_run_id}$"}},
+        )
+    )
+    if not runs:
+        return {}
+    runs.sort(key=lambda r: r.created_at, reverse=True)
+    return dict(runs[0].summary), runs[0].id
+
+
+def main(argv: list[str]) -> int:
+    api = wandb.Api()
+    out_rows = []
+    for label, source_run_id in CANDIDATES:
+        result = _summary(api, label, source_run_id)
+        if not result:
+            print(f"!! no H235 eval run found for {label} ({source_run_id})", file=sys.stderr)
+            continue
+        summary, h235_run_id = result
+
+        def f(key: str) -> float | None:
+            v = summary.get(key)
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        v_orig = f("val_surface/orig/abupt_axis_mean_rel_l2_pct")
+        v_tta = f("val_surface/tta/abupt_axis_mean_rel_l2_pct")
+        t_orig = f("test_surface/orig/abupt_axis_mean_rel_l2_pct")
+        t_tta = f("test_surface/tta/abupt_axis_mean_rel_l2_pct")
+        wssx_orig = f("test_surface/orig/wall_shear_x_rel_l2_pct")
+        wssx_tta = f("test_surface/tta/wall_shear_x_rel_l2_pct")
+        sp_tta = f("test_surface/tta/surface_pressure_rel_l2_pct")
+        vp_tta = f("test_surface/tta/volume_pressure_rel_l2_pct")
+        wss_tta = f("test_surface/tta/wall_shear_rel_l2_pct")
+        wssy_tta = f("test_surface/tta/wall_shear_y_rel_l2_pct")
+        wssz_tta = f("test_surface/tta/wall_shear_z_rel_l2_pct")
+        val_tta_delta_bp = (v_tta - v_orig) * 100 if v_orig is not None and v_tta is not None else None
+        test_tta_delta_bp = (t_tta - t_orig) * 100 if t_orig is not None and t_tta is not None else None
+        wssx_delta_bp = (wssx_tta - wssx_orig) * 100 if wssx_orig is not None and wssx_tta is not None else None
+        out_rows.append({
+            "label": label,
+            "source_run": source_run_id,
+            "h235_run": h235_run_id,
+            "val_orig": v_orig,
+            "val_tta": v_tta,
+            "test_orig": t_orig,
+            "test_tta": t_tta,
+            "val_tta_delta_bp": val_tta_delta_bp,
+            "test_tta_delta_bp": test_tta_delta_bp,
+            "wssx_orig": wssx_orig,
+            "wssx_tta": wssx_tta,
+            "wssx_delta_bp": wssx_delta_bp,
+            "test_tta_sp": sp_tta,
+            "test_tta_vp": vp_tta,
+            "test_tta_wss": wss_tta,
+            "test_tta_wssy": wssy_tta,
+            "test_tta_wssz": wssz_tta,
+        })
+
+    print("\n=== H235 cross-checkpoint TTA mirror sweep (corrected split, full_val + test_primary) ===\n")
+    hdr = ("ckpt", "val_orig", "val_tta", "Δv(bp)", "test_orig", "test_tta", "Δt(bp)",
+           "wssx_o", "wssx_tta", "Δwx(bp)", "sp_tta", "vp_tta", "wss_tta")
+    fmt_hdr = "{:<6} {:>9} {:>9} {:>7} {:>10} {:>10} {:>7} {:>8} {:>9} {:>8} {:>7} {:>7} {:>8}"
+    fmt_row = "{:<6} {:>9.4f} {:>9.4f} {:>+7.2f} {:>10.4f} {:>10.4f} {:>+7.2f} {:>8.4f} {:>9.4f} {:>+8.2f} {:>7.4f} {:>7.4f} {:>8.4f}"
+    print(fmt_hdr.format(*hdr))
+    sota_gate_passes = []
+    for row in out_rows:
+        if any(row[k] is None for k in ("val_orig", "val_tta", "test_orig", "test_tta", "wssx_orig", "wssx_tta")):
+            print(f"{row['label']:<6} (missing summary metrics — check run)")
+            continue
+        print(fmt_row.format(
+            row['label'],
+            row['val_orig'], row['val_tta'], row['val_tta_delta_bp'],
+            row['test_orig'], row['test_tta'], row['test_tta_delta_bp'],
+            row['wssx_orig'], row['wssx_tta'], row['wssx_delta_bp'],
+            row['test_tta_sp'] or 0.0, row['test_tta_vp'] or 0.0, row['test_tta_wss'] or 0.0,
+        ))
+        if row['val_tta'] < 5.9755 and row['test_tta'] < 5.8221:
+            sota_gate_passes.append(row['label'])
+    print()
+    if sota_gate_passes:
+        print(f"*** SOTA-candidate gate hits: {sota_gate_passes} ***")
+    else:
+        print("No checkpoint+TTA passes both SOTA gates (val < 5.9755 AND test < 5.8221).")
+    print()
+    out_path = Path("outputs/h235_eval/h235_summary.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out_rows, indent=2))
+    print(f"Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/download_h235.py
+++ b/download_h235.py
@@ -1,0 +1,58 @@
+"""H235 helper: download the EP13 EMA checkpoint for each mirror candidate run.
+
+Each W&B run logs a single `model` artifact aliased `best` / `epoch-13` / `latest`,
+which is the EP13 EMA checkpoint we want. Drop them under ``artifacts/`` so
+``eval_tta_h209.py --checkpoint`` can pick them up.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import wandb
+
+CANDIDATES = [
+    ("yw2a5dyl", "H185"),
+    ("5k58uzqc", "H183"),
+    ("9f2jtrg2", "H190"),
+    ("18t5rx2t", "H188"),
+    ("2qr5guel", "H148"),
+    ("5y5a5tgr", "H191"),
+    ("w7w92npw", "H181b"),
+    ("d15dm825", "H186"),
+]
+
+
+def main() -> None:
+    api = wandb.Api()
+    entity = "wandb-applied-ai-team"
+    project = "senpai-v1-drivaerml-ddp8"
+    out_root = Path("artifacts")
+    out_root.mkdir(exist_ok=True)
+    paths: list[tuple[str, str, str]] = []
+    for run_id, label in CANDIDATES:
+        run = api.run(f"{entity}/{project}/{run_id}")
+        match = None
+        for art in run.logged_artifacts():
+            if art.type != "model":
+                continue
+            if "epoch-13" in art.aliases or "best" in art.aliases:
+                match = art
+                break
+        if match is None:
+            print(f"!! no model artifact with alias epoch-13/best on run {run_id} ({label})", file=sys.stderr)
+            continue
+        download_dir = match.download()
+        ckpt = Path(download_dir) / "checkpoint.pt"
+        if not ckpt.exists():
+            print(f"!! checkpoint.pt missing under {download_dir} for {run_id} ({label})", file=sys.stderr)
+            continue
+        paths.append((run_id, label, str(ckpt)))
+        print(f"OK {label:8s} {run_id} -> {ckpt}")
+    print("\n# all_paths")
+    for run_id, label, p in paths:
+        print(f"{label}\t{run_id}\t{p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_h235_sweep.sh
+++ b/run_h235_sweep.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# H235: run eval_tta_h209.py once per mirror-trained EP13 EMA checkpoint.
+# Sequential — every job uses all 8 GPUs for DDP-strided eval.
+set -euo pipefail
+
+ART=/workspace/senpai/target/artifacts
+OUT=/workspace/senpai/target/outputs/h235_eval
+LOG=/workspace/senpai/target/outputs/h235_eval/sweep.log
+mkdir -p "$OUT"
+
+# label run_id drop_path_max
+ROWS=(
+  "H185 yw2a5dyl 0.1"
+  "H183 5k58uzqc 0.1"
+  "H190 9f2jtrg2 0.1"
+  "H188 18t5rx2t 0.15"
+  "H148 2qr5guel 0.1"
+  "H191 5y5a5tgr 0.1"
+  "H181b w7w92npw 0.1"
+  "H186 d15dm825 0.1"
+)
+
+declare -A ARTDIR
+ARTDIR[yw2a5dyl]="model-thorfinn-h185-h171-mirror-aug-compound-yw2a5dyl:v0"
+ARTDIR[5k58uzqc]="model-fern-h183-mirror-aug-tau-y-3p0-compound-5k58uzqc:v0"
+ARTDIR[9f2jtrg2]="model-nezuko-h190-mirror-aug-p025-9f2jtrg2:v0"
+ARTDIR[18t5rx2t]="model-alphonse-h188-mirror-droppath-015-18t5rx2t:v0"
+ARTDIR[2qr5guel]="model-askeladd-h148-mirror-aug-2qr5guel:v0"
+ARTDIR[5y5a5tgr]="model-tanjiro-h191-mirror-tau-y-2p0-5y5a5tgr:v0"
+ARTDIR[w7w92npw]="model-askeladd-h181b-mirror-aug-ema-9999-w7w92npw:v0"
+ARTDIR[d15dm825]="model-fern-h186-mirror-aug-adamw-cross-axis-d15dm825:v0"
+
+cd /workspace/senpai/target
+
+for ROW in "${ROWS[@]}"; do
+  read -r LABEL RUNID DPM <<<"$ROW"
+  CKPT="$ART/${ARTDIR[$RUNID]}/checkpoint.pt"
+  RUN_OUT="$OUT/$RUNID"
+  mkdir -p "$RUN_OUT"
+  echo
+  echo "=================================================="
+  echo "=== ${LABEL} run=${RUNID} dpm=${DPM}"
+  echo "  ckpt: ${CKPT}"
+  echo "  out:  ${RUN_OUT}"
+  echo "=================================================="
+  if ! ls "$CKPT" >/dev/null 2>&1; then
+    echo "!! missing checkpoint, skipping"
+    continue
+  fi
+  T0=$(date +%s)
+  torchrun --standalone --nproc-per-node=8 eval_tta_h209.py \
+    --checkpoint "$CKPT" \
+    --output-dir "$RUN_OUT" \
+    --wandb-group h235-frieren-finding-q-extension \
+    --wandb-name "frieren/h235-tta-${LABEL}-${RUNID}" \
+    --batch-size 2 \
+    --drop-path-max "$DPM" \
+    >"$RUN_OUT/eval.log" 2>&1
+  T1=$(date +%s)
+  echo "  done in $((T1 - T0))s"
+done
+
+echo
+echo "All sweep runs finished."


### PR DESCRIPTION
**Current SOTA (PR #1382 H209)**: val_abupt=5.9755, test_abupt=5.8221, test_WSS=6.7214, test_VP=3.4400, test_SP=3.6806
**Source checkpoint**: W&B run `yw2a5dyl` EP13 EMA (`epoch-13`/`best`)
**TTA infra**: `target/eval_tta_h209.py` (read this — it has the mirror_inputs / unmirror_surface_pred / unmirror_volume_pred working baseline; copy and extend)
**Merge gate**: val_abupt < 5.9755 AND test_abupt < 5.8221
**Paper floor**: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS ≤ 6.727
**DDP**: 8 GPUs every run
**Budget**: ~45-60min each (eval-only, NO training)

**Context findings just banked (2026-05-29 05:50-06:00Z)**:
- Finding V (askeladd H223): Rotation TTA falsified — H185 has zero rotational invariance at any angle θ ≥ 0.1°
- Finding W (alphonse H224): Coordinate scale TTA falsified — ε=±2% destroys predictions
- Mirror y remains the SOLE validated TTA augmentation for H185

Terminal marker required:
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt","value":<number>},"test_metric":{"name":"test_abupt","value":<number>}}

## Hypothesis

Finding Q established TTA-mirror gives +4-5bp uniform gain on N=3 mirror-trained checkpoints (H183, H185, H190). Extend N to ≥6 for publication-grade statistics on the TTA mechanism, and identify if any specific checkpoint beats H209's val_abupt 5.9755 when TTA-augmented.

## Instructions

Pull W&B runs for additional mirror-trained checkpoints from the program archive (use wandb-primary skill). Candidates:
- H148 (askeladd, mirror p=0.5, tau_y=1.5) — find run id
- H164 family (frieren, your own historical runs)
- H171 (mirror + plateau)
- Any other run on a `*mirror*` branch with EP13 EMA artifact

For each, run eval_tta_h209.py unchanged with the checkpoint loaded. Single pass through, take ~5min per checkpoint.

```bash
for run_id in <list of candidate run ids>; do
  torchrun --standalone --nproc-per-node=8 target/eval_tta_h209.py \
    --checkpoint <download checkpoint via wandb artifact get> \
    --output-dir outputs/h235_eval/<run_id> \
    --wandb-group h235-frieren-finding-q-extension \
    --wandb-name "frieren/h235-tta-<run_id>" \
    --batch-size 2
done
```

Report a 6+ row table: checkpoint | val_abupt orig | val_abupt TTA | test_abupt orig | test_abupt TTA | TTA_delta (bp) | WSS_x slope.

If ANY checkpoint + TTA passes both gates (val < 5.9755 AND test < 5.8221) → IMMEDIATE merge candidate, that's a SOTA.

Otherwise, bank Finding Q at high N for paper-quality evidence.
