### PR TITLE
H175: wss_charb yz @ 0.05 — magnitude-preserving coverage extension

### DIFF
--- a/train.py
+++ b/train.py
@@ -156,7 +156,8 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         ),
         "wss_charbonnier_axes": (
             "Which WSS channels the supplementary Charbonnier loss applies to. "
-            "'all' = tau_x, tau_y, tau_z (H10 default). 'z' = tau_z only (H10b)."
+            "'all' = tau_x, tau_y, tau_z (H10 default). 'z' = tau_z only (H10b). "
+            "'yz' = tau_y + tau_z (H175 coverage extension)."
         ),
         "surface_out_width_factor": (
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
@@ -164,7 +165,7 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         ),
     }
     choices_text = {
-        "wss_charbonnier_axes": ["all", "z"],
+        "wss_charbonnier_axes": ["all", "z", "yz"],
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -451,6 +452,12 @@ def train_loss(
             if wss_charbonnier_axes == "z":
                 pred_wss = out["surface_preds"][..., 3:4]
                 target_wss = surface_target[..., 3:4]
+            elif wss_charbonnier_axes == "yz":
+                # H175: tau_y (idx 2) + tau_z (idx 3) coverage extension at
+                # magnitude-preserving per-axis weight (0.05 vs H147's 0.10 on z).
+                # surface_preds channel layout is [cp, tau_x, tau_y, tau_z].
+                pred_wss = out["surface_preds"][..., 2:4]
+                target_wss = surface_target[..., 2:4]
             elif wss_charbonnier_axes == "all":
                 pred_wss = out["surface_preds"][..., 1:4]
                 target_wss = surface_target[..., 1:4]
@@ -806,12 +813,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                     if "loss_wss_charb_unweighted" in batch_loss_metrics:
                         # H10b diagnostics: key suffix follows --wss-charbonnier-axes
-                        # so dashboards can compare "wss" (all-axes) vs "tau_z" (z-only).
-                        wss_axes_label = (
-                            "tau_z"
-                            if config.wss_charbonnier_axes == "z"
-                            else "wss"
-                        )
+                        # so dashboards can compare "wss" (all-axes) vs "tau_z" (z-only)
+                        # vs "tau_yz" (H175 yz coverage extension).
+                        if config.wss_charbonnier_axes == "z":
+                            wss_axes_label = "tau_z"
+                        elif config.wss_charbonnier_axes == "yz":
+                            wss_axes_label = "tau_yz"
+                        else:
+                            wss_axes_label = "wss"
                         target_mse = batch_loss_metrics["loss_wss_charb_target_mse"]
                         charb_unw = batch_loss_metrics["loss_wss_charb_unweighted"]
                         charb_w = batch_loss_metrics["loss_wss_charb_weighted"]


### PR DESCRIPTION
## Hypothesis

**Magnitude-preserving WSS Charbonnier coverage extension: yz axes at weight 0.05.** Tests whether axis-coverage extension is beneficial when the TOTAL Charbonnier contribution is held constant at H147's level.

H169 (PR #1463, closed NON-MERGE at 07:05Z) extended `wss_charbonnier_axes` from z-only to yz at the SAME weight 0.10, which effectively DOUBLED the WSS Charbonnier gradient pressure on the model (Charbonnier on a second axis is additional gradient signal, not a redistribution). Result: test_WSS=6.6686% (+0.128pp regression) **and test_SP=3.6933% (+0.116pp over the 3.577 floor)**. This makes H169 the 6th axis to break the SP floor in wave-2, joining H164/H165/H166/H167/H168.

**Meta-finding from H164-H169: any perturbation that increases optimization pressure on the WSS pathway — structural, allocation, or loss — breaks the SP floor.** H147's GradNorm equilibrium runs SP at +0.014pp floor cushion; any extra WSS-pathway gradient steals from SP, and SP loses first.

**H175 is the clean ablation.** By halving the per-axis weight to 0.05 while extending to yz, the TOTAL Charbonnier contribution becomes 0.05 + 0.05 = 0.10 — matching H147's z-only @ 0.10. This isolates COVERAGE (which axes get Charbonnier) from MAGNITUDE (total Charbonnier loss weight).

**Three possible outcomes (mechanism payoff table):**

| Outcome | Interpretation |
|---|---|
| test_WSS, test_SP match H147 ±0.05pp | Coverage at preserved magnitude is **neutral**; H169 failure was pure magnitude doubling |
| test_WSS_y improves while SP floor holds | **Partial coverage win** — extending coverage at preserved magnitude provides real benefit; worth merging even small |
| test_SP breaches floor again | **Coverage itself diffuses optimization pressure** → close the entire Charbonnier-coverage direction |

**Why this is high-priority despite 3 prior NON-MERGE in Charbonnier family:** the H164-H169 negative results all involved adding optimization pressure. This is the FIRST controlled experiment that holds pressure constant while changing distribution. If it works, it would be the cleanest mechanism win in wave-2 because it would mean H147 is leaving free entropy on the table that can be captured without disturbing the floor-tight equilibrium.

**Paper anchor:** Charbonnier loss is a robust penalty (Sun et al. CVPR 2008, "Learning Optical Flow"). Distributing it across more axes at proportionally reduced per-axis weight is the standard practice in multi-axis robust estimation when the total robustness budget is fixed.

## Instructions

**Single-flag change vs H147:**
- `--wss-charbonnier-weight 0.05` (was 0.1)
- `--wss-charbonnier-axes yz` (was z)
- All other H147 flags identical

**Smoke run first (2 EP DDP8, ~1h):**
```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 2 \
  --model-pe string_multisigma \
  --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --vol-p-charbonnier-eps 1e-3 \
  --wss-charbonnier-weight 0.05 --wss-charbonnier-axes yz \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 --epochs 2 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --wandb-name "dl24-nezuko/h175-wss-charb-yz-005-smoke" \
  --wandb-group "h175-wss-charb-yz-005" --agent dl24-nezuko
```

**Smoke gate:** EP1 val_WSS ≤ 13.5% (H147 ref 12.82%). Should match H147 EP1 closely because the Charbonnier weight is now magnitude-preserving.

**Main run after smoke passes (8 EP DDP8, ~5-6h):** same command but `--epochs 8 --lr-cosine-t-max 8 --wandb-name "dl24-nezuko/h175-wss-charb-yz-005-main"`. 8 EP matches H169/H169-family comparison contract.

**Kill ladder (8 EP):**
- EP3 val_WSS > 7.20% → KILL
- EP5 val_WSS > 6.85% → KILL
- EP6 val_VP > 4.10% OR val_SP > 4.05% → KILL (floor watchdog — H169 EP6 val_SP=3.967, EP8 test_SP=3.693; if H175 EP6 val_SP higher than H169's, predicted test_SP breach)
- EP8 terminal harvest with EMA best-val checkpoint for test eval

**Critical reporting:** include both `val_primary/*` and `val_raw_primary/*` at terminal. Track val_WSS_y and val_WSS_z descent rates EP-by-EP (mechanism signal: does y-axis benefit at preserved magnitude?).

**Decision band at terminal:**
- test_WSS < 6.5409 AND test_SP ≤ 3.577 → **MERGE**
- test_WSS < 6.5409 AND test_SP ≤ 3.62 (10bp tolerance) → review, likely merge
- test_WSS ≥ 6.5409 OR test_SP > 3.62 → NON-MERGE close

## Baseline (H147 SOTA — `k6q4c3on`)

| metric | H147 test value | floor cap |
|---|---:|---:|
| `test_primary/wall_shear_rel_l2_pct` ⭐ | **6.5409%** | — |
| `test_primary/wall_shear_x_rel_l2_pct` | 5.8155 | — |
| `test_primary/wall_shear_y_rel_l2_pct` | 7.0556 | — |
| `test_primary/wall_shear_z_rel_l2_pct` | 8.4882 | — |
| `test_primary/volume_pressure_rel_l2_pct` | 3.4014 | ≤ 3.643 |
| `test_primary/surface_pressure_rel_l2_pct` | 3.5634 | ≤ 3.577 (cushion 0.014pp) |
| `test_primary/abupt_axis_mean_rel_l2_pct` | 5.6648 | ≤ 5.844 |

**H147 baseline W&B run:** `k6q4c3on` (https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/k6q4c3on)

**Reproduce command (identical to H175 main except `--wss-charbonnier-weight 0.1 --wss-charbonnier-axes z`):**
```bash
cd "target/" && torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 \
  --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 8 \
  --model-pe string_multisigma --pe-init-sigmas "0.25,0.5,1.0,2.0,4.0" --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --vol-p-charbonnier-eps 1e-3 \
  --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 --epochs 8 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500
```

## Wave-2 Charbonnier family — closing the loss-axis lever after H175

| H# | wss_charbonnier setting | result |
|---|---|---|
| H147 | z @ 0.10 (1 axis × 0.10 = 0.10 total) | **SOTA** |
| H161 | z @ 0.30 (1 axis × 0.30 = 0.30 total) | falsified +0.199 (magnitude up on single axis) |
| H169 | yz @ 0.10 (2 axes × 0.10 = 0.20 total) | falsified +0.128 / SP break (magnitude doubled via coverage) |
| **H175** | **yz @ 0.05 (2 axes × 0.05 = 0.10 total)** | **THIS PR — magnitude preserved, coverage extended** |

After H175 lands the wave-2 Charbonnier family is exhausted on the magnitude × coverage 2D plane; next directions become asymmetric per-axis weights, Charbonnier-eps tuning, or alternative robust losses (Huber, log-cosh).
