### PR TITLE
H317: Quadratic per-channel post-hoc calibration (15 params vs H300's 10)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -95,6 +95,14 @@ class EvalConfig:
     # and calibrated rel_l2-family metrics; MAE is not analytically expressible
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
+    # H317: degree of the per-channel test-time calibration polynomial.
+    #   1 = affine     y = alpha*p + beta              (H300, 2 params/channel)
+    #   2 = quadratic  y = a0 + a1*p + a2*p^2          (H317, 3 params/channel)
+    # Quadratic adds 1 DOF/channel (+5 params total over the affine version) and
+    # is fit from extended sufficient stats (sum_ppp, sum_pppp, sum_ppt) on the
+    # val split, then applied to test. Only consulted when test_time_calibration
+    # is True.
+    test_time_calibration_degree: int = 1
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -466,16 +474,20 @@ def process_case_stacked(
 # Surface preds are [cp, tau_x, tau_y, tau_z]; volume preds are [volume_pressure].
 N_SURF_CHANNELS = 4
 N_VOL_CHANNELS = 1
-# Sufficient-stats column layout: [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt].
-N_STAT_COLS = 6
+# Sufficient-stats column layout. The first 6 columns are the H300 affine stats;
+# the last 3 are needed for the H317 per-channel quadratic fit (y = a0 + a1*p + a2*p^2)
+# and its analytic SSE under that quadratic map:
+#   [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt, sum_ppp, sum_pppp, sum_ppt]
+N_STAT_COLS = 9
 
 
 @dataclass
 class CalibrationStats:
-    """Per-case per-channel sufficient stats for fitting an affine OLS
-    calibration y_hat = alpha * y + beta and recomputing per-case rel_l2
-    metrics under that affine map. Surface has 4 channels (cp, tau_x, tau_y,
-    tau_z), volume has 1 (volume_pressure)."""
+    """Per-case per-channel sufficient stats for fitting either an affine
+    (H300, y = alpha*p + beta) or a quadratic (H317, y = a0 + a1*p + a2*p^2)
+    OLS calibration map and recomputing per-case rel_l2 metrics under it.
+    Surface has 4 channels (cp, tau_x, tau_y, tau_z); volume has 1
+    (volume_pressure)."""
 
     surf_global: torch.Tensor = field(
         default_factory=lambda: torch.zeros(N_SURF_CHANNELS, N_STAT_COLS, dtype=torch.float64)
@@ -488,22 +500,32 @@ class CalibrationStats:
 
 
 def _channel_stats(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Return (n_channels, 6) tensor with [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt].
+    """Return (n_channels, 9) tensor with the per-channel sufficient stats:
+    [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt, sum_ppp, sum_pppp, sum_ppt].
 
-    pred, target: (N_points, n_channels) tensors in real units. Computed in float64
-    so accumulation across cases / DDP ranks does not lose precision.
+    The first 6 columns are the H300 affine OLS stats; the last 3 are required
+    to (a) build the 3x3 normal equations for the H317 per-channel quadratic
+    fit and (b) compute the analytic SSE under the resulting quadratic map.
+
+    pred, target: (N_points, n_channels) tensors in real units. Computed in
+    float64 so accumulation across cases / DDP ranks does not lose precision
+    (especially for sum_ppp / sum_pppp, which grow like |p|^3 / |p|^4).
     """
     p = pred.double()
     t = target.double()
     n_points = p.shape[0]
     n_ch = p.shape[1]
+    pp = p * p
     stats = torch.empty(n_ch, N_STAT_COLS, dtype=torch.float64)
     stats[:, 0] = float(n_points)
     stats[:, 1] = p.sum(0)
     stats[:, 2] = t.sum(0)
-    stats[:, 3] = (p * p).sum(0)
+    stats[:, 3] = pp.sum(0)
     stats[:, 4] = (t * t).sum(0)
     stats[:, 5] = (p * t).sum(0)
+    stats[:, 6] = (pp * p).sum(0)
+    stats[:, 7] = (pp * pp).sum(0)
+    stats[:, 8] = (pp * t).sum(0)
     return stats
 
 
@@ -565,7 +587,7 @@ def _affine_error_sq(
 ) -> torch.Tensor:
     """Sum_p (alpha * p + beta - t)^2 per channel given sufficient stats.
 
-    stats: (..., 6) with [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt].
+    stats: (..., 9) with [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt, ...].
     alpha, beta: broadcastable to stats[..., 0] shape.
     """
     N = stats[..., 0]
@@ -584,19 +606,135 @@ def _affine_error_sq(
     )
 
 
+def fit_quadratic_per_channel(
+    global_stats: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """H317: OLS a0, a1, a2 per channel for y = a0 + a1*p + a2*p^2.
+
+    Solves the 3x3 normal equations per channel from the sufficient stats:
+
+        [ N        sum_p     sum_pp   ] [a0]   [sum_t   ]
+        [ sum_p    sum_pp    sum_ppp  ] [a1] = [sum_pt  ]
+        [ sum_pp   sum_ppp   sum_pppp ] [a2]   [sum_ppt ]
+
+    Falls back to the identity map (a0=0, a1=1, a2=0) on any channel whose
+    3x3 design matrix is singular (e.g. constant predictions).
+    """
+    N = global_stats[:, 0]
+    sum_p = global_stats[:, 1]
+    sum_t = global_stats[:, 2]
+    sum_pp = global_stats[:, 3]
+    sum_pt = global_stats[:, 5]
+    sum_ppp = global_stats[:, 6]
+    sum_pppp = global_stats[:, 7]
+    sum_ppt = global_stats[:, 8]
+
+    n_channels = N.shape[0]
+    a0 = torch.zeros(n_channels, dtype=N.dtype, device=N.device)
+    a1 = torch.ones(n_channels, dtype=N.dtype, device=N.device)
+    a2 = torch.zeros(n_channels, dtype=N.dtype, device=N.device)
+    for c in range(n_channels):
+        M = torch.tensor(
+            [
+                [N[c].item(), sum_p[c].item(), sum_pp[c].item()],
+                [sum_p[c].item(), sum_pp[c].item(), sum_ppp[c].item()],
+                [sum_pp[c].item(), sum_ppp[c].item(), sum_pppp[c].item()],
+            ],
+            dtype=N.dtype,
+            device=N.device,
+        )
+        rhs = torch.tensor(
+            [sum_t[c].item(), sum_pt[c].item(), sum_ppt[c].item()],
+            dtype=N.dtype,
+            device=N.device,
+        )
+        try:
+            coeffs = torch.linalg.solve(M, rhs)
+            a0[c] = coeffs[0]
+            a1[c] = coeffs[1]
+            a2[c] = coeffs[2]
+        except torch._C._LinAlgError:
+            # Singular normal matrix (constant or near-constant predictions);
+            # keep the identity init (a0=0, a1=1, a2=0).
+            pass
+    return a0, a1, a2
+
+
+def _quadratic_error_sq(
+    stats: torch.Tensor,
+    a0: torch.Tensor,
+    a1: torch.Tensor,
+    a2: torch.Tensor,
+) -> torch.Tensor:
+    """Sum_p (a0 + a1*p + a2*p^2 - t)^2 per channel given sufficient stats.
+
+    Expanding the square and summing termwise:
+
+        sum (a0 + a1*p + a2*p^2 - t)^2
+          = a0^2 * N
+          + a1^2 * sum_pp
+          + a2^2 * sum_pppp
+          + 2*a0*a1 * sum_p
+          + 2*a0*a2 * sum_pp
+          + 2*a1*a2 * sum_ppp
+          - 2*a0 * sum_t
+          - 2*a1 * sum_pt
+          - 2*a2 * sum_ppt
+          + sum_tt
+
+    stats: (..., 9) sufficient-stats tensor; a0, a1, a2 broadcastable to
+    stats[..., 0] shape.
+    """
+    N = stats[..., 0]
+    sum_p = stats[..., 1]
+    sum_t = stats[..., 2]
+    sum_pp = stats[..., 3]
+    sum_tt = stats[..., 4]
+    sum_pt = stats[..., 5]
+    sum_ppp = stats[..., 6]
+    sum_pppp = stats[..., 7]
+    sum_ppt = stats[..., 8]
+    return (
+        a0 * a0 * N
+        + a1 * a1 * sum_pp
+        + a2 * a2 * sum_pppp
+        + 2.0 * a0 * a1 * sum_p
+        + 2.0 * a0 * a2 * sum_pp
+        + 2.0 * a1 * a2 * sum_ppp
+        - 2.0 * a0 * sum_t
+        - 2.0 * a1 * sum_pt
+        - 2.0 * a2 * sum_ppt
+        + sum_tt
+    )
+
+
 def compute_calibrated_metrics(
     cal: CalibrationStats,
-    alpha_surf: torch.Tensor,
-    beta_surf: torch.Tensor,
-    alpha_vol: torch.Tensor,
-    beta_vol: torch.Tensor,
+    surf_coeffs: tuple[torch.Tensor, ...],
+    vol_coeffs: tuple[torch.Tensor, ...],
 ) -> dict[str, float]:
     """Per-case averaged rel_l2 metrics on calibrated predictions.
 
     Mirrors the keys produced by ``finalize_eval_accumulator`` for the rel_l2
     family. MAE-style metrics are not analytically computable from these
-    sufficient stats under an affine map and are omitted.
+    sufficient stats under a polynomial map and are omitted.
+
+    ``surf_coeffs`` / ``vol_coeffs`` are per-channel coefficient tuples:
+      - length 2  -> affine     (alpha, beta), error via ``_affine_error_sq``
+      - length 3  -> quadratic  (a0, a1, a2), error via ``_quadratic_error_sq``
     """
+    if len(surf_coeffs) not in (2, 3) or len(vol_coeffs) != len(surf_coeffs):
+        raise ValueError(
+            f"compute_calibrated_metrics: surf_coeffs/vol_coeffs must both be "
+            f"length 2 (affine) or 3 (quadratic); got "
+            f"surf={len(surf_coeffs)} vol={len(vol_coeffs)}"
+        )
+
+    def _err_sq(stats: torch.Tensor, coeffs: tuple[torch.Tensor, ...]) -> torch.Tensor:
+        if len(coeffs) == 2:
+            return _affine_error_sq(stats, coeffs[0], coeffs[1])
+        return _quadratic_error_sq(stats, coeffs[0], coeffs[1], coeffs[2])
+
     surf_ids = sorted(cal.surf_per_case.keys())
     if not surf_ids:
         raise RuntimeError("CalibrationStats is empty; cannot compute calibrated metrics")
@@ -604,14 +742,15 @@ def compute_calibrated_metrics(
     surf_per_channel_rel_l2: list[torch.Tensor] = []
     vec_rel_l2_list: list[torch.Tensor] = []
     for case_id in surf_ids:
-        s = cal.surf_per_case[case_id]  # (4, 6)
-        e_sq = _affine_error_sq(s, alpha_surf, beta_surf)  # (4,)
+        s = cal.surf_per_case[case_id]  # (4, N_STAT_COLS)
+        e_sq = _err_sq(s, surf_coeffs)  # (4,)
         t_sq = s[..., 4]  # sum of squared targets per channel
         rel = torch.sqrt(e_sq.clamp(min=0.0) / t_sq.clamp(min=1e-12))
         surf_per_channel_rel_l2.append(rel)
 
-        s_vec = s[1:4]  # (3, 6): tau_x, tau_y, tau_z
-        e_sq_vec = _affine_error_sq(s_vec, alpha_surf[1:4], beta_surf[1:4])  # (3,)
+        s_vec = s[1:4]  # (3, N_STAT_COLS): tau_x, tau_y, tau_z
+        vec_coeffs = tuple(c[1:4] for c in surf_coeffs)
+        e_sq_vec = _err_sq(s_vec, vec_coeffs)  # (3,)
         t_sq_vec = s_vec[..., 4]
         rel_vec = torch.sqrt(e_sq_vec.sum().clamp(min=0.0) / t_sq_vec.sum().clamp(min=1e-12))
         vec_rel_l2_list.append(rel_vec)
@@ -621,8 +760,8 @@ def compute_calibrated_metrics(
     vol_ids = sorted(cal.vol_per_case.keys())
     vol_per_channel_rel_l2: list[torch.Tensor] = []
     for case_id in vol_ids:
-        v = cal.vol_per_case[case_id]  # (1, 6)
-        e_sq = _affine_error_sq(v, alpha_vol, beta_vol)  # (1,)
+        v = cal.vol_per_case[case_id]  # (1, N_STAT_COLS)
+        e_sq = _err_sq(v, vol_coeffs)  # (1,)
         t_sq = v[..., 4]
         rel = torch.sqrt(e_sq.clamp(min=0.0) / t_sq.clamp(min=1e-12))
         vol_per_channel_rel_l2.append(rel)
@@ -1053,9 +1192,16 @@ def main(argv: Iterable[str] | None = None) -> None:
     # Always restore clean weights at the end.
     restore_clean_params(eval_module, clean)
 
-    # H300: per-channel affine calibration applied on val, transferred to test.
+    # H300/H317: per-channel test-time calibration fit on val, applied to test.
+    # Degree 1 = affine (H300); degree 2 = quadratic (H317).
     cal_metrics_by_split_mode: dict[str, dict[str, dict[str, float]]] = {}
     if cfg.test_time_calibration and state.is_main:
+        degree = int(cfg.test_time_calibration_degree)
+        if degree not in (1, 2):
+            raise ValueError(
+                f"--test-time-calibration-degree must be 1 (affine) or 2 (quadratic); "
+                f"got {degree}"
+            )
         for mode in modes:
             val_cal = cal_summary.get("val_surface", {}).get(mode)
             test_cal = cal_summary.get("test_surface", {}).get(mode)
@@ -1066,29 +1212,51 @@ def main(argv: Iterable[str] | None = None) -> None:
                     flush=True,
                 )
                 continue
-            alpha_surf, beta_surf = fit_affine_per_channel(val_cal.surf_global)
-            alpha_vol, beta_vol = fit_affine_per_channel(val_cal.vol_global)
 
             channel_names = ["cp", "tau_x", "tau_y", "tau_z"]
-            print(f"\n=== H300 calibration (fit on val, mode={mode}) ===", flush=True)
-            for c, name in enumerate(channel_names):
+            if degree == 1:
+                alpha_surf, beta_surf = fit_affine_per_channel(val_cal.surf_global)
+                alpha_vol, beta_vol = fit_affine_per_channel(val_cal.vol_global)
+                surf_coeffs: tuple[torch.Tensor, ...] = (alpha_surf, beta_surf)
+                vol_coeffs: tuple[torch.Tensor, ...] = (alpha_vol, beta_vol)
                 print(
-                    f"  surface[{name:6s}]  alpha={alpha_surf[c].item():+.6f} "
-                    f"beta={beta_surf[c].item():+.6f}",
+                    f"\n=== H300 affine calibration (fit on val, mode={mode}) ===",
                     flush=True,
                 )
-            print(
-                f"  volume[volume_pressure]  alpha={alpha_vol[0].item():+.6f} "
-                f"beta={beta_vol[0].item():+.6f}",
-                flush=True,
-            )
+                for c, name in enumerate(channel_names):
+                    print(
+                        f"  surface[{name:6s}]  alpha={alpha_surf[c].item():+.6f} "
+                        f"beta={beta_surf[c].item():+.6f}",
+                        flush=True,
+                    )
+                print(
+                    f"  volume[volume_pressure]  alpha={alpha_vol[0].item():+.6f} "
+                    f"beta={beta_vol[0].item():+.6f}",
+                    flush=True,
+                )
+            else:
+                a0_surf, a1_surf, a2_surf = fit_quadratic_per_channel(val_cal.surf_global)
+                a0_vol, a1_vol, a2_vol = fit_quadratic_per_channel(val_cal.vol_global)
+                surf_coeffs = (a0_surf, a1_surf, a2_surf)
+                vol_coeffs = (a0_vol, a1_vol, a2_vol)
+                print(
+                    f"\n=== H317 quadratic calibration (fit on val, mode={mode}) ===",
+                    flush=True,
+                )
+                for c, name in enumerate(channel_names):
+                    print(
+                        f"  surface[{name:6s}]  a0={a0_surf[c].item():+.6e} "
+                        f"a1={a1_surf[c].item():+.6f} a2={a2_surf[c].item():+.6e}",
+                        flush=True,
+                    )
+                print(
+                    f"  volume[volume_pressure]  a0={a0_vol[0].item():+.6e} "
+                    f"a1={a1_vol[0].item():+.6f} a2={a2_vol[0].item():+.6e}",
+                    flush=True,
+                )
 
-            val_cal_metrics = compute_calibrated_metrics(
-                val_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
-            )
-            test_cal_metrics = compute_calibrated_metrics(
-                test_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
-            )
+            val_cal_metrics = compute_calibrated_metrics(val_cal, surf_coeffs, vol_coeffs)
+            test_cal_metrics = compute_calibrated_metrics(test_cal, surf_coeffs, vol_coeffs)
             cal_metrics_by_split_mode.setdefault("val_surface", {})[mode] = val_cal_metrics
             cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
 
@@ -1104,12 +1272,22 @@ def main(argv: Iterable[str] | None = None) -> None:
             )
 
             if run is not None:
-                # Log alpha/beta to W&B summary so they appear on the run page.
-                for c, name in enumerate(channel_names):
-                    run.summary[f"calibration/{mode}/alpha_{name}"] = float(alpha_surf[c].item())
-                    run.summary[f"calibration/{mode}/beta_{name}"] = float(beta_surf[c].item())
-                run.summary[f"calibration/{mode}/alpha_volume_pressure"] = float(alpha_vol[0].item())
-                run.summary[f"calibration/{mode}/beta_volume_pressure"] = float(beta_vol[0].item())
+                if degree == 1:
+                    # Log alpha/beta to W&B summary so they appear on the run page.
+                    for c, name in enumerate(channel_names):
+                        run.summary[f"calibration/{mode}/alpha_{name}"] = float(alpha_surf[c].item())
+                        run.summary[f"calibration/{mode}/beta_{name}"] = float(beta_surf[c].item())
+                    run.summary[f"calibration/{mode}/alpha_volume_pressure"] = float(alpha_vol[0].item())
+                    run.summary[f"calibration/{mode}/beta_volume_pressure"] = float(beta_vol[0].item())
+                else:
+                    # Log a0/a1/a2 per channel to W&B summary.
+                    for c, name in enumerate(channel_names):
+                        run.summary[f"calibration/quadratic/{mode}/a0_{name}"] = float(a0_surf[c].item())
+                        run.summary[f"calibration/quadratic/{mode}/a1_{name}"] = float(a1_surf[c].item())
+                        run.summary[f"calibration/quadratic/{mode}/a2_{name}"] = float(a2_surf[c].item())
+                    run.summary[f"calibration/quadratic/{mode}/a0_volume_pressure"] = float(a0_vol[0].item())
+                    run.summary[f"calibration/quadratic/{mode}/a1_volume_pressure"] = float(a1_vol[0].item())
+                    run.summary[f"calibration/quadratic/{mode}/a2_volume_pressure"] = float(a2_vol[0].item())
 
                 # Log calibrated primary metrics to W&B history (and as
                 # split-level summary keys for downstream parsing).
@@ -1136,6 +1314,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 run.summary["test_abupt_h300_raw"] = float(
                     summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
                 )
+                run.summary["test_time_calibration_degree"] = degree
 
     if state.is_main and summary:
         print("\n=== Summary (rel_l2_pct lower-is-better) ===")


### PR DESCRIPTION
## Hypothesis

H300 (PR #1489) gained −28bp on test by fitting a linear per-channel affine map `y = α·p + β` on 34 val cases and applying it to 50 test cases. The fitted coefficients were α∈[0.992, 1.000] (all small scale corrections) but β_VP = **−0.8554** (substantial volume_pressure intercept shift). The residual after affine calibration may still contain a *curvature* term — the model's prediction error vs target value relationship may not be perfectly linear.

**Hypothesis:** A per-channel **quadratic** calibration `y = a₀ + a₁·p + a₂·p²` (3 params/channel × 5 channels = 15 params total, +5 over H300's 10) can squeeze additional bp out of test by absorbing residual curvature. The 34-case val set has ~10⁷ surface points, so the quadratic fit is heavily over-determined.

**Risk:** Over-fitting the 34-case val. The quadratic adds 1 DOF per channel, so the val→test generalization gap should be inspected per arm.

This is an **eval-only** experiment (no retraining) on H185 EP15 + H296 raw TTA recipe — same compute path as H300/H312.

**Relationship to in-flight calibration work:**
- H300 (merged): linear affine, 10 params, test_cal=5.7399
- H312 (edward, running): confirm H300 on K=4+8-res base
- H313 (askeladd, running): regional per-zone *linear* — different DOF allocation
- H314 (frieren, running): Student-t weight noise — orthogonal axis
- H315 (nezuko, running): robust aggregation — orthogonal axis
- H316 (alphonse, running): bias-only vs scale-only ablation — same 10 params, restricted
- **H317 (this PR): quadratic — strictly more params** — answers "are 10 params enough?"

## Instructions

**Code change in `target/eval_tta_h252.py`:**

1. Extend the sufficient statistics. Find `CalibrationStats` (around line 480) and add columns for `sum_pp_p` (Σp³) and `sum_ppp_p` (Σp⁴), needed for normal equations of the 3-parameter polynomial.

Current `CalibrationStats` accumulates per-channel: `[N, sum_p, sum_t, sum_pp, sum_pp, sum_pt]` (6 cols). Extend to 8 cols by adding `sum_ppp = sum(p^3)` and `sum_pppp = sum(p^4)` per channel.

Update `add_case_to_calibration` (line 510) and `merge_calibration_stats` (line 527) accordingly.

2. Add a new function `fit_quadratic_per_channel` next to `fit_affine_per_channel`:

```python
def fit_quadratic_per_channel(
    global_stats: torch.Tensor,
) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    """OLS a0, a1, a2 per channel for y = a0 + a1*p + a2*p^2.

    Solves the 3x3 normal equations per channel using the sufficient stats.
    Falls back to affine (a2=0) on any degenerate channel.
    """
    N        = global_stats[:, 0]
    sum_p    = global_stats[:, 1]
    sum_t    = global_stats[:, 2]
    sum_pp   = global_stats[:, 3]
    sum_pt   = global_stats[:, 5]
    sum_ppp  = global_stats[:, 6]   # new
    sum_pppp = global_stats[:, 7]   # new
    # We also need sum(p^2 * t) — store it as a new column too,
    # or derive from existing if possible (it isn't), so just add sum_ppt = global_stats[:, 8]

    n_channels = N.shape[0]
    a0 = torch.zeros(n_channels, dtype=N.dtype, device=N.device)
    a1 = torch.zeros_like(a0)
    a2 = torch.zeros_like(a0)
    for c in range(n_channels):
        # Build the 3x3 normal matrix and RHS for channel c
        M = torch.tensor([
            [N[c],       sum_p[c],   sum_pp[c]],
            [sum_p[c],   sum_pp[c],  sum_ppp[c]],
            [sum_pp[c],  sum_ppp[c], sum_pppp[c]],
        ], dtype=N.dtype, device=N.device)
        b = torch.tensor([sum_t[c], sum_pt[c], sum_ppt[c]], dtype=N.dtype, device=N.device)
        try:
            coeffs = torch.linalg.solve(M, b)
            a0[c], a1[c], a2[c] = coeffs[0], coeffs[1], coeffs[2]
        except torch._C._LinAlgError:
            # Fall back to identity if matrix is singular
            a0[c], a1[c], a2[c] = 0.0, 1.0, 0.0
    return a0, a1, a2
```

You also need to add `sum_ppt = sum(p^2 * t)` to the sufficient stats (column 8 → 9 cols total).

3. Add CLI field next to `test_time_calibration`:
```python
test_time_calibration_degree: int = 1  # 1=affine (H300), 2=quadratic (H317)
```

4. In the main eval loop where `fit_affine_per_channel` is called (around line 1069-1070), branch on degree:
```python
if cfg.test_time_calibration_degree == 1:
    alpha_surf, beta_surf = fit_affine_per_channel(val_cal.surf_global)
    # apply y = alpha * p + beta to test preds (existing path)
elif cfg.test_time_calibration_degree == 2:
    a0_surf, a1_surf, a2_surf = fit_quadratic_per_channel(val_cal.surf_global)
    # apply y = a0 + a1 * p + a2 * p^2 to test preds (NEW path)
    test_preds_surface = a0_surf + a1_surf * test_preds_surface + a2_surf * test_preds_surface**2
    # same for volume
```

5. Log all coefficients to W&B summary:
```python
for c, name in enumerate(channel_names):
    run.summary[f"calibration/quadratic/a0_{name}"] = a0[c].item()
    run.summary[f"calibration/quadratic/a1_{name}"] = a1[c].item()
    run.summary[f"calibration/quadratic/a2_{name}"] = a2[c].item()
```

**Smoke test (5 min):**

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/h252_eval/_artifacts/0gjfv45i/epoch-15/checkpoint.pt \
  --resolutions "65536" \
  --eval-modes "mirror" \
  --test-time-calibration \
  --test-time-calibration-degree 2 \
  --debug --batch-size 2 --num-workers 4 \
  --agent tanjiro \
  --wandb-group "h317-tanjiro-quadratic-cal-smoke" \
  --wandb-name "tanjiro/h317-smoke-quadratic"
```

Verify the new flag parses, all 15 coefficients log to W&B summary, a₂ is small (~10⁻³ range for VP, ~10⁻⁶ for SP based on dimensional reasoning), and metrics compute without error.

**Primary arm (1 run, full val+test, K=4+8-res+mirror = H296 recipe):**

```bash
H185_EP15_CKPT="outputs/h252_eval/_artifacts/0gjfv45i/epoch-15/checkpoint.pt"

torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint $H185_EP15_CKPT \
  --resolutions "32768,49152,65536,81920,98304,114688,131072,147456" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 \
  --weight-noise-passes 4 \
  --antithetic-noise \
  --test-time-calibration \
  --test-time-calibration-degree 2 \
  --batch-size 2 --num-workers 4 \
  --agent tanjiro \
  --wandb-group "h317-tanjiro-quadratic-cal" \
  --wandb-name "tanjiro/h317-quadratic-K4-8res"
```

Compute matches H312/H316 (~300-340 min).

**Decision logic:**

| Configuration | val_cal | test_cal | Δtest vs H300 |
|---|---|---|---|
| H300 linear ref | 5.9011 | 5.7399 | 0 |
| H317 quadratic (this PR) | ? | ? | ? |

- **Merge if** val_cal < 5.9011 AND test_cal < 5.7399 (passes new gate).
- **Close if** test_cal > 5.7399 + 2bp (overfitting val).
- **Send back for variant** if test_cal in [5.7399, 5.7419] (marginal — try cubic, or constrained quadratic).

Inspect the a₂ coefficients in the final report: if any |a₂| · max(|p|²) >> |a₁| · max(|p|), the quadratic is dominated and may be overfitting; otherwise it's a genuine signal.

## SENPAI-RESULT marker

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_h300_calibrated","value":<val_cal>},"test_metric":{"name":"test_abupt_h300_calibrated","value":<test_cal>}}
```

Include the full coefficient table (a₀, a₁, a₂ per channel) in the results comment.

## Baseline

Current SOTA (PR #1489 H300, merged 2026-05-30 18:48Z):

- val_abupt_calibrated = **5.9011%** (val_abupt_raw 5.9228%)
- test_abupt_calibrated = **5.7399%** (test_abupt_raw 5.7683%)
- test_VP = 3.3763%, test_SP = 3.6132%, test_WSS = 6.6404%
- W&B run: `59r4noqh` (edward/h300-cal-K4-6res)
- H300 fitted coefficients: α∈[0.99187, 0.99975]; β_VP = −0.8554, others |β|≈0

**Merge gate**: val_abupt_calibrated < 5.9011% AND test_abupt_calibrated < 5.7399%

## Constraints

- **8 GPUs DDP** (--nproc-per-node=8)
- Dataset: `/mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511`
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- `SENPAI_TIMEOUT_MINUTES=360`
- Numerical stability: if you use float32 throughout for the calibration fit, the quadratic normal matrix can be ill-conditioned. Consider centering predictions (subtract mean per channel) before fitting if you see numerical issues — this trivially recoverable post-fit.
