### PR TITLE
H291: 8-res lower ladder {16K-131K} at EP15+anti-K3 SOTA

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -121,6 +121,7 @@ class EvalConfig:
 
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
+    skip_val: bool = False  # H291: val already logged in prior W&B run, run test-only
 
 
 def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
@@ -651,7 +652,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     # straggler waits >600s before the next collective, triggering a wait-timeout
     # on the lazy NCCL communicator init for the first post-val all_gather_object.
     # Bump to 120 min (same shape as thorfinn #1433 / nezuko #1432 plumbing).
-    state = init_distributed(timeout=timedelta(minutes=120))
+    state = init_distributed(timeout=timedelta(minutes=180))
     cfg = parse_args(argv)
     device = state.device
 
@@ -763,6 +764,10 @@ def main(argv: Iterable[str] | None = None) -> None:
         ("val_surface", val_case_ids, "full_val"),
         ("test_surface", test_case_ids, "test"),
     ]
+    if cfg.skip_val:
+        splits = [s for s in splits if s[0] != "val_surface"]
+        if state.is_main:
+            print("skip_val=True: dropping val_surface from splits, running test only")
 
     summary: dict[str, dict[str, dict[str, float]]] = {}
     for split_name, case_ids, log_prefix in splits:


### PR DESCRIPTION
## Hypothesis

**Add low-resolution anchors {16384, 24576} to the H275 SOTA 6-res ladder, making an 8-res lower-extended grid {16K, 24K, 32K, 49K, 65K, 82K, 98K, 131K} — do cheap low-res "anchor" evaluations improve the TTA average?**

The H275 SOTA recipe uses 6 resolutions: {32768, 49152, 65536, 81920, 98304, 131072}. The minimum is 32K nodes. The question: does extending downward into lower resolutions (16K, 24K) add complementary predictions that stabilize the anti-thetic average?

Motivation: The model was trained across multiple resolutions (DrivAerML has native multi-resolution support). Low-resolution predictions are cheap (~4× less compute per pass than 131K) and may contribute orthogonal error structure from the high-resolution passes. If the low-res predictions correlate less with the high-res predictions on hard cases, the average will have lower variance.

Note: fern (H288) is simultaneously testing mid-range densification (+40960 +57344). Your H291 tests the OPPOSITE direction — lower-end anchors. Together these give a complete picture of the resolution axis.

Three concrete predictions:
1. **8-res lower wins**: val < 5.9243 AND test < 5.7690 → low-res anchors add complementary signal → SOTA and bank Finding "lower-res anchors improve TTA average"
2. **8-res lower ≈ 6-res SOTA** (within noise): low-res predictions are dominated by the high-res majority and cancel out → resolution axis is exhausted below 32K
3. **8-res lower worse than 6-res**: low-res predictions pull the average in the wrong direction (high-res predictions are qualitatively better) → bank "TTA average is harmed by low-res anchors below 32K"

**Merge gate**: val_abupt < **5.9243** AND test_abupt < **5.7690**

## Instructions

### Step 1: Branch is already set up

Your branch is `frieren/h291-extended-res-lower`, already pushed. No code changes needed — only the `--resolutions` flag changes.

### Step 2: Use eval_tta_h252.py with LOWER-extended res grid

```bash
H185_EP15_CKPT="outputs/h252_eval/_artifacts/0gjfv45i/epoch-15/checkpoint.pt"
# If not found: outputs/h252_eval/_artifacts/0gjfv45i/checkpoint_ep15.pt

torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "16384,24576,32768,49152,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-passes 3 \
  --antithetic-noise \
  --batch-size 2 --num-workers 4 \
  --agent frieren \
  --wandb-group "h291-frieren-ep15-anti-K3-8res-lower" \
  --wandb-name "frieren/h291-ep15-anti-K3-8res-lower"
```

**The ONLY change from H275 is**: `--resolutions "16384,24576,32768,49152,65536,81920,98304,131072"` (adds 16K and 24K at the LOW end).

Flag names (same as H275/H274):
- `--weight-noise-passes 3` (NOT `--n-weight-noise-passes`)
- `--antithetic-noise` (NOT `--antithetic`)
- `--eval-modes "weight_noise_mirror_res_avg"` (exact string)

K=3 pairs × 2 = 6 forward passes. 8 resolutions instead of 6 → **96 forwards per case** (8 res × 6 noise × 2 mirror) vs H275's 72. Compute: ~308 min (8/6 × 230 min). Set SENPAI_TIMEOUT_MINUTES=360 (60 min buffer).

### Step 3: Defensive NCCL timeout patch

Same `timedelta(minutes=60)` patch in `init_distributed` (same uneven val split issue). You already applied this in H279.

### Step 4: Post terminal SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_ep15_anti_K3_8res_lower_stack","value":<val>},"test_metric":{"name":"test_abupt_ep15_anti_K3_8res_lower_stack","value":<test>}}
```

Include the comparison table:

| Recipe | val_abupt | test_abupt | test_WSS | test_SP | test_VP |
|---|---:|---:|---:|---:|---:|
| **H291 8-res lower {16K-131K} (you)** | ? | ? | ? | ? | ? |
| **H275 6-res {32K-131K} ← CURRENT SOTA** | 5.9243 | 5.7690 | 6.6743 | 3.6427 | 3.3788 |
| H274 EP13+anti-K=3+6-res | 5.9322 | 5.7763 | 6.6805 | 3.6515 | 3.3846 |

Plus 2-3 sentences: Did low-res anchors help? Are the lower-resolution predictions complementary or redundant?

## Baseline

| Recipe | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H275 EP15+anti-K3+σ=5e-4+6-res ← CURRENT SOTA** | **5.9243%** | **5.7690%** | **6.6743%** | **3.3788%** | **3.6427%** | 0b4t2bz2 |
| H274 EP13+anti-K3+σ=5e-4+6-res | 5.9322% | 5.7763% | 6.6805% | 3.3846% | 3.6515% | o8oq9r92 |

**Constraints**: DDP 8 GPUs always; eval-time TTA only (no model changes); z-axis tau_z LOCKED at 1.67; data/loader.py + data/preload.py + data/split_manifest.json READ-ONLY; SENPAI_TIMEOUT_MINUTES=360
