### PR TITLE
H191: Sharper WSD on H183 stack (lr→1e-6 100× drop, stable=24EP, decay=6EP)

### DIFF
--- a/train.py
+++ b/train.py
@@ -113,6 +113,9 @@ class Config:
     lr_warmup_start_lr: float = 1e-5
     lr_cosine_t_max: int = 0
     lr_min: float = 1e-6
+    lr_schedule: str = "cosine"
+    lr_wsd_stable_epochs: int = 24
+    lr_wsd_decay_epochs: int = 6
     grad_clip_norm: float = 1.0
     gradient_log_every: int = 250
     log_gradient_histograms: bool = False
@@ -162,9 +165,21 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "Width multiplier for surface_out hidden layer (H39 PR #1284). "
             "1.0 = matched-width 2-layer head; 2.0 = wider head (Linear(h, 2h)->GELU->Linear(2h, 4))."
         ),
+        "lr_schedule": (
+            "LR schedule type: 'cosine' (default) or 'wsd' (warmup-stable-decay). "
+            "WSD uses lr_warmup_epochs for warmup, then lr_wsd_stable_epochs at peak LR, "
+            "then linear decay over lr_wsd_decay_epochs from lr to lr_min."
+        ),
+        "lr_wsd_stable_epochs": (
+            "WSD schedule: number of constant-LR (stable) epochs between warmup and decay."
+        ),
+        "lr_wsd_decay_epochs": (
+            "WSD schedule: number of linear decay epochs from lr to lr_min."
+        ),
     }
     choices_text = {
         "wss_charbonnier_axes": ["all", "z"],
+        "lr_schedule": ["cosine", "wsd"],
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -638,6 +653,16 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         optimizer = build_optimizer(base_model, config)
         scheduler = build_lr_scheduler(optimizer, config, max_epochs)
+        if state.is_main:
+            _probe_opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=config.lr)
+            _probe_sched = build_lr_scheduler(_probe_opt, config, max_epochs)
+            _traj = [_probe_opt.param_groups[0]["lr"]]
+            for _ in range(max_epochs):
+                _probe_sched.step()
+                _traj.append(_probe_opt.param_groups[0]["lr"])
+            print(f"LR trajectory ({config.lr_schedule}, max_epochs={max_epochs}):")
+            for _i, _lr in enumerate(_traj[:max_epochs]):
+                print(f"  EP{_i:02d} train: lr={_lr:.4e}")
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
         gradnorm_weights: GradNormWeights | None = None

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1414,6 +1414,41 @@ def build_lr_scheduler(
     config,
     max_epochs: int,
 ) -> torch.optim.lr_scheduler.LRScheduler:
+    schedule_type = getattr(config, "lr_schedule", "cosine")
+
+    if schedule_type == "wsd":
+        warmup_epochs = max(1, config.lr_warmup_epochs)
+        stable_epochs = max(1, config.lr_wsd_stable_epochs)
+        decay_epochs = max(1, config.lr_wsd_decay_epochs)
+        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=config.lr_warmup_start_lr / config.lr,
+            end_factor=1.0,
+            total_iters=warmup_epochs,
+        )
+        stable_scheduler = torch.optim.lr_scheduler.ConstantLR(
+            optimizer,
+            factor=1.0,
+            total_iters=stable_epochs,
+        )
+        decay_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=1.0,
+            end_factor=config.lr_min / config.lr,
+            total_iters=decay_epochs,
+        )
+        # Milestone shift: train.py calls scheduler.step() AFTER each epoch, so the lr
+        # USED for training epoch K is the lr after K step() calls. To make the final
+        # training epoch use lr_min, the decay phase must START one boundary step earlier.
+        # SequentialLR's transition step calls decay.step(0) which keeps lr at peak (the
+        # "last stable epoch"), so we still get warmup_epochs + stable_epochs effective
+        # stable epochs and decay_epochs effective decay-advancing epochs.
+        return torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup_scheduler, stable_scheduler, decay_scheduler],
+            milestones=[warmup_epochs, warmup_epochs + stable_epochs - 1],
+        )
+
     t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer,


### PR DESCRIPTION
## H191: Sharper WSD LR Schedule on H183 Stack (lr → 1e-6, 100× drop)

### Hypothesis

H184 used a Warmup-Stable-Decay (WSD) schedule but with a critically wrong decay shape: the LR only dropped to ~0.32× peak (not the intended 100× drop). The result was neither a true cosine tail nor a true WSD — it was a broken hybrid.

This hypothesis tests WSD as it was designed: a long stable phase followed by a **sharp** decay to lr_min=1e-6 (100× drop from lr_peak=1e-4). Theory and practice (MuP, MiniCPM, DeepSeek) suggest this sharp annealing phase can:
1. Allow extended flat-loss exploration before converging
2. Produce a sharper final basin than cosine annealing
3. Reduce WSS errors that stem from the model "coasting" through the cosine tail

This runs on the full H183 stack (per-channel surface heads, GradNorm, curvature attention bias, y-symmetry aug).

### Current Baseline

H183 (PR #1510, run `guw83mge`, best EP24 EMA):
- **test_WSS = 6.4427%** ← primary target, must improve
- test_ABUPT = 5.6152%
- test_VP = 3.4415% (hard floor ≤ 3.643%)
- test_SP = 3.5187% (hard floor ≤ 3.577%)
- Per-axis WSS: τ_x=5.6983%, τ_y=6.9813%, τ_z=8.4364%

### Part 1: Implementation (WSD Scheduler — NOT in main branch)

**IMPORTANT**: The WSD scheduler is not implemented in the codebase. You must add it before running the experiment.

#### Step 1: Add Config fields to `train.py`

In the `Config` dataclass, after the `lr_min: float = 1e-6` field (around line 115), add:

```python
lr_schedule: str = "cosine"           # "cosine" or "wsd"
lr_wsd_stable_epochs: int = 24        # WSD: length of stable (flat) phase
lr_wsd_decay_epochs: int = 6          # WSD: length of linear decay phase
```

Also add the corresponding CLI args in `parse_args()` (search for `--lr-min` to find the right location):

```python
parser.add_argument("--lr-schedule", type=str, default="cosine",
                    choices=["cosine", "wsd"],
                    help="LR schedule type: cosine or warmup-stable-decay")
parser.add_argument("--lr-wsd-stable-epochs", type=int, default=24,
                    help="WSD schedule: number of stable (constant LR) epochs")
parser.add_argument("--lr-wsd-decay-epochs", type=int, default=6,
                    help="WSD schedule: number of linear decay epochs")
```

#### Step 2: Implement WSD branch in `trainer_runtime.py`

Find the `build_lr_scheduler` function (around line 1412). Currently it only supports cosine + optional warmup. Replace with:

```python
def build_lr_scheduler(
    optimizer: torch.optim.Optimizer,
    config: "Config",
    max_epochs: int,
) -> torch.optim.lr_scheduler.LRScheduler:
    schedule_type = getattr(config, "lr_schedule", "cosine")

    if schedule_type == "wsd":
        # Warmup-Stable-Decay schedule
        # Phase 1: Linear warmup (lr_warmup_start_lr → lr)
        # Phase 2: Constant at lr (stable phase)
        # Phase 3: Linear decay (lr → lr_min)
        warmup_epochs = max(1, config.lr_warmup_epochs)
        stable_epochs = config.lr_wsd_stable_epochs
        decay_epochs = config.lr_wsd_decay_epochs
        
        # Warmup: linearly ramp from lr_warmup_start_lr to lr
        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer,
            start_factor=config.lr_warmup_start_lr / config.lr,
            end_factor=1.0,
            total_iters=warmup_epochs,
        )
        # Stable: constant at lr (use ConstantLR with factor=1)
        stable_scheduler = torch.optim.lr_scheduler.ConstantLR(
            optimizer,
            factor=1.0,
            total_iters=stable_epochs,
        )
        # Decay: linear from lr to lr_min
        decay_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer,
            start_factor=1.0,
            end_factor=config.lr_min / config.lr,
            total_iters=decay_epochs,
        )
        return torch.optim.lr_scheduler.SequentialLR(
            optimizer,
            schedulers=[warmup_scheduler, stable_scheduler, decay_scheduler],
            milestones=[warmup_epochs, warmup_epochs + stable_epochs],
        )
    else:
        # Original cosine schedule (unchanged)
        t_max = config.lr_cosine_t_max if config.lr_cosine_t_max > 0 else max_epochs
        cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
            optimizer,
            T_max=t_max,
            eta_min=config.lr_min,
        )
        if config.lr_warmup_epochs <= 0:
            return cosine_scheduler
        warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
            optimizer,
            start_factor=config.lr_warmup_start_lr / config.lr,
            end_factor=1.0,
            total_iters=max(1, config.lr_warmup_epochs),
        )
        return torch.optim.lr_scheduler.SequentialLR(
            optimizer,
            schedulers=[warmup_scheduler, cosine_scheduler],
            milestones=[config.lr_warmup_epochs],
        )
```

**Verify your implementation**: Add a quick sanity check before running — print the LR at epoch 1 (should be ~1e-4), epoch 15 (should be ~1e-4), epoch 29 (should be ~1e-5), epoch 31 (should be ~1e-6).

### Part 2: Experiment

#### Run command

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 \
  --lr-warmup-epochs 1 \
  --lr-schedule wsd \
  --lr-wsd-stable-epochs 24 \
  --lr-wsd-decay-epochs 6 \
  --epochs 31 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 \
  --per-channel-surface-heads \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --wandb_group h191-wsd-sharper
```

**Schedule breakdown**: EP1=warmup, EP2-25=stable at lr=1e-4, EP26-31=linear decay to lr_min=1e-6. Total: 31 epochs.

#### Kill gates

| Epoch | val_WSS kill threshold | Action |
|-------|----------------------|--------|
| EP3   | > 7.6%               | Kill and report |
| EP5   | > 7.1%               | Kill and report |
| EP10  | > 6.75%              | Kill and report |
| EP25  | > 6.55%              | Kill and report |
| Final | > 6.4427%            | No improvement — report and close |

#### What to report

After each kill gate check and at completion, report in a PR comment:
- Current epoch and val_WSS (EMA)
- W&B run ID
- Whether kill gate was triggered

At completion, report the full metrics table:

| Metric | val | test |
|--------|-----|------|
| WSS (%) | | |
| VP (%) | | |
| SP (%) | | |
| ABUPT (%) | | |

And the terminal SENPAI-RESULT marker:

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_WSS","value":<number>},"test_metric":{"name":"test_WSS","value":<number>}}
```

### Key differences from H184

| | H184 | H191 |
|--|------|------|
| LR peak | 1e-4 | 1e-4 |
| LR min | ~3.2e-5 (broken) | 1e-6 (100× drop) |
| Stable phase | ~22 EP | 24 EP |
| Decay phase | ~8 EP | 6 EP |
| Total epochs | 30 | 31 |
| H183 stack | No (pre-H183) | **Yes** |

H184 was run on a pre-H183 stack without per-channel heads, GradNorm, or curvature attention bias. H191 tests the correct WSD shape on the current SOTA stack.

### Hard floor constraints (must not regress)

- test_vol_p ≤ 3.643%
- test_SP ≤ 3.577%
