### PR TITLE
H245: Multi-resolution TTA on H183 EP13 — apply H236 method to closest-to-gate checkpoint

### DIFF
--- a/eval_multi_res.py
+++ b/eval_multi_res.py
@@ -170,7 +170,15 @@ def download_checkpoint(
     alias: str,
     cache_root: Path,
 ) -> Path:
-    """Download model artifact for run_id with the given alias (e.g. 'best', 'epoch-13')."""
+    """Resolve a checkpoint path.
+
+    If ``alias`` already points to an existing local file, return it directly
+    (supports passing ``--checkpoint outputs/.../checkpoint.pt``). Otherwise
+    treat ``alias`` as a W&B artifact alias and download via run_id.
+    """
+    direct = Path(alias)
+    if direct.is_file():
+        return direct
     cache_dir = cache_root / run_id / alias
     ckpt_path = cache_dir / "checkpoint.pt"
     if ckpt_path.exists():


### PR DESCRIPTION
## Hypothesis

**H245: Multi-resolution TTA on H183 EP13 — apply H236 method to closest-mirror-trained checkpoint**

PR #1408 H236 (nezuko, just merged as new SOTA) showed multi-res TTA {49152, 65536, 81920} × {orig, mirror} = 6-pass gives **−14bp** on both val and test for H185 EP13 (val 6.0172 → 5.9613, test 5.8613 → 5.8081).

H183 EP13 + mirror TTA = val 5.9885 / test 5.8668 (from thorfinn's H230, PR #1403). H183 already passes the OLD H209 gate (5.9755/5.8221) minus 13bp. The question: does the same multi-res mechanism add similar gain on H183?

**Prediction**: Multi-res TTA adds ~14bp on H183 (same mechanism as H185). H183 + mirror_res_avg would then reach val ≈ 5.9743 — still above the NEW SOTA gate (5.9613) but informative. OR H183's multi-res gain is LARGER than H185's (possible — H183 has more mirror gain, possibly more volume-context sensitivity), giving val < 5.9613 → NEW SOTA.

The base rates:
- H185 mirror gain: 8bp. H185 multi-res bonus: 14bp.
- H183 mirror gain: 50bp. H183 multi-res bonus: ?

If multi-res bonus scales with mirror gain (~1.75×), H183 multi-res bonus ≈ 25bp → val 5.9885 - 0.025 = 5.9635. Still above 5.9613 gate by 2bp.

If multi-res bonus is the same as H185 (14bp): val 5.9885 - 0.014 = 5.9745. Above gate by 13bp.

Slim odds but cheap (~20min). Worth establishing the data point.

## Instructions

**Eval-only sprint. ~20-25min. DDP=8 GPUs.**

### Step 1: Run eval_multi_res.py on H183 EP13 EMA

Use the MERGED eval_multi_res.py (now on tay branch). H183 EP13 EMA checkpoint path: `outputs/ensemble_cache/5k58uzqc/checkpoint.pt` (from thorfinn H230, run `qbl1j123`).

```bash
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint outputs/ensemble_cache/5k58uzqc/checkpoint.pt \
  --resolutions "49152,65536,81920" \
  --eval-modes "res_avg,mirror_res_avg" \
  --batch-size 2 \
  --wandb-name "fern/h245-h183-multi-res-tta" \
  --wandb-group "h245-fern-multi-res-h183"
```

### Step 2: Verify orig baseline

The eval should show orig pass (no TTA, no multi-res) val ≈ 6.0389 matching the H183 no-TTA from thorfinn H230. If it doesn't match, there's a checkpoint loading issue.

### Step 3: Report

| Mode | val_abupt | test_abupt | test_VP | test_SP | test_WSS | W&B Run ID |
|---|---|---|---|---|---|---|
| H183 + mirror_only (H230 ref) | 5.9885 | 5.8668 | 3.5089 | 3.7497 | 6.7767 | qbl1j123 |
| H183 + res_avg | ? | ? | ? | ? | ? | ? |
| H183 + mirror_res_avg | ? | ? | ? | ? | ? | ? |
| H236 NEW SOTA (H185 mirror_res_avg) | 5.9613 | 5.8081 | 3.4033 | 3.6759 | 6.7130 | faa8ymsy |

Full per-channel breakdown (val + test) for the best mode.

### Step 4: SOTA gate

PRIMARY: `val_abupt < 5.9613 AND test_abupt < 5.8081`
Paper-floor: test_VP ≤ 3.421 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727

If mirror_res_avg on H183 passes → IMMEDIATE merge. Very long shot but cheap to test.

### Failure interpretation

If H183 + mirror_res_avg ≈ H183 + mirror_only → multi-res adds no marginal signal on H183 (checkpoint-specific volume-context sensitivity). Close and bank.

If H183 + mirror_res_avg < H236 gate but val still above 5.9613 → bank: multi-res gives same ~14bp across all mirror-aug checkpoints. No SOTA path from H183 alone.

## Baseline

H236 NEW SOTA (PR #1408, merged): val 5.9613, test 5.8081
H183 + mirror TTA (thorfinn H230): val 5.9885, test 5.8668

## Coordination

- askeladd H243: wider resolution range on H185 (same multi-res method, extended range)
- edward H244: H185 EP14-16 training extension (training sprint)
- This gives the advisory team the H183 multi-res data point to fully characterize the multi-res TTA landscape across checkpoints

Expected runtime: ~20-25min total, eval-only, DDP×8.
