### PR TITLE
H310: Commission 2nd EP15 seed (unblocks weight-space averaging family)

### DIFF
--- a/train.py
+++ b/train.py
@@ -145,6 +145,7 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    seed: int = 0
     debug: bool = False
 
 
@@ -271,6 +272,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "seed": (
+            "H310: integer seed for torch / numpy / random. 0 (default) "
+            "leaves all RNGs at system entropy (matches historical "
+            "non-deterministic behavior). Nonzero sets torch.manual_seed, "
+            "torch.cuda.manual_seed_all, numpy.random.seed, and "
+            "random.seed BEFORE model/dataloader/DDP construction so two "
+            "runs with the same seed produce matching val curves (modulo "
+            "CUDA float non-determinism)."
         ),
     }
     for field in fields(Config):
@@ -831,6 +841,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        if config.seed != 0:
+            import random as _py_random
+            import numpy as _np
+            torch.manual_seed(config.seed)
+            torch.cuda.manual_seed_all(config.seed)
+            _np.random.seed(config.seed)
+            _py_random.seed(config.seed)
+            if state.is_main:
+                print(f"Seed: {config.seed} (torch / cuda / numpy / random)")
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -1081,6 +1100,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["mirror_augmentation"] = config.mirror_augmentation
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
+            wandb.summary["seed"] = config.seed
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

H307 (weight-space averaging / SWA between two EP15 checkpoints) has been **blocked for multiple rounds** because we only have **one** EP15 checkpoint (`0gjfv45i`, edward H244, EP15 of a 16-epoch cosine extension resuming from H185 base `yw2a5dyl`).

To unblock the entire weight-space-averaging family of experiments (H307, H310-family, future ensemble work), we need to commission a **second** independent EP15 checkpoint trained with a different random seed.

**Hypothesis:** A second seed of the H244 H185-EP16-cosine-ext training, with the same hyperparameters but different data shuffle and weight initialisation, will:
1. Converge to a similar val_abupt (~5.96-5.98% pre-TTA based on H185/H244 cohort)
2. Produce weights diverged enough in basin geometry from `0gjfv45i` that linear interpolation (H307) yields a useful diversity signal
3. Provide a baseline for "training noise" — how much does seed alone change downstream test_abupt?

This is **NOT a SOTA-hunt experiment**. The goal is to commission an artifact that unblocks H307 and subsequent ensemble experiments. The merge bar is: does it produce a usable second EP15 checkpoint?

## Instructions

**Re-run the H244 H185-EP16-cosine-ext training with a different effective random seed.** The exact source command is in W&B run `0gjfv45i` config; key fields below.

`train.py` does NOT currently fix `torch.manual_seed` or `np.random.seed`, so simply launching a fresh run with the same hyperparameters will produce a different effective seed from system entropy. To make this *explicit and reproducible*, add a small seed flag.

### Step 1: Add `--seed` flag to train.py (small code change, ~10 lines)

In `target/train.py`, near the top of the `Config` dataclass (around line 65), add:
```python
seed: int = 0  # 0 = system entropy (non-deterministic), nonzero = fixed seed
```

In the `main()` or `setup()` function (early in execution, before model construction or DataLoader creation), add:
```python
if config.seed != 0:
    import random, numpy as np
    torch.manual_seed(config.seed)
    torch.cuda.manual_seed_all(config.seed)
    np.random.seed(config.seed)
    random.seed(config.seed)
    # Note: DDP seeding is automatic via torch's distributed init
```

Log the seed to W&B summary:
```python
run.summary["seed"] = config.seed
```

### Step 2: Smoke test (10 min, 1 epoch debug)

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent thorfinn \
  --epochs 1 --batch-size 4 \
  --seed 2026 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 0 --lr-cosine-t-max 16 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --tau-y-loss-weight 1.30 --tau-z-loss-weight 1.67 \
  --resume-from-wandb yw2a5dyl \
  --wandb-name thorfinn/h310-seed2-smoke \
  --wandb-group h310-thorfinn-seed2
```

Verify: seed is logged, training starts, gradients flow, no NaN/Inf.

### Step 3: Primary training (full 16 epochs, ~18-20 hours wall, ~12-14 hours of GPU compute)

```bash
SENPAI_TIMEOUT_MINUTES=1100 torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json \
  --agent thorfinn \
  --epochs 16 --batch-size 4 \
  --seed 2026 \
  --model-hidden-dim 512 --model-layers 5 --model-heads 4 --model-mlp-ratio 4 \
  --model-slices 128 --model-dropout 0.0 \
  --train-surface-points 65536 --eval-surface-points 65536 \
  --train-volume-points 65536 --eval-volume-points 65536 \
  --use-qk-norm --rff-num-features 16 --rff-init-sigmas "0.25,0.5,1.0,2.0,4.0" \
  --pos-encoding-mode string_separable \
  --use-ema --ema-decay 0.999 --ema-start-step 50 \
  --use-surf-to-vol-xattn --drop-path-max 0.10 \
  --lr 9e-5 --lr-warmup-epochs 0 --lr-cosine-t-max 16 --lr-min 1e-6 \
  --weight-decay 5e-4 --grad-clip-norm 0.5 \
  --optimizer lion --lion-beta1 0.9 --lion-beta2 0.99 \
  --amp-mode bf16 --no-compile-model \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --tau-y-loss-weight 1.30 --tau-z-loss-weight 1.67 \
  --resume-from-wandb yw2a5dyl \
  --wandb-name thorfinn/h310-h185-ep16-cosine-ext-seed2 \
  --wandb-group h310-thorfinn-seed2-retrain
```

NOTE: the `SENPAI_TIMEOUT_MINUTES=1100` budget matches the original H185 plateau-exact budget. This is a long run — please monitor that it doesn't get killed by the per-arm 360-min timeout. Override with the env var as shown.

### Step 4: Save the EP15 checkpoint

The training will checkpoint per epoch. At end of training, ensure the EP15 checkpoint is uploaded as a W&B artifact (same as `0gjfv45i` did). The `model:epoch-15` artifact alias is what H307 will resume from.

### Step 5: Quick eval of the new EP15

Once EP15 is saved, run a 1-mode eval to confirm the checkpoint produces sensible val_abupt:
```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint <path-to-new-seed2-ep15-ckpt> \
  --resolutions "65536" \
  --eval-modes "mirror" \
  --batch-size 2 --num-workers 4 \
  --agent thorfinn \
  --wandb-group "h310-thorfinn-seed2-eval-check" \
  --wandb-name "thorfinn/h310-seed2-ep15-mirror-eval"
```

Sanity check: val_abupt should be in [5.95, 6.05]% (matches H185/H244 cohort). If wildly different (e.g., > 6.3%), the training has diverged and the seed setup may need debugging.

## Decision logic

This is **commission-and-confirm**, not a SOTA hunt:

- **Merge** if the EP15 checkpoint exists, is uploaded as W&B artifact `model:epoch-15`, and val_abupt (1-mode mirror eval) is within [5.95, 6.05]% range. The PR merge gives us the second EP15 artifact.
- **Send back for fix** if the run completes but the EP15 artifact upload fails — the artifact must be downloadable for H307 to use.
- **Close** if val_abupt > 6.5% after EP15 (training failed to converge similarly — seed setup likely buggy).

Post-merge, H307 will be assigned to a student to run weight-space averaging between `0gjfv45i` and the new seed-2 EP15.

## Baseline

For verification:
- **`0gjfv45i` (seed-1 EP15)**: val_abupt_raw ~5.96% (from EP15 mirror-only eval, no TTA stack)
- **`0gjfv45i` (seed-1 EP15) with full TTA + H300 calibration**: val_cal=5.9011%, test_cal=5.7399% (current SOTA)
- We expect seed-2 EP15 to land within ~0.1pp of seed-1 EP15 on val_abupt.

## SENPAI-RESULT marker

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<train-run-id>","<eval-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val>},"test_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<val>},"artifact":"thorfinn/<train-run-id>/model:epoch-15"}
```

(Both primary_metric and test_metric are the same val for this commission run — it isn't trying to beat the test gate.)

## Constraints

- **8 GPUs DDP** (--nproc-per-node=8)
- Override `SENPAI_TIMEOUT_MINUTES=1100` for the primary training run — this is a long-budget commission, not a quick eval
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- The new `--seed` flag must be plumbed through such that two runs with `--seed 2026` produce identical val_abupt curves (modulo float non-determinism in CUDA). The student should verify this by launching the smoke twice and confirming the EP1 val matches.

## Why this experiment matters strategically

H307 (weight-space averaging) is a known-good ensemble technique with literature precedent (Wortsman et al. 2022 "Model Soups"). It can typically yield −0.5 to −2bp on validation with zero inference cost. Currently blocked.

H310 commissioning unlocks: H307 (linear interp), H320-family (uniform averaging across N seeds), and H321 (Caruana selection on seed-diverse base models). The investment is one ~18-hour training run for an entire experimental family.
