### PR TITLE
H275: EP15 + Anti-Thetic K=3 in full 6-res×mirror stack

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -657,6 +657,9 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     resolutions = parse_resolutions(cfg.resolutions)
     modes = parse_modes(cfg.eval_modes)
+    # PR-convention alias used by H275 instructions; semantically identical.
+    mode_aliases = {"mirror_res_weight_noise_avg": "weight_noise_mirror_res_avg"}
+    modes = [mode_aliases.get(m, m) for m in modes]
     valid_modes = ("weight_noise_only", "weight_noise_mirror_res_avg")
     for mode in modes:
         if mode not in valid_modes:


### PR DESCRIPTION
## Hypothesis

The two strongest banked findings compound directly:

1. **Finding QQ-EP15-stack-compound** (H267, just merged): EP15 EMA compounds with K=5 weight-noise×6-res×mirror full stack at sub-additive rate (−5.1bp vs −9.3bp pure-additive). Net val 5.9367 / test 5.7825 = **current SOTA**.
2. **Finding NN-antithetic** (H268, banked): Anti-thetic K=3 pairs (6 forwards) beats random K=5 (5 forwards) by +1.3bp at EP13 standalone. Cancels linear Taylor term `∇f(w)·ε` via ±δ pairing.

H275 swaps random K=5 for anti-thetic K=3 pairs in the H267 SOTA recipe. If both findings stack, predicted val ≈ **5.928–5.935** (−0.8 to −1.5bp gain over H267).

This is **orthogonal to every in-flight EP13 experiment** (H269 K=10, H270 σ-sweep, H271 Sobol, H272 Hutchinson, H273 Taylor, H274 anti-thetic) — all are on EP13 base. H275 is the first anti-thetic experiment on EP15.

**Predicted val_abupt: 5.928–5.935%**

## Instructions

### Step 1: Verify EP15 checkpoint
```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
ls -lh $H185_EP15_CKPT
```
This is the same checkpoint you used for H267.

### Step 2: Implement anti-thetic K=3 in eval_tta_h252.py

Derive from your H267 eval script (already on this branch). Add an `--antithetic` flag that replaces random K passes with K anti-thetic pairs (each pair = two forward passes with ±δ_k):

```python
def antithetic_pairs(K_pairs, params, sigma, seed_base=42):
    """K_pairs=3 → 6 perturbed states (3 pos + 3 neg)."""
    pairs = []
    for k in range(K_pairs):
        g = torch.Generator(device=params[0].device).manual_seed(seed_base + k)
        delta_k = [torch.randn(p.shape, generator=g, device=p.device, dtype=p.dtype) * sigma
                   for p in params]
        pairs.append(delta_k)
    return pairs
```

In the eval loop: for each `(res, mirror)` combination, for each pair `delta_k`, perturb to `w+δ_k` and `w-δ_k`, run both forwards, average the pair, then average across K pairs. Restore `w` exactly after each pair via `assert torch.equal(p, snapshot)`.

**Easiest path**: diff fern's `fern/h274-antithetic-stacked` branch — the eval script is already correct for EP13+anti. Cherry-pick or adapt it for EP15 checkpoint.

### Step 3: Run primary arm

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
torchrun --standalone --nproc-per-node=8 target/eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_weight_noise_avg" \
  --weight-noise-sigma 5e-4 \
  --n-weight-noise-passes 3 \
  --antithetic \
  --batch-size 2 --num-workers 4 \
  --agent edward \
  --wandb-group "h275-edward-ep15-antithetic-stack" \
  --wandb-name "edward/h275-ep15-anti-K3-stack"
```

`--n-weight-noise-passes 3` with `--antithetic` = K=3 PAIRS = 6 forward passes per (res, mirror). Total passes = 6×6-res×2-mirror = 72 forwards. ETA ~230 min on DDP×8.

**If val < 5.9367 AND test < 5.7825 → post terminal SENPAI-RESULT and merge via senpai:merge-winner.**

### Step 4: Post SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_ep15_antithetic_K3_stack","value":<val>},"test_metric":{"name":"test_abupt_ep15_antithetic_K3_stack","value":<test>}}
```

Include comparison table:

| Recipe | val_abupt | test_abupt | Δ vs H267 |
|---|---|---|---|
| H267 EP15+K=5 random (SOTA) | 5.9367 | 5.7825 | reference |
| H268 EP13+anti-K=3 standalone | 5.9691 | 5.8165 | — |
| H274 EP13+anti-K=3 full stack (fern, in-flight) | pending | pending | — |
| **H275 EP15+anti-K=3 full stack (this)** | result | result | Δ |

And per-channel breakdown (SP, VP, WSS_x/y/z).

## Baseline Metrics (post-H267 SOTA merge)

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H267 EP15+K=5+6-res+mirror ← CURRENT SOTA** | **5.9367** | **5.7825** | **6.6898** | **3.3850** | **3.6505** | snouz8zi |
| H253 EP13+K=5+6-res+mirror (prior SOTA) | 5.9418 | 5.7847 | 6.6895 | 3.3891 | 3.6592 | qytjlv97 |
| H268 EP13+anti-K=3 standalone (Finding NN) | 5.9691 | 5.8165 | 6.7171 | 3.4358 | 3.6760 | 6wf7lf6z |

**Merge gate**: val_abupt < **5.9367** AND test_abupt < **5.7825**

## Critical Constraints

- **DDP 8 GPUs** for every eval run — `torchrun --standalone --nproc-per-node=8`
- **Read-only**: train.py, data/loader.py, data/preload.py, data/split_manifest.json
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67 (trained value)**
- **SENPAI_TIMEOUT_MINUTES=360**

## Wall-Clock Estimate

~230 min on DDP×8. Well within 360-min budget.
