### PR TITLE
H314: Student-t weight-space noise for TTA diversity

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -89,6 +89,14 @@ class EvalConfig:
     # Anti-thetic pairs cancel the linear Taylor term, reducing variance.
     antithetic_noise: bool = False
 
+    # H314: weight-noise distribution family. "gaussian" (default) preserves the
+    # H274/H300 baseline. "student_t" draws from a scaled Student-t(df) with the
+    # same per-element variance as the Gaussian baseline (so RMS noise magnitude
+    # matches), but heavier tails. Symmetric, so anti-thetic cancellation of the
+    # linear Taylor term still holds.
+    weight_noise_dist: str = "gaussian"
+    weight_noise_df: int = 4
+
     # H300: per-channel affine calibration. Fits alpha_c, beta_c via OLS on val
     # predictions vs val targets (after TTA aggregation), then applies the SAME
     # (alpha, beta) to test predictions before metric computation. Logs both raw
@@ -263,6 +271,46 @@ def restore_clean_params(module: nn.Module, clean: dict[str, torch.Tensor]) -> N
 
 
 @torch.no_grad()
+def _draw_unit_variance_noise(
+    shape: torch.Size,
+    *,
+    gen: torch.Generator,
+    device: torch.device,
+    dtype: torch.dtype,
+    dist: str,
+    df: int,
+) -> torch.Tensor:
+    """Sample noise with mean 0, variance 1 from ``dist``.
+
+    For ``dist="gaussian"`` returns N(0, 1).
+
+    For ``dist="student_t"`` returns scaled Student-t(df) with unit variance:
+    a Student-t(df) variate equals Z / sqrt(V/df) for Z~N(0, 1) and V~chi2(df);
+    its raw variance is df/(df-2), so we scale by sqrt((df-2)/df) to land on
+    unit variance. Requires ``df >= 3`` (integer); ``df=4`` is the recommended
+    starting point (4th moment exists; tails noticeably heavier than Gaussian).
+    """
+    if dist == "gaussian":
+        return torch.randn(shape, generator=gen, device=device, dtype=dtype)
+    if dist == "student_t":
+        if df < 3:
+            raise ValueError(
+                f"student_t weight_noise_df={df!r} not supported "
+                "(df>=3 required for finite variance)"
+            )
+        z = torch.randn(shape, generator=gen, device=device, dtype=dtype)
+        # chi2(df) via sum of df independent N(0,1)^2; same generator so the
+        # full draw is reproducible across DDP ranks and across +ε / −ε pairs.
+        v = torch.randn(shape, generator=gen, device=device, dtype=dtype).pow_(2)
+        for _ in range(int(df) - 1):
+            v.add_(torch.randn(shape, generator=gen, device=device, dtype=dtype).pow_(2))
+        raw_t = z * torch.sqrt(float(df) / v.clamp_min(1e-12))
+        scale = ((df - 2) / df) ** 0.5
+        return raw_t.mul_(scale)
+    raise ValueError(f"Unknown weight_noise_dist {dist!r} (expected gaussian|student_t)")
+
+
+@torch.no_grad()
 def perturb_relative_(
     module: nn.Module,
     clean: dict[str, torch.Tensor],
@@ -270,11 +318,16 @@ def perturb_relative_(
     seed: int,
     device: torch.device,
     sign: float = 1.0,
+    dist: str = "gaussian",
+    df: int = 4,
 ) -> None:
-    """p <- clean_p + sign * randn(seed) * sigma * |clean_p|, identical across DDP ranks.
+    """p <- clean_p + sign * draw(seed) * sigma * |clean_p|, identical across DDP ranks.
 
-    With matched ``seed`` and ``sign=±1.0`` calls, produces an anti-thetic pair
-    whose linear Taylor term cancels in the average (Finding NN / H274).
+    ``draw`` is a unit-variance sample from ``dist`` (gaussian or scaled
+    Student-t(df)). With matched ``seed`` and ``sign=±1.0`` calls, produces an
+    anti-thetic pair whose linear Taylor term cancels in the average (Finding
+    NN / H274). Student-t draws are symmetric around zero, so anti-thetic
+    cancellation still holds; only the marginal tail mass changes.
     """
     gen = torch.Generator(device=device)
     gen.manual_seed(seed)
@@ -282,7 +335,9 @@ def perturb_relative_(
         if not p.dtype.is_floating_point:
             continue
         clean_p = clean[name]
-        noise = torch.randn(p.shape, generator=gen, device=device, dtype=p.dtype)
+        noise = _draw_unit_variance_noise(
+            p.shape, gen=gen, device=device, dtype=p.dtype, dist=dist, df=df
+        )
         noise.mul_(sigma * sign).mul_(clean_p.abs())
         p.data.copy_(clean_p).add_(noise)
 
@@ -306,6 +361,8 @@ def process_case_stacked(
     sigma: float,
     seed_base: int,
     antithetic: bool = False,
+    noise_dist: str = "gaussian",
+    noise_df: int = 4,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
     """Run K_eff x R x M (mirror) TTA passes for one case and return per-point
     averaged predictions in real units. The outer K loop perturbs the model
@@ -348,7 +405,14 @@ def process_case_stacked(
         if sigma > 0.0:
             seed = (seed_base + k) * 100003
             perturb_relative_(
-                eval_module, clean, sigma=sigma, seed=seed, device=device, sign=sign
+                eval_module,
+                clean,
+                sigma=sigma,
+                seed=seed,
+                device=device,
+                sign=sign,
+                dist=noise_dist,
+                df=noise_df,
             )
         else:
             restore_clean_params(eval_module, clean)
@@ -748,6 +812,8 @@ def evaluate_split_stacked(
     distributed_state,
     antithetic: bool = False,
     collect_calibration: bool = False,
+    noise_dist: str = "gaussian",
+    noise_df: int = 4,
 ) -> tuple[dict[str, float], CalibrationStats | None]:
     rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
     world_size = (
@@ -780,6 +846,8 @@ def evaluate_split_stacked(
             sigma=sigma,
             seed_base=seed_base,
             antithetic=antithetic,
+            noise_dist=noise_dist,
+            noise_df=noise_df,
         )
         add_case_to_accumulator(
             acc,
@@ -887,14 +955,29 @@ def main(argv: Iterable[str] | None = None) -> None:
         if mode not in valid_modes:
             raise ValueError(f"Unknown eval mode: {mode!r} (valid: {valid_modes})")
 
+    if cfg.weight_noise_dist not in ("gaussian", "student_t"):
+        raise ValueError(
+            f"--weight-noise-dist {cfg.weight_noise_dist!r} not supported "
+            "(expected gaussian|student_t)"
+        )
+    if cfg.weight_noise_dist == "student_t" and cfg.weight_noise_df < 3:
+        raise ValueError(
+            f"--weight-noise-df {cfg.weight_noise_df!r} not supported for "
+            "student_t (df>=3 required for finite variance)"
+        )
+
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
         print(f"Device: {device}{ddp_suffix}")
         print(f"Resolutions: {resolutions}")
         print(f"Modes: {modes}")
         k_eff_print = cfg.weight_noise_passes * (2 if cfg.antithetic_noise else 1)
+        dist_suffix = (
+            f" df={cfg.weight_noise_df}" if cfg.weight_noise_dist == "student_t" else ""
+        )
         print(
-            f"Weight-noise TTA: sigma_rel={cfg.weight_noise_sigma} "
+            f"Weight-noise TTA: dist={cfg.weight_noise_dist}{dist_suffix} "
+            f"sigma_rel={cfg.weight_noise_sigma} "
             f"K_passes={cfg.weight_noise_passes} "
             f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
             f"seed_base={cfg.weight_noise_seed_base}"
@@ -1035,6 +1118,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 distributed_state=state,
                 antithetic=cfg.antithetic_noise,
                 collect_calibration=cfg.test_time_calibration,
+                noise_dist=cfg.weight_noise_dist,
+                noise_df=cfg.weight_noise_df,
             )
             dt = time.time() - t0
             if state.is_main:


### PR DESCRIPTION
## Hypothesis — H314: Student-t Weight-Space Noise for TTA

Current TTA (H296/H300, current SOTA) draws K anti-thetic Gaussian noise pairs in weight space: δ_k ~ N(0, σ²I), with σ=5e-4. Gaussian tails decay rapidly — large perturbations that probe the boundary of the weight-space neighborhood are extremely rare.

**Hypothesis**: A heavier-tailed distribution for weight perturbations may better cover the neighborhood of the EP15 checkpoint, sampling the model's prediction manifold more broadly with the same K passes. Student-t noise at ν=4 degrees of freedom has the same variance as Gaussian at σ=5e-4 (when scaled appropriately) but draws occasional large-magnitude perturbations. These "outlier" noise draws may expose prediction variance in high-uncertainty surface regions (e.g., the wake zone where WSS_z is 8.6195% — the largest sub-channel error). The anti-thetic pairing (±δ_k) ensures mean-zero draws and preserves symmetry.

This hypothesis was designated H294 ("Never ran") in the backlog.

## Current SOTA Metrics (H300, PR #1489, W&B: 59r4noqh)

| Metric | Value |
|--------|-------|
| val_abupt | 5.9011% |
| test_abupt | **5.7399%** |
| test_WSS | **6.6404%** |
| test_WSS_x | 5.9033% |
| test_WSS_y | 7.1873% |
| test_WSS_z | 8.6195% |
| test_VP | 3.3763% |
| test_SP | 3.6132% |

Hard constraints (from PR #972 baseline):
- test_VP ≤ 3.643%
- test_SP ≤ 3.577% (currently 3.6132% — watch this)
- test_abupt < 5.844%

**Gate to beat**: val_abupt_calibrated < **5.9011%** AND test_abupt_calibrated < **5.7399%**

## Method

### Student-t Weight Noise
Replace the Gaussian noise draw with a Student-t draw at ν degrees of freedom:
```python
import torch

def student_t_weight_noise(model_params, sigma, nu=4, antithetic=True):
    """
    Draw noise from scaled Student-t(nu) distribution.
    Scale so that variance = sigma^2 (matching Gaussian baseline).
    Var(t_nu) = nu/(nu-2), so scale = sigma / sqrt(nu/(nu-2))
    """
    scale = sigma / (nu / (nu - 2)) ** 0.5
    noise = torch.distributions.StudentT(df=nu).sample(model_params.shape) * scale
    if antithetic:
        return noise, -noise
    return noise
```

For ν=4: Var(t_4) = 4/2 = 2, so scale = σ/√2 ≈ 5e-4/1.414 ≈ 3.54e-4. This gives the same RMS noise magnitude as Gaussian σ=5e-4 but with heavier tails.

**Important**: Noise is applied in **weight space only** — NEVER to input coordinates. Input-coordinate noise causes +190bp regression (empirically validated).

### TTA Stack (same as H296/H300)
- Checkpoint: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt`
- K=4 anti-thetic noise pairs (8 forward passes), σ=5e-4 (same RMS)
- 8 resolutions: `32768,40960,49152,57344,65536,81920,98304,131072`
- Mirror augmentation, arithmetic mean aggregation
- Apply H300 per-channel affine calibration after averaging

### Variants to Run (in priority order)
- **Arm A** — ν=4 (heavier tails, recommended starting point): 4 degrees of freedom
- **Arm B** — ν=3 (even heavier tails): More extreme; risk of very occasional very large draws
- **Arm C** — ν=8 (lighter tails, approaching Gaussian): Sanity check; should approach baseline

Run Arm A first. Report val_abupt after Arm A before proceeding to B and C.

### Implementation
Modify the noise sampling in `eval_tta_h252.py` (or the underlying TTA utility) to support `--weight-noise-dist student_t --weight-noise-df 4`. If the script doesn't already have this flag, add it. The change is isolated to the noise sampling step — everything else (anti-thetic pairing, aggregation, calibration) remains identical.

## Reproduce Command

```bash
export H185_EP15_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt"

# Arm A: Student-t ν=4
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg,weight_noise_mirror_res_avg_calibrated" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-passes 4 \
  --antithetic-noise \
  --weight-noise-dist student_t \
  --weight-noise-df 4 \
  --calibrate \
  --batch-size 2 --num-workers 4 \
  --wandb_group "h314-student-t-noise"
```

If `--weight-noise-dist` is not yet a supported flag, implement it. The change is small — only the noise generation line changes. Log ν as a W&B config parameter.

## Expected Outcome
- If the Gaussian baseline undersamples the prediction manifold boundary, heavier-tailed noise at the same RMS should improve diversity across K TTA samples
- Expected gain: 5–20bp improvement in test_abupt; likely largest impact on high-uncertainty zones (WSS_z)
- Risk: if K=4 passes are too few to benefit from heavy-tail diversity, the effect may be noise. If Arm A shows no improvement, close this hypothesis.

## Checklist
- [ ] Implement Student-t noise in eval_tta_h252.py (if not already present)
- [ ] Run Arm A (ν=4)
- [ ] Confirm val_abupt_calibrated < 5.9011% (gate to beat H300)
- [ ] Run Arm B (ν=3) and Arm C (ν=8) if time allows
- [ ] Report all 5 sub-channel metrics (VP, SP, WSS_x, WSS_y, WSS_z)
- [ ] Post terminal SENPAI-RESULT marker when all arms complete

