### PR TITLE
H173: gradnorm_min_w_vol_p 0.15→0.05 — release vol_p clamp, free WSS budget

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,25 +1,49 @@
 # SENPAI Research State
 
-_Last updated: 2026-05-30 03:18Z._
+_Last updated: 2026-05-30 03:58Z._
 
-**03:18Z snapshot — Wave-2 strong signals + H172 smoke raw-vs-EMA finding:**
-1. **H169 (nezuko) EP3 BEATS H147 by 0.004pp** (6.976% vs 6.98%). val_WSS_y=7.742% leading target axis per mechanism. EP2→EP3 cooled 0.248pp (strong slope). Axis-coverage-at-same-weight hypothesis showing predicted mechanism.
-2. **H168 (fern) EP4=6.937%** behind H147 by 0.087pp BUT EP3→EP4 cooled 0.133pp (matches H147 cooling band). val_WSS_z=9.342% with fastest cooling among all axes — σ=0.1 STRING low-band PE resolving boundary-layer transition geometry.
-3. **H170 (frieren) EP4=6.961%** trail by 0.111pp. EP3→EP4 cooled 0.167pp (slower than H168). α=0.3 softer restoring force settling into smooth oscillation but trail pattern emerging.
-4. **H172 (tanjiro) smoke EP1 RAW BRANCH = 13.18%** ✓ PASS (vs H147 EP1=12.82%, gap +0.36pp normal). Earlier 52.04% was the **EMA-evaluated branch at decay=0.9999** — shadow at step 10975 has only ~1 effective averaging window, still heavily weighted toward init. EMA only meaningful EP3-5+. My 14% kill threshold was incorrectly applied to EMA branch — corrected to raw branch in PR #1469 comment. Train loss healthy (0.214 at step 5000 → 0.089 at EP1).
+**03:58Z snapshot — H170 CLOSED (α-axis bracketed), H173 dispatched, H172 smoke EP2 PASS:**
 
-**H172 best_checkpoint_source flag:** config dump showed flag NOT explicitly set. Asked tanjiro to verify CLI passes `--best-checkpoint-source ema` before 30 EP main launch — otherwise test eval would reload raw weights and the hypothesis would be untestable.
+1. **H170 (frieren) CLOSED PR #1464** — EP5 kill 6.899% > 6.80% gate. α=0.3 mechanism falsified in OPPOSITE direction: w_τ_z oscillation 3.2× larger, drift upward 1.21→1.55. KEY FINDING: w_vol_p pinned at 0.15 clamp for 100% of run (H147 too). GradNorm wants to push vol_p lower but clamp blocks. α-axis bracketed (H874 0.75 blow-up, H170 0.3 kill) — α=0.5 TIGHT.
+2. **H173 dispatched to frieren PR #1474** — gradnorm_min_w_vol_p 0.15→0.05. Tests if releasing the vol_p clamp lets GradNorm route more budget to WSS heads. Direct H170 follow-on.
+3. **H172 (tanjiro) smoke EP2 PASS** — raw val_WSS=8.03% at step 21951. Expected trail vs H147 EP2=7.26% due to slower LR drop in 30-EP cosine schedule. EMA shadow still warming (49.35% — expected). **30-EP main launched pending tanjiro verification of `--best-checkpoint-source ema` and `--ema-decay 0.9999` flags.** Status:wip; kill ladder updated.
 
-### Wave-2 EP3-EP4 status (03:18Z W&B reads)
+### Wave-2 EP4-EP5 status (03:58Z W&B reads)
 
-| Run | PR | rank0 | rt | ~EP | val_WSS | vs H147 ref | val_WSS_y | val_WSS_z | EP3→EP4 slope | Watch |
+| Run | PR | rank0 | rt | ~EP | val_WSS | vs H147 ref | val_WSS_y | val_WSS_z | Last slope | Watch |
 |---|---|---|---:|---:|---:|---|---:|---:|---|---|
-| **H168 `pe-lo-sigma`** fern | #1462 | t9h0inur | 3.46h | EP4 | **6.937%** | +0.087pp trail | 7.726% | **9.342% FAST** | **−0.133pp** | extrap EP5 ~6.80% (close to H147 6.75%) |
-| **H169 `wss-charb-yz`** nezuko | #1463 | aco66tdm | 2.54h | EP3 | **6.976%** | **−0.004pp BEAT** | **7.742% LEADING** | 9.395% | **−0.248pp EP2→3** | **LEADING — sustained slope** |
-| H170 `gradnorm-alpha-03` frieren | #1464 | nkc26gvj | 3.30h | EP4 | 6.961% | +0.111pp trail | 7.752% | 9.391% | −0.167pp | EP5 gate: > 6.95% = KILL |
-| **H172 `ema-weights` smoke** tanjiro | #1469 | z5352gm6 | 0.86h | EP1 raw | **13.18% PASS** | +0.36pp normal | — | — | — | EP2 verify + 30-EP main green-light pending config |
+| **H168 `pe-lo-sigma`** fern | #1462 | t9h0inur | 4.20h | **EP5** | **6.858%** | +0.108pp | 7.593% | **9.248% FASTEST** | −0.079pp EP4→5 | BORDERLINE — above 6.85% gate by 0.008pp, **CONTINUE** on WSSz signal |
+| **H169 `wss-charb-yz`** nezuko | #1463 | aco66tdm | 3.26h | **EP4** | **6.886%** | +0.036pp | **7.563% LEADING** | 9.299% | −0.090pp EP3→4 | Lost EP3 BEAT, mechanism partially intact (WSS_y still leading); continue to terminal |
+| **H170 `gradnorm-alpha-03`** frieren | #1464 | nkc26gvj | 3.58h | EP5 | **6.899% KILL** | +0.149pp | — | — | −0.062pp EP4→5 | **CLOSED** PR #1464 — α=0.5 bracketed, α-axis closed |
+| **H172 `ema-weights` smoke** tanjiro | #1469 | z5352gm6 | 1.49h | EP2 raw | **8.03% PASS** | +0.77pp (schedule diff) | — | — | — | 30-EP main pending config verify + launch |
+| **H173 `gradnorm-clamp-vol-p`** frieren | #1474 | TBD | 0h | not started | — | — | — | — | — | Smoke EP1 then 8-EP main |
 
-**Wave-2 verdict (preliminary):** H169 axis-coverage and H168 σ=0.1 low-band PE both delivering mechanism-aligned signals. H170 α=0.3 trail pattern emerging. H172 smoke alive (raw model healthy). All four arms producing useful information.
+### Wave-2 trail pattern — CONFIRMED EXPANDING
+
+| Run | Mechanism class | EP trail pattern | α-axis? | Outcome |
+|---|---|---|---|---|
+| H164 slices=192 | Structural | EP1-only-gain, late trail | — | CLOSED |
+| H165 pe=12 | Structural | EP1-only-gain, late trail | — | CLOSED |
+| H166 surfw=3 | Structural | EP1-only-gain, late trail | — | CLOSED |
+| H168 pe-lo-sigma | Data-rep (PE freq) | EP5 borderline, WSSz signal | — | **Continuing** |
+| H169 wss-charb-yz | Loss-axis-coverage | EP3 BEAT → EP4 trail +0.036 | — | **Continuing** |
+| **H170 gradnorm-α** | **Loss-allocation** | **EP2→5 widening trail → KILL** | **BRACKETED** | **CLOSED** |
+
+**Emerging conclusion:** single-flag perturbations fail across structural, PE-freq, Charbonnier-coverage, AND GradNorm-allocation axes. The 4-axis structural wave finding extends to the loss-allocation dimension. Next plateau-escape requires either (a) multi-flag joint moves, (b) architecture, or (c) optimizer-level (Lookahead, LLRD). H168/H169 are the last two single-flag arms in flight with mechanism-aligned signals.
+
+### H173 (frieren) — vol_p clamp probe
+
+**Mechanism:** H170 trace showed w_vol_p pinned at clamp=0.15 throughout (H147 same). GradNorm wants to route less budget to vol_p but floor blocks it. Lowering clamp to 0.05 lets GradNorm optimize freely — may free WSS budget.
+
+**H147 test_VP headroom:** 3.4014% vs floor 3.643% = 0.242pp headroom. Safe margin for vol_p budget reduction.
+
+**If H173 ALSO trails** → GradNorm clamp axis is also closed → next move must be multi-flag joint (H168+H169 mechanisms combined) or architectural.
+
+### H172 (tanjiro) — 30-EP EMA decay=0.9999 main run key flags
+- `--ema-decay 0.9999` (switch from H147's 0.999)
+- `--best-checkpoint-source ema` (required for EMA test eval)  
+- `--ema-start-step 500` (default)
+- Kill ladder: EP5 raw > 8.50%, EP10 EMA > 6.80%, EP15 EMA > 6.65%, EP25 EMA > 6.55%
 
 ### H172 (tanjiro) — EMA hyperparameter swap with key implementation clarification
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -4473,3 +4473,55 @@ The 4-axis structural-wave sealing + 5+ prior consecutive non-merge results trig
 **Assigning H171 next:** tanjiro → `mirror-y-train-aug` — exploit known x-z plane geometric symmetry of automotive aero. Train-time mirror-y aug doubles effective dataset, geometric-symmetry-respecting model should generalize better to held-out test geometries. Fully orthogonal to all 4 structural axes and all loss-weight axes. The other-advisor's H275 in drivaerml-ddp8 track uses 6-res×mirror TTA at inference (val_ABUPT=5.92, test_ABUPT=5.77) — direct cross-track evidence that mirror-y is a real exploitable symmetry. Train-time mirror should reach similar generalization without 72-pass inference cost.
 
 
+
+## 2026-05-30 03:49Z — PR #1464 H170 frieren CLOSED: α=0.3 GradNorm mechanism falsified, α-axis bracketed
+
+- `dl24-frieren/h170-gradnorm-alpha-03`, rank0 run `nkc26gvj` (8 DDP ranks)
+- Hypothesis: Lower GradNorm restoring force α=0.5→0.3 would reduce w_τ_z oscillation amplitude, smoothing gradient budget for the τ_z head and consolidating τ_z learning signal.
+- **Terminal verdict: CLOSE NON-MERGE — EP5 kill at 6.899% > 6.80% gate. Mechanism falsified in opposite direction.**
+
+### Per-epoch val trajectory vs H147
+
+| EP | step | val_WSS | wss_z | vs H147 ref | Δ |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 10975 | 12.829% | 16.713% | 12.82% | +0.01 |
+| 2 | 21950 | 7.375% | 9.869% | 7.26% | **+0.115** |
+| 3 | 32925 | 7.128% | 9.594% | 6.98% | **+0.148** |
+| 4 | 43900 | 6.961% | 9.391% | ~6.85 | **+0.111** |
+| 5 | 54875 | **6.899%** | **9.323%** | 6.75% | **+0.149** |
+
+Cooling: EP2→3 −0.247pp; EP3→4 −0.167pp; EP4→5 −0.062pp (near-stall). Kill gate 6.80% fired at EP5 = 6.899%.
+
+### GradNorm weight trace — discriminating diagnostic
+
+| EP | w_cp | w_τ_x | w_τ_y | w_τ_z | w_vol_p | clamp |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 1.089 | 1.311 | 1.238 | 1.213 | 0.150 | ✓ |
+| 2 | 1.069 | 1.393 | 1.050 | 1.338 | 0.150 | ✓ |
+| 3 | 0.906 | 1.438 | 1.057 | **1.449** | 0.150 | ✓ |
+| 4 | 0.832 | 1.389 | 1.083 | **1.547** | 0.150 | ✓ |
+| 5 | 0.780 | 1.404 | 1.119 | **1.547** | 0.150 | ✓ |
+
+**Mechanism falsified — opposite direction:** α=0.3 increased w_τ_z oscillation 3.2× (std 0.147 vs H147 0.046). w_τ_z drifted UPWARD monotonically (1.21→1.55) instead of stabilizing. w_cp collapsed (1.09→0.78). val_WSS_z +0.5pp worse than H147 trajectory.
+
+**Key finding: vol_p clamp binding throughout (both H147 AND H170).** w_vol_p pinned at 0.15 floor for 100% of both runs. GradNorm wants to push vol_p below 0.15 but clamp blocks it → dispatching H173 (clamp 0.15→0.05) to test this directly.
+
+### Joint α-axis closure with H874
+
+| Run | α | Outcome |
+|---|---:|---|
+| H874 (pre-dataset) | 0.75 | Blew up EP16 (high tail) |
+| H147 SOTA | 0.50 | SOTA (stable, tight oscillation) |
+| **H170** | **0.30** | **Kill EP5 trail (low tail)** |
+
+**α=0.5 is now bracketed and TIGHT.** α-axis closed for this stack.
+
+### Wave-2 trail pattern confirmation
+
+Across H164/H165/H166 (structural wave) + H168/H169/H170 (wave-2 loss-rep-allocation):
+- H164/H165/H166: EP1-only-gain, late-EP trail → CLOSED
+- H170: EP2→EP5 monotonically widening gap → KILL
+- H169: Lost EP3 BEAT by EP4 (+0.036pp trail, continuing)
+- H168: EP5 borderline (6.858%), mechanism-signal (WSSz FASTEST cooling) still intact
+
+**H147 stack is rigid against single-flag perturbation across 5+ mechanistic axes.** Combined finding spans structural, loss-density, β, lr, per-axis-weight, GradNorm-α axes.


### PR DESCRIPTION
## Hypothesis

**H173 `gradnorm-clamp-vol-p-005`** — Lower `--gradnorm-min-w-vol-p` from 0.15 → 0.05 on the full H147 SOTA stack. Direct follow-on to H170's diagnostic finding: w_vol_p is pinned at the 0.15 clamp for the ENTIRE run in both H147 (SOTA) and H170 (α=0.3 just closed), meaning GradNorm consistently wants to push vol_p weight below 0.15 but is blocked.

**Why the clamp binds.** In H170's GradNorm trace: w_vol_p mean 0.166 ± 0.079, range "clamp" (100% of run). In H147: same pattern (mean 0.172 ± 0.091). The vol_p component has the HIGHEST gradient norm relative to target among all tasks — GradNorm's restoring force says "vol_p doesn't need more budget; route it to WSS heads." The floor at 0.15 prevents this.

**Mechanism.** Lowering the clamp to 0.05 lets GradNorm push w_vol_p down to ~0.05 if needed, redistributing ~0.10 gradient budget to WSS heads (τ_x, τ_y, τ_z). Since τ_z is the hardest channel and GradNorm's w_τ_z is already elevated at ~1.32–1.55 (both H147 and H170), freeing more budget may let the optimizer consolidate τ_z gradients without the vol_p floor absorbing share it doesn't need.

**Why this is safe.** H147's test_VP = 3.4014% vs the floor cap 3.643% — there is 0.242pp of test-side headroom. Even if lowering the clamp weakens vol_p training somewhat, it has substantial margin before hitting the floor cap. The clamp change is a one-line config delta; no architecture, loss form, or LR change.

**α-axis context (H170, just closed).** H170 (α=0.3) CLOSED at EP5 kill 6.899%. H874 (α=0.75) blew up EP16. α=0.5 is now BRACKETED and TIGHT. The α-axis is closed. H173 attacks a DIFFERENT lever: not how quickly GradNorm rebalances, but how far it is ALLOWED to rebalance on the vol_p floor.

**Expected outcome:**
- If GradNorm redistributes from vol_p toward WSS → WSS cooling rate should be slightly faster in EP3-8 relative to H147.
- val_SP/val_VP may trail H147 slightly (by ≤0.1pp) if vol_p budget genuinely decreases.
- If vol_p needs its share regardless (because it provides trunk context) → null result, same as H147.
- If the GradNorm balance is robust to clamp changes → null result confirms the floor doesn't matter.

**Single-flag change.** Zero VRAM impact. Zero runtime impact.

## Instructions

**Single-flag change** vs H147 SOTA: change `--gradnorm-min-w-vol-p 0.15` to `--gradnorm-min-w-vol-p 0.05`. Everything else identical to H147 SOTA stack.

**Run protocol:**
1. **Smoke EP1**: 1-epoch DDP8 run. Kill gate: EP1 val_WSS ≤ 13.5%.
2. **Main 8-EP run**: T_max=8, full DDP8.

**Kill ladder:**
- EP1 ≤ 13.5% (smoke gate)
- EP3 ≤ 7.20%
- EP5 ≤ 6.80%
- EP8 terminal with test harvest

**Diagnostic trace to report (required):** per-epoch GradNorm weights at each EP boundary — specifically w_vol_p, w_τ_z, w_τ_y. The mechanism prediction is: w_vol_p should DROP from the floor (0.15→lower) while w_τ_z stays high or rises. If w_vol_p stays pinned at 0.05 (new floor), the floor still binds and the next probe should remove it entirely.

**CLI delta vs H147 SOTA stack:**

```bash
# REMOVE:
--gradnorm-min-w-vol-p 0.15
# ADD:
--gradnorm-min-w-vol-p 0.05
```

**Full reproduce command (H147 SOTA stack with H173 clamp change):**

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 8 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --vol-p-charbonnier-eps 1e-3 \
  --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.05 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 --epochs 8 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --wandb-name "dl24-frieren/h173-gradnorm-clamp-vol-p-005" \
  --wandb-group "h173-gradnorm-clamp-vol-p-005" --agent dl24-frieren
```

**Note on H170 premise check:** You already confirmed in H170 that `--gradnorm-min-w-vol-p` is an active flag in the H147 stack at value 0.15. No premise check needed this round — the flag is confirmed present.

**Terminal SENPAI-RESULT marker required:**
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0-id>"],"primary_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<float>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<float>}}
```

Plus standard results table (test_WSS, test_WSS_x/y/z, test_VP, test_SP, test_ABUPT vs H147) **plus the per-epoch GradNorm weight trace** (w_vol_p, w_τ_z, w_τ_y at each EP boundary) — this is the discriminating diagnostic.

## Baseline

**H147 SOTA (PR #1344, run `k6q4c3on`) — corrected metrics:**
- test_primary/wall_shear_rel_l2_pct = **6.5409%** ⭐ (primary)
- test_primary/wall_shear_x_rel_l2_pct = 5.8155%
- test_primary/wall_shear_y_rel_l2_pct = 7.0556%
- test_primary/wall_shear_z_rel_l2_pct = 8.4882% (worst — mechanism target)
- test_primary/volume_pressure_rel_l2_pct = 3.4014% (floor 3.643%, clears by 0.242pp)
- test_primary/surface_pressure_rel_l2_pct = 3.5634% (floor 3.577%, clears by 0.014pp)
- test_primary/abupt_axis_mean_rel_l2_pct = 5.6648% (floor 5.844%, clears by 0.179pp)

**Floor caps (must NOT regress on test):**
- test_VP ≤ 3.643%
- test_SP ≤ 3.577%
- test_ABUPT ≤ 5.844%

**H147 val_WSS trajectory reference:**
| EP | 1 | 2 | 3 | 5 | 8 |
|---|---:|---:|---:|---:|---:|
| val_WSS | 12.82% | 7.26% | 6.98% | 6.75% | ~6.68% |

**H147 GradNorm weight trace reference (α=0.5, clamp=0.15):**

| weight | H147 mean | H147 std | H147 range |
|---|---:|---:|---:|
| w_cp | 0.895 | 0.061 | 0.202 |
| w_τ_x | 1.301 | 0.068 | 0.388 |
| w_τ_y | 1.318 | 0.104 | 0.439 |
| **w_τ_z** | **1.315** | **0.046** | **0.325** |
| w_vol_p | 0.172 | 0.091 | **pinned at clamp** |

**H170 GradNorm weight trace (α=0.3, clamp=0.15 — for comparison):**

| weight | H170 mean | H170 std | note |
|---|---:|---:|---|
| w_vol_p | 0.166 | 0.079 | pinned at clamp throughout |
| w_τ_z | 1.377 | 0.147 | drifted upward 1.21→1.55 |

**Mechanism:** Both H147 and H170 spend 100% of training with w_vol_p at clamp floor. H173 lowers the floor to 0.05. If w_vol_p drops to ~0.05, GradNorm will have allocated ~0.10 more gradient budget to WSS heads. If w_vol_p stays at 0.05 (new floor still binding), close and try removing the clamp entirely.

**Your H170 result (just closed):**
- EP5 kill at 6.899% (+0.149pp trail). α-axis BRACKETED: H874(0.75 blow-up) + H170(0.3 kill) = α=0.5 is TIGHT. α-axis closed.
- GradNorm weight trace data from H170 directly motivates H173.

**Wave-2 context:** H168 (fern EP5 6.858%, continuing), H169 (nezuko EP4 6.886% trail, continuing), H172 (tanjiro 30-EP EMA main). All four students now active.
