### PR TITLE
H183-cleanup: make per-channel surface heads default, remove flag

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,7 +343,6 @@ class SurfaceTransolver(nn.Module):
         use_curvature_attention_bias: bool = False,
         curvature_dim: int = 3,
         surface_out_width_factor: float = 1.0,
-        per_channel_surface_heads: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -357,7 +356,6 @@ class SurfaceTransolver(nn.Module):
         self.use_curvature_attention_bias = use_curvature_attention_bias
         self.curvature_dim = curvature_dim
         self.surface_out_width_factor = float(surface_out_width_factor)
-        self.per_channel_surface_heads = bool(per_channel_surface_heads)
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -402,37 +400,22 @@ class SurfaceTransolver(nn.Module):
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         # H39 (PR #1284): widened 2-layer surface_out head (Linear-GELU-Linear)
-        # with hidden width = int(n_hidden * surface_out_width_factor). At
-        # factor=2.0 this matches tay H102's wider-head mechanism on top of
-        # H21 base. Note: at factor=1.0 this is NOT byte-identical to the
-        # pre-H39 single-Linear canonical (it adds an extra Linear+GELU);
-        # this is documented in the PR and is acceptable as the H39 test
-        # explicitly uses factor=2.0.
+        # with hidden width = int(n_hidden * surface_out_width_factor).
+        # H183 (PR #1510): split shared MLP decoder into per-channel heads
+        # (cp, tau_x, tau_y, tau_z). Each head is the same 2-layer MLP shape
+        # but with a 1-dim output. Eliminates cross-channel capacity bottleneck.
         surf_hidden_width = max(1, int(n_hidden * self.surface_out_width_factor))
         self.surface_out_hidden_width = surf_hidden_width
-        if self.per_channel_surface_heads:
-            # H183 (PR #1510): split shared MLP decoder into 4 per-channel heads
-            # (cp, tau_x, tau_y, tau_z). Each head is the same 2-layer MLP
-            # shape as the shared head, but with a 1-dim output. Eliminates
-            # cross-channel capacity bottleneck.
-            self.surface_out = None
-            self.surface_out_heads = nn.ModuleList(
-                [
-                    nn.Sequential(
-                        nn.Linear(n_hidden, surf_hidden_width),
-                        nn.GELU(),
-                        nn.Linear(surf_hidden_width, 1),
-                    )
-                    for _ in range(self.surface_output_dim)
-                ]
-            )
-        else:
-            self.surface_out = nn.Sequential(
-                nn.Linear(n_hidden, surf_hidden_width),
-                nn.GELU(),
-                nn.Linear(surf_hidden_width, self.surface_output_dim),
-            )
-            self.surface_out_heads = None
+        self.surface_out_heads = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(n_hidden, surf_hidden_width),
+                    nn.GELU(),
+                    nn.Linear(surf_hidden_width, 1),
+                )
+                for _ in range(self.surface_output_dim)
+            ]
+        )
         self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
 
     def _encode_group(
@@ -514,13 +497,10 @@ class SurfaceTransolver(nn.Module):
         volume_hidden = hidden_norm[:, cursor : cursor + volume_tokens]
 
         if surface_x is not None:
-            if self.surface_out_heads is not None:
-                surface_preds = torch.cat(
-                    [head(surface_hidden) for head in self.surface_out_heads],
-                    dim=-1,
-                ) * surface_mask.unsqueeze(-1)
-            else:
-                surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = torch.cat(
+                [head(surface_hidden) for head in self.surface_out_heads],
+                dim=-1,
+            ) * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -141,7 +141,6 @@ class Config:
     vol_p_charbonnier_eps: float = 1e-3
     tau_z_loss_weight: float = 1.0
     surface_out_width_factor: float = 1.0
-    per_channel_surface_heads: bool = False
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -162,11 +161,6 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
         "surface_out_width_factor": (
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
-        ),
-        "per_channel_surface_heads": (
-            "H183 (PR #1510): split shared surface MLP decoder into "
-            "4 independent per-channel heads (cp, tau_x, tau_y, tau_z), "
-            "each Linear(h, h*width_factor)->GELU->Linear(.., 1)."
         ),
     }
     choices_text = {
@@ -291,7 +285,6 @@ def build_model(config: Config) -> SurfaceTransolver:
         pe_init_sigmas=parse_pe_init_sigmas(config.pe_init_sigmas),
         use_curvature_attention_bias=config.use_curvature_attention_bias,
         surface_out_width_factor=config.surface_out_width_factor,
-        per_channel_surface_heads=config.per_channel_surface_heads,
     )
 
 


### PR DESCRIPTION
## Hypothesis

PR #1510 (H183) merged per-channel surface decoder heads as the new single-model SOTA (test_WSS=6.4427%). The merged code added `--per-channel-surface-heads` as an opt-in CLI flag and kept the old shared-MLP path as the default for backward compatibility.

Now that per-channel heads is the confirmed SOTA, the shared-head path is dead code. All future experiments should always use per-channel heads. This cleanup removes the flag, makes per-channel heads unconditional, and deletes the legacy shared-MLP path.

**This is a code-quality cleanup, NOT a new experiment.** No long training run required — just a 1-EP smoke to verify correctness.

## Instructions

### Changes to make

**In `target/model.py`:**
1. Remove the `per_channel_surface_heads` parameter from the `Transolver.__init__` signature
2. Remove the `if per_channel_surface_heads:` / `else:` branch — keep ONLY the `nn.ModuleList` per-channel path (the `if` branch). Delete the shared MLP `else` branch entirely.
3. Remove the `self.surface_out = None` dead-code alias
4. The result: `self.surface_out_heads` is always created, no condition needed

**In `target/train.py`:**
1. Remove the `--per-channel-surface-heads` CLI argument (or its equivalent in the Config class)
2. Remove passing `per_channel_surface_heads=...` to the model constructor
3. The result: the flag no longer exists; per-channel heads are always on

### Smoke run (1 EP DDP8)

After making the code changes, run a 1-EP smoke to confirm:
- Training starts without errors
- val metrics are finite
- The `--per-channel-surface-heads` flag no longer exists in the CLI help

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 1 --epochs 1 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-tanjiro \
  --wandb-group h183-cleanup \
  --wandb-name dl24-tanjiro/h183-cleanup-smoke
```

**Smoke gates:**
- `val_WSS ≤ 13.5%` (H183 EP1 was 12.973%)
- `nonfinite_grads = 0`
- Confirm `--per-channel-surface-heads` flag no longer in CLI help output

### Post smoke results

Post EP1 val metrics as a comment, confirm the flag is gone, then mark PR ready for review.

## Baseline (H183 SOTA — PR #1510, run `guw83mge`)

| Metric | H183 SOTA | Floor |
|---|---:|---:|
| test_WSS | **6.4427%** ⭐ | PRIMARY |
| test_SP | 3.5187% | ≤ 3.577% |
| test_VP | 3.4415% | ≤ 3.643% |
| test_ABU | 5.6152% | ≤ 5.844% |
| test_τ_x | 5.6983% | track |
| test_τ_y | 6.9813% | track |
| test_τ_z | 8.4364% | track |

H183 reproduce command (this is now the default — no `--per-channel-surface-heads` needed after this cleanup):
```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 30 --epochs 30 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-tanjiro
```

## Terminal result format

After smoke passes and PR is ready for review, post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<smoke-run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<ep1_val>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":0.0}}
```
