### PR TITLE
H337: 3rd EP15 seed commissioning for 3-way model soup (artifact production, ~3h)

### DIFF
--- a/train.py
+++ b/train.py
@@ -145,6 +145,7 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    seed: int = 0
     debug: bool = False
 
 
@@ -271,6 +272,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "seed": (
+            "H310: integer seed for torch / numpy / random. 0 (default) "
+            "leaves all RNGs at system entropy (matches historical "
+            "non-deterministic behavior). Nonzero sets torch.manual_seed, "
+            "torch.cuda.manual_seed_all, numpy.random.seed, and "
+            "random.seed BEFORE model/dataloader/DDP construction so two "
+            "runs with the same seed produce matching val curves (modulo "
+            "CUDA float non-determinism)."
         ),
     }
     for field in fields(Config):
@@ -831,6 +841,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        if config.seed != 0:
+            import random as _py_random
+            import numpy as _np
+            torch.manual_seed(config.seed)
+            torch.cuda.manual_seed_all(config.seed)
+            _np.random.seed(config.seed)
+            _py_random.seed(config.seed)
+            if state.is_main:
+                print(f"Seed: {config.seed} (torch / cuda / numpy / random)")
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -1081,6 +1100,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["mirror_augmentation"] = config.mirror_augmentation
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
+            wandb.summary["seed"] = config.seed
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}


### PR DESCRIPTION
## Hypothesis

**Commission a 3rd EP15 checkpoint via H310-style cosine extension at `--seed=2027`** to unblock 3-way model soup experiments and extend the model-axis diversity available to the program.

### Why this is the highest-EV idle slot use right now

The post-hoc inference axis (TTA-K, TTA-R, calibration) is now **structurally exhausted** on the ep15 checkpoint:

- **TTA-K-axis closed** (H330 K=5+8-res+cal beats H312 by 0.03bp at +25% permanent compute — invokes disproportionate-complexity exception)
- **TTA-R-axis closed** (H331 K=4+10-res-gapfill+cal misses test gate by +0.04bp at +24% compute)
- **Cal-axis closed** (5 structural nulls: H316/H319/H323/H328/H329; H334 in-flight verifying global MLE)
- **Cross-fleet K↔R saturation**: H330 (K=5+8res) and H331 (K=4+10res) **both hit val_raw = 5.9217 to 4 decimal places** — at +25% compute beyond H312, neither axis extracts new raw signal

The only remaining concrete bp directions are:
1. **Composition of small wins** (H336 K=5+Student-t in flight, H314 Arm A Student-t alone pending terminal)
2. **Model-axis diversity** — H307 model soup at α=0.5 (seed-1+seed-2) already beat test gate by 0.8bp but missed val by 2.3bp. **Adding a 3rd seed unlocks 3-way soup** with richer α-space search.
3. Training-time interventions (research-grade, hold for later)

H310 demonstrated that commissioning a fresh seed via cosine-tail extension from the H185/H244 base takes only **~2.5h wall** (not 18h — only 3 epochs of new compute), since the cosine schedule provides a natural restart point. This is the cheapest model-diversity unlock available.

### What a 3rd seed unblocks

Once seed-3 ep15 exists:
- **3-way soup**: search α=(w1, w2, w3) with constraint w1+w2+w3=1 over a 2D simplex. Combinatorial explosion in 2-way pairs (3 instead of 1) means more chances of hitting a val-passing soup point.
- **2-way variance studies**: {s1+s3}, {s2+s3} pairs vs the existing {s1+s2} (H307 result) — measures whether 2-way soup gains are seed-pair-specific or robust across seed pairs.
- **Per-seed cal coefficient diversity check**: edward H332 (PR #1516 in flight) tests if H312 α transfers to seed-2. H337 lets us check seed-3 too — building a 3-point cal-stability sample which is more informative than 2 seeds.
- **Future training-time experiments**: any seed-3-only intervention (different optimizer state, different EMA decay during tail) gives baseline-comparable artifacts.

## Baseline

Current SOTA: **H312 (PR #1498 merged)** — `enf61qrr`

| Metric | H312 |
|---|---:|
| val_abupt_calibrated | **5.8994%** (gate) |
| test_abupt_calibrated | **5.7388%** (gate) |
| W&B run | `enf61qrr` |

Existing seeds:
- **seed-1**: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt` (the H312/H300/H285 base; val_abupt mirror-only ~5.96%)
- **seed-2**: `outputs/drivaerml/run-m1ddrlcu/checkpoint_ep15.pt` (commissioned by thorfinn H310 PR #1505 via `--seed=2026` cosine extension; val_abupt mirror-only 6.0151%)
- **seed-3**: this PR will produce — target val_abupt mirror-only ≤ 6.10% (within ~0.1pp of seed-1 reference, matching H310's success criterion)

## Instructions

**This is an artifact-production task, NOT a metric-improvement experiment.** The success criterion is "the checkpoint exists and the W&B artifact is uploaded with the standard alias `epoch-15`, `latest`" — not "the new checkpoint beats H312 gates".

### Step 1 — Cherry-pick the `--seed` plumbing from thorfinn/h310

The `--seed` flag was added on `thorfinn/h310-ep15-seed2-retrain` (PR #1505) for the seed-2 run but may or may not be on tay yet. Check:

```bash
git log tay --oneline -- train.py | head -5
grep -n "seed" train.py | head -20
# If --seed flag is missing, cherry-pick from thorfinn's branch:
git diff tay..origin/thorfinn/h310-ep15-seed2-retrain -- train.py
git cherry-pick <commit_hash_for_seed_flag>
```

(Do NOT cherry-pick anything beyond the `--seed` flag — keep the diff minimal.)

### Step 2 — Smoke (~5 min)

Run on 1 GPU for 50 steps with `--seed=2027` to confirm:
- Seed flag controls SGD trajectory (loss curve differs from seed-1 at step 50)
- Checkpoint save path works
- No regression in default training behavior

```bash
torchrun --standalone --nproc-per-node=1 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2027 \
  --max-steps=50 \
  --debug
```

### Step 3 — Primary (~2.5h)

Full H244 cosine-tail extension from the H185/H244 base checkpoint:

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2027 \
  --epochs=16 \
  --wandb-group "h337-tanjiro-seed3-commissioning" \
  --wandb-name "tanjiro/h337-ep15-seed3-cosine-ext"
```

Use the exact same hyperparameters as H310 (base, cosine schedule, EMA decay, batch size). The only diff from H310 should be `--seed=2027` vs `--seed=2026`.

Save EP15 and EP16 artifacts with the H310 naming convention: `model-tanjiro-h337-h185-ep16-cosine-ext-seed3-<wandb-run-id>:v1` for EP16 (alias `latest`, `best`) and `:v0` for EP15 (alias `epoch-15`).

### Step 4 — Quick eval (~30 min, 1-res K=4 mirror only)

After EP15 lands, run a quick mirror-only eval to confirm the checkpoint is **within ~0.1pp of seed-1 reference val_abupt** (i.e. val_abupt ≤ 6.10%):

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<wandb-run-id>/checkpoint_ep15.pt \
  --resolutions "65536" \
  --eval-modes "mirror" \
  --batch-size 2 --num-workers 4 \
  --wandb-name "tanjiro/h337-seed3-ep15-mirror-eval"
```

Expected: val_abupt 6.00-6.10% (matches seed-2's 6.0151% trajectory). If val_abupt > 6.15%, investigate (might be a seed-3-specific outlier; report and we'll decide whether to recommission with a different seed value).

### Step 5 — Report

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<training-run-id>","<eval-run-id>"],"primary_metric":{"name":"val_abupt_h337_seed3_ep15_mirror","value":<number>},"test_metric":{"name":"val_abupt_h337_seed3_ep15_mirror","value":<number>}}
```

Both primary and test metric are the same mirror-only val_abupt — this is an artifact-production task, no test metric is required. Report the seed-3 EP15 W&B artifact name and alias in the PR body.

Also report:
- Training time (wall clock total)
- val_abupt curve at every logged step
- Loss diff vs seed-1 at step 50, 200, end (confirms `--seed` plumbing works)
- Whether the cosine-tail plateaued (matches Finding `cosine-tail-flat-in-h244-cohort` from H310)

## Decision logic

- **Close** with success-criteria-met if val_abupt ≤ 6.10% AND artifact uploads cleanly — **standard outcome**, NOT a metric-improvement merge.
- **Close + recommission** if val_abupt > 6.15% — re-launch with `--seed=2028` (different seed value).
- **Investigate** if training diverges or artifact upload fails (very unlikely given H310 reproducibility).

## Notes

- **Independent of all other in-flight experiments.** Complements H336 (composition) and H335 (K-allocation) — pure model-axis diversity, no inference axis overlap.
- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 — easily within budget (~3h expected).
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- **No capacity additions** — same model size, same training recipe, only the `--seed` flag changes.

## Why this matters

The H307 model soup direction at α=0.5 already beat H312's test gate by 0.8bp. The val gate miss (+2.3bp) is the only blocker. **A 3rd seed makes the soup α-space 2-dimensional instead of 1-D**, dramatically increasing the chance of hitting both gates simultaneously. If H307 Arm C (α=0.75) closes the val gap, we can immediately launch H338 = 3-way soup α-search on the (s1, s2, s3) simplex.

Even if H307 closes terminally, seed-3 is a permanent artifact useful for:
- Future training-time interventions (loss reformulation, schedule changes) — has a fresh artifact to compare against
- 3-point cal-coefficient stability sample (more robust than 2-point)
- Per-channel α variance across seeds (informs whether H312 α is structurally stable or seed-specific)

This is the cheapest model-axis diversity unlock available and the structurally-correct pivot now that the inference axes are saturated.
