### PR TITLE
H346: Per-vertex focal EMA upweighting on WSS_z residuals (spatial not magnitude)

### DIFF
--- a/train.py
+++ b/train.py
@@ -145,6 +145,9 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H346: per-batch focal loss on WSS_z residual (Option A — no EMA, no DDP sync)
+    focal_batch: bool = False
+    focal_gamma: float = 2.0
     debug: bool = False
 
 
@@ -271,6 +274,23 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "focal_batch": (
+            "H346 Option A: enable per-batch focal weighting on the WSS_z "
+            "surface channel. For each batch, compute per-element |tau_z error|, "
+            "normalise to mean=1 over valid positions, raise to focal_gamma, "
+            "renormalise to mean=1, and use as weights on the WSS_z squared "
+            "error. No cross-step EMA, no DDP all-reduce (each rank computes "
+            "its own per-batch weights; DDP gradient averaging suffices). "
+            "Other channels (cp, tau_x, tau_y) and volume_pressure are "
+            "unweighted. Mutually exclusive with --use-gradnorm; channel-level "
+            "--tau-z-loss-weight is still applied as a final multiplier."
+        ),
+        "focal_gamma": (
+            "H346: focal exponent applied to the per-batch per-position "
+            "weights. 2.0 = canonical focal default; 1.0 = linear; "
+            "3.0 = aggressive. Higher gamma concentrates more loss on the "
+            "highest-residual points within each batch."
         ),
     }
     for field in fields(Config):
@@ -474,6 +494,135 @@ def train_loss(
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+
+
+def focal_batch_train_loss(
+    model: nn.Module,
+    batch,
+    transform: TargetTransform,
+    device: torch.device,
+    amp_mode: str,
+    *,
+    surface_loss_weight: float,
+    volume_loss_weight: float,
+    surface_channel_weights: torch.Tensor | None,
+    focal_gamma: float,
+) -> tuple[torch.Tensor, dict[str, float], dict[str, float]]:
+    """H346 Option A: per-batch focal weighting on the WSS_z surface channel.
+
+    Within each batch, compute per-element |tau_z error|, normalise to
+    mean = 1 over valid positions, raise to focal_gamma, renormalise to
+    mean = 1, and use as a per-element weight on the WSS_z squared error.
+    No cross-step EMA and no DDP all-reduce: each rank computes its own
+    per-batch weights; DDP gradient averaging gives the correct expected
+    update. Other surface channels (cp, tau_x, tau_y) and the volume loss
+    are unchanged.
+
+    Returns (loss, batch_loss_metrics, focal_diagnostics).
+    """
+    batch = batch.to(device)
+    surface_target = transform.apply_surface(batch.surface_y)
+    volume_target = transform.apply_volume(batch.volume_y)
+    with autocast_context(device, amp_mode):
+        out = model(
+            surface_x=batch.surface_x,
+            surface_mask=batch.surface_mask,
+            volume_x=batch.volume_x,
+            volume_mask=batch.volume_mask,
+        )
+        surface_pred = out["surface_preds"]
+        volume_pred = out["volume_preds"]
+
+        # Per-element |tau_z error| in fp32 for stable weight statistics
+        # under bf16 autocast.
+        mask_f = batch.surface_mask.to(device=surface_pred.device, dtype=torch.float32)
+        abs_err_z = (surface_pred[..., 3].float() - surface_target[..., 3].float()).abs()
+        masked_abs_err_z = abs_err_z * mask_f
+
+        valid_pts = mask_f.sum().clamp_min(1.0)
+        err_z_mean = (masked_abs_err_z.sum() / valid_pts).clamp_min(1e-12)
+        # Per-(b, n) focal weight: (|err_z| / mean(|err_z|))**gamma, mean = 1.
+        w = (masked_abs_err_z / err_z_mean).pow(focal_gamma)
+        # Renormalise to mean = 1 over valid positions so the WSS_z loss
+        # magnitude stays comparable to the baseline.
+        w_mean = ((w * mask_f).sum() / valid_pts).clamp_min(1e-12)
+        w = (w / w_mean).detach()
+        weights_loss = w.to(dtype=surface_pred.dtype)
+
+        # Build per-element channel weight tensor [B, N, C]: tau_z (idx 3)
+        # carries the focal weights, other channels are 1.0.
+        n_ch = surface_pred.shape[-1]
+        focal_ch_weights = torch.ones_like(surface_pred)
+        focal_ch_weights[..., 3] = weights_loss
+
+        # External per-channel scaling (tau_y_loss_weight, tau_z_loss_weight)
+        # stacks as a final multiplier so the existing tau-z scaling carries
+        # through.
+        if surface_channel_weights is not None:
+            ext_w = surface_channel_weights.to(
+                device=surface_pred.device, dtype=surface_pred.dtype
+            )
+            focal_ch_weights = focal_ch_weights * ext_w
+
+        # Weighted masked MSE over (B, N, C). Matches weighted_channel_mse
+        # normalisation: denominator = valid_pts * n_channels.
+        sq_err = (surface_pred - surface_target).square()
+        mask_3d = mask_f.to(surface_pred.dtype).unsqueeze(-1)
+        weighted_sq = sq_err * focal_ch_weights * mask_3d
+        denom = (valid_pts * float(n_ch)).clamp_min(1.0)
+        surface_loss = weighted_sq.sum() / denom
+
+        surface_loss_unweighted = masked_mse(surface_pred, surface_target, batch.surface_mask)
+        volume_loss = masked_mse(volume_pred, volume_target, batch.volume_mask)
+        weighted_surface = surface_loss_weight * surface_loss
+        weighted_volume = volume_loss_weight * volume_loss
+        loss = weighted_surface + weighted_volume
+        base_mse_loss = surface_loss_unweighted + volume_loss
+
+    batch_loss_metrics = {
+        "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
+        "surface_loss": float(surface_loss_unweighted.detach().cpu().item()),
+        "volume_loss": float(volume_loss.detach().cpu().item()),
+        "surface_loss_weighted": float(weighted_surface.detach().cpu().item()),
+        "volume_loss_weighted": float(weighted_volume.detach().cpu().item()),
+    }
+
+    # Diagnostics: only over valid (masked) positions. fp32 for stability.
+    # Skip the per-element stats when a batch has zero valid surface points
+    # (rare, e.g. all-volume views) — otherwise torch.quantile crashes and
+    # one rank's exception turns into an NCCL all-reduce timeout for the
+    # rest of the world.
+    mask_bool = batch.surface_mask.to(device=surface_pred.device).bool()
+    n_valid_diag = int(mask_bool.sum().item())
+    if n_valid_diag > 0:
+        w_valid = w[mask_bool]
+        err_z_valid = masked_abs_err_z[mask_bool]
+        tauz_truth_valid = surface_target[..., 3].float().abs()[mask_bool]
+        w_mean_v = w_valid.mean().clamp_min(1e-12)
+        err_p95 = torch.quantile(err_z_valid, 0.95)
+        err_p5 = torch.quantile(err_z_valid, 0.05)
+        # Pearson r between per-element focal weight and |tau_z_truth|.
+        w_centered = w_valid - w_valid.mean()
+        t_centered = tauz_truth_valid - tauz_truth_valid.mean()
+        denom_corr = (w_centered.norm() * t_centered.norm()).clamp_min(1e-12)
+        corr_w_tauz = (w_centered * t_centered).sum() / denom_corr
+        focal_diagnostics = {
+            "focal/w_min": float(w_valid.min().detach().cpu().item()),
+            "focal/w_max": float(w_valid.max().detach().cpu().item()),
+            "focal/w_mean": float(w_valid.mean().detach().cpu().item()),
+            "focal/w_std": float(w_valid.std().detach().cpu().item()),
+            "focal/w_max_over_mean": float((w_valid.max() / w_mean_v).detach().cpu().item()),
+            "focal/w_std_over_mean": float((w_valid.std() / w_mean_v).detach().cpu().item()),
+            "focal/corr_w_vs_tauz_magnitude": float(corr_w_tauz.detach().cpu().item()),
+            "focal/err_z_p95": float(err_p95.detach().cpu().item()),
+            "focal/err_z_p5": float(err_p5.detach().cpu().item()),
+            "focal/err_z_p95_minus_p5": float((err_p95 - err_p5).detach().cpu().item()),
+            "focal/err_z_mean": float(err_z_mean.detach().cpu().item()),
+            "focal/valid_pts": float(n_valid_diag),
+        }
+    else:
+        focal_diagnostics = {"focal/valid_pts": 0.0}
+    return loss, batch_loss_metrics, focal_diagnostics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -965,6 +1114,21 @@ def main(argv: Iterable[str] | None = None) -> None:
                 )
         ema = EMA(base_model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
 
+        # H346 Option A: per-batch focal weighting on WSS_z residual.
+        # No persistent EMA state and no DDP all-reduce — each rank computes
+        # its own per-batch weights and DDP gradient averaging handles the
+        # rest.
+        if config.focal_batch and config.use_gradnorm:
+            raise ValueError(
+                "--focal-batch cannot be combined with --use-gradnorm: both rewrite "
+                "the surface loss objective. Choose one."
+            )
+        if config.focal_batch and state.is_main:
+            print(
+                f"Focal-batch enabled (H346 Option A): gamma={config.focal_gamma}, "
+                f"channel=tau_z (idx 3); per-batch weights, no EMA, no DDP sync"
+            )
+
         balancer: GradNormBalancer | None = None
         gradnorm_shared_params: list[nn.Parameter] = []
         if config.use_gradnorm:
@@ -1081,6 +1245,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["mirror_augmentation"] = config.mirror_augmentation
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
+            wandb.summary["focal/enabled"] = config.focal_batch
+            if config.focal_batch:
+                wandb.summary["focal/gamma"] = config.focal_gamma
+                wandb.summary["focal/mode"] = "per_batch"
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1137,6 +1305,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 if config.mirror_augmentation:
                     batch = mirror_augment_batch(batch.to(device), p=0.5)
                 gradnorm_metrics: dict[str, float] = {}
+                focal_diagnostics: dict[str, float] = {}
                 if balancer is not None:
                     per_task_losses = per_task_train_losses(
                         model, batch, transform, device, config.amp_mode
@@ -1220,6 +1389,22 @@ def main(argv: Iterable[str] | None = None) -> None:
                         )
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
+                elif config.focal_batch:
+                    loss, batch_loss_metrics, focal_diagnostics = (
+                        focal_batch_train_loss(
+                            model,
+                            batch,
+                            transform,
+                            device,
+                            config.amp_mode,
+                            surface_loss_weight=config.surface_loss_weight,
+                            volume_loss_weight=config.volume_loss_weight,
+                            surface_channel_weights=(
+                                surface_channel_weights if use_channel_weights else None
+                            ),
+                            focal_gamma=config.focal_gamma,
+                        )
+                    )
                 else:
                     loss, batch_loss_metrics = train_loss(
                         model,
@@ -1272,6 +1457,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
+                if focal_diagnostics:
+                    train_log.update(focal_diagnostics)
 
                 if skip_step:
                     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Hypothesis

**H339 (uniform-WSS reweight) and H341 (wz-only reweight) failed because they weighted by τ_z MAGNITUDE — but high-τ_z regions may actually be where the model already does well. The model's residual error likely concentrates at LOW-τ_z transition regions (attachment lines, stagnation points, separation onset) where absolute values are small but RELATIVE errors are large.** Apply per-vertex focal loss (Lin et al., ICCV 2017, regression analogue [arxiv:2206.09676](https://arxiv.org/abs/2206.09676)) where each vertex's WSS_z loss is reweighted by the EMA of its OWN running residual error — not by τ_z magnitude. Cosine-tail from H336 base, ~5h/arm.

### Why this is the right next experiment

- H339+H341 just closed the loss-weight axis as `wss-reweight-null-wrong-direction`. Both reweighted by **field magnitude** — and both regressed every channel monotonically.
- The mechanistic counter-hypothesis: model errors are NOT magnitude-correlated. They are difficulty-correlated. Per-vertex focal upweighting tracks the model's OWN residuals (via EMA), not the underlying field magnitude.
- Focal loss is the canonical method for "imbalanced regions" — well-cited in classification (Lin et al., 30k+ citations) and now extended to regression (Yang et al. 2022, focal regression).
- Per-vertex (not per-channel) focal: addresses the spatial distribution of error, not the channel distribution.

### Mechanistic differentiator from H339/H341

| | H339 / H341 | H346 (this PR) |
|---|---|---|
| Weight basis | τ_z field magnitude | running prediction residual per vertex |
| Granularity | per-channel (whole field) | per-vertex (spatial) |
| Adaptivity | fixed throughout training | adapts each step via EMA |
| Failure mode if null | weight is too large/small | EMA collapses to few vertices |

## Instructions

### Step 1 — Smoke: EMA initialization + DDP sync (~30 min)

Verify the EMA state synchronizes correctly across DDP ranks. Run 50 steps on 8 GPUs and confirm `ema_vertex_err` produces identical values on each rank after the all-reduce step.

### Step 2 — Implementation (~1h)

Add `--focal-ema` boolean flag to `train.py` plus `--focal-gamma` (default 2.0) and `--focal-alpha-ema` (default 0.95):

```python
# Maintained state (per-rank, then all-reduced)
ema_vertex_err_z = None  # [N_surface] running EMA of per-vertex WSS_z abs error

def compute_focal_wss_loss(pred, truth, ema_err, gamma=2.0, alpha=0.95):
    """Per-vertex focal weighting on WSS_z only.
    
    Args:
        pred, truth: [B, N, 5] surface_y predictions (CP, tau_x, tau_y, tau_z, ...)
        ema_err: [N] current EMA of per-vertex WSS_z abs error
        gamma: focal exponent (2.0 = focal-default)
        alpha: EMA decay (0.95 = standard)
    """
    err = (pred - truth).abs()  # [B, N, 5]
    
    # Update EMA of per-vertex WSS_z error (batch-mean per vertex)
    batch_err_z = err[..., 3].mean(dim=0).detach()  # [N]
    
    # DDP all-reduce so all ranks share the same EMA state
    torch.distributed.all_reduce(batch_err_z, op=torch.distributed.ReduceOp.SUM)
    batch_err_z /= torch.distributed.get_world_size()
    
    if ema_err is None:
        ema_err = batch_err_z.clone()
    else:
        ema_err.mul_(alpha).add_(batch_err_z, alpha=1.0 - alpha)
    
    # Focal weight: higher weight on high-residual vertices
    # Normalized so mean weight ≈ 1 (so total loss magnitude is comparable to baseline)
    weights = ema_err / (ema_err.mean() + 1e-12)  # [N], mean = 1
    weights = weights ** gamma  # focal exponent
    weights = weights / weights.mean()  # renormalize after gamma
    
    # Apply focal weighting to WSS_z only (preserve other channels unweighted)
    loss_wss_z = (err[..., 3] * weights.unsqueeze(0)).mean()
    loss_other = err[..., [0, 1, 2, 4]].mean()
    
    return loss_wss_z + loss_other, ema_err
```

Initialize `ema_err` from a single val-set forward pass at start of cosine-tail (gives a principled non-uniform start). Save the EMA state per checkpoint for reproducibility.

**DDP subtlety**: all-reduce the per-batch error BEFORE the EMA update, so all ranks maintain identical EMA state. This is cheap (one O(N) all-reduce per step).

### Step 3 — Diagnostic logging (~10 min)

At end of each epoch, log:
- `ema_err.min()`, `ema_err.max()`, `ema_err.mean()`, `ema_err.std()`
- Top-10 vertex indices by `ema_err` (which vertices are persistently hardest?)
- Bottom-10 vertex indices (which vertices does the model fit easily?)
- `weights.std() / weights.mean()` — the "focal intensity"; if this drops to near 0, focal is collapsing to uniform (Bad)

If at any point `weights.max() / weights.mean() > 50`, focal is collapsing to a tiny vertex subset — early stop and report as `focal-ema-collapsing`.

### Step 4 — Primary (3 arms sequential, ~15h total chain)

```bash
H185_EP14_CKPT="outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt"  # H336 cosine-tail base

# Arm A — γ=2.0 (standard focal default)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint $H185_EP14_CKPT \
  --cosine-extension --seed=2025 --epochs=16 \
  --focal-ema --focal-gamma 2.0 --focal-alpha-ema 0.95 \
  --wandb-group "h346-askeladd-focal-ema" \
  --wandb-name "askeladd/h346-arm-A-gamma2.0"

# Arm B — γ=1.0 (linear weighting — milder focal)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint $H185_EP14_CKPT \
  --cosine-extension --seed=2025 --epochs=16 \
  --focal-ema --focal-gamma 1.0 --focal-alpha-ema 0.95 \
  --wandb-group "h346-askeladd-focal-ema" \
  --wandb-name "askeladd/h346-arm-B-gamma1.0"

# Arm C — γ=3.0 (aggressive focal)
torchrun --standalone --nproc-per-node=8 train.py \
  --base-checkpoint $H185_EP14_CKPT \
  --cosine-extension --seed=2025 --epochs=16 \
  --focal-ema --focal-gamma 3.0 --focal-alpha-ema 0.95 \
  --wandb-group "h346-askeladd-focal-ema" \
  --wandb-name "askeladd/h346-arm-C-gamma3.0"
```

Save each EP15 checkpoint as `model-askeladd-h346-arm-{A,B,C}:v1`.

### Step 5 — Eval each EP15 via H336 TTA recipe (~6-7h per arm)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<arm-X-train-id>/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --batch-size 2 --num-workers 4 \
  --agent askeladd --wandb-group "h346-askeladd-focal-ema-eval" \
  --wandb-name "askeladd/h346-arm-X-eval-cal"
```

### Step 6 — Skip-rule for chain (apply autonomously)

After Arm A (γ=2.0):
- If Arm A `test_WSS_cal` < 6.59 (≥5bp improvement) AND val_cal < 5.92 (no large regression): proceed with full chain B + C, find the optimal γ
- If Arm A `test_WSS_cal` ∈ [6.59, 6.66): proceed to Arm B only (γ=1.0 milder, likely closer to baseline) — skip C
- If Arm A `test_WSS_cal` ≥ 6.66 (no improvement or regression): skip B and C, close as `focal-ema-null` Finding
- If Step 3 diagnostic shows EMA collapsing to <5% of vertices for >2 epochs: skip remaining arms, close as `focal-ema-collapsing`

### Step 7 — Report

| Arm | γ | val_cal | test_cal | test_SP_cal | test_VP_cal | test_WSS_cal | test_WSS_z_cal | Δtest_WSS vs H336 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| H336 (ref) | none | 5.8978 | 5.7379 | 3.6133 | 3.3735 | 6.6382 | 8.6175 | 0 |
| A | 2.0 | ? | ? | ? | ? | ? | ? | ? |
| B | 1.0 | ? | ? | ? | ? | ? | ? | ? |
| C | 3.0 | ? | ? | ? | ? | ? | ? | ? |

Plus the per-epoch EMA error map summary (which vertices dominate the focal weights).

## Baseline

Current SOTA: **H336 (PR #1520 merged 2026-06-01 00:16Z)** — `348i3z1v`

| Metric | H336 (current SOTA) |
|---|---:|
| val_abupt_cal | **5.8978%** (strict gate) |
| test_abupt_cal | **5.7379%** (strict gate) |
| test_VP_cal | 3.3735% (below floor 3.421) ✓ |
| test_SP_cal | 3.6133% (vs floor 3.577 = +3.6bp gap) ✗ |
| **test_WSS_cal** | **6.6382%** (vs floor 5.85 = +78.8bp gap) ✗ |
| **test_WSS_z_cal** | **8.6175%** (worst WSS channel — primary target) |

**Reproduce H336**: `cd "target/" && torchrun --standalone --nproc-per-node=8 eval_tta_h252.py --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" --eval-modes "weight_noise_mirror_res_avg" --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise --weight-noise-dist student_t --weight-noise-df 4 --test-time-calibration --batch-size 2 --num-workers 4`

H336 calibration coefficients: α_cp=0.99489, α_τx=0.99440, α_τy=0.99408, α_τz=0.99172, α_VP=0.99975, β_VP=−0.83281. Cal-axis is closed (H316/H319/H323/H328/H329/H334/H336/H332). **Do NOT refit cal per-arm**.

## SENPAI-RESULT format

```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<armA-train>","<armA-eval>",...],"primary_metric":{"name":"val_abupt_h346_best_arm","value":<number>},"test_metric":{"name":"test_abupt_h346_best_arm","value":<number>}}
```

## Decision logic

- **Merge** if any arm satisfies BOTH: (a) val_cal < 5.8978 AND test_cal < 5.7379 (H336 gates), AND (b) test_WSS_cal < 6.59 (≥5bp WSS improvement). New SOTA.
- **Merge with caveat** if any arm has test_WSS_cal < 6.3 (≥40bp) at marginal val_cal regression ≤1bp — paper-relevant single-channel win. Escalate to advisor.
- **Close + Finding `focal-ema-null`** if all 3 arms produce test_WSS_cal ≥ 6.59 — per-vertex focal upweighting does not concentrate model capacity on WSS error at this regime.
- **Close + Finding `focal-ema-collapsing`** if EMA state degenerates (weights collapse to <5% of vertices for >2 epochs).
- **Close + Finding `focal-ema-magnitude-equivalent`** if per-vertex weights end up strongly correlated (r > 0.9) with τ_z field magnitude — would mean focal IS equivalent to H341 magnitude reweighting, falsifying the mechanistic differentiation.

## Notes

- **Independent of all other in-flight experiments.** Mechanistically distinct from frieren H345 (PCGrad gradient surgery), edward H338 (SP-weight), alphonse H342 (multi-checkpoint averaging).
- DDP 8-GPU required
- Hard wall: SENPAI_TIMEOUT_MINUTES=540 per arm
- Read-only files: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- z-axis τ_z LOCKED at trained value (1.67) — never modify
- **No capacity additions** — focal is a loss-weighting change, not architectural
- Use `--wandb_group "h346-askeladd-focal-ema"` for both train and eval

## Why this matters

The H339/H341 negative results closed the per-channel magnitude reweighting axis. Per-vertex focal-EMA reopens the loss-weight space at a mechanistically distinct level: spatial (per-vertex) instead of channel (per-task), and adaptive (running residual EMA) instead of fixed (multiplier). If the WSS_z residual is concentrated at specific spatial regions (separation lines, A-pillar wake, underbody wheel arches — physically plausible), focal-EMA should find and upweight them. If WSS_z error is spatially diffuse, focal-EMA will null cleanly with the `focal-ema-magnitude-equivalent` falsification — also informative because it rules out spatial concentration as the WSS_z gap mechanism, narrowing the search space to architecture/representation interventions.
