### PR TITLE
H332: Per-seed α robustness diagnostic on H310 seed-2 EP15 (3-arm cal transfer test)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -95,6 +95,10 @@ class EvalConfig:
     # and calibrated rel_l2-family metrics; MAE is not analytically expressible
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
+    # H332: save the per-case sufficient stats (CalibrationStats) for post-hoc
+    # re-calibration with externally supplied (alpha, beta) coefficients (e.g.
+    # to apply seed-1's H312 cal to a seed-2 run for transfer-arm analysis).
+    save_calibration_stats: bool = False
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -1136,6 +1140,25 @@ def main(argv: Iterable[str] | None = None) -> None:
                 run.summary["test_abupt_h300_raw"] = float(
                     summary["test_surface"][mode]["abupt_axis_mean_rel_l2_pct"]
                 )
+
+    if cfg.save_calibration_stats and state.is_main:
+        cal_out_dir = Path(cfg.output_dir) / "calibration_stats"
+        cal_out_dir.mkdir(parents=True, exist_ok=True)
+        for split, modes_dict in cal_summary.items():
+            for mode, cal in modes_dict.items():
+                if cal is None:
+                    continue
+                out_path = cal_out_dir / f"{split}__{mode}.pt"
+                torch.save(
+                    {
+                        "surf_global": cal.surf_global,
+                        "vol_global": cal.vol_global,
+                        "surf_per_case": cal.surf_per_case,
+                        "vol_per_case": cal.vol_per_case,
+                    },
+                    out_path,
+                )
+                print(f"[save_calibration_stats] wrote {out_path}", flush=True)
 
     if state.is_main and summary:
         print("\n=== Summary (rel_l2_pct lower-is-better) ===")

--- a/h332_arm_b_transfer.py
+++ b/h332_arm_b_transfer.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H332 Arm B: apply seed-1 H312 alpha/beta to seed-2 calibration sufficient stats.
+
+Loads the CalibrationStats dumped by --save-calibration-stats, applies the
+seed-1 H312 (alpha, beta) per channel and recomputes the rel_l2 family.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from eval_tta_h252 import CalibrationStats, compute_calibrated_metrics, fit_affine_per_channel
+
+
+# Seed-1 H312 calibration coefficients, pulled from W&B run enf61qrr summary
+# (calibration/weight_noise_mirror_res_avg/{alpha,beta}_*).
+H312_SEED1 = {
+    "alpha_surf": torch.tensor(
+        [
+            0.9948879107893270,  # cp
+            0.9943967724085607,  # tau_x
+            0.9940827941471600,  # tau_y
+            0.9917222517819623,  # tau_z
+        ],
+        dtype=torch.float64,
+    ),
+    "beta_surf": torch.tensor(
+        [
+            -0.0023220681890909756,  # cp
+            -0.0070268912492144064,  # tau_x
+            -0.0002359419212976590,  # tau_y
+            -0.0001458997813937601,  # tau_z
+        ],
+        dtype=torch.float64,
+    ),
+    "alpha_vol": torch.tensor([0.9996868405490413], dtype=torch.float64),
+    "beta_vol": torch.tensor([-0.8328109532412498], dtype=torch.float64),
+}
+
+
+def load_calibration_stats(path: Path) -> CalibrationStats:
+    blob = torch.load(path, map_location="cpu", weights_only=False)
+    cal = CalibrationStats()
+    cal.surf_global = blob["surf_global"]
+    cal.vol_global = blob["vol_global"]
+    cal.surf_per_case = blob["surf_per_case"]
+    cal.vol_per_case = blob["vol_per_case"]
+    return cal
+
+
+def report(name: str, metrics: dict[str, float]) -> None:
+    keys = (
+        "abupt_axis_mean_rel_l2_pct",
+        "surface_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+    )
+    print(f"\n[{name}]")
+    for k in keys:
+        print(f"  {k:<36s}  {metrics[k]:>8.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cal-stats-dir",
+        default="outputs/h332_primary/calibration_stats",
+        help="Directory containing val_surface__*.pt and test_surface__*.pt",
+    )
+    parser.add_argument(
+        "--mode",
+        default="weight_noise_mirror_res_avg",
+        help="Eval mode suffix matching the saved filenames",
+    )
+    args = parser.parse_args()
+
+    cal_dir = Path(args.cal_stats_dir)
+    val_path = cal_dir / f"val_surface__{args.mode}.pt"
+    test_path = cal_dir / f"test_surface__{args.mode}.pt"
+
+    val_cal = load_calibration_stats(val_path)
+    test_cal = load_calibration_stats(test_path)
+
+    print(f"Loaded val_cal: {len(val_cal.surf_per_case)} surface cases, "
+          f"{len(val_cal.vol_per_case)} volume cases")
+    print(f"Loaded test_cal: {len(test_cal.surf_per_case)} surface cases, "
+          f"{len(test_cal.vol_per_case)} volume cases")
+
+    # Refit seed-2's own alpha/beta from the val sufficient stats and report —
+    # cross-check vs the in-run values logged to W&B.
+    alpha_surf_s2, beta_surf_s2 = fit_affine_per_channel(val_cal.surf_global)
+    alpha_vol_s2, beta_vol_s2 = fit_affine_per_channel(val_cal.vol_global)
+
+    print("\n=== Seed-2 own-fit calibration (from saved sufficient stats) ===")
+    surf_names = ["cp", "tau_x", "tau_y", "tau_z"]
+    for c, name in enumerate(surf_names):
+        print(
+            f"  surface[{name:6s}]  alpha={alpha_surf_s2[c].item():+.6f} "
+            f"beta={beta_surf_s2[c].item():+.6f}"
+        )
+    print(
+        f"  volume[volume_pressure]  alpha={alpha_vol_s2[0].item():+.6f} "
+        f"beta={beta_vol_s2[0].item():+.6f}"
+    )
+
+    print("\n=== Seed-1 H312 alpha/beta (transfer source) ===")
+    for c, name in enumerate(surf_names):
+        print(
+            f"  surface[{name:6s}]  alpha={H312_SEED1['alpha_surf'][c].item():+.6f} "
+            f"beta={H312_SEED1['beta_surf'][c].item():+.6f}"
+        )
+    print(
+        f"  volume[volume_pressure]  alpha={H312_SEED1['alpha_vol'][0].item():+.6f} "
+        f"beta={H312_SEED1['beta_vol'][0].item():+.6f}"
+    )
+
+    print("\n=== Per-channel alpha delta (seed-2 minus seed-1) ===")
+    for c, name in enumerate(surf_names):
+        d = alpha_surf_s2[c].item() - H312_SEED1["alpha_surf"][c].item()
+        d_rel = d / H312_SEED1["alpha_surf"][c].item()
+        print(f"  alpha[{name:6s}]  delta={d:+.6f}  rel={d_rel*100:+.4f}%")
+    d = alpha_vol_s2[0].item() - H312_SEED1["alpha_vol"][0].item()
+    d_rel = d / H312_SEED1["alpha_vol"][0].item()
+    print(f"  alpha[volume_pressure]  delta={d:+.6f}  rel={d_rel*100:+.4f}%")
+
+    # ---- Arm B: apply seed-1 H312 cal to seed-2 sufficient stats. ----
+    arm_b_val = compute_calibrated_metrics(
+        val_cal,
+        H312_SEED1["alpha_surf"],
+        H312_SEED1["beta_surf"],
+        H312_SEED1["alpha_vol"],
+        H312_SEED1["beta_vol"],
+    )
+    arm_b_test = compute_calibrated_metrics(
+        test_cal,
+        H312_SEED1["alpha_surf"],
+        H312_SEED1["beta_surf"],
+        H312_SEED1["alpha_vol"],
+        H312_SEED1["beta_vol"],
+    )
+
+    report("Arm B (seed-2 + seed-1 H312 cal) val", arm_b_val)
+    report("Arm B (seed-2 + seed-1 H312 cal) test", arm_b_test)
+
+    # ---- Arm C: seed-2 + seed-2 own cal (refit), for cross-check. ----
+    arm_c_val = compute_calibrated_metrics(
+        val_cal, alpha_surf_s2, beta_surf_s2, alpha_vol_s2, beta_vol_s2
+    )
+    arm_c_test = compute_calibrated_metrics(
+        test_cal, alpha_surf_s2, beta_surf_s2, alpha_vol_s2, beta_vol_s2
+    )
+    report("Arm C (seed-2 + own cal, refit cross-check) val", arm_c_val)
+    report("Arm C (seed-2 + own cal, refit cross-check) test", arm_c_test)
+
+    # ---- Arm A (raw): identity affine, prints for completeness. ----
+    identity_alpha_surf = torch.ones(4, dtype=torch.float64)
+    identity_beta_surf = torch.zeros(4, dtype=torch.float64)
+    identity_alpha_vol = torch.ones(1, dtype=torch.float64)
+    identity_beta_vol = torch.zeros(1, dtype=torch.float64)
+    arm_a_val = compute_calibrated_metrics(
+        val_cal,
+        identity_alpha_surf,
+        identity_beta_surf,
+        identity_alpha_vol,
+        identity_beta_vol,
+    )
+    arm_a_test = compute_calibrated_metrics(
+        test_cal,
+        identity_alpha_surf,
+        identity_beta_surf,
+        identity_alpha_vol,
+        identity_beta_vol,
+    )
+    report("Arm A (seed-2 raw / no cal) val", arm_a_val)
+    report("Arm A (seed-2 raw / no cal) test", arm_a_test)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hypothesis

H300/H312's α coefficients (the calibration "win" per H316 finding) were fit on **seed-1** (W&B `0gjfv45i`). Thorfinn's H310 commission produced a second EP15 of the H244 recipe — **seed-2** (W&B `m1ddrlcu`). Two questions are jointly open:

1. **Is α a robust model-level property** — i.e., does training the same recipe with a different seed produce essentially the same WSS scale correction (α_τx ≈ 0.995, α_τy ≈ 0.994, α_τz ≈ 0.992)? If yes, the calibration "discovery" was a fundamental property of the architecture × data, not a seed-specific quirk.

2. **What's seed-2's standalone performance** under the H312 TTA stack + cal? This is a critical input to H307 (thorfinn's model soup): if seed-2 alone is competitive with seed-1, the soup operates on two roughly equal endpoints. If seed-2 is weaker, the soup is biased toward seed-1.

H332 tests both with a single TTA pass on seed-2's EP15 checkpoint, reporting 3 calibration arms from the same sufficient stats (post-hoc cal fits are seconds).

**Win criterion (Arm C primary)**: val_cal < **5.8994%** AND test_cal < **5.7388%** (H312 gates) for the seed-2-with-own-cal arm.

**Even if the win criterion isn't met**, the **diagnostic value is high**:
- Arm comparison tells H307 whether seed-1 H312 cal transfers cleanly to soup checkpoints
- α robustness across seeds informs all future calibration work (whether to refit per-seed or trust transfer)
- Establishes whether seed-2 (which used a slightly extended cosine schedule per thorfinn's H310 spec) reaches the same calibration regime

## Baseline (CURRENT SOTA — H312 PR #1498 merged)

| Metric | H312 seed-1 (CURRENT SOTA) |
|---|---:|
| val_abupt_calibrated | **5.8994%** (gate) |
| test_abupt_calibrated | **5.7388%** (gate) |
| val_abupt_raw | 5.9221% |
| test_abupt_raw | 5.7678% |
| H312 cal coefficients | α ∈ [0.9917, 0.9997]; β_VP=-0.8328 |
| W&B run | `enf61qrr` |

**Seed-1 H312 per-channel α (transfer target)**:
- α_cp = 0.99943
- α_τx = 0.99504
- α_τy = 0.99454
- α_τz = 0.99172
- α_VP = 0.99969

Paper floors: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS target < 5.85.

## Instructions

This is a **single-run eval experiment** — no new code. Use the existing `eval_tta_h252.py` infrastructure, switching the checkpoint to seed-2 and reporting 3 calibration arms from the same TTA sufficient stats.

### Step 1 — Locate seed-2 checkpoint

Use thorfinn's H310 commission artifact:
- W&B run: `m1ddrlcu`
- Artifact alias: `epoch-15` (or `best` if EP15 was best-by-val)
- Local path candidate: `outputs/drivaerml/run-m1ddrlcu/checkpoint_ep15.pt` (already present per thorfinn's PR #1507 comment)

If not present locally, download via `wandb artifact get wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/model-thorfinn-h310-h185-ep16-cosine-ext-seed2-m1ddrlcu:epoch-15`.

### Step 2 — Smoke test (~5 min)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-m1ddrlcu/checkpoint_ep15.pt \
  --resolutions "32768,65536" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 2 --antithetic-noise \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent edward --wandb-group "h332-edward-debug"
```

Confirm: checkpoint loads cleanly (missing/unexpected keys = 0), DDP world_size=8, K_eff=4, calibration=True.

### Step 3 — Primary run (full TTA stack on seed-2)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-m1ddrlcu/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent edward \
  --wandb-group "h332-edward-seed2-cal-robust" \
  --wandb-name "edward/h332-K4-8res-mirror-seed2-cal-robust"
```

ETA: ~7h (same TTA stack as H312, just a different checkpoint). The `--test-time-calibration` flag fits cal on the run's own val predictions — this gives Arm C.

### Step 4 — Post-hoc: apply seed-1 H312 cal to seed-2 (Arm B)

After the primary completes, **re-apply** H312's hardcoded α and β values (from seed-1, listed in baseline above) to the seed-2 test predictions. This is a 10-line python script that loads seed-2's saved test predictions and applies the H312 affine. No new TTA run needed.

(Implementation: load `predictions/test_predictions.pt` from this run's output, multiply by H312 α per channel, add H312 β per channel, recompute the abupt metric.)

### Step 5 — Report

3 arms in one report:

| Arm | Description | val_raw | val_cal | test_raw | test_cal |
|---|---|---:|---:|---:|---:|
| A | seed-2 raw (no cal) | ? | — | ? | — |
| B | seed-2 + seed-1 H312 cal (transfer) | ? | ? | ? | ? |
| C | seed-2 + seed-2-fitted cal (own cal, from `--test-time-calibration`) | ? | ? | ? | ? |
| ref | H312 seed-1 SOTA | 5.9221 | 5.8994 | 5.7678 | 5.7388 |

Plus the **seed-2 fitted α per channel** vs seed-1 H312 α (the central diagnostic):

| Channel | seed-1 α (H312) | seed-2 α (this run) | Δ | Δ/seed-1 |
|---|---:|---:|---:|---:|
| cp | 0.99943 | ? | ? | ? |
| τ_x | 0.99504 | ? | ? | ? |
| τ_y | 0.99454 | ? | ? | ? |
| τ_z | 0.99172 | ? | ? | ? |
| VP | 0.99969 | ? | ? | ? |

## SENPAI-RESULT format

Report the **best-performing arm**:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<primary>"],"primary_metric":{"name":"val_abupt_h332_seed2_own_cal","value":<number>},"test_metric":{"name":"test_abupt_h332_seed2_own_cal","value":<number>}}
```

Include in the comment:
- 3-arm table (above)
- Per-channel α comparison (above)
- Verdict on α robustness: are seed-1 and seed-2 α coefficients within ±0.001 per channel? If yes, calibration is seed-independent at this recipe. If no, identify which channels diverge.
- Verdict on H307 implication: does the transfer arm (B) match the own-cal arm (C)? If yes, soup cal can use H312 coefficients directly. If no, soup must refit.

## Decision logic

- **Merge** if Arm C (seed-2 + own cal) produces val_cal < 5.8994 AND test_cal < 5.7388 — seed-2 becomes a new SOTA candidate with own-fitted cal
- **Send back for cross-seed average diagnostic** if Arm C is within +5bp of either gate (suggests both seeds individually fail gate but averaging α across seeds might match the soup's expected α)
- **Close** with Finding `seed-2-weaker-baseline` if Arm C regresses by >3bp on test_cal vs H312 AND |Δα| < 0.001 per channel (confirms α is seed-robust, seed-2 is just a weaker base — H307 model soup should still help via flatter-minimum effect)
- **Close** with Finding `cal-coefficients-seed-dependent` if |Δα| > 0.003 on any channel (cal is seed-specific, H307 must refit cal on each soup checkpoint)

## Notes

- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 (~7h primary + overhead)
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- No code changes needed — just swap the checkpoint path and report 3 arms from the same TTA pass
- **Depends on seed-2 checkpoint at outputs/drivaerml/run-m1ddrlcu/checkpoint_ep15.pt** — thorfinn confirmed this exists locally in PR #1507. If missing, download via wandb artifact.
- This is independent of all other in-flight cal experiments and of H307 (which composes seeds via weight-average). H332 evaluates the **calibration-axis half** of the seed-2 question; H307 evaluates the **weight-space-averaging half**.

## Why this matters

After H316's finding that α is the entire calibration win, the next question is "**how stable is that α?**" — seed-to-seed, fold-to-fold, schedule-to-schedule. H332 answers the seed-to-seed question with a clean single-pass diagnostic. The answer informs:
- Whether H307's model soup will inherit H312's α directly (Arm B matches Arm C) or need refitting (Arm B regresses vs Arm C)
- Whether future seeds can be calibrated by transferring H312 coefficients (cheap) or each new seed needs its own val pass (expensive)
- Whether α reflects a model-architecture invariant or a training-noise idiosyncrasy

**This is the cleanest experiment edward can run to maximize the information yield of seed-2's existence.** It answers the diagnostic question that's currently load-bearing for H307, with the bonus possibility that seed-2 itself surprises and edges H312 directly.
