### PR TITLE
H357: GeoTransolver geometric content embedding (surface normal MLP → additive content)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -140,6 +140,9 @@ class EvalConfig:
     use_qk_norm: bool = True
     use_surf_to_vol_xattn: bool = True
     drop_path_max: float = 0.1
+    # H357: geometric content embedding (normals + log-area -> additive content).
+    use_geo_content: bool = False
+    geo_content_hidden: int = 64
 
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
@@ -195,6 +198,8 @@ def build_model(cfg: EvalConfig) -> SurfaceTransolver:
         use_qk_norm=cfg.use_qk_norm,
         use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
         drop_path_max=cfg.drop_path_max,
+        use_geo_content=cfg.use_geo_content,
+        geo_content_hidden=cfg.geo_content_hidden,
     )
 
 

--- a/model.py
+++ b/model.py
@@ -394,6 +394,34 @@ class Transformer(nn.Module):
         return x
 
 
+class GeometricContentNet(nn.Module):
+    """Dedicated geometric content MLP: normals + log-area -> additive content embedding.
+
+    H357 (GeoTransolver, arxiv:2512.20399 §3.2): inject geometry (surface normals
+    + log1p(area)) through a SiLU MLP additively into the token content space
+    BEFORE the Transolver backbone, instead of routing or raw feature concat.
+    Zero-init on the output layer keeps the model identical to a SOTA warm-start
+    checkpoint at step 0; the geometric content signal is learned during the
+    fine-tune.
+    """
+
+    def __init__(self, d_model: int, hidden: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(4, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, d_model),
+        )
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, normals: torch.Tensor, log_area: torch.Tensor) -> torch.Tensor:
+        geo = torch.cat([normals, log_area], dim=-1)
+        return self.net(geo)
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -419,6 +447,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_geo_content: bool = False,
+        geo_content_hidden: int = 64,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +464,8 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_geo_content = use_geo_content
+        self.geo_content_hidden = geo_content_hidden
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -558,6 +590,16 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H357: dedicated geometric content embedding for the surface path.
+        # Surface inputs are [x, y, z, nx, ny, nz, area]; normals = [..., 3:6],
+        # area = [..., 6:7]. log1p(area) makes the curvature proxy scale-stable
+        # for both small and large facets. Zero-init in GeometricContentNet keeps
+        # the model identical to the SOTA warm-start at step 0.
+        if use_geo_content:
+            self.geo_net = GeometricContentNet(d_model=n_hidden, hidden=geo_content_hidden)
+        else:
+            self.geo_net = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -567,6 +609,7 @@ class SurfaceTransolver(nn.Module):
         project_features: LinearProjection | None,
         bias: MLP,
         placeholder: torch.Tensor,
+        geo_net: GeometricContentNet | None = None,
     ) -> torch.Tensor:
         pos = x[:, :, : self.space_dim]
         hidden = self.pos_embed(pos)
@@ -582,7 +625,15 @@ class SurfaceTransolver(nn.Module):
                 feature_parts[0] if len(feature_parts) == 1 else torch.cat(feature_parts, dim=-1)
             )
             hidden = hidden + project_features(features)
-        return bias(hidden) + placeholder
+        hidden = bias(hidden) + placeholder
+        if geo_net is not None:
+            # Surface inputs are [x, y, z, nx, ny, nz, area]; the geometric
+            # content pathway sees normals + log1p(area) only and is additive.
+            normals = x[:, :, self.space_dim : self.space_dim + 3]
+            area = x[:, :, self.space_dim + 3 : self.space_dim + 4]
+            log_area = torch.log1p(area.clamp(min=0))
+            hidden = hidden + geo_net(normals, log_area)
+        return hidden
 
     def forward(
         self,
@@ -614,6 +665,7 @@ class SurfaceTransolver(nn.Module):
                     project_features=self.project_surface_features,
                     bias=self.surface_bias,
                     placeholder=self.surface_placeholder,
+                    geo_net=self.geo_net,
                 )
             )
             masks.append(surface_mask)

--- a/train.py
+++ b/train.py
@@ -146,6 +146,13 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    smoke_steps: int = 0
+    # H357: local-checkpoint warm-start with relaxed key-matching.
+    checkpoint: str = ""
+    checkpoint_strict_load: bool = True
+    # H357: geometric content embedding (normals + log-area -> additive content).
+    use_geo_content: bool = False
+    geo_content_hidden: int = 64
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -429,6 +436,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_geo_content=config.use_geo_content,
+        geo_content_hidden=config.geo_content_hidden,
     )
 
 
@@ -917,6 +926,36 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"missing={len(missing)} unexpected={len(unexpected)}"
                 )
 
+        # H357: local-checkpoint warm-start. Mirrors the W&B path above but
+        # loads from a filesystem checkpoint. With --no-checkpoint-strict-load,
+        # only `geo_net.*` keys may be missing (e.g. fine-tuning a SOTA
+        # checkpoint that did not have the geometric content head).
+        if config.checkpoint:
+            ck = torch.load(config.checkpoint, map_location="cpu", weights_only=False)
+            state_dict = ck["model"]
+            state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
+            strict = config.checkpoint_strict_load
+            missing, unexpected = model.load_state_dict(state_dict, strict=strict)
+            if not strict:
+                non_geo_missing = [k for k in missing if "geo_net" not in k]
+                assert not non_geo_missing, (
+                    f"Unexpected missing checkpoint keys (not geo_net.*): {non_geo_missing}"
+                )
+            resume_epoch_info = {
+                "resume_epoch": ck.get("epoch"),
+                "resume_checkpoint_source": ck.get("checkpoint_source"),
+                "resume_checkpoint_path": config.checkpoint,
+                "resume_strict_load": strict,
+                "resume_missing": len(missing),
+                "resume_unexpected": len(unexpected),
+            }
+            if state.is_main:
+                print(
+                    f"Resumed from local checkpoint {config.checkpoint} "
+                    f"epoch={ck.get('epoch')} source={ck.get('checkpoint_source')} "
+                    f"strict={strict} missing={len(missing)} unexpected={len(unexpected)}"
+                )
+
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry
         # the largest gap to AB-UPT, so we expose per-channel weights here.
         surface_channel_weights = torch.tensor(
@@ -1362,6 +1401,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             f"Train timeout ({train_timeout_minutes:.1f} min) mid-epoch "
                             f"at step {global_step}. Forcing validation and stopping."
                         )
+                    break
+                if config.smoke_steps > 0 and global_step >= config.smoke_steps:
+                    if state.is_main:
+                        print(
+                            f"Smoke-steps cap reached at step {global_step}; exiting "
+                            "training loop (smoke test, no validation/checkpoint)."
+                        )
+                    early_stop_reason = "smoke-steps cap"
                     break
 
             scheduler.step()


### PR DESCRIPTION
## Hypothesis

Surface normals contain rich geometric information about the wall boundary but are currently used only as raw input features processed by a shared linear projection. The hypothesis is that a dedicated **geometric content embedding** — a small, separate MLP applied to per-point surface geometry (normals + log-area) before the main Transolver encoder — can provide a geometry-aware content signal that improves WSS predictions without any routing changes.

**Rationale:** H351 (NGSB, closed) demonstrated that geometric signal through the *routing path* (slice-logit bias) is pessimal — coarse normal-slice routing cannot discriminate near-wall from far-field for WSS_z. H348 (fern, in-flight) tests raw curvature concatenation as additional input features. H357 takes a third architectural path: a **separate geometric content pathway** (inspired by GeoTransolver arxiv:2512.20399, §3.2) that injects geometric inductive bias *additively* into the token content space. Routing is untouched; raw feature concat is avoided in favour of a learned non-linear projection.

**Why this might work:** The current encoder projects [x, y, z, nx, ny, nz, area] through a single shared linear layer. A dedicated `GeometricContentNet` with its own SiLU-activated pathway gives the model a richer geometric representation that cannot be learned by a single linear projection. Crucially, **zero-init on the output layer** ensures the model starts identical to H185 EP15 EMA (SOTA-preserving warm-start) and gradually learns to use the geometric content signal.

**Key distinctions from prior axes:**
- H351 NGSB: geometry → slice-logit BIAS (routing path) → `encoder-routing-axis-coarse-normals-falsified`
- H348 fern: geometry → raw concat into input features (same linear projection)
- H357 this PR: geometry → dedicated SiLU MLP → additive to token content (`x += geo_content`)

**Expected impact:** If surface curvature (proxied by log-area, since small area → high curvature on structured surface meshes) is a meaningful discriminator for WSS stress concentrations, injecting it as a learned non-linear content signal should help. Potential 5-15bp on val_WSS_z with minimal regression risk from zero-init. Param overhead: ~20K for d_model=256 (<<+1% cap).

**References:**
- GeoTransolver (arxiv:2512.20399): §3.2 geometric content embedding as separate pathway
- H351 PR #1543 (tanjiro, CLOSED): `ngsb-normal-only-routing-pessimal` + `encoder-routing-axis-coarse-normals-falsified`
- H355 PR #1547 (askeladd, in-flight): see partial-weight-load pattern for warm-starting with new modules

## Instructions

### Step 0: Smoke test (1-GPU, 50 steps)

Before DDP launch, verify model forward pass compiles and runs cleanly on 1 GPU. Copy from the `--checkpoint-strict-load false` pattern used in H355 PR #1547 (or add the flag if it doesn't exist in train.py yet):

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --epochs 18 --epochs-already-done 15 \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --checkpoint-strict-load false \
  --train-surface-points 16384 --train-volume-points 8192 \
  --debug --smoke-steps 50 \
  --wandb-name "tanjiro/h357-smoke" --wandb-group "h357-geo-content"
```

**Pass criteria:** no NaN in loss, loss < 0.2 at step 50, output shapes match. Report W&B smoke run ID.

**Stop/close trigger:** If smoke fails with OOM or NaN → investigate, fix, or close if unfixable.

### Module to add (model.py)

Add the following class to `model.py` BEFORE the main model class:

```python
class GeometricContentNet(nn.Module):
    """Dedicated geometric content MLP: normals + log-area → additive content embedding.
    Zero-init output: model starts identical to SOTA checkpoint (safe warm-start)."""
    def __init__(self, d_model: int, hidden: int = 64):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(4, hidden),
            nn.SiLU(),
            nn.Linear(hidden, hidden),
            nn.SiLU(),
            nn.Linear(hidden, d_model),
        )
        # Zero-init output: geo contribution is 0 at init
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)

    def forward(self, normals: torch.Tensor, log_area: torch.Tensor) -> torch.Tensor:
        # normals: [B, N, 3], log_area: [B, N, 1]
        geo = torch.cat([normals, log_area], dim=-1)  # [B, N, 4]
        return self.net(geo)  # [B, N, d_model]
```

**Integrate into the surface encoder forward:** In the surface encoder `__init__`, add:
```python
self.geo_net = GeometricContentNet(d_model=self.d_model, hidden=64)
```

In `forward()`, after computing surface token embedding `x` and BEFORE the Transolver slicing:
```python
# surface_normals: [B, N, 3], surface_area: [B, N] or [B, N, 1]
area = surface_area.unsqueeze(-1) if surface_area.dim() == 2 else surface_area
log_area = torch.log1p(area.clamp(min=0))  # [B, N, 1], safe for zero areas
geo_content = self.geo_net(surface_normals, log_area)  # [B, N, d_model]
x = x + geo_content  # additive content injection
```

**Verify param overhead:** `4×64 + 64×64 + 64×d_model`. For d_model=256: ~20K params total → <<+1% of ~30-50M model params. Confirm with `sum(p.numel() for p in model.parameters())`.

### Partial checkpoint loading

The H185 EP15 checkpoint does not contain `geo_net.*` keys. Load with `strict=False` (see H355 pattern):

```python
missing, unexpected = model.load_state_dict(checkpoint['model'], strict=False)
assert all('geo_net' in k for k in missing), \
    f"Unexpected missing: {[k for k in missing if 'geo_net' not in k]}"
```

If `--checkpoint-strict-load false` does not exist in `train.py`, add it:
```python
parser.add_argument('--checkpoint-strict-load', action=argparse.BooleanOptionalAction, default=True)
```
Then pass `strict=args.checkpoint_strict_load` to `load_state_dict`.

### Step 1: Phase 1 DDP-8 fine-tune (3 cosine-tail epochs from EP15)

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --epochs 18 --epochs-already-done 15 \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --checkpoint-strict-load false \
  --wandb-name "tanjiro/h357-geofine-p1" --wandb-group "h357-geo-content"
```

(lr, optimizer, scheduler — carry forward from the H244 base training config; the cosine schedule from ep15→18 naturally gives a small tail lr.)

**Report after training completes:** W&B run ID, best_epoch, val_abupt (raw), val_WSS_z (raw) at each epoch.

**Pre-committed close rule:** If val_abupt (raw) at any checkpoint is >+30bp vs H336 raw baseline (6.3178%) → the geo head is regressing; close immediately with finding.

### Step 2: TTA eval on best Phase 1 checkpoint

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<H357-run-id>/checkpoint_ep<best>.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group "h357-geo-content" --wandb-name "tanjiro/h357-tta"
```

Report: val_abupt_calibrated, test_abupt_calibrated, test_WSS, test_WSS_z, test_VP, test_SP.

### Decision matrix

| Outcome | Action |
|---------|--------|
| val_cal < 5.8962 AND test_cal < 5.7357 | MERGE (new SOTA) |
| val_cal ∈ [5.8962, 5.8978) AND test_cal < 5.7379 | Boundary — report, advisor decides |
| val_cal ≥ 5.8978 OR test_cal ≥ 5.7379 | CLOSE (fails H342 gate) |

If Phase 1 (3 extra epochs) fails the gate but shows meaningful val_WSS_z improvement, flag it — advisor may direct Phase 2 (retrain from scratch with geo head).

## Baseline (H342 SOTA — PR #1526, merged 2026-06-01)

| Metric | Value |
|--------|-------|
| val_abupt_calibrated | **5.8962%** |
| test_abupt_calibrated | **5.7357%** |
| test_VP | 3.3751% |
| test_SP | 3.6124% |
| test_WSS | 6.6351% |
| test_WSS_z | 8.6122% |

W&B: `3icmxaqe` (ep13 TTA) · `qgw0ix77` (ep14 TTA) · `ijadzof0` (ep15 TTA)

**Merge gate:** val_abupt_calibrated < **5.8962%** AND test_abupt_calibrated < **5.7357%**

Reproduce command:
```bash
cd target/
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group "h357-baseline-repro" --wandb-name "tanjiro/h342-baseline"
```

Source checkpoint: H185 EP15 EMA at `outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt`
