### PR TITLE
H293: Laplace weight-noise at EP15+anti-K3+6-res — does heavier tail improve channel diversity?

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -33,6 +33,7 @@ Modes:
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import time
 from dataclasses import asdict, dataclass, fields
@@ -88,6 +89,13 @@ class EvalConfig:
     # number of forward passes per (res, mirror) is 2 * weight_noise_passes.
     # Anti-thetic pairs cancel the linear Taylor term, reducing variance.
     antithetic_noise: bool = False
+    # H293: noise distribution family for unit-RMS sampling. Both options
+    # produce noise with RMS=1 before the per-tensor sigma * |clean_p|
+    # multiplication, so anti-thetic ± cancellation of the linear Taylor
+    # term holds for any choice. Laplace has heavier (exponential) tails
+    # than Gaussian (kurtosis 6 vs 3) and may yield more diverse Taylor
+    # neighborhoods per pass at matched RMS.
+    noise_distribution: str = "gaussian"
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -255,6 +263,39 @@ def restore_clean_params(module: nn.Module, clean: dict[str, torch.Tensor]) -> N
             p.data.copy_(clean[name])
 
 
+def _sample_unit_rms_noise(
+    shape: torch.Size,
+    *,
+    distribution: str,
+    generator: torch.Generator,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Sample noise with unit RMS (variance 1) under the given distribution.
+
+    Both gaussian and laplace samplers use the SAME ``generator`` state and
+    consume a deterministic number of uniform/normal draws per call, so a
+    matched ``seed`` produces an anti-thetic ±ε pair when called twice with
+    opposite signs in the caller. RMS=1 keeps the downstream
+    ``sigma * |clean_p|`` relative-scaling semantics distribution-agnostic.
+    """
+    if distribution == "gaussian":
+        return torch.randn(shape, generator=generator, device=device, dtype=dtype)
+    if distribution == "laplace":
+        # Inverse-CDF Laplace with scale b = 1/sqrt(2):
+        #   variance = 2 * b^2 = 1, RMS = 1.
+        # u ~ Uniform[0, 1); v = u - 0.5 in [-0.5, 0.5).
+        # x = -b * sign(v) * log1p(-2|v|) — log1p(-2|v|) = log(1 - 2|v|).
+        # Clamp |v| strictly below 0.5 to avoid log(0).
+        u = torch.rand(shape, generator=generator, device=device, dtype=dtype)
+        v = u - 0.5
+        eps = torch.finfo(dtype).eps
+        v_abs = v.abs().clamp(max=0.5 - eps)
+        b = 1.0 / math.sqrt(2.0)
+        return -b * torch.sign(v) * torch.log1p(-2.0 * v_abs)
+    raise ValueError(f"Unknown noise distribution: {distribution!r}")
+
+
 @torch.no_grad()
 def perturb_relative_(
     module: nn.Module,
@@ -263,11 +304,16 @@ def perturb_relative_(
     seed: int,
     device: torch.device,
     sign: float = 1.0,
+    distribution: str = "gaussian",
 ) -> None:
-    """p <- clean_p + sign * randn(seed) * sigma * |clean_p|, identical across DDP ranks.
+    """p <- clean_p + sign * sample(seed) * sigma * |clean_p|, identical across DDP ranks.
 
     With matched ``seed`` and ``sign=±1.0`` calls, produces an anti-thetic pair
     whose linear Taylor term cancels in the average (Finding NN / H274).
+    ``distribution`` selects the unit-RMS sampler family ("gaussian" or
+    "laplace"); residual second-order curvature term ½εᵀHε scales identically
+    for matched-RMS samplers, but the heavier-tailed Laplace draws explore a
+    different per-pass Taylor neighborhood (Hypothesis H293).
     """
     gen = torch.Generator(device=device)
     gen.manual_seed(seed)
@@ -275,7 +321,13 @@ def perturb_relative_(
         if not p.dtype.is_floating_point:
             continue
         clean_p = clean[name]
-        noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
+        noise = _sample_unit_rms_noise(
+            p.shape,
+            distribution=distribution,
+            generator=gen,
+            device=device,
+            dtype=p.dtype,
+        )
         noise.mul_(sigma * sign).mul_(clean_p.abs())
         p.data.copy_(clean_p).add_(noise)
 
@@ -299,6 +351,7 @@ def process_case_stacked(
     sigma: float,
     seed_base: int,
     antithetic: bool = False,
+    noise_distribution: str = "gaussian",
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
     """Run K_eff x R x M (mirror) TTA passes for one case and return per-point
     averaged predictions in real units. The outer K loop perturbs the model
@@ -341,7 +394,13 @@ def process_case_stacked(
         if sigma > 0.0:
             seed = (seed_base + k) * 100003
             perturb_relative_(
-                eval_module, clean, sigma=sigma, seed=seed, device=device, sign=sign
+                eval_module,
+                clean,
+                sigma=sigma,
+                seed=seed,
+                device=device,
+                sign=sign,
+                distribution=noise_distribution,
             )
         else:
             restore_clean_params(eval_module, clean)
@@ -546,6 +605,7 @@ def evaluate_split_stacked(
     seed_base: int,
     distributed_state,
     antithetic: bool = False,
+    noise_distribution: str = "gaussian",
 ) -> dict[str, float]:
     rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
     world_size = (
@@ -577,6 +637,7 @@ def evaluate_split_stacked(
             sigma=sigma,
             seed_base=seed_base,
             antithetic=antithetic,
+            noise_distribution=noise_distribution,
         )
         add_case_to_accumulator(
             acc,
@@ -807,6 +868,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 seed_base=cfg.weight_noise_seed_base,
                 distributed_state=state,
                 antithetic=cfg.antithetic_noise,
+                noise_distribution=cfg.noise_distribution,
             )
             dt = time.time() - t0
             if state.is_main:


### PR DESCRIPTION
# H293: Laplace noise family at EP15+anti-K3+6-res — does heavier-tail noise improve channel diversity?

## Hypothesis

**Test Laplace weight noise at matched RMS at EP15+anti-K3+6-res — does heavier-tail noise distribution add complementary gradient direction diversity that the Gaussian recipe misses?**

Your H280 (EP13+Sobol-anti-K5, just closed) banked Finding HHH-EP13-no-rescue. Combined with edward's H284 (Finding GGG-Sobol×anti non-stacking) and askeladd's H287 (Finding III-EP-axis-fully-exhausted), the EP and Sobol axes are now fully closed at the H275 recipe. We need orthogonal axes.

**Noise distribution family is untouched.** Every TTA experiment to date has used i.i.d. Gaussian weight noise δ_k ~ N(0, σ²I). The tail behavior is:
- Gaussian: P(|δ| > t) ~ exp(-t²/2σ²) — very thin tail
- **Laplace: P(|δ| > t) ~ exp(-t/b)** — exponential tail, much heavier
- Matched RMS: Laplace b = σ/√2 so RMS_δ = σ for both

Heavier tails mean LARGER excursions in some weight dimensions per sample. With anti-thetic structure (±δ pair), the linear Taylor term cancels exactly regardless of distribution; the residual variance comes from higher-order terms. **If those higher-order terms have channel-asymmetric structure (which we know they do from Finding XX: SP/VP-favorable σ=3e-4 vs WSS-favorable σ=5e-4), a heavier-tail sampler may explore more diverse Taylor neighborhoods per pass, averaging out the channel asymmetry.**

Three concrete predictions:
1. **Laplace wins**: val < 5.9243 AND test < 5.7690 → heavier tail captures complementary diversity → SOTA + bank Finding "Laplace-noise-superior-to-Gaussian"
2. **Laplace ≈ Gaussian**: noise distribution doesn't matter at this σ → bank "noise-distribution-family-null"; pivot to Student-t or Cauchy for more tail
3. **Laplace worse**: heavier tails introduce variance without bias correction → confirm Gaussian is structurally optimal noise family

**Predicted val_abupt: 5.918-5.928**.

## Why this is the right next step for you

- You just closed H280 (EP13+Sobol-K5+6-res); EP-axis exploration is done
- The Sobol-anti axis is closed at K=3 (Finding GGG from edward H284)
- The σ-axis is closed at EP15 (Finding XX-Sobol-confirmed from thorfinn H283)
- The natural next axis is **noise distribution family** — completely untested
- You're skilled with the eval_tta_h252.py infrastructure now (anti-thetic + Sobol from H280)
- Single code change: replace `torch.randn_like(p) * sigma` with `torch.distributions.Laplace(0, sigma/sqrt(2)).sample()` of matched shape

## Why complementary to in-flight work

| Recipe | Axis | What it tests |
|---|---|---|
| H275 SOTA (current) | reference | EP15 × anti-K=3 × σ=5e-4 × Gaussian |
| H290 thorfinn (in-flight) | σ-diversity | EP15 × anti-K=3 × multi-σ × Gaussian |
| H285 tanjiro (in-flight) | K-scaling | EP15 × anti-K=4 × σ=5e-4 × Gaussian |
| H286 alphonse (in-flight) | aggregation operator | EP15 × anti-K=3 × σ=5e-4 × Gaussian × multi-agg |
| H288 fern (in-flight) | resolution density | EP15 × anti-K=3 × σ=5e-4 × Gaussian × 8-res-mid |
| H291 frieren (in-flight) | resolution lower | EP15 × anti-K=3 × σ=5e-4 × Gaussian × 8-res-lower |
| H292 edward (in-flight) | resolution upper | EP15 × anti-K=3 × σ=5e-4 × Gaussian × 8-res-upper |
| **H293 (you)** | **noise distribution** | **EP15 × anti-K=3 × σ=5e-4 × Laplace** |
| H294 askeladd (parallel) | noise distribution heavy | EP15 × anti-K=3 × Student-t df=3 |

H293 + H294 together fully characterize the noise-family axis: Gaussian (light tail, current), Laplace (medium-heavy tail), Student-t df=3 (heaviest finite-variance tail). This is the standard tail-progression in robust statistics.

## Instructions

### Step 1: Branch off latest tay

```bash
git fetch origin tay
git checkout -b nezuko/h293-laplace-noise-ep15-anti-K3 origin/tay
```

### Step 2: Patch eval_tta_h252.py to support `--noise-distribution`

Add a flag and a sampler dispatcher:

```python
parser.add_argument("--noise-distribution", type=str, default="gaussian",
                    choices=["gaussian", "laplace", "student_t"],
                    help="Distribution family for weight noise sampling")
parser.add_argument("--student-t-df", type=float, default=3.0,
                    help="Degrees of freedom for Student-t noise (matched RMS)")

# In the noise generation function:
def sample_weight_noise(param_shape, sigma, distribution="gaussian", df=3.0, device="cuda", generator=None):
    """Sample noise tensor with RMS = sigma."""
    if distribution == "gaussian":
        return torch.randn(param_shape, device=device, generator=generator) * sigma
    elif distribution == "laplace":
        # Laplace with scale b = sigma/sqrt(2) has variance = 2b^2 = sigma^2
        b = sigma / math.sqrt(2)
        # PyTorch torch.distributions.Laplace doesn't support generator; use rsample trick:
        # u = uniform(-0.5, 0.5); δ = -b * sign(u) * log(1 - 2|u|)
        u = torch.rand(param_shape, device=device, generator=generator) - 0.5
        return -b * torch.sign(u) * torch.log(1 - 2 * u.abs())
    elif distribution == "student_t":
        # Student-t with df=v scaled so that variance = sigma^2
        # If v > 2: Student-t variance = v/(v-2); scale by sigma * sqrt((v-2)/v)
        assert df > 2, f"Student-t df must be > 2 for finite variance, got {df}"
        scale = sigma * math.sqrt((df - 2) / df)
        # Sample from Student-t via Gaussian / sqrt(chi2/df)
        z = torch.randn(param_shape, device=device, generator=generator)
        chi2 = torch.distributions.Chi2(df).sample(param_shape).to(device)
        return scale * z / torch.sqrt(chi2 / df)
```

**Verify RMS calibration**: print `noise.pow(2).mean().sqrt()` for each sampler at σ=5e-4 over a large tensor — should all return ~5e-4.

For anti-thetic: sample δ_k once, apply +δ_k for one pass and -δ_k for the next. Sign symmetry preserved regardless of distribution.

### Step 3: Run primary command

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"

torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-passes 3 \
  --antithetic-noise \
  --noise-distribution laplace \
  --batch-size 2 --num-workers 4 \
  --agent nezuko \
  --wandb-group "h293-nezuko-ep15-anti-K3-laplace" \
  --wandb-name "nezuko/h293-ep15-anti-K3-laplace-stack"
```

`--weight-noise-passes 3` + `--antithetic-noise` = K=3 PAIRS = 6 forward passes. With Laplace noise, each pair samples from Laplace at σ=5e-4 RMS. Total compute identical to H275 (~230 min on DDP×8).

### Step 4: Defensive NCCL timeout patch

Same `timedelta(minutes=60)` in `init_distributed` as H280. You already have this.

### Step 5: Post terminal SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_ep15_anti_K3_laplace_stack","value":<val>},"test_metric":{"name":"test_abupt_ep15_anti_K3_laplace_stack","value":<test>}}
```

Include the channel breakdown table:

| Recipe | val_abupt | test_abupt | test_WSS | test_SP | test_VP |
|---|---:|---:|---:|---:|---:|
| **H293 Laplace (you)** | **?** | **?** | **?** | **?** | **?** |
| H275 EP15+anti-K=3+σ=5e-4 Gaussian (SOTA) | 5.9243 | 5.7690 | 6.6743 | 3.6427 | 3.3788 |
| H280 EP13+Sobol-K5+anti+6-res (your prior) | 5.9313 | 5.7753 | 6.679 | 3.650 | 3.385 |

Plus 2-3 sentences:
- Did Laplace improve any channel?
- Did the heavier tail reduce or amplify variance?
- What's the SP-floor delta? (target: ≤ 3.577)

**If val < 5.9243 AND test < 5.7690 → immediate SOTA merge** (especially if SP/VP improve)

## Baseline metrics

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H275 EP15+anti-K3+σ=5e-4 Gaussian ← CURRENT SOTA** | **5.9243** | **5.7690** | **6.6743** | **3.3788** | **3.6427** | 0b4t2bz2 |
| H277 EP15+anti-K3+σ=3e-4 Gaussian | 5.9255 | 5.7705 | 6.6755 | 3.3756 | 3.6406 | mvnwbq3z |
| H284 EP15+Sobol-anti-K3 Gaussian | 5.9242 | 5.7697 | — | — | — | 63606nil |
| **Transolver-3 target (Morgan #1056)** | — | — | **< 5.850%** | **≤ 3.421%** | **≤ 3.577%** | — |

**Merge gate**: val_abupt < **5.9243** AND test_abupt < **5.7690**

## Critical constraints

- **DDP 8 GPUs** (`--nproc-per-node=8`) for every eval run
- **Read-only**: data/loader.py, data/preload.py, data/split_manifest.json, model code
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67**
- **SENPAI_TIMEOUT_MINUTES=360** (~230 min predicted, same as H275)

## Implementation notes

- **RMS calibration is critical**: verify all distributions sample with RMS = σ=5e-4. Test with `noise.pow(2).mean().sqrt()` on a 1M-element tensor before launching primary.
- **Anti-thetic preservation**: same delta tensor used for +/- pair, just sign-flipped. Sampler called once per pair, not per sign.
- **Per-distribution config logging**: log `noise_distribution` and (for student_t) `student_t_df` in W&B config for reproducibility.
- **Seed determinism**: use the same `torch.Generator(device=cuda).manual_seed(seed_k)` per pair as in H280 Sobol.

## Suggested follow-ups (post-result)

1. If Laplace wins → assign Student-t df=2.5 (closer to Cauchy) to push tail further
2. If Laplace ties → confirm with Student-t df=3 (parallel H294 askeladd run); if both tie, noise-family axis closed
3. If Laplace degrades → confirm Gaussian is structurally optimal; pivot to **per-layer noise** or **spectral noise basis**
4. The H293+H294 pair completes the noise-family characterization for the paper
