### PR TITLE
H279: EP15 + Sobol QMC K=5 + 6-res + mirror — EP15×QMC compound

### DIFF
--- a/eval_h271_sobol_tta.py
+++ b/eval_h271_sobol_tta.py
@@ -37,6 +37,7 @@ import math
 import os
 import time
 from dataclasses import asdict, dataclass, fields
+from datetime import timedelta
 from pathlib import Path
 from typing import Iterable
 
@@ -1046,7 +1047,7 @@ def evaluate_split_multires(
 
 
 def main(argv: Iterable[str] | None = None) -> None:
-    state = init_distributed()
+    state = init_distributed(timeout=timedelta(minutes=60))
     cfg = parse_args(argv)
     device = state.device
 


### PR DESCRIPTION
# H279: EP15 + Sobol QMC K=5 + 6-res + Mirror — Test EP15 × QMC Compound

## Hypothesis

**You just found that Sobol QMC K=5 beats random K=5 by −2.8bp test at EP13** (Finding UU-Sobol-QMC-coverage, just merged as PR #1451 — new SOTA val 5.9368/test 5.7797). The natural next test is whether QMC advantage compounds with the EP15 checkpoint.

From the two strongest banked findings:
1. **Finding QQ-EP15-stack-compound** (H267): EP15 stacks on the full recipe at ~55% additive rate → H267 val 5.9367 / test 5.7825 (prior SOTA)
2. **Finding UU-Sobol-QMC-coverage** (H271, just merged): Sobol K=5 vs random K=5 gives uniform −0.5bp/channel improvement → val 5.9368 / test 5.7797 (current SOTA)

H279 swaps random K=5 for Sobol K=5 in the H267 EP15+full-stack recipe. If QMC advantage stacks independently with the EP15 gain:
- **Expected val**: 5.934-5.937 (H271 5.9368 plus the EP15 advantage ~55% × −5.1bp expected val gain ≈ −2.8bp more)
- **Expected test**: ~5.777 (H271 5.7797 minus EP15 compound gain ~2-3bp)

**Predicted test_WSS**: 6.666-6.675% — continued WSS improvement toward Transolver-3's 5.85% target.

## Why complementary to in-flight work

- H274 fern: EP13 + anti-thetic K=3 (running, val 5.9322 leading)
- H275 edward: EP15 + anti-thetic K=3 — checkpoint dimension of anti-thetic
- H276 thorfinn: EP15 + σ=3e-4 + random K=5 — σ dimension at EP15
- H277 tanjiro: EP15 + σ=3e-4 + anti-thetic K=3 — σ+anti-thetic at EP15
- **H279 (this)**: EP15 + **Sobol** K=5 — **QMC dimension at EP15** (no overlap with any in-flight)

## Instructions

### Step 1: Verify EP15 checkpoint

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
ls -lh $H185_EP15_CKPT
```

Same checkpoint edward used for H267. If missing, recover from W&B artifact `yw2a5dyl` alias `epoch-15`.

### Step 2: Use your H271 eval_h271_sobol_tta.py unchanged

You need **zero code changes** — just swap the checkpoint. Your H271 eval script is correct and just merged to the `tay` branch. Pull and use it directly:

```bash
git pull origin tay  # gets eval_h271_sobol_tta.py at HEAD
```

### Step 3: Run primary arm

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"
torchrun --standalone --nproc-per-node=8 eval_h271_sobol_tta.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "mirror_res_weight_noise_avg" \
  --weight-noise-mode sobol \
  --weight-noise-sigma 5e-4 \
  --n-weight-noise-passes 5 \
  --sobol-proj-dim 1024 \
  --sobol-seed 43 \
  --basis-seed 42 \
  --batch-size 2 --num-workers 4 \
  --agent frieren \
  --wandb-group "h279-frieren-ep15-sobol" \
  --wandb-name "frieren/h279-ep15-sobol-k5-stack"
```

NOTE: **Only change from H271 is the checkpoint path** (`checkpoint_ep15.pt` instead of EP13). All other flags identical to your winning H271 run.

**ETA**: ~185 min on DDP×8 (same as H271 since EP15 eval complexity is identical).

**Merge gate (updated after H271 merge)**: val_abupt < **5.9368** AND test_abupt < **5.7797**

### Step 4: Post terminal SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_ep15_sobol_k5_stack","value":<val>},"test_metric":{"name":"test_abupt_ep15_sobol_k5_stack","value":<test>}}
```

Include comparison table:

| Recipe | val_abupt | test_abupt | test_WSS | Δ vs gate |
|---|---|---|---|---|
| H271 EP13+Sobol K=5 (current SOTA) | 5.9368 | 5.7797 | 6.6848 | reference |
| H267 EP15+random K=5 (prior SOTA) | 5.9367 | 5.7825 | 6.6898 | test +2.8bp |
| H253 EP13+random K=5 | 5.9418 | 5.7847 | 6.6895 | — |
| **H279 EP15+Sobol K=5 (this)** | result | result | result | Δ |

Plus per-channel breakdown and discussion of whether EP15×QMC compounding is additive or sub-additive vs EP13×QMC and EP15×random.

## Baseline metrics

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H271 EP13+Sobol K=5 ← CURRENT SOTA** | **5.9368** | **5.7797** | **6.6848** | **3.3864** | **3.6512** | o9hb87lt |
| H267 EP15+K=5 random (prior SOTA) | 5.9367 | 5.7825 | 6.6898 | 3.3850 | 3.6505 | snouz8zi |
| H253 EP13+K=5 random | 5.9418 | 5.7847 | 6.6895 | 3.3891 | 3.6592 | qytjlv97 |

**Merge gate**: val_abupt < **5.9368** AND test_abupt < **5.7797**

## Critical constraints

- **DDP 8 GPUs** for every eval run
- **Read-only**: train.py, data/loader.py, data/preload.py, data/split_manifest.json
- **Modifiable**: eval_h271_sobol_tta.py (pull from tay HEAD — no changes needed, just checkpoint)
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67**
- **SENPAI_TIMEOUT_MINUTES=360** (185 min expected — well in budget)

## Wall-clock estimate

~185 min on DDP×8 (matches H271 exactly). Well within 360-min budget.
