### PR TITLE
H351: Normal-Relative Geometric Slice Bias (24-param zero-init WSS_z attack)

### DIFF
--- a/model.py
+++ b/model.py
@@ -284,12 +284,33 @@ class TransolverAttention(nn.Module):
         else:
             self.q_norm = None
             self.k_norm = None
+        # H351 NGSB: 3 normal components -> per-(head, slice) additive bias on slice logits.
+        # The advisor's per-head spec (3 -> num_heads) is a no-op because a bias that is
+        # constant along the softmax axis cancels under softmax; the bias must vary along
+        # the slice axis to influence slice assignment. Zero-init keeps identity-at-start.
+        # See PR comment for deviation justification.
+        self.normal_slice_bias = nn.Linear(3, self.num_heads * num_slices, bias=False)
+        nn.init.zeros_(self.normal_slice_bias.weight)
 
-    def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    def create_slices(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
+        # H351 NGSB: add per-(head, slice) normal-derived bias to slice logits
+        # before softmax. normals: [B, N, 3] (unit surface normals; zeros for volume
+        # token positions). normal_slice_bias maps 3 -> num_heads * num_slices.
+        if normals is not None:
+            head_bias = self.normal_slice_bias(normals)  # [B, N, num_heads*num_slices]
+            head_bias = head_bias.view(
+                batch_size, num_tokens, self.num_heads, self.num_slices
+            ).permute(0, 2, 1, 3)  # [B, num_heads, N, num_slices]
+            slice_logits = slice_logits + head_bias
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
@@ -300,8 +321,13 @@ class TransolverAttention(nn.Module):
         slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
         return slice_tokens, slice_weights
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask, normals=normals)
         qkv = self.qkv(slice_tokens)
         q, k, v = qkv.chunk(3, dim=-1)
         if self.q_norm is not None:
@@ -346,9 +372,14 @@ class TransformerBlock(nn.Module):
         self.drop_path_attn = DropPath(drop_path_prob)
         self.drop_path_mlp = DropPath(drop_path_prob)
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = _apply_token_mask(x, attn_mask)
-        x = x + self.drop_path_attn(self.attention(self.norm1(x), attn_mask=attn_mask))
+        x = x + self.drop_path_attn(self.attention(self.norm1(x), attn_mask=attn_mask, normals=normals))
         x = _apply_token_mask(x, attn_mask)
         x = x + self.drop_path_mlp(self.mlp(self.norm2(x)))
         x = _apply_token_mask(x, attn_mask)
@@ -388,9 +419,14 @@ class Transformer(nn.Module):
             ]
         )
 
-    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        normals: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         for block in self.blocks:
-            x = block(x, attn_mask=attn_mask)
+            x = block(x, attn_mask=attn_mask, normals=normals)
         return x
 
 
@@ -634,7 +670,19 @@ class SurfaceTransolver(nn.Module):
 
         attn_mask = torch.cat(masks, dim=1)
         hidden = _apply_token_mask(torch.cat(tokens, dim=1), attn_mask)
-        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        # H351 NGSB: build a normals tensor padded to the full token sequence.
+        # Surface normals are channels 3:6 of surface_x (unit vectors).
+        # Volume token positions receive zeros so normal_slice_bias is a no-op there.
+        if surface_x is not None:
+            surf_normals = surface_x[:, :surface_tokens, 3:6]  # [B, surface_tokens, 3]
+            if volume_tokens > 0:
+                vol_zeros = surf_normals.new_zeros(surf_normals.shape[0], volume_tokens, 3)
+                backbone_normals = torch.cat([surf_normals, vol_zeros], dim=1)
+            else:
+                backbone_normals = surf_normals
+        else:
+            backbone_normals = None
+        hidden = self.backbone(hidden, attn_mask=attn_mask, normals=backbone_normals)
         hidden = _apply_token_mask(hidden, attn_mask)
         hidden_norm = _apply_token_mask(self.norm(hidden), attn_mask)
 


### PR DESCRIPTION
## Hypothesis

The Transolver slice attention uses a content-driven slice assignment: `slice_logits = in_project_slice(x_mid) / temperature`. **No geometric structural prior** influences which tokens cluster into the same physics state. Surface normals (channels 3:6 of `SURFACE_X_DIM=7`) exist in the input but are consumed only through the flat input embedding — they never appear inside `TransolverAttention` as a relational signal.

**H351 Normal-Relative Geometric Slice Bias (NGSB)** adds a single zero-init `nn.Linear(3 → num_heads, bias=False)` that maps per-token surface normals to per-head additive biases on `slice_logits` BEFORE softmax. At initialization this is identical to H336 SOTA (zero contribution → zero regression risk). During training the model can learn to cluster tokens with similar surface orientation into the same physics-state slice — giving τ_z, which is geometrically sensitive to the normal-relative freestream direction, a more coherent representational group.

**Param overhead**: exactly 24 parameters (3 × 8 heads). Well under +1% constraint.

**References:**
- GeoTransolver (Adams et al., NVIDIA, Dec 2025, arxiv:2512.20399) — benchmarked on DrivAerML, achieves test_WSS ~4.9% vs our 6.6% by injecting geometric context into Transolver slice attention. NGSB is a 24-parameter zero-init variant of the same structural idea.
- Original Transolver (Wu et al., 2024) — defines the slice attention mechanism.
- Perez et al. FiLM (2018, arxiv:1709.07871) — broader feature-wise modulation reference (H350 askeladd uses sibling idea on the decoder).

**Mechanism orthogonality** (each axis is structurally non-redundant):
- H347 nezuko: training-time physics loss (OBJECTIVE axis)
- H348 fern: input channels (INPUT-FEATURE axis)
- H349 frieren: target transform (OUTPUT-TRANSFORM axis)
- H350 askeladd: output decoder (OUTPUT-DECODER axis)
- **H351 (this): encoder attention slice-routing (TOKEN-ROUTING axis)** — NEW

**Why this attacks WSS_z specifically:**
The WSS gap is concentrated in test_WSS_z=8.62% (vs test_WSS_x=5.90, test_WSS_y=7.18). WSS_z (out-of-plane shear) is the channel most sensitive to relative orientation of the surface normal versus the freestream direction. Currently the encoder's slice attention has no direct way to express "these tokens have similar normals → put them in the same slice." NGSB gives it exactly that, at zero capacity cost.

## Instructions

### Code changes in `model.py`

1. In `TransolverAttention.__init__`, add the bias module:
   ```python
   self.normal_slice_bias = nn.Linear(3, self.num_heads, bias=False)
   nn.init.zeros_(self.normal_slice_bias.weight)  # CRITICAL: zero-init for identity-at-start
   ```

2. Modify `TransolverAttention.forward` to accept normals and apply the bias:
   ```python
   def forward(self, x, normals=None):
       # ... existing x_mid computation ...
       slice_logits = self.in_project_slice(x_mid) / self.temperature  # [B, T, num_heads, slice_num]
       if normals is not None:
           head_bias = self.normal_slice_bias(normals)               # [B, T, num_heads]
           slice_logits = slice_logits + head_bias.unsqueeze(-1)     # broadcast over slice_num
       # ... existing softmax + slice aggregation ...
   ```

3. Thread `normals` through the encoder: at the top of the surface branch, extract `normals = x[..., 3:6]` (channels 3:6 of SURFACE_X_DIM=7). Pass `normals` into each `TransolverAttention.forward(...)` call in the surface encoder stack. The volume branch does not need this — volume tokens have no surface normal.

4. Confirm `SURFACE_X_DIM=7` channel layout in `data/loader.py` is `[xyz, normals(3), one_more]` so `[..., 3:6]` is indeed normals. If layout differs, adapt indexing accordingly. (loader is read-only — only read the layout, do not edit.)

### Training plan: Phase A diagnostic gate, then Phase B full finetune

**Phase A (4-6h GPU diagnostic gate)**
- Resume from H336 cosine-tail base artifact `yw2a5dyl:epoch-13`
- Train 2-3 cosine-tail epochs with NGSB attached
- Use `--wandb_group h351-ngsb-phase-a`

**Phase A gate (decide GO/NOGO):**
- Compare `train/loss_wss_z` against H336 baseline cosine-tail trajectory at matched step (e.g. step 1500, midpoint of EP14).
- GO: NGSB `train/loss_wss_z` at or below H336 baseline ± noise → mechanism alive, run Phase B.
- NOGO: NGSB `train/loss_wss_z` ≥ +5% above H336 baseline at step 1500 → close. Save ~20h on dead mechanism.

**Phase B (20-24h GPU full finetune, only if Phase A passes)**
- Full cosine-tail finetune (EP14 → EP15, ~3000 steps)
- Apply H336 K=5 + Student-t ν=4 + σ=5e-4 + 8-res + mirror + per-channel-OLS-cal TTA recipe to the final checkpoint
- Use `--wandb_group h351-ngsb-phase-b`

### Falsifiers

1. **Phase A gate** (described above): saves 20h on a dead mechanism.
2. **`cal-cannot-rescue-train-raw-regression` rule**: if val_abupt RAW (no TTA cal) of NGSB model is >+10bp worse than H336 EP15 raw (≈5.91xx), TTA cal cannot rescue. Close.

### Final merge gate

val_abupt_cal < **5.8978%** AND test_abupt_cal < **5.7379%**

### Reproduce command (Phase A template — adapt to actual CLI flags via `python train.py --help`)

```bash
torchrun --nproc-per-node=8 train.py \
  --resume_from_artifact yw2a5dyl:epoch-13 \
  --epochs 14 \
  --K 5 --noise_family student_t --noise_df 4 --noise_sigma 5e-4 \
  --wandb_group h351-ngsb-phase-a \
  --output_dir outputs/h351/phase-a
```

If `--resume_from_artifact` isn't the exact flag in train.py, check `--help` for the correct artifact-resume mechanism — the H336 EP13 base is W&B artifact `yw2a5dyl:epoch-13`.

### Constraints

- **Param overhead**: exactly 24 parameters (3 × 8 heads). Confirm `<<+1%` in W&B run config or params table at start of run.
- **Read-only files** (do NOT modify): `data/loader.py`, `data/preload.py`, `data/split_manifest.json`. Read layouts only.
- **Architecture**: do NOT modify the trained `tau_z=1.67` value or any other H336 architectural constant.
- **DDP 8 GPUs** for all training runs (`torchrun --nproc-per-node=8`).

## Baseline (H336 SOTA — current merge target)

| Metric | H336 (current SOTA) | Transolver-3 floor | Δ remaining |
|---|---:|---:|---:|
| val_abupt_cal | **5.8978%** | — | (merge gate) |
| test_abupt_cal | **5.7379%** | <5.85% | passed, gate is val |
| test_VP | 3.3735% | ≤3.421 | -3.5bp ✓ |
| test_SP | 3.6133% | ≤3.577 | +3.6bp gap |
| test_WSS | 6.6382% | <5.85% | +79bp gap |
| test_WSS_x | 5.9014% | — | — |
| test_WSS_y | 7.1841% | — | — |
| **test_WSS_z** | **8.6175%** (primary obstacle) | <5.85% | **+277bp gap** |

**Merge gate (strict)**: val_cal < 5.8978 AND test_cal < 5.7379.

- H336 SOTA W&B run: **`348i3z1v`**
- H336 cosine-tail base artifact: **`yw2a5dyl:epoch-13`**
- H336 cal coefs (for reference): α_cp=0.99476/β=−0.00236, α_τx=0.99443/β=−0.00721, α_τy=0.99425/β=−0.00023, α_τz=0.99172/β=−0.00018, α_VP=0.99963/β=−0.86162
- Reproduce H336 (sanity check): `torchrun --nproc-per-node=8 train.py --resume_from_artifact yw2a5dyl:epoch-13 --epochs 15 --K 5 --noise_family student_t --noise_df 4 --noise_sigma 5e-4 ...`

Tanjiro — you've been our cleanest TTA-recipe engineer and the closure of `sigma-axis-closed-nu4` (H340) was methodologically tight. H351 is your first encoder-architecture experiment for this program. The zero-init guarantee means there's no downside risk at epoch 0; the upside is potentially closing the WSS_z gap in a way the loss-axis and TTA-axis closures cannot. Go for it.
