### PR TITLE
H297: Per-layer noise stratification — zero σ on attention layers

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -81,6 +81,11 @@ class EvalConfig:
 
     # Weight-noise stacking knobs
     weight_noise_sigma: float = 5e-4
+    # H297: per-layer-group sigma stratification. Negative sentinel means
+    # "inherit from weight_noise_sigma". Use to set σ_attn = 0 while keeping
+    # σ_mlp = 5e-4 (or any other anisotropic split).
+    weight_noise_sigma_attn: float = -1.0
+    weight_noise_sigma_mlp: float = -1.0
     weight_noise_passes: int = 5
     weight_noise_seed_base: int = 42
     # H274: anti-thetic noise pairs. When True, each of weight_noise_passes
@@ -239,6 +244,24 @@ def chunk_global_indices(view_index: int, view_count: int, n_full: int) -> torch
 # --- weight-noise helpers ---
 
 
+def get_param_group(name: str) -> str:
+    """Classify a parameter into {"attn", "mlp", "other"} by substring matching.
+
+    Used by H297 to stratify weight noise by layer type. Attention substrings
+    catch Transolver's `attention.qkv`, `attention.proj`, `attention.in_project_*`,
+    `attention.q_norm`, `attention.k_norm`, `attention.temperature`, plus the
+    `surf_to_vol_xattn` MultiheadAttention (`xattn`, `in_proj_*`, `out_proj.*`).
+    MLP substrings catch `blocks.<N>.mlp.fc1/fc2`. Everything else (LayerNorm,
+    pos_embed, surface_bias MLP, output heads, RFF, projections) is "other".
+    """
+    lname = name.lower()
+    if any(k in lname for k in ["attn", "attention", "q_proj", "k_proj", "v_proj", "out_proj", "qkv"]):
+        return "attn"
+    if any(k in lname for k in ["mlp", "ffn", "fc1", "fc2", "gate_proj", "up_proj", "down_proj"]):
+        return "mlp"
+    return "other"
+
+
 @torch.no_grad()
 def snapshot_clean_params(module: nn.Module) -> dict[str, torch.Tensor]:
     snap: dict[str, torch.Tensor] = {}
@@ -259,12 +282,17 @@ def restore_clean_params(module: nn.Module, clean: dict[str, torch.Tensor]) -> N
 def perturb_relative_(
     module: nn.Module,
     clean: dict[str, torch.Tensor],
-    sigma: float,
+    group_sigma: dict[str, float],
     seed: int,
     device: torch.device,
     sign: float = 1.0,
 ) -> None:
-    """p <- clean_p + sign * randn(seed) * sigma * |clean_p|, identical across DDP ranks.
+    """p <- clean_p + sign * randn(seed) * sigma_g * |clean_p|, identical across DDP ranks.
+
+    ``group_sigma`` maps {"attn", "mlp", "other"} -> σ. ``get_param_group(name)``
+    selects which σ to apply per parameter, enabling H297-style anisotropy
+    (e.g. σ_attn=0 with σ_mlp=5e-4). The generator is always advanced once per
+    parameter (even when σ=0) so anti-thetic +ε / −ε pairs draw identical noise.
 
     With matched ``seed`` and ``sign=±1.0`` calls, produces an anti-thetic pair
     whose linear Taylor term cancels in the average (Finding NN / H274).
@@ -275,9 +303,16 @@ def perturb_relative_(
         if not p.dtype.is_floating_point:
             continue
         clean_p = clean[name]
+        sg = group_sigma[get_param_group(name)]
+        # Always draw randn to keep generator state consistent across calls,
+        # so sigma_g=0 parameters don't desync the anti-thetic pair on the
+        # remaining noisy parameters.
         noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
-        noise.mul_(sigma * sign).mul_(clean_p.abs())
-        p.data.copy_(clean_p).add_(noise)
+        if sg == 0.0:
+            p.data.copy_(clean_p)
+        else:
+            noise.mul_(sg * sign).mul_(clean_p.abs())
+            p.data.copy_(clean_p).add_(noise)
 
 
 # --- per-case stacked TTA ---
@@ -296,7 +331,7 @@ def process_case_stacked(
     use_mirror: bool,
     clean: dict[str, torch.Tensor],
     K_passes: int,
-    sigma: float,
+    group_sigma: dict[str, float],
     seed_base: int,
     antithetic: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
@@ -308,6 +343,10 @@ def process_case_stacked(
     ``antithetic=True`` K_eff = ``2 * K_passes``: for each k we sample ε once
     (same seed) and evaluate both f(θ+ε) and f(θ−ε), so the linear Taylor term
     cancels in the per-point average (Finding NN / H274).
+
+    ``group_sigma`` maps {"attn","mlp","other"} -> σ. Any σ > 0 triggers
+    weight-noise sampling; if all σ == 0 the model is held at the clean
+    snapshot (deterministic baseline).
     """
     counts = store.case_point_counts(case_id)
     n_surf = counts["n_surface"]
@@ -328,9 +367,11 @@ def process_case_stacked(
 
     mirror_flags = (False, True) if use_mirror else (False,)
 
+    any_noise = any(s > 0.0 for s in group_sigma.values())
+
     # Build the (noise_idx, sign) schedule. Anti-thetic pairs share a seed so
     # +ε / −ε use the SAME draw of ε (otherwise it would just be 2K i.i.d.).
-    if antithetic and sigma > 0.0:
+    if antithetic and any_noise:
         schedule = [(k, sign) for k in range(K_passes) for sign in (+1.0, -1.0)]
     else:
         schedule = [(k, +1.0) for k in range(K_passes)]
@@ -338,10 +379,11 @@ def process_case_stacked(
     for k, sign in schedule:
         # Perturb once per (k, sign); reuse across (res, mirror) inner passes.
         t_p = time.time()
-        if sigma > 0.0:
+        if any_noise:
             seed = (seed_base + k) * 100003
             perturb_relative_(
-                eval_module, clean, sigma=sigma, seed=seed, device=device, sign=sign
+                eval_module, clean, group_sigma=group_sigma, seed=seed,
+                device=device, sign=sign,
             )
         else:
             restore_clean_params(eval_module, clean)
@@ -448,7 +490,7 @@ def process_case_stacked(
     surf_y = case.surface_y.float()
     vol_y = case.volume_y.float()
 
-    k_eff = K_passes * (2 if (antithetic and sigma > 0.0) else 1)
+    k_eff = K_passes * (2 if (antithetic and any_noise) else 1)
     n_passes = k_eff * len(resolutions) * (2 if use_mirror else 1)
     return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
 
@@ -542,7 +584,7 @@ def evaluate_split_stacked(
     use_mirror: bool,
     clean: dict[str, torch.Tensor],
     K_passes: int,
-    sigma: float,
+    group_sigma: dict[str, float],
     seed_base: int,
     distributed_state,
     antithetic: bool = False,
@@ -574,7 +616,7 @@ def evaluate_split_stacked(
             use_mirror=use_mirror,
             clean=clean,
             K_passes=K_passes,
-            sigma=sigma,
+            group_sigma=group_sigma,
             seed_base=seed_base,
             antithetic=antithetic,
         )
@@ -665,6 +707,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         if mode not in valid_modes:
             raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
 
+    sigma_attn = (
+        cfg.weight_noise_sigma if cfg.weight_noise_sigma_attn < 0
+        else cfg.weight_noise_sigma_attn
+    )
+    sigma_mlp = (
+        cfg.weight_noise_sigma if cfg.weight_noise_sigma_mlp < 0
+        else cfg.weight_noise_sigma_mlp
+    )
+    sigma_other = cfg.weight_noise_sigma
+    group_sigma = {"attn": sigma_attn, "mlp": sigma_mlp, "other": sigma_other}
+
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
         print(f"Device: {device}{ddp_suffix}")
@@ -676,6 +729,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"K_passes={cfg.weight_noise_passes} "
             f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
             f"seed_base={cfg.weight_noise_seed_base}"
+        )
+        print(
+            f"Per-group sigma: attn={sigma_attn} mlp={sigma_mlp} other={sigma_other}"
         )
 
     ckpt_path, ckpt_source = resolve_checkpoint_path(cfg, state)
@@ -717,6 +773,28 @@ def main(argv: Iterable[str] | None = None) -> None:
         n_perturbed = sum(t.numel() for t in clean.values())
         print(f"Snapshotted {len(clean)} fp tensors ({n_perturbed:,} elements)")
 
+        # H297: print layer-group breakdown to verify the per-group sigma split.
+        # Expected: ~30–50% attn, ~40–60% mlp, ~5–10% other for Transolver.
+        group_numel = {"attn": 0, "mlp": 0, "other": 0}
+        group_count = {"attn": 0, "mlp": 0, "other": 0}
+        print("Layer-group breakdown (H297 noise-stratification):")
+        for name, p in eval_module.named_parameters():
+            g = get_param_group(name)
+            group_numel[g] += p.numel()
+            group_count[g] += 1
+            print(f"  {g:<6s}: {name}  (numel={p.numel():,})")
+        total_numel = sum(group_numel.values())
+        if total_numel > 0:
+            print(
+                f"Group totals: "
+                f"attn={group_numel['attn']:,} ({group_count['attn']} tensors, "
+                f"{100.0 * group_numel['attn'] / total_numel:.1f}%) | "
+                f"mlp={group_numel['mlp']:,} ({group_count['mlp']} tensors, "
+                f"{100.0 * group_numel['mlp'] / total_numel:.1f}%) | "
+                f"other={group_numel['other']:,} ({group_count['other']} tensors, "
+                f"{100.0 * group_numel['other'] / total_numel:.1f}%)"
+            )
+
     val_case_ids = store.case_ids("val")
     test_case_ids = store.case_ids("test")
     if cfg.debug:
@@ -745,6 +823,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "n_val_cases": len(val_case_ids),
                 "n_test_cases": len(test_case_ids),
                 "ckpt_source": ckpt_source,
+                "sigma_attn_effective": sigma_attn,
+                "sigma_mlp_effective": sigma_mlp,
+                "sigma_other_effective": sigma_other,
             },
             tags=[
                 "h252",
@@ -803,7 +884,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 use_mirror=use_mirror,
                 clean=clean,
                 K_passes=cfg.weight_noise_passes,
-                sigma=cfg.weight_noise_sigma,
+                group_sigma=group_sigma,
                 seed_base=cfg.weight_noise_seed_base,
                 distributed_state=state,
                 antithetic=cfg.antithetic_noise,


### PR DESCRIPTION
## Hypothesis

**Apply weight-noise to MLP/projection layers ONLY (σ_mlp = 5e-4) while setting σ_attn = 0 for attention parameters, at K=4 anti-thetic + 6-res + mirror. The noise anisotropy axis — zero attention noise, full MLP noise — is completely untested.**

The σ-axis (single, multi-σ via H290), K-axis (K=4 merged as SOTA, K=5 in flight), and aggregation axes are all explored or in flight. **Per-layer noise stratification is the next untouched lever.**

**Why attention might be the bottleneck for SP**: Surface pressure (SP=3.6425, target ≤3.577, gap=6.5bp) is the binding Morgan constraint. SP depends on attention correctly identifying which surface points bear most pressure. If uniform σ noise randomizes attention patterns, it may be suppressing SP rather than improving it. Excluding attention from noise preserves geometric attention coherence.

## Instructions

### Step 1: Branch

```bash
git fetch origin tay
git checkout -b thorfinn/h297-per-layer-noise-stratification origin/tay
```

### Step 2: Patch eval_tta_h252.py

Add two new flags and a `get_param_group` utility:

```python
# In argparse section, after --weight-noise-sigma:
parser.add_argument("--weight-noise-sigma-attn", type=float, default=None,
                    help="σ for attention params (q/k/v/out projections). Default: same as --weight-noise-sigma")
parser.add_argument("--weight-noise-sigma-mlp", type=float, default=None,
                    help="σ for MLP/FFN params (gate/up/down/fc projections). Default: same as --weight-noise-sigma")

# Param group classifier (add near top of eval loop):
def get_param_group(name):
    lname = name.lower()
    if any(k in lname for k in ["attn", "attention", "q_proj", "k_proj", "v_proj", "out_proj", "qkv"]):
        return "attn"
    if any(k in lname for k in ["mlp", "ffn", "fc1", "fc2", "gate_proj", "up_proj", "down_proj"]):
        return "mlp"
    return "other"

# Replace the per-param noise sampling loop with:
sigma_attn = args.weight_noise_sigma_attn if args.weight_noise_sigma_attn is not None else args.weight_noise_sigma
sigma_mlp  = args.weight_noise_sigma_mlp  if args.weight_noise_sigma_mlp  is not None else args.weight_noise_sigma
sigma_other = args.weight_noise_sigma

group_sigma = {"attn": sigma_attn, "mlp": sigma_mlp, "other": sigma_other}
delta = {}
for name, p in model.named_parameters():
    sg = group_sigma[get_param_group(name)]
    if sg == 0.0:
        delta[name] = torch.zeros_like(p)
    else:
        delta[name] = torch.randn(p.shape, device=p.device, generator=generator, dtype=p.dtype) * sg
```

Anti-thetic pair reuses same `delta`, just sign-flipped — no change needed there.

### Step 3: Smoke run + layer split verification

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-sigma-attn 0.0 \
  --weight-noise-sigma-mlp 5e-4 \
  --weight-noise-passes 4 \
  --antithetic-noise \
  --batch-size 2 --num-workers 4 \
  --agent thorfinn \
  --wandb-group "h297-thorfinn-per-layer-noise" \
  --wandb-name "thorfinn/h297-smoke"
```

**Before running primary**: print the layer-group breakdown to verify the split makes sense:

```python
for name, p in model.named_parameters():
    g = get_param_group(name)
    print(f"  {g:8s}: {name}  (numel={p.numel():,})")
```

Verify: ~30–50% attn params, ~40–60% mlp params, ~5–10% other. If `attn` params have 0% share, your substring patterns don't match the model's naming — debug before primary.

### Step 4: Primary run (96 forwards/case, same as H285)

```bash
H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"

torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-sigma-attn 0.0 \
  --weight-noise-sigma-mlp 5e-4 \
  --weight-noise-passes 4 \
  --antithetic-noise \
  --batch-size 2 --num-workers 4 \
  --agent thorfinn \
  --wandb-group "h297-thorfinn-per-layer-noise" \
  --wandb-name "thorfinn/h297-attn0-mlp5e-4-anti-K4"
```

ETA ~314 min (same as H285). Within 360-min cap.

### Step 5: Post terminal SENPAI-RESULT

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_h297_attn0_mlp5e4_anti_K4","value":<val>},"test_metric":{"name":"test_abupt_h297_attn0_mlp5e4_anti_K4","value":<test>}}
```

Include channel matrix:

| Recipe | σ_attn | σ_mlp | val_abupt | test_abupt | test_WSS | test_VP | test_SP |
|---|---:|---:|---:|---:|---:|---:|---:|
| H285 K=4 SOTA (uniform σ=5e-4) | 5e-4 | 5e-4 | 5.9235 | 5.7683 | 6.6735 | 3.3783 | 3.6425 |
| H290 multi-σ K=3 (your prior) | mixed | mixed | 5.9241 | 5.7689 | 6.6739 | 3.3786 | 3.6428 |
| **H297 attn=0, mlp=5e-4 (you)** | **0** | **5e-4** | **?** | **?** | **?** | **?** | **?** |

Plus 2-3 sentences: did SP improve? Did any channel regress? What does this tell us about attention's role in the linear-Taylor cancellation?

**If val < 5.9235 AND test < 5.7683 → immediate SOTA merge**

## Baseline metrics

| Reference | val_abupt | test_abupt | test_WSS | test_VP | test_SP | W&B |
|---|---:|---:|---:|---:|---:|---|
| **H285 EP15+anti-K4+6-res ← CURRENT SOTA** | **5.9235** | **5.7683** | **6.6735** | **3.3783** | **3.6425** | 4vvc40zs |
| H290 multi-σ K=3 (your prior, new gate) | 5.9241 | 5.7689 | 6.6739 | 3.3786 | 3.6428 | slzcnzs7 |
| **Transolver-3 target (Morgan #1056)** | — | — | **< 5.850** | **≤ 3.421** | **≤ 3.577** | — |

**Merge gate**: val_abupt < **5.9235** AND test_abupt < **5.7683**
**SP target** (paper floor): test_SP ≤ **3.577** (current: 3.6425, gap = 6.5bp)

## Critical constraints

- **DDP 8 GPUs** (`--nproc-per-node=8`) for every eval run
- **Read-only**: data/loader.py, data/preload.py, data/split_manifest.json, model code
- **No model capacity changes** — eval-time TTA only
- **z-axis tau_z LOCKED at 1.67**
- **SENPAI_TIMEOUT_MINUTES=360** (~314 min predicted, within cap)
