### PR TITLE
H356: 3-cp output-avg (ep13+ep14+ep15) × K=5 TTA

### DIFF
--- a/tools/h356_chain_ep13.sh
+++ b/tools/h356_chain_ep13.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# H356: Wait for ep14 K=5 eval to finish, then launch ep13 K=5 eval.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ep14_pid=$(cat logs/h356/ep14_k5_raw.pid)
+echo "[$(date -u +%FT%TZ)] chain ep13 waiting on ep14 PID=$ep14_pid"
+while kill -0 "$ep14_pid" 2>/dev/null; do
+  sleep 60
+done
+echo "[$(date -u +%FT%TZ)] ep14 PID=$ep14_pid exited"
+
+if [ ! -f outputs/h356/ep14_k5_raw.npz ]; then
+  echo "[$(date -u +%FT%TZ)] ERROR: outputs/h356/ep14_k5_raw.npz missing; not launching ep13"
+  exit 1
+fi
+echo "[$(date -u +%FT%TZ)] ep14 raw .npz present, launching ep13"
+
+exec tools/h356_launch_eval.sh \
+  outputs/drivaerml/run-yw2a5dyl/checkpoint_ep13.pt \
+  outputs/h356/ep13_k5_raw.npz \
+  "alphonse/h356-ep13-k5-tta"

--- a/tools/h356_chain_ep14.sh
+++ b/tools/h356_chain_ep14.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# H356: Wait for ep15 K=5 eval to finish, then launch ep14 K=5 eval.
+# Designed to be nohup'd so the chain survives shell exits.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ep15_pid=$(cat logs/h356/ep15_k5_raw.pid)
+echo "[$(date -u +%FT%TZ)] chain ep14 waiting on ep15 PID=$ep15_pid"
+while kill -0 "$ep15_pid" 2>/dev/null; do
+  sleep 60
+done
+echo "[$(date -u +%FT%TZ)] ep15 PID=$ep15_pid exited"
+
+if [ ! -f outputs/h356/ep15_k5_raw.npz ]; then
+  echo "[$(date -u +%FT%TZ)] ERROR: outputs/h356/ep15_k5_raw.npz missing; not launching ep14"
+  exit 1
+fi
+echo "[$(date -u +%FT%TZ)] ep15 raw .npz present, launching ep14"
+
+tools/h356_launch_eval.sh \
+  outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt \
+  outputs/h356/ep14_k5_raw.npz \
+  "alphonse/h356-ep14-k5-tta"
+
+# After ep14 launch, also chain ep13 to start after ep14 terminates.
+nohup tools/h356_chain_ep13.sh > logs/h356/chain_ep13.log 2>&1 &
+echo "[$(date -u +%FT%TZ)] launched chain_ep13 PID=$!"

--- a/tools/h356_launch_eval.sh
+++ b/tools/h356_launch_eval.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# H356: Launch a single TTA eval mirroring the H342 SOTA recipe, upgraded to K=5
+# (matching H336's K=5 axis). Usage:
+#   tools/h356_launch_eval.sh <ckpt_path> <raw_npz_path> <wandb_name>
+# Background launch with logging to logs/h356/<basename>.log and pidfile.
+set -euo pipefail
+ckpt=${1:?ckpt path}
+raw=${2:?raw .npz path}
+wname=${3:?wandb name}
+
+mkdir -p outputs/h356 logs/h356
+log="logs/h356/$(basename "${raw%.npz}")_eval.log"
+pidfile="logs/h356/$(basename "${raw%.npz}").pid"
+
+nohup torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
+  --checkpoint "$ckpt" \
+  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
+  --eval-modes "weight_noise_mirror_res_avg" \
+  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
+  --weight-noise-dist student_t --weight-noise-df 4 \
+  --test-time-calibration \
+  --batch-size 2 --num-workers 4 \
+  --save-raw-predictions "$raw" \
+  --agent alphonse --wandb-group "h356-alphonse-3cp-k5" \
+  --wandb-name "$wname" \
+  > "$log" 2>&1 &
+pid=$!
+echo "$pid" > "$pidfile"
+echo "Launched torchrun PID=$pid log=$log pidfile=$pidfile"


### PR DESCRIPTION
## Hypothesis
Direct extension of H342 (PR #1526 merged): run the same ep13+ep14+ep15 symmetric 3-checkpoint output-average but upgrade each per-checkpoint TTA from K=4 to K=5 antithetic passes (matching H336's recipe exactly). Predicted gain: ~0.7-1.0bp test_cal beyond H342, compounding the checkpoint-diversity dividend with the K-axis improvement that H336 captured over H314.

**Background**: H342 Arm D used K=4 (weight-noise-passes=4) per checkpoint → val_cal=5.8962%, test_cal=5.7357% (new SOTA). H336 uses K=5 per single checkpoint → val_cal=5.8978%, test_cal=5.7379%. The K=4→K=5 delta on a single checkpoint was ~0.9bp test. With 3 checkpoints each upgraded to K=5, and assuming the averaging preserves ~70-80% of the per-checkpoint gain, expected net improvement is ~0.6-0.9bp test_cal beyond H342. If this holds, test_cal lands ≈5.726-5.730.

## Instructions

### Prep (no training needed — this is pure TTA evaluation)
Branch off `tay`. All other flags identical to H342 Arm D — only change is `--weight-noise-passes 5` (was 4).

```bash
# Eval 1: EP13 checkpoint, K=5
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --save-raw-predictions outputs/h356/ep13_k5_raw.npz \
  --agent alphonse --wandb-group "h356-alphonse-3cp-k5" \
  --wandb-name "alphonse/h356-ep13-k5-tta"
```

```bash
# Eval 2: EP14 checkpoint, K=5
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --save-raw-predictions outputs/h356/ep14_k5_raw.npz \
  --agent alphonse --wandb-group "h356-alphonse-3cp-k5" \
  --wandb-name "alphonse/h356-ep14-k5-tta"
```

```bash
# Eval 3: EP15 checkpoint, K=5 (sanity check vs H336 — should reproduce val_cal ≈ 5.8978 ± 3bp)
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --save-raw-predictions outputs/h356/ep15_k5_raw.npz \
  --agent alphonse --wandb-group "h356-alphonse-3cp-k5" \
  --wandb-name "alphonse/h356-ep15-k5-tta"
```

```bash
# Post-hoc 3-cp symmetric average (Arm D equivalent at K=5)
python tools/h342_avg_checkpoints.py \
  --inputs outputs/h356/ep13_k5_raw.npz outputs/h356/ep14_k5_raw.npz outputs/h356/ep15_k5_raw.npz \
  --arms "A:2 B:1,2 C:0,2 D:0,1,2" \
  --out outputs/h356/results_4arm_k5.json
```

Wall-time: ~7-8h per eval × 3 = ~21-24h total (sequential on same 8 GPUs).

### Pre-committed close rules
- If EP15 K=5 sanity (Arm A) does NOT reproduce H336 val_cal ≈ 5.8978 ± 3bp → abort and report immediately.
- If final Arm D val_cal ≥ 5.8962% (no improvement over H342) → close with `3cp-k5-null`.
- If final Arm D test_cal ≥ 5.7357% (no improvement over H342) → close with `3cp-k5-test-null`.

## Baseline
Strict merge gate: val_abupt_calibrated < **5.8962%** AND test_abupt_calibrated < **5.7357%** (H342 SOTA, PR #1526).

| Run | val_cal | test_cal | test_WSS | test_WSS_z | Notes |
|-----|---------|----------|----------|------------|-------|
| H342 Arm D (current SOTA, PR #1526) | 5.8962% | 5.7357% | 6.6351% | 8.6122% | 3cp K=4 |
| H336 single-cp K=5 (W&B: 348i3z1v) | 5.8978% | 5.7379% | — | — | single-cp K=5 |
| H342 Arm A single-cp K=4 (W&B: ijadzof0) | 5.8987% | 5.7387% | — | — | ep15 K=4 |

Cosine-tail source artifacts:
- ep13: `yw2a5dyl:v0` → `outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt`
- ep14: `run-0gjfv45i-ep14:v0` → `outputs/drivaerml/run-0gjfv45i/checkpoint_ep14.pt`
- ep15: `run-0gjfv45i:best_epoch=15` → `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt`

H342 W&B runs: ep13 TTA=`3icmxaqe`, ep14 TTA=`qgw0ix77`, ep15 TTA=`ijadzof0`

## Working directory
All commands should be run from within `target/`.
