### PR TITLE
H354: FiLM decoder with EP13-warm-started head_mlp (corrected H350)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -133,6 +133,11 @@ class EvalConfig:
     use_qk_norm: bool = True
     use_surf_to_vol_xattn: bool = True
     drop_path_max: float = 0.1
+    # H350: enable FiLM-conditioned surface decoder when loading checkpoints
+    # trained with --film-decoder. Must match the training-time setting exactly
+    # or load_state_dict will mismatch the surface_out vs FiLM head keys.
+    film_decoder: bool = False
+    film_axis_dim: int = 32
 
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
@@ -188,6 +193,8 @@ def build_model(cfg: EvalConfig) -> SurfaceTransolver:
         use_qk_norm=cfg.use_qk_norm,
         use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
         drop_path_max=cfg.drop_path_max,
+        film_decoder=cfg.film_decoder,
+        film_axis_dim=cfg.film_axis_dim,
     )
 
 

--- a/model.py
+++ b/model.py
@@ -419,6 +419,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        film_decoder: bool = False,
+        film_axis_dim: int = 32,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +436,8 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.film_decoder = film_decoder
+        self.film_axis_dim = film_axis_dim
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -513,7 +517,37 @@ class SurfaceTransolver(nn.Module):
             drop_path_max=drop_path_max,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
-        if use_aux_decoder_heads:
+        if film_decoder:
+            # H354 (corrects H350): per-channel FiLM modulation of the shared
+            # surface representation, with a head_mlp whose architecture mirrors
+            # H336's surface_out so it can be warm-started from the EP13
+            # checkpoint. Shapes: Linear(D, D) + SiLU + Linear(D, C) where C is
+            # surface_output_dim. Each surface channel c reads from its own
+            # (gamma_c, beta_c) modulation, then we take the c-th output dim of
+            # head_mlp(h_c). At gamma=beta=0 (zero-init film_proj),
+            # head_mlp(h_c)[..., c] == surface_out(h)[..., c] after warm-start,
+            # so step-0 prediction equals EP13 exactly.
+            self.axis_embed = nn.Embedding(self.surface_output_dim, film_axis_dim)
+            self.film_proj = nn.Linear(film_axis_dim, 2 * n_hidden)
+            self.head_mlp = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, self.surface_output_dim),
+            )
+            self.head_mlp.apply(_init_linear)
+            nn.init.zeros_(self.film_proj.weight)
+            nn.init.zeros_(self.film_proj.bias)
+            nn.init.normal_(self.axis_embed.weight, std=0.01)
+            self.surface_out = None
+            self.volume_out = nn.Sequential(
+                nn.Linear(n_hidden, n_hidden // 2),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 2, n_hidden // 4),
+                nn.SiLU(),
+                nn.Linear(n_hidden // 4, self.volume_output_dim),
+            )
+            self.volume_out.apply(_init_linear)
+        elif use_aux_decoder_heads:
             # PR #958: dedicated vol_p auxiliary decoder head.
             # Surface head is a 2-layer MLP (cp, tau_x, tau_y, tau_z).
             # Volume head is a deeper 3-layer MLP for the harder vol_p task —
@@ -557,6 +591,33 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
+
+    def _film_surface_decode(self, surface_hidden: torch.Tensor) -> torch.Tensor:
+        """H354: FiLM-conditioned per-channel surface decode.
+
+        For each channel c we FiLM-modulate the shared representation with
+        (gamma_c, beta_c), run it through head_mlp (which outputs all C channels
+        because its shape mirrors H336's surface_out for warm-start), then keep
+        only the c-th output dim. At step 0 (gamma=beta=0) the modulation is
+        identity, head_mlp matches the warm-started surface_out, and the c-th
+        output of head_mlp(h) equals surface_out(h)[..., c] — so the final
+        prediction equals EP13 exactly.
+
+        surface_hidden : (B, N, D)
+        returns        : (B, N, surface_output_dim)
+        """
+        C = self.surface_output_dim  # 4 surface channels: cp, tau_x, tau_y, tau_z
+        axis_ids = torch.arange(C, device=surface_hidden.device)
+        axis_e = self.axis_embed(axis_ids)              # (C, axis_dim)
+        gb = self.film_proj(axis_e)                     # (C, 2*D)
+        gamma, beta = gb.chunk(2, dim=-1)               # each (C, D)
+        # Sequential per-channel loop; head_mlp is called C times rather than
+        # broadcasting (B, N, C, D) which would cost ~4 GB at H336 scale.
+        channel_preds = []
+        for c in range(C):
+            h_c = surface_hidden * (1.0 + gamma[c]) + beta[c]   # (B, N, D)
+            channel_preds.append(self.head_mlp(h_c)[..., c:c + 1])  # (B, N, 1)
+        return torch.cat(channel_preds, dim=-1)                 # (B, N, C)
 
     def _encode_group(
         self,
@@ -661,7 +722,11 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.film_decoder:
+                surface_preds = self._film_surface_decode(surface_hidden)
+            else:
+                surface_preds = self.surface_out(surface_hidden)
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -145,6 +145,10 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H350: FiLM-conditioned axis-specific surface decoder + frozen-backbone mode
+    film_decoder: bool = False
+    film_axis_dim: int = 32
+    freeze_backbone: bool = False
     debug: bool = False
 
 
@@ -272,6 +276,31 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
         ),
+        "film_decoder": (
+            "H350: replace the shared Linear(d_model->4) surface decoder "
+            "with 4 axis-conditioned MLP heads modulated via FiLM (Perez "
+            "et al. 2018, arxiv 1709.07871). Each channel (cp, tau_x, "
+            "tau_y, tau_z) reads from its own (gamma, beta) modulation of "
+            "the shared n_hidden representation, then a shared head_mlp "
+            "maps the modulated features to a scalar. film_proj is "
+            "zero-initialised so the FiLM modulation is identity (gamma=0, "
+            "beta=0) at step 0. Volume head is unchanged."
+        ),
+        "film_axis_dim": (
+            "H350: dimensionality of the per-channel axis embedding fed "
+            "into film_proj. Defaults to 32 — only 4 discrete channels "
+            "need to be distinguished, so a low-dim signature keeps the "
+            "param overhead under +1% on H336-scale models. Ignored when "
+            "--film-decoder is off."
+        ),
+        "freeze_backbone": (
+            "H350 Phase A diagnostic: freeze every parameter except the "
+            "FiLM surface decoder (axis_embed, film_proj, head_mlp) and "
+            "the volume_out head. Used with --film-decoder and "
+            "--resume-from-wandb to test whether the FiLM decoder can "
+            "improve val_WSS_z on top of a fixed pre-trained encoder. "
+            "Sets requires_grad=False on all other modules."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -288,9 +317,15 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
 
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    # H350: respect requires_grad so freeze_backbone-mode runs only optimise the
+    # FiLM decoder + volume head. When no params are frozen this is identical
+    # to passing model.parameters().
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
+    if not trainable_params:
+        raise RuntimeError("build_optimizer: no trainable parameters.")
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
-            model.parameters(),
+            trainable_params,
             lr=config.lr,
             weight_decay=config.weight_decay,
         )
@@ -298,7 +333,7 @@ def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
         from lion_pytorch import Lion
 
         return Lion(
-            model.parameters(),
+            trainable_params,
             lr=config.lr,
             weight_decay=config.weight_decay,
             betas=(config.lion_beta1, config.lion_beta2),
@@ -429,7 +464,30 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        film_decoder=config.film_decoder,
+        film_axis_dim=config.film_axis_dim,
     )
+
+
+def freeze_all_but_film_decoder(model: nn.Module) -> tuple[int, int, list[str]]:
+    """H350 Phase A: freeze every parameter except the FiLM surface decoder
+    (axis_embed, film_proj, head_mlp) and the volume_out head.
+
+    Returns (num_frozen, num_trainable, trainable_param_paths) for logging.
+    """
+    trainable_prefixes = ("axis_embed", "film_proj", "head_mlp", "volume_out")
+    trainable_paths: list[str] = []
+    n_trainable = 0
+    n_frozen = 0
+    for name, param in model.named_parameters():
+        if any(name.startswith(p) or f".{p}" in name for p in trainable_prefixes):
+            param.requires_grad_(True)
+            n_trainable += param.numel()
+            trainable_paths.append(name)
+        else:
+            param.requires_grad_(False)
+            n_frozen += param.numel()
+    return n_frozen, n_trainable, trainable_paths
 
 
 def train_loss(
@@ -917,6 +975,132 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"missing={len(missing)} unexpected={len(unexpected)}"
                 )
 
+            # H354: warm-start head_mlp from EP13's surface_out. head_mlp is built
+            # with matching shape (Linear(D,D) + SiLU + Linear(D,C)) in model.py
+            # so the .copy_() lands without reshape. Combined with zero-init
+            # film_proj this makes step-0 prediction exactly equal EP13.
+            base_for_warmstart = unwrap_model(model)
+            if (
+                config.film_decoder
+                and hasattr(base_for_warmstart, "head_mlp")
+                and "surface_out.0.weight" in state_dict
+            ):
+                src_w0 = state_dict["surface_out.0.weight"]
+                src_b0 = state_dict["surface_out.0.bias"]
+                src_w2 = state_dict["surface_out.2.weight"]
+                src_b2 = state_dict["surface_out.2.bias"]
+                dst_w0 = base_for_warmstart.head_mlp[0].weight
+                dst_b0 = base_for_warmstart.head_mlp[0].bias
+                dst_w2 = base_for_warmstart.head_mlp[2].weight
+                dst_b2 = base_for_warmstart.head_mlp[2].bias
+                # Fail loudly on shape mismatch — silent reshape would corrupt
+                # the warm-start mechanism that gates Phase A'.
+                if (
+                    src_w0.shape != dst_w0.shape
+                    or src_b0.shape != dst_b0.shape
+                    or src_w2.shape != dst_w2.shape
+                    or src_b2.shape != dst_b2.shape
+                ):
+                    raise RuntimeError(
+                        "H354 warm-start shape mismatch: "
+                        f"src_w0={tuple(src_w0.shape)} vs dst_w0={tuple(dst_w0.shape)}, "
+                        f"src_w2={tuple(src_w2.shape)} vs dst_w2={tuple(dst_w2.shape)}. "
+                        "head_mlp must mirror surface_out's shape; see model.py."
+                    )
+                with torch.no_grad():
+                    pre_norm_w0 = dst_w0.norm().item()
+                    pre_norm_w2 = dst_w2.norm().item()
+                    dst_w0.copy_(src_w0.to(dst_w0.device, dtype=dst_w0.dtype))
+                    dst_b0.copy_(src_b0.to(dst_b0.device, dtype=dst_b0.dtype))
+                    dst_w2.copy_(src_w2.to(dst_w2.device, dtype=dst_w2.dtype))
+                    dst_b2.copy_(src_b2.to(dst_b2.device, dtype=dst_b2.dtype))
+                    post_norm_w0 = dst_w0.norm().item()
+                    post_norm_w2 = dst_w2.norm().item()
+                    src_norm_w0 = src_w0.norm().item()
+                    src_norm_w2 = src_w2.norm().item()
+                resume_epoch_info["head_mlp_warmstart"] = True
+                resume_epoch_info["head_mlp_warmstart_pre_norm_w0"] = pre_norm_w0
+                resume_epoch_info["head_mlp_warmstart_post_norm_w0"] = post_norm_w0
+                resume_epoch_info["head_mlp_warmstart_src_norm_w0"] = src_norm_w0
+                resume_epoch_info["head_mlp_warmstart_pre_norm_w2"] = pre_norm_w2
+                resume_epoch_info["head_mlp_warmstart_post_norm_w2"] = post_norm_w2
+                resume_epoch_info["head_mlp_warmstart_src_norm_w2"] = src_norm_w2
+                if state.is_main:
+                    print(
+                        f"[H354] head_mlp warm-started from EP13 surface_out: "
+                        f"||w0|| {pre_norm_w0:.4f} -> {post_norm_w0:.4f} "
+                        f"(src {src_norm_w0:.4f}), "
+                        f"||w2|| {pre_norm_w2:.4f} -> {post_norm_w2:.4f} "
+                        f"(src {src_norm_w2:.4f})"
+                    )
+
+                # H354 step-0 invariant: with zero-init film_proj (gamma=beta=0)
+                # and warm-started head_mlp, _film_surface_decode(h) must equal
+                # head_mlp(h) element-wise (since each channel selects its own
+                # c-th column, which together IS head_mlp(h)). Combined with
+                # head_mlp ≡ EP13 surface_out after warm-start, the model's
+                # step-0 surface prediction equals EP13's exactly. Fail loudly
+                # if the invariant breaks — the entire Phase A' diagnostic
+                # depends on it.
+                with torch.no_grad():
+                    film_proj_w_norm = base_for_warmstart.film_proj.weight.norm().item()
+                    film_proj_b_norm = base_for_warmstart.film_proj.bias.norm().item()
+                    d_in = base_for_warmstart.head_mlp[0].in_features
+                    synth_h = torch.randn(
+                        2, 128, d_in,
+                        device=base_for_warmstart.head_mlp[0].weight.device,
+                        dtype=base_for_warmstart.head_mlp[0].weight.dtype,
+                    )
+                    film_out = base_for_warmstart._film_surface_decode(synth_h)
+                    direct = base_for_warmstart.head_mlp(synth_h)
+                    invariant_mse = (film_out - direct).pow(2).mean().item()
+                resume_epoch_info["h354_film_proj_w_norm"] = film_proj_w_norm
+                resume_epoch_info["h354_film_proj_b_norm"] = film_proj_b_norm
+                resume_epoch_info["h354_step0_invariant_mse"] = invariant_mse
+                if film_proj_w_norm != 0.0 or film_proj_b_norm != 0.0:
+                    raise RuntimeError(
+                        f"H354: film_proj must be zero-init at step 0 "
+                        f"(||w||={film_proj_w_norm}, ||b||={film_proj_b_norm}). "
+                        f"This violates the gamma=beta=0 precondition."
+                    )
+                if invariant_mse > 1e-6:
+                    raise RuntimeError(
+                        f"H354 step-0 invariant FAILED: "
+                        f"MSE(FiLM decode, head_mlp direct) = {invariant_mse:.6e} "
+                        f"> 1e-6. With zero-init film_proj the FiLM modulation "
+                        f"should be identity. Bug in _film_surface_decode."
+                    )
+                if state.is_main:
+                    print(
+                        f"[H354] step-0 invariant PASSED: "
+                        f"MSE(FiLM, head_mlp) = {invariant_mse:.3e} "
+                        f"(||film_proj.w||={film_proj_w_norm:.2e}, "
+                        f"||film_proj.b||={film_proj_b_norm:.2e})"
+                    )
+
+        # H350: freeze everything except the FiLM decoder + volume head for the
+        # Phase A diagnostic. Must run AFTER load_state_dict (resume_from_wandb)
+        # so requires_grad isn't reset, and BEFORE torch.compile / DDP wrap so
+        # the freeze is visible to the optimizer and EMA.
+        freeze_info: dict[str, object] = {}
+        if config.freeze_backbone:
+            n_frozen, n_trainable, trainable_paths = freeze_all_but_film_decoder(model)
+            freeze_info = {
+                "freeze_n_frozen_params": n_frozen,
+                "freeze_n_trainable_params": n_trainable,
+                "freeze_trainable_fraction": (
+                    n_trainable / max(1, n_frozen + n_trainable)
+                ),
+            }
+            if state.is_main:
+                print(
+                    f"H350 freeze_backbone=True: trainable={n_trainable:,d} "
+                    f"frozen={n_frozen:,d} "
+                    f"({100.0 * n_trainable / max(1, n_frozen + n_trainable):.2f}% "
+                    f"of params trainable). Trainable modules: "
+                    + ", ".join(sorted({p.split('.')[0] for p in trainable_paths}))
+                )
+
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
         surface_channel_weights = torch.tensor(
@@ -943,6 +1127,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
             if config.use_surf_to_vol_xattn:
+                ddp_kwargs["find_unused_parameters"] = True
+            # H350: frozen-backbone Phase A leaves the encoder without gradients,
+            # which trips DDP's default find_unused_parameters=False allreduce.
+            if config.freeze_backbone:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

The closure of H350 (PR #1542) demonstrated that **randomly-initialized head_mlp catastrophically fails to recover EP13 surface predictions** in 3 epochs at frozen backbone (val_wss_z +316bp, val_abupt +297bp). The mechanism failure was head_mlp re-init — NOT the FiLM-decoder architectural direction.

H354 tests the **proper diagnostic**: same FiLM architecture as H350, but `head_mlp` is **warm-started from EP13's `surface_out` weights** at training initialization. With FiLM γ=β=0 zero-init, the model's step-0 prediction is EXACTLY EP13 (modulo float precision). Phase A' then only needs to **not regress** the FiLM heads, while the per-channel modulation can specialize.

**Mechanism**: H336/EP13 ships a *shared* `surface_out` 2-layer MLP that outputs 4 surface channels (cp, τx, τy, τz) jointly. The FiLM-conditioned-decoder hypothesis is that **per-channel decoder capacity** (via FiLM γβ modulation conditioned on a 4-way channel embedding) lets τ_z develop its own decoder behavior without interfering with cp/τx/τy. The H336 raw test_WSS_z floor at 8.62% (vs 5.85% Transolver target) is hypothesized to be partly representational at the decoder, not just at the backbone.

If Phase A' passes the strict 5bp val_wss_z gate at frozen backbone, the mechanism is alive and Phase B (16-epoch cosine-tail full unfreeze finetune) is justified. If Phase A' FAILS even with warm-start (i.e., adding learnable FiLM modulation cannot improve a frozen H336 base), the FiLM-decoder mechanism is **definitively closed** and we move to other axes.

**Why this is the correct version of H350**: zero-init γβ means at step 0, `head_mlp(x_film(γ=1, β=0)) = head_mlp(x)` which IS EP13's surface_out. The FiLM heads have to actively *learn to specialize* via gradient descent, but they START from a known-good operating point. H350 with random-init head_mlp had to LEARN the entire surface prediction task from scratch — different question entirely.

## Instructions

**Repo state**: branch off `tay`. Confirm `axis_embed`, `film_proj`, `head_mlp` modules already exist from your H350 implementation (they were committed in #1542, which closed but the branch / code may still be in your working tree). If not, re-implement per your H350 spec.

**Only delta vs H350**: change the checkpoint-load logic so `head_mlp` is initialized from EP13's `surface_out` weights instead of random trunc_normal.

**Specifically**: in your model construction / checkpoint resume code, AFTER loading the EP13 checkpoint via `--resume-from-wandb yw2a5dyl --resume-alias epoch-13`:

```python
# In the checkpoint-load path AFTER model.load_state_dict(strict=False) succeeds:
# strict=False catches the "unexpected=4 surface_out.* / missing=7 axis_embed/film_proj/head_mlp.*"
# But now ALSO copy surface_out weights into head_mlp:

if hasattr(model, 'head_mlp') and 'surface_out.0.weight' in checkpoint_state_dict:
    with torch.no_grad():
        model.head_mlp[0].weight.copy_(checkpoint_state_dict['surface_out.0.weight'])
        model.head_mlp[0].bias.copy_(  checkpoint_state_dict['surface_out.0.bias'])
        model.head_mlp[2].weight.copy_(checkpoint_state_dict['surface_out.2.weight'])
        model.head_mlp[2].bias.copy_(  checkpoint_state_dict['surface_out.2.bias'])
    print("[H354] head_mlp warm-started from EP13 surface_out")
```

Verify (sanity check, fail loudly if not):
- After load, `model.head_mlp[0].weight.norm()` ≈ `surface_out.0.weight.norm()` of EP13 (not the trunc_normal scale).
- FiLM γ=0, β=0 at step 0 (zero-init `film_proj.weight`, `film_proj.bias`).
- A forward pass on a fixed batch (e.g., first val sample) yields surface predictions whose MSE vs an EP13-loaded model on the same batch is **< 1e-6**. If not, find the bug — the warm-start failed.

**Phase A' command** (same as H350 Phase A; ONLY checkpoint-load logic changes):

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json --agent askeladd \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs 3 --lr-cosine-t-max 3 --epochs-already-done 0 --lr-warmup-epochs 0 \
  --seed 2025 \
  --optimizer lion --lr 3e-4 --weight-decay 5e-4 --batch-size 4 --lr-min 1e-6 \
  --train-surface-points 65536 --train-volume-points 65536 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --mirror-augmentation --save-every-epoch \
  --ema-decay 0.999 --ema-start-step 50 --grad-clip-norm 0.5 \
  --vol-points-schedule "0:65536" \
  --use-qk-norm --use-surf-to-vol-xattn --drop-path-max 0.1 \
  --rff-num-features 16 --rff-sigma 1.0 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --pos-encoding-mode string_separable \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-mlp-ratio 4 --model-slices 128 \
  --film-decoder \
  --freeze-backbone \
  --wandb-group "h354-askeladd-filmdec-ep13-warmstart" \
  --wandb-name "askeladd/h354-phase-a-prime-warmstart"
```

(Reuse whatever your `--film-decoder` and `--freeze-backbone` flags are from H350 — same plumbing. Only the head_mlp init logic changed.)

## Pre-committed gate (Phase A' decision rule)

After Phase A' terminates (3 epochs, ~50-60min @ 8-GPU DDP):

- **GATE PASSES**: `val_primary/wall_shear_z_rel_l2_pct < 9.13%` (5bp improvement over H336 raw 9.1839%) AND `val_primary/abupt_axis_mean_rel_l2_pct < 5.97%` (no regression on overall val).
  - → Launch Phase B: full 16-epoch cosine-tail with backbone UNFROZEN, mirror-aug ON, all H336 recipe params. ETA ~24h.
- **GATE FAILS**: val_wss_z ≥ 9.13% OR val_abupt > 5.97%.
  - → Post terminal `SENPAI-RESULT` with `{"terminal":true,"status":"complete","pending_arms":false,...}`.
  - → I will close PR with **finding `filmdec-mechanism-falsified-warmstart-still-fails`** (definitively closes the FiLM-decoder mechanism even with the EP13 init).

**Skip rule for Phase B**: also skip Phase B if Phase A' fails the step-0 sanity check (step-0 prediction ≠ EP13's prediction within 1e-6 MSE). That means warm-start is buggy — fix before any Phase B commitment.

## Baseline

Strict merge gate (val_cal < 5.8978 AND test_cal < 5.7379) — H336 SOTA.

Phase A' diagnostic gate (val_wss_z < 9.13%) — H336 raw single-checkpoint reference.

H336 single-checkpoint raw reference (`0gjfv45i`, NO TTA):
- val_abupt = 5.97%
- val_wss_z = 9.1839%
- test_wss_z = 8.7551%

Cosine-tail base artifact: `yw2a5dyl:epoch-13` (W&B).

Reproduce baseline: same as your H350 (the EP13 reload itself produces ~6.0% val_abupt at step 0, no further training).
