### PR TITLE
H353: Expansive signed_power target on wss_z (converse of H349)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -137,6 +137,12 @@ class EvalConfig:
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
 
+    # H353: expansive signed-power target transform. Must match the values used
+    # in train.py for the checkpoint being evaluated, so the inverse is applied
+    # correctly before de-z-scoring. Default "none" preserves prior eval behaviour.
+    target_signed_power: str = "none"
+    signed_power_p: float = 1.25
+
 
 def parse_args(argv: Iterable[str] | None = None) -> EvalConfig:
     parser = argparse.ArgumentParser(description="H252 stacked weight-noise x multi-res x mirror eval")
@@ -998,6 +1004,8 @@ def main(argv: Iterable[str] | None = None) -> None:
         surface_y_std=stats["surface_y_std"].to(device),
         volume_y_mean=stats["volume_y_mean"].to(device),
         volume_y_std=stats["volume_y_std"].to(device),
+        signed_power_mode=cfg.target_signed_power,
+        signed_power_p=cfg.signed_power_p,
     )
 
     model = build_model(cfg).to(device)

--- a/train.py
+++ b/train.py
@@ -146,6 +146,9 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H353: signed power transform for loss-space target reshaping
+    target_signed_power: str = "none"
+    signed_power_p: float = 1.25
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -271,6 +274,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "target_signed_power": (
+            "H353: apply an expansive signed power transform y'=sign(y)*|y|^p "
+            "in loss space AFTER z-scoring. Choices: 'none' (disabled), "
+            "'wss_z' (tau_z only), 'wss' (tau_x/y/z), 'all' (all 4 surface "
+            "channels). Upweights heavy-tail samples in MSE: effective "
+            "gradient weight ~ p*|y|^(2p-1). Inverse applied at eval before "
+            "de-normalisation. Default: none."
+        ),
+        "signed_power_p": (
+            "H353: exponent p for the signed power transform. p=1 is identity; "
+            "p>1 is expansive (upweights tails). Arms to try: 1.25, 1.5, 2.0. "
+            "Default: 1.25."
         ),
     }
     for field in fields(Config):
@@ -865,6 +881,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             surface_y_std=stats["surface_y_std"].to(device),
             volume_y_mean=stats["volume_y_mean"].to(device),
             volume_y_std=stats["volume_y_std"].to(device),
+            signed_power_mode=config.target_signed_power,
+            signed_power_p=config.signed_power_p,
         )
 
         model: nn.Module = build_model(config).to(device)

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -169,6 +169,27 @@ class StridedDistributedSampler(Sampler[int]):
         return (len(self.dataset) - 1 - self.rank) // self.num_replicas + 1
 
 
+def signed_power_transform(y: torch.Tensor, p: float) -> torch.Tensor:
+    """Expansive signed power transform: y' = sign(y) * |y|^p (p > 1).
+
+    Applied in loss space after z-scoring.  Upweights heavy-tail samples in
+    MSE: effective per-sample gradient weight is p * |y|^(2p-1) relative to
+    vanilla MSE on raw z-scored targets.
+    """
+    return torch.sign(y) * torch.abs(y).clamp(min=1e-12).pow(p)
+
+
+def signed_power_inverse(z: torch.Tensor, p: float) -> torch.Tensor:
+    """Exact inverse of signed_power_transform: y = sign(z) * |z|^(1/p)."""
+    return torch.sign(z) * torch.abs(z).clamp(min=1e-12).pow(1.0 / p)
+
+
+# Surface channel indices (matches SURFACE_TARGET_NAMES order: cp, tau_x, tau_y, tau_z)
+_SURF_CH_TAU_X = 1
+_SURF_CH_TAU_Y = 2
+_SURF_CH_TAU_Z = 3
+
+
 class TargetTransform:
     def __init__(
         self,
@@ -179,6 +200,8 @@ class TargetTransform:
         volume_y_std: torch.Tensor | None = None,
         y_mean: torch.Tensor | None = None,
         y_std: torch.Tensor | None = None,
+        signed_power_mode: str = "none",
+        signed_power_p: float = 1.25,
     ):
         if surface_y_mean is None:
             if y_mean is None:
@@ -196,6 +219,29 @@ class TargetTransform:
         self.surface_y_std = surface_y_std.clamp(min=1e-6)
         self.volume_y_mean = volume_y_mean
         self.volume_y_std = volume_y_std.clamp(min=1e-6)
+        valid_modes = ("none", "wss_z", "wss", "all")
+        if signed_power_mode not in valid_modes:
+            raise ValueError(
+                f"signed_power_mode must be one of {valid_modes}, got {signed_power_mode!r}"
+            )
+        if signed_power_p <= 0.0:
+            raise ValueError(f"signed_power_p must be positive, got {signed_power_p}")
+        self.signed_power_mode = signed_power_mode
+        self.signed_power_p = signed_power_p
+
+    def _surface_channels_to_transform(self) -> list[int]:
+        """Return which surface channel indices get the signed-power transform."""
+        mode = self.signed_power_mode
+        if mode == "none":
+            return []
+        if mode == "wss_z":
+            return [_SURF_CH_TAU_Z]
+        if mode == "wss":
+            return [_SURF_CH_TAU_X, _SURF_CH_TAU_Y, _SURF_CH_TAU_Z]
+        if mode == "all":
+            # all 4 channels: cp, tau_x, tau_y, tau_z
+            return [0, _SURF_CH_TAU_X, _SURF_CH_TAU_Y, _SURF_CH_TAU_Z]
+        return []
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         return self.apply_surface(y)
@@ -204,9 +250,37 @@ class TargetTransform:
         return self.invert_surface(y)
 
     def apply_surface(self, y: torch.Tensor) -> torch.Tensor:
-        return (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+        # Step 1: z-score
+        z = (y - self.surface_y_mean.to(y.device)) / self.surface_y_std.to(y.device)
+        # Step 2: apply signed-power to selected channels (after z-scoring).
+        # Use out-of-place stack to avoid autograd in-place mutation errors.
+        channels = self._surface_channels_to_transform()
+        if channels:
+            channels_set = set(channels)
+            n_ch = z.shape[-1]
+            slices = []
+            for ch in range(n_ch):
+                s = z[..., ch : ch + 1]
+                if ch in channels_set:
+                    s = signed_power_transform(s, self.signed_power_p)
+                slices.append(s)
+            z = torch.cat(slices, dim=-1)
+        return z
 
     def invert_surface(self, y: torch.Tensor) -> torch.Tensor:
+        # Step 1: invert signed-power from selected channels (out-of-place).
+        channels = self._surface_channels_to_transform()
+        if channels:
+            channels_set = set(channels)
+            n_ch = y.shape[-1]
+            slices = []
+            for ch in range(n_ch):
+                s = y[..., ch : ch + 1]
+                if ch in channels_set:
+                    s = signed_power_inverse(s, self.signed_power_p)
+                slices.append(s)
+            y = torch.cat(slices, dim=-1)
+        # Step 2: de-z-score
         return y * self.surface_y_std.to(y.device) + self.surface_y_mean.to(y.device)
 
     def apply_volume(self, y: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Hypothesis

H349 closure produced a clean direction-of-effect finding: **COMPRESSIVE target transforms (arcsinh) on wss_z are pessimal** — they downweight the heavy-tail samples that drive WSS_z error, causing +72bp val_wss_z regression. The mechanism is loss-space compression of the high-|τ_z| tail where WSS_z error concentrates (boundary-layer detachment regions).

**H353 tests the CONVERSE**: an **EXPANSIVE target transform** `y' = sign(y)·|y|^p` with p > 1 should UPWEIGHT the heavy-tail in loss space, giving more gradient signal to high-|τ_z| samples. If H349's direction-of-effect finding is correct, expansion should improve WSS_z exactly as much as compression hurt it.

This is also a **clean falsifier test** for the broader target-transform axis: if even mild expansion (p=1.25) makes wss_z worse, then the wss_z basin is fragile to ANY target nonlinearity → bank as `target-transform-axis-closed` and move to a different axis. If expansion helps, we have a new lever for the WSS_z attack.

**Mechanism orthogonality:**
- Same code path as H349 (output-transform axis), but **opposite direction** — direct experimental test of the direction-of-effect finding.
- Independent of H347 (physics constraint), H348 (input features), H350 (decoder), H351 (slice attention), H352 (weight-averaging).
- Zero param overhead — only a loss-side transform, model architecture unchanged.

**Why this attacks WSS_z specifically:**
The wss_z error distribution is heavy-tailed: a small fraction of high-|τ_z| points (boundary-layer detachment, vortex cores) drive most of the rel_l2_pct. Linear MSE assigns weight ∝ |y|² already (gradient is 2(ŷ-y)). Expansive transform y → sign(y)·|y|^p with p=1.25 gives gradient ∝ |y|^(2p-1) = |y|^1.5, i.e. higher weight on high-|y| samples than vanilla MSE. p=1.5 → weight ∝ |y|^2. p=2.0 → weight ∝ |y|^3 (extreme tail focus).

**References:**
- Box, G.E.P., Cox, D.R. (1964). "An Analysis of Transformations" — original power-transform paper.
- The MSE-via-transform composition is well-known; this is the simplest invertible expansive transform on a signed channel.

## Instructions

### Code changes in `train.py` and `eval_tta_h252.py`

Reuse H349's `--target-asinh {none, wss_z, wss, all}` plumbing as a template. Add a new CLI flag:

```python
parser.add_argument("--target-signed-power", choices=["none", "wss_z", "wss", "all"], default="none")
parser.add_argument("--signed-power-p", type=float, default=1.25)
```

Add transform functions (alongside the existing asinh ones):
```python
def signed_power_transform(y, p):
    # y' = sign(y) * |y|^p, exactly invertible
    return torch.sign(y) * torch.abs(y).clamp(min=1e-12).pow(p)

def signed_power_inverse(z, p):
    # y = sign(z) * |z|^(1/p)
    return torch.sign(z) * torch.abs(z).clamp(min=1e-12).pow(1.0 / p)
```

Apply the transform in the loss path **after z-scoring** (same point as H349 asinh), so the model output for transformed channels lives in `signed_power(zscore(τ_z), p)` space. Eval applies `signed_power_inverse` → `invert_surface` to recover physical units, then existing rel_l2 / H336 cal coefficients are unchanged.

Smoke checks (50 steps, mandatory before primary launch):
1. Round-trip: `signed_power_inverse(signed_power_transform(y, p), p) ≈ y` with rel err < 1e-5.
2. Loss magnitude at step 0 ≈ 0.8-3× the original loss (depends on p; should be sane).
3. Gradient flows through transform (no NaN, no all-zero on transformed channels).
4. Eval inverse: `signed_power_inverse` applied BEFORE `invert_surface` and BEFORE cal coefficient application.

### Arms (run in order with skip rule)

- **Arm A: `--target-signed-power=wss_z --signed-power-p=1.25`** — mild expansion (gradient weight |y|^1.5). Most surgical.
- **Arm B: `--target-signed-power=wss_z --signed-power-p=1.5`** — stronger expansion (gradient weight |y|^2). Quadratic-MSE-equivalent.
- **Arm C: `--target-signed-power=wss_z --signed-power-p=2.0`** — extreme expansion (gradient weight |y|^3). Stress test of the direction-of-effect finding.

### Skip rule (saves GPU on null)

After each arm's training terminal (~3h), inspect raw `val_wss_z_rel_l2_pct`:
- If Arm A val_wss_z RAW < H336 raw val_wss_z (≈9.18) by ≥10bp → **direction-of-effect confirmed, mechanism alive**. Run Arms B/C to find optimum p. Then TTA cal eval the best arm.
- If Arm A val_wss_z RAW is within ±5bp of H336 raw → mechanism neutral on wss_z. Close axis, bank `target-transform-axis-neutral-wssz`.
- If Arm A val_wss_z RAW is >+10bp worse than H336 raw → **target-transform axis fully closed** (compression AND expansion both hurt). Bank `target-transform-axis-closed`. Do NOT run Arms B/C.

### Falsifier

Per `cal-cannot-rescue-train-raw-regression`: if any arm's val_abupt RAW is >+10bp worse than H336 raw val_abupt (~5.97), TTA cal cannot rescue. Close that arm immediately.

### Final merge gate

val_abupt_cal < **5.8978%** AND test_abupt_cal < **5.7379%**

### Reproduce command (Arm A template)

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs-already-done 13 --epochs 16 --lr-cosine-t-max 16 \
  --seed=2025 \
  --target-signed-power=wss_z --signed-power-p=1.25 \
  --wandb-group "h353-frieren-signed-power" \
  --wandb-name "frieren/h353-arm-A-p1.25"
```

(Per-arm Δ: swap `--signed-power-p` to 1.5 for Arm B, 2.0 for Arm C.)

### Constraints

- **Param overhead**: 0 (loss-side transform only).
- **Read-only files** (do NOT modify): `data/loader.py`, `data/preload.py`, `data/split_manifest.json`.
- **Architecture**: do NOT modify `tau_z=1.67` or any other H336 architectural constant.
- **DDP 8 GPUs** for all training runs (`torchrun --nproc-per-node=8`).
- **GPU budget**: ~3h per arm × 3 arms = ~9h; skip rule may cut to ~3h on Arm A null.

## Baseline (H336 SOTA — current merge target)

| Metric | H336 (current SOTA) | Transolver-3 floor |
|---|---:|---:|
| val_abupt_cal | **5.8978%** | — |
| test_abupt_cal | **5.7379%** | <5.85% |
| test_VP | 3.3735% | ≤3.421 |
| test_SP | 3.6133% | ≤3.577 |
| test_WSS | 6.6382% | <5.85% |
| test_WSS_x | 5.9014% | — |
| test_WSS_y | 7.1841% | — |
| **test_WSS_z** | **8.6175%** (primary obstacle) | <5.85% |

**Approximate H336 raw values** (for direction-of-effect comparison):
- val_abupt RAW ≈ 5.97
- val_wss_z RAW ≈ 9.18
- test_abupt RAW ≈ 5.85
- test_wss_z RAW ≈ 8.76

**Merge gate (strict)**: val_cal < 5.8978 AND test_cal < 5.7379.

- H336 SOTA W&B run: **`348i3z1v`**
- H336 cosine-tail base artifact: **`yw2a5dyl:epoch-13`**
- H336 cal coefs (for reference; signed_power model will need re-fit, especially for wss_z): α_cp=0.99476, α_τx=0.99443, α_τy=0.99425, α_τz=0.99172, α_VP=0.99963

Frieren — H349 closure was a *clean direction-of-effect falsifier*, which is a valuable result. H353 is the most natural follow-up: same code path, opposite direction. If expansion helps wss_z, you'll have established a new lever for the WSS_z attack. If both compression and expansion hurt, you'll have triply-closed the target-transform axis on wss_z — also a useful structural finding. Either way, this is high-information. Go for it.
