### PR TITLE
H184: WSD LR schedule (warmup-stable-decay) — replace cosine for deeper-minimum tail

### DIFF
--- a/train.py
+++ b/train.py
@@ -113,6 +113,9 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
+    lr_schedule: str = "cosine"
+    lr_wsd_stable_epochs: int = 0
+    lr_wsd_decay_epochs: int = 0
     grad_clip_norm: float = 1.0
     gradient_log_every: int = 250
     log_gradient_histograms: bool = False
@@ -162,9 +165,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
         ),
+        "lr_schedule": (
+            "LR schedule shape. 'cosine' (default, H147) = warmup -> cosine decay. "
+            "'wsd' = Warmup-Stable-Decay (Hu et al. 2024 MiniCPM, Hagele et al. 2024): "
+            "warmup -> constant peak LR for lr_wsd_stable_epochs -> cosine decay for "
+            "lr_wsd_decay_epochs. Requires warmup + stable + decay == epochs."
+        ),
+        "lr_wsd_stable_epochs": (
+            "WSD: number of epochs at peak LR after warmup. Only used when lr_schedule=wsd."
+        ),
+        "lr_wsd_decay_epochs": (
+            "WSD: number of epochs in the final cosine decay tail. Only used when lr_schedule=wsd."
+        ),
     }
     choices_text = {
         "wss_charbonnier_axes": ["all", "z"],
+        "lr_schedule": ["cosine", "wsd"],
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1414,6 +1414,9 @@ def build_lr_scheduler(
     config,
     max_epochs: int,
 ) -> torch.optim.lr_scheduler.LRScheduler:
+    schedule = getattr(config, "lr_schedule", "cosine")
+    if schedule == "wsd":
+        return _build_wsd_scheduler(optimizer, config, max_epochs)
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer,
@@ -1432,6 +1435,55 @@ def build_lr_scheduler(
         optimizer,
         schedulers=[warmup_scheduler, cosine_scheduler],
         milestones=[config.lr_warmup_epochs],
+    )
+
+
+def _build_wsd_scheduler(
+    optimizer: torch.optim.Optimizer,
+    config,
+    max_epochs: int,
+) -> torch.optim.lr_scheduler.LRScheduler:
+    warmup_epochs = max(0, int(config.lr_warmup_epochs))
+    stable_epochs = int(getattr(config, "lr_wsd_stable_epochs", 0))
+    decay_epochs = int(getattr(config, "lr_wsd_decay_epochs", 0))
+    if stable_epochs <= 0 or decay_epochs <= 0:
+        raise ValueError(
+            "lr_schedule=wsd requires lr_wsd_stable_epochs>0 and "
+            f"lr_wsd_decay_epochs>0 (got stable={stable_epochs}, decay={decay_epochs})."
+        )
+    total = warmup_epochs + stable_epochs + decay_epochs
+    if total != max_epochs:
+        raise ValueError(
+            "lr_schedule=wsd requires lr_warmup_epochs + lr_wsd_stable_epochs + "
+            f"lr_wsd_decay_epochs == epochs; got {warmup_epochs}+{stable_epochs}+"
+            f"{decay_epochs}={total} vs epochs={max_epochs}."
+        )
+    stable_scheduler = torch.optim.lr_scheduler.ConstantLR(
+        optimizer,
+        factor=1.0,
+        total_iters=stable_epochs,
+    )
+    decay_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer,
+        T_max=max(1, decay_epochs),
+        eta_min=config.lr_min,
+    )
+    if warmup_epochs <= 0:
+        return torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[stable_scheduler, decay_scheduler],
+            milestones=[stable_epochs],
+        )
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+        optimizer,
+        start_factor=0.05,
+        end_factor=1.0,
+        total_iters=warmup_epochs,
+    )
+    return torch.optim.lr_scheduler.SequentialLR(
+        optimizer,
+        schedulers=[warmup_scheduler, stable_scheduler, decay_scheduler],
+        milestones=[warmup_epochs, warmup_epochs + stable_epochs],
     )
 
 


### PR DESCRIPTION
## Hypothesis (H-W5-1 — WSD LR Schedule)

H147 SOTA uses a 30-EP **cosine** LR decay schedule starting from peak lr=1e-4 with 1 EP warmup. The cosine curve spends most of training in a low-LR tail — after EP10 the effective LR is < 50% peak, and after EP20 it is < 10% peak. The recent fleet (H172 EMA-0.9999, H178 16-EP slow cosine, H173 8-EP, H180 α=1.0) has consistently shown the same plateau structure: a strong descent through EP5-EP10 followed by a near-flat tail.

**Warmup-Stable-Decay (WSD)** schedules — popularized by Chinchilla follow-up work (Hu et al. 2024 "MiniCPM", Hägele et al. 2024 "Scaling Laws and Compute-Optimal Training Beyond Fixed Training Durations") — keep the LR at **peak** for the bulk of training and only decay over the final 20-25% of steps. The intuition: at fixed compute, more steps at peak LR explore the loss surface more aggressively, then a sharper final decay locks in a deeper minimum.

For our 30-EP H147 stack, WSD reorders the LR budget as:
- **Warmup** EP0→EP1 (linear, 0.05× → 1.0× peak) — unchanged from H147
- **Stable** EP1→EP22 (21 epochs at peak lr=1e-4) — replaces cosine's slow descent
- **Decay** EP22→EP30 (8-EP cosine decay from peak to lr_min) — concentrated decay tail

This is **not** a sweep — single arm targeted at the WSD-vs-cosine question at 30-EP budget. If WSD wins on test_WSS without breaching floors, we open a Wave-5 sub-direction on stable/decay split ratios.

## Code changes

You need to extend the LR scheduler in `target/trainer_runtime.py` and add config flags in `target/train.py`.

### 1. Add config flags in `target/train.py` (around line 114, near `lr_cosine_t_max`):

```python
lr_schedule: str = "cosine"  # "cosine" (default, H147) | "wsd"
lr_wsd_stable_epochs: int = 0  # # of EPs at peak LR; 0 = error if lr_schedule=wsd
lr_wsd_decay_epochs: int = 0   # # of EPs in cosine decay tail; 0 = error if lr_schedule=wsd
```

Add CLI parser entries with `argparse` flags `--lr-schedule`, `--lr-wsd-stable-epochs`, `--lr-wsd-decay-epochs`. Default to existing behavior (cosine) when not specified.

### 2. Modify `build_lr_scheduler` in `target/trainer_runtime.py` (lines 1412-1435):

Branch on `config.lr_schedule`:
- If `"cosine"` (default): current code path unchanged.
- If `"wsd"`: build a 3-stage SequentialLR:
  - Stage 1 (warmup): `LinearLR(optimizer, start_factor=0.05, end_factor=1.0, total_iters=warmup_epochs)`
  - Stage 2 (stable): `ConstantLR(optimizer, factor=1.0, total_iters=lr_wsd_stable_epochs)` — peak LR plateau
  - Stage 3 (decay): `CosineAnnealingLR(optimizer, T_max=lr_wsd_decay_epochs, eta_min=config.lr_min)` — final tail
  
  Milestones for SequentialLR: `[warmup_epochs, warmup_epochs + lr_wsd_stable_epochs]`.

Validate `warmup_epochs + stable_epochs + decay_epochs == max_epochs` and raise if mismatch.

### 3. Verify in smoke (smoke command below)

Print LR per epoch from rank0 in the first 3 EPs to confirm:
- EP0: ramps 0.05e-4 → 1e-4 (warmup)
- EP1: 1e-4 (stable plateau begins)
- EP2: 1e-4 (still stable)

W&B should log `train/lr` per step. After smoke, post the EP0/EP1/EP2 LR snapshots in the smoke comment so I can verify the schedule shape before launching the 30-EP primary.

## Smoke command (3 EP, no time pressure)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=45 torchrun --nproc_per_node=8 train.py \
  --hidden-dim 512 --layers 6 --heads 4 --slices 128 \
  --surface-out-width-factor 2.0 \
  --pe-type string_multisigma \
  --optimizer lion --lion-beta1 0.95 --lion-beta2 0.98 \
  --ema-decay 0.999 --ema-start-step 500 \
  --lr 1e-4 --lr-warmup-epochs 1 \
  --lr-schedule wsd --lr-wsd-stable-epochs 1 --lr-wsd-decay-epochs 1 \
  --epochs 3 --batch-size 1 \
  --use-curvature-attention-bias --use-y-symmetry-aug \
  --vol-p-charbonnier --wss-charbonnier-axes z \
  --wandb-group h184-wsd-lr-schedule \
  --wandb-name dl24-fern/h184-smoke-3ep
```

Confirm in smoke:
- LR per EP matches WSD shape (warmup → flat → decay)
- val_WSS at EP1/EP2 is in the expected range (since the smoke schedule is degenerate-tight, the val values themselves are NOT meaningful — just verifying mechanism)
- No NaN/divergence

## Primary command (30 EP, H147 stack + WSD)

```bash
cd target/ && SENPAI_TIMEOUT_MINUTES=1440 torchrun --nproc_per_node=8 train.py \
  --hidden-dim 512 --layers 6 --heads 4 --slices 128 \
  --surface-out-width-factor 2.0 \
  --pe-type string_multisigma \
  --optimizer lion --lion-beta1 0.95 --lion-beta2 0.98 \
  --ema-decay 0.999 --ema-start-step 500 \
  --lr 1e-4 --lr-warmup-epochs 1 \
  --lr-schedule wsd --lr-wsd-stable-epochs 21 --lr-wsd-decay-epochs 8 \
  --epochs 30 --batch-size 1 \
  --use-curvature-attention-bias --use-y-symmetry-aug \
  --vol-p-charbonnier --wss-charbonnier-axes z \
  --wandb-group h184-wsd-lr-schedule \
  --wandb-name dl24-fern/h184-main-30ep
```

`30 EP × ~5400 steps/EP × ~0.15s/step ≈ 13.5h` — well within 24h limit.

## Kill ladder vs H147 (lower=worse means kill)

H147 SOTA EP-boundary val_WSS trajectory (from `k6q4c3on`):

| EP | val_WSS | kill threshold (≤) |
|---:|---:|---:|
| 1 | 12.82 | 13.30 |
| 2 | 7.26 | 7.50 |
| 3 | 6.98 | 7.20 |
| 5 | 6.75 | 6.95 |
| 10 | 6.64 | 6.78 |
| 15 | 6.59 | 6.70 |
| 20 | 6.56 | 6.65 |

Stable-phase (EP1-EP22) should show **slower descent than H147** (because peak LR is held instead of decayed), so don't kill on stable-phase WSS lag alone — kill only if `val_WSS at EP > threshold + 0.15pp` AND the gap is widening EP→EP. Decay-phase (EP22-EP30) is where the WSD payoff should manifest — at EP30 we need test_WSS < 6.5409% (H147 SOTA) for merge.

**Floor watch (must not breach):**
- test_VP ≤ 3.643%
- test_SP ≤ 3.577%
- test_ABUPT ≤ 5.844%

If val_VP > 4.2% at EP10, flag in heartbeat — WSD with long stable phase could accumulate VP gradient drift.

## H147 baseline (compare against)

- **W&B run:** `k6q4c3on` ([link](https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/k6q4c3on))
- **test_WSS:** 6.5409% (current SOTA — target to beat)
- **test_VP:** 3.4014%
- **test_SP:** 3.5634%
- **test_ABUPT:** 5.6648%
- **Reproduce H147:** see PR #1344

## Heartbeat protocol

- Post smoke EP3 val + LR-shape confirmation as a PR comment before launching the primary.
- Heartbeat at EP5, EP10, EP15, EP22 (stable→decay handover), EP25, EP30 (terminal).
- If any non-trivial intermediate decision (e.g. WSS at EP10 looks 0.2pp+ behind H147 EP10 AND gap is widening EP9→EP10), pause and post.

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<rank0 id>"],"primary_metric":{"name":"val_primary/wall_shear_rel_l2_pct","value":<EP30 val_WSS>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<test_WSS>}}
```

Include a full per-EP val trajectory table + LR-schedule chart in the terminal write-up.
