### PR TITLE
H258: H148 EP13 + 6-res mirror multi-res TTA — flat-basin portability probe

### DIFF
--- a/eval_multi_res.py
+++ b/eval_multi_res.py
@@ -62,7 +62,9 @@ from trainer_runtime import (
 class EvalConfig:
     """H236 eval config. Defaults match the H185 yw2a5dyl training-time config."""
 
-    # Checkpoint source — fetch from W&B by run_id + artifact alias.
+    # Checkpoint source — either a direct path (preferred when present) or
+    # fetch from W&B by run_id + artifact alias.
+    ckpt_path: str = ""  # if set, load this checkpoint directly (skip W&B download)
     run_id: str = "yw2a5dyl"
     checkpoint: str = "epoch-13"  # artifact alias; can also be "best"
     use_ema: bool = True  # validates that loaded checkpoint_source == "ema"
@@ -70,9 +72,11 @@ class EvalConfig:
 
     # Multi-resolution TTA configuration
     resolutions: str = "49152,65536,81920"
-    eval_modes: str = "res_avg,mirror_res_avg"  # comma-separated: res_avg, mirror_res_avg
-    # Surface resolution stays fixed; only volume is varied.
+    eval_modes: str = "res_avg,mirror_res_avg"  # comma-separated: orig, mirror, res_avg, mirror_res_avg
+    # Surface resolution stays fixed; only volume is varied (except for orig/mirror modes,
+    # which run at the single resolution ``eval_volume_points``).
     eval_surface_points: int = 65536
+    eval_volume_points: int = 65536  # used by single-resolution modes (orig, mirror)
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -549,27 +553,37 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     resolutions = parse_resolutions(cfg.resolutions)
     modes = parse_modes(cfg.eval_modes)
+    valid_modes = ("orig", "mirror", "res_avg", "mirror_res_avg")
     for mode in modes:
-        if mode not in ("res_avg", "mirror_res_avg"):
-            raise ValueError(f"Unknown eval mode: {mode!r}")
+        if mode not in valid_modes:
+            raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
 
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
         print(f"Device: {device}{ddp_suffix}")
-        print(f"Source run_id={cfg.run_id} alias={cfg.checkpoint} use_ema={cfg.use_ema}")
+        if cfg.ckpt_path:
+            print(f"Source ckpt_path={cfg.ckpt_path} use_ema={cfg.use_ema}")
+        else:
+            print(f"Source run_id={cfg.run_id} alias={cfg.checkpoint} use_ema={cfg.use_ema}")
         print(f"Resolutions: {resolutions}")
+        print(f"Single-res volume points (for orig/mirror): {cfg.eval_volume_points}")
         print(f"Modes: {modes}")
 
-    # Download/locate the checkpoint on rank 0 only, then broadcast the path.
+    # Resolve checkpoint path on rank 0 only, then broadcast.
     cache_root = Path(cfg.cache_root)
     if state.is_main:
-        ckpt_path = download_checkpoint(
-            entity=cfg.wandb_entity,
-            project=cfg.wandb_project,
-            run_id=cfg.run_id,
-            alias=cfg.checkpoint,
-            cache_root=cache_root,
-        )
+        if cfg.ckpt_path:
+            ckpt_path = Path(cfg.ckpt_path)
+            if not ckpt_path.exists():
+                raise FileNotFoundError(f"--ckpt-path not found: {ckpt_path}")
+        else:
+            ckpt_path = download_checkpoint(
+                entity=cfg.wandb_entity,
+                project=cfg.wandb_project,
+                run_id=cfg.run_id,
+                alias=cfg.checkpoint,
+                cache_root=cache_root,
+            )
         ckpt_path_str = str(ckpt_path)
     else:
         ckpt_path_str = ""
@@ -657,11 +671,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     for split_name, case_ids, log_prefix in splits:
         summary[split_name] = {}
         for mode in modes:
-            use_mirror = mode == "mirror_res_avg"
+            use_mirror = mode in ("mirror", "mirror_res_avg")
+            if mode in ("orig", "mirror"):
+                mode_resolutions = [cfg.eval_volume_points]
+            else:
+                mode_resolutions = resolutions
             if state.is_main:
                 print(
                     f"\n=== Evaluating split={split_name} mode={mode} "
-                    f"resolutions={resolutions} mirror={use_mirror} ===",
+                    f"resolutions={mode_resolutions} mirror={use_mirror} ===",
                     flush=True,
                 )
             t0 = time.time()
@@ -673,7 +691,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 device=device,
                 store=store,
                 cfg=cfg,
-                resolutions=resolutions,
+                resolutions=mode_resolutions,
                 use_mirror=use_mirror,
                 distributed_state=state,
             )


### PR DESCRIPTION
## Hypothesis

**Multi-res mirror TTA (the H243 recipe) ports to the H148 EP13 flat-basin checkpoint and yields a new SOTA.**

H252 thorfinn established that H148 EP13 sits in a wide flat basin (Finding FF generalized): weight-noise σ=5e-4 gives −39bp val / −37bp test, reaching test 5.7978 which **ties** H243's 5.7979. Two completely different mechanisms on two different checkpoints hit the same wall — the single-checkpoint information ceiling.

H251 nezuko (Finding HH N=4) showed that 6-res mirror multi-res TTA ports to H185/H183/H188 (+12-15bp). H148 was not in that test because it lacks mirror_aug=True training. **This experiment tests whether multi-res portability extends to H148 (flat-basin, no mirror-aug at train time).**

Two outcomes both advance the programme:
- **Positive (Finding HH N=5)**: H148 base test 5.835 − 15bp → test **~5.72–5.80** → potential SOTA, opens H148 + 6-res + weight-noise stack path.
- **Negative (Finding GG strict)**: Confirms multi-res mechanism requires train-time mirror augmentation — a clean mechanistic finding about TTA coupling to training recipe.

## Instructions

Reuse `eval_multi_res.py` with the **exact H243 6-res recipe** but point the checkpoint at H148 EP13 instead of H185:

```bash
cd /workspace/senpai/target

torchrun --standalone --nproc-per-node=8 eval_multi_res.py \
  --checkpoint <H148_CHECKPOINT_PATH> \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "orig,mirror,mirror_res_avg" \
  --wandb-group "h258-frieren-h148-multi-res" \
  --wandb-name "frieren/h258-h148-6res-mirror"
```

**Finding the H148 checkpoint:**
- H252 thorfinn referenced it as `runs/h210/artifacts/h148/checkpoint.pt`  
- Also check `outputs/h148_ckpt/checkpoint.pt` and W&B artifact downloads for `h148`
- It is H148 EP13 EMA checkpoint (the same one used in the H252 weight-noise eval)

**Include `orig` and `mirror` modes** in addition to `mirror_res_avg` so we can decompose the gain: we need to know how much comes from the multi-res axis alone vs. the mirror axis on H148.

**DDP on 8 GPUs required.** 12-pass eval (6 res × 2 mirror), ~25-35 min wall-clock. Set `SENPAI_TIMEOUT_MINUTES=90` for safety.

**Critical constraints:**
- z-axis tau_z locked at 1.67 (do not modify)
- data/loader.py, data/preload.py, data/split_manifest.json — read-only, never touch
- No model capacity changes — pure eval-time TTA only

## Expected results and baseline

| Mode | Predicted val_abupt | Predicted test_abupt | Basis |
|---|---:|---:|---|
| orig (H148 baseline) | ~6.00 | ~5.835 | H252 thorfinn baseline (noise_only vs. orig delta) |
| mirror only | ~5.98 | ~5.815 | Mirror-only gain ~5bp (if mirror_aug not needed) or 0 (if coupled) |
| mirror_res_avg (6-res) | ~5.93-5.95 | ~5.73-5.80 | IF Finding HH N=5 |

## Baseline for merge gate

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP |
|---|---:|---:|---:|---:|---|
| H148 + weight-noise σ=5e-4 | ~5.96 | 5.7978 | — | — | — | H252 thorfinn |
| **H243 6-res mirror TTA ← CURRENT SOTA** | **5.9546** | **5.7979** | **6.7025** | **3.3947** | **3.6672** | PR #1414 |
| Transolver-3 target (Morgan) | — | — | **<5.850** | ≤3.643 | ≤3.577 | Issue #1056 |

**Merge gate**: val_abupt < **5.9546** AND test_abupt < **5.7979** → immediate SOTA merge.

## Required SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_axis_mean_rel_l2_pct","value":<number>},"test_metric":{"name":"test_abupt_axis_mean_rel_l2_pct","value":<number>}}
```

Plus a comment table with val/test for each mode (orig, mirror, mirror_res_avg) and all per-channel metrics (SP, WSS, WSS_x/y/z, VP) for the best mode.

## Why this is the best next bet for frieren

- Cheapest possible experiment (~30 min) with both a SOTA path (positive) and a clean mechanistic finding (negative)
- H148 is the ONLY checkpoint where flat-basin + multi-res portability remains untested — fills the last cell in the portability matrix
- If positive, enables a follow-up stack: H148 + 6-res mirror + weight-noise σ=5e-4 (all three mechanisms at once) which has estimated test ~5.74-5.76
