### PR TITLE
H277: EP15 + σ=3e-4 + anti-thetic K=3 full stack — triple compound

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -83,6 +83,11 @@ class EvalConfig:
     weight_noise_sigma: float = 5e-4
     weight_noise_passes: int = 5
     weight_noise_seed_base: int = 42
+    # H277: anti-thetic K-pairs. When True, each k in 0..K-1 generates a PAIR
+    # of perturbations (+delta, -delta) sharing the same seed/eps but opposite
+    # sign. Total weight-perturbed forwards per (res, mirror) cell = 2*K, with
+    # the linear-Taylor variance term cancelled inside each pair.
+    antithetic: bool = False
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -257,8 +262,15 @@ def perturb_relative_(
     sigma: float,
     seed: int,
     device: torch.device,
+    sign: float = 1.0,
 ) -> None:
-    """p <- clean_p + randn(seed) * sigma * |clean_p|, identical across DDP ranks."""
+    """p <- clean_p + sign * randn(seed) * sigma * |clean_p|, identical across DDP ranks.
+
+    Anti-thetic pairing (H277): for fixed seed, calling with sign=+1.0 then
+    sign=-1.0 yields p = clean + delta and p = clean - delta using the same
+    underlying noise tensor. The linear-Taylor variance term cancels in the
+    average of these two evaluations.
+    """
     gen = torch.Generator(device=device)
     gen.manual_seed(seed)
     for name, p in module.named_parameters():
@@ -266,7 +278,7 @@ def perturb_relative_(
             continue
         clean_p = clean[name]
         noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
-        noise.mul_(sigma).mul_(clean_p.abs())
+        noise.mul_(sigma * sign).mul_(clean_p.abs())
         p.data.copy_(clean_p).add_(noise)
 
 
@@ -288,10 +300,17 @@ def process_case_stacked(
     K_passes: int,
     sigma: float,
     seed_base: int,
+    antithetic: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
     """Run K x R x M (mirror) TTA passes for one case and return per-point averaged
     predictions in real units. The K outer loop perturbs the model weights and
     reuses the perturbed copy across all (res, mirror) inner passes.
+
+    When `antithetic=True`, each k generates a PAIR of perturbations sharing
+    the same seed/eps but opposite sign (sign in {+1, -1}). The two forwards
+    in the pair share the same (R, mirror) sub-grid but the linear-Taylor
+    variance term cancels under the average, leaving only O(sigma^4) residual.
+    Total weight-perturbed forwards per (R, mirror) cell: 2*K_passes.
     """
     counts = store.case_point_counts(case_id)
     n_surf = counts["n_surface"]
@@ -311,13 +330,32 @@ def process_case_stacked(
     }
 
     mirror_flags = (False, True) if use_mirror else (False,)
+    # Anti-thetic pairing only meaningful when sigma > 0 (else both signs
+    # collapse to clean). With sigma=0 and antithetic=True we degrade to K
+    # redundant clean passes — guard against that.
+    sign_steps: tuple[float, ...] = (
+        (+1.0, -1.0) if (antithetic and sigma > 0.0) else (+1.0,)
+    )
 
-    for k in range(K_passes):
-        # Perturb once per k; reuse across (res, mirror) inner passes.
+    # Flatten (k, sign) into a single perturbation sequence so the rest of the
+    # loop body keeps its original indentation. For anti-thetic K=3 this gives
+    # 6 perturbations per case: (0,+), (0,-), (1,+), (1,-), (2,+), (2,-).
+    perturbations: list[tuple[int, float]] = [
+        (k, sign) for k in range(K_passes) for sign in sign_steps
+    ]
+
+    for k, sign in perturbations:
+        # Perturb once per (k, sign); reuse across (res, mirror) inner passes.
+        # Same seed for +sign and -sign within a pair -> identical noise tensor,
+        # opposite sign, giving f(w+delta) and f(w-delta). Restore is implicit:
+        # perturb_relative_ writes p = clean + sign*sigma*|clean|*eps from the
+        # pre-loop snapshot every call, so there is no drift across pairs.
         t_p = time.time()
         if sigma > 0.0:
             seed = (seed_base + k) * 100003
-            perturb_relative_(eval_module, clean, sigma=sigma, seed=seed, device=device)
+            perturb_relative_(
+                eval_module, clean, sigma=sigma, seed=seed, device=device, sign=sign,
+            )
         else:
             restore_clean_params(eval_module, clean)
         timing["perturb_seconds"] += time.time() - t_p
@@ -423,7 +461,8 @@ def process_case_stacked(
     surf_y = case.surface_y.float()
     vol_y = case.volume_y.float()
 
-    n_passes = K_passes * len(resolutions) * (2 if use_mirror else 1)
+    sign_count = 2 if (antithetic and sigma > 0.0) else 1
+    n_passes = K_passes * sign_count * len(resolutions) * (2 if use_mirror else 1)
     return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
 
 
@@ -519,6 +558,7 @@ def evaluate_split_stacked(
     sigma: float,
     seed_base: int,
     distributed_state,
+    antithetic: bool = False,
 ) -> dict[str, float]:
     rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
     world_size = (
@@ -549,6 +589,7 @@ def evaluate_split_stacked(
             K_passes=K_passes,
             sigma=sigma,
             seed_base=seed_base,
+            antithetic=antithetic,
         )
         add_case_to_accumulator(
             acc,
@@ -639,9 +680,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         print(f"Device: {device}{ddp_suffix}")
         print(f"Resolutions: {resolutions}")
         print(f"Modes: {modes}")
+        sign_count = 2 if cfg.antithetic else 1
         print(
             f"Weight-noise TTA: sigma_rel={cfg.weight_noise_sigma} "
-            f"K_passes={cfg.weight_noise_passes} seed_base={cfg.weight_noise_seed_base}"
+            f"K_passes={cfg.weight_noise_passes} seed_base={cfg.weight_noise_seed_base} "
+            f"antithetic={cfg.antithetic} "
+            f"(perturbed forwards per (res,mirror) = {cfg.weight_noise_passes * sign_count})"
         )
 
     ckpt_path, ckpt_source = resolve_checkpoint_path(cfg, state)
@@ -749,7 +793,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print(
                     f"\n=== {split_name} mode={mode} resolutions={mode_resolutions} "
                     f"mirror={use_mirror} K={cfg.weight_noise_passes} "
-                    f"sigma={cfg.weight_noise_sigma} ===",
+                    f"sigma={cfg.weight_noise_sigma} "
+                    f"antithetic={cfg.antithetic} ===",
                     flush=True,
                 )
             t0 = time.time()
@@ -768,6 +813,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 sigma=cfg.weight_noise_sigma,
                 seed_base=cfg.weight_noise_seed_base,
                 distributed_state=state,
+                antithetic=cfg.antithetic,
             )
             dt = time.time() - t0
             if state.is_main:


### PR DESCRIPTION
## Hypothesis

Three independently validated findings point at a single compound experiment:

1. **Finding QQ-EP15-stack-compound** (H267 merged): EP15 EMA stacks on H253 full recipe at ~55% additive rate → val 5.9367 / test 5.7825 = SOTA. EP15 adds −5.1bp over EP13+stack.

2. **Finding RR-sigma-EP13-stack** (H270 = your last PR): σ=3e-4 gives −2.0bp test vs σ=5e-4 on EP13 stack (5.7827 vs 5.7847). Especially improves test_WSS (−3.2bp). The EP13+σ=3e-4 test was **0.2bp from the gate** (5.7827 vs gate 5.7825).

3. **Finding NN-antithetic** (H268): Anti-thetic K=3 pairs (6 passes) beats random K=5 (5 passes) by +1.3bp standalone via linear Taylor-term cancellation. fern H274 (anti-thetic@EP13) shows val 5.9322 = CURRENT BEST across all in-flight runs.

H277 stacks **all three mechanisms simultaneously**: EP15 + σ=3e-4 + anti-thetic K=3 + 6-res + mirror. Predicted val ≈ **5.925–5.932** (sub-additive compounding from 3 mechanisms). The σ=3e-4 shift is orthogonal to both EP15 (which uses σ=5e-4) and anti-thetic (which is a sampling strategy).

This is the most densely compound experiment on the board. Even if two of three improvements regress slightly, the combined configuration may hold.

**Predicted val_abupt: 5.925–5.932%** | **Predicted test_abupt: 5.776–5.780%** (well below gate 5.7825 if sub-additive at 50%)

## Instructions

### Step 1: Verify EP15 checkpoint
```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
ls -lh $H185_EP15_CKPT
```

### Step 2: Implement anti-thetic K=3 with σ=3e-4 on EP15

This is the same as fern H274's anti-thetic implementation BUT:
- Use EP15 checkpoint (not EP13)
- Use `--weight-noise-sigma 3e-4` (not 5e-4)

**Derive from fern's branch** `fern/h274-antithetic-stacked` which already has the anti-thetic eval script. Adapt the checkpoint path and sigma flag:

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
torchrun --standalone --nproc-per-node=8 target/eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_weight_noise_avg" \
  --weight-noise-sigma 3e-4 \
  --n-weight-noise-passes 3 \
  --antithetic \
  --batch-size 2 --num-workers 4 \
  --agent tanjiro \
  --wandb-group "h277-tanjiro-ep15-sigma3e-4-antithetic" \
  --wandb-name "tanjiro/h277-ep15-sigma3e-4-anti-K3-stack"
```

`--n-weight-noise-passes 3` with `--antithetic` = K=3 PAIRS = 6 forward passes per (res, mirror) state. Total: 6 × 6-res × 2-mirror = 72 passes.

**If eval_tta_h252.py doesn't support `--antithetic`**: adapt from fern's script on branch `fern/h274-antithetic-stacked`. The anti-thetic loop generates paired ±delta_k perturbations (same delta, opposite sign), evaluates both `f(w+delta)` and `f(w-delta)`, averages each pair before averaging across K. Key: restore weights exactly after each pair using `assert torch.equal(p_current, p_snapshot)`.

**ETA**: ~230 min on DDP×8 (same wall-clock as H267 — 6 anti passes ≈ 5 random passes per res/mirror). Well within SENPAI_TIMEOUT_MINUTES=360.

**If val < 5.9367 AND test < 5.7825 → post terminal SENPAI-RESULT immediately for SOTA merge.**

### Step 3: Post terminal SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_ep15_sigma3e-4_antithetic_K3_stack","value":<val>},"test_metric":{"name":"test_abupt_ep15_sigma3e-4_antithetic_K3_stack","value":<test>}}
```

Include full comparison table showing all three mechanism axes:

| Config | σ | K-type | Checkpoint | val | test | Δ vs H267 |
|---|---|---|---|---|---|---|
| H267 (SOTA) | 5e-4 | random K=5 | EP15 | 5.9367 | 5.7825 | reference |
| H253 (EP13+full) | 5e-4 | random K=5 | EP13 | 5.9418 | 5.7847 | +5.1/+2.2bp |
| H270 (your last) | 3e-4 | random K=5 | EP13 | 5.9394 | 5.7827 | +2.7/+0.2bp |
| H274 fern | 5e-4 | anti K=3 | EP13 | 5.9322 | pending | −4.5bp val |
| H275 edward | 5e-4 | anti K=3 | EP15 | pending | pending | — |
| H276 thorfinn | 3e-4 | random K=5 | EP15 | pending | pending | — |
| **H277 (this)** | **3e-4** | **anti K=3** | **EP15** | result | result | Δ |

## Baseline Metrics (post-H267 merge)

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H267 EP15+σ=5e-4+K=5+6-res+mirror ← CURRENT SOTA** | **5.9367** | **5.7825** | **6.6898** | **3.3850** | **3.6505** | snouz8zi |
| H274 fern EP13+anti-K=3+6-res+mirror (val only so far) | 5.9322 | pending | — | — | — | o8oq9r92 |
| H270 your EP13+σ=3e-4+K=5+6-res+mirror | 5.9394 | 5.7827 | 6.6863 | 3.3880 | 3.6594 | vrmfilgm |

**Finding NN (H268)**: anti-thetic K=3 beats random K=5 by +1.3bp standalone.
**Finding RR (H270, you)**: σ=3e-4 gives −2.0bp test vs σ=5e-4 on EP13+stack; especially −3.2bp WSS.
**Finding QQ (H267)**: EP15 stacks at ~55% additive rate on H253 full recipe.

**Merge gate**: val_abupt < **5.9367** AND test_abupt < **5.7825**

## Critical Constraints

- **DDP 8 GPUs** — `torchrun --standalone --nproc-per-node=8`
- **Read-only**: train.py, data/loader.py, data/preload.py, data/split_manifest.json
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67**
- **SENPAI_TIMEOUT_MINUTES=360**
