### PR TITLE
H266: TTA mechanism ANOVA — decompose mirror×res×noise contributions

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -27,6 +27,8 @@ Mirror convention (H148/H183/H209), unchanged:
 Modes:
     weight_noise_only:           K passes at a single eval_volume_points
                                  (no mirror). Sanity-reproduces H242 noise_only.
+    weight_noise_res_avg:        K x R = noise + multi-res, NO mirror.
+                                 Used by H266 ANOVA arm C.
     weight_noise_mirror_res_avg: K x R x 2 = full stacked TTA.
 """
 
@@ -624,7 +626,11 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     resolutions = parse_resolutions(cfg.resolutions)
     modes = parse_modes(cfg.eval_modes)
-    valid_modes = ("weight_noise_only", "weight_noise_mirror_res_avg")
+    valid_modes = (
+        "weight_noise_only",
+        "weight_noise_res_avg",
+        "weight_noise_mirror_res_avg",
+    )
     for mode in modes:
         if mode not in valid_modes:
             raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
@@ -733,6 +739,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                 # K-pass weight-noise average at a single resolution, no mirror.
                 # Used to reproduce the H242 noise_only result.
                 mode_resolutions = [cfg.eval_surface_points]  # single resolution
+                use_mirror = False
+            elif mode == "weight_noise_res_avg":
+                # K x R noise + multi-res, NO mirror. H266 ANOVA arm C.
+                mode_resolutions = list(resolutions)
                 use_mirror = False
             elif mode == "weight_noise_mirror_res_avg":
                 mode_resolutions = list(resolutions)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-**Updated**: 2026-05-29 15:00Z | Branch: `tay` | **SOTA: H244 EP15+6-res (PR #1415 merged 14:57Z)** | Round 4j: 8 active
+**Updated**: 2026-05-29 15:20Z | Branch: `tay` | **SOTA: H244 EP15+6-res (PR #1415 merged 14:57Z)** | Round 4j: 8 active | **H253 val clears gate** ✓
 
 ---
 
@@ -20,18 +20,18 @@
 
 ---
 
-## Active Fleet (Round 4j, as of 15:00Z)
+## Active Fleet (Round 4j, as of 15:20Z)
 
 | PR | Student | Hypothesis | Status | ETA |
 |---|---|---|---|---|
-| **#1428** | **alphonse** | **H253: noise σ=5e-4 + 6-res stack EP13 (HIGHEST EV)** | 🟢 running | ~16:30Z |
+| **#1428** | **alphonse** | **H253: noise σ=5e-4 + 6-res stack EP13 (val 5.9418 ✓ clears gate)** | 🟢 test arm pending | ~17:00Z |
 | **#1432** | **nezuko** | **H256: H183 + 6-res + noise stack (portability)** | 🟢 running (crash fixed) | ~16:00Z |
 | **#1433** | **thorfinn** | **H257: σ-sweep on 6-res+noise stack** | 🟢 running (σ=1e-3 arm) | ~16:30Z |
-| **#1438** | **tanjiro** | **H262: K-noise saturation K=10/20 noise_only** | 🟡 just assigned | ~15:45Z |
-| **#1439** | **frieren** | **H263: avg(EP14,EP15) EMA + 6-res mirror TTA** | 🟡 just assigned | ~16:15Z |
-| **#1440** | **fern** | **H264: EP16 + 6-res mirror TTA** | 🟡 just assigned | ~16:10Z |
-| **#1441** | **edward** | **H265: EP14 + 6-res mirror TTA (fills EP-chain gap)** | 🟡 just assigned | ~16:10Z |
-| **#1442** | **askeladd** | **H268: Anti-thetic noise pairs ±δ (novel mechanism)** | 🟡 just assigned | ~15:45Z |
+| **#1438** | **tanjiro** | **H262: K-noise saturation K=10/20 noise_only** (run dev5yglv) | 🟢 running, step=0 only | ~16:00Z |
+| **#1439** | **frieren** | **H263: avg(EP14,EP15) EMA + 6-res mirror TTA** | 🟡 BLOCKED on edward W&B artifact upload | TBD |
+| **#1440** | **fern** | **H264: EP16 + 6-res mirror TTA** | 🟡 BLOCKED on edward W&B artifact upload | TBD |
+| **#1441** | **edward** | **H265: EP14 + 6-res mirror TTA + UPLOAD ARTIFACTS** | 🟡 instructed to upload EP14/15/16 first | ~16:30Z+ |
+| **#1442** | **askeladd** | **H268: Anti-thetic noise pairs ±δ** (run n2j8u2lo) | 🟢 running, no metrics yet | ~16:00Z |
 | (background) | edward | Arm 2: EP15+full stack h1ae7x1j | 🟢 running | ~16:39Z |
 
 ---
@@ -49,10 +49,16 @@ The EP15 checkpoint is the key differentiator. EP15 single-res val_orig 6.0079 (
 
 ### Next SOTA candidates (ranked by EV)
 
-1. **Edward Arm 2 (h1ae7x1j)**: EP15 + full H252 stack = EP15 × noise × 6-res × mirror. Predicted val ~5.938-5.942. ETA ~16:39Z.
-2. **Alphonse H253**: EP13 + noise × 6-res × mirror. Predicted val ~5.940-5.945. ETA ~16:30Z.
-3. **Frieren H263**: avg(EP14,EP15) + 6-res mirror. Novel weight-averaging — predicted val ~5.940-5.945 if EMAs diverse. ETA ~16:15Z.
-4. **Fern H264**: EP16 + 6-res mirror. Could push further if EP16 > EP15 (sanity arm decides). ETA ~16:10Z.
+1. **Alphonse H253** (`qytjlv97`): val_stacked **5.9418** ✓ clears val gate. EP13 + noise × 6-res × mirror. Test arm pending ~17:00Z. **If test_stacked < 5.7896 → IMMEDIATE SOTA merge.**
+2. **Edward Arm 2 (h1ae7x1j)**: EP15 + full H252 stack = EP15 × noise × 6-res × mirror. Predicted val ~5.935-5.940 (compounds H253 stack with EP15 advantage). ETA ~16:39Z.
+3. **Frieren H263** (BLOCKED): avg(EP14,EP15) + 6-res mirror. Pending edward W&B artifact upload.
+4. **Fern H264** (BLOCKED): EP16 + 6-res mirror. Pending edward W&B artifact upload.
+
+### Checkpoint accessibility blocker (15:15Z)
+
+- **Issue**: EP14/EP15/EP16 EMA checkpoints from edward's H244 run `0gjfv45i` exist ONLY on his pod local disk (`outputs/drivaerml/run-0gjfv45i/`). The W&B run only logged the final `model-edward-h244-h185-ep16-cosine-ext-0gjfv45i:v0` artifact (single `checkpoint.pt` = EP15 EMA).
+- **Resolution**: Instructed edward (PR #1441) to log EP14, EP15, EP16 as W&B artifacts before running H265. Frieren and fern will download via W&B API and proceed.
+- **Lesson for next round**: Add a routine artifact-upload step to checkpoint-saving training PRs so downstream eval-time hypotheses don't get blocked on pod-local files.
 
 ---
 


### PR DESCRIPTION
## Hypothesis

The H253 SOTA push (val 5.9418 vs H243 mirror+res-only 5.9546) stacks three orthogonal TTA axes: mirror × 6-res × weight_noise. We currently know the full-stack result but NOT how much each axis contributes independently or in two-way pairs. A full 2³ ANOVA over {mirror, res, noise} will tell us which axis is most additive and which is saturated when stacked — critical for deciding where to focus future SOTA pushes.

**Five cells of the 2³ design already exist from prior PRs:**

| # | Mirror | Res | Noise | Config | val_abupt | Source |
|---|:-:|:-:|:-:|---|---:|---|
| 1 | ✗ | ✗ | ✗ | orig (baseline) | 6.0172 | H185 single-res |
| 3 | ✗ | ✓ | ✗ | res_avg 6-res | ~5.998 | H243 res-only sanity |
| 4 | ✓ | ✓ | ✗ | mirror_res_avg 6-res | 5.9546 | H243 / H253 sanity |
| 5 | ✗ | ✗ | ✓ | weight_noise_only | 5.9676 | H242 noise_only |
| 8 | ✓ | ✓ | ✓ | weight_noise_mirror_res_avg | 5.9418 | H253 full stack |

**Three cells missing — H266 fills them:**

| # | Mirror | Res | Noise | Config | val_abupt |
|---|:-:|:-:|:-:|---|---:|
| **2** | **✓** | **✗** | **✗** | **mirror_only (arm A)** | **?** |
| **6** | **✓** | **✗** | **✓** | **mirror+noise, no res (arm B)** | **?** |
| **7** | **✗** | **✓** | **✓** | **res+noise, no mirror (arm C — NEW MODE)** | **?** |

## Instructions

### Step 0: Set up EP13 checkpoint

Download the H185 EP13 EMA checkpoint (same one alphonse used for H253):

```bash
cd /workspace/senpai/target
python -c "
import wandb, pathlib
api = wandb.Api()
# H185 EP13 EMA — check alphonse's PR #1428 reproduce block for exact artifact name
# Most likely: yw2a5dyl run with 'epoch-13' alias
art = api.artifact('wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/yw2a5dyl-h185-best:epoch-13')
art.download(root='./outputs/h266_inputs/ep13')
"
```

If that fails, check alphonse's PR #1428 for the exact artifact path used for H253.

### Step 1: Add `weight_noise_res_avg` mode to eval_tta_h252.py

Read `eval_tta_h252.py` carefully. Find the `valid_modes` tuple (around line 626) and the mode-dispatch section (around line 732). Add a new mode `weight_noise_res_avg` that is identical to `weight_noise_mirror_res_avg` BUT passes only `mirror=False` in the per-pass loop (i.e., no mirror flip). Add it to `valid_modes` and the dispatch.

This is the ONLY file to modify. Do NOT touch train.py, data/loader.py, data/preload.py, data/split_manifest.json.

### Step 2: Run three arms (DDP × 8 GPUs)

**Arm A: mirror_only** (~5-8 min)
```bash
torchrun --standalone --nproc-per-node=8 eval_multi_res.py \
  --local-checkpoint-path outputs/h266_inputs/ep13/checkpoint.pt \
  --resolutions "65536" \
  --eval-modes "mirror_res_avg" \
  --agent fern \
  --wandb-group "h266-fern-tta-anova" \
  --wandb-name "fern/h266-arm-a-mirror-only"
```
_Expected val: ~6.012 (≈ −5bp from baseline). This is 2 passes at 65k._

**Arm B: mirror+noise, no res** (~12-15 min)
```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --local-checkpoint-path outputs/h266_inputs/ep13/checkpoint.pt \
  --resolutions "65536" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --noise-sigma 5e-4 \
  --noise-k 5 \
  --agent fern \
  --wandb-group "h266-fern-tta-anova" \
  --wandb-name "fern/h266-arm-b-mirror-noise"
```
_Expected val: ~5.953-5.960. This is 2×5=10 passes at 65k._

(Verify the exact flag names match `eval_tta_h252.py --help` — may be `--noise_sigma` / `--noise_k` depending on underscore/hyphen convention.)

**Arm C: res+noise, no mirror (new mode)** (~30-35 min)
```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --local-checkpoint-path outputs/h266_inputs/ep13/checkpoint.pt \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "weight_noise_res_avg" \
  --noise-sigma 5e-4 \
  --noise-k 5 \
  --agent fern \
  --wandb-group "h266-fern-tta-anova" \
  --wandb-name "fern/h266-arm-c-res-noise"
```
_Expected val: ~5.948-5.955. This is 6×5=30 passes._

### Step 3: Post ANOVA decomposition

Post a results comment with the completed 8-row table (5 from history + 3 from arms) and the main-effect + interaction decomposition:

- Main effect mirror = (mean of mirror=T rows) − (mean of mirror=F rows)
- Main effect res = (mean of res=T rows) − (mean of res=F rows)
- Main effect noise = (mean of noise=T rows) − (mean of noise=F rows)
- 2-way interactions (mirror×res, mirror×noise, res×noise) = observed combined − (sum of main effects)
- 3-way interaction = observed full-stack − (sum of all main effects + 2-way interactions)

Include a per-channel breakdown (SP, VP, WSS) in the interpretation.

## Merge gate (diagnostic — SOTA push not expected)

**val_abupt < 5.9452 AND test_abupt < 5.7896** → IMMEDIATE SOTA merge.

None of arms A/B/C are expected to beat SOTA individually (each is a strict subset of H253). If any does, investigate and report — that would be a significant finding.

## Baseline metrics (Current SOTA: PR #1415 H244)

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | Source |
|---|---:|---:|---:|---:|---:|---|
| **H244 EP15+6-res mirror TTA ← CURRENT SOTA** | **5.9452** | **5.7896** | **6.6947** | **3.3882** | **3.6595** | bh7we7p6 |
| H243 EP13+6-res mirror TTA | 5.9546 | 5.7979 | 6.7025 | 3.3947 | 3.6672 | 7s55r8gj |
| H253 EP13+full stack (in-flight) | 5.9418 (val only) | pending ~17:00Z | — | — | — | qytjlv97 |
| H185 EP13 single-res | 5.9755 | 5.8221 | — | — | — | yw2a5dyl |
| H242 noise_only σ=5e-4 K=5 | 5.9676 | — | — | — | — | H242 result |

**Merge gate (updated):** val_abupt < **5.9452** AND test_abupt < **5.7896**

## Critical constraints

- **DDP 8 GPUs** for every eval run
- **Read-only**: train.py, data/loader.py, data/preload.py, data/split_manifest.json
- **Modifiable**: eval_tta_h252.py (add one new mode), eval_multi_res.py if needed
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67**
- **SENPAI_TIMEOUT_MINUTES=90**

## Required output (SENPAI-RESULT format)

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA>","<armB>","<armC>"],"primary_metric":{"name":"val_abupt_arm_a_mirror_only","value":<number>},"test_metric":{"name":"test_abupt_arm_a_mirror_only","value":<number>}}
```

Plus the complete 8-row ANOVA table and ANOVA decomposition (main effects + interactions) with per-channel interpretation.

## Why this experiment now

- **Mechanism gap**: We know H253 works but not WHY. This completes the decomposition.
- **Cheap**: ~75 min total (45 min GPU + 30 min implementation of new mode).
- **Paper value**: A clean 2³ ablation on the TTA axes is a publishable contribution.
- **Strategic**: The decomposition tells us exactly which axis to push harder in Round 4k.
