### PR TITLE
H339: WSS-targeted loss reweighting cosine-tail (close 0.79pp WSS gap)

### DIFF
--- a/train.py
+++ b/train.py
@@ -106,6 +106,7 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_loss_weight: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -146,6 +147,8 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H310: deterministic seed plumbing
+    seed: int = 0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -271,6 +274,20 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "wss_loss_weight": (
+            "H339: uniform multiplier applied to all three WSS channels "
+            "(tau_x, tau_y, tau_z) in the surface channel-weighted MSE. "
+            "Composes multiplicatively with --tau-y-loss-weight and "
+            "--tau-z-loss-weight: effective tau_y channel weight = "
+            "tau_y_loss_weight * wss_loss_weight, etc. Default 1.0 = no "
+            "change vs current behaviour."
+        ),
+        "seed": (
+            "H310/H337/H338/H339: deterministic random seed. 0 (default) "
+            "leaves system entropy untouched; non-zero seeds "
+            "torch/CUDA/numpy/random for reproducible cosine-extension "
+            "runs across arms."
         ),
     }
     for field in fields(Config):
@@ -831,6 +848,15 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        if config.seed != 0:
+            import random as _random
+
+            import numpy as _np
+
+            torch.manual_seed(config.seed)
+            torch.cuda.manual_seed_all(config.seed)
+            _np.random.seed(config.seed)
+            _random.seed(config.seed)
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -919,13 +945,22 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
+        # H339: wss_loss_weight multiplies all three WSS channels uniformly,
+        # composing with the existing tau_y/tau_z per-channel weights.
         surface_channel_weights = torch.tensor(
-            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+            [
+                1.0,
+                1.0 * config.wss_loss_weight,
+                config.tau_y_loss_weight * config.wss_loss_weight,
+                config.tau_z_loss_weight * config.wss_loss_weight,
+            ],
             device=device,
             dtype=torch.float32,
         )
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
+            or (config.wss_loss_weight != 1.0)
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -1029,9 +1064,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"(log_freq[d, f] = log(sigmas[f % len(sigmas)]))"
                 )
             if use_channel_weights:
+                effective = surface_channel_weights.tolist()
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
-                    f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                    f"Surface channel weights: cp={effective[0]} "
+                    f"tau_x={effective[1]} tau_y={effective[2]} "
+                    f"tau_z={effective[3]} "
+                    f"(wss_loss_weight={config.wss_loss_weight})"
                 )
 
         run = init_wandb_run(
@@ -1064,6 +1102,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_loss_weight"] = config.wss_loss_weight
+            wandb.summary["seed"] = config.seed
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1268,6 +1308,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/wss_loss_weight": config.wss_loss_weight,
                         }
                     )
                 if gradnorm_metrics:


### PR DESCRIPTION
## Hypothesis

**WSS-targeted loss reweighting during the cosine-tail extension (ep12→ep15) is the highest-EV next step for closing the primary stretch goal: test_WSS 6.639% → 5.85% (gap = 0.79pp = 78.9bp).** The cal axis is structurally exhausted (6 nulls: H316/H319/H323/H328/H329/H334-in-flight). TTA inference axes are saturated (H330 K-axis, H331 R-axis, joint saturation confirmed). The H314 noise-family sweep identified ν=4 as the unique optimum — now merged. **Training is the only remaining lever for channel-specific WSS reduction.**

### Why WSS and why now

| Axis | Status | WSS progress |
|---|---|---|
| TTA inference (K, R, resolution) | Saturated (H330/H331) | Uniform ~0bp per axis |
| Post-hoc calibration (OLS, WLS, per-res, per-region) | Exhausted (6 nulls) | ~0bp structure |
| Noise family (H314 ν-sweep) | Merged — ν=4 optimal | Uniform −0.14bp (WSS same as abupt) |
| **Training-time loss reweighting** | **NOT YET TRIED** | **Unknown — highest EV remaining** |

H338 (edward PR #1522 in flight) targets SP (3.4bp gap, multipliers {1.05, 1.10, 1.20}). H339 targets WSS (78.9bp gap — 23× bigger, requires wider multiplier sweep {1.5, 2.0, 3.0}).

### What changes vs H312/H337 training

Only the WSS loss multiplier in the last 3 epochs (ep12→ep15 cosine extension). Everything else (seed=2025, optimizer state, schedule, batch size, SP/VP loss weights) stays identical to H310/H312/H337:

```python
# Existing (in train.py):
loss = (
    loss_cp * w_cp
    + loss_wx * w_wx + loss_wy * w_wy + loss_wz * w_wz
    + loss_vp * w_vp
)

# New (with --wss-loss-weight flag, default 1.0 = current behavior):
loss = (
    loss_cp * w_cp
    + loss_wx * w_wx * args.wss_loss_weight
    + loss_wy * w_wy * args.wss_loss_weight
    + loss_wz * w_wz * args.wss_loss_weight
    + loss_vp * w_vp
)
```

Verify the channel naming convention (loss_wx/wy/wz vs other naming) by reading `train.py` before implementing. Do NOT modify edward's already-merged `--sp-loss-weight` flag.

## Baseline

Current SOTA: **H314 (PR #1500 merged 17:45Z)** — `2scozlaf`

| Metric | H314 (current SOTA) |
|---|---:|
| val_abupt_cal | **5.8987%** (gate) |
| test_abupt_cal | **5.7387%** (gate) |
| test_VP_cal | 3.3739% (below floor 3.421) ✓ |
| test_SP_cal | 3.6136% (above floor 3.577 = +3.6bp gap) ✗ — H338 in flight |
| **test_WSS_cal** | **6.6390%** (vs target 5.85% = **+78.9bp gap**) ✗ ← this PR |

Reference checkpoint: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt` (base ep12 for cosine extension — same as H310/H337/H338).

## Instructions

### Step 1 — Check `--wss-loss-weight` plumbing (~30 min)

```bash
grep -n "wss_loss_weight\|sp_loss_weight\|w_wx\|w_wy\|w_wz\|loss_wx\|loss_wy\|loss_wz" train.py | head -30
```

If `--wss-loss-weight` already present (edward may have added both flags in H338) → use it directly. If only `--sp-loss-weight` → add `--wss-loss-weight float=1.0` following the exact same pattern. Diff should be minimal (< 10 lines). Do NOT bundle any other changes.

### Step 2 — Smoke (~10 min)

```bash
torchrun --standalone --nproc-per-node=1 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension \
  --seed=2025 \
  --max-steps=50 \
  --wss-loss-weight=2.0 \
  --debug
```

Confirm: per-channel loss for wx/wy/wz logs 2× the value vs a `--wss-loss-weight=1.0` run at step 50. VP and CP loss should be identical between runs.

### Step 3 — Primary (3 arms sequential or chained, ~9h training)

```bash
# Arm A — WSS 1.5× (light)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-loss-weight=1.5 \
  --wandb-group "h339-frieren-wss-loss-reweight" \
  --wandb-name "frieren/h339-arm-A-wss1.5"

# Arm B — WSS 2.0× (medium)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-loss-weight=2.0 \
  --wandb-group "h339-frieren-wss-loss-reweight" \
  --wandb-name "frieren/h339-arm-B-wss2.0"

# Arm C — WSS 3.0× (heavy)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-loss-weight=3.0 \
  --wandb-group "h339-frieren-wss-loss-reweight" \
  --wandb-name "frieren/h339-arm-C-wss3.0"
```

Save EP15 checkpoint per arm as `model-frieren-h339-arm-{A,B,C}-wss{1.5,2.0,3.0}:v1`.

### Step 4 — Eval each EP15 checkpoint via H314 TTA recipe + H312 cal (~6-7h per arm)

Use the CURRENT SOTA eval recipe (H314 Student-t ν=4 + 8-res + mirror + cal). Use hardcoded H312 cal coefficients (α-seed-invariant per H332, cal-transfer-lossless confirmed for same recipe + seed):

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<arm-X-wandb-run-id>/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent frieren --wandb-group "h339-frieren-wss-loss-reweight-eval" \
  --wandb-name "frieren/h339-arm-X-eval-cal"
```

**Wall budget**: 3 training arms (~3h each = 9h) + 3 eval arms (~6-7h each = 18-21h) = ~27-30h total. Use chained background launchers across sessions (same pattern as askeladd H335). Report each arm result as it lands; submit terminal SENPAI-RESULT once all 6 runs complete.

H312 cal coefficients for hardcoded use: α_cp=0.994888, α_τx=0.994397, α_τy=0.994083, α_τz=0.991722, α_VP=0.999687, β_VP=−0.832811.

### Step 5 — Report

| Arm | WSS wt | val_cal | test_cal | test_WSS | test_SP | test_VP | Δtest_WSS vs H314 | Δtest_abupt vs H314 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| H314 (ref) | 1.0× | 5.8987 | 5.7387 | 6.6390 | 3.6136 | 3.3739 | 0 | 0 |
| A | 1.5× | ? | ? | ? | ? | ? | ? | ? |
| B | 2.0× | ? | ? | ? | ? | ? | ? | ? |
| C | 3.0× | ? | ? | ? | ? | ? | ? | ? |

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA-train>","<armA-eval>","<armB-train>","<armB-eval>","<armC-train>","<armC-eval>"],"primary_metric":{"name":"val_abupt_h339_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h339_best_arm","value":<number>}}
```

## Decision logic

- **Merge** if any arm: val_cal < 5.8987 AND test_cal < 5.7387 (H314 strict gates). New SOTA.
- **Merge with caveat** if val/test gates pass but WSS improvement < 5bp — marginal SOTA, document WSS tradeoff.
- **Close + Finding 'wss-reweight-monotone-good'** if test_WSS decreases monotonically with WSS weight but gate fails — try Arm D 4.0× or report bounded interior.
- **Close + Finding 'wss-reweight-collapses-abupt'** if WSS improves ≥5bp but abupt (SP/VP) regresses >5bp — structural WSS-SP/VP tradeoff, not addressable by simple reweighting.
- **Close + Finding 'wss-reweight-null'** if all 3 arms produce test_WSS within ±5bp of H314 6.6390 — WSS gap is NOT training-time addressable via loss reweighting from the ep12 base; pivot to architecture or alternative training interventions.

## Notes

- **Independent of H338** (edward SP reweighting, PR #1522 in flight). Both share ep12 base + seed=2025. Results compose: if both succeed, a combined arm H340 runs both multipliers simultaneously.
- DDP 8-GPU required for training and eval.
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- No capacity additions — same model, same recipe, only WSS loss multiplier changes

## Why this matters

The WSS gap (0.79pp) is the primary obstacle to Morgan's stretch goal (Issue #1056: test_WSS < 5.85%). Every inference-axis avenue is now closed. If loss reweighting produces even a 20-30bp WSS reduction at matched SP/VP, it would be the most impactful single experiment since the H300 calibration discovery (28bp abupt gain). If it's null, we know the WSS gap is an architectural limitation and can refocus on capacity or different representations — which is equally valuable information.
