### PR TITLE
H242: Weight-space Gaussian-noise TTA on H185 EP13 — loss surface flatness probe

### DIFF
--- a/eval_tta_h242.py
+++ b/eval_tta_h242.py
@@ -1,0 +1,589 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H242: Weight-space Gaussian-noise TTA on H185 EP13 — loss surface flatness probe.
+
+Eval-only. Per batch the model is evaluated under four modes:
+    * orig       : forward pass on the clean (unperturbed) weights
+    * mirror     : forward pass with y-mirrored inputs on clean weights, output un-mirrored
+    * noise_only : average of K forward passes, each with a freshly perturbed copy of the
+                   clean weights, where perturbation is per-tensor relative Gaussian noise
+                   `delta_p = randn_like(p) * sigma * p.abs()`
+    * tta        : equally weighted average of the K noise passes + orig + mirror
+
+Mirror convention (H148/H183/H209), unchanged:
+    surface_x [x, y, z, nx, ny, nz, area] -> negate y(1) and ny(4)
+    volume_x  [x, y, z, sdf]              -> negate y(1)
+    surface_y predictions [cp, tau_x, tau_y, tau_z] -> un-mirror by negating tau_y(2)
+    volume_y predictions [volume_pressure] -> invariant
+
+DDP correctness note: the per-pass weight noise MUST be identical across ranks (otherwise
+each rank has a different model). We seed a device-local Generator with
+`seed = (42 + pass_idx) * 100003` and draw noise from it on every rank. The shared
+default-RNG manipulation that drove the seed formula in the assignment is avoided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import asdict, dataclass, fields
+from typing import Iterable
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import wandb
+
+from data import SurfaceBatch
+from model import SurfaceTransolver
+from trainer_runtime import (
+    EvalAccumulator,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    finalize_eval_accumulator,
+    init_distributed,
+    make_loaders,
+    merge_eval_accumulators,
+    primary_metric_log,
+    print_metrics,
+    unwrap_model,
+)
+
+
+@dataclass
+class EvalConfig:
+    """Minimal config mirroring H209 — only the fields we need for eval.
+
+    Defaults match the H185 yw2a5dyl training-time config so the reconstructed model
+    matches the checkpoint exactly.
+    """
+
+    checkpoint: str = "runs/h210/artifacts/h185/checkpoint.pt"
+    manifest: str = "data/split_manifest.json"
+    data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+    output_dir: str = "outputs/h242_eval"
+    wandb_group: str = "h242-tanjiro-weight-noise-tta"
+    wandb_name: str = ""
+    agent: str = "tanjiro"
+
+    # Eval-only loader params
+    batch_size: int = 4
+    eval_surface_points: int = 65536
+    eval_volume_points: int = 65536
+    train_surface_points: int = 65536
+    train_volume_points: int = 65536
+    num_workers: int = -1
+    pin_memory: bool = True
+    persistent_workers: bool = True
+    prefetch_factor: int = 2
+
+    # Model arch (must match H185 yw2a5dyl exactly)
+    model_layers: int = 5
+    model_hidden_dim: int = 512
+    model_heads: int = 4
+    model_mlp_ratio: int = 4
+    model_slices: int = 128
+    model_dropout: float = 0.0
+    rff_num_features: int = 16
+    rff_sigma: float = 1.0
+    rff_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    pos_encoding_mode: str = "string_separable"
+    use_qk_norm: bool = True
+    use_surf_to_vol_xattn: bool = True
+    drop_path_max: float = 0.1
+
+    amp_mode: str = "bf16"
+    debug: bool = False
+
+    # H242 weight-noise TTA knobs
+    weight_noise_sigma: float = 1e-4
+    weight_noise_passes: int = 5
+    weight_noise_seed_base: int = 42
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H242 weight-noise TTA eval")
+    defaults = EvalConfig()
+    for f in fields(EvalConfig):
+        v = getattr(defaults, f.name)
+        cli = f"--{f.name.replace('_', '-')}"
+        if isinstance(v, bool):
+            parser.add_argument(cli, action="store_true", default=v, dest=f.name)
+            parser.add_argument(
+                f"--no-{f.name.replace('_', '-')}",
+                action="store_false",
+                dest=f.name,
+            )
+        else:
+            parser.add_argument(cli, type=type(v), default=v)
+    ns = parser.parse_args(argv)
+    cfg = EvalConfig(**{f.name: getattr(ns, f.name) for f in fields(EvalConfig)})
+    return cfg
+
+
+def parse_rff_init_sigmas(spec: str) -> list[float] | None:
+    if not spec:
+        return None
+    return [float(x) for x in spec.split(",") if x.strip()]
+
+
+def build_model(cfg: EvalConfig) -> SurfaceTransolver:
+    return SurfaceTransolver(
+        n_layers=cfg.model_layers,
+        n_hidden=cfg.model_hidden_dim,
+        dropout=cfg.model_dropout,
+        n_head=cfg.model_heads,
+        mlp_ratio=cfg.model_mlp_ratio,
+        slice_num=cfg.model_slices,
+        rff_num_features=cfg.rff_num_features,
+        rff_sigma=cfg.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(cfg.rff_init_sigmas),
+        pos_encoding_mode=cfg.pos_encoding_mode,
+        use_qk_norm=cfg.use_qk_norm,
+        use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
+        drop_path_max=cfg.drop_path_max,
+    )
+
+
+# --- TTA mirror helpers (H148 convention) ---
+
+
+def mirror_inputs(batch: SurfaceBatch) -> SurfaceBatch:
+    """Negate y/normal_y in surface_x, y in volume_x. Keep masks and targets unchanged."""
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1].neg_()  # y
+    surface_x[..., 4].neg_()  # normal_y
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1].neg_()  # y
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+
+
+def unmirror_surface_pred(pred: torch.Tensor) -> torch.Tensor:
+    """surface_pred channels [cp, tau_x, tau_y, tau_z]: un-mirror = negate tau_y."""
+    out = pred.clone()
+    out[..., 2].neg_()
+    return out
+
+
+def unmirror_volume_pred(pred: torch.Tensor) -> torch.Tensor:
+    """volume_pressure is invariant under y-mirror — return as-is."""
+    return pred
+
+
+# --- Eval accumulation shared with H209 (copied to keep this script self-contained) ---
+
+
+def _accumulate_outputs(
+    acc: EvalAccumulator,
+    batch: SurfaceBatch,
+    surface_pred_norm: torch.Tensor,
+    volume_pred_norm: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    surface_target_norm = transform.apply_surface(batch.surface_y)
+    volume_target_norm = transform.apply_volume(batch.volume_y)
+
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, batch.surface_mask
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, batch.volume_mask
+    )
+    acc.surface_loss_sse += surface_sse
+    acc.surface_loss_count += surface_count
+    acc.volume_loss_sse += volume_sse
+    acc.volume_loss_count += volume_count
+
+    surface_pred = transform.invert_surface(surface_pred_norm)
+    volume_pred = transform.invert_volume(volume_pred_norm)
+
+    if bool(batch.surface_mask.any()):
+        surface_abs = (surface_pred - batch.surface_y).abs()
+        valid_surface_abs = surface_abs[batch.surface_mask]
+        acc.abs_sums["surface_pressure"] += float(
+            valid_surface_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["surface_pressure"] += int(valid_surface_abs[:, 0].numel())
+        wall_abs = valid_surface_abs[:, 1:4]
+        acc.abs_sums["wall_shear"] += float(wall_abs.sum().detach().cpu().item())
+        acc.abs_counts["wall_shear"] += int(wall_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = wall_abs[:, offset]
+            acc.abs_sums[f"wall_shear_{axis}"] += float(channel.sum().detach().cpu().item())
+            acc.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+        wall_vector_error = torch.linalg.vector_norm(
+            surface_pred[batch.surface_mask][:, 1:4]
+            - batch.surface_y[batch.surface_mask][:, 1:4],
+            dim=-1,
+        )
+        acc.wall_shear_vector_abs_sum += float(
+            wall_vector_error.sum().detach().cpu().item()
+        )
+        acc.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    if bool(batch.volume_mask.any()):
+        volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
+        acc.abs_sums["volume_pressure"] += float(
+            volume_abs[:, 0].sum().detach().cpu().item()
+        )
+        acc.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    for case_idx, case_id in enumerate(batch.case_ids):
+        surface_valid = batch.surface_mask[case_idx].bool()
+        if bool(surface_valid.any()):
+            surface_pred_valid = surface_pred[case_idx][surface_valid]
+            surface_target_valid = batch.surface_y[case_idx][surface_valid]
+            _accumulate_case_rel_l2(
+                acc.case_sums["surface_pressure"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 0:1],
+                target=surface_target_valid[:, 0:1],
+            )
+            _accumulate_case_rel_l2(
+                acc.case_sums["wall_shear"],
+                case_id=case_id,
+                pred=surface_pred_valid[:, 1:4],
+                target=surface_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    acc.case_sums[f"wall_shear_{axis}"],
+                    case_id=case_id,
+                    pred=surface_pred_valid[:, channel : channel + 1],
+                    target=surface_target_valid[:, channel : channel + 1],
+                )
+        volume_valid = batch.volume_mask[case_idx].bool()
+        if bool(volume_valid.any()):
+            _accumulate_case_rel_l2(
+                acc.case_sums["volume_pressure"],
+                case_id=case_id,
+                pred=volume_pred[case_idx][volume_valid],
+                target=batch.volume_y[case_idx][volume_valid],
+            )
+
+
+# --- Weight-noise helpers ---
+
+
+@torch.no_grad()
+def snapshot_clean_params(module: nn.Module) -> dict[str, torch.Tensor]:
+    """Pre-copy of all floating-point parameter tensors for fast restore between passes."""
+    snap: dict[str, torch.Tensor] = {}
+    for name, p in module.named_parameters():
+        if p.dtype.is_floating_point:
+            snap[name] = p.detach().clone()
+    return snap
+
+
+@torch.no_grad()
+def restore_clean_params(module: nn.Module, clean: dict[str, torch.Tensor]) -> None:
+    for name, p in module.named_parameters():
+        if name in clean:
+            p.data.copy_(clean[name])
+
+
+@torch.no_grad()
+def perturb_relative_(
+    module: nn.Module,
+    clean: dict[str, torch.Tensor],
+    sigma: float,
+    seed: int,
+    device: torch.device,
+) -> None:
+    """In-place: p <- clean_p + randn(seed) * sigma * clean_p.abs(), with the same RNG draw
+    on every DDP rank (assumes identical param order/shapes — they are identical because
+    the model and checkpoint are identical on every rank).
+    """
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    for name, p in module.named_parameters():
+        if not p.dtype.is_floating_point:
+            continue
+        clean_p = clean[name]
+        noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
+        noise.mul_(sigma).mul_(clean_p.abs())
+        p.data.copy_(clean_p).add_(noise)
+
+
+# --- Main eval loop with weight noise + mirror TTA ---
+
+
+def evaluate_weight_noise_tta_split(
+    *,
+    model: nn.Module,
+    loader,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    distributed_state,
+    clean: dict[str, torch.Tensor],
+    sigma: float,
+    K: int,
+    seed_base: int,
+) -> tuple[dict[str, float], dict[str, float], dict[str, float], dict[str, float]]:
+    """Run four eval modes (orig, mirror, noise_only, tta) in a single pass through the loader.
+
+    Returns (orig_metrics, mirror_metrics, noise_only_metrics, tta_metrics).
+    Predictions are averaged in normalized space; denormalization happens in
+    `_accumulate_outputs`.
+    """
+    acc_orig = EvalAccumulator()
+    acc_mirror = EvalAccumulator()
+    acc_noise_only = EvalAccumulator()
+    acc_tta = EvalAccumulator()
+
+    model.eval()
+    eval_module = unwrap_model(model)
+
+    with torch.no_grad():
+        for batch in loader:
+            batch = batch.to(device)
+            mirrored = mirror_inputs(batch)
+
+            surface_noise_sum: torch.Tensor | None = None
+            volume_noise_sum: torch.Tensor | None = None
+
+            for k in range(K):
+                seed = (seed_base + k) * 100003
+                perturb_relative_(eval_module, clean, sigma=sigma, seed=seed, device=device)
+                with autocast_context(device, amp_mode):
+                    out_k = eval_module(
+                        surface_x=batch.surface_x,
+                        surface_mask=batch.surface_mask,
+                        volume_x=batch.volume_x,
+                        volume_mask=batch.volume_mask,
+                    )
+                surface_pred_k = out_k["surface_preds"].float()
+                volume_pred_k = out_k["volume_preds"].float()
+                if surface_noise_sum is None:
+                    surface_noise_sum = surface_pred_k.clone()
+                    volume_noise_sum = volume_pred_k.clone()
+                else:
+                    surface_noise_sum.add_(surface_pred_k)
+                    volume_noise_sum.add_(volume_pred_k)
+
+            # Restore clean weights for orig + mirror passes.
+            restore_clean_params(eval_module, clean)
+
+            with autocast_context(device, amp_mode):
+                out_orig = eval_module(
+                    surface_x=batch.surface_x,
+                    surface_mask=batch.surface_mask,
+                    volume_x=batch.volume_x,
+                    volume_mask=batch.volume_mask,
+                )
+                out_mirror = eval_module(
+                    surface_x=mirrored.surface_x,
+                    surface_mask=mirrored.surface_mask,
+                    volume_x=mirrored.volume_x,
+                    volume_mask=mirrored.volume_mask,
+                )
+
+            surface_pred_orig = out_orig["surface_preds"].float()
+            volume_pred_orig = out_orig["volume_preds"].float()
+
+            surface_pred_mirror_raw = out_mirror["surface_preds"].float()
+            volume_pred_mirror_raw = out_mirror["volume_preds"].float()
+            surface_pred_mirror = unmirror_surface_pred(surface_pred_mirror_raw)
+            volume_pred_mirror = unmirror_volume_pred(volume_pred_mirror_raw)
+
+            assert surface_noise_sum is not None and volume_noise_sum is not None
+            surface_pred_noise_only = surface_noise_sum / float(K)
+            volume_pred_noise_only = volume_noise_sum / float(K)
+
+            denom = float(K + 2)
+            surface_pred_tta = (surface_noise_sum + surface_pred_orig + surface_pred_mirror) / denom
+            volume_pred_tta = (volume_noise_sum + volume_pred_orig + volume_pred_mirror) / denom
+
+            _accumulate_outputs(acc_orig, batch, surface_pred_orig, volume_pred_orig, transform)
+            _accumulate_outputs(acc_mirror, batch, surface_pred_mirror, volume_pred_mirror, transform)
+            _accumulate_outputs(
+                acc_noise_only, batch, surface_pred_noise_only, volume_pred_noise_only, transform
+            )
+            _accumulate_outputs(acc_tta, batch, surface_pred_tta, volume_pred_tta, transform)
+
+    metrics = []
+    for acc in (acc_orig, acc_mirror, acc_noise_only, acc_tta):
+        if distributed_state is not None and distributed_state.enabled:
+            gathered = [None for _ in range(distributed_state.world_size)]
+            dist.all_gather_object(gathered, acc)
+            if distributed_state.is_main:
+                acc = merge_eval_accumulators(g for g in gathered if g is not None)
+                metrics.append(finalize_eval_accumulator(acc))
+            else:
+                metrics.append({})
+        else:
+            metrics.append(finalize_eval_accumulator(acc))
+
+    return metrics[0], metrics[1], metrics[2], metrics[3]
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+    if state.is_main:
+        ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
+        print(f"Device: {device}{ddp_suffix}")
+        print(f"Checkpoint: {cfg.checkpoint}")
+        print(
+            f"Weight-noise TTA: sigma_rel={cfg.weight_noise_sigma}, "
+            f"K_passes={cfg.weight_noise_passes}, seed_base={cfg.weight_noise_seed_base}"
+        )
+
+    train_loader, val_loaders, test_loaders, stats = make_loaders(cfg, distributed_state=state)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(cfg).to(device)
+    ck = torch.load(cfg.checkpoint, map_location="cpu", weights_only=False)
+    state_dict = ck["model"]
+    state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if state.is_main:
+        print(f"Loaded checkpoint epoch={ck.get('epoch')} source={ck.get('checkpoint_source')}")
+        print(f"  missing={len(missing)} unexpected={len(unexpected)}")
+        if missing:
+            print(f"  missing[:5]={missing[:5]}")
+        if unexpected:
+            print(f"  unexpected[:5]={unexpected[:5]}")
+    model.eval()
+
+    eval_module = unwrap_model(model)
+    clean = snapshot_clean_params(eval_module)
+    if state.is_main:
+        n_perturbed = sum(t.numel() for t in clean.values())
+        print(f"Snapshotted {len(clean)} floating-point tensors ({n_perturbed:,} elements)")
+
+    run = None
+    if state.is_main:
+        run_name = cfg.wandb_name or f"{cfg.agent}/h242-sigma-{cfg.weight_noise_sigma}"
+        run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", "senpai-v1-drivaerml-ddp8"),
+            entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
+            group=cfg.wandb_group,
+            name=run_name,
+            config={
+                **asdict(cfg),
+                "checkpoint_run_id": "yw2a5dyl",
+                "checkpoint_epoch": ck.get("epoch"),
+                "checkpoint_source": ck.get("checkpoint_source"),
+            },
+            tags=["h242", "tta", "weight-noise", "eval-only", cfg.agent],
+            reinit="finish_previous",
+        )
+
+    splits = [
+        ("val_surface", val_loaders["val_surface"], "full_val"),
+        ("test_surface", test_loaders["test_surface"], "test"),
+    ]
+
+    summary: dict[str, dict[str, dict[str, float]]] = {}
+    for name, loader, log_prefix in splits:
+        if state.is_main:
+            print(f"\n=== Evaluating split={name} (sigma={cfg.weight_noise_sigma}, K={cfg.weight_noise_passes}) ===")
+        t0 = time.time()
+        orig, mirror, noise_only, tta = evaluate_weight_noise_tta_split(
+            model=model,
+            loader=loader,
+            transform=transform,
+            device=device,
+            amp_mode=cfg.amp_mode,
+            distributed_state=state,
+            clean=clean,
+            sigma=cfg.weight_noise_sigma,
+            K=cfg.weight_noise_passes,
+            seed_base=cfg.weight_noise_seed_base,
+        )
+        dt = time.time() - t0
+        if state.is_main:
+            print(f"  done in {dt:.1f}s")
+            print("  -- orig --")
+            print_metrics(name, orig)
+            print("  -- mirror --")
+            print_metrics(name, mirror)
+            print("  -- noise_only --")
+            print_metrics(name, noise_only)
+            print("  -- tta (noise+orig+mirror) --")
+            print_metrics(name, tta)
+            summary[name] = {
+                "orig": orig,
+                "mirror": mirror,
+                "noise_only": noise_only,
+                "tta": tta,
+            }
+
+            log_obj: dict[str, float] = {}
+            for mode, metrics in (
+                ("orig", orig),
+                ("mirror", mirror),
+                ("noise_only", noise_only),
+                ("tta", tta),
+            ):
+                log_obj.update(primary_metric_log(f"{log_prefix}_primary/{mode}", metrics))
+                log_obj.update({f"{log_prefix}_extra/{mode}/loss": metrics["loss"]})
+            if run is not None:
+                wandb.log(log_obj)
+
+    # Always restore clean weights at the end for safety (no-op if last mode was orig/mirror).
+    restore_clean_params(eval_module, clean)
+
+    if state.is_main and summary:
+        print("\n=== Summary (rel_l2_pct lower-is-better) ===")
+        for split, modes in summary.items():
+            print(f"\n[{split}]")
+            keys = (
+                "abupt_axis_mean_rel_l2_pct",
+                "surface_pressure_rel_l2_pct",
+                "wall_shear_rel_l2_pct",
+                "wall_shear_x_rel_l2_pct",
+                "wall_shear_y_rel_l2_pct",
+                "wall_shear_z_rel_l2_pct",
+                "volume_pressure_rel_l2_pct",
+            )
+            print(
+                f"  {'metric':<36s} {'orig':>10s} {'mirror':>10s} {'noise_only':>11s} {'tta':>10s} {'tta-orig':>10s}"
+            )
+            for k in keys:
+                o = modes["orig"][k]
+                m = modes["mirror"][k]
+                no = modes["noise_only"][k]
+                t = modes["tta"][k]
+                d = t - o
+                print(
+                    f"  {k:<36s} {o:>10.4f} {m:>10.4f} {no:>11.4f} {t:>10.4f} {d:>+10.4f}"
+                )
+
+        if run is not None:
+            for split, modes in summary.items():
+                for mode, metrics in modes.items():
+                    for k, v in metrics.items():
+                        try:
+                            run.summary[f"{split}/{mode}/{k}"] = float(v)
+                        except Exception:
+                            pass
+            run.finish()
+
+    cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -1,0 +1,819 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H252: Stacked weight-noise × multi-res × mirror TTA on H185 EP13.
+
+Builds on H236 (multi-res × mirror) by adding an outer K-pass weight-perturbation
+loop. For each case the total prediction is averaged over K × R × M passes:
+
+    for k in 0..K-1:                # weight perturbation index
+        perturb model: p <- clean_p + randn(seed_k) * sigma * |clean_p|
+        for R in resolutions:       # eval_volume_points value
+            for mirror in (False, True):
+                forward; un-mirror if needed; accumulate per-point in real units
+
+Perturbed weights are deterministic across DDP ranks (Generator seeded by
+`(seed_base + k) * 100003`), and reused across (res, mirror) inner passes.
+The same per-point chunk-accumulation logic as eval_multi_res.py covers every
+surface and volume point across the (R, mirror) sub-grid; the K outer loop just
+adds K independent perturbed-weight samples to the average.
+
+Mirror convention (H148/H183/H209), unchanged:
+    surface_x [x, y, z, nx, ny, nz, area] -> negate y(1) and ny(4)
+    volume_x  [x, y, z, sdf]              -> negate y(1)
+    surface_y predictions [cp, tau_x, tau_y, tau_z] -> un-mirror by negating tau_y(2)
+    volume_y predictions [volume_pressure] -> invariant
+
+Modes:
+    weight_noise_only:           K passes at a single eval_volume_points
+                                 (no mirror). Sanity-reproduces H242 noise_only.
+    weight_noise_mirror_res_avg: K x R x 2 = full stacked TTA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Iterable
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import wandb
+
+from data import SurfaceBatch, pad_collate
+from data.loader import DrivAerMLCaseStore, DrivAerMLSurfaceDataset
+from model import SurfaceTransolver
+from trainer_runtime import (
+    EvalAccumulator,
+    TargetTransform,
+    _accumulate_case_rel_l2,
+    _masked_sse_count,
+    autocast_context,
+    cleanup_distributed,
+    finalize_eval_accumulator,
+    init_distributed,
+    merge_eval_accumulators,
+    primary_metric_log,
+    print_metrics,
+    unwrap_model,
+)
+
+
+@dataclass
+class EvalConfig:
+    """H252 eval config — extends H236 with weight-noise stacking."""
+
+    # Checkpoint: local path first (path exists), else W&B fetch via run_id+alias.
+    checkpoint: str = "runs/h210/artifacts/h185/checkpoint.pt"
+    run_id: str = "yw2a5dyl"
+    checkpoint_alias: str = "epoch-13"
+    cache_root: str = "outputs/h252_eval/_artifacts"
+
+    # Multi-resolution TTA configuration
+    resolutions: str = "49152,65536,81920"
+    eval_modes: str = "weight_noise_mirror_res_avg"
+    eval_surface_points: int = 65536
+
+    # Weight-noise stacking knobs
+    weight_noise_sigma: float = 5e-4
+    weight_noise_passes: int = 5
+    weight_noise_seed_base: int = 42
+
+    manifest: str = "data/split_manifest.json"
+    data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
+    output_dir: str = "outputs/h252_eval"
+    wandb_group: str = "h242-tanjiro-stacked-tta"
+    wandb_name: str = ""
+    wandb_project: str = "senpai-v1-drivaerml-ddp8"
+    wandb_entity: str = "wandb-applied-ai-team"
+    agent: str = "tanjiro"
+
+    batch_size: int = 2
+    num_workers: int = 2
+    pin_memory: bool = True
+    persistent_workers: bool = False
+    prefetch_factor: int = 2
+
+    # Model arch (must match H185 yw2a5dyl exactly)
+    model_layers: int = 5
+    model_hidden_dim: int = 512
+    model_heads: int = 4
+    model_mlp_ratio: int = 4
+    model_slices: int = 128
+    model_dropout: float = 0.0
+    rff_num_features: int = 16
+    rff_sigma: float = 1.0
+    rff_init_sigmas: str = "0.25,0.5,1.0,2.0,4.0"
+    pos_encoding_mode: str = "string_separable"
+    use_qk_norm: bool = True
+    use_surf_to_vol_xattn: bool = True
+    drop_path_max: float = 0.1
+
+    amp_mode: str = "bf16"
+    debug: bool = False  # 2 val + 2 test cases
+
+
+def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
+    parser = argparse.ArgumentParser(description="H252 stacked weight-noise x multi-res x mirror eval")
+    defaults = EvalConfig()
+    for f in fields(EvalConfig):
+        v = getattr(defaults, f.name)
+        dashed = f"--{f.name.replace('_', '-')}"
+        underscored = f"--{f.name}"
+        cli_args = [dashed] if dashed == underscored else [dashed, underscored]
+        if isinstance(v, bool):
+            parser.add_argument(*cli_args, action="store_true", default=v, dest=f.name)
+            neg_dashed = f"--no-{f.name.replace('_', '-')}"
+            neg_underscored = f"--no_{f.name}"
+            neg_args = [neg_dashed] if neg_dashed == neg_underscored else [neg_dashed, neg_underscored]
+            parser.add_argument(*neg_args, action="store_false", dest=f.name)
+        else:
+            parser.add_argument(*cli_args, type=type(v), default=v, dest=f.name)
+    ns = parser.parse_args(argv)
+    cfg = EvalConfig(**{f.name: getattr(ns, f.name) for f in fields(EvalConfig)})
+    return cfg
+
+
+def parse_rff_init_sigmas(spec: str) -> list[float] | None:
+    if not spec:
+        return None
+    return [float(x) for x in spec.split(",") if x.strip()]
+
+
+def parse_resolutions(spec: str) -> list[int]:
+    return [int(p) for p in spec.split(",") if p.strip()]
+
+
+def parse_modes(spec: str) -> list[str]:
+    return [m.strip() for m in spec.split(",") if m.strip()]
+
+
+def build_model(cfg: EvalConfig) -> SurfaceTransolver:
+    return SurfaceTransolver(
+        n_layers=cfg.model_layers,
+        n_hidden=cfg.model_hidden_dim,
+        dropout=cfg.model_dropout,
+        n_head=cfg.model_heads,
+        mlp_ratio=cfg.model_mlp_ratio,
+        slice_num=cfg.model_slices,
+        rff_num_features=cfg.rff_num_features,
+        rff_sigma=cfg.rff_sigma,
+        rff_init_sigmas=parse_rff_init_sigmas(cfg.rff_init_sigmas),
+        pos_encoding_mode=cfg.pos_encoding_mode,
+        use_qk_norm=cfg.use_qk_norm,
+        use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
+        drop_path_max=cfg.drop_path_max,
+    )
+
+
+def download_checkpoint(
+    entity: str,
+    project: str,
+    run_id: str,
+    alias: str,
+    cache_root: Path,
+) -> Path:
+    cache_dir = cache_root / run_id / alias
+    ckpt_path = cache_dir / "checkpoint.pt"
+    if ckpt_path.exists():
+        return ckpt_path
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    api = wandb.Api()
+    run = api.run(f"{entity}/{project}/{run_id}")
+    matched = None
+    for art in run.logged_artifacts():
+        if art.type != "model":
+            continue
+        if alias in art.aliases:
+            matched = art
+            break
+    if matched is None:
+        raise RuntimeError(f"No model artifact with alias '{alias}' for run {run_id}")
+    matched.download(root=str(cache_dir))
+    return ckpt_path
+
+
+# --- mirror helpers ---
+
+
+def mirror_inputs(batch: SurfaceBatch) -> SurfaceBatch:
+    surface_x = batch.surface_x.clone()
+    surface_x[..., 1].neg_()  # y
+    surface_x[..., 4].neg_()  # normal_y
+    volume_x = batch.volume_x.clone()
+    volume_x[..., 1].neg_()  # y
+    return SurfaceBatch(
+        case_ids=batch.case_ids,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
+
+
+def unmirror_surface_real(pred: torch.Tensor) -> torch.Tensor:
+    out = pred.clone()
+    out[..., 2].neg_()  # tau_y un-mirror
+    return out
+
+
+def chunk_global_indices(view_index: int, view_count: int, n_full: int) -> torch.Tensor:
+    if view_index >= view_count:
+        return torch.empty(0, dtype=torch.long)
+    return torch.arange(view_index, n_full, view_count, dtype=torch.long)
+
+
+# --- weight-noise helpers ---
+
+
+@torch.no_grad()
+def snapshot_clean_params(module: nn.Module) -> dict[str, torch.Tensor]:
+    snap: dict[str, torch.Tensor] = {}
+    for name, p in module.named_parameters():
+        if p.dtype.is_floating_point:
+            snap[name] = p.detach().clone()
+    return snap
+
+
+@torch.no_grad()
+def restore_clean_params(module: nn.Module, clean: dict[str, torch.Tensor]) -> None:
+    for name, p in module.named_parameters():
+        if name in clean:
+            p.data.copy_(clean[name])
+
+
+@torch.no_grad()
+def perturb_relative_(
+    module: nn.Module,
+    clean: dict[str, torch.Tensor],
+    sigma: float,
+    seed: int,
+    device: torch.device,
+) -> None:
+    """p <- clean_p + randn(seed) * sigma * |clean_p|, identical across DDP ranks."""
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    for name, p in module.named_parameters():
+        if not p.dtype.is_floating_point:
+            continue
+        clean_p = clean[name]
+        noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
+        noise.mul_(sigma).mul_(clean_p.abs())
+        p.data.copy_(clean_p).add_(noise)
+
+
+# --- per-case stacked TTA ---
+
+
+@torch.no_grad()
+def process_case_stacked(
+    *,
+    case_id: str,
+    model: nn.Module,
+    transform: TargetTransform,
+    device: torch.device,
+    store: DrivAerMLCaseStore,
+    cfg: EvalConfig,
+    resolutions: list[int],
+    use_mirror: bool,
+    clean: dict[str, torch.Tensor],
+    K_passes: int,
+    sigma: float,
+    seed_base: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
+    """Run K x R x M (mirror) TTA passes for one case and return per-point averaged
+    predictions in real units. The K outer loop perturbs the model weights and
+    reuses the perturbed copy across all (res, mirror) inner passes.
+    """
+    counts = store.case_point_counts(case_id)
+    n_surf = counts["n_surface"]
+    n_vol = counts["n_volume"]
+
+    surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
+    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
+    vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
+    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)
+
+    eval_module = unwrap_model(model)
+    timing: dict[str, float] = {
+        "forward_seconds": 0.0,
+        "io_seconds": 0.0,
+        "perturb_seconds": 0.0,
+        "n_forwards": 0,
+    }
+
+    mirror_flags = (False, True) if use_mirror else (False,)
+
+    for k in range(K_passes):
+        # Perturb once per k; reuse across (res, mirror) inner passes.
+        t_p = time.time()
+        if sigma > 0.0:
+            seed = (seed_base + k) * 100003
+            perturb_relative_(eval_module, clean, sigma=sigma, seed=seed, device=device)
+        else:
+            restore_clean_params(eval_module, clean)
+        timing["perturb_seconds"] += time.time() - t_p
+
+        for R in resolutions:
+            dataset = DrivAerMLSurfaceDataset(
+                case_ids=[case_id],
+                store=store,
+                max_surface_points=cfg.eval_surface_points,
+                max_volume_points=R,
+                sampling_mode="eval_chunk",
+            )
+            loader_iter = torch.utils.data.DataLoader(
+                dataset,
+                batch_size=cfg.batch_size,
+                shuffle=False,
+                num_workers=cfg.num_workers,
+                pin_memory=cfg.pin_memory,
+                collate_fn=pad_collate,
+                persistent_workers=False,
+                prefetch_factor=cfg.prefetch_factor if cfg.num_workers > 0 else None,
+            )
+            for batch in loader_iter:
+                batch = batch.to(device)
+                metas_cached = list(batch.metadata)
+                for mirror in mirror_flags:
+                    t0 = time.time()
+                    model_input = mirror_inputs(batch) if mirror else batch
+                    with autocast_context(device, cfg.amp_mode):
+                        out = eval_module(
+                            surface_x=model_input.surface_x,
+                            surface_mask=model_input.surface_mask,
+                            volume_x=model_input.volume_x,
+                            volume_mask=model_input.volume_mask,
+                        )
+                    surface_pred_real = transform.invert_surface(out["surface_preds"].float())
+                    volume_pred_real = transform.invert_volume(out["volume_preds"].float())
+                    if mirror:
+                        surface_pred_real = unmirror_surface_real(surface_pred_real)
+                    timing["forward_seconds"] += time.time() - t0
+                    timing["n_forwards"] += int(batch.surface_x.shape[0])
+
+                    t1 = time.time()
+                    surface_pred_real_cpu = surface_pred_real.detach().cpu()
+                    volume_pred_real_cpu = volume_pred_real.detach().cpu()
+                    surface_mask_cpu = batch.surface_mask.detach().cpu()
+                    volume_mask_cpu = batch.volume_mask.detach().cpu()
+                    for i in range(len(batch.case_ids)):
+                        meta = metas_cached[i]
+                        s_view_idx = int(meta["surface_view_index"])
+                        s_view_count = int(meta["surface_view_count"])
+                        v_view_idx = int(meta["volume_view_index"])
+                        v_view_count = int(meta["volume_view_count"])
+
+                        if s_view_idx < s_view_count:
+                            s_global = chunk_global_indices(s_view_idx, s_view_count, n_surf)
+                            s_mask_i = surface_mask_cpu[i].bool()
+                            s_chunk = surface_pred_real_cpu[i][s_mask_i]
+                            if s_global.shape[0] != s_chunk.shape[0]:
+                                raise RuntimeError(
+                                    f"surface global-index mismatch case={case_id} K={R} "
+                                    f"view_idx={s_view_idx}/{s_view_count}: "
+                                    f"global={s_global.shape[0]} vs chunk={s_chunk.shape[0]}"
+                                )
+                            if s_global.numel() > 0:
+                                surf_sum.index_add_(0, s_global, s_chunk)
+                                surf_cnt.index_add_(
+                                    0, s_global, torch.ones_like(s_global, dtype=torch.int32)
+                                )
+
+                        if v_view_idx < v_view_count:
+                            v_global = chunk_global_indices(v_view_idx, v_view_count, n_vol)
+                            v_mask_i = volume_mask_cpu[i].bool()
+                            v_chunk = volume_pred_real_cpu[i][v_mask_i]
+                            if v_global.shape[0] != v_chunk.shape[0]:
+                                raise RuntimeError(
+                                    f"volume global-index mismatch case={case_id} K={R} "
+                                    f"view_idx={v_view_idx}/{v_view_count}: "
+                                    f"global={v_global.shape[0]} vs chunk={v_chunk.shape[0]}"
+                                )
+                            if v_global.numel() > 0:
+                                vol_sum.index_add_(0, v_global, v_chunk)
+                                vol_cnt.index_add_(
+                                    0, v_global, torch.ones_like(v_global, dtype=torch.int32)
+                                )
+                    timing["io_seconds"] += time.time() - t1
+
+    if int(surf_cnt.min()) == 0:
+        raise RuntimeError(
+            f"surface coverage incomplete for case {case_id}: "
+            f"{int((surf_cnt == 0).sum())} points have zero contributing chunks"
+        )
+    if int(vol_cnt.min()) == 0:
+        raise RuntimeError(
+            f"volume coverage incomplete for case {case_id}: "
+            f"{int((vol_cnt == 0).sum())} points have zero contributing chunks"
+        )
+
+    surf_avg = surf_sum / surf_cnt.unsqueeze(-1).to(torch.float32)
+    vol_avg = vol_sum / vol_cnt.unsqueeze(-1).to(torch.float32)
+
+    case = store.load_case(case_id)
+    surf_y = case.surface_y.float()
+    vol_y = case.volume_y.float()
+
+    n_passes = K_passes * len(resolutions) * (2 if use_mirror else 1)
+    return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
+
+
+def add_case_to_accumulator(
+    acc: EvalAccumulator,
+    *,
+    case_id: str,
+    surface_pred_real: torch.Tensor,
+    volume_pred_real: torch.Tensor,
+    surface_y: torch.Tensor,
+    volume_y: torch.Tensor,
+    transform: TargetTransform,
+) -> None:
+    surface_pred_norm = transform.apply_surface(surface_pred_real)
+    volume_pred_norm = transform.apply_volume(volume_pred_real)
+    surface_target_norm = transform.apply_surface(surface_y)
+    volume_target_norm = transform.apply_volume(volume_y)
+
+    mask_surface = torch.ones(surface_pred_norm.shape[0], dtype=torch.bool)
+    mask_volume = torch.ones(volume_pred_norm.shape[0], dtype=torch.bool)
+    surface_sse, surface_count = _masked_sse_count(
+        surface_pred_norm, surface_target_norm, mask_surface
+    )
+    volume_sse, volume_count = _masked_sse_count(
+        volume_pred_norm, volume_target_norm, mask_volume
+    )
+    acc.surface_loss_sse += surface_sse
+    acc.surface_loss_count += surface_count
+    acc.volume_loss_sse += volume_sse
+    acc.volume_loss_count += volume_count
+
+    surface_abs = (surface_pred_real - surface_y).abs()
+    acc.abs_sums["surface_pressure"] += float(surface_abs[:, 0].sum().item())
+    acc.abs_counts["surface_pressure"] += int(surface_abs[:, 0].numel())
+    wall_abs = surface_abs[:, 1:4]
+    acc.abs_sums["wall_shear"] += float(wall_abs.sum().item())
+    acc.abs_counts["wall_shear"] += int(wall_abs.numel())
+    for offset, axis in enumerate(("x", "y", "z")):
+        channel = wall_abs[:, offset]
+        acc.abs_sums[f"wall_shear_{axis}"] += float(channel.sum().item())
+        acc.abs_counts[f"wall_shear_{axis}"] += int(channel.numel())
+    wall_vector_error = torch.linalg.vector_norm(
+        surface_pred_real[:, 1:4] - surface_y[:, 1:4],
+        dim=-1,
+    )
+    acc.wall_shear_vector_abs_sum += float(wall_vector_error.sum().item())
+    acc.wall_shear_vector_count += int(wall_vector_error.numel())
+
+    volume_abs = (volume_pred_real - volume_y).abs()
+    acc.abs_sums["volume_pressure"] += float(volume_abs[:, 0].sum().item())
+    acc.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+
+    _accumulate_case_rel_l2(
+        acc.case_sums["surface_pressure"],
+        case_id=case_id,
+        pred=surface_pred_real[:, 0:1],
+        target=surface_y[:, 0:1],
+    )
+    _accumulate_case_rel_l2(
+        acc.case_sums["wall_shear"],
+        case_id=case_id,
+        pred=surface_pred_real[:, 1:4],
+        target=surface_y[:, 1:4],
+    )
+    for channel, axis in enumerate(("x", "y", "z"), start=1):
+        _accumulate_case_rel_l2(
+            acc.case_sums[f"wall_shear_{axis}"],
+            case_id=case_id,
+            pred=surface_pred_real[:, channel : channel + 1],
+            target=surface_y[:, channel : channel + 1],
+        )
+    _accumulate_case_rel_l2(
+        acc.case_sums["volume_pressure"],
+        case_id=case_id,
+        pred=volume_pred_real,
+        target=volume_y,
+    )
+
+
+def evaluate_split_stacked(
+    *,
+    split_name: str,
+    case_ids: list[str],
+    model: nn.Module,
+    transform: TargetTransform,
+    device: torch.device,
+    store: DrivAerMLCaseStore,
+    cfg: EvalConfig,
+    resolutions: list[int],
+    use_mirror: bool,
+    clean: dict[str, torch.Tensor],
+    K_passes: int,
+    sigma: float,
+    seed_base: int,
+    distributed_state,
+) -> dict[str, float]:
+    rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
+    world_size = (
+        distributed_state.world_size
+        if distributed_state and distributed_state.enabled
+        else 1
+    )
+    my_cases = case_ids[rank::world_size]
+
+    acc = EvalAccumulator()
+    total_t0 = time.time()
+    total_forward = 0.0
+    total_io = 0.0
+    total_perturb = 0.0
+    total_forwards = 0
+    for case_idx, case_id in enumerate(my_cases):
+        t0 = time.time()
+        surf_avg, vol_avg, surf_y, vol_y, n_passes, timing = process_case_stacked(
+            case_id=case_id,
+            model=model,
+            transform=transform,
+            device=device,
+            store=store,
+            cfg=cfg,
+            resolutions=resolutions,
+            use_mirror=use_mirror,
+            clean=clean,
+            K_passes=K_passes,
+            sigma=sigma,
+            seed_base=seed_base,
+        )
+        add_case_to_accumulator(
+            acc,
+            case_id=case_id,
+            surface_pred_real=surf_avg,
+            volume_pred_real=vol_avg,
+            surface_y=surf_y,
+            volume_y=vol_y,
+            transform=transform,
+        )
+        total_forward += timing["forward_seconds"]
+        total_io += timing["io_seconds"]
+        total_perturb += timing["perturb_seconds"]
+        total_forwards += timing["n_forwards"]
+        dt = time.time() - t0
+        print(
+            f"  [rank {rank}] {split_name} {case_id} ({case_idx + 1}/{len(my_cases)}): "
+            f"n_passes={n_passes} forwards={timing['n_forwards']} "
+            f"forward={timing['forward_seconds']:.1f}s "
+            f"perturb={timing['perturb_seconds']:.1f}s "
+            f"io={timing['io_seconds']:.1f}s total={dt:.1f}s",
+            flush=True,
+        )
+
+    print(
+        f"[rank {rank}] {split_name} complete: {len(my_cases)} cases in "
+        f"{time.time() - total_t0:.1f}s "
+        f"(forward={total_forward:.1f}s perturb={total_perturb:.1f}s "
+        f"io={total_io:.1f}s n_forwards={total_forwards})",
+        flush=True,
+    )
+
+    if distributed_state is not None and distributed_state.enabled:
+        gathered: list[EvalAccumulator | None] = [None for _ in range(world_size)]
+        dist.all_gather_object(gathered, acc)
+        if not distributed_state.is_main:
+            return {}
+        merged = merge_eval_accumulators(g for g in gathered if g is not None)
+    else:
+        merged = acc
+
+    return finalize_eval_accumulator(merged)
+
+
+def resolve_checkpoint_path(cfg: EvalConfig, state) -> tuple[Path, str]:
+    """Use local checkpoint path if it exists; else download from W&B."""
+    local = Path(cfg.checkpoint)
+    if local.exists():
+        return local, "local"
+
+    cache_root = Path(cfg.cache_root)
+    if state.is_main:
+        ckpt_path = download_checkpoint(
+            entity=cfg.wandb_entity,
+            project=cfg.wandb_project,
+            run_id=cfg.run_id,
+            alias=cfg.checkpoint_alias,
+            cache_root=cache_root,
+        )
+        ckpt_path_str = str(ckpt_path)
+    else:
+        ckpt_path_str = ""
+    if state.enabled:
+        obj = [ckpt_path_str]
+        dist.broadcast_object_list(obj, src=0)
+        ckpt_path_str = obj[0]
+    return Path(ckpt_path_str), "wandb"
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    state = init_distributed()
+    cfg = parse_args(argv)
+    device = state.device
+
+    resolutions = parse_resolutions(cfg.resolutions)
+    modes = parse_modes(cfg.eval_modes)
+    valid_modes = ("weight_noise_only", "weight_noise_mirror_res_avg")
+    for mode in modes:
+        if mode not in valid_modes:
+            raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
+
+    if state.is_main:
+        ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
+        print(f"Device: {device}{ddp_suffix}")
+        print(f"Resolutions: {resolutions}")
+        print(f"Modes: {modes}")
+        print(
+            f"Weight-noise TTA: sigma_rel={cfg.weight_noise_sigma} "
+            f"K_passes={cfg.weight_noise_passes} seed_base={cfg.weight_noise_seed_base}"
+        )
+
+    ckpt_path, ckpt_source = resolve_checkpoint_path(cfg, state)
+    if state.is_main:
+        print(f"Checkpoint: {ckpt_path} (source={ckpt_source})")
+
+    store = DrivAerMLCaseStore(
+        manifest_path=cfg.manifest, root=cfg.data_root or None
+    )
+    from data.loader import target_stats_from_normalizers  # noqa: PLC0415 — late import
+
+    stats = target_stats_from_normalizers(store)
+    transform = TargetTransform(
+        surface_y_mean=stats["surface_y_mean"].to(device),
+        surface_y_std=stats["surface_y_std"].to(device),
+        volume_y_mean=stats["volume_y_mean"].to(device),
+        volume_y_std=stats["volume_y_std"].to(device),
+    )
+
+    model = build_model(cfg).to(device)
+    ck = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    state_dict = ck["model"]
+    state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if state.is_main:
+        print(
+            f"Loaded checkpoint epoch={ck.get('epoch')} source={ck.get('checkpoint_source')}"
+        )
+        print(f"  missing={len(missing)} unexpected={len(unexpected)}")
+        if missing:
+            print(f"  missing[:5]={missing[:5]}")
+        if unexpected:
+            print(f"  unexpected[:5]={unexpected[:5]}")
+    model.eval()
+
+    eval_module = unwrap_model(model)
+    clean = snapshot_clean_params(eval_module)
+    if state.is_main:
+        n_perturbed = sum(t.numel() for t in clean.values())
+        print(f"Snapshotted {len(clean)} fp tensors ({n_perturbed:,} elements)")
+
+    val_case_ids = store.case_ids("val")
+    test_case_ids = store.case_ids("test")
+    if cfg.debug:
+        val_case_ids = val_case_ids[:2]
+        test_case_ids = test_case_ids[:2]
+        if state.is_main:
+            print(f"DEBUG: {len(val_case_ids)} val + {len(test_case_ids)} test cases only")
+
+    run = None
+    if state.is_main:
+        run_name = (
+            cfg.wandb_name
+            or f"{cfg.agent}/h252-stacked-sigma-{cfg.weight_noise_sigma}-K{cfg.weight_noise_passes}"
+        )
+        run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", cfg.wandb_project),
+            entity=os.environ.get("WANDB_ENTITY", cfg.wandb_entity),
+            group=cfg.wandb_group,
+            name=run_name,
+            config={
+                **asdict(cfg),
+                "checkpoint_epoch": ck.get("epoch"),
+                "checkpoint_source": ck.get("checkpoint_source"),
+                "resolutions_list": resolutions,
+                "modes_list": modes,
+                "n_val_cases": len(val_case_ids),
+                "n_test_cases": len(test_case_ids),
+                "ckpt_source": ckpt_source,
+            },
+            tags=[
+                "h252",
+                "tta",
+                "stacked",
+                "weight-noise",
+                "multi-res",
+                "mirror",
+                "eval-only",
+                cfg.agent,
+            ],
+            reinit="finish_previous",
+        )
+
+    splits = [
+        ("val_surface", val_case_ids, "full_val"),
+        ("test_surface", test_case_ids, "test"),
+    ]
+
+    summary: dict[str, dict[str, dict[str, float]]] = {}
+    for split_name, case_ids, log_prefix in splits:
+        summary[split_name] = {}
+        for mode in modes:
+            if mode == "weight_noise_only":
+                # K-pass weight-noise average at a single resolution, no mirror.
+                # Used to reproduce the H242 noise_only result.
+                mode_resolutions = [cfg.eval_surface_points]  # single resolution
+                use_mirror = False
+            elif mode == "weight_noise_mirror_res_avg":
+                mode_resolutions = list(resolutions)
+                use_mirror = True
+            else:
+                raise ValueError(f"Unknown mode {mode!r}")
+
+            if state.is_main:
+                print(
+                    f"\n=== {split_name} mode={mode} resolutions={mode_resolutions} "
+                    f"mirror={use_mirror} K={cfg.weight_noise_passes} "
+                    f"sigma={cfg.weight_noise_sigma} ===",
+                    flush=True,
+                )
+            t0 = time.time()
+            metrics = evaluate_split_stacked(
+                split_name=f"{split_name}/{mode}",
+                case_ids=case_ids,
+                model=model,
+                transform=transform,
+                device=device,
+                store=store,
+                cfg=cfg,
+                resolutions=mode_resolutions,
+                use_mirror=use_mirror,
+                clean=clean,
+                K_passes=cfg.weight_noise_passes,
+                sigma=cfg.weight_noise_sigma,
+                seed_base=cfg.weight_noise_seed_base,
+                distributed_state=state,
+            )
+            dt = time.time() - t0
+            if state.is_main:
+                print(f"  total {split_name}/{mode}: {dt:.1f}s")
+                print_metrics(f"{split_name}/{mode}", metrics)
+                summary[split_name][mode] = metrics
+
+                log_obj: dict[str, float] = {}
+                log_obj.update(primary_metric_log(f"{log_prefix}_primary/{mode}", metrics))
+                log_obj.update({f"{log_prefix}_extra/{mode}/loss": metrics["loss"]})
+                log_obj[f"{log_prefix}_extra/{mode}/seconds"] = dt
+                if run is not None:
+                    wandb.log(log_obj)
+
+    # Always restore clean weights at the end.
+    restore_clean_params(eval_module, clean)
+
+    if state.is_main and summary:
+        print("\n=== Summary (rel_l2_pct lower-is-better) ===")
+        for split, modes_dict in summary.items():
+            print(f"\n[{split}]")
+            keys_to_show = (
+                "abupt_axis_mean_rel_l2_pct",
+                "surface_pressure_rel_l2_pct",
+                "wall_shear_rel_l2_pct",
+                "wall_shear_x_rel_l2_pct",
+                "wall_shear_y_rel_l2_pct",
+                "wall_shear_z_rel_l2_pct",
+                "volume_pressure_rel_l2_pct",
+            )
+            mode_keys = list(modes_dict.keys())
+            header = f"  {'metric':<36s} " + " ".join(f"{m:>22s}" for m in mode_keys)
+            print(header)
+            for k in keys_to_show:
+                row = f"  {k:<36s} " + " ".join(
+                    f"{modes_dict[m][k]:>22.4f}" for m in mode_keys
+                )
+                print(row)
+
+        if run is not None:
+            for split, modes_dict in summary.items():
+                for mode, metrics in modes_dict.items():
+                    for k, v in metrics.items():
+                        try:
+                            run.summary[f"{split}/{mode}/{k}"] = float(v)
+                        except Exception:
+                            pass
+            run.finish()
+
+    cleanup_distributed(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_h242_sweep.sh
+++ b/run_h242_sweep.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# H242 weight-noise TTA σ sweep over {1e-5, 5e-5, 1e-4, 5e-4} on H185 EP13 EMA.
+set -e
+cd "$(dirname "$0")"
+
+LOGDIR="logs/h242"
+mkdir -p "$LOGDIR"
+
+CKPT="runs/h210/artifacts/h185/checkpoint.pt"
+
+for SIGMA in 1e-5 5e-5 1e-4 5e-4; do
+  echo "=== H242 σ=${SIGMA} starting at $(date -Is) ==="
+  torchrun --standalone --nproc-per-node=8 eval_tta_h242.py \
+    --checkpoint "$CKPT" \
+    --weight-noise-sigma "$SIGMA" \
+    --weight-noise-passes 5 \
+    --wandb-group h242-tanjiro-weight-noise-tta \
+    --wandb-name "tanjiro/h242-sigma-${SIGMA}" \
+    2>&1 | tee "$LOGDIR/sigma_${SIGMA}.log"
+  echo "=== H242 σ=${SIGMA} done at $(date -Is) ==="
+done
+echo "H242 sweep complete at $(date -Is)"


### PR DESCRIPTION
## Hypothesis

**H242: Weight-space TTA via Gaussian parameter perturbation on H185 EP13**

Finding Z (your H229 close) established that input-noise TTA fails — no usable σ band. But that's INPUT noise. **Weight noise** is a different mechanism: instead of perturbing inputs, perturb the EMA model weights by small Gaussian noise, run K forward passes with different perturbed copies, and average outputs.

This is "MC-Dropout in weight space" — Monte Carlo over a local approximation of the posterior at H185 EP13.

**Prediction**: 
- If H185's loss surface is locally FLAT (Polyak/SWA-good), small weight perturbations produce nearly-equal predictions and averaging adds variance reduction → -1 to -3bp gain.
- If H185's loss surface is locally SHARP, perturbations cause divergence → catastrophic failure.
- If H185 is at a saddle, asymmetric behavior across perturbations may reveal structure.

This is a **non-input-perturbation, non-weight-averaging-of-trajectory** mechanism — orthogonal to all TTA work to date. Tests the FLATNESS of H185's local optimum.

## Instructions

**Eval-only sprint. ~30-45min. DDP=8 GPUs.**

### Step 1: Modify eval_tta_h209.py to apply weight-noise TTA

Copy `target/eval_tta_h209.py` → `target/eval_tta_h242.py`. The new behavior:

1. Load H185 EP13 EMA weights into model (`yw2a5dyl` or however H209 loads it). Keep a deep copy of the original state_dict as `clean_state`.
2. For pass `k` in `0..K-1` where K=5 (default):
   - Restore model from `clean_state`
   - Add `torch.randn_like(p) * sigma * p.abs()` to each parameter (per-tensor relative-magnitude noise)
   - Run forward on val + test as in eval_tta_h209
3. Restore `clean_state` for the unperturbed "orig" pass
4. Run mirror pass from `clean_state` (the standard H209 mirror)
5. Average all K+1+1 = K+2 passes (K noise + orig + mirror) with equal weight 1/(K+2)

NOTE: This is RELATIVE noise (proportional to |weight|), NOT absolute noise. Magnitude varies per layer — large weights get bigger absolute perturbations.

Seed handling: use `seed = (42 + pass_idx) * 100003 ^ (rank * 1009)` for the per-pass perturbation RNG. Different ranks must see the SAME perturbed weights (otherwise it's broken DDP) — set the RNG seed BEFORE the per-rank-noise generation OR broadcast the noise tensors from rank 0 to all ranks.

### Step 2: σ sweep

Sweep relative noise magnitude σ ∈ {1e-5, 5e-5, 1e-4, 5e-4}:

```bash
for sigma in 1e-5 5e-5 1e-4 5e-4; do
  torchrun --standalone --nproc-per-node=8 target/eval_tta_h242.py \
    --checkpoint <H185_EP13_path> \
    --weight-noise-sigma $sigma \
    --weight-noise-passes 5 \
    --wandb-group h242-tanjiro-weight-noise-tta \
    --wandb-name "tanjiro/h242-sigma-${sigma}"
done
```

### Step 3: Report

| σ_rel | val_abupt | test_abupt | test_VP | test_SP | test_WSS | noise_only val | noise_only test | W&B Run ID |
|---|---|---|---|---|---|---|---|---|
| 0 (H209 ref) | 5.9755 | 5.8221 | 3.4400 | 3.6806 | 6.7214 | — | — | bx3t1vdw |
| 1e-5 | ? | ? | ? | ? | ? | ? | ? | ? |
| 5e-5 | ? | ? | ? | ? | ? | ? | ? | ? |
| 1e-4 | ? | ? | ? | ? | ? | ? | ? | ? |
| 5e-4 | ? | ? | ? | ? | ? | ? | ? | ? |

Include the per-σ "noise_only" mode (average of K noise passes without orig+mirror) to characterize loss-surface flatness directly: if noise_only val ≈ orig val, surface is flat at that σ.

### Step 4: SOTA gate

PRIMARY: `val_abupt < 5.9755 AND test_abupt < 5.8221`
Paper-floor: test_VP ≤ 3.421 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727

If any σ passes PRIMARY → IMMEDIATE merge candidate, tag advisor.

### Failure interpretation

- If noise_only val grows monotonically with σ but TTA stays at H209-level → orig+mirror still dominates, weight noise adds nothing useful.
- If noise_only val diverges sharply at σ=1e-4 or higher → H185 sits in a sharp basin (consistent with Findings O/P/R/U showing inter-recipe loss landscape disconnection).
- If σ ≤ 1e-5 gives flat noise_only ≈ orig AND TTA mode improves slightly → weight-noise TTA mechanism is viable, but small.

This is a Findings-grade experiment regardless of SOTA outcome.

## Baseline

H209 (PR #1382): val_abupt 5.9755, test_abupt 5.8221

## Coordination

- 6 other students testing input-side TTA mechanisms in parallel (mesh subsample, α-blending, per-channel α, permutation, multi-res)
- Your weight-space mechanism is unique — gives complementary info on H185's local geometry
- Finding R/U showed inter-recipe basins are NOT linearly connected. This experiment tests INTRA-recipe (same checkpoint) loss surface flatness — different question.

Expected runtime: ~30-45min total (4 σ × 5-7min eval, DDP×8).
