### PR TITLE
H329: Abupt-weighted (per-car relative L2) calibration objective

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -95,6 +95,15 @@ class EvalConfig:
     # and calibrated rel_l2-family metrics; MAE is not analytically expressible
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
+    # H329: per-car abupt-weighted OLS. Weights each car's contribution by
+    # w_c = 1/||t_c||^2 (per channel), so the fit objective aligns with the
+    # eval metric (mean over cars of per-car relative L2) rather than uniform
+    # pointwise L2. With uniform weights this reduces to the H300/H312 fit.
+    # Only meaningful when test_time_calibration is also set. When this flag
+    # is set, both unweighted (H300/H312) and weighted (H329) (alpha,beta)
+    # are logged for comparison; the weighted coefficients are applied to
+    # test predictions before computing the final calibrated metrics.
+    abupt_weighted_calibration: bool = False
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -557,6 +566,63 @@ def fit_affine_per_channel(
     alpha_raw = cov_pt / var_p.clamp(min=1e-12)
     alpha = torch.where(degenerate, torch.ones_like(alpha_raw), alpha_raw)
     beta = torch.where(degenerate, torch.zeros_like(alpha_raw), mu_t - alpha * mu_p)
+    return alpha, beta
+
+
+def fit_affine_per_channel_weighted(
+    per_case_stats: dict[str, torch.Tensor],
+    weight_mode: str = "abupt",
+    eps: float = 1e-12,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """H329 weighted-OLS alpha, beta per channel from per-case sufficient stats.
+
+    Each car c contributes weight w_c per channel; current weight modes:
+
+    - ``abupt``: w_c = 1.0 / max(sum_tt_c, eps). Minimizing the weighted-OLS
+      objective Σ_cars w_c · Σ_pts (α·p + β − t)^2 then approximates the
+      abupt-axis-mean-rel-L2 objective Σ_cars ||α·p + β − t||² / ||t||².
+    - ``uniform``: w_c = 1.0 (exact reproduction of unweighted OLS — used as
+      an invariant check in the smoke test).
+
+    Weighted normal equations per channel (2x2):
+        [A11 A12] [α]   [b1]
+        [A12 A22] [β] = [b2]
+    with A11 = Σ w_c·sum_pp_c, A12 = Σ w_c·sum_p_c, A22 = Σ w_c·N_c,
+    b1 = Σ w_c·sum_pt_c, b2 = Σ w_c·sum_t_c.
+
+    Falls back to identity (α=1, β=0) on degenerate channels (det ≤ eps).
+    """
+    if not per_case_stats:
+        raise RuntimeError("per_case_stats is empty; cannot fit weighted affine")
+    cases = sorted(per_case_stats.keys())
+    stack = torch.stack([per_case_stats[c] for c in cases], dim=0)  # (n_cases, n_ch, 6)
+    n_per_case = stack[..., 0]      # (n_cases, n_ch)
+    sum_p = stack[..., 1]
+    sum_t = stack[..., 2]
+    sum_pp = stack[..., 3]
+    sum_tt = stack[..., 4]
+    sum_pt = stack[..., 5]
+
+    if weight_mode == "abupt":
+        w = 1.0 / sum_tt.clamp(min=eps)  # (n_cases, n_ch)
+    elif weight_mode == "uniform":
+        w = torch.ones_like(sum_tt)
+    else:
+        raise ValueError(f"Unknown weight_mode {weight_mode!r}")
+
+    A11 = (w * sum_pp).sum(dim=0)
+    A12 = (w * sum_p).sum(dim=0)
+    A22 = (w * n_per_case).sum(dim=0)
+    b1 = (w * sum_pt).sum(dim=0)
+    b2 = (w * sum_t).sum(dim=0)
+
+    det = A11 * A22 - A12 * A12
+    degenerate = det.abs() <= eps
+    det_safe = torch.where(degenerate, torch.ones_like(det), det)
+    alpha_raw = (A22 * b1 - A12 * b2) / det_safe
+    beta_raw = (A11 * b2 - A12 * b1) / det_safe
+    alpha = torch.where(degenerate, torch.ones_like(alpha_raw), alpha_raw)
+    beta = torch.where(degenerate, torch.zeros_like(beta_raw), beta_raw)
     return alpha, beta
 
 
@@ -1066,22 +1132,95 @@ def main(argv: Iterable[str] | None = None) -> None:
                     flush=True,
                 )
                 continue
-            alpha_surf, beta_surf = fit_affine_per_channel(val_cal.surf_global)
-            alpha_vol, beta_vol = fit_affine_per_channel(val_cal.vol_global)
+            alpha_surf_u, beta_surf_u = fit_affine_per_channel(val_cal.surf_global)
+            alpha_vol_u, beta_vol_u = fit_affine_per_channel(val_cal.vol_global)
 
             channel_names = ["cp", "tau_x", "tau_y", "tau_z"]
             print(f"\n=== H300 calibration (fit on val, mode={mode}) ===", flush=True)
             for c, name in enumerate(channel_names):
                 print(
-                    f"  surface[{name:6s}]  alpha={alpha_surf[c].item():+.6f} "
-                    f"beta={beta_surf[c].item():+.6f}",
+                    f"  surface[{name:6s}]  alpha={alpha_surf_u[c].item():+.6f} "
+                    f"beta={beta_surf_u[c].item():+.6f}",
                     flush=True,
                 )
             print(
-                f"  volume[volume_pressure]  alpha={alpha_vol[0].item():+.6f} "
-                f"beta={beta_vol[0].item():+.6f}",
+                f"  volume[volume_pressure]  alpha={alpha_vol_u[0].item():+.6f} "
+                f"beta={beta_vol_u[0].item():+.6f}",
                 flush=True,
             )
+
+            # H329 abupt-weighted fit and uniform-weight invariant check.
+            alpha_surf_w = beta_surf_w = alpha_vol_w = beta_vol_w = None
+            if cfg.abupt_weighted_calibration:
+                # Invariant: with uniform weights, weighted fit == unweighted.
+                a_chk_s, b_chk_s = fit_affine_per_channel_weighted(
+                    val_cal.surf_per_case, weight_mode="uniform"
+                )
+                a_chk_v, b_chk_v = fit_affine_per_channel_weighted(
+                    val_cal.vol_per_case, weight_mode="uniform"
+                )
+                surf_atol = float((a_chk_s - alpha_surf_u).abs().max().item())
+                surf_btol = float((b_chk_s - beta_surf_u).abs().max().item())
+                vol_atol = float((a_chk_v - alpha_vol_u).abs().max().item())
+                vol_btol = float((b_chk_v - beta_vol_u).abs().max().item())
+                tol = 1e-6
+                assert surf_atol < tol and surf_btol < tol, (
+                    f"H329 invariant failed (surface): "
+                    f"alpha_max_abs_diff={surf_atol:.3e}, beta_max_abs_diff={surf_btol:.3e}"
+                )
+                assert vol_atol < tol and vol_btol < tol, (
+                    f"H329 invariant failed (volume): "
+                    f"alpha_max_abs_diff={vol_atol:.3e}, beta_max_abs_diff={vol_btol:.3e}"
+                )
+                print(
+                    f"  [H329 invariant] uniform-weight fit matches unweighted "
+                    f"(surf max_abs Δα={surf_atol:.2e}, Δβ={surf_btol:.2e}; "
+                    f"vol max_abs Δα={vol_atol:.2e}, Δβ={vol_btol:.2e})",
+                    flush=True,
+                )
+
+                alpha_surf_w, beta_surf_w = fit_affine_per_channel_weighted(
+                    val_cal.surf_per_case, weight_mode="abupt"
+                )
+                alpha_vol_w, beta_vol_w = fit_affine_per_channel_weighted(
+                    val_cal.vol_per_case, weight_mode="abupt"
+                )
+                print(
+                    f"\n=== H329 abupt-weighted calibration (fit on val, mode={mode}) ===",
+                    flush=True,
+                )
+                for c, name in enumerate(channel_names):
+                    d_alpha = alpha_surf_w[c].item() - alpha_surf_u[c].item()
+                    d_beta = beta_surf_w[c].item() - beta_surf_u[c].item()
+                    print(
+                        f"  surface[{name:6s}]  alpha={alpha_surf_w[c].item():+.6f} "
+                        f"beta={beta_surf_w[c].item():+.6f}  "
+                        f"(Δalpha={d_alpha:+.6f} Δbeta={d_beta:+.6f})",
+                        flush=True,
+                    )
+                d_alpha_v = alpha_vol_w[0].item() - alpha_vol_u[0].item()
+                d_beta_v = beta_vol_w[0].item() - beta_vol_u[0].item()
+                print(
+                    f"  volume[volume_pressure]  alpha={alpha_vol_w[0].item():+.6f} "
+                    f"beta={beta_vol_w[0].item():+.6f}  "
+                    f"(Δalpha={d_alpha_v:+.6f} Δbeta={d_beta_v:+.6f})",
+                    flush=True,
+                )
+
+            # Choose which (alpha,beta) drives the calibrated metrics that get
+            # logged as the experiment's primary outcome.
+            if cfg.abupt_weighted_calibration:
+                alpha_surf = alpha_surf_w
+                beta_surf = beta_surf_w
+                alpha_vol = alpha_vol_w
+                beta_vol = beta_vol_w
+                fit_label = "h329_abupt_weighted"
+            else:
+                alpha_surf = alpha_surf_u
+                beta_surf = beta_surf_u
+                alpha_vol = alpha_vol_u
+                beta_vol = beta_vol_u
+                fit_label = "h300_unweighted"
 
             val_cal_metrics = compute_calibrated_metrics(
                 val_cal, alpha_surf, beta_surf, alpha_vol, beta_vol
@@ -1092,24 +1231,61 @@ def main(argv: Iterable[str] | None = None) -> None:
             cal_metrics_by_split_mode.setdefault("val_surface", {})[mode] = val_cal_metrics
             cal_metrics_by_split_mode.setdefault("test_surface", {})[mode] = test_cal_metrics
 
+            # Also compute unweighted metrics for side-by-side logging when in
+            # H329 mode, so the comparison vs H312 baseline is auditable.
+            val_cal_metrics_u = None
+            test_cal_metrics_u = None
+            if cfg.abupt_weighted_calibration:
+                val_cal_metrics_u = compute_calibrated_metrics(
+                    val_cal, alpha_surf_u, beta_surf_u, alpha_vol_u, beta_vol_u
+                )
+                test_cal_metrics_u = compute_calibrated_metrics(
+                    test_cal, alpha_surf_u, beta_surf_u, alpha_vol_u, beta_vol_u
+                )
+
             print(
-                f"  val  (raw -> cal)  abupt {summary['val_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
+                f"  val  (raw -> cal[{fit_label}])  abupt "
+                f"{summary['val_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
                 f"-> {val_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
                 flush=True,
             )
             print(
-                f"  test (raw -> cal)  abupt {summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
+                f"  test (raw -> cal[{fit_label}])  abupt "
+                f"{summary['test_surface'][mode]['abupt_axis_mean_rel_l2_pct']:.4f} "
                 f"-> {test_cal_metrics['abupt_axis_mean_rel_l2_pct']:.4f}",
                 flush=True,
             )
+            if cfg.abupt_weighted_calibration:
+                val_u = val_cal_metrics_u["abupt_axis_mean_rel_l2_pct"]
+                val_w = val_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                test_u = test_cal_metrics_u["abupt_axis_mean_rel_l2_pct"]
+                test_w = test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                print(
+                    f"  val  cal[h300_unweighted]  abupt {val_u:.4f}  "
+                    f"(weighted Δ {val_w - val_u:+.4f})",
+                    flush=True,
+                )
+                print(
+                    f"  test cal[h300_unweighted]  abupt {test_u:.4f}  "
+                    f"(weighted Δ {test_w - test_u:+.4f})",
+                    flush=True,
+                )
 
             if run is not None:
                 # Log alpha/beta to W&B summary so they appear on the run page.
+                # The unweighted coefficients keep their historical key names
+                # (calibration/...) for backward compatibility with H300/H312.
                 for c, name in enumerate(channel_names):
-                    run.summary[f"calibration/{mode}/alpha_{name}"] = float(alpha_surf[c].item())
-                    run.summary[f"calibration/{mode}/beta_{name}"] = float(beta_surf[c].item())
-                run.summary[f"calibration/{mode}/alpha_volume_pressure"] = float(alpha_vol[0].item())
-                run.summary[f"calibration/{mode}/beta_volume_pressure"] = float(beta_vol[0].item())
+                    run.summary[f"calibration/{mode}/alpha_{name}"] = float(alpha_surf_u[c].item())
+                    run.summary[f"calibration/{mode}/beta_{name}"] = float(beta_surf_u[c].item())
+                run.summary[f"calibration/{mode}/alpha_volume_pressure"] = float(alpha_vol_u[0].item())
+                run.summary[f"calibration/{mode}/beta_volume_pressure"] = float(beta_vol_u[0].item())
+                if cfg.abupt_weighted_calibration:
+                    for c, name in enumerate(channel_names):
+                        run.summary[f"calibration_h329/{mode}/alpha_{name}"] = float(alpha_surf_w[c].item())
+                        run.summary[f"calibration_h329/{mode}/beta_{name}"] = float(beta_surf_w[c].item())
+                    run.summary[f"calibration_h329/{mode}/alpha_volume_pressure"] = float(alpha_vol_w[0].item())
+                    run.summary[f"calibration_h329/{mode}/beta_volume_pressure"] = float(beta_vol_w[0].item())
 
                 # Log calibrated primary metrics to W&B history (and as
                 # split-level summary keys for downstream parsing).
@@ -1124,6 +1300,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 wandb.log({**val_log, **test_log})
 
                 # Single-line paper-facing primary metrics (no mode suffix).
+                # H300/H312 keys reflect the selected fit's metrics (so existing
+                # downstream queries pick up the H329 numbers when active).
                 run.summary["val_abupt_h300_calibrated"] = float(
                     val_cal_metrics["abupt_axis_mean_rel_l2_pct"]
                 )
@@ -1136,6 +1314,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                 run.summary["test_abupt_h300_raw"] = float(
                     summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
                 )
+                if cfg.abupt_weighted_calibration:
+                    # H329-specific summary keys (primary outcome for this PR).
+                    run.summary["val_abupt_h329_calibrated"] = float(
+                        val_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                    )
+                    run.summary["test_abupt_h329_calibrated"] = float(
+                        test_cal_metrics["abupt_axis_mean_rel_l2_pct"]
+                    )
+                    # Also log the unweighted baseline computed on the same
+                    # run's per-case stats for an apples-to-apples comparison.
+                    run.summary["val_abupt_h329_unweighted_for_compare"] = float(
+                        val_cal_metrics_u["abupt_axis_mean_rel_l2_pct"]
+                    )
+                    run.summary["test_abupt_h329_unweighted_for_compare"] = float(
+                        test_cal_metrics_u["abupt_axis_mean_rel_l2_pct"]
+                    )
 
     if state.is_main and summary:
         print("\n=== Summary (rel_l2_pct lower-is-better) ===")


### PR DESCRIPTION
## Hypothesis

Your H316 ablation produced the cleanest mechanistic finding of the whole calibration arc: **scale (α) does 81% of the work; bias (β) is inert for test_abupt**. The huge β_VP = -0.89 is just the OLS intercept of α≠1, not an independent bias correction.

H329 attacks a different misalignment in the H300/H312 recipe: **the objective the OLS fit minimizes is not the metric we care about**.

Current: H300/H312 fits per-channel `min Σ_pts Σ_cars (α·p - t)²` — uniform pointwise L2.

Eval metric: `abupt_axis_mean_rel_l2 = mean_over_cars sqrt( Σ_pts (α·p - t)² / Σ_pts t² )` — **per-car relative L2** averaged across cars.

The mismatch: uniform L2 over-weights cars with large prediction magnitudes (large `||t||`) at the expense of cars with small magnitudes. Cars with the largest tau-z norms dominate the OLS fit but each car contributes equally to the abupt metric.

**H329 fix**: Weight each car's OLS contribution by `1/||t_c||²` (or equivalently, `1/||t_c||` per residual). The weighted normal equations:

```
α_c = Σ_cars w_c · sum_pp_c   /   Σ_cars w_c · sum_pt_c
where w_c = 1 / (Σ_pts_in_car t_c²)
```

This directly minimizes the abupt-style objective: `min Σ_cars (1/||t_c||²) · Σ_pts (α·p - t)²` ≈ `min Σ_cars (||α·p - t||² / ||t||²)`.

**Predicted outcome**: 1–3bp gain on test_cal, primarily on cars where the unweighted OLS was previously favoring high-magnitude cars at the expense of mid-magnitude cars.

**Win criterion**: val_cal < **5.8994%** AND test_cal < **5.7388%** (H312 gates).

**Why this is the right next step for you**:
- Your H316 finding showed where the calibration win actually comes from (α scaling). The natural next question is: **can we estimate α better?**
- Abupt-weighted OLS directly aligns the fit objective with the eval metric, which textbook regression theory says minimizes the right thing.
- This is the cheapest possible win on the calibration axis (zero new architecture, zero new TTA, just a weighting change).

## Baseline (CURRENT SOTA — H312 PR #1498 merged)

| Metric | H312 (CURRENT SOTA) | H316 full arm (your run) |
|---|---:|---:|
| val_abupt_calibrated | **5.8994%** (gate) | 5.9069% (fails gate, K=4 reroll variance) |
| test_abupt_calibrated | **5.7388%** (gate) | 5.7420% (fails gate by +3.2bp) |
| test_WSS | 6.6391% | 6.6431% |
| test_VP | 3.3743% | 3.3767% |
| test_SP | 3.6137% | 3.6143% |
| H312 cal coefficients | α ∈ [0.9917, 0.9997]; β_VP=-0.8328 | — |

W&B reference run: `enf61qrr` (H312 SOTA), `yg4sbrtw` (your H316).

Paper floors (don't degrade): test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS target < 5.85.

## Instructions

This is a **code extension + eval experiment**. You'll extend the calibration fit in `eval_tta_h252.py` to support per-car-weighted OLS, then run the same K=4+8-res+mirror TTA stack as H312/H316.

### Step 1 — Extend the affine cal fit to support per-car weighting

The existing fit accumulates sufficient stats per (car, channel): `sum_pp_c`, `sum_pt_c`, `sum_p_c`, `sum_t_c`, `n_c`. For per-car weighted OLS, also accumulate `sum_tt_c = Σ_pts_in_car t²` per (car, channel). Then the weighted fit is:

```python
# w_car_c = 1.0 / max(sum_tt_per_car_c, eps)
# Weighted normal equations:
#   Σ_cars w_c · [sum_pp_c   sum_p_c]   [α]     Σ_cars w_c · [sum_pt_c]
#   Σ_cars w_c · [sum_p_c    n_c    ] · [β]  =  Σ_cars w_c · [sum_t_c ]

W = np.array([w_c for w_c in w_cars])
A11 = (W * sum_pp_per_car).sum()
A12 = (W * sum_p_per_car).sum()
A22 = (W * n_per_car).sum()
b1 = (W * sum_pt_per_car).sum()
b2 = (W * sum_t_per_car).sum()
# Solve 2x2 system
det = A11*A22 - A12*A12
alpha = (A22*b1 - A12*b2) / det
beta  = (A11*b2 - A12*b1) / det
```

New CLI flag: `--abupt-weighted-calibration` (boolean). When set, uses per-car weighted OLS. Otherwise falls back to H300/H312 unweighted OLS.

**Validation invariant in smoke test**: When `weights = 1.0` for all cars (uniform), the abupt-weighted result must reproduce H300/H312 unweighted OLS exactly (within float precision). Add an assertion check.

### Step 2 — Smoke test (~5 min, 2 val + 2 test cases)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,65536" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 2 --antithetic-noise \
  --test-time-calibration --abupt-weighted-calibration \
  --batch-size 2 --num-workers 4 \
  --agent alphonse --wandb-group "h329-alphonse-debug"
```

**Post the (α, β) per channel for both unweighted and weighted modes** — these should differ slightly (weighted should pull α_c toward fitting smaller-||t|| cars better).

### Step 3 — Primary run (identical TTA stack as H312/H316)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --test-time-calibration --abupt-weighted-calibration \
  --batch-size 2 --num-workers 4 \
  --agent alphonse \
  --wandb-group "h329-alphonse-abupt-weighted-cal" \
  --wandb-name "alphonse/h329-K4-8res-mirror-abupt-weighted-cal"
```

ETA: same as H316/H312 (~5.5-7h).

### Step 4 — Report the per-channel (α_w, β_w) and metrics

Post a comparison table:

| Channel | α (unweighted, from H312) | α (abupt-weighted, H329) | β (unweighted) | β (abupt-weighted) |
|---|---:|---:|---:|---:|
| cp | 0.9994 | ? | -0.0033 | ? |
| tau_x | 0.9970 | ? | -0.0166 | ? |
| tau_y | 0.9945 | ? | -0.0007 | ? |
| tau_z | 0.9917 | ? | -0.0001 | ? |
| volume_pressure | 0.9994 | ? | -0.8328 | ? |

Plus val/test calibrated metrics + comparison to H312 baseline.

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<primary>"],"primary_metric":{"name":"val_abupt_h329_calibrated","value":<number>},"test_metric":{"name":"test_abupt_h329_calibrated","value":<number>}}
```

Include in the comment:
- Per-channel (α, β) comparison table (unweighted vs weighted)
- val/test cal metrics with per-channel breakdown
- The change in fit residuals: which cars are now contributing more vs less to the fit

## Decision logic

- **Merge** if val_cal < 5.8994 AND test_cal < 5.7388
- **Send back for ridge variant** if val improves but test regresses (suggests the re-weighting still overfits — try ridge on top, with shrinkage toward unweighted H312 fit)
- **Close** with Finding `abupt-weighting-irrelevant-at-this-scale` if val/test cal match H312 within ±1bp (the per-car ||t|| variation is uniform enough that weighted ≡ unweighted at the population level)

## Notes

- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- This is **a different axis** from the in-flight H319 (fern, per-resolution cal) and H328 (askeladd, ridge regional cal). H329 modifies the **fit objective**; the others modify the **fit structure** (parameter sharing). All three can compose if they all win independently.
- If you've already saved the per-car sufficient stats from yg4sbrtw (your H316 run), you can re-fit offline in seconds without re-running TTA. Worth trying as Arm 0 before launching the full 7h pass.

## Why this matters

The H316 finding tells us α is the win — but the H312 α coefficients (0.9917–0.9997) might be biased by the OLS objective itself, since OLS treats per-pt error uniformly while abupt-axis-mean averages per-car relative L2. If we re-fit α with the right objective:
- For high-magnitude cars (large ||t_z||), the weight w_c = 1/||t_c||² is smaller → less influence on α_τz
- For small-magnitude cars, more influence
- Net effect on α_τz: depends on whether the systematic bias differs by magnitude

If the data has heteroscedastic residuals (variance ∝ ||t||), the abupt-weighted estimate is the maximum-likelihood α under the abupt metric assumption — strictly better. If residuals are homoscedastic, the two estimates converge.

Either outcome is informative. A win cleanly extends the calibration arc. A null tells us the predictions are homoscedastic relative to magnitude — useful structural information about the model's failure modes.
