### PR TITLE
H250: Frequency-weighted multi-res TTA — non-uniform blend biased to K=65536

### DIFF
--- a/eval_multi_res.py
+++ b/eval_multi_res.py
@@ -13,8 +13,15 @@ processes its assigned cases sequentially with single-case loaders. Per-case
 scratch buffers live on CPU (~200MB per case).
 
 Modes:
-    res_avg:        average over N resolutions, no mirror
-    mirror_res_avg: 2N-pass = orig + mirror at each of N resolutions
+    res_avg:                 average over N resolutions, no mirror
+    mirror_res_avg:          2N-pass = orig + mirror at each of N resolutions
+    res_avg_weighted:        average over N resolutions, no mirror, using
+                             per-resolution weights from --resolution-weights
+    mirror_res_avg_weighted: 2N-pass weighted variant of mirror_res_avg
+
+H250 weighting motivation: predictions at K=65536 (training-dominant) carry
+lower bias than K=49152 (less-trained) and K=81920 (OOD high). Bayes-optimal
+blending therefore upweights the most-calibrated resolution.
 
 Mirror convention (H148/H183/H209):
     surface_x [x, y, z, nx, ny, nz, area] -> negate y(1) and ny(4)
@@ -70,7 +77,11 @@ class EvalConfig:
 
     # Multi-resolution TTA configuration
     resolutions: str = "49152,65536,81920"
-    eval_modes: str = "res_avg,mirror_res_avg"  # comma-separated: res_avg, mirror_res_avg
+    eval_modes: str = "res_avg,mirror_res_avg"  # comma-separated: res_avg, mirror_res_avg, res_avg_weighted, mirror_res_avg_weighted
+    # Per-resolution blending weights for *_weighted modes. Comma-separated
+    # floats with one entry per --resolutions; auto-normalized to sum=1.
+    # Empty (default) preserves uniform weighting and the unweighted modes.
+    resolution_weights: str = ""
     # Surface resolution stays fixed; only volume is varied.
     eval_surface_points: int = 65536
 
@@ -143,6 +154,24 @@ def parse_resolutions(spec: str) -> list[int]:
 
 def parse_modes(spec: str) -> list[str]:
     return [m.strip() for m in spec.split(",") if m.strip()]
+
+
+def parse_weights(spec: str, n_resolutions: int) -> list[float]:
+    """Parse comma-separated floats, normalize to sum=1. Empty → uniform."""
+    if not spec.strip():
+        return [1.0 / n_resolutions] * n_resolutions
+    parts = [float(x.strip()) for x in spec.split(",") if x.strip()]
+    if len(parts) != n_resolutions:
+        raise ValueError(
+            f"--resolution-weights has {len(parts)} entries but "
+            f"--resolutions has {n_resolutions}"
+        )
+    if any(w < 0 for w in parts):
+        raise ValueError(f"--resolution-weights must be non-negative, got {parts}")
+    total = sum(parts)
+    if total <= 0:
+        raise ValueError(f"--resolution-weights must sum to a positive value, got {total}")
+    return [w / total for w in parts]
 
 
 def build_model(cfg: EvalConfig) -> SurfaceTransolver:
@@ -250,27 +279,37 @@ def process_case_multires(
     store: DrivAerMLCaseStore,
     cfg: EvalConfig,
     resolutions: list[int],
+    weights: list[float],
     use_mirror: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
     """Run multi-res TTA passes for one case and return per-point averaged predictions.
+
+    ``weights[r]`` is the blending weight applied to all predictions from
+    resolution ``resolutions[r]`` (mirror and orig get the same weight). The
+    per-point output is sum_r(w_r * pred_r) / sum_r(w_r), which trivially
+    reduces to the uniform mean when all weights are equal.
 
     Returns (surface_avg_real[n_surf, 4], volume_avg_real[n_vol, 1],
              surface_y[n_surf, 4], volume_y[n_vol, 1], n_passes, timing).
     Predictions are in **real units** (already denormalized).
     """
+    assert len(weights) == len(resolutions), (
+        f"weights ({len(weights)}) must match resolutions ({len(resolutions)})"
+    )
     counts = store.case_point_counts(case_id)
     n_surf = counts["n_surface"]
     n_vol = counts["n_volume"]
 
     surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
-    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
+    surf_cnt = torch.zeros(n_surf, dtype=torch.float32)
     vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
-    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)
+    vol_cnt = torch.zeros(n_vol, dtype=torch.float32)
 
     eval_module = unwrap_model(model)
     timing: dict[str, float] = {"forward_seconds": 0.0, "io_seconds": 0.0, "n_forwards": 0}
 
-    for K in resolutions:
+    for r_idx, K in enumerate(resolutions):
+        w_r = float(weights[r_idx])
         dataset = DrivAerMLSurfaceDataset(
             case_ids=[case_id],
             store=store,
@@ -336,9 +375,13 @@ def process_case_multires(
                                 f"global={s_global.shape[0]} vs chunk={s_chunk.shape[0]}"
                             )
                         if s_global.numel() > 0:
-                            surf_sum.index_add_(0, s_global, s_chunk)
+                            surf_sum.index_add_(0, s_global, s_chunk * w_r)
                             surf_cnt.index_add_(
-                                0, s_global, torch.ones_like(s_global, dtype=torch.int32)
+                                0,
+                                s_global,
+                                torch.full(
+                                    (s_global.shape[0],), w_r, dtype=torch.float32
+                                ),
                             )
 
                     if v_view_idx < v_view_count:
@@ -352,25 +395,29 @@ def process_case_multires(
                                 f"global={v_global.shape[0]} vs chunk={v_chunk.shape[0]}"
                             )
                         if v_global.numel() > 0:
-                            vol_sum.index_add_(0, v_global, v_chunk)
+                            vol_sum.index_add_(0, v_global, v_chunk * w_r)
                             vol_cnt.index_add_(
-                                0, v_global, torch.ones_like(v_global, dtype=torch.int32)
+                                0,
+                                v_global,
+                                torch.full(
+                                    (v_global.shape[0],), w_r, dtype=torch.float32
+                                ),
                             )
                 timing["io_seconds"] += time.time() - t1
 
-    if int(surf_cnt.min()) == 0:
+    if float(surf_cnt.min()) <= 0.0:
         raise RuntimeError(
             f"surface coverage incomplete for case {case_id}: "
-            f"{int((surf_cnt == 0).sum())} points have zero contributing chunks"
+            f"{int((surf_cnt <= 0).sum())} points have zero contributing chunks"
         )
-    if int(vol_cnt.min()) == 0:
+    if float(vol_cnt.min()) <= 0.0:
         raise RuntimeError(
             f"volume coverage incomplete for case {case_id}: "
-            f"{int((vol_cnt == 0).sum())} points have zero contributing chunks"
+            f"{int((vol_cnt <= 0).sum())} points have zero contributing chunks"
         )
 
-    surf_avg = surf_sum / surf_cnt.unsqueeze(-1).to(torch.float32)
-    vol_avg = vol_sum / vol_cnt.unsqueeze(-1).to(torch.float32)
+    surf_avg = surf_sum / surf_cnt.unsqueeze(-1)
+    vol_avg = vol_sum / vol_cnt.unsqueeze(-1)
 
     # Load full ground truth once for metric computation.
     case = store.load_case(case_id)
@@ -472,6 +519,7 @@ def evaluate_split_multires(
     store: DrivAerMLCaseStore,
     cfg: EvalConfig,
     resolutions: list[int],
+    weights: list[float],
     use_mirror: bool,
     distributed_state,
 ) -> dict[str, float]:
@@ -499,6 +547,7 @@ def evaluate_split_multires(
             store=store,
             cfg=cfg,
             resolutions=resolutions,
+            weights=weights,
             use_mirror=use_mirror,
         )
         add_case_to_accumulator(
@@ -549,15 +598,27 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     resolutions = parse_resolutions(cfg.resolutions)
     modes = parse_modes(cfg.eval_modes)
+    valid_modes = ("res_avg", "mirror_res_avg", "res_avg_weighted", "mirror_res_avg_weighted")
     for mode in modes:
-        if mode not in ("res_avg", "mirror_res_avg"):
-            raise ValueError(f"Unknown eval mode: {mode!r}")
+        if mode not in valid_modes:
+            raise ValueError(f"Unknown eval mode: {mode!r}; valid={valid_modes}")
+
+    uniform_weights = [1.0 / len(resolutions)] * len(resolutions)
+    custom_weights = parse_weights(cfg.resolution_weights, len(resolutions))
+    any_weighted = any(m.endswith("_weighted") for m in modes)
+    if any_weighted and not cfg.resolution_weights.strip():
+        raise ValueError(
+            "*_weighted eval modes require --resolution-weights; got empty string"
+        )
 
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
         print(f"Device: {device}{ddp_suffix}")
         print(f"Source run_id={cfg.run_id} alias={cfg.checkpoint} use_ema={cfg.use_ema}")
         print(f"Resolutions: {resolutions}")
+        print(f"Uniform weights: {uniform_weights}")
+        if any_weighted:
+            print(f"Custom weights (normalized): {custom_weights}")
         print(f"Modes: {modes}")
 
     # Download/locate the checkpoint on rank 0 only, then broadcast the path.
@@ -635,6 +696,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "checkpoint_source": ck.get("checkpoint_source"),
                 "resolutions_list": resolutions,
                 "modes_list": modes,
+                "uniform_weights": uniform_weights,
+                "custom_weights_normalized": custom_weights,
+                "any_weighted_mode": any_weighted,
                 "n_val_cases": len(val_case_ids),
                 "n_test_cases": len(test_case_ids),
             },
@@ -657,11 +721,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     for split_name, case_ids, log_prefix in splits:
         summary[split_name] = {}
         for mode in modes:
-            use_mirror = mode == "mirror_res_avg"
+            use_mirror = mode in ("mirror_res_avg", "mirror_res_avg_weighted")
+            mode_weights = custom_weights if mode.endswith("_weighted") else uniform_weights
             if state.is_main:
                 print(
                     f"\n=== Evaluating split={split_name} mode={mode} "
-                    f"resolutions={resolutions} mirror={use_mirror} ===",
+                    f"resolutions={resolutions} weights={mode_weights} "
+                    f"mirror={use_mirror} ===",
                     flush=True,
                 )
             t0 = time.time()
@@ -674,6 +740,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 store=store,
                 cfg=cfg,
                 resolutions=resolutions,
+                weights=mode_weights,
                 use_mirror=use_mirror,
                 distributed_state=state,
             )


### PR DESCRIPTION
## Hypothesis

**H250: Frequency-weighted multi-resolution TTA on H185 EP13 — non-uniform resolution blend biased toward training-dominant resolution**

H236 (PR #1408, merged SOTA) blends {49152, 65536, 81920} with **uniform weights (1/3 each)**. Your H241 (just closed) confirmed that per-channel α-sweep collapses to α=0.5 when predictions are equal-bias estimators. But the H236 resolution blend involves predictions that are **NOT equal-bias** — they come from different input-size samples with different training exposure:

- **K=65536**: H185 spent ~4 epochs at this resolution (EP10-13). The model's volume-context understanding is calibrated at this size. LOWEST BIAS.
- **K=49152**: H185 spent ~3 epochs at this resolution (EP6-9). Moderate training exposure. MODERATE BIAS.
- **K=81920**: H185 was NEVER trained at this resolution — it's OOD on the HIGH side. HIGHEST BIAS.

**The theoretical motivation**: Bayes-optimal blending assigns HIGHER weight to LOWER-BIAS estimators. A uniform blend over-weights K=81920 (OOD, highest bias) relative to its information contribution. Shifting weight toward K=65536 (most-calibrated) should reduce the aggregate bias in the multi-res blend.

This avoids the Finding DD failure mode: Finding DD applies when BOTH streams are equal-bias (e.g., orig+mirror from the same model). Here the streams have DIFFERENT biases due to training-schedule exposure, so non-uniform weighting is theoretically justified.

**Prediction**: heavy-65k weighting with {0.25, 0.50, 0.25} (or even {0.15, 0.70, 0.15}) should match or beat H236's 1/3-1/3-1/3 blend by reducing the OOD-resolution contribution. Expected gain: 2-5bp.

## Instructions

**Eval-only sprint. ~45-55min. DDP=8 GPUs.**

### Step 1: Add resolution-weight support to target/eval_multi_res.py

Add a `--resolution-weights` CLI flag (comma-separated floats, auto-normalized to sum to 1). In the blend step, multiply each resolution's prediction contribution by its weight before summing.

```python
# In the per-case accumulation loop:
#   pred_blended = sum_r (w_r * pred_r) / sum_r(w_r)
# where w_r comes from --resolution-weights
```

Default (no flag): uniform weights (preserves H236 behavior). New mode flag: `mirror_res_avg_weighted` (same as `mirror_res_avg` but uses custom weights).

### Step 2: Run sanity + weight sweep

```bash
H185_CKPT="outputs/ensemble_cache/<H185_EP13_EMA_PATH>/checkpoint.pt"
# Confirm path from your faa8ymsy run config — same as H236/H241

# Sanity: H236 uniform reproduce
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "49152,65536,81920" \
  --eval-modes "mirror_res_avg" \
  --wandb-name "frieren/h250-sanity-uniform" \
  --wandb-group "h250-frieren-resolution-weighted"

# Mild heavy-65k: {0.25, 0.50, 0.25}
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "49152,65536,81920" \
  --eval-modes "mirror_res_avg_weighted" \
  --resolution-weights "0.25,0.50,0.25" \
  --wandb-name "frieren/h250-heavy65k-mild" \
  --wandb-group "h250-frieren-resolution-weighted"

# Aggressive heavy-65k: {0.15, 0.70, 0.15}
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "49152,65536,81920" \
  --eval-modes "mirror_res_avg_weighted" \
  --resolution-weights "0.15,0.70,0.15" \
  --wandb-name "frieren/h250-heavy65k-aggressive" \
  --wandb-group "h250-frieren-resolution-weighted"

# Extreme heavy-65k: {0.1, 0.80, 0.1}
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "49152,65536,81920" \
  --eval-modes "mirror_res_avg_weighted" \
  --resolution-weights "0.1,0.80,0.1" \
  --wandb-name "frieren/h250-heavy65k-extreme" \
  --wandb-group "h250-frieren-resolution-weighted"
```

### Step 3: Report

| Config | weights (49k:65k:82k) | val_abupt | test_abupt | test_VP | test_SP | test_WSS | W&B Run ID |
|---|---|---|---|---|---|---|---|
| H236 sanity (uniform) | 1/3:1/3:1/3 | 5.9613 | 5.8081 | 3.4033 | 3.6759 | 6.7130 | faa8ymsy |
| H250 mild | 0.25:0.50:0.25 | ? | ? | ? | ? | ? | ? |
| H250 aggressive | 0.15:0.70:0.15 | ? | ? | ? | ? | ? | ? |
| H250 extreme | 0.10:0.80:0.10 | ? | ? | ? | ? | ? | ? |

Full per-channel breakdown (val + test) for the BEST weighted config.

### Step 4: SOTA gate

PRIMARY: `val_abupt < 5.9613 AND test_abupt < 5.8081` (both must pass)
Paper-floor: test_VP ≤ 3.421 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727

If any weighted config passes → IMMEDIATE merge candidate.

### Failure interpretation

If ALL weighted configs WORSE than uniform: multi-res predictions are empirically equal-bias (the OOD bias of K=81920 is small enough that uniform averaging is already near-optimal). **Bank Finding DD extension to resolution weighting**: the equal-bias argument applies across resolutions as well as mirror-pairs for this model.

If mild/aggressive IMPROVES but extreme WORSENS: there's an optimal non-uniform weight between 0.25:0.50:0.25 and uniform. The sweet spot is near mild/moderate. Report optimal config, tag advisor for follow-up with finer sweep.

If aggressive or extreme IMPROVES monotonically: K=81920 contributes nearly zero useful signal; the OOD resolution is actively noisy. Consider dropping it entirely → 2-res {49152, 65536} × mirror = 4-pass TTA. Run a 4-pass sanity check as a bonus arm if time permits.

## Baseline

H236 NEW SOTA (PR #1408, merged): val 5.9613, test 5.8081, test_WSS 6.7130

## Coordination

- **H243 askeladd**: wider resolution range (tests if more resolutions help)
- **H249 fern**: tighter resolution spacing (tests if IID-proximity helps)
- **H250 this**: resolution WEIGHTING (tests if frequency-prior helps)

Together, H236 + H243 + H249 + H250 fully characterize the multi-res blend design space: range width, spacing, and weighting.

Expected runtime: 4 configs × ~12min each ≈ ~50min + code extension. Set SENPAI_TIMEOUT_MINUTES=90 for safety.
