### PR TITLE
H335: Per-resolution K allocation under fixed 32-pair budget (3 arms)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -97,6 +97,14 @@ class EvalConfig:
     weight_noise_dist: str = "gaussian"
     weight_noise_df: int = 4
 
+    # H335: per-resolution K allocation. When set, overrides
+    # ``weight_noise_passes`` with a comma-separated list of per-resolution K
+    # values, one per entry in ``--resolutions``. Schedule preserves H312 noise
+    # seeding: K_max = max(per_res_K) (k, sign) pairs are built, and at each
+    # (k, sign) only resolutions with K_r > k receive a forward. Same noise
+    # samples are reused across resolutions where they appear.
+    per_res_K: str = ""
+
     # H300: per-channel affine calibration. Fits alpha_c, beta_c via OLS on val
     # predictions vs val targets (after TTA aggregation), then applies the SAME
     # (alpha, beta) to test predictions before metric computation. Logs both raw
@@ -171,6 +179,29 @@ def parse_resolutions(spec: str) -> list[int]:
 
 def parse_modes(spec: str) -> list[str]:
     return [m.strip() for m in spec.split(",") if m.strip()]
+
+
+def parse_per_res_K(spec: str, n_res: int) -> list[int] | None:
+    """Parse --per-res-K into a list[int] of length n_res, or None if unset.
+
+    Raises ValueError on length mismatch or non-positive entries (a K_r=0
+    would silently disable that resolution; force the user to drop the
+    resolution from --resolutions instead).
+    """
+    if not spec.strip():
+        return None
+    values = [int(p) for p in spec.split(",") if p.strip()]
+    if len(values) != n_res:
+        raise ValueError(
+            f"--per-res-K has {len(values)} entries but --resolutions has "
+            f"{n_res}; lengths must match."
+        )
+    if any(v <= 0 for v in values):
+        raise ValueError(
+            f"--per-res-K must be positive ints (got {values}); drop a "
+            f"resolution rather than passing K_r=0."
+        )
+    return values
 
 
 def build_model(cfg: EvalConfig) -> SurfaceTransolver:
@@ -363,6 +394,7 @@ def process_case_stacked(
     antithetic: bool = False,
     noise_dist: str = "gaussian",
     noise_df: int = 4,
+    per_res_K: list[int] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, dict]:
     """Run K_eff x R x M (mirror) TTA passes for one case and return per-point
     averaged predictions in real units. The outer K loop perturbs the model
@@ -372,6 +404,11 @@ def process_case_stacked(
     ``antithetic=True`` K_eff = ``2 * K_passes``: for each k we sample ε once
     (same seed) and evaluate both f(θ+ε) and f(θ−ε), so the linear Taylor term
     cancels in the per-point average (Finding NN / H274).
+
+    When ``per_res_K`` is provided, K_max = max(per_res_K) drives the schedule
+    and resolutions with K_r < K_max receive forwards only for k < K_r. The
+    per-point average then weights each resolution by its K_r (× 2 for
+    antithetic, × 2 for mirror).
     """
     counts = store.case_point_counts(case_id)
     n_surf = counts["n_surface"]
@@ -392,12 +429,24 @@ def process_case_stacked(
 
     mirror_flags = (False, True) if use_mirror else (False,)
 
+    if per_res_K is not None:
+        if len(per_res_K) != len(resolutions):
+            raise ValueError(
+                f"per_res_K length {len(per_res_K)} != resolutions length "
+                f"{len(resolutions)}"
+            )
+        K_max = max(per_res_K)
+        K_by_R = list(zip(resolutions, per_res_K))
+    else:
+        K_max = K_passes
+        K_by_R = [(R, K_passes) for R in resolutions]
+
     # Build the (noise_idx, sign) schedule. Anti-thetic pairs share a seed so
     # +ε / −ε use the SAME draw of ε (otherwise it would just be 2K i.i.d.).
     if antithetic and sigma > 0.0:
-        schedule = [(k, sign) for k in range(K_passes) for sign in (+1.0, -1.0)]
+        schedule = [(k, sign) for k in range(K_max) for sign in (+1.0, -1.0)]
     else:
-        schedule = [(k, +1.0) for k in range(K_passes)]
+        schedule = [(k, +1.0) for k in range(K_max)]
 
     for k, sign in schedule:
         # Perturb once per (k, sign); reuse across (res, mirror) inner passes.
@@ -418,7 +467,9 @@ def process_case_stacked(
             restore_clean_params(eval_module, clean)
         timing["perturb_seconds"] += time.time() - t_p
 
-        for R in resolutions:
+        for R, K_r in K_by_R:
+            if k >= K_r:
+                continue
             dataset = DrivAerMLSurfaceDataset(
                 case_ids=[case_id],
                 store=store,
@@ -519,8 +570,12 @@ def process_case_stacked(
     surf_y = case.surface_y.float()
     vol_y = case.volume_y.float()
 
-    k_eff = K_passes * (2 if (antithetic and sigma > 0.0) else 1)
-    n_passes = k_eff * len(resolutions) * (2 if use_mirror else 1)
+    sign_mult = 2 if (antithetic and sigma > 0.0) else 1
+    mirror_mult = 2 if use_mirror else 1
+    if per_res_K is not None:
+        n_passes = sum(per_res_K) * sign_mult * mirror_mult
+    else:
+        n_passes = K_passes * sign_mult * len(resolutions) * mirror_mult
     return surf_avg, vol_avg, surf_y, vol_y, n_passes, timing
 
 
@@ -814,6 +869,7 @@ def evaluate_split_stacked(
     collect_calibration: bool = False,
     noise_dist: str = "gaussian",
     noise_df: int = 4,
+    per_res_K: list[int] | None = None,
 ) -> tuple[dict[str, float], CalibrationStats | None]:
     rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
     world_size = (
@@ -848,6 +904,7 @@ def evaluate_split_stacked(
             antithetic=antithetic,
             noise_dist=noise_dist,
             noise_df=noise_df,
+            per_res_K=per_res_K,
         )
         add_case_to_accumulator(
             acc,
@@ -965,23 +1022,36 @@ def main(argv: Iterable[str] | None = None) -> None:
             f"--weight-noise-df {cfg.weight_noise_df!r} not supported for "
             "student_t (df>=3 required for finite variance)"
         )
+    per_res_K = parse_per_res_K(cfg.per_res_K, len(resolutions))
 
     if state.is_main:
         ddp_suffix = f", DDP world_size={state.world_size}" if state.enabled else ""
         print(f"Device: {device}{ddp_suffix}")
         print(f"Resolutions: {resolutions}")
         print(f"Modes: {modes}")
-        k_eff_print = cfg.weight_noise_passes * (2 if cfg.antithetic_noise else 1)
         dist_suffix = (
             f" df={cfg.weight_noise_df}" if cfg.weight_noise_dist == "student_t" else ""
         )
-        print(
-            f"Weight-noise TTA: dist={cfg.weight_noise_dist}{dist_suffix} "
-            f"sigma_rel={cfg.weight_noise_sigma} "
-            f"K_passes={cfg.weight_noise_passes} "
-            f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
-            f"seed_base={cfg.weight_noise_seed_base}"
-        )
+        if per_res_K is not None:
+            sign_mult = 2 if cfg.antithetic_noise else 1
+            total_passes_per_case = sum(per_res_K) * sign_mult * 2  # × mirror
+            print(
+                f"Weight-noise TTA: dist={cfg.weight_noise_dist}{dist_suffix} "
+                f"sigma_rel={cfg.weight_noise_sigma} "
+                f"per_res_K={per_res_K} (K_max={max(per_res_K)} sum={sum(per_res_K)}) "
+                f"antithetic={cfg.antithetic_noise} "
+                f"seed_base={cfg.weight_noise_seed_base} "
+                f"total_forwards_per_case_mirror_mode={total_passes_per_case}"
+            )
+        else:
+            k_eff_print = cfg.weight_noise_passes * (2 if cfg.antithetic_noise else 1)
+            print(
+                f"Weight-noise TTA: dist={cfg.weight_noise_dist}{dist_suffix} "
+                f"sigma_rel={cfg.weight_noise_sigma} "
+                f"K_passes={cfg.weight_noise_passes} "
+                f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
+                f"seed_base={cfg.weight_noise_seed_base}"
+            )
 
     ckpt_path, ckpt_source = resolve_checkpoint_path(cfg, state)
     if state.is_main:
@@ -1088,18 +1158,31 @@ def main(argv: Iterable[str] | None = None) -> None:
             else:
                 raise ValueError(f"Unknown mode {mode!r}")
 
+            # weight_noise_only uses a single resolution (cfg.eval_surface_points)
+            # so per_res_K (length-matched to --resolutions) cannot apply there.
+            mode_per_res_K = per_res_K if mode == "weight_noise_mirror_res_avg" else None
             if state.is_main:
-                k_eff_print = cfg.weight_noise_passes * (
-                    2 if cfg.antithetic_noise else 1
-                )
-                print(
-                    f"\n=== {split_name} mode={mode} resolutions={mode_resolutions} "
-                    f"mirror={use_mirror} K={cfg.weight_noise_passes} "
-                    f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
-                    f"sigma={cfg.weight_noise_sigma} "
-                    f"calibration={cfg.test_time_calibration} ===",
-                    flush=True,
-                )
+                if mode_per_res_K is not None:
+                    print(
+                        f"\n=== {split_name} mode={mode} resolutions={mode_resolutions} "
+                        f"mirror={use_mirror} per_res_K={mode_per_res_K} "
+                        f"antithetic={cfg.antithetic_noise} "
+                        f"sigma={cfg.weight_noise_sigma} "
+                        f"calibration={cfg.test_time_calibration} ===",
+                        flush=True,
+                    )
+                else:
+                    k_eff_print = cfg.weight_noise_passes * (
+                        2 if cfg.antithetic_noise else 1
+                    )
+                    print(
+                        f"\n=== {split_name} mode={mode} resolutions={mode_resolutions} "
+                        f"mirror={use_mirror} K={cfg.weight_noise_passes} "
+                        f"antithetic={cfg.antithetic_noise} K_eff={k_eff_print} "
+                        f"sigma={cfg.weight_noise_sigma} "
+                        f"calibration={cfg.test_time_calibration} ===",
+                        flush=True,
+                    )
             t0 = time.time()
             metrics, cal_stats = evaluate_split_stacked(
                 split_name=f"{split_name}/{mode}",
@@ -1120,6 +1203,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 collect_calibration=cfg.test_time_calibration,
                 noise_dist=cfg.weight_noise_dist,
                 noise_df=cfg.weight_noise_df,
+                per_res_K=mode_per_res_K,
             )
             dt = time.time() - t0
             if state.is_main:


### PR DESCRIPTION
## Hypothesis

**The H312 K-allocation (K=4 uniform across 8 resolutions) is one of many feasible (K_r) tuples at the 32-pair compute budget. We have not yet tested whether the K-budget should be reallocated across resolutions for a free improvement at H312-cost.**

Five structural nulls now bracket the cal axis (H316 β-null, H319 per-res-invariant, H323 cross-channel-diagonal, H328 regional-cal-irrecoverable, H329 abupt-weighting-irrelevant). The remaining open dimension at fixed H312 compute is **how the TTA noise budget is allocated across resolutions**, not the cal that consumes its output.

Hypothesis: **resolutions with more inherent prediction noise benefit more from K-averaging, so K should be allocated non-uniformly across the ladder.**

Two competing physical intuitions:
- **Low-res-heavy (Arm A)**: Low-resolution evals (32K, 40K) have fewer sample points per car → higher per-pass Taylor variance → more K reduces variance more. K_lowres > 4.
- **High-res-heavy (Arm B)**: High-resolution evals (98K, 131K) are closer to ground truth point density → carry more signal per pass → averaging more high-res passes extracts more info. K_highres > 4.

If H312's K=4 uniform is at the Pareto-optimal allocation, both arms will be neutral or worse vs H312. If one arm wins, the K-budget reallocation extracts free bp without changing the total forwards-per-case count.

## Baseline (CURRENT SOTA — H312 PR #1498 merged)

| Metric | H312 (CURRENT SOTA) |
|---|---:|
| val_abupt_calibrated | **5.8994%** (gate) |
| test_abupt_calibrated | **5.7388%** (gate) |
| val_abupt_raw | 5.9221% |
| test_abupt_raw | 5.7678% |
| W&B run | `enf61qrr` |
| K-allocation | K=4 uniform across all 8 resolutions |
| Total forwards/case | 64 (= 32 anti-thetic pairs × mirror) |

Paper floors: test_VP ≤ 3.421, test_SP ≤ 3.577, test_WSS target < 5.85.

## Instructions

**3 arms × ~6h each ≈ 18h total** — fits within timeout. All arms use the same H312 cal recipe (10-param per-channel affine OLS); only the per-resolution K-pair count varies.

### Arm A — Low-res-heavy (K_lowres > 4)

K-allocation per resolution (32K → 131K):

`K = [8, 6, 4, 4, 4, 4, 2, 2]` → total 34 anti-thetic pairs (slightly over H312's 32; if you need to match exactly, drop to `[8, 5, 4, 4, 4, 4, 2, 1]` = 32)

Concrete:
- Resolutions `{32768, 40960}`: K=8 anti-thetic each
- Resolutions `{49152, 57344, 65536, 81920}`: K=4 anti-thetic each
- Resolutions `{98304, 131072}`: K=2 anti-thetic each

### Arm B — High-res-heavy (K_highres > 4)

K-allocation per resolution: `K = [2, 2, 4, 4, 4, 4, 6, 8]` — mirror reflection of Arm A.

### Arm C (CONTROL) — H312 uniform reproduction

`K = [4, 4, 4, 4, 4, 4, 4, 4]` — identical to H312. Sanity check that the per-resolution K plumbing reproduces H312 exactly. **If Arm C's val_cal differs from H312's 5.8994 by more than 0.001bp, there's a code bug** — debug Arm C first before reporting.

### Step 1 — Implementation (~1-2 hours)

The current `eval_tta_h252.py` accepts a single `--weight-noise-passes` flag that applies uniformly across all resolutions. Extend to accept per-resolution K:

```bash
--per-res-K "8,6,4,4,4,4,2,2"   # comma-separated, one per resolution in --resolutions order
```

When `--per-res-K` is set, override the global K with per-resolution values. Validate the list length matches `--resolutions` length; error out cleanly if not.

### Step 2 — Smoke (~10 min, 2-res)

Run with `--resolutions "32768,131072"` and `--per-res-K "8,2"` to verify:
- DDP launches without rank-skew (some ranks have more passes than others if K varies — need to confirm DDP rank distribution is consistent across resolutions)
- Cal fit completes; α/β reproduce H312 to ±0.005 (since the same model/data)
- Total forwards-per-case prints correctly

### Step 3 — Primary (~6h each, 3 arms sequential)

```bash
# Arm C (CONTROL — RUN FIRST as code-correctness check)
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --per-res-K "4,4,4,4,4,4,4,4" --antithetic-noise \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent askeladd --wandb-group "h335-askeladd-per-res-K" \
  --wandb-name "askeladd/h335-arm-C-uniform"
```

(Arm A and Arm B use the same command with `--per-res-K "8,6,4,4,4,4,2,2"` and `"2,2,4,4,4,4,6,8"` and `--wandb-name "askeladd/h335-arm-A-lowres"` / `"askeladd/h335-arm-B-highres"`.)

ETA: ~6h per arm × 3 arms = ~18h sequential (within timeout 540min = 9h hardwall, so plan as 3 separate launches or chain them in a single torchrun loop). The smaller per-res-K arms run faster than H312 (Arm A: 34 pairs vs H312's 32, Arm B: 32 pairs — both ≤ H312 timing).

### Step 4 — Report

| Arm | val_raw | val_cal | test_raw | test_cal | Δval_cal vs C | Δtest_cal vs C |
|---|---:|---:|---:|---:|---:|---:|
| C (uniform, H312 control) | ? | ? | ? | ? | 0 | 0 |
| A (low-res-heavy) | ? | ? | ? | ? | ? | ? |
| B (high-res-heavy) | ? | ? | ? | ? | ? | ? |

Plus per-channel α coefficients table (one column per arm) — verifies cal is K-allocation-invariant (expected) or reveals K-allocation-dependent residual structure.

## SENPAI-RESULT format

Report the **best arm by both gates** (val < 5.8994 AND test < 5.7388):

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<C>","<A>","<B>"],"primary_metric":{"name":"val_abupt_h335_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h335_best_arm","value":<number>}}
```

## Decision logic

- **Merge** if either Arm A or Arm B achieves val_cal < 5.8994 AND test_cal < 5.7388 by ≥0.5bp (real signal — K-allocation has structure at fixed budget)
- **Close** with Finding `K-uniform-is-Pareto-at-h312-budget` if both Arm A and Arm B are within ±0.5bp of Arm C (uniform K=4 across 8 res is the budget-optimal allocation)
- **Close + investigate** with Finding `K-allocation-asymmetric` if exactly one of A/B beats Arm C by ≥0.5bp (asymmetric K-Pareto)

## Notes

- **Code correctness gate**: Arm C MUST reproduce H312 to ±0.001bp on both gates. If not, debug before reporting other arms (a discrepancy means the per-res-K plumbing has a bug).
- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 (~9h hardwall × 3 arms = either chain them or run 3 separate launches)
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- All 3 arms reuse the H312 cal recipe (10-param diagonal-affine OLS, per-channel) — no cal change vs H312
- Total forwards/case: Arm A=34 pairs × mirror = 68; Arm B=32 pairs × mirror = 64; Arm C=32 pairs × mirror = 64. Arm A is ~6% more compute than H312, others equal.
- **Independent of all other in-flight experiments.** Complements H330 (K-axis at fixed 8-res) and H331 (R-axis at fixed K=4) — H335 is the **K×R interaction axis at fixed H312 compute**.

## Why this matters

The cal axis is exhaustively closed structurally (5 nulls, H316+H319+H323+H328+H329 + alphonse H334 in flight verifying MLE). At single-model + H312 cal, the next free-compute axis is K-allocation: **does K=4 uniform across 8 res Pareto-dominate any non-uniform allocation at the same 32-pair budget?**

Two paper-citable outcomes:
- **Both arms null** → "K=4 uniform across 8-res is Pareto-optimal at the 32-pair budget." Confirms H312's recipe is structurally tight on the TTA axis too — frees future work to focus on cross-recipe ensembles, train-time interventions, or architectural changes.
- **One arm wins** → free 0.5-3bp on test by reallocating K. The clean structural finding gives a small SOTA improvement and informs the K-budget asymmetry for future TTA designs.

This is the cleanest experiment askeladd can run to **either close the K-allocation sub-axis** or find a final post-cal structural improvement at the same compute as H312.
