### PR TITLE
H342: Multi-checkpoint output-averaging TTA — ep14+ep15+ep16 from H312 SOTA cosine-tail

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -104,6 +104,13 @@ class EvalConfig:
     # under affine + sufficient stats and is reported only on the raw output.
     test_time_calibration: bool = False
 
+    # H342: dump per-case averaged predictions (real units, shape (n_pts, ch))
+    # plus targets to this .npz path, for post-hoc multi-checkpoint output
+    # averaging. Cross-ckpt mean of per-ckpt per-case averages equals the mean
+    # across all (ckpt, k, R, mirror) passes (uniform per-point contributions),
+    # so the per-case averaged form is sufficient for H342's hypothesis.
+    save_raw_predictions: str = ""
+
     manifest: str = "data/split_manifest.json"
     data_root: str = "/mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511"
     output_dir: str = "outputs/h252_eval"
@@ -598,6 +605,26 @@ def merge_calibration_stats(parts: Iterable[CalibrationStats]) -> CalibrationSta
     return merged
 
 
+@dataclass
+class RawPredictions:
+    """Per-case TTA-averaged predictions in real units (H342 plumbing)."""
+
+    surface_preds: dict[str, torch.Tensor] = field(default_factory=dict)
+    volume_preds: dict[str, torch.Tensor] = field(default_factory=dict)
+    surface_targets: dict[str, torch.Tensor] = field(default_factory=dict)
+    volume_targets: dict[str, torch.Tensor] = field(default_factory=dict)
+
+
+def merge_raw_predictions(parts: Iterable[RawPredictions]) -> RawPredictions:
+    merged = RawPredictions()
+    for part in parts:
+        merged.surface_preds.update(part.surface_preds)
+        merged.volume_preds.update(part.volume_preds)
+        merged.surface_targets.update(part.surface_targets)
+        merged.volume_targets.update(part.volume_targets)
+    return merged
+
+
 def fit_affine_per_channel(
     global_stats: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -812,9 +839,10 @@ def evaluate_split_stacked(
     distributed_state,
     antithetic: bool = False,
     collect_calibration: bool = False,
+    collect_raw_predictions: bool = False,
     noise_dist: str = "gaussian",
     noise_df: int = 4,
-) -> tuple[dict[str, float], CalibrationStats | None]:
+) -> tuple[dict[str, float], CalibrationStats | None, RawPredictions | None]:
     rank = distributed_state.rank if distributed_state and distributed_state.enabled else 0
     world_size = (
         distributed_state.world_size
@@ -825,6 +853,7 @@ def evaluate_split_stacked(
 
     acc = EvalAccumulator()
     cal = CalibrationStats() if collect_calibration else None
+    raw = RawPredictions() if collect_raw_predictions else None
     total_t0 = time.time()
     total_forward = 0.0
     total_io = 0.0
@@ -867,6 +896,11 @@ def evaluate_split_stacked(
                 surface_y=surf_y,
                 volume_y=vol_y,
             )
+        if raw is not None:
+            raw.surface_preds[case_id] = surf_avg.detach().cpu().to(torch.float32)
+            raw.volume_preds[case_id] = vol_avg.detach().cpu().to(torch.float32)
+            raw.surface_targets[case_id] = surf_y.detach().cpu().to(torch.float32)
+            raw.volume_targets[case_id] = vol_y.detach().cpu().to(torch.float32)
         total_forward += timing["forward_seconds"]
         total_io += timing["io_seconds"]
         total_perturb += timing["perturb_seconds"]
@@ -896,19 +930,29 @@ def evaluate_split_stacked(
         if cal is not None:
             gathered_cal = [None for _ in range(world_size)]
             dist.all_gather_object(gathered_cal, cal)
+        gathered_raw: list[RawPredictions | None] | None = None
+        if raw is not None:
+            gathered_raw = [None for _ in range(world_size)]
+            dist.all_gather_object(gathered_raw, raw)
         if not distributed_state.is_main:
-            return {}, None
+            return {}, None, None
         merged = merge_eval_accumulators(g for g in gathered if g is not None)
         merged_cal = (
             merge_calibration_stats(c for c in gathered_cal if c is not None)
             if gathered_cal is not None
             else None
         )
+        merged_raw = (
+            merge_raw_predictions(r for r in gathered_raw if r is not None)
+            if gathered_raw is not None
+            else None
+        )
     else:
         merged = acc
         merged_cal = cal
+        merged_raw = raw
 
-    return finalize_eval_accumulator(merged), merged_cal
+    return finalize_eval_accumulator(merged), merged_cal, merged_raw
 
 
 def resolve_checkpoint_path(cfg: EvalConfig, state) -> tuple[Path, str]:
@@ -1071,10 +1115,12 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     summary: dict[str, dict[str, dict[str, float]]] = {}
     cal_summary: dict[str, dict[str, CalibrationStats | None]] = {}
+    raw_summary: dict[str, dict[str, RawPredictions | None]] = {}
     log_prefix_by_split: dict[str, str] = {}
     for split_name, case_ids, log_prefix in splits:
         summary[split_name] = {}
         cal_summary[split_name] = {}
+        raw_summary[split_name] = {}
         log_prefix_by_split[split_name] = log_prefix
         for mode in modes:
             if mode == "weight_noise_only":
@@ -1101,7 +1147,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     flush=True,
                 )
             t0 = time.time()
-            metrics, cal_stats = evaluate_split_stacked(
+            metrics, cal_stats, raw_preds = evaluate_split_stacked(
                 split_name=f"{split_name}/{mode}",
                 case_ids=case_ids,
                 model=model,
@@ -1118,6 +1164,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 distributed_state=state,
                 antithetic=cfg.antithetic_noise,
                 collect_calibration=cfg.test_time_calibration,
+                collect_raw_predictions=bool(cfg.save_raw_predictions),
                 noise_dist=cfg.weight_noise_dist,
                 noise_df=cfg.weight_noise_df,
             )
@@ -1127,6 +1174,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 print_metrics(f"{split_name}/{mode}", metrics)
                 summary[split_name][mode] = metrics
                 cal_summary[split_name][mode] = cal_stats
+                raw_summary[split_name][mode] = raw_preds
 
                 log_obj: dict[str, float] = {}
                 log_obj.update(primary_metric_log(f"{log_prefix}_primary/{mode}", metrics))
@@ -1137,6 +1185,49 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     # Always restore clean weights at the end.
     restore_clean_params(eval_module, clean)
+
+    # H342: dump per-case TTA-averaged predictions for post-hoc multi-checkpoint
+    # output averaging. One mode per checkpoint expected; if more than one mode
+    # runs the first non-empty mode wins (per H342 we only use a single mode).
+    if cfg.save_raw_predictions and state.is_main:
+        import json  # noqa: PLC0415 — local import
+        import numpy as np  # noqa: PLC0415 — local import
+
+        out_path = Path(cfg.save_raw_predictions)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        arrays: dict[str, np.ndarray] = {}
+        modes_dumped: list[str] = []
+        for split, mode_dict in raw_summary.items():
+            for mode, rp in mode_dict.items():
+                if rp is None:
+                    continue
+                modes_dumped.append(f"{split}/{mode}")
+                for cid, t in rp.surface_preds.items():
+                    arrays[f"surf_pred__{split}__{mode}__{cid}"] = t.numpy()
+                for cid, t in rp.volume_preds.items():
+                    arrays[f"vol_pred__{split}__{mode}__{cid}"] = t.numpy()
+                for cid, t in rp.surface_targets.items():
+                    arrays[f"surf_y__{split}__{mode}__{cid}"] = t.numpy()
+                for cid, t in rp.volume_targets.items():
+                    arrays[f"vol_y__{split}__{mode}__{cid}"] = t.numpy()
+        metadata = {
+            "checkpoint": str(ckpt_path),
+            "checkpoint_source": ckpt_source,
+            "checkpoint_epoch": ck.get("epoch"),
+            "checkpoint_source_field": ck.get("checkpoint_source"),
+            "resolutions": resolutions,
+            "modes": modes,
+            "modes_dumped": modes_dumped,
+            "weight_noise_sigma": cfg.weight_noise_sigma,
+            "weight_noise_passes": cfg.weight_noise_passes,
+            "antithetic_noise": cfg.antithetic_noise,
+            "weight_noise_dist": cfg.weight_noise_dist,
+            "weight_noise_df": cfg.weight_noise_df,
+            "wandb_name": cfg.wandb_name,
+        }
+        arrays["__metadata__"] = np.array(json.dumps(metadata))
+        np.savez_compressed(out_path, **arrays)
+        print(f"[H342] saved {len(arrays) - 1} raw arrays to {out_path}", flush=True)
 
     # H300: per-channel affine calibration applied on val, transferred to test.
     cal_metrics_by_split_mode: dict[str, dict[str, dict[str, float]]] = {}

--- a/tools/h342_avg_checkpoints.py
+++ b/tools/h342_avg_checkpoints.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+"""H342: Post-hoc multi-checkpoint output-averaging script.
+
+Loads N per-case prediction .npz files (one per checkpoint) produced by
+``eval_tta_h252.py --save-raw-predictions`` and averages the per-case
+real-unit predictions point-wise across selected checkpoints, then computes
+both H300 fresh-fit calibrated metrics (α/β fit on the averaged val output,
+applied to the averaged test output) AND H312-hardcoded calibrated metrics
+(fixed α/β recipe-invariant, applied identically across all arms).
+
+Per-checkpoint and per-(k, R, mirror) pass averaging are linear with uniform
+weights, so the cross-checkpoint mean of per-checkpoint per-case averages
+equals the mean over all (ckpt, k, R, mirror) tuples — sufficient for
+H342's output-averaging hypothesis.
+
+Usage:
+    python tools/h342_avg_checkpoints.py \\
+        --inputs outputs/h342/ep13_raw.npz outputs/h342/ep14_raw.npz \\
+                 outputs/h342/ep15_raw.npz \\
+        --arms "A:2 B:1,2 C:0,2 D:0,1,2"
+
+Each arm is "name:i,j,k" where i,j,k index into --inputs (0-based).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+SURF_CHANNELS = ["cp", "tau_x", "tau_y", "tau_z"]
+N_SURF = 4
+N_VOL = 1
+N_STAT_COLS = 6  # [N, sum_p, sum_t, sum_pp, sum_tt, sum_pt]
+
+# H312 hardcoded affine calibration (recipe-invariant — H332 finding).
+# Surface betas are omitted in the PR text and observed ~0 across H314 fits,
+# so we set them to exact zero. Volume beta is explicit.
+H312_CAL = {
+    "alpha_surf": torch.tensor(
+        [0.994888, 0.994397, 0.994083, 0.991722], dtype=torch.float64
+    ),
+    "beta_surf": torch.tensor([0.0, 0.0, 0.0, 0.0], dtype=torch.float64),
+    "alpha_vol": torch.tensor([0.999687], dtype=torch.float64),
+    "beta_vol": torch.tensor([-0.832811], dtype=torch.float64),
+}
+
+
+def _channel_stats(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    p = pred.double()
+    t = target.double()
+    n_points = p.shape[0]
+    n_ch = p.shape[1]
+    stats = torch.empty(n_ch, N_STAT_COLS, dtype=torch.float64)
+    stats[:, 0] = float(n_points)
+    stats[:, 1] = p.sum(0)
+    stats[:, 2] = t.sum(0)
+    stats[:, 3] = (p * p).sum(0)
+    stats[:, 4] = (t * t).sum(0)
+    stats[:, 5] = (p * t).sum(0)
+    return stats
+
+
+def _fit_affine(global_stats: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    N = global_stats[:, 0]
+    sum_p = global_stats[:, 1]
+    sum_t = global_stats[:, 2]
+    sum_pp = global_stats[:, 3]
+    sum_pt = global_stats[:, 5]
+    N_safe = N.clamp(min=1.0)
+    mu_p = sum_p / N_safe
+    mu_t = sum_t / N_safe
+    cov_pt = sum_pt - N * mu_p * mu_t
+    var_p = sum_pp - N * mu_p * mu_p
+    degenerate = var_p <= 1e-12
+    alpha_raw = cov_pt / var_p.clamp(min=1e-12)
+    alpha = torch.where(degenerate, torch.ones_like(alpha_raw), alpha_raw)
+    beta = torch.where(degenerate, torch.zeros_like(alpha_raw), mu_t - alpha * mu_p)
+    return alpha, beta
+
+
+def _affine_err_sq(
+    stats: torch.Tensor, alpha: torch.Tensor, beta: torch.Tensor
+) -> torch.Tensor:
+    N = stats[..., 0]
+    sum_p = stats[..., 1]
+    sum_t = stats[..., 2]
+    sum_pp = stats[..., 3]
+    sum_tt = stats[..., 4]
+    sum_pt = stats[..., 5]
+    return (
+        alpha * alpha * sum_pp
+        + 2.0 * alpha * beta * sum_p
+        - 2.0 * alpha * sum_pt
+        + beta * beta * N
+        - 2.0 * beta * sum_t
+        + sum_tt
+    )
+
+
+def _compute_metrics_from_per_case_stats(
+    per_case_surf: dict[str, torch.Tensor],
+    per_case_vol: dict[str, torch.Tensor],
+    alpha_surf: torch.Tensor | None = None,
+    beta_surf: torch.Tensor | None = None,
+    alpha_vol: torch.Tensor | None = None,
+    beta_vol: torch.Tensor | None = None,
+) -> dict[str, float]:
+    """Compute per-case averaged rel_l2 metrics. If alpha/beta are None,
+    metrics are computed on raw predictions (identity affine)."""
+    if alpha_surf is None:
+        alpha_surf = torch.ones(N_SURF, dtype=torch.float64)
+        beta_surf = torch.zeros(N_SURF, dtype=torch.float64)
+        alpha_vol = torch.ones(N_VOL, dtype=torch.float64)
+        beta_vol = torch.zeros(N_VOL, dtype=torch.float64)
+
+    surf_ids = sorted(per_case_surf.keys())
+    if not surf_ids:
+        raise RuntimeError("Empty per-case stats")
+    surf_per_ch: list[torch.Tensor] = []
+    vec_l2: list[torch.Tensor] = []
+    for cid in surf_ids:
+        s = per_case_surf[cid]
+        e_sq = _affine_err_sq(s, alpha_surf, beta_surf)
+        t_sq = s[..., 4]
+        rel = torch.sqrt(e_sq.clamp(min=0.0) / t_sq.clamp(min=1e-12))
+        surf_per_ch.append(rel)
+        s_vec = s[1:4]
+        e_sq_vec = _affine_err_sq(s_vec, alpha_surf[1:4], beta_surf[1:4])
+        t_sq_vec = s_vec[..., 4]
+        rel_vec = torch.sqrt(e_sq_vec.sum().clamp(min=0.0) / t_sq_vec.sum().clamp(min=1e-12))
+        vec_l2.append(rel_vec)
+    surf_rel = torch.stack(surf_per_ch, dim=0)
+    vec_rel = torch.stack(vec_l2, dim=0)
+
+    vol_ids = sorted(per_case_vol.keys())
+    vol_per_ch: list[torch.Tensor] = []
+    for cid in vol_ids:
+        v = per_case_vol[cid]
+        e_sq = _affine_err_sq(v, alpha_vol, beta_vol)
+        t_sq = v[..., 4]
+        rel = torch.sqrt(e_sq.clamp(min=0.0) / t_sq.clamp(min=1e-12))
+        vol_per_ch.append(rel)
+    vol_rel = torch.stack(vol_per_ch, dim=0)
+
+    sp = float(surf_rel[:, 0].mean().item())
+    tx = float(surf_rel[:, 1].mean().item())
+    ty = float(surf_rel[:, 2].mean().item())
+    tz = float(surf_rel[:, 3].mean().item())
+    ws_vec = float(vec_rel.mean().item())
+    vp = float(vol_rel[:, 0].mean().item())
+    abupt = (sp + tx + ty + tz + vp) / 5.0
+    return {
+        "surface_pressure_rel_l2_pct": sp * 100.0,
+        "wall_shear_rel_l2_pct": ws_vec * 100.0,
+        "wall_shear_x_rel_l2_pct": tx * 100.0,
+        "wall_shear_y_rel_l2_pct": ty * 100.0,
+        "wall_shear_z_rel_l2_pct": tz * 100.0,
+        "volume_pressure_rel_l2_pct": vp * 100.0,
+        "abupt_axis_mean_rel_l2_pct": abupt * 100.0,
+        "cases": float(len(surf_ids)),
+    }
+
+
+def _load_one(path: Path) -> dict:
+    """Load one .npz; return {'val': {'surf':{cid:array},...}, 'test': {...},
+    'metadata': dict}."""
+    data = np.load(path, allow_pickle=False)
+    keys = [k for k in data.keys() if not k.startswith("__")]
+    parsed: dict[str, dict[str, dict[str, np.ndarray]]] = {}
+    for k in keys:
+        # surf_pred__val_surface__weight_noise_mirror_res_avg__run_4
+        parts = k.split("__")
+        kind = parts[0]  # surf_pred|vol_pred|surf_y|vol_y
+        split = parts[1]
+        cid = parts[3]
+        parsed.setdefault(split, {}).setdefault(kind, {})[cid] = data[k]
+    metadata = json.loads(str(data["__metadata__"]))
+    return {**parsed, "metadata": metadata}
+
+
+def _avg_predictions(
+    loaded: list[dict], indices: list[int], split: str
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """For an arm = list of checkpoint indices, average predictions across
+    them per case. Returns dicts of cid -> tensor for surf_pred, vol_pred,
+    and the (shared) surf_y, vol_y targets."""
+    if not indices:
+        raise ValueError("Empty arm composition")
+
+    case_id_sets = []
+    for i in indices:
+        ckpt_split = loaded[i].get(split, {})
+        sp_keys = set(ckpt_split.get("surf_pred", {}).keys())
+        vp_keys = set(ckpt_split.get("vol_pred", {}).keys())
+        if sp_keys != vp_keys:
+            raise RuntimeError(
+                f"Checkpoint {i} split={split} has mismatched surf/vol case sets"
+            )
+        case_id_sets.append(sp_keys)
+    cids = case_id_sets[0]
+    for s in case_id_sets[1:]:
+        if s != cids:
+            extra = (s - cids) | (cids - s)
+            raise RuntimeError(
+                f"Checkpoints {indices} disagree on case IDs for split={split}: "
+                f"diff={sorted(extra)}"
+            )
+
+    surf_pred: dict[str, torch.Tensor] = {}
+    vol_pred: dict[str, torch.Tensor] = {}
+    surf_y: dict[str, torch.Tensor] = {}
+    vol_y: dict[str, torch.Tensor] = {}
+    for cid in sorted(cids):
+        # Average surf preds across checkpoints (float32 -> float64 for stability).
+        sp_stack = np.stack(
+            [loaded[i][split]["surf_pred"][cid].astype(np.float64) for i in indices], axis=0
+        )
+        sp_avg = sp_stack.mean(axis=0)
+        vp_stack = np.stack(
+            [loaded[i][split]["vol_pred"][cid].astype(np.float64) for i in indices], axis=0
+        )
+        vp_avg = vp_stack.mean(axis=0)
+        surf_pred[cid] = torch.from_numpy(sp_avg.astype(np.float32))
+        vol_pred[cid] = torch.from_numpy(vp_avg.astype(np.float32))
+        # Targets should be identical across files; take from the first.
+        surf_y[cid] = torch.from_numpy(loaded[indices[0]][split]["surf_y"][cid])
+        vol_y[cid] = torch.from_numpy(loaded[indices[0]][split]["vol_y"][cid])
+    return surf_pred, vol_pred, surf_y, vol_y
+
+
+def _per_case_stats(
+    preds: dict[str, torch.Tensor],
+    targets: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    for cid in sorted(preds.keys()):
+        out[cid] = _channel_stats(preds[cid], targets[cid])
+    return out
+
+
+def _global_stats(per_case: dict[str, torch.Tensor]) -> torch.Tensor:
+    return torch.stack(list(per_case.values()), dim=0).sum(dim=0)
+
+
+def evaluate_arm(
+    arm_name: str,
+    indices: list[int],
+    loaded: list[dict],
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Returns {split: {recipe: metrics_dict}} where recipe in {raw, cal_fitted, cal_hardcoded}."""
+    out: dict[str, dict[str, dict[str, float]]] = {}
+
+    # Aggregate per-case stats for both splits first; fit α/β on val.
+    per_case_by_split: dict[str, tuple[dict, dict]] = {}
+    for split in ("val_surface", "test_surface"):
+        sp, vp, sy, vy = _avg_predictions(loaded, indices, split)
+        surf_stats = _per_case_stats(sp, sy)
+        vol_stats = _per_case_stats(vp, vy)
+        per_case_by_split[split] = (surf_stats, vol_stats)
+
+    val_surf_global = _global_stats(per_case_by_split["val_surface"][0])
+    val_vol_global = _global_stats(per_case_by_split["val_surface"][1])
+    alpha_surf_fit, beta_surf_fit = _fit_affine(val_surf_global)
+    alpha_vol_fit, beta_vol_fit = _fit_affine(val_vol_global)
+
+    print(f"\n=== Arm {arm_name} (ckpts={indices}) calibration coefs (fit on val) ===")
+    for c, name in enumerate(SURF_CHANNELS):
+        print(
+            f"  surface[{name:6s}]  alpha_fit={alpha_surf_fit[c].item():+.6f} "
+            f"beta_fit={beta_surf_fit[c].item():+.6f}"
+        )
+    print(
+        f"  volume[volume_pressure]  alpha_fit={alpha_vol_fit[0].item():+.6f} "
+        f"beta_fit={beta_vol_fit[0].item():+.6f}"
+    )
+
+    for split, (surf_per_case, vol_per_case) in per_case_by_split.items():
+        out.setdefault(split, {})
+        out[split]["raw"] = _compute_metrics_from_per_case_stats(
+            surf_per_case, vol_per_case
+        )
+        out[split]["cal_fitted"] = _compute_metrics_from_per_case_stats(
+            surf_per_case, vol_per_case,
+            alpha_surf=alpha_surf_fit, beta_surf=beta_surf_fit,
+            alpha_vol=alpha_vol_fit, beta_vol=beta_vol_fit,
+        )
+        out[split]["cal_hardcoded"] = _compute_metrics_from_per_case_stats(
+            surf_per_case, vol_per_case,
+            alpha_surf=H312_CAL["alpha_surf"], beta_surf=H312_CAL["beta_surf"],
+            alpha_vol=H312_CAL["alpha_vol"], beta_vol=H312_CAL["beta_vol"],
+        )
+    return out
+
+
+def parse_arms(spec: str) -> list[tuple[str, list[int]]]:
+    """'A:2 B:1,2 C:0,2 D:0,1,2' -> [('A',[2]), ('B',[1,2]), ...]."""
+    arms: list[tuple[str, list[int]]] = []
+    for tok in spec.split():
+        name, idx_spec = tok.split(":")
+        indices = [int(x) for x in idx_spec.split(",") if x.strip()]
+        arms.append((name.strip(), indices))
+    return arms
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--inputs", nargs="+", required=True,
+        help="Per-checkpoint .npz files (order matters; refer to by index in --arms)",
+    )
+    ap.add_argument(
+        "--arms", default="",
+        help='Space-separated "name:idx1,idx2,..." (defaults: all single + all pairwise + all-N)',
+    )
+    ap.add_argument(
+        "--out", default="",
+        help="Optional .json path to write the full results dict.",
+    )
+    args = ap.parse_args()
+
+    paths = [Path(p) for p in args.inputs]
+    for p in paths:
+        if not p.exists():
+            raise FileNotFoundError(p)
+    print(f"Loading {len(paths)} checkpoint files:")
+    loaded = []
+    for i, p in enumerate(paths):
+        d = _load_one(p)
+        meta = d["metadata"]
+        ckpt = meta.get("checkpoint", "?")
+        ep = meta.get("checkpoint_epoch", "?")
+        print(f"  [{i}] {p.name}  checkpoint={ckpt} epoch={ep}")
+        loaded.append(d)
+
+    if args.arms:
+        arms = parse_arms(args.arms)
+    else:
+        arms = []
+        N = len(paths)
+        # Single-checkpoint controls
+        for i in range(N):
+            arms.append((f"single_{i}", [i]))
+        # All adjacent / 2-cp pairs
+        for i in range(N):
+            for j in range(i + 1, N):
+                arms.append((f"pair_{i}_{j}", [i, j]))
+        # All-N
+        if N >= 3:
+            arms.append((f"all_{N}", list(range(N))))
+
+    results: dict[str, dict] = {}
+    for name, indices in arms:
+        if max(indices) >= len(paths):
+            raise ValueError(f"Arm {name} indices out of range: {indices}")
+        print(f"\n{'=' * 60}\nArm {name}: ckpts={indices}\n{'=' * 60}")
+        arm_metrics = evaluate_arm(name, indices, loaded)
+        results[name] = {
+            "indices": indices,
+            "metrics": arm_metrics,
+        }
+
+    # Pretty-print summary table
+    print(f"\n\n{'=' * 100}")
+    print("H342 multi-checkpoint output-averaging summary")
+    print(f"{'=' * 100}")
+    keys_to_show = (
+        "abupt_axis_mean_rel_l2_pct",
+        "surface_pressure_rel_l2_pct",
+        "wall_shear_rel_l2_pct",
+        "wall_shear_x_rel_l2_pct",
+        "wall_shear_y_rel_l2_pct",
+        "wall_shear_z_rel_l2_pct",
+        "volume_pressure_rel_l2_pct",
+    )
+    for split in ("val_surface", "test_surface"):
+        print(f"\n[{split}]")
+        for recipe in ("raw", "cal_fitted", "cal_hardcoded"):
+            print(f"\n  -- {recipe} --")
+            header = f"  {'metric':<36s} " + " ".join(
+                f"{name:>15s}" for name, _ in arms
+            )
+            print(header)
+            for k in keys_to_show:
+                row = f"  {k:<36s} " + " ".join(
+                    f"{results[name]['metrics'][split][recipe][k]:>15.4f}"
+                    for name, _ in arms
+                )
+                print(row)
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nSaved full results to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/h342_chain_ep13.sh
+++ b/tools/h342_chain_ep13.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# H342: Wait for ep14 eval to finish, then launch ep13 eval. Designed to be
+# nohup'd so the chain survives shell exits.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ep14_pid=$(cat logs/h342/ep14_raw.pid)
+echo "[$(date -u +%FT%TZ)] chain waiting on ep14 PID=$ep14_pid"
+# Poll, then bail out if ep14 raw .npz never gets written (eval failed).
+while kill -0 "$ep14_pid" 2>/dev/null; do
+  sleep 60
+done
+echo "[$(date -u +%FT%TZ)] ep14 PID=$ep14_pid exited"
+
+if [ ! -f outputs/h342/ep14_raw.npz ]; then
+  echo "[$(date -u +%FT%TZ)] ERROR: outputs/h342/ep14_raw.npz missing; not launching ep13"
+  exit 1
+fi
+echo "[$(date -u +%FT%TZ)] ep14 raw .npz present, launching ep13"
+
+exec tools/h342_launch_eval.sh \
+  outputs/drivaerml/run-yw2a5dyl/checkpoint_ep13.pt \
+  outputs/h342/ep13_raw.npz \
+  "alphonse/h342-ep13-tta"

--- a/tools/h342_launch_eval.sh
+++ b/tools/h342_launch_eval.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# H342: Launch a single TTA eval mirroring the H314 SOTA recipe used for ep15
+# sanity. Usage:
+#   tools/h342_launch_eval.sh <ckpt_path> <raw_npz_path> <wandb_name>
+# Background launch with logging to logs/h342/<basename>.log and pidfile.
+set -euo pipefail
+ckpt=${1:?ckpt path}
+raw=${2:?raw .npz path}
+wname=${3:?wandb name}
+
+mkdir -p outputs/h342 logs/h342
+log="logs/h342/$(basename "${raw%.npz}")_eval.log"
+pidfile="logs/h342/$(basename "${raw%.npz}").pid"
+
+nohup torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
+  --checkpoint "$ckpt" \
+  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
+  --eval-modes "weight_noise_mirror_res_avg" \
+  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
+  --weight-noise-dist student_t --weight-noise-df 4 \
+  --test-time-calibration \
+  --batch-size 2 --num-workers 4 \
+  --save-raw-predictions "$raw" \
+  --agent alphonse --wandb-group "h342-alphonse-multi-checkpoint-avg" \
+  --wandb-name "$wname" \
+  > "$log" 2>&1 &
+pid=$!
+echo "$pid" > "$pidfile"
+echo "Launched torchrun PID=$pid log=$log pidfile=$pidfile"


### PR DESCRIPTION
## Hypothesis

**Output-space averaging of TTA predictions across 3 nearby checkpoints (ep14, ep15, ep16) from the H312 SOTA cosine-tail will produce decorrelated noise reduction beyond single-checkpoint TTA**, in a mechanism distinct from H307's weight-space averaging.

### Two distinct mechanisms

| Mechanism | Where averaging happens | Operates on | Examples |
|---|---|---|---|
| **Weight-space** | Combine parameters first, then forward | Parameter manifold | H307 (cross-seed), SWA |
| **Output-space** | Forward independently, then combine | Prediction manifold | **H342 (this PR)**, classical ensembling |

Output-space averaging preserves nonlinearities that weight-space averaging collapses. H307 has shown α-monotone-no-cross (Arm D α=0.85 trending toward seed-1, weight-soup cannot improve val_cal at val_N=34). H342 tests whether output-space averaging across nearby snapshots in a single cosine-tail can succeed where weight-space averaging across seeds has not.

### Why ep14, ep15, ep16

Cosine annealing across ep12→ep16 with LR ~8.5e-6 at the tail means weights at ep14 and ep16 are very close to ep15 but represent slightly different snapshots of the same trajectory. They should:
- Share the same broad val/test geometry (val_raw within ~5-15bp of ep15)
- Have decorrelated stochastic-gradient noise from the 2720 steps/epoch
- Average to a smoother prediction surface than ep15 alone

This is structurally **different from K-anti-thetic** (which adds noise to ep15 weights and averages outputs across noisy copies of the same checkpoint). H342 averages outputs across genuinely different checkpoints — additional diversity.

## Baseline

Current SOTA: **H314 (PR #1500, merged 17:45Z)** — `2scozlaf`

| Metric | H314 |
|---|---:|
| val_abupt_cal | **5.8987%** (gate) |
| test_abupt_cal | **5.7387%** (gate) |
| test_WSS_cal | 6.6390% |
| test_SP_cal | 3.6136% |
| test_VP_cal | 3.3739% |

Reference checkpoint: `outputs/drivaerml/run-enf61qrr/` (H312 SOTA training run, was the source of `0gjfv45i` ep15 EMA used by H314). Verify ep14, ep15, ep16 EMA checkpoints all exist before launching.

## Instructions

### Step 1 — Verify checkpoint availability (~15 min)

```bash
ls -la outputs/drivaerml/run-enf61qrr/checkpoint_ep*.pt outputs/drivaerml/run-enf61qrr/checkpoint_ep*_ema.pt 2>/dev/null
# Or wherever H312 SOTA training saved checkpoints
```

If only ep15 EMA exists → flag to advisor BEFORE launching. Either:
(a) Pivot to a shorter H342 commissioning run (~3h) producing ep14/ep15/ep16 from a re-trained cosine-tail
(b) Re-scope to "average ep15 across 3 different seed-1 noise draws" — but that is just K-anti-thetic (already done by H314)

If all 3 exist → proceed.

### Step 2 — Add --save-raw-predictions plumbing to eval_tta_h252.py (~30 min)

Add a flag `--save-raw-predictions /path/to/output.npz` that dumps per-case per-resolution predictions BEFORE post-TTA averaging (i.e., before the `*_avg` reduction) to allow post-hoc combination across checkpoints.

Structure suggested:
```python
# Inside eval_tta_h252.py main loop, after gathering all forward passes:
if args.save_raw_predictions:
    # Save shape: (n_cases, n_resolutions, n_kpasses, n_mirror_axes, n_output_channels, n_points)
    # Or whatever shape fits — just preserve the per-pass-per-resolution structure
    np.savez(args.save_raw_predictions,
             predictions=raw_outputs,
             metadata={'checkpoint': args.checkpoint, 'resolutions': args.resolutions, ...})
```

Diff should be < 30 LOC.

### Step 3 — Run 3 TTA evals (one per checkpoint, ~18-21h chained)

```bash
# Eval 1: ep14
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-enf61qrr/checkpoint_ep14_ema.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --save-raw-predictions outputs/h342/ep14_raw.npz \
  --agent alphonse --wandb-group "h342-alphonse-multi-checkpoint-avg" \
  --wandb-name "alphonse/h342-ep14-tta"

# Eval 2: ep15 (= H314 SOTA reproduction sanity)
torchrun ... --checkpoint outputs/drivaerml/run-enf61qrr/checkpoint_ep15_ema.pt \
  --save-raw-predictions outputs/h342/ep15_raw.npz \
  --wandb-name "alphonse/h342-ep15-tta-sota-sanity"

# Eval 3: ep16
torchrun ... --checkpoint outputs/drivaerml/run-enf61qrr/checkpoint_ep16_ema.pt \
  --save-raw-predictions outputs/h342/ep16_raw.npz \
  --wandb-name "alphonse/h342-ep16-tta"
```

**Sanity gate on ep15 alone**: should reproduce H314 to within ±0.5bp on val_cal and test_cal. If ep15 alone reports val_cal > 5.9000 or test_cal > 5.7400, flag immediately — checkpoint or recipe drift.

### Step 4 — Post-hoc averaging script + arms (~30 min compute)

Write `tools/h342_avg_checkpoints.py` that loads N raw prediction files, averages them point-wise, applies H312 hardcoded cal, computes all metrics.

Run 4 arms (post-hoc, fast):

| Arm | Composition | Hypothesis |
|---|---|---|
| A (control) | ep15 alone | = H314 SOTA reproduction sanity |
| B | ep14 + ep15 | Earlier-bias 2-cp average |
| C | ep15 + ep16 | Later-bias 2-cp average |
| D | ep14 + ep15 + ep16 | 3-cp symmetric average |

H312 hardcoded cal coefficients: α_cp=0.994888, α_τx=0.994397, α_τy=0.994083, α_τz=0.991722, α_VP=0.999687, β_VP=−0.832811.

### Step 5 — Report

| Arm | Composition | val_cal | test_cal | test_WSS | test_SP | test_VP | Δ vs H314 |
|---|---|---:|---:|---:|---:|---:|---:|
| H314 ref | ep15 single | 5.8987 | 5.7387 | 6.6390 | 3.6136 | 3.3739 | 0 |
| A | ep15 single (sanity) | ? | ? | ? | ? | ? | ? |
| B | ep14+ep15 avg | ? | ? | ? | ? | ? | ? |
| C | ep15+ep16 avg | ? | ? | ? | ? | ? | ? |
| D | ep14+ep15+ep16 avg | ? | ? | ? | ? | ? | ? |

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<ep14>","<ep15>","<ep16>"],"primary_metric":{"name":"val_abupt_h342_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h342_best_arm","value":<number>}}
```

## Decision logic

- **MERGE** if any arm B/C/D: val_cal < 5.8987 AND test_cal < 5.7387.
- **Close + Finding 'multi-cp-symmetric-best'** if Arm D wins over B and C (3-cp symmetric better than asymmetric pairs) — could compose with H314 noise as additional diversity.
- **Close + Finding 'multi-cp-asymmetric-favors-late'** if Arm C > Arm B (ep16-anchor better than ep14-anchor) → cosine-tail late checkpoints carry more useful diversity.
- **Close + Finding 'multi-cp-output-avg-null'** if all arms B/C/D within ±5bp of Arm A → output-space averaging across nearby cosine-tail checkpoints provides no SOTA gain beyond H314 single-checkpoint K-anti-thetic — combined with H307 α-monotone-no-cross, weight-space AND output-space averaging both null at val_N=34.

## Notes

- **Pure inference** — no training, no model code touched.
- DDP 8-GPU required for each eval run.
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`.
- z-axis τ_z LOCKED at 1.67 — never modify.
- Independent of H338 (edward SP-loss), H339 (frieren WSS uniform), H341 (fern wz-only), H340 (tanjiro σ-sweep), H336 (nezuko K=5+Student-t composition), H307 (thorfinn weight-soup).
- If `--save-raw-predictions` plumbing in eval_tta_h252.py conflicts with H336/H335/H341 pending merges, defer plumbing until rebase window; you can still compute the experiment using a tmp branch.

## Why this matters

- Output-space averaging is a fundamentally different mechanism from weight-space averaging (H307). If H307 nulls because val_N=34 cannot discriminate nearby weight points, output-space may still succeed because it preserves nonlinearities.
- This is the LAST major inference-axis mechanism that hasn't been definitively tested. After H342, if all 4 averaging mechanisms (K-anti-thetic / multi-res / mirror / multi-checkpoint output) are saturated, the inference axes are conclusively closed and the program must rely on training-time interventions (H338/H339/H341) and architectural changes for further progress.
- Even a null result here is high-value: it confirms output-space ensembling is structurally limited at val_N=34, which informs the program's stretch-goal strategy.
