### PR TITLE
H355: Boundary-layer derivative decoder (Morgan #1 — Richardson FD on off-wall ghost probes)

### DIFF
--- a/model.py
+++ b/model.py
@@ -394,6 +394,161 @@ class Transformer(nn.Module):
         return x
 
 
+class BLDerivativeHead(nn.Module):
+    """H355: Boundary-layer derivative decoder for wall shear stress.
+
+    Predicts off-wall velocity via cross-attention from ghost probe positions
+    into the post-backbone volume hidden states, then derives tau_w via
+    Richardson finite-difference extrapolation to the wall:
+
+        u(eta) = a * eta + b * eta^2 + O(eta^3)
+        tau_w = mu * du/dn |_{wall} = mu * a
+
+    With two off-wall samples u1 = u(eta1), u2 = u(eta2), the linear
+    coefficient is recovered exactly as:
+
+        tau_fd = mu * (eta2^2 * u1 - eta1^2 * u2) / (eta1 * eta2 * (eta2 - eta1))
+
+    The cross-attention output projection is zero-initialised and the
+    velocity decoder's final linear is zero-initialised so the head is
+    identity-zero at warm-start (tau_fd == 0 at step 0); gradients then
+    awaken naturally via the auxiliary loss.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        eta_distances: list[float],
+        num_volume_slices: int = 256,
+        dropout: float = 0.0,
+        mu: float = 1.8e-5,
+    ):
+        super().__init__()
+        if len(eta_distances) < 2:
+            raise ValueError(
+                f"BLDerivativeHead requires at least 2 eta distances; got {eta_distances}"
+            )
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.num_eta = len(eta_distances)
+        self.num_volume_slices = num_volume_slices
+        self.register_buffer("eta_grid", torch.tensor(eta_distances, dtype=torch.float32))
+        self.register_buffer("mu", torch.tensor(mu, dtype=torch.float32))
+        # Slice-pool volume_hidden (B, N_v, H) -> (B, S, H) via learnable
+        # queries. Without this compression the ghost xattn cost is
+        # O(N_s*K * N_v) which explodes at full Phase-1 scale
+        # (N_s*K=131k, N_v=65k -> ~9G attention-matrix elements per sample).
+        # Pooling to S=256 slice tokens caps attention memory at O(N_s*K * S).
+        self.volume_slice_queries = nn.Parameter(
+            torch.randn(1, num_volume_slices, hidden_dim) * 0.02
+        )
+        self.volume_pool = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            batch_first=True,
+            dropout=dropout,
+        )
+        nn.init.zeros_(self.volume_pool.out_proj.weight)
+        nn.init.zeros_(self.volume_pool.out_proj.bias)
+        self.volume_pool_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        # Cross-attention: ghost queries attend the pooled volume slice tokens.
+        self.ghost_xattn = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            batch_first=True,
+            dropout=dropout,
+        )
+        nn.init.zeros_(self.ghost_xattn.out_proj.weight)
+        nn.init.zeros_(self.ghost_xattn.out_proj.bias)
+        self.ghost_norm = nn.LayerNorm(hidden_dim, eps=1e-6)
+        # Velocity decoder: hidden -> hidden//2 -> 3 (halved bottleneck to
+        # keep step-time overhead bounded at full Phase-1 scale; the
+        # bottleneck still has SiLU non-linearity needed to learn the
+        # off-wall velocity distribution). Final linear is zero-init so
+        # u_probe == 0 at warm-start, killing all gradient flow from the
+        # aux loss back into the backbone until the head wakes up.
+        self.velocity_decoder = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.SiLU(),
+            nn.Linear(hidden_dim // 2, 3),
+        )
+        nn.init.trunc_normal_(self.velocity_decoder[0].weight, std=0.02)
+        nn.init.zeros_(self.velocity_decoder[0].bias)
+        nn.init.zeros_(self.velocity_decoder[2].weight)
+        nn.init.zeros_(self.velocity_decoder[2].bias)
+
+    def forward(
+        self,
+        *,
+        ghost_query: torch.Tensor,
+        volume_hidden: torch.Tensor,
+        volume_mask: torch.Tensor | None,
+        surface_normals: torch.Tensor,
+        surface_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Compute tau_fd from ghost queries attending volume hidden states.
+
+        Args:
+            ghost_query: (B, N_s, K, hidden_dim) pre-encoded ghost positions.
+            volume_hidden: (B, N_v, hidden_dim) post-backbone volume tokens.
+            volume_mask: (B, N_v) bool/float mask; True = real, False = pad.
+            surface_normals: (B, N_s, 3) outward unit normals.
+            surface_mask: (B, N_s) bool/float mask for the surface tokens.
+
+        Returns:
+            dict with key 'tau_fd' = (B, N_s, 3) wall-tangential WSS in physical
+            units (Pa), and 'u_probe' = (B, N_s, K, 3) for diagnostics.
+        """
+        B, N_s, K, H = ghost_query.shape
+        if K != self.num_eta:
+            raise ValueError(f"Expected K={self.num_eta} ghost probes; got {K}")
+        # Flatten ghost queries for MHA: (B, N_s*K, H)
+        q = ghost_query.reshape(B, N_s * K, H)
+        if volume_mask is not None:
+            # MHA key_padding_mask: True = ignore. volume_mask has 1 for real.
+            key_padding_mask = ~volume_mask.bool()
+        else:
+            key_padding_mask = None
+        # Step 1: pool volume_hidden to S slice tokens with learnable queries.
+        slice_q = self.volume_slice_queries.expand(B, -1, -1).to(volume_hidden.dtype)
+        slice_pool_out, _ = self.volume_pool(
+            query=slice_q,
+            key=volume_hidden,
+            value=volume_hidden,
+            key_padding_mask=key_padding_mask,
+            need_weights=False,
+        )
+        slice_tokens = self.volume_pool_norm(slice_q + slice_pool_out)
+        # Step 2: ghost queries attend the compressed slice tokens.
+        xattn_out, _ = self.ghost_xattn(
+            query=q,
+            key=slice_tokens,
+            value=slice_tokens,
+            need_weights=False,
+        )
+        # Residual-norm: ghost_query + xattn_out (xattn_out == 0 at init).
+        ghost_feat = self.ghost_norm(q + xattn_out)
+        # Predict velocity at each probe (in physical units).
+        u_flat = self.velocity_decoder(ghost_feat)  # (B, N_s*K, 3)
+        u_probe = u_flat.view(B, N_s, K, 3)
+        # Richardson 2-point extrapolation using the first two eta values.
+        eta1 = self.eta_grid[0]
+        eta2 = self.eta_grid[1]
+        u1 = u_probe[:, :, 0, :]
+        u2 = u_probe[:, :, 1, :]
+        denom = eta1 * eta2 * (eta2 - eta1)
+        a = (eta2 * eta2 * u1 - eta1 * eta1 * u2) / denom
+        tau_fd_vec = self.mu * a  # (B, N_s, 3) in physical units
+        # Project onto wall-tangent plane: subtract (tau . n) * n.
+        normal_component = (tau_fd_vec * surface_normals).sum(dim=-1, keepdim=True)
+        tau_fd = tau_fd_vec - normal_component * surface_normals
+        if surface_mask is not None:
+            tau_fd = tau_fd * surface_mask.unsqueeze(-1).to(tau_fd.dtype)
+        return {"tau_fd": tau_fd, "u_probe": u_probe}
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -419,6 +574,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        bl_derivative_decoder: bool = False,
+        bl_eta_distances: list[float] | None = None,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -558,6 +715,29 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H355: boundary-layer derivative decoder. Ghost probes at K wall-normal
+        # offsets attend volume_hidden to produce u(probe); a Richardson 2-point
+        # FD then derives tau_w = mu * du/dn. Aux head is parallel to the main
+        # surface_out, so warm-start safety is achieved by zero-init out_proj of
+        # ghost_xattn AND zero-init final linear of velocity_decoder.
+        self.bl_derivative_decoder = bool(bl_derivative_decoder)
+        if self.bl_derivative_decoder:
+            etas = bl_eta_distances if bl_eta_distances else [1e-5, 1e-4]
+            if len(etas) < 2:
+                raise ValueError(
+                    f"bl-derivative-decoder requires >=2 eta distances; got {etas}"
+                )
+            self.bl_eta_distances = list(etas)
+            self.bl_head = BLDerivativeHead(
+                hidden_dim=n_hidden,
+                num_heads=n_head,
+                eta_distances=self.bl_eta_distances,
+                dropout=dropout,
+            )
+        else:
+            self.bl_eta_distances = None
+            self.bl_head = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -672,10 +852,39 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        outputs: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+
+        if (
+            self.bl_head is not None
+            and surface_x is not None
+            and volume_x is not None
+            and surface_tokens > 0
+            and volume_tokens > 0
+        ):
+            surface_coords = surface_x[:, :, : self.space_dim]
+            surface_normals = surface_x[:, :, self.space_dim : self.space_dim + 3]
+            eta_t = surface_coords.new_tensor(self.bl_eta_distances).view(
+                1, 1, len(self.bl_eta_distances), 1
+            )
+            # ghost_coords = x_surf + eta * n_outward (probe sits in fluid).
+            ghost_coords = surface_coords.unsqueeze(2) + eta_t * surface_normals.unsqueeze(2)
+            B, N_s, K, _ = ghost_coords.shape
+            ghost_query = self.pos_embed(ghost_coords.reshape(B, N_s * K, self.space_dim))
+            ghost_query = ghost_query.view(B, N_s, K, -1)
+            bl_out = self.bl_head(
+                ghost_query=ghost_query,
+                volume_hidden=volume_hidden,
+                volume_mask=volume_mask,
+                surface_normals=surface_normals,
+                surface_mask=surface_mask,
+            )
+            outputs["tau_fd"] = bl_out["tau_fd"]
+            outputs["bl_u_probe"] = bl_out["u_probe"]
+
+        return outputs

--- a/train.py
+++ b/train.py
@@ -145,6 +145,11 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H355: boundary-layer derivative decoder (Morgan #1)
+    bl_derivative_decoder: bool = False
+    lambda_bl: float = 0.5
+    bl_eta_distances: str = "1e-5,1e-4"
+    bl_lambda_warmup_steps: int = 0
     debug: bool = False
 
 
@@ -271,6 +276,34 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "bl_derivative_decoder": (
+            "H355: enable the boundary-layer derivative decoder (Morgan #1). "
+            "Generates ghost-probe positions at K wall-normal offsets, attends "
+            "them into volume_hidden via a dedicated zero-init MHA module, "
+            "predicts off-wall velocity u(eta), and derives tau_fd via "
+            "Richardson 2-point extrapolation: "
+            "tau_fd = mu * (eta2^2*u1 - eta1^2*u2) / (eta1*eta2*(eta2-eta1)). "
+            "Adds an L1 aux loss (normalised by wss std) against the ground-truth "
+            "wss xyz, weighted by --lambda-bl. The BL head is parallel to the "
+            "direct surface_out; zero-init out_proj of ghost_xattn and the final "
+            "linear of velocity_decoder make the head identity-zero at warm-start."
+        ),
+        "lambda_bl": (
+            "H355: weight for the BL-derivative auxiliary L1 loss "
+            "(normalised by surface_y_std[1:4]). Default 0.5 per PR spec."
+        ),
+        "bl_eta_distances": (
+            "H355: comma-separated wall-normal offsets (meters) for ghost probes. "
+            "Only the first two values enter the Richardson formula; additional "
+            "values are diagnostic. Default '1e-5,1e-4' targets the viscous "
+            "sublayer (y+~1) and buffer layer (y+~10) where the linear-in-eta "
+            "ansatz holds. Probes beyond y+~30 violate the Taylor expansion."
+        ),
+        "bl_lambda_warmup_steps": (
+            "H355: optional linear ramp on lambda_bl over the first N steps "
+            "(0 = no ramp, full lambda from step 0). Useful if the BL head's "
+            "early predictions perturb the main loss too aggressively."
         ),
     }
     for field in fields(Config):
@@ -414,6 +447,22 @@ def mirror_augment_batch(batch, p: float = 0.5):
     )
 
 
+def parse_bl_eta_distances(spec: str) -> list[float]:
+    spec = (spec or "").strip()
+    if not spec:
+        raise ValueError("--bl-eta-distances must be a non-empty comma-separated list")
+    etas = [float(tok.strip()) for tok in spec.split(",") if tok.strip()]
+    if len(etas) < 2:
+        raise ValueError(
+            f"--bl-eta-distances requires >=2 values; got {etas} (spec={spec!r})"
+        )
+    if any(e <= 0.0 for e in etas):
+        raise ValueError(f"--bl-eta-distances must be positive; got {etas}")
+    if any(etas[i] >= etas[i + 1] for i in range(len(etas) - 1)):
+        raise ValueError(f"--bl-eta-distances must be strictly increasing; got {etas}")
+    return etas
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -429,6 +478,12 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        bl_derivative_decoder=config.bl_derivative_decoder,
+        bl_eta_distances=(
+            parse_bl_eta_distances(config.bl_eta_distances)
+            if config.bl_derivative_decoder
+            else None
+        ),
     )
 
 
@@ -442,6 +497,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    bl_lambda: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -467,13 +523,40 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        bl_metrics: dict[str, float] = {}
+        if "tau_fd" in out:
+            tau_fd = out["tau_fd"]
+            wss_target_raw = batch.surface_y[..., 1:4]
+            # L1 in normalized space: divide by surface_y_std[1:4] so the BL
+            # loss magnitude is comparable to the (normalized) main losses.
+            wss_std = transform.surface_y_std.to(tau_fd.device, dtype=tau_fd.dtype)[1:4]
+            mask = batch.surface_mask.unsqueeze(-1).to(tau_fd.dtype)
+            diff_norm = ((tau_fd - wss_target_raw) / wss_std) * mask
+            denom = (mask.sum() * 3.0).clamp(min=1.0)
+            bl_loss_raw = diff_norm.abs().sum() / denom
+            bl_loss_weighted = bl_lambda * bl_loss_raw
+            loss = loss + bl_loss_weighted
+            with torch.no_grad():
+                tau_fd_abs_mean = (tau_fd.abs() * mask).sum() / denom
+                wss_target_abs_mean = (wss_target_raw.abs() * mask).sum() / denom
+                u_probe_abs_mean = out["bl_u_probe"].detach().abs().mean()
+            bl_metrics = {
+                "bl/loss_raw": float(bl_loss_raw.detach().cpu().item()),
+                "bl/loss_weighted": float(bl_loss_weighted.detach().cpu().item()),
+                "bl/lambda": float(bl_lambda),
+                "bl/tau_fd_abs_mean": float(tau_fd_abs_mean.cpu().item()),
+                "bl/wss_target_abs_mean": float(wss_target_abs_mean.cpu().item()),
+                "bl/u_probe_abs_mean": float(u_probe_abs_mean.cpu().item()),
+            }
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    metrics.update(bl_metrics)
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -941,8 +1024,10 @@ def main(argv: Iterable[str] | None = None) -> None:
             # batch, so DDP's default find_unused_parameters=False deadlocks
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
-            # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            # params across ranks, at a small per-step overhead. H355: same
+            # consideration applies to the BL derivative decoder which also
+            # gates on surface_tokens > 0 AND volume_tokens > 0.
+            if config.use_surf_to_vol_xattn or config.bl_derivative_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1221,6 +1306,17 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
+                    if config.bl_derivative_decoder:
+                        if config.bl_lambda_warmup_steps > 0:
+                            ramp = min(
+                                1.0,
+                                (global_step + 1) / float(config.bl_lambda_warmup_steps),
+                            )
+                            bl_lambda = config.lambda_bl * ramp
+                        else:
+                            bl_lambda = config.lambda_bl
+                    else:
+                        bl_lambda = 0.0
                     loss, batch_loss_metrics = train_loss(
                         model,
                         batch,
@@ -1230,6 +1326,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        bl_lambda=bl_lambda,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1270,6 +1367,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for bl_key in (
+                        "bl/loss_raw",
+                        "bl/loss_weighted",
+                        "bl/lambda",
+                        "bl/tau_fd_abs_mean",
+                        "bl/wss_target_abs_mean",
+                        "bl/u_probe_abs_mean",
+                    ):
+                        if bl_key in batch_loss_metrics:
+                            train_log[bl_key] = batch_loss_metrics[bl_key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

Direct implementation of **Morgan's directive #1** (Issue #1056, 2026-06-01 13:15Z): a **Boundary-Layer derivative decoder** that predicts WSS as a finite-difference gradient of an off-wall velocity field, rather than as a direct surface regression. Target: **~30bp test_WSS improvement** by giving the model the physically-correct mechanism for wall shear computation.

**Background**: WSS in DrivAerML is the wall-tangential velocity gradient: `τ_w = μ · (∂u_t/∂n)|_wall`. The H336 model predicts `τ_xyz` *directly* as a 3-channel surface output. It never sees the off-wall velocity profile that physically determines τ_w. We're asking the model to regress the derivative without ever seeing the function it's differentiating — a fundamentally indirect prediction task.

**Why this is the right move now**: FiLM decoder axis fully closed at both endpoints (H350 random-init catastrophic + H354 warm-start no-lift). The H354 student's finding: "H336/EP13's shared surface_out is already a Pareto-optimal point under the frozen-backbone constraint... the H336 raw test_wss_z floor at 8.62% is NOT representational at the decoder — it's bottlenecked upstream." Combined with TRIPLY-CLOSED loss-reweight axis (H339+H341+H346), TTA-saturation (H330+H340+H344), SAM-closed (H343), and compressive target-transform falsified (H349): five closed/saturated axes converge on **upstream representational bottleneck**. BL derivative decoder is the structurally different intervention — it leverages the *volume* backbone representation to derive τ_w via physical formula.

## Instructions

Branch off `tay`. Smoke test FIRST (1-GPU, ~50 steps). Three implementation parts.

### Part 1: Ghost probe generation (utility)

```python
def generate_ghost_probes(surface_coords, surface_normals, eta_distances):
    """
    surface_coords:  (B, N, 3) per-vertex positions
    surface_normals: (B, N, 3) outward unit normals
    eta_distances:   tuple of K offsets in same units as coords
    Returns ghost_coords (B, N, K, 3), eta tensor (K,)
    """
    K = len(eta_distances)
    eta_t = surface_coords.new_tensor(eta_distances).view(1, 1, K, 1)
    ghost = surface_coords.unsqueeze(2) + eta_t * surface_normals.unsqueeze(2)
    return ghost, surface_coords.new_tensor(eta_distances)
```

Surface normals: use `data/canonical/normals_haku_v1/<case>.npy` if available (per existing data structure). If not present in the loader output, compute on-the-fly from face geometry in `train.py` collation step. **`data/loader.py`, `data/preload.py`, `data/split_manifest.json` are read-only — do NOT modify them.** Add normals plumbing in `train.py` only.

### Part 2: BL decoder head (re-use volume cross-attention)

```python
class BLDerivativeHead(nn.Module):
    def __init__(self, hidden_dim, eta_distances):
        super().__init__()
        # Re-use volume cross-attention to predict velocity at ghost points
        self.velocity_decoder = nn.Sequential(
            nn.Linear(hidden_dim, hidden_dim), nn.SiLU(),
            nn.Linear(hidden_dim, 3),  # u_x, u_y, u_z
        )
        self.register_buffer("eta_grid", torch.tensor(eta_distances))
        self.register_buffer("mu", torch.tensor(1.8e-5))  # air dynamic viscosity (Pa·s)

    def forward(self, ghost_features):
        # ghost_features: (B, N, K, hidden_dim) from cross-attention into volume tokens
        u_probe = self.velocity_decoder(ghost_features)  # (B, N, K, 3)
        eta1 = self.eta_grid[0]
        if u_probe.shape[2] >= 2:
            eta2 = self.eta_grid[1]
            # Richardson 2-point: tau ≈ mu * (eta2^2 * u1 - eta1^2 * u2) / (eta1*eta2*(eta2-eta1))
            u1, u2 = u_probe[:, :, 0, :], u_probe[:, :, 1, :]
            tau_fd = self.mu * (eta2**2 * u1 - eta1**2 * u2) / (eta1 * eta2 * (eta2 - eta1))
        else:
            tau_fd = self.mu * u_probe[:, :, 0, :] / eta1
        return tau_fd  # (B, N, 3) wall shear xyz
```

Cross-attention path: re-use the model's existing volume cross-attention module to attend ghost-point coordinates into volume tokens. Specifically, treat `ghost_coords.reshape(B, N*K, 3)` as a batch of query positions and feed through the same volume_decoder cross-attention used for cell-center predictions. Reshape output back to `(B, N, K, hidden_dim)`.

### Part 3: Auxiliary loss + flag plumbing

Add CLI flags:
- `--bl-derivative-decoder` (default False)
- `--lambda-bl` (default 0.5)
- `--bl-eta-distances` (default "1e-5,1e-4,1e-3,1e-2")

```python
if args.bl_derivative_decoder:
    ghost_coords, _ = generate_ghost_probes(surface_coords, surface_normals, eta_list)
    ghost_features = volume_decoder.cross_attn(
        ghost_coords.reshape(B, N*K, 3), volume_tokens
    ).view(B, N, K, -1)
    tau_fd = bl_head(ghost_features)
    bl_loss = (tau_fd - target_wss_xyz).abs().mean()  # L1 like main loss
    total_loss = total_loss + args.lambda_bl * bl_loss
    log({"bl/loss_raw": bl_loss.item(),
         "bl/tau_fd_mean": tau_fd.abs().mean().item(),
         "bl/loss_weighted": (args.lambda_bl * bl_loss).item()})
```

### Smoke test (1-GPU, 50 steps) — DO BEFORE DDP-8 LAUNCH

Verify:
1. Forward completes — no shape errors, no NaN
2. `bl/loss_raw` finite, O(0.01-0.1). If >1, reduce η_1 to 1e-6.
3. `bl/tau_fd_mean` ≈ `target_wss_xyz_mean` (~0.01 Pa order)
4. Wall-time overhead < 30% per step

Post smoke results to PR before proceeding. If smoke fails, do NOT launch DDP-8.

### Phase 1: Auxiliary loss training (DDP-8, full cosine-tail)

After smoke passes:

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --manifest data/split_manifest.json --agent askeladd \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs-already-done 13 --epochs 16 --lr-cosine-t-max 16 --lr-warmup-epochs 0 \
  --seed 2025 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 --batch-size 4 --lr-min 1e-6 \
  --train-surface-points 65536 --train-volume-points 65536 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --mirror-augmentation --save-every-epoch \
  --ema-decay 0.999 --ema-start-step 50 --grad-clip-norm 0.5 \
  --vol-points-schedule "0:65536" \
  --use-qk-norm --use-surf-to-vol-xattn --drop-path-max 0.1 \
  --rff-num-features 16 --rff-sigma 1.0 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --pos-encoding-mode string_separable \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-mlp-ratio 4 --model-slices 128 \
  --bl-derivative-decoder --lambda-bl 0.5 \
  --bl-eta-distances "1e-5,1e-4,1e-3,1e-2" \
  --wandb-group "h355-askeladd-bl-decoder-aux" \
  --wandb-name "askeladd/h355-arm-A-lambda05"
```

### Phase 2 (if Phase 1 passes): Inference-time ensemble

If Arm A wall_shear_z RAW improves ≥ 5bp over H336 raw 9.1839%, then run inference with BOTH heads and OLS-blend on val:
- `τ_blend = α · τ_direct + (1-α) · τ_fd`
- Optimize α per-channel on val_N=34 (the same 34-case calibration set H312 used).
- Then run TTA+cal cascade (K=5, Student-t ν=4, σ=5e-4, 8-res, mirror, per-channel-OLS-cal — H336 recipe) on this blend.
- Compare against strict gate: val_cal < 5.8978 AND test_cal < 5.7379.

### Phase 3 (if Phase 2 wins): λ sweep

Arms p ∈ {0.25, 0.5, 1.0, 2.0} for `lambda_bl` to find optimal.

## Pre-committed close rules

- **Smoke regression**: `bl/loss_raw` doesn't decrease in first 50 steps → abort.
- **NaN at any step**: abort, report instability for η-grid redesign.
- **Phase 1 wall_shear_z RAW regression > 10bp**: close immediately. Auxiliary loss is destabilizing.
- **Phase 1 wall_shear_z RAW improvement < 5bp**: close with finding `bl-derivative-decoder-aux-neutral`. Physical structure didn't unlock representational headroom.

## Baseline

Strict merge gate (after Phase 2 ensemble + TTA + cal):
- **val_cal < 5.8978 AND test_cal < 5.7379**

H336 raw (no TTA, no cal):
- val_abupt = 5.97, val_wss_z = 9.1839
- test_wss_z = 8.7551, test_WSS = 6.6382

H336 cal (full TTA + per-channel-OLS-cal):
- val_abupt = 5.8978, test_abupt = 5.7379
- test_WSS = 6.6382, test_wss_z = 8.6175

**Morgan target (Issue #1056)**: drive test_WSS below 5.85% (Transolver-3). Current 6.6382 → 5.85 needs ~80bp test_WSS reduction. BL decoder targets ~30bp of that gap.

Cosine-tail base artifact: `yw2a5dyl:epoch-13` (W&B).

Reproduce baseline (with `--bl-derivative-decoder` disabled, all else identical): val_abupt ≈ 5.97, val_wss_z ≈ 9.18.

Closed predecessor: **H350 + H354 FiLM decoder axis** fully closed (decoder-side perturbations of H336 cannot improve τ_z). This hypothesis is the **upstream / volume-rooted** alternative.
