### PR TITLE
H183: Per-channel surface decoder heads — split shared MLP 4×1

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class SurfaceTransolver(nn.Module):
         use_curvature_attention_bias: bool = False,
         curvature_dim: int = 3,
         surface_out_width_factor: float = 1.0,
+        per_channel_surface_heads: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -356,6 +357,7 @@ class SurfaceTransolver(nn.Module):
         self.use_curvature_attention_bias = use_curvature_attention_bias
         self.curvature_dim = curvature_dim
         self.surface_out_width_factor = float(surface_out_width_factor)
+        self.per_channel_surface_heads = bool(per_channel_surface_heads)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -408,11 +410,29 @@ class SurfaceTransolver(nn.Module):
         # explicitly uses factor=2.0.
         surf_hidden_width = max(1, int(n_hidden * self.surface_out_width_factor))
         self.surface_out_hidden_width = surf_hidden_width
-        self.surface_out = nn.Sequential(
-            nn.Linear(n_hidden, surf_hidden_width),
-            nn.GELU(),
-            nn.Linear(surf_hidden_width, self.surface_output_dim),
-        )
+        if self.per_channel_surface_heads:
+            # H183 (PR #1510): split shared MLP decoder into 4 per-channel heads
+            # (cp, tau_x, tau_y, tau_z). Each head is the same 2-layer MLP
+            # shape as the shared head, but with a 1-dim output. Eliminates
+            # cross-channel capacity bottleneck.
+            self.surface_out = None
+            self.surface_out_heads = nn.ModuleList(
+                [
+                    nn.Sequential(
+                        nn.Linear(n_hidden, surf_hidden_width),
+                        nn.GELU(),
+                        nn.Linear(surf_hidden_width, 1),
+                    )
+                    for _ in range(self.surface_output_dim)
+                ]
+            )
+        else:
+            self.surface_out = nn.Sequential(
+                nn.Linear(n_hidden, surf_hidden_width),
+                nn.GELU(),
+                nn.Linear(surf_hidden_width, self.surface_output_dim),
+            )
+            self.surface_out_heads = None
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -494,7 +514,13 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.surface_out_heads is not None:
+                surface_preds = torch.cat(
+                    [head(surface_hidden) for head in self.surface_out_heads],
+                    dim=-1,
+                ) * surface_mask.unsqueeze(-1)
+            else:
+                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -141,6 +141,7 @@ class Config:
     vol_p_charbonnier_eps: float = 1e-3
     tau_z_loss_weight: float = 1.0
     surface_out_width_factor: float = 1.0
+    per_channel_surface_heads: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -161,6 +162,11 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         "surface_out_width_factor": (
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
+        ),
+        "per_channel_surface_heads": (
+            "H183 (PR #1510): split shared surface MLP decoder into "
+            "4 independent per-channel heads (cp, tau_x, tau_y, tau_z), "
+            "each Linear(h, h*width_factor)->GELU->Linear(.., 1)."
         ),
     }
     choices_text = {
@@ -285,6 +291,7 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
         use_curvature_attention_bias=config.use_curvature_attention_bias,
         surface_out_width_factor=config.surface_out_width_factor,
+        per_channel_surface_heads=config.per_channel_surface_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

The current model routes all 4 surface outputs (cp, τ_x, τ_y, τ_z) through a **single shared MLP decoder**:
```
surface_out: Linear(512, 1024) → GELU → Linear(1024, 4)
```
This forces a single set of weights to simultaneously learn near-zero cp features (already well-fit at ~3.56%) AND high-gradient τ_z wake features (~8.59% in H172, well above 3.63% paper target). These are competing representational demands.

**Hypothesis:** splitting the decoder into 4 independent per-channel MLPs — one for each output (cp, τ_x, τ_y, τ_z) — eliminates this capacity bottleneck and gives τ_y and τ_z their own dedicated nonlinear pathways. Expected gain: −0.1 to −0.3pp test_WSS; primary impact on per-axis τ_y and τ_z.

This architecture change was explicitly flagged as the most natural follow-up in H39 (PR #1284, "widened surface head"), which enlarged the shared head but could not address the multi-target competition. Splitting is the natural next step.

The total parameter increase is modest (~8M extra params in the decoder vs ~0.5M for the shared head), a small fraction of the full Transolver encoder (~100M+).

## Instructions

### Code change — `target/model.py`

Replace the single `self.surface_out` nn.Sequential with `self.surface_out_heads` — an `nn.ModuleList` of 4 independent MLPs.

**Step 1: Locate the current surface_out construction (~line 411):**
```python
surf_hidden_width = max(1, int(n_hidden * self.surface_out_width_factor))
self.surface_out_hidden_width = surf_hidden_width
self.surface_out = nn.Sequential(
    nn.Linear(n_hidden, surf_hidden_width),
    nn.GELU(),
    nn.Linear(surf_hidden_width, self.surface_output_dim),
)
```

**Step 2: Replace with per-channel heads:**
```python
surf_hidden_width = max(1, int(n_hidden * self.surface_out_width_factor))
self.surface_out_hidden_width = surf_hidden_width
# 4 independent heads: one per surface output channel
self.surface_out_heads = nn.ModuleList([
    nn.Sequential(
        nn.Linear(n_hidden, surf_hidden_width),
        nn.GELU(),
        nn.Linear(surf_hidden_width, 1),
    )
    for _ in range(self.surface_output_dim)
])
# Keep surface_out as None or alias for compatibility:
self.surface_out = None
```

**Step 3: Update the forward pass (~line 497):**

Find this line:
```python
surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
```

Replace with:
```python
surface_preds = torch.cat(
    [head(surface_hidden) for head in self.surface_out_heads], dim=-1
) * surface_mask.unsqueeze(-1)
```

**Step 4: Add `--per-channel-surface-heads` flag to `train.py`** (Config class + forward to `Transolver`):

In `Config`:
```python
per_channel_surface_heads: bool = False
```

Pass through to model instantiation as `per_channel_surface_heads=config.per_channel_surface_heads`. In `model.py` constructor, wrap the split with `if per_channel_surface_heads:` else use the existing `nn.Sequential`. This keeps the run backward compatible.

### Smoke run (run this FIRST before the 30-EP primary)

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 1 --epochs 1 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --per-channel-surface-heads \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-tanjiro \
  --wandb-group h183-per-channel-decoder-heads \
  --wandb-name dl24-tanjiro/h183-smoke-ep1
```

**Smoke EP1 gates (compare to H147 EP1 references below):**
- `val_WSS ≤ 13.5%` (H147 EP1 = 12.815%)
- `val_VP < 15.0%` (H147 EP1 = 14.118%)
- `train_loss` finite, no `grad_nonfinite > 0`

If smoke passes, launch the 30-EP primary (change `--lr-cosine-t-max 1 --epochs 1` to `--lr-cosine-t-max 30 --epochs 30`, keep all else identical).

### Primary run (30-EP DDP8 after smoke clears)

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 30 --epochs 30 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --per-channel-surface-heads \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-tanjiro \
  --wandb-group h183-per-channel-decoder-heads \
  --wandb-name dl24-tanjiro/h183-main-30ep
```

### Kill ladder (primary run)

| EP | Kill if val_WSS > | Kill if val_VP > | Kill if val_SP > |
|---:|---:|---:|---:|
| EP2 | 7.60 | 5.20 | 4.40 |
| EP5 | 7.10 | 4.00 | 4.20 |
| EP10 | 6.80 | 3.70 | 4.00 |
| EP15 | 6.65 | 3.65 | 3.90 |
| EP20 | 6.60 | 3.65 | 3.65 |
| EP25 | 6.57 | 3.64 | 3.63 |
| EP30 | terminal | — | — |

**Hard kill criteria (any EP, any time):**
- `train/grad/nonfinite_count > 0` → kill immediately
- val_WSS > H147 same-EP val_WSS by >0.20pp for 2+ consecutive EPs → kill
- val_VP > 4.50 at EP5+ → kill (structural starvation, same as H173/H178 pattern)

### Heartbeat protocol

Post boundary reads at EP2, EP5, EP10, EP15, EP20, EP25, EP30 with:
- `val_primary/wall_shear_rel_l2_pct`, `val_primary/volume_pressure_rel_l2_pct`
- `val_primary/surface_pressure_rel_l2_pct`, `val_primary/abupt_axis_mean_rel_l2_pct`
- `val_raw_primary/wall_shear_x_rel_l2_pct`, `val_raw_primary/wall_shear_y_rel_l2_pct`, `val_raw_primary/wall_shear_z_rel_l2_pct`

The per-axis τ_x/τ_y/τ_z breakdown is especially important here — the hypothesis makes a specific prediction that τ_y and τ_z improve relative to H147.

## Baseline (H147 SOTA — PR #1344, run `k6q4c3on`)

### Test metrics (current best to beat)

| Metric | H147 SOTA | Hard floor | Target |
|---|---:|---:|---:|
| `test_primary/wall_shear_rel_l2_pct` | **6.5409** | — | **< 6.5409** |
| `test_primary/surface_pressure_rel_l2_pct` | 3.5634 | **≤ 3.577** | must not regress |
| `test_primary/volume_pressure_rel_l2_pct` | 3.4014 | **≤ 3.643** | must not regress |
| `test_primary/abupt_axis_mean_rel_l2_pct` | 5.6648 | **≤ 5.844** | must not regress |
| `test_primary/wall_shear_x_rel_l2_pct` | — | — | track |
| `test_primary/wall_shear_y_rel_l2_pct` | — | **≤ 3.65** (paper) | track |
| `test_primary/wall_shear_z_rel_l2_pct` | — | **≤ 3.63** (paper) | track |

### H147 val trajectory (use for kill-ladder comparisons)

| EP | val_WSS | val_VP | val_SP | val_ABU |
|---:|---:|---:|---:|---:|
| 1 | 12.815 | 14.118 | 8.901 | 13.046 |
| 2 | 7.259 | 4.907 | 4.252 | 6.676 |
| 5 | 6.756 | 3.730 | 3.949 | 5.979 |
| 10 | 6.650 | 3.559 | 3.865 | 5.903 |
| 15 | 6.547 | 3.440 | 3.826 | 5.829 |
| 20 | 6.545 | 3.414 | 3.808 | 5.792 |
| 30 (terminal) | 6.545 | 3.409 | 3.808 | 5.792 |

### H147 reproduce command

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 30 --epochs 30 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-tanjiro
```

H183 adds exactly one flag: `--per-channel-surface-heads`.

## Terminal result format

When the run completes (or is killed), post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<value>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<value>}}
```
