### PR TITLE
H188: H183-stack + mild tau_y/z weights (1.2/1.3) + lr=9e-5

### DIFF
--- a/train.py
+++ b/train.py
@@ -139,6 +139,7 @@ class Config:
     wss_charbonnier_axes: str = "all"
     vol_p_charbonnier_weight: float = 0.0
     vol_p_charbonnier_eps: float = 1e-3
+    tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
     surface_out_width_factor: float = 1.0
     per_channel_surface_heads: bool = False
@@ -363,6 +364,7 @@ def train_loss(
     wss_charbonnier_axes: str = "all",
     vol_p_charbonnier_weight: float = 0.0,
     vol_p_charbonnier_eps: float = 1e-3,
+    tau_y_loss_weight: float = 1.0,
     tau_z_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     surface_curvature = getattr(batch, "surface_curvature", None)
@@ -418,15 +420,18 @@ def train_loss(
             surface_per_ch = per_channel_masked_mse(
                 out["surface_preds"], surface_target, batch.surface_mask
             ) * surface_loss_weight  # [4]: cp, tau_x, tau_y, tau_z
-            # H36: Asymmetric tau_z boost. Multiply ONLY index 3 (tau_z) by
-            # tau_z_loss_weight. Same pre-GradNorm injection point as H26 —
-            # L0 absorbs the scaling so the lever acts through gradient
-            # magnitudes (c_tau_z / G_bar) and the total backward signal,
-            # without disturbing cp/tau_x/tau_y budgets.
-            tau_z_scale = surface_per_ch.new_tensor(
-                [1.0, 1.0, 1.0, tau_z_loss_weight]
+            # H36: Asymmetric per-channel tau boost. Multiply index 2 (tau_y)
+            # by tau_y_loss_weight and index 3 (tau_z) by tau_z_loss_weight.
+            # Same pre-GradNorm injection point as H26 — L0 absorbs the
+            # scaling so the lever acts through gradient magnitudes
+            # (c_tau_y, c_tau_z / G_bar) and the total backward signal.
+            # H188 (PR #1532): extended from tau_z-only to tau_y+tau_z to
+            # leverage the H183 per-channel decoder's full per-channel
+            # gradient independence.
+            tau_scale = surface_per_ch.new_tensor(
+                [1.0, 1.0, tau_y_loss_weight, tau_z_loss_weight]
             )
-            surface_per_ch = surface_per_ch * tau_z_scale
+            surface_per_ch = surface_per_ch * tau_scale
             if loss_vol_p_charb is not None:
                 # H19 advisor fix: vol_p slot carries the Charbonnier tensor
                 # so GradNorm's L0 anchor and per-task gradient norms reflect
@@ -758,6 +763,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     wss_charbonnier_axes=config.wss_charbonnier_axes,
                     vol_p_charbonnier_weight=config.vol_p_charbonnier_weight,
                     vol_p_charbonnier_eps=config.vol_p_charbonnier_eps,
+                    tau_y_loss_weight=config.tau_y_loss_weight,
                     tau_z_loss_weight=config.tau_z_loss_weight,
                 )
                 if (
@@ -808,6 +814,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss": batch_loss_metrics["volume_loss"],
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
+                            "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )


### PR DESCRIPTION
## Hypothesis

H183 (PR #1510) established per-channel surface decoder heads as the SOTA mechanism, gaining −0.098pp on WSS (test_WSS=6.4427%) via improved test-set generalization. The per-channel decoder gives each surface output (cp, τ_x, τ_y, τ_z) an **independent** gradient pathway, eliminating cross-channel competition in the shared MLP.

This independence opens the door for per-channel loss weighting to be more effective than previously. On the OLD shared decoder, upweighting τ_y/τ_z loss would also affect cp and τ_x through shared weights, causing indirect interference. On the H183 decoder, each channel is fully isolated.

Research map evidence: mild τ_y=1.2/τ_z=1.3 weighting with lr=9e-5 (run `9mm3sz7x`, W&B: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/9mm3sz7x`) was the best pre-wave single-model mechanism, giving test_WSS=8.123% on an older stack. On the H183 SOTA stack — which already benefits from per-channel independence — the same mild tau weighting should produce a cleaner, stronger response since the weighting now operates on a truly decoupled output head rather than a shared MLP.

**Hypothesis: mild τ_y/τ_z channel weighting (1.2×/1.3×) + lr=9e-5 on the H183 per-channel decoder stack will further reduce test_WSS below the current SOTA 6.4427%.**

Expected gain: −0.05 to −0.15pp on test_WSS, with τ_y/τ_z per-axis metrics improving relative to H183.

## Instructions

**Important:** The current `drivaerml-long-20260504` branch already has `per_channel_surface_heads` as the **unconditional default** (merged in PR #1510). Do NOT add any `--per-channel-surface-heads` flag — it no longer exists. The per-channel decoder is always active.

### Step 1: Check flag availability

First verify which flags exist for per-axis tau weighting:
```bash
python train.py --help 2>&1 | grep -i "wss\|tau\|weight"
```

Look for flags like `--wss-loss-weight-y`, `--wss-loss-weight-z`, `--tau-y-weight`, `--tau-z-weight` etc. If they don't exist, add them to the Config class and the loss computation — they should multiply the per-axis wall-shear loss contribution for τ_y and τ_z only.

### Step 2: Smoke run (1 EP DDP8)

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 9e-5 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 1 --epochs 1 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --wss-loss-weight-y 1.2 --wss-loss-weight-z 1.3 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-frieren \
  --wandb-group h188-per-channel-tau-mild-weights \
  --wandb-name dl24-frieren/h188-smoke-ep1
```

(Adjust flag names if `--wss-loss-weight-y`/`--wss-loss-weight-z` don't exist — check --help first.)

**Smoke gates:** val_WSS ≤ 13.5%, nonfinite_grads = 0. Post EP1 val metrics as a comment.

### Step 3: Primary run (30-EP DDP8, after smoke passes)

Same as smoke but:
- `--lr-cosine-t-max 30 --epochs 30`
- `--wandb-name dl24-frieren/h188-main-30ep`

### Changes vs H183 baseline (2 changes only)
1. `--lr 9e-5` (was 1e-4) — mirrors the research map's best mild-weighting config (`9mm3sz7x`)
2. `--wss-loss-weight-y 1.2 --wss-loss-weight-z 1.3` — mild per-axis τ upweight

### Kill ladder

| EP | Kill if val_WSS > |
|---:|---:|
| EP2 | 7.60 |
| EP5 | 7.10 |
| EP10 | 6.75 |
| EP15 | 6.55 |
| EP20 | 6.50 |
| EP25 | 6.48 |
| EP30 | terminal |

Post EP2, EP5, EP10, EP15, EP20, EP25, EP30 heartbeats including per-axis τ_x/τ_y/τ_z breakdown.

### Hard kill criteria
- `nonfinite_grads > 0` → kill immediately
- val_VP > 4.50 at EP5+ → kill

## Baseline (H183 SOTA — PR #1510, run `guw83mge`)

| Metric | H183 SOTA | Floor |
|---|---:|---:|
| test_WSS | **6.4427%** ⭐ | PRIMARY |
| test_SP | 3.5187% | ≤ 3.577% |
| test_VP | 3.4415% | ≤ 3.643% |
| test_ABU | 5.6152% | ≤ 5.844% |
| test_τ_x | 5.6983% | track |
| test_τ_y | 6.9813% | track |
| test_τ_z | 8.4364% | track |

W&B run: `guw83mge` — https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/guw83mge

H183 reproduce (now the default — no extra flags needed):
```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 30 --epochs 30 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --agent dl24-frieren
```

## Terminal result format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_primary/abupt_axis_mean_rel_l2_pct","value":<value>},"test_metric":{"name":"test_primary/wall_shear_rel_l2_pct","value":<value>}}
```
