### PR TITLE
H338: SP-targeted loss reweighting cosine-tail (close paper SP floor gap +3.4bp)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -33,6 +33,7 @@ Modes:
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import time
 from dataclasses import asdict, dataclass, field, fields
@@ -110,6 +111,17 @@ class EvalConfig:
     # across all (ckpt, k, R, mirror) passes (uniform per-point contributions),
     # so the per-case averaged form is sufficient for H342's hypothesis.
     save_raw_predictions: str = ""
+
+    # H338: optional hardcoded alpha/beta override. When the surf strings are
+    # non-empty (comma-separated 4-tuples in [cp, tau_x, tau_y, tau_z] order)
+    # and/or the vp scalars are not NaN, those values replace the OLS-on-val
+    # fit. Used to transfer cal coefficients across seeds/arms (H332 shows the
+    # affine cal is seed-invariant, so we can apply the H312-fit coefficients
+    # to H338 arms without refitting on a noisy val_N=34).
+    cal_hardcoded_alpha_surf: str = ""
+    cal_hardcoded_beta_surf: str = ""
+    cal_hardcoded_alpha_vp: float = float("nan")
+    cal_hardcoded_beta_vp: float = float("nan")
 
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
@@ -1245,8 +1257,44 @@ def main(argv: Iterable[str] | None = None) -> None:
             alpha_surf, beta_surf = fit_affine_per_channel(val_cal.surf_global)
             alpha_vol, beta_vol = fit_affine_per_channel(val_cal.vol_global)
 
+            cal_source_surf_alpha = "ols_val"
+            cal_source_surf_beta = "ols_val"
+            cal_source_vp_alpha = "ols_val"
+            cal_source_vp_beta = "ols_val"
+            if cfg.cal_hardcoded_alpha_surf:
+                hc = [float(x) for x in cfg.cal_hardcoded_alpha_surf.split(",")]
+                if len(hc) != alpha_surf.numel():
+                    raise ValueError(
+                        f"--cal-hardcoded-alpha-surf expected {alpha_surf.numel()} values, got {len(hc)}"
+                    )
+                alpha_surf = torch.tensor(hc, dtype=alpha_surf.dtype, device=alpha_surf.device)
+                cal_source_surf_alpha = "hardcoded"
+            if cfg.cal_hardcoded_beta_surf:
+                hc = [float(x) for x in cfg.cal_hardcoded_beta_surf.split(",")]
+                if len(hc) != beta_surf.numel():
+                    raise ValueError(
+                        f"--cal-hardcoded-beta-surf expected {beta_surf.numel()} values, got {len(hc)}"
+                    )
+                beta_surf = torch.tensor(hc, dtype=beta_surf.dtype, device=beta_surf.device)
+                cal_source_surf_beta = "hardcoded"
+            if not math.isnan(cfg.cal_hardcoded_alpha_vp):
+                alpha_vol = torch.tensor(
+                    [cfg.cal_hardcoded_alpha_vp], dtype=alpha_vol.dtype, device=alpha_vol.device
+                )
+                cal_source_vp_alpha = "hardcoded"
+            if not math.isnan(cfg.cal_hardcoded_beta_vp):
+                beta_vol = torch.tensor(
+                    [cfg.cal_hardcoded_beta_vp], dtype=beta_vol.dtype, device=beta_vol.device
+                )
+                cal_source_vp_beta = "hardcoded"
+
             channel_names = ["cp", "tau_x", "tau_y", "tau_z"]
-            print(f"\n=== H300 calibration (fit on val, mode={mode}) ===", flush=True)
+            print(
+                f"\n=== H300 calibration (mode={mode}; "
+                f"surf alpha={cal_source_surf_alpha}, beta={cal_source_surf_beta}; "
+                f"vp alpha={cal_source_vp_alpha}, beta={cal_source_vp_beta}) ===",
+                flush=True,
+            )
             for c, name in enumerate(channel_names):
                 print(
                     f"  surface[{name:6s}]  alpha={alpha_surf[c].item():+.6f} "
@@ -1286,6 +1334,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                     run.summary[f"calibration/{mode}/beta_{name}"] = float(beta_surf[c].item())
                 run.summary[f"calibration/{mode}/alpha_volume_pressure"] = float(alpha_vol[0].item())
                 run.summary[f"calibration/{mode}/beta_volume_pressure"] = float(beta_vol[0].item())
+                run.summary[f"calibration/{mode}/source_surf_alpha"] = cal_source_surf_alpha
+                run.summary[f"calibration/{mode}/source_surf_beta"] = cal_source_surf_beta
+                run.summary[f"calibration/{mode}/source_vp_alpha"] = cal_source_vp_alpha
+                run.summary[f"calibration/{mode}/source_vp_beta"] = cal_source_vp_beta
 
                 # Log calibrated primary metrics to W&B history (and as
                 # split-level summary keys for downstream parsing).

--- a/train.py
+++ b/train.py
@@ -104,6 +104,7 @@ class Config:
     use_qk_norm: bool = False
     use_surf_to_vol_xattn: bool = False
     drop_path_max: float = 0.0
+    sp_loss_weight: float = 1.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
@@ -917,15 +918,23 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"missing={len(missing)} unexpected={len(unexpected)}"
                 )
 
-        # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
-        # the largest gap to AB-UPT, so we expose per-channel weights here.
+        # Surface targets are [cp, tau_x, tau_y, tau_z]. tau_y/tau_z carry the
+        # largest gap to AB-UPT; the cp/SP channel gets its own multiplier so
+        # H338-style train-time SP rebalancing can target the paper-floor gap.
         surface_channel_weights = torch.tensor(
-            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+            [
+                config.sp_loss_weight,
+                1.0,
+                config.tau_y_loss_weight,
+                config.tau_z_loss_weight,
+            ],
             device=device,
             dtype=torch.float32,
         )
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.sp_loss_weight != 1.0)
+            or (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -1030,7 +1039,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
             if use_channel_weights:
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
+                    f"Surface channel weights: cp={config.sp_loss_weight} tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
 
@@ -1062,6 +1071,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 else []
             )
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
+            wandb.summary["loss/sp_loss_weight"] = config.sp_loss_weight
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
             backbone = getattr(base_model, "backbone", None)
@@ -1266,6 +1276,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/sp_loss_weight": config.sp_loss_weight,
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }


### PR DESCRIPTION
## Hypothesis

**Surface pressure (SP) is the only channel above paper floor: test_SP = 3.6116 vs target 3.577 = +3.4bp gap. The H332 finding (`α-seed-invariant`) shows the cal axis is closed structurally — SP cannot improve from post-hoc cal. The next concrete bp on SP must come from training. SP-targeted loss reweighting on the H244 cosine-tail extension (last 3 epochs from base ep12) should close the SP floor gap at ~9h total GPU cost (3-arm sweep).**

### Why this is the right experiment now

The exhaustive cal-axis structural sweep (H316/H319/H323/H328/H329 + H334 in flight) confirms **diagonal-affine OLS is the MLE** at val_N=34. H332 just confirmed **α is model-class invariant across seeds** at the H244 recipe. So:

- Cal cannot close the SP gap (α_cp = 0.99489 is already at MLE within ±2.6e-4 across seeds)
- TTA inference axes saturated (H330 K-axis, H331 R-axis joint K-R saturation)
- The 3.4bp SP gap to paper floor must come from **training-time** intervention

The cheapest training-time intervention is **loss-weight rebalancing during the cosine-tail**, which H310 demonstrated takes only ~3h wall (not 18h — only 3 epochs of new compute since H244 cosine extension restarts from ep12 base).

3 arms × ~3h = ~9h total — fits within timeout 540min × 3 sequential or 1 launch chain.

### What changes vs H312 training

Only the SP loss multiplier in the last 3 epochs (ep12 → ep15) of the cosine extension. Everything else (seed=2025, optimizer state, schedule, batch size, all other channel loss weights) stays identical to H310/H312. The student should produce a single train.py diff like:

```python
# Existing (in train.py, training loop):
loss = (
    loss_cp * w_cp
    + loss_wx * w_wx + loss_wy * w_wy + loss_wz * w_wz
    + loss_vp * w_vp
)

# New (with --sp-loss-weight flag, default 1.0 = current behavior):
loss = (
    loss_cp * w_cp * args.sp_loss_weight  # NEW: SP-only multiplier
    + loss_wx * w_wx + loss_wy * w_wy + loss_wz * w_wz
    + loss_vp * w_vp
)
```

(Note: `cp` is the surface-pressure channel in this codebase — not "centerline pressure" or anything else. Verify by reading `train.py` for the channel naming convention before launching.)

## Baseline

Current SOTA: **H312 (PR #1498 merged)** — `enf61qrr`

| Metric | H312 (current SOTA) |
|---|---:|
| val_abupt_cal | **5.8994%** (gate) |
| test_abupt_cal | **5.7388%** (gate) |
| test_VP_cal | 3.3743% (below floor 3.421) ✓ |
| **test_SP_cal** | **3.6116%** (vs floor 3.577 = **+3.4bp gap**) ✗ |
| test_WSS_cal | 6.6391% (vs floor 5.85 = +79bp gap) ✗ |

The test_SP gap is the ONLY paper-floor-eligible channel still open (test_VP already below floor, test_WSS far enough that train-time will need a different recipe).

Reference checkpoint to extend: **`outputs/drivaerml/run-<base-ep12>.pt`** — the same checkpoint used by H310 for seed-2 commissioning. Inherit `--seed=2025` (the H244 default, same as H312 base).

## Instructions

### Step 1 — Confirm the `--sp-loss-weight` flag plumbing (~30 min)

The H310 student (thorfinn) added `--seed` flag plumbing. Check whether a per-channel loss-weight CLI flag already exists in `train.py`. If yes, parameterize the SP weight via the existing flag. If no, add a minimal `--sp-loss-weight float = 1.0` flag.

Diff should be minimal — just the multiplier on the SP loss term, gated by a CLI arg defaulting to 1.0 (i.e. no-op when not set). Do NOT change anything else.

### Step 2 — Smoke (~10 min)

Run 50 steps on 1 GPU with `--sp-loss-weight=1.10` to verify the flag actually changes the loss decomposition (compare logged per-channel losses to a `--sp-loss-weight=1.0` baseline run).

### Step 3 — Primary (3 arms sequential or chained, ~9h total)

```bash
# Arm A — SP weight 1.05× (light)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2025 \
  --epochs=16 \
  --sp-loss-weight=1.05 \
  --wandb-group "h338-edward-sp-loss-reweight" \
  --wandb-name "edward/h338-arm-A-sp1.05"

# Arm B — SP weight 1.10× (medium)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2025 \
  --epochs=16 \
  --sp-loss-weight=1.10 \
  --wandb-group "h338-edward-sp-loss-reweight" \
  --wandb-name "edward/h338-arm-B-sp1.10"

# Arm C — SP weight 1.20× (heavy)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2025 \
  --epochs=16 \
  --sp-loss-weight=1.20 \
  --wandb-group "h338-edward-sp-loss-reweight" \
  --wandb-name "edward/h338-arm-C-sp1.20"
```

Save EP15 checkpoint for each arm as `model-edward-h338-arm-{A,B,C}-sp{1.05,1.10,1.20}:v1`.

### Step 4 — Eval each EP15 checkpoint via H312 TTA recipe (~1h per arm)

For each arm, run the H312 TTA recipe with H312 hardcoded cal coefficients (per H332 finding: cal is seed-invariant, so the same α applies):

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<arm-X-wandb-run-id>/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent edward --wandb-group "h338-edward-sp-loss-reweight-eval" \
  --wandb-name "edward/h338-arm-X-eval-cal"
```

### Step 5 — Report

| Arm | SP weight | val_cal | test_cal | test_SP_cal | test_VP_cal | test_WSS_cal | Δtest_SP vs H312 | Δtest_abupt vs H312 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| H312 (ref) | 1.00× | 5.8994 | 5.7388 | 3.6116 | 3.3743 | 6.6391 | 0 | 0 |
| A | 1.05× | ? | ? | ? | ? | ? | ? | ? |
| B | 1.10× | ? | ? | ? | ? | ? | ? | ? |
| C | 1.20× | ? | ? | ? | ? | ? | ? | ? |

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA-train>","<armA-eval>","<armB-train>","<armB-eval>","<armC-train>","<armC-eval>"],"primary_metric":{"name":"val_abupt_h338_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h338_best_arm","value":<number>}}
```

Primary = best val_cal across arms. Test = matching test_cal for the same arm.

## Decision logic

- **Merge** if any arm satisfies BOTH: (a) val_cal < 5.8994 AND test_cal < 5.7388 (H312 gates), AND (b) test_SP < 3.577 (paper floor closed). New SOTA + paper-citable floor closure.
- **Merge with caveat** if any arm has test_SP < 3.577 but val_cal misses H312 gate by ≤1bp: this is a paper-relevant single-metric improvement at small overall regression. Document and discuss before merging.
- **Close + Finding `sp-reweight-monotone-good`** if test_SP decreases monotonically with SP weight but doesn't quite cross 3.577 — try Arm D 1.30× or report as bounded interior.
- **Close + Finding `sp-reweight-collapses-other-channels`** if SP improves but VP/WSS regress by >2bp on test — SP-VP tradeoff is structural, not addressable by simple reweighting.
- **Close + Finding `sp-reweight-null`** if all 3 arms produce checkpoints with test_SP within ±0.3bp of H312's 3.6116 — the SP loss-weight axis is locally flat, SP residual structure not driven by sample-weighting.

## Notes

- **Independent of all other in-flight experiments.** Complementary to tanjiro H337 (3rd seed commission via same cosine-extension recipe at different seed); H337 changes the SGD trajectory, H338 changes the loss weighting at the same trajectory.
- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 — fits 3 sequential arms × ~3h each, or chain via a launch script as thorfinn did for H310→H307.
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- **No capacity additions** — same model, same training recipe, only the SP loss multiplier changes.
- Use the H312 cal coefficients hardcoded for eval (verified seed-invariant via H332): α_cp=0.994888, α_τx=0.994397, α_τy=0.994083, α_τz=0.991722, α_VP=0.999687, β_VP=−0.866712 (others ≤2.4e-3 |β|). **Do NOT refit cal per-arm** — the cal transfer is lossless per H332, and refitting introduces val_N=34 noise.

## Why this matters

H332's `α-seed-invariant` finding closes the post-hoc cal axis structurally. The only remaining concrete bp on test_SP comes from training. SP is the only paper-floor-eligible channel still open (VP already below floor, WSS too far to close at this checkpoint horizon). If we close test_SP < 3.577 at ≤9h GPU spend, we have a paper-citable floor closure in addition to whatever H336/H314-Arm-A composition delivers on test_abupt.

The 3-arm sweep (1.05× / 1.10× / 1.20×) covers the expected sensitivity range: too light = null (no measurable SP shift), too heavy = other-channel regression (SP-VP/WSS tradeoff). The interior arm (1.10×) is the most likely winner; the boundary arms confirm the sensitivity is monotone-not-flat.

This is the cleanest train-time intervention experiment at the current frontier and the best use of edward's idle slot.
