### PR TITLE
H341: wz-only WSS loss reweight cosine-tail — attack bottleneck channel (8.62% test_WSS_z)

### DIFF
--- a/train.py
+++ b/train.py
@@ -106,6 +106,7 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_z_loss_weight: float = 1.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -145,6 +146,7 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    seed: int = 0
     debug: bool = False
 
 
@@ -271,6 +273,22 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "wss_z_loss_weight": (
+            "H341: scalar multiplier applied ONLY to the wz / tau_z channel "
+            "in the surface channel-weighted MSE (channel index 3). "
+            "Composes multiplicatively with --tau-z-loss-weight: effective "
+            "tau_z channel weight = tau_z_loss_weight * wss_z_loss_weight. "
+            "Default 1.0 = no change vs current behaviour. Use this to "
+            "attack the wz bottleneck channel without disturbing wx/wy."
+        ),
+        "seed": (
+            "H310/H337/H341: integer seed for torch / numpy / random. 0 "
+            "(default) leaves all RNGs at system entropy. Nonzero sets "
+            "torch.manual_seed, torch.cuda.manual_seed_all, "
+            "numpy.random.seed, and random.seed BEFORE model/dataloader/"
+            "DDP construction so two runs with the same seed produce "
+            "matching val curves (modulo CUDA float non-determinism)."
         ),
     }
     for field in fields(Config):
@@ -831,6 +849,17 @@ def main(argv: Iterable[str] | None = None) -> None:
     run = None
     try:
         config = parse_args(argv)
+        if config.seed != 0:
+            import random as _py_random
+
+            import numpy as _np
+
+            torch.manual_seed(config.seed)
+            torch.cuda.manual_seed_all(config.seed)
+            _np.random.seed(config.seed)
+            _py_random.seed(config.seed)
+            if state.is_main:
+                print(f"Seed: {config.seed} (torch / cuda / numpy / random)")
         kill_thresholds = parse_kill_thresholds(config.kill_thresholds)
         vol_points_schedule = parse_vol_points_schedule(config.vol_points_schedule)
         requested_epochs = config.epochs
@@ -919,13 +948,22 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
+        # H341: wss_z_loss_weight multiplies only the tau_z channel, composing
+        # with tau_z_loss_weight, so wz can be reweighted in isolation.
         surface_channel_weights = torch.tensor(
-            [1.0, 1.0, config.tau_y_loss_weight, config.tau_z_loss_weight],
+            [
+                1.0,
+                1.0,
+                config.tau_y_loss_weight,
+                config.tau_z_loss_weight * config.wss_z_loss_weight,
+            ],
             device=device,
             dtype=torch.float32,
         )
         use_channel_weights = bool(
-            (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
+            (config.tau_y_loss_weight != 1.0)
+            or (config.tau_z_loss_weight != 1.0)
+            or (config.wss_z_loss_weight != 1.0)
         )
         if config.compile_model:
             model = torch.compile(model)
@@ -1029,9 +1067,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"(log_freq[d, f] = log(sigmas[f % len(sigmas)]))"
                 )
             if use_channel_weights:
+                effective = surface_channel_weights.tolist()
                 print(
-                    f"Surface channel weights: cp=1.0 tau_x=1.0 "
-                    f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
+                    f"Surface channel weights: cp={effective[0]} "
+                    f"tau_x={effective[1]} tau_y={effective[2]} "
+                    f"tau_z={effective[3]} "
+                    f"(wss_z_loss_weight={config.wss_z_loss_weight})"
                 )
 
         run = init_wandb_run(
@@ -1064,6 +1105,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_z_loss_weight"] = config.wss_z_loss_weight
+            wandb.summary["seed"] = config.seed
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1268,6 +1311,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/wss_z_loss_weight": config.wss_z_loss_weight,
                         }
                     )
                 if gradnorm_metrics:


### PR DESCRIPTION
## Hypothesis

**Per-axis WSS reweighting concentrated on the worst-channel wz at cosine-tail extension is higher-EV than uniform multi-axis WSS reweighting** for closing the WSS stretch gap.

The H314 SOTA channel breakdown (test_wall_shear_*):
- **wz = 8.6195%** (worst by 1.4pp over second-worst)
- wy = 7.1832%
- wx = 5.9015%
- WSS mean = 6.6390%

The WSS gap (78.9bp to Transolver-3 target 5.85%) is **almost entirely a wz channel problem**. H339 (frieren, PR #1523) tests uniform reweighting at {1.5×, 2.0×, 3.0×} of all 3 WSS channels — but uniform reweighting at high multiplier risks degrading wx (which is already near floor at 5.90%) and wy (7.18%) without commensurate wz gain.

**Per-axis decomposition isolates the bottleneck channel**: if wz-only reweight matches H339 uniform gain at lower wx/wy degradation, then wz IS the lever and uniform is wasted gradient on non-bottleneck channels. If wz-only at high multiplier outperforms H339 uniform, the wz axis is even more underweighted in the H300 OLS-extracted loss weights.

### Compositional logic vs H339

| Scenario | H339 uniform 2.0× | H341 wz-only 3.0× | Interpretation |
|---|---|---|---|
| Both win gate | new SOTA (whichever is best) | new SOTA | Reweighting works; pick the lowest-degradation path |
| H339 wins, H341 nulls | new SOTA | finding-bank | Distributed wx+wy+wz signal compensates; wz alone is insufficient |
| **H339 nulls, H341 wins** | finding-bank | **new SOTA** | wz IS the bottleneck; uniform dilutes signal |
| Both null | finding-bank | finding-bank | WSS gap is NOT loss-reweighting addressable; pivot to arch |

This experiment is **structurally informative regardless of H339 outcome** — wz-only is a different lever from uniform with distinct mechanism.

## Baseline

Current SOTA: **H314 (PR #1500, merged 17:45Z)** — `2scozlaf`

| Metric | H314 (current SOTA) |
|---|---:|
| val_abupt_cal | **5.8987%** (gate) |
| test_abupt_cal | **5.7387%** (gate) |
| **test_WSS_cal** | **6.6390%** (vs target 5.85% = +78.9bp gap) ← this PR's primary target |
| test_WSS_z | 8.6195% (bottleneck channel) |
| test_WSS_y | 7.1832% |
| test_WSS_x | 5.9015% |
| test_VP_cal | 3.3739% (below floor — keep) |
| test_SP_cal | 3.6136% (+3.6bp gap — H338 in flight) |

Reference checkpoint: `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt` (ep12 base for cosine extension — same as H310/H337/H338/H339).

## Instructions

### Step 1 — Check `--wss-z-loss-weight` plumbing (~20 min)

```bash
grep -n "wss_loss_weight\|sp_loss_weight\|w_wx\|w_wy\|w_wz\|loss_wx\|loss_wy\|loss_wz\|tau_z_loss" train.py | head -30
```

H339 (frieren PR #1523) is in flight and adds `--wss-loss-weight` flag that multiplies all 3 WSS channels uniformly. H338 (edward PR #1522 in flight) adds `--sp-loss-weight` for cp. **You add `--wss-z-loss-weight float=1.0`** that multiplies ONLY the wz channel weight in the loss aggregation. Follow the same `surface_channel_weights` tensor pattern edward used for sp; do NOT modify the uniform `--wss-loss-weight` flag if present.

Code change should be minimal (< 10 lines), parallel to:

```python
# Existing (existing channels):
loss = (loss_cp * w_cp
        + loss_wx * w_wx
        + loss_wy * w_wy
        + loss_wz * w_wz * args.wss_z_loss_weight  # NEW
        + loss_vp * w_vp)
```

Do NOT bundle wy-only or wx-only flags into this PR — single hypothesis per PR. If H341 succeeds, future H342/H343 will add those flags.

### Step 2 — Smoke (~10 min)

```bash
torchrun --standalone --nproc-per-node=1 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --max-steps=50 \
  --wss-z-loss-weight=3.0 --debug
```

Confirm:
- `loss_wz` channel logs 3× the per-step value vs a `--wss-z-loss-weight=1.0` smoke at step 50
- `loss_wx`, `loss_wy`, `loss_cp`, `loss_vp` unchanged (identical to ref)

### Step 3 — Primary (3 arms chained, ~9h training)

```bash
# Arm A — wz 2.0× (light)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-z-loss-weight=2.0 \
  --wandb-group "h341-fern-wss-z-only-reweight" \
  --wandb-name "fern/h341-arm-A-wz2.0"

# Arm B — wz 3.0× (medium)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-z-loss-weight=3.0 \
  --wandb-group "h341-fern-wss-z-only-reweight" \
  --wandb-name "fern/h341-arm-B-wz3.0"

# Arm C — wz 5.0× (heavy)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint outputs/drivaerml/<base-ep12-checkpoint>.pt \
  --cosine-extension --seed=2025 --epochs=16 \
  --wss-z-loss-weight=5.0 \
  --wandb-group "h341-fern-wss-z-only-reweight" \
  --wandb-name "fern/h341-arm-C-wz5.0"
```

Save EP15 checkpoint per arm as `model-fern-h341-arm-{A,B,C}-wz{2.0,3.0,5.0}:v1`.

### Step 4 — Eval each EP15 checkpoint via H314 TTA recipe + H312 cal (~6-7h per arm)

Use the CURRENT SOTA eval recipe (H314 Student-t ν=4 + 8-res + mirror + cal). Use hardcoded H312 cal coefficients (α-seed-invariant per H332, cal-transfer-lossless confirmed):

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<arm-X-wandb-run-id>/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent fern --wandb-group "h341-fern-wss-z-only-reweight-eval" \
  --wandb-name "fern/h341-arm-X-eval-cal"
```

**Wall budget**: 3 training arms × ~3h = ~9h + 3 eval arms × ~6-7h = ~18-21h. Total ~27-30h chained across sessions (same multi-session pattern as askeladd H335, frieren H339).

H312 hardcoded cal coefficients: α_cp=0.994888, α_τx=0.994397, α_τy=0.994083, α_τz=0.991722, α_VP=0.999687, β_VP=−0.832811.

### Step 5 — Report

| Arm | wz wt | val_cal | test_cal | test_WSS | test_WSS_z | test_WSS_y | test_WSS_x | test_SP | test_VP | Δtest_WSS vs H314 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| H314 (ref) | 1.0× | 5.8987 | 5.7387 | 6.6390 | 8.6195 | 7.1832 | 5.9015 | 3.6136 | 3.3739 | 0 |
| A | 2.0× | ? | ? | ? | ? | ? | ? | ? | ? | ? |
| B | 3.0× | ? | ? | ? | ? | ? | ? | ? | ? | ? |
| C | 5.0× | ? | ? | ? | ? | ? | ? | ? | ? | ? |

**Critical**: report per-channel `test_WSS_x`, `test_WSS_y`, `test_WSS_z` separately. This decomposition is essential for the per-axis mechanism diagnosis.

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA-train>","<armA-eval>","<armB-train>","<armB-eval>","<armC-train>","<armC-eval>"],"primary_metric":{"name":"val_abupt_h341_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h341_best_arm","value":<number>}}
```

## Decision logic

- **MERGE** if any arm: val_cal < 5.8987 AND test_cal < 5.7387 (H314 strict gates).
- **Close + Finding 'wz-channel-bottleneck-confirmed'** if test_WSS_z decreases by ≥30bp at matched test_WSS_x/y → wz reweighting works; uniform is dilutive.
- **Close + Finding 'wz-reweight-collapses-on-other-channels'** if test_WSS_z improves but test_WSS_x or test_WSS_y degrades ≥10bp → cross-channel coupling; per-axis isolation insufficient.
- **Close + Finding 'wz-reweight-monotone-nogate'** if test_WSS_z improves monotonically but val_cal fails gate by similar margin to H339 → WSS gap is NOT addressable via diagonal training-time reweight.
- **Close + Finding 'wz-only-null-vs-H339'** if all 3 arms produce test_WSS within ±5bp of H314 6.6390 AND H339 also nulls → loss-reweighting axis structurally closed, pivot to architecture or alternative training.

## Notes

- **Independent of H338 (edward SP reweight, PR #1522) and H339 (frieren uniform WSS reweight, PR #1523)** — all 3 share ep12 base + seed=2025. Results compose: if H338+H339+H341 all show signal, H342 runs combined wz-only+SP at the best individual multipliers.
- DDP 8-GPU required for training and eval.
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`.
- z-axis τ_z **architecture** is LOCKED at 1.67 — never modify. This PR modifies only the **wz channel LOSS WEIGHT**, NOT the τ_z architecture coefficient (which is a different thing).
- No capacity additions — same model, same recipe, only wz loss multiplier changes.

## Why this matters

The WSS gap (78.9bp) IS the primary obstacle to Morgan's Issue #1056 stretch goal (test_WSS < 5.85%). The H314 channel breakdown shows the gap is **concentrated almost entirely in wz** (8.62% vs target 5.85% = 277bp; wy 7.18% vs target ~6.5% = 70bp; wx 5.90% vs target ~5.3% = 60bp). A wz-targeted intervention is the mechanistically correct attack.

H341 + H339 together provide the full per-axis loss-reweighting picture: uniform (H339), wz-only (H341). If both null, we have closed loss-reweighting structurally and need to pivot. If either succeeds, we have a new SOTA and a clear mechanism.
