### PR TITLE
H253: Stack weight-noise σ=5e-4 on H243 6-res TTA — compounding SOTA push

### DIFF
--- a/eval_multi_res.py
+++ b/eval_multi_res.py
@@ -1,26 +1,32 @@
 # SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: senpai
-"""H236: Multi-resolution TTA — eval at varied volume point counts and average.
+"""H236/H253: Multi-resolution TTA — eval at varied volume point counts and average.
 
 For each case, accumulates per-point predictions across multiple
-``eval_volume_points`` resolutions (optionally combined with mirror TTA),
-averages them per-point in real space, and reports the standard relL2/MAE
-metrics against the unchanged ground truth.
+``eval_volume_points`` resolutions (optionally combined with mirror TTA and
+weight-space noise TTA), averages them per-point in real space, and reports
+the standard relL2/MAE metrics against the unchanged ground truth.
 
 Cases are sharded across DDP ranks (case_ids[rank::world_size]); each rank
 processes its assigned cases sequentially with single-case loaders. Per-case
 scratch buffers live on CPU (~200MB per case).
 
 Modes:
-    res_avg:        average over N resolutions, no mirror
-    mirror_res_avg: 2N-pass = orig + mirror at each of N resolutions
+    res_avg:                    average over N resolutions, no mirror
+    mirror_res_avg:             2N-pass = orig + mirror at each of N resolutions
+    mirror_res_weight_noise_avg: K*2N-pass = K weight-noise passes wrapping mirror_res_avg
 
 Mirror convention (H148/H183/H209):
     surface_x [x, y, z, nx, ny, nz, area] -> negate y(1) and ny(4)
     volume_x  [x, y, z, sdf]              -> negate y(1)
     surface_y predictions [cp, tau_x, tau_y, tau_z] -> un-mirror by negating tau_y(2)
     volume_y predictions [volume_pressure] -> invariant
+
+Weight-noise convention (H242/H253):
+    Relative Gaussian noise: perturbed = w + sigma * |w| * eps, eps ~ N(0, 1).
+    CPU generator with deterministic per-parameter seed -> identical noise
+    on all DDP ranks, so each rank's perturbed model matches the others.
 """
 
 from __future__ import annotations
@@ -70,9 +76,14 @@ class EvalConfig:
 
     # Multi-resolution TTA configuration
     resolutions: str = "49152,65536,81920"
-    eval_modes: str = "res_avg,mirror_res_avg"  # comma-separated: res_avg, mirror_res_avg
+    # comma-separated: res_avg, mirror_res_avg, mirror_res_weight_noise_avg
+    eval_modes: str = "res_avg,mirror_res_avg"
     # Surface resolution stays fixed; only volume is varied.
     eval_surface_points: int = 65536
+
+    # H253: weight-space noise TTA (used by mirror_res_weight_noise_avg)
+    weight_noise_sigma: float = 5e-4
+    n_weight_noise_passes: int = 5
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -241,7 +252,7 @@ def chunk_global_indices(view_index: int, view_count: int, n_full: int) -> torch
 
 
 @torch.no_grad()
-def process_case_multires(
+def _accumulate_multires_mirror(
     *,
     case_id: str,
     model: nn.Module,
@@ -251,24 +262,20 @@ def process_case_multires(
     cfg: EvalConfig,
     resolutions: list[int],
     use_mirror: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
-    """Run multi-res TTA passes for one case and return per-point averaged predictions.
+    n_surf: int,
+    n_vol: int,
+    surf_sum: torch.Tensor,
+    surf_cnt: torch.Tensor,
+    vol_sum: torch.Tensor,
+    vol_cnt: torch.Tensor,
+    timing: dict,
+) -> None:
+    """Run a single (resolutions × {orig, mirror}) accumulation pass into provided buffers.
 
-    Returns (surface_avg_real[n_surf, 4], volume_avg_real[n_vol, 1],
-             surface_y[n_surf, 4], volume_y[n_vol, 1], n_passes, timing).
-    Predictions are in **real units** (already denormalized).
+    Shared by ``process_case_multires`` (single noise pass) and
+    ``process_case_multires_weight_noise`` (K noise passes, same buffer reused).
     """
-    counts = store.case_point_counts(case_id)
-    n_surf = counts["n_surface"]
-    n_vol = counts["n_volume"]
-
-    surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
-    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
-    vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
-    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)
-
     eval_module = unwrap_model(model)
-    timing: dict[str, float] = {"forward_seconds": 0.0, "io_seconds": 0.0, "n_forwards": 0}
 
     for K in resolutions:
         dataset = DrivAerMLSurfaceDataset(
@@ -358,6 +365,54 @@ def process_case_multires(
                             )
                 timing["io_seconds"] += time.time() - t1
 
+
+@torch.no_grad()
+def process_case_multires(
+    *,
+    case_id: str,
+    model: nn.Module,
+    transform: TargetTransform,
+    device: torch.device,
+    store: DrivAerMLCaseStore,
+    cfg: EvalConfig,
+    resolutions: list[int],
+    use_mirror: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
+    """Run multi-res TTA passes for one case and return per-point averaged predictions.
+
+    Returns (surface_avg_real[n_surf, 4], volume_avg_real[n_vol, 1],
+             surface_y[n_surf, 4], volume_y[n_vol, 1], n_passes, timing).
+    Predictions are in **real units** (already denormalized).
+    """
+    counts = store.case_point_counts(case_id)
+    n_surf = counts["n_surface"]
+    n_vol = counts["n_volume"]
+
+    surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
+    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
+    vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
+    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)
+
+    timing: dict[str, float] = {"forward_seconds": 0.0, "io_seconds": 0.0, "n_forwards": 0}
+
+    _accumulate_multires_mirror(
+        case_id=case_id,
+        model=model,
+        transform=transform,
+        device=device,
+        store=store,
+        cfg=cfg,
+        resolutions=resolutions,
+        use_mirror=use_mirror,
+        n_surf=n_surf,
+        n_vol=n_vol,
+        surf_sum=surf_sum,
+        surf_cnt=surf_cnt,
+        vol_sum=vol_sum,
+        vol_cnt=vol_cnt,
+        timing=timing,
+    )
+
     if int(surf_cnt.min()) == 0:
         raise RuntimeError(
             f"surface coverage incomplete for case {case_id}: "
@@ -378,6 +433,259 @@ def process_case_multires(
     vol_y = case.volume_y.float()
 
     n_passes = len(resolutions) * (2 if use_mirror else 1)
+    return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
+
+
+def _compute_perturbed_state_dicts(
+    *,
+    clean_state_cpu: dict[str, torch.Tensor],
+    device: torch.device,
+    sigma: float,
+    n_noise_passes: int,
+) -> list[dict[str, torch.Tensor]]:
+    """Pre-compute K perturbed state-dicts on GPU once per case.
+
+    Uses deterministic CPU generator per (noise_idx, param_idx) so the noise
+    pattern is identical across DDP ranks. Returns K GPU-resident state dicts
+    suitable for ``load_state_dict``. Floating-point params are perturbed with
+    relative noise ``sigma * |w| * eps``; non-float buffers are passed through.
+    """
+    perturbed_states: list[dict[str, torch.Tensor]] = []
+    for noise_idx in range(n_noise_passes):
+        state: dict[str, torch.Tensor] = {}
+        for param_idx, (k, v) in enumerate(clean_state_cpu.items()):
+            if v.dtype.is_floating_point:
+                seed = (noise_idx * 100003 + param_idx * 1009) % (2 ** 31)
+                g = torch.Generator()
+                g.manual_seed(seed)
+                noise = torch.empty_like(v).normal_(generator=g)
+                state[k] = (v + sigma * v.abs() * noise).to(device)
+            else:
+                state[k] = v.to(device)
+        perturbed_states.append(state)
+    return perturbed_states
+
+
+@torch.no_grad()
+def process_case_multires_weight_noise(
+    *,
+    case_id: str,
+    model: nn.Module,
+    transform: TargetTransform,
+    device: torch.device,
+    store: DrivAerMLCaseStore,
+    cfg: EvalConfig,
+    resolutions: list[int],
+    sigma: float,
+    n_noise_passes: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
+    """Stack weight-space noise TTA on top of mirror×multires TTA.
+
+    K weight-noise passes × N resolutions × 2 mirror states = K*N*2 total
+    predictions per point, averaged per-point in real units.
+
+    **Noise-INNER batch-reuse layout** to fit the SENPAI runtime budget:
+    each (resolution, batch, mirror) tuple loads data once, then we swap
+    between K pre-computed GPU-resident perturbed state-dicts and run K
+    forward passes back-to-back. The K predictions are summed on GPU and
+    accumulated into the per-point CPU buffer **as a single K-averaged
+    contribution** per (batch, mirror). The mathematical result is identical
+    to averaging K*N*2 individual predictions per point, but I/O is paid once
+    per (resolution, batch) instead of K times, and CPU accumulation runs
+    N*2 times instead of K*N*2 times.
+
+    Returns (surface_avg_real[n_surf, 4], volume_avg_real[n_vol, 1],
+             surface_y[n_surf, 4], volume_y[n_vol, 1], n_passes, timing).
+    """
+    counts = store.case_point_counts(case_id)
+    n_surf = counts["n_surface"]
+    n_vol = counts["n_volume"]
+
+    surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
+    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
+    vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
+    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)
+
+    timing: dict[str, float] = {
+        "forward_seconds": 0.0,
+        "io_seconds": 0.0,
+        "n_forwards": 0,
+        "perturb_seconds": 0.0,
+        "state_swap_seconds": 0.0,
+    }
+
+    eval_module = unwrap_model(model)
+    clean_state_cpu = {
+        k: v.detach().cpu().clone() for k, v in eval_module.state_dict().items()
+    }
+
+    t_perturb = time.time()
+    perturbed_states_gpu = _compute_perturbed_state_dicts(
+        clean_state_cpu=clean_state_cpu,
+        device=device,
+        sigma=sigma,
+        n_noise_passes=n_noise_passes,
+    )
+    timing["perturb_seconds"] += time.time() - t_perturb
+
+    try:
+        # Start with the first perturbed state loaded so we are never running
+        # on the clean weights inside the main loop.
+        t0 = time.time()
+        eval_module.load_state_dict(perturbed_states_gpu[0])
+        current_K_idx = 0
+        timing["state_swap_seconds"] += time.time() - t0
+
+        for K in resolutions:
+            dataset = DrivAerMLSurfaceDataset(
+                case_ids=[case_id],
+                store=store,
+                max_surface_points=cfg.eval_surface_points,
+                max_volume_points=K,
+                sampling_mode="eval_chunk",
+            )
+            loader_iter = torch.utils.data.DataLoader(
+                dataset,
+                batch_size=cfg.batch_size,
+                shuffle=False,
+                num_workers=cfg.num_workers,
+                pin_memory=cfg.pin_memory,
+                collate_fn=pad_collate,
+                persistent_workers=False,
+                prefetch_factor=cfg.prefetch_factor if cfg.num_workers > 0 else None,
+            )
+
+            for batch in loader_iter:
+                batch = batch.to(device)
+                metas_cached = list(batch.metadata)
+
+                for mirror in (False, True):
+                    model_input = mirror_inputs(batch) if mirror else batch
+
+                    sum_pred_surf: torch.Tensor | None = None
+                    sum_pred_vol: torch.Tensor | None = None
+                    for K_idx in range(n_noise_passes):
+                        if K_idx != current_K_idx:
+                            t_swap = time.time()
+                            eval_module.load_state_dict(perturbed_states_gpu[K_idx])
+                            current_K_idx = K_idx
+                            timing["state_swap_seconds"] += time.time() - t_swap
+
+                        t0 = time.time()
+                        with autocast_context(device, cfg.amp_mode):
+                            out = eval_module(
+                                surface_x=model_input.surface_x,
+                                surface_mask=model_input.surface_mask,
+                                volume_x=model_input.volume_x,
+                                volume_mask=model_input.volume_mask,
+                            )
+                        surface_pred_real = transform.invert_surface(
+                            out["surface_preds"].float()
+                        )
+                        volume_pred_real = transform.invert_volume(
+                            out["volume_preds"].float()
+                        )
+                        if mirror:
+                            surface_pred_real = unmirror_surface_real(surface_pred_real)
+                        timing["forward_seconds"] += time.time() - t0
+                        timing["n_forwards"] += int(batch.surface_x.shape[0])
+
+                        if sum_pred_surf is None:
+                            sum_pred_surf = surface_pred_real
+                            sum_pred_vol = volume_pred_real
+                        else:
+                            sum_pred_surf = sum_pred_surf + surface_pred_real
+                            sum_pred_vol = sum_pred_vol + volume_pred_real
+
+                    # K-average on GPU so the CPU accumulator below pays the
+                    # transfer + index_add_ cost ONCE per (batch, mirror), not K
+                    # times.
+                    inv_K = 1.0 / float(n_noise_passes)
+                    avg_pred_surf = sum_pred_surf * inv_K
+                    avg_pred_vol = sum_pred_vol * inv_K
+
+                    t1 = time.time()
+                    surface_pred_real_cpu = avg_pred_surf.detach().cpu()
+                    volume_pred_real_cpu = avg_pred_vol.detach().cpu()
+                    surface_mask_cpu = batch.surface_mask.detach().cpu()
+                    volume_mask_cpu = batch.volume_mask.detach().cpu()
+                    for i in range(len(batch.case_ids)):
+                        meta = metas_cached[i]
+                        s_view_idx = int(meta["surface_view_index"])
+                        s_view_count = int(meta["surface_view_count"])
+                        v_view_idx = int(meta["volume_view_index"])
+                        v_view_count = int(meta["volume_view_count"])
+
+                        if s_view_idx < s_view_count:
+                            s_global = chunk_global_indices(
+                                s_view_idx, s_view_count, n_surf
+                            )
+                            s_mask_i = surface_mask_cpu[i].bool()
+                            s_chunk = surface_pred_real_cpu[i][s_mask_i]
+                            if s_global.shape[0] != s_chunk.shape[0]:
+                                raise RuntimeError(
+                                    f"surface global-index mismatch case={case_id} "
+                                    f"K={K} view_idx={s_view_idx}/{s_view_count}: "
+                                    f"global={s_global.shape[0]} vs "
+                                    f"chunk={s_chunk.shape[0]}"
+                                )
+                            if s_global.numel() > 0:
+                                surf_sum.index_add_(0, s_global, s_chunk)
+                                surf_cnt.index_add_(
+                                    0,
+                                    s_global,
+                                    torch.ones_like(s_global, dtype=torch.int32),
+                                )
+
+                        if v_view_idx < v_view_count:
+                            v_global = chunk_global_indices(
+                                v_view_idx, v_view_count, n_vol
+                            )
+                            v_mask_i = volume_mask_cpu[i].bool()
+                            v_chunk = volume_pred_real_cpu[i][v_mask_i]
+                            if v_global.shape[0] != v_chunk.shape[0]:
+                                raise RuntimeError(
+                                    f"volume global-index mismatch case={case_id} "
+                                    f"K={K} view_idx={v_view_idx}/{v_view_count}: "
+                                    f"global={v_global.shape[0]} vs "
+                                    f"chunk={v_chunk.shape[0]}"
+                                )
+                            if v_global.numel() > 0:
+                                vol_sum.index_add_(0, v_global, v_chunk)
+                                vol_cnt.index_add_(
+                                    0,
+                                    v_global,
+                                    torch.ones_like(v_global, dtype=torch.int32),
+                                )
+                    timing["io_seconds"] += time.time() - t1
+    finally:
+        # Always restore clean weights so subsequent cases start from the
+        # unperturbed model. Also drop the K perturbed GPU state-dicts so they
+        # don't survive past this case.
+        eval_module.load_state_dict(
+            {k: v.to(device) for k, v in clean_state_cpu.items()}
+        )
+        del perturbed_states_gpu
+
+    if int(surf_cnt.min()) == 0:
+        raise RuntimeError(
+            f"surface coverage incomplete for case {case_id}: "
+            f"{int((surf_cnt == 0).sum())} points have zero contributing chunks"
+        )
+    if int(vol_cnt.min()) == 0:
+        raise RuntimeError(
+            f"volume coverage incomplete for case {case_id}: "
+            f"{int((vol_cnt == 0).sum())} points have zero contributing chunks"
+        )
+
+    surf_avg = surf_sum / surf_cnt.unsqueeze(-1).to(torch.float32)
+    vol_avg = vol_sum / vol_cnt.unsqueeze(-1).to(torch.float32)
+
+    case = store.load_case(case_id)
+    surf_y = case.surface_y.float()
+    vol_y = case.volume_y.float()
+
+    n_passes = n_noise_passes * len(resolutions) * 2
     return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
 
 
@@ -472,7 +780,7 @@ def evaluate_split_multires(
     store: DrivAerMLCaseStore,
     cfg: EvalConfig,
     resolutions: list[int],
-    use_mirror: bool,
+    mode: str,
     distributed_state,
 ) -> dict[str, float]:
     """Distribute cases across ranks, run multi-res TTA per case, return finalized metrics."""
@@ -484,23 +792,43 @@ def evaluate_split_multires(
     )
     my_cases = case_ids[rank::world_size]
 
+    use_mirror = mode in ("mirror_res_avg", "mirror_res_weight_noise_avg")
+    use_weight_noise = mode == "mirror_res_weight_noise_avg"
+
     acc = EvalAccumulator()
     total_t0 = time.time()
     total_forward = 0.0
     total_io = 0.0
+    total_perturb = 0.0
+    total_swap = 0.0
     total_forwards = 0
     for case_idx, case_id in enumerate(my_cases):
         t0 = time.time()
-        surf_avg, vol_avg, surf_y, vol_y, n_passes, timing = process_case_multires(
-            case_id=case_id,
-            model=model,
-            transform=transform,
-            device=device,
-            store=store,
-            cfg=cfg,
-            resolutions=resolutions,
-            use_mirror=use_mirror,
-        )
+        if use_weight_noise:
+            surf_avg, vol_avg, surf_y, vol_y, n_passes, timing = (
+                process_case_multires_weight_noise(
+                    case_id=case_id,
+                    model=model,
+                    transform=transform,
+                    device=device,
+                    store=store,
+                    cfg=cfg,
+                    resolutions=resolutions,
+                    sigma=cfg.weight_noise_sigma,
+                    n_noise_passes=cfg.n_weight_noise_passes,
+                )
+            )
+        else:
+            surf_avg, vol_avg, surf_y, vol_y, n_passes, timing = process_case_multires(
+                case_id=case_id,
+                model=model,
+                transform=transform,
+                device=device,
+                store=store,
+                cfg=cfg,
+                resolutions=resolutions,
+                use_mirror=use_mirror,
+            )
         add_case_to_accumulator(
             acc,
             case_id=case_id,
@@ -512,20 +840,35 @@ def evaluate_split_multires(
         )
         total_forward += timing["forward_seconds"]
         total_io += timing["io_seconds"]
+        total_perturb += timing.get("perturb_seconds", 0.0)
+        total_swap += timing.get("state_swap_seconds", 0.0)
         total_forwards += timing["n_forwards"]
         dt = time.time() - t0
+        extra_parts = []
+        if "perturb_seconds" in timing:
+            extra_parts.append(f"perturb={timing['perturb_seconds']:.1f}s")
+        if "state_swap_seconds" in timing:
+            extra_parts.append(f"swap={timing['state_swap_seconds']:.1f}s")
+        extra = (" " + " ".join(extra_parts)) if extra_parts else ""
         print(
             f"  [rank {rank}] {split_name} {case_id} ({case_idx + 1}/{len(my_cases)}): "
             f"n_passes={n_passes} forwards={timing['n_forwards']} "
-            f"forward={timing['forward_seconds']:.1f}s io={timing['io_seconds']:.1f}s "
-            f"total={dt:.1f}s",
+            f"forward={timing['forward_seconds']:.1f}s io={timing['io_seconds']:.1f}s"
+            f"{extra} total={dt:.1f}s",
             flush=True,
         )
 
+    extra_total_parts = []
+    if total_perturb > 0:
+        extra_total_parts.append(f"perturb={total_perturb:.1f}s")
+    if total_swap > 0:
+        extra_total_parts.append(f"swap={total_swap:.1f}s")
+    extra_total = (" " + " ".join(extra_total_parts)) if extra_total_parts else ""
     print(
         f"[rank {rank}] {split_name} complete: {len(my_cases)} cases in "
         f"{time.time() - total_t0:.1f}s "
-        f"(forward={total_forward:.1f}s io={total_io:.1f}s n_forwards={total_forwards})",
+        f"(forward={total_forward:.1f}s io={total_io:.1f}s{extra_total} "
+        f"n_forwards={total_forwards})",
         flush=True,
     )
 
@@ -549,9 +892,10 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     resolutions = parse_resolutions(cfg.resolutions)
     modes = parse_modes(cfg.eval_modes)
+    valid_modes = ("res_avg", "mirror_res_avg", "mirror_res_weight_noise_avg")
     for mode in modes:
-        if mode not in ("res_avg", "mirror_res_avg"):
-            raise ValueError(f"Unknown eval mode: {mode!r}")
+        if mode not in valid_modes:
+            raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
 
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
@@ -657,11 +1001,17 @@ def main(argv: Iterable[str] | None = None) -> None:
     for split_name, case_ids, log_prefix in splits:
         summary[split_name] = {}
         for mode in modes:
-            use_mirror = mode == "mirror_res_avg"
+            use_mirror = mode in ("mirror_res_avg", "mirror_res_weight_noise_avg")
+            use_weight_noise = mode == "mirror_res_weight_noise_avg"
             if state.is_main:
+                wn_suffix = (
+                    f" K={cfg.n_weight_noise_passes} sigma={cfg.weight_noise_sigma}"
+                    if use_weight_noise
+                    else ""
+                )
                 print(
                     f"\n=== Evaluating split={split_name} mode={mode} "
-                    f"resolutions={resolutions} mirror={use_mirror} ===",
+                    f"resolutions={resolutions} mirror={use_mirror}{wn_suffix} ===",
                     flush=True,
                 )
             t0 = time.time()
@@ -674,7 +1024,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 store=store,
                 cfg=cfg,
                 resolutions=resolutions,
-                use_mirror=use_mirror,
+                mode=mode,
                 distributed_state=state,
             )
             dt = time.time() - t0

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass, field
+from datetime import timedelta
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -113,7 +114,18 @@ def init_distributed() -> DistributedState:
         if not dist.is_available():
             raise RuntimeError("torch.distributed is not available, but WORLD_SIZE > 1")
         backend = "nccl" if device.type == "cuda" else "gloo"
-        dist.init_process_group(backend=backend)
+        # Long collective timeout (default is 10min for NCCL). Heavy TTA eval
+        # workloads can have ~15-20min gaps between the fastest and slowest
+        # rank hitting the all_gather barrier when case distribution is uneven
+        # (e.g. 50 test cases / 8 ranks = 6 vs 7 cases × ~15min/case → ~15min
+        # gap). The default 10-minute timeout fires before the slowest rank
+        # arrives and kills the process group mid-eval. Override via
+        # ``SENPAI_NCCL_TIMEOUT_MINUTES`` if a workload needs even longer.
+        timeout_minutes = float(os.environ.get("SENPAI_NCCL_TIMEOUT_MINUTES", "120"))
+        dist.init_process_group(
+            backend=backend,
+            timeout=timedelta(minutes=timeout_minutes),
+        )
     return DistributedState(
         enabled=enabled,
         rank=rank,


### PR DESCRIPTION
## Hypothesis

**H253: Stack weight-space Gaussian noise TTA on top of H243 extended multi-res — the compounding SOTA push**

H243 (askeladd, just merged as NEW SOTA) gives val 5.9546 / test 5.7979 using 6-res mirror_res_avg on H185 EP13. H242 (tanjiro) showed weight-noise σ=5e-4 (relative) adds −8bp val / −7bp test from the H209 mirror-only baseline. These two mechanisms operate in ORTHOGONAL spaces:
- Multi-res TTA perturbs the INPUT sampling (vol_points resolution)  
- Weight-noise TTA perturbs the MODEL PARAMETERS (weight space)

If orthogonal, gains ADD: H243 (−21bp from H209) + H242 weight-noise (−8bp from H209) = stacked val ≈ 5.946 / test ≈ 5.791 vs H209 starting point of 5.9755/5.8221.

**Predicted result**: val ~5.946 / test ~5.791 → BOTH below new H243 gate (5.9546/5.7979) → NEW SOTA.

Note: tanjiro's H252 stacking arm is already running but uses H236 3-res as base. Your H253 uses the stronger H243 6-res base. Even if tanjiro's result passes the H243 gate (possible but marginal), your 6-res base should give a cleaner 8-12bp gain above that.

## Instructions

**Eval-only sprint. ~75-90min. DDP=8 GPUs. Set SENPAI_TIMEOUT_MINUTES=120.**

### Step 1: Extend eval_multi_res.py to add weight-noise outer loop

Add a new eval mode `mirror_res_weight_noise_avg` to `target/eval_multi_res.py`. Also add CLI flags:
- `--weight-noise-sigma`: relative noise σ (default 5e-4). Scales noise by `sigma * |param|`.
- `--n-weight-noise-passes`: number of noise passes K (default 5).

**Implementation — add to `process_case_multires`**:

The weight-noise loop wraps the existing resolution×mirror loops. For each noise pass, the model weights are temporarily perturbed, then all (resolution, mirror) passes run normally.

New `EvalConfig` fields:
```python
weight_noise_sigma: float = 5e-4
n_weight_noise_passes: int = 5
```

New eval mode in `main()` / `run_eval()`:
```python
if mode == "mirror_res_weight_noise_avg":
    result = process_case_multires_weight_noise(
        case_id=case_id,
        model=model,
        transform=transform,
        device=device,
        store=store,
        cfg=cfg,
        resolutions=resolutions,
        sigma=cfg.weight_noise_sigma,
        n_noise_passes=cfg.n_weight_noise_passes,
    )
```

New function `process_case_multires_weight_noise`:
```python
@torch.no_grad()
def process_case_multires_weight_noise(
    *, case_id, model, transform, device, store, cfg, resolutions, sigma, n_noise_passes
):
    """
    K weight-noise passes × N resolutions × 2 mirror states = K*N*2 total passes.
    Saves clean state, perturbs K times, restores between passes.
    Seeds are deterministic and rank-independent (same noise on all DDP ranks).
    """
    eval_module = unwrap_model(model)
    clean_state = {k: v.cpu().clone() for k, v in eval_module.state_dict().items()}

    # Pre-compute accumulation shape
    counts = store.case_point_counts(case_id)
    n_surf = counts["n_surface"]
    n_vol = counts["n_volume"]
    surf_sum = torch.zeros(n_surf, 4, dtype=torch.float32)
    surf_cnt = torch.zeros(n_surf, dtype=torch.int32)
    vol_sum = torch.zeros(n_vol, 1, dtype=torch.float32)
    vol_cnt = torch.zeros(n_vol, dtype=torch.int32)

    timing = {"forward_seconds": 0.0, "io_seconds": 0.0, "n_forwards": 0}

    for noise_idx in range(n_noise_passes):
        # Perturb weights — SAME seed on all ranks (ensures consistent DDP forward)
        perturbed = {}
        for param_idx, (k, v) in enumerate(clean_state.items()):
            if v.dtype.is_floating_point:
                seed = (noise_idx * 100003 + param_idx * 1009) % (2 ** 31)
                g = torch.Generator()  # CPU generator — same on all ranks
                g.manual_seed(seed)
                noise = torch.empty_like(v).normal_(generator=g)
                perturbed[k] = (v + sigma * v.abs() * noise).to(device)
            else:
                perturbed[k] = v.to(device)
        eval_module.load_state_dict(perturbed)

        # Run the standard multi-res ×  mirror accumulation for this noise pass
        # (delegate to per-K, per-mirror loop; accumulate into shared surf_sum/vol_sum)
        _accumulate_multires_mirror(
            case_id=case_id,
            model=model,
            transform=transform,
            device=device,
            store=store,
            cfg=cfg,
            resolutions=resolutions,
            use_mirror=True,
            surf_sum=surf_sum, surf_cnt=surf_cnt,
            vol_sum=vol_sum, vol_cnt=vol_cnt,
            timing=timing,
        )

    # Restore clean weights
    eval_module.load_state_dict({k: v.to(device) for k, v in clean_state.items()})

    # Average
    surf_avg = surf_sum / surf_cnt.unsqueeze(-1).float()
    vol_avg = vol_sum / vol_cnt.unsqueeze(-1).float()

    # Load GT
    case = store.load_case(case_id)
    surf_y = case.surface_y.float()
    vol_y = case.volume_y.float()

    n_passes = n_noise_passes * len(resolutions) * 2
    return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
```

Extract the inner loader loops from `process_case_multires` into a helper `_accumulate_multires_mirror` that takes pre-allocated `surf_sum`/`surf_cnt`/`vol_sum`/`vol_cnt` tensors and adds to them. Then call it from both `process_case_multires` (once, K=1 noise) and `process_case_multires_weight_noise` (K times).

**Don't over-engineer** — the goal is one working script that produces the 60-pass avg. If refactoring feels complex, it's also acceptable to copy-paste the loader loop into the new function.

### Step 2: Run eval

```bash
H185_CKPT="outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt"
# Or if using W&B fetch: --run-id yw2a5dyl --checkpoint epoch-13

# Sanity check: reproduce H243 6-res baseline
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_avg" \
  --wandb-name "alphonse/h253-sanity-6res" \
  --wandb-group "h253-alphonse-stacked-noise-multires"

# Main: stacked weight-noise + 6-res mirror
torchrun --standalone --nproc-per-node=8 target/eval_multi_res.py \
  --checkpoint $H185_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_weight_noise_avg" \
  --weight-noise-sigma 5e-4 \
  --n-weight-noise-passes 5 \
  --wandb-name "alphonse/h253-stacked-noise-6res-sigma5e-4" \
  --wandb-group "h253-alphonse-stacked-noise-multires"
```

### Step 3: Report

| Config | val_abupt | test_abupt | test_VP | test_SP | test_WSS | W&B Run ID |
|---|---|---|---|---|---|---|
| H243 (6-res mirror, CURRENT SOTA) | 5.9546 | 5.7979 | 3.3947 | 3.6672 | 6.7025 | yty4tnew |
| H253 sanity (reproduce H243) | ? | ? | ? | ? | ? | ? |
| H253 stacked: σ=5e-4, K=5, 6-res mirror | ? | ? | ? | ? | ? | ? |

Full per-channel breakdown for the stacked config.

### Step 4: SOTA gate

PRIMARY: `val_abupt < 5.9546 AND test_abupt < 5.7979` (both must beat NEW H243 SOTA)
Paper-floor: test_VP ≤ 3.421 AND test_SP ≤ 3.577 AND test_WSS ≤ 6.727

If passes → IMMEDIATE merge candidate. Stack is the new SOTA.

### Failure interpretation

If sanity reproduces H243 but stacking WORSENS: weight-noise and multi-res are NOT orthogonal — they share the same variance source (cross-resolution predictions already capture the weight-space variance). Bank Finding II: weight-noise TTA is subsumed by multi-res TTA; adding noise passes on top of multi-res provides no marginal benefit.

If stacking gives val ~5.946 / test ~5.791 or better (predicted): mechanisms ARE orthogonal, bank as Finding JJ: TTA mechanisms operating in parameter space and input space are additively composable for H185 EP13.

## Baseline

H243 NEW SOTA (PR #1414, just merged): val 5.9546, test 5.7979, test_WSS 6.7025, test_VP 3.3947

## Coordination

- tanjiro H252: running stacking arm using H236 3-res base (not 6-res). If their result passes H243 gate: merge theirs, yours is still a valid improvement ON TOP. If their result misses H243 gate: yours with 6-res base has a stronger signal and is the primary stacking bet.
- askeladd H254: surface-points multi-res TTA (different axis — surface_points vary, vol_points fixed)
- edward H244: H185 EP14-16 retrain. When it finishes (~14:00Z), evaluate with H243-style TTA.

Expected runtime: 60 passes × ~0.9 sec/pass/GPU ≈ ~75-90min on DDP×8. Set SENPAI_TIMEOUT_MINUTES=120.
