### PR TITLE
H263: Multi-EP EMA avg(EP14,EP15) + 6-res mirror TTA

### DIFF
--- a/tools/average_ema_checkpoints.py
+++ b/tools/average_ema_checkpoints.py
@@ -1,0 +1,122 @@
+"""Average EMA tensor weights from multiple training checkpoints.
+
+Produces a single checkpoint whose `model` state-dict is the element-wise
+mean of the input checkpoints' state-dicts. Non-tensor / non-numeric values
+(integer counters, strings, NoneType) are taken from the first input.
+
+The output dict preserves the surrounding metadata from the first input
+(epoch, config, val_metrics, checkpoint_source, selection_metric) so the
+eval pipeline (`eval_multi_res.py`) can load it without modification. We
+add an `averaged_from` list recording the input file paths for traceability.
+"""
+
+import argparse
+import os
+import torch
+
+
+def _avg_state_dict(state_dicts: list[dict]) -> dict:
+    """Element-wise mean of a list of state-dicts.
+
+    All inputs must share keys. Non-floating-point tensors (e.g. integer
+    buffers) are taken from the first input verbatim; floating-point
+    tensors are averaged in fp32 then cast back to the original dtype.
+    """
+    keys = list(state_dicts[0].keys())
+    for i, sd in enumerate(state_dicts[1:], start=1):
+        if set(sd.keys()) != set(keys):
+            extra = set(sd.keys()) - set(keys)
+            missing = set(keys) - set(sd.keys())
+            raise ValueError(
+                f"Input {i} state-dict keys differ; extra={list(extra)[:5]} missing={list(missing)[:5]}"
+            )
+
+    out: dict = {}
+    n = len(state_dicts)
+    for k in keys:
+        t0 = state_dicts[0][k]
+        if not torch.is_tensor(t0):
+            out[k] = t0
+            continue
+        if not t0.is_floating_point():
+            out[k] = t0.clone()
+            continue
+        target_dtype = t0.dtype
+        acc = torch.zeros_like(t0, dtype=torch.float32)
+        for sd in state_dicts:
+            acc.add_(sd[k].to(torch.float32))
+        acc.div_(n)
+        out[k] = acc.to(target_dtype)
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inputs",
+        nargs="+",
+        required=True,
+        help="Paths to checkpoint files to average (>=2).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for the averaged checkpoint.",
+    )
+    parser.add_argument(
+        "--key",
+        default=None,
+        help=(
+            "Top-level key holding the state-dict to average. If omitted, "
+            "auto-detect: tries 'ema_state_dict', 'model_ema_state_dict', "
+            "then 'model'."
+        ),
+    )
+    args = parser.parse_args()
+
+    if len(args.inputs) < 2:
+        raise SystemExit("Need at least 2 input checkpoints to average")
+
+    print(f"Loading {len(args.inputs)} checkpoints...")
+    ckpts = [torch.load(p, map_location="cpu", weights_only=False) for p in args.inputs]
+
+    if args.key is None:
+        candidates = ["ema_state_dict", "model_ema_state_dict", "model"]
+        chosen = None
+        for c in candidates:
+            if c in ckpts[0] and isinstance(ckpts[0][c], dict):
+                chosen = c
+                break
+        if chosen is None:
+            raise SystemExit(
+                f"Could not auto-detect state-dict key; tried {candidates}; "
+                f"top-level keys in first ckpt: {list(ckpts[0].keys())}"
+            )
+        key = chosen
+    else:
+        key = args.key
+
+    print(f"Using state-dict key: '{key}'")
+    for p, ck in zip(args.inputs, ckpts):
+        if key not in ck:
+            raise SystemExit(f"Key '{key}' not in {p}; available: {list(ck.keys())}")
+        src = ck.get("checkpoint_source")
+        ep = ck.get("epoch")
+        print(f"  {os.path.basename(p)}: epoch={ep} source={src} n_params={len(ck[key])}")
+
+    state_dicts = [ck[key] for ck in ckpts]
+    averaged = _avg_state_dict(state_dicts)
+
+    out = dict(ckpts[0])
+    out[key] = averaged
+    out["averaged_from"] = [os.path.abspath(p) for p in args.inputs]
+    out["averaged_n"] = len(args.inputs)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    torch.save(out, args.output)
+    print(f"Saved averaged checkpoint -> {args.output}")
+    print(f"  averaged_from = {out['averaged_from']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

Averaging EP14 and EP15 EMA checkpoint tensors element-wise before running 6-res mirror TTA produces a model that generalizes better than either individual epoch. This is Stochastic Weight Averaging (SWA) applied to late-cosine EMA snapshots.

**Mechanism**: Standard SWA theory — averages of nearby loss-landscape checkpoints lie in wider basins. The EP13→EP15 cosine extension improved single-res val_orig by −9.3bp. The EP14 and EP15 EMA states are adjacent on the cosine descent trajectory; their average may have lower variance than either alone.

**Predicted**: avg(EP14,EP15)+6-res mirror → val ~5.940-5.945, test ~5.785-5.790 (if EP14 is within 3bp of EP15, the average stays close and we get basin-width benefit).

**Note**: This is NOT an ensemble — it's a single averaged model. Morgan's ensemble ban does not apply.

## Instructions

### Step 1: Write checkpoint averaging script (new file, safe to create)

Create `tools/average_ema_checkpoints.py`:

```python
import argparse, torch
parser = argparse.ArgumentParser()
parser.add_argument("--inputs", nargs="+", required=True)
parser.add_argument("--output", required=True)
parser.add_argument("--key", default="ema_state_dict")
args = parser.parse_args()

ckpts = [torch.load(p, map_location="cpu") for p in args.inputs]
if args.key not in ckpts[0]:
    print(f"Warning: key '{args.key}' not found, trying 'model_state_dict'")
    args.key = "model_state_dict"
avg = {k: sum(c[args.key][k].float() for c in ckpts) / len(ckpts)
       for k in ckpts[0][args.key]}
out = dict(ckpts[0]); out[args.key] = avg
torch.save(out, args.output)
print(f"Averaged {len(ckpts)} checkpoints → {args.output}")
```

### Step 2: Locate EP14 and EP15 checkpoints

Edward's H244 training run `0gjfv45i` with `--save-every-epoch` saved checkpoints at:
- EP14: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt`
- EP15: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt`

Verify they exist:
```bash
ls -lh /workspace/senpai/target/outputs/drivaerml/run-0gjfv45i/checkpoint_ep*.pt
```

If not local, download from W&B run `0gjfv45i` artifacts (epoch 14 and 15).

### Step 3: Average the checkpoints

```bash
python tools/average_ema_checkpoints.py \
  --inputs outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt \
           outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --output outputs/h263_avg_ep14_ep15.pt \
  --key ema_state_dict
```

### Step 4: Sanity at 65k single-res

```bash
torchrun --standalone --nproc-per-node=8 eval_multi_res.py \
  --local-checkpoint-path outputs/h263_avg_ep14_ep15.pt \
  --resolutions "65536" \
  --eval-modes "orig" \
  --agent frieren \
  --wandb-group "h263-frieren-multi-ep-swa" \
  --wandb-name "frieren/h263-avg-ep14-15-sanity"
```

Expected: val_orig between EP14 and EP15 (EP15 is 6.0079; EP14 is likely 6.012-6.015). Post this as a comment.

### Step 5: 6-res mirror TTA on averaged checkpoint

```bash
torchrun --standalone --nproc-per-node=8 eval_multi_res.py \
  --local-checkpoint-path outputs/h263_avg_ep14_ep15.pt \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_avg" \
  --agent frieren \
  --wandb-group "h263-frieren-multi-ep-swa" \
  --wandb-name "frieren/h263-avg-ep14-15-6res-mirror"
```

~60 min on DDP×8.

## Merge gate

**val_abupt < 5.9452 AND test_abupt < 5.7896** → IMMEDIATE SOTA merge.

## Baseline

**Current SOTA**: H244 EP15+6-res mirror TTA — val **5.9452** / test **5.7896** (run bh7we7p6, PR #1415)
- EP15 single-res val_orig: **6.0079**
- EP13 single-res val_orig: **6.0172** (−9.3bp improvement from EP15)
- H252 prior SOTA: val 5.9492 / test 5.7975

## Critical constraints

- **DDP 8 GPUs** for every run
- **z-axis tau_z LOCKED at 1.67**
- **No ensembles** — this is a single averaged model, not an ensemble
- **Read-only**: data/loader.py, data/preload.py, data/split_manifest.json, train.py
- **May create**: tools/average_ema_checkpoints.py (new file)
- **SENPAI_TIMEOUT_MINUTES=90**

## Required output

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<sanity-id>","<6res-id>"],"primary_metric":{"name":"val_abupt_mirror_res_avg","value":<number>},"test_metric":{"name":"test_abupt_mirror_res_avg","value":<number>}}
```

Plus per-channel comparison table vs EP15+6-res baseline.
