### PR TITLE
H307: Weight-space averaging of two EP15 seeds + H300 calibration (model soup)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -96,13 +96,6 @@ class EvalConfig:
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
 
-    # H307: skip the test_surface loop entirely. Useful when the only goal is
-    # to fit affine calibration coefficients on val and emit
-    # val_abupt_h300_calibrated for triage on a tight budget. When skip_test is
-    # True the calibration block computes alpha/beta from val_cal alone and
-    # writes only val_*_h300_calibrated summary keys.
-    skip_test: bool = False
-
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
     output_dir: str = "outputs/h252_eval"
@@ -992,10 +985,6 @@ def main(argv: Iterable[str] | None = None) -> None:
         ("val_surface", val_case_ids, "full_val"),
         ("test_surface", test_case_ids, "test"),
     ]
-    if cfg.skip_test:
-        splits = [s for s in splits if s[0] != "test_surface"]
-        if state.is_main:
-            print("[skip_test] test_surface loop disabled; calibration fit on val only", flush=True)
 
     summary: dict[str, dict[str, dict[str, float]]] = {}
     cal_summary: dict[str, dict[str, CalibrationStats | None]] = {}
@@ -1065,22 +1054,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     restore_clean_params(eval_module, clean)
 
     # H300: per-channel affine calibration applied on val, transferred to test.
-    # H307: allow val-only calibration (test_cal absent) when skip_test=True.
     cal_metrics_by_split_mode: dict[str, dict[str, dict[str, float]]] = {}
     if cfg.test_time_calibration and state.is_main:
         for mode in modes:
             val_cal = cal_summary.get("val_surface", {}).get(mode)
             test_cal = cal_summary.get("test_surface", {}).get(mode)
-            if val_cal is None:
+            if val_cal is None or test_cal is None:
                 print(
-                    f"[calibration] mode={mode}: missing val cal stats; skipping",
-                    flush=True,
-                )
-                continue
-            if test_cal is None and not cfg.skip_test:
-                print(
-                    f"[calibration] mode={mode}: missing test cal stats and "
-                    "skip_test=False; skipping",
+                    f"[calibration] mode={mode}: missing cal stats "
+                    f"(val={val_cal is not None}, test={test_cal is not None}); skipping",
                     flush=True,
                 )
                 continue
@@ -1104,28 +1086,22 @@ def main(argv: Iterable[str] | None = None) -> None:
             val_cal_metrics = compute_calibrated_metrics(
                 val_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
             )
-            test_cal_metrics: dict[str, float] | None = None
-            if test_cal is not None:
-                test_cal_metrics = compute_calibrated_metrics(
-                    test_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
-                )
+            test_cal_metrics = compute_calibrated_metrics(
+                test_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
+            )
             cal_metrics_by_split_mode.setdefault("val_surface", {})[mode] = val_cal_metrics
-            if test_cal_metrics is not None:
-                cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
+            cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
 
             print(
                 f"  val  (raw -> cal)  abupt {summary['val_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
                 f"-> {val_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
                 flush=True,
             )
-            if test_cal_metrics is not None:
-                print(
-                    f"  test (raw -> cal)  abupt {summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
-                    f"-> {test_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
-                    flush=True,
-                )
-            else:
-                print("  test (raw -> cal)  skipped (skip_test=True)", flush=True)
+            print(
+                f"  test (raw -> cal)  abupt {summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
+                f"-> {test_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
+                flush=True,
+            )
 
             if run is not None:
                 # Log alpha/beta to W&B summary so they appear on the run page.
@@ -1141,30 +1117,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"full_val_primary_calibrated/{mode}/{k}": v
                     for k, v in val_cal_metrics.items()
                 }
-                log_payload: dict[str, float] = dict(val_log)
-                if test_cal_metrics is not None:
-                    log_payload.update(
-                        {
-                            f"test_primary_calibrated/{mode}/{k}": v
-                            for k, v in test_cal_metrics.items()
-                        }
-                    )
-                wandb.log(log_payload)
+                test_log = {
+                    f"test_primary_calibrated/{mode}/{k}": v
+                    for k, v in test_cal_metrics.items()
+                }
+                wandb.log({**val_log, **test_log})
 
                 # Single-line paper-facing primary metrics (no mode suffix).
                 run.summary["val_abupt_h300_calibrated"] = float(
                     val_cal_metrics["abupt_axis_mean_rel_l2_pct"]
                 )
+                run.summary["test_abupt_h300_calibrated"] = float(
+                    test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                )
                 run.summary["val_abupt_h300_raw"] = float(
                     summary["val_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
                 )
-                if test_cal_metrics is not None:
-                    run.summary["test_abupt_h300_calibrated"] = float(
-                        test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
-                    )
-                    run.summary["test_abupt_h300_raw"] = float(
-                        summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
-                    )
+                run.summary["test_abupt_h300_raw"] = float(
+                    summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
+                )
 
     if state.is_main and summary:
         print("\n=== Summary (rel_l2_pct lower-is-better) ===")

--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -96,6 +96,13 @@ class EvalConfig:
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
 
+    # H307: skip the test_surface loop entirely. Useful when the only goal is
+    # to fit affine calibration coefficients on val and emit
+    # val_abupt_h300_calibrated for triage on a tight budget. When skip_test is
+    # True the calibration block computes alpha/beta from val_cal alone and
+    # writes only val_*_h300_calibrated summary keys.
+    skip_test: bool = False
+
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
     output_dir: str = "outputs/h252_eval"
@@ -985,6 +992,10 @@ def main(argv: Iterable[str] | None = None) -> None:
         ("val_surface", val_case_ids, "full_val"),
         ("test_surface", test_case_ids, "test"),
     ]
+    if cfg.skip_test:
+        splits = [s for s in splits if s[0] != "test_surface"]
+        if state.is_main:
+            print("[skip_test] test_surface loop disabled; calibration fit on val only", flush=True)
 
     summary: dict[str, dict[str, dict[str, float]]] = {}
     cal_summary: dict[str, dict[str, CalibrationStats | None]] = {}
@@ -1054,15 +1065,22 @@ def main(argv: Iterable[str] | None = None) -> None:
     restore_clean_params(eval_module, clean)
 
     # H300: per-channel affine calibration applied on val, transferred to test.
+    # H307: allow val-only calibration (test_cal absent) when skip_test=True.
     cal_metrics_by_split_mode: dict[str, dict[str, dict[str, float]]] = {}
     if cfg.test_time_calibration and state.is_main:
         for mode in modes:
             val_cal = cal_summary.get("val_surface", {}).get(mode)
             test_cal = cal_summary.get("test_surface", {}).get(mode)
-            if val_cal is None or test_cal is None:
+            if val_cal is None:
                 print(
-                    f"[calibration] mode={mode}: missing cal stats "
-                    f"(val={val_cal is not None}, test={test_cal is not None}); skipping",
+                    f"[calibration] mode={mode}: missing val cal stats; skipping",
+                    flush=True,
+                )
+                continue
+            if test_cal is None and not cfg.skip_test:
+                print(
+                    f"[calibration] mode={mode}: missing test cal stats and "
+                    "skip_test=False; skipping",
                     flush=True,
                 )
                 continue
@@ -1086,22 +1104,28 @@ def main(argv: Iterable[str] | None = None) -> None:
             val_cal_metrics = compute_calibrated_metrics(
                 val_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
             )
-            test_cal_metrics = compute_calibrated_metrics(
-                test_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
-            )
+            test_cal_metrics: dict[str, float] | None = None
+            if test_cal is not None:
+                test_cal_metrics = compute_calibrated_metrics(
+                    test_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
+                )
             cal_metrics_by_split_mode.setdefault("val_surface", {})[mode] = val_cal_metrics
-            cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
+            if test_cal_metrics is not None:
+                cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
 
             print(
                 f"  val  (raw -> cal)  abupt {summary['val_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
                 f"-> {val_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
                 flush=True,
             )
-            print(
-                f"  test (raw -> cal)  abupt {summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
-                f"-> {test_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
-                flush=True,
-            )
+            if test_cal_metrics is not None:
+                print(
+                    f"  test (raw -> cal)  abupt {summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
+                    f"-> {test_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
+                    flush=True,
+                )
+            else:
+                print("  test (raw -> cal)  skipped (skip_test=True)", flush=True)
 
             if run is not None:
                 # Log alpha/beta to W&B summary so they appear on the run page.
@@ -1117,25 +1141,30 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"full_val_primary_calibrated/{mode}/{k}": v
                     for k, v in val_cal_metrics.items()
                 }
-                test_log = {
-                    f"test_primary_calibrated/{mode}/{k}": v
-                    for k, v in test_cal_metrics.items()
-                }
-                wandb.log({**val_log, **test_log})
+                log_payload: dict[str, float] = dict(val_log)
+                if test_cal_metrics is not None:
+                    log_payload.update(
+                        {
+                            f"test_primary_calibrated/{mode}/{k}": v
+                            for k, v in test_cal_metrics.items()
+                        }
+                    )
+                wandb.log(log_payload)
 
                 # Single-line paper-facing primary metrics (no mode suffix).
                 run.summary["val_abupt_h300_calibrated"] = float(
                     val_cal_metrics["abupt_axis_mean_rel_l2_pct"]
                 )
-                run.summary["test_abupt_h300_calibrated"] = float(
-                    test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
-                )
                 run.summary["val_abupt_h300_raw"] = float(
                     summary["val_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
                 )
-                run.summary["test_abupt_h300_raw"] = float(
-                    summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
-                )
+                if test_cal_metrics is not None:
+                    run.summary["test_abupt_h300_calibrated"] = float(
+                        test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                    )
+                    run.summary["test_abupt_h300_raw"] = float(
+                        summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
+                    )
 
     if state.is_main and summary:
         print("\n=== Summary (rel_l2_pct lower-is-better) ===")

--- a/scripts/soup_checkpoints.py
+++ b/scripts/soup_checkpoints.py
@@ -1,0 +1,102 @@
+"""H307: Linear weight-space averaging of two checkpoints (model soup).
+
+Loads two checkpoints, asserts identical state_dict keys/shapes, then writes
+out  alpha*A + (1 - alpha)*B  as a new checkpoint with the same on-disk
+structure expected by eval_tta_h252.py (top-level keys: model, epoch,
+checkpoint_source, config, selection_metric, val_metrics).
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+
+def soup(ckpt_a: Path, ckpt_b: Path, alpha: float, output: Path) -> None:
+    ck_a = torch.load(ckpt_a, map_location="cpu", weights_only=False)
+    ck_b = torch.load(ckpt_b, map_location="cpu", weights_only=False)
+    sd_a: dict[str, torch.Tensor] = ck_a["model"]
+    sd_b: dict[str, torch.Tensor] = ck_b["model"]
+
+    keys_a = set(sd_a.keys())
+    keys_b = set(sd_b.keys())
+    if keys_a != keys_b:
+        raise RuntimeError(
+            f"state_dict key mismatch: A-B={list(keys_a - keys_b)[:5]} "
+            f"B-A={list(keys_b - keys_a)[:5]}"
+        )
+
+    soup_sd: dict[str, torch.Tensor] = {}
+    n_tensor = 0
+    n_float = 0
+    n_nonfloat_diff = 0
+    delta_norm_total = 0.0
+    soup_norm_total = 0.0
+    for k in sorted(keys_a):
+        ta = sd_a[k]
+        tb = sd_b[k]
+        if ta.shape != tb.shape:
+            raise RuntimeError(f"shape mismatch on {k}: {ta.shape} vs {tb.shape}")
+        n_tensor += 1
+        if ta.dtype.is_floating_point:
+            ta_f = ta.float()
+            tb_f = tb.float()
+            soup_t = alpha * ta_f + (1.0 - alpha) * tb_f
+            soup_sd[k] = soup_t.to(ta.dtype)
+            n_float += 1
+            delta_norm_total += float((ta_f - tb_f).norm().item() ** 2)
+            soup_norm_total += float(soup_t.norm().item() ** 2)
+        else:
+            # Integer buffers (e.g., num_batches_tracked): require exact match
+            # so the soup is well-defined; otherwise prefer A as the canonical.
+            if not torch.equal(ta, tb):
+                n_nonfloat_diff += 1
+            soup_sd[k] = ta.clone()
+
+    print(
+        f"Soup: tensors={n_tensor} float={n_float} non-float-mismatches={n_nonfloat_diff}\n"
+        f"  ||A-B||_2 (float params only) = {delta_norm_total ** 0.5:.6f}\n"
+        f"  ||soup||_2                    = {soup_norm_total ** 0.5:.6f}\n"
+        f"  alpha = {alpha:.4f}  (A weight = alpha, B weight = 1 - alpha)"
+    )
+
+    # Preserve metadata structure from A so downstream eval can read epoch /
+    # config / etc.  Tag provenance so future tooling can detect a soup ckpt.
+    out_ck: dict = {
+        "model": soup_sd,
+        "epoch": ck_a.get("epoch"),
+        "checkpoint_source": ck_a.get("checkpoint_source", "ema"),
+        "config": ck_a.get("config", {}),
+        "selection_metric": ck_a.get("selection_metric"),
+        "val_metrics": ck_a.get("val_metrics"),
+        "soup": {
+            "alpha": alpha,
+            "ckpt_a": str(ckpt_a),
+            "ckpt_b": str(ckpt_b),
+            "epoch_a": ck_a.get("epoch"),
+            "epoch_b": ck_b.get("epoch"),
+            "source_a": ck_a.get("checkpoint_source"),
+            "source_b": ck_b.get("checkpoint_source"),
+        },
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(out_ck, output)
+    size_mb = output.stat().st_size / 1024 / 1024
+    print(f"Saved soup checkpoint -> {output}  ({size_mb:.1f} MB)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="H307 weight-space soup")
+    p.add_argument("--ckpt-a", required=True, type=Path, help="checkpoint A (weight alpha)")
+    p.add_argument("--ckpt-b", required=True, type=Path, help="checkpoint B (weight 1 - alpha)")
+    p.add_argument("--alpha", type=float, default=0.5)
+    p.add_argument("--output", required=True, type=Path)
+    args = p.parse_args()
+    if not (0.0 <= args.alpha <= 1.0):
+        raise SystemExit(f"alpha must be in [0,1], got {args.alpha}")
+    soup(args.ckpt_a, args.ckpt_b, args.alpha, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

Linear weight-space averaging ("model soup", [Wortsman et al. 2022](https://arxiv.org/abs/2203.05482)) of two independently-trained EP15 seeds should land in a flatter loss-landscape minimum and give 5–20bp lower val/test error than either constituent. We now have two H244-recipe EP15 checkpoints with different seeds:

- **Seed-1**: W&B run `0gjfv45i` (edward H244, the original H244 EP15 — currently the seed-1 component of the H300 SOTA stack)
- **Seed-2**: W&B run `m1ddrlcu` (thorfinn H310 commission — your own EP15)

The +0.055pp val gap between seeds at EP15 (within natural H244-recipe training noise) is exactly the signal H307 needs: independent SGD trajectories converged to nearby-but-distinct flat regions. Averaging in weight-space should land between them in a smoother neighborhood.

H307 tests whether averaging + H300 calibration improves the current SOTA (val_cal < 5.9011%, test_cal < 5.7399%).

## Baseline (NEW SOTA — H300 PR #1489 merged)

| Metric | Value | Source |
|---|---:|---|
| **val_abupt_h300_calibrated** | **5.9011%** | run `59r4noqh`, gate |
| **test_abupt_h300_calibrated** | **5.7399%** | run `59r4noqh`, gate |
| Seed-1 EP15 raw (K=4+8-res+mirror) | val 5.9215% / test 5.7683% | H296/H300 stack |
| H300 affine coefficients | α∈[0.99187, 0.99975]; β_VP = −0.8554 dominant | per-channel OLS on val |
| Paper floors (don't degrade) | test_VP ≤ 3.421, test_SP ≤ 3.577 | Transolver-3 ref |

## Instructions

3 arms (Arms A/B mandatory, Arm C conditional). All eval runs use the **canonical full TTA stack** (K=4 anti-thetic + 8-resolution ladder + mirror + mean aggregation + H300 calibration on top) for direct comparison to the SOTA chain.

### Step 1 — Smoke test (~5 min)

Write a small helper `scripts/soup_checkpoints.py`:
1. Load checkpoint A and B (from W&B artifact downloads or local .pt files)
2. For each key in the state_dict: assert both have it and shapes match
3. Compute `α·A[key] + (1−α)·B[key]` elementwise
4. Save the averaged state_dict as a new .pt (preserve any non-tensor metadata from A — optimizer state, epoch counter, etc., are not needed for inference but keep the structure consistent)

Smoke-test on 2–4 val cases with K=1, 1-res to confirm the soup loads and runs end-to-end. If you encounter EMA-vs-raw weight ambiguity (the H244 checkpoints have both), use the EMA weights — those are what H244/H300 evaluate.

### Step 2 — Arm A: seed-2 EP15 CONTROL (full stack + H300 calibration)

Establishes seed-2's standalone performance under the same stack as H300/H312 — tells us whether the seed-2 deltas are within seed noise or larger:

```bash
# Download seed-2 EP15 (your own commission):
#   artifact: wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/model-thorfinn-h310-h185-ep16-cosine-ext-seed2-m1ddrlcu:epoch-15
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint <path-to-seed2-ep15.pt> \
  --resolutions "8192,16384,24576,32768,40960,49152,57344,65536" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --num-passes 4 --mirror-augmentation --noise-sigma 5e-4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent thorfinn \
  --wandb-group "h307-thorfinn-armA-seed2-control" \
  --wandb-name "thorfinn/h307-armA-seed2-fullstack-cal"
```

(Cross-check the exact `eval_tta_h252.py` flag names by running `--help` — the flag spellings here are based on H296/H300/H312 commands but verify before launching the long run.)

Expected: val_abupt_raw 5.92–6.02%; val_cal and test_cal will report whether seed-2 alone is competitive or weaker than seed-1.

### Step 3 — Arm B: model soup α=0.5 (PRIMARY)

```bash
python scripts/soup_checkpoints.py \
  --ckpt-a <seed1-ep15.pt>  \
  --ckpt-b <seed2-ep15.pt>  \
  --alpha 0.5 \
  --output outputs/.../soup-alpha050.pt

torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/.../soup-alpha050.pt \
  --resolutions "8192,16384,24576,32768,40960,49152,57344,65536" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --num-passes 4 --mirror-augmentation --noise-sigma 5e-4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent thorfinn \
  --wandb-group "h307-thorfinn-armB-soup-alpha050" \
  --wandb-name "thorfinn/h307-armB-soup-alpha050-fullstack-cal"
```

**Merge gate (Arm B):** val_abupt_h300_calibrated < **5.9011%** AND test_abupt_h300_calibrated < **5.7399%**.

### Step 4 — Arm C (conditional α-sweep)

**Only launch if Arm B beats the gate OR is within +5bp of either gate value.** Soup optimum is rarely exactly 50/50 — sample the local neighborhood:
- α = 0.25 (favor seed-2)
- α = 0.75 (favor seed-1)

Each uses identical Arm B eval command with a different averaged checkpoint. Report all three (0.25, 0.5, 0.75) val_cal/test_cal pairs.

### Step 5 — Optional Arm D (EP16⊕EP16) — only if Arm B beats gate

You suggested this in your H310 close: the best-by-val of each seed is EP16 (not EP15) in the H310 commission and EP15 in the seed-1 H244 (best=EP15 was alias `best`). Average the best-by-val checkpoint of each seed instead of EP15⊕EP15. Use seed-1 `model-edward-h244-...:best` and seed-2 `model-thorfinn-h310-...:best` (alias `epoch-16` in your run).

## SENPAI-RESULT structure

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA>","<armB>",...],"primary_metric":{"name":"val_abupt_h307_calibrated_alpha050","value":<number>},"test_metric":{"name":"test_abupt_h307_calibrated_alpha050","value":<number>}}
```

Include a table in the body with raw and calibrated val/test for every arm run.

## Decision logic

- **Merge** if any α produces val_cal < 5.9011 AND test_cal < 5.7399 — pick the α with lowest test_cal as the SOTA candidate
- **Send back** if Arm B is within +10bp on val_cal but misses (suggests averaging direction is right; try α-sweep)
- **Close** with Finding `model-soup-null-on-h244-cohort` if all α produce val_cal > 5.92 (averaging is destructive — two seeds occupy the same basin and averaging only smooths variance without finding a flatter neighborhood)

## Notes

- DDP 8-GPU required (matches H300/H312/H316 cadence)
- `--test-time-calibration` is the H300 flag (eval_tta_h252.py line 510 / `fit_affine_per_channel`)
- z-axis τ_z LOCKED at 1.67 (trained value — do not change)
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 (3 arms × ~150min = ~450min plus overhead)
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json` — never touch
- The soup checkpoint creation is a few-second operation locally; don't upload soup .pt as a W&B artifact unless Arm B/C beats baseline (in which case I'll request artifact upload for downstream reuse)
- Seed-1 artifact: locate via W&B run `0gjfv45i` Files/Artifacts panel — the EP15 alias is `epoch-15` (or `best` if EP15 was best-by-val); copy the full artifact identifier and use `wandb artifact get` to download
- Seed-2 artifact: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/model-thorfinn-h310-h185-ep16-cosine-ext-seed2-m1ddrlcu:epoch-15`

## Why this hypothesis matters

Calibration (H300) showed that 10-param post-hoc affine adds +28bp test improvement on top of a fully-trained model — the model output has structured residual error. Weight-space averaging works at a different level: it changes the model *itself* so the residuals are different (smaller in flat-minimum theory). H307 stacks with H300, not in competition.

If H307 wins by even 5bp on test_cal, the resulting calibrated soup becomes the new SOTA chain endpoint and unblocks H320 (3-seed extension) and H321 (weight-soup × calibration co-fit).
