### PR TITLE
H358: Native tangent-basis residual output head (physics-correct τ·n=0)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -140,6 +140,11 @@ class EvalConfig:
     use_qk_norm: bool = True
     use_surf_to_vol_xattn: bool = True
     drop_path_max: float = 0.1
+    # H358: tangent-basis residual head on wall-shear output (physics-correct
+    # τ·n=0). Must match the trained checkpoint's architecture; flip this on
+    # when evaluating an H358-trained checkpoint.
+    use_tangent_resid_head: bool = False
+    tangent_resid_hidden: int = 128
 
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
@@ -195,6 +200,8 @@ def build_model(cfg: EvalConfig) -> SurfaceTransolver:
         use_qk_norm=cfg.use_qk_norm,
         use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
         drop_path_max=cfg.drop_path_max,
+        use_tangent_resid_head=cfg.use_tangent_resid_head,
+        tangent_resid_hidden=cfg.tangent_resid_hidden,
     )
 
 

--- a/model.py
+++ b/model.py
@@ -240,6 +240,71 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+def _compute_tangent_basis(
+    normals: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Deterministic per-point orthonormal tangent basis (t1, t2) from normals.
+
+    For each surface point, picks the global axis e_i with smallest |n·e_i| as
+    an auxiliary direction, builds t1 = normalize(n × e_aux), then t2 = n × t1.
+    By construction t1 and t2 are unit-length, mutually orthogonal, and lie in
+    the tangent plane (t·n = 0).
+
+    Note: with axis-min selection, the basis is per-vertex discontinuous near
+    the n_x≈n_y or n_y≈n_z diagonals (an aux-axis switch). The model can
+    learn to absorb this gauge inconsistency; if it ever shows as a
+    bottleneck, swap in Duff et al. JCGT 2017's branchless ONB.
+
+    Args:
+        normals: [..., 3], expected (approximately) unit-norm.
+    Returns:
+        t1, t2 each [..., 3]; both unit-norm, both ⊥ n, mutually orthogonal.
+    """
+    # Pick aux axis per-point as the global basis vector least aligned with n.
+    n_abs = normals.abs()  # [..., 3]
+    aux_idx = n_abs.argmin(dim=-1)  # [...]
+    eye = torch.eye(3, device=normals.device, dtype=normals.dtype)  # [3, 3]
+    aux = eye[aux_idx]  # [..., 3]
+    t1 = torch.linalg.cross(normals, aux, dim=-1)
+    t1 = t1 / (t1.norm(dim=-1, keepdim=True) + 1e-8)
+    t2 = torch.linalg.cross(normals, t1, dim=-1)
+    return t1, t2
+
+
+class TangentResidualHead(nn.Module):
+    """2-channel tangent-frame shear residual, projected to global frame.
+
+    Predicts (τ_t1, τ_t2) in the surface-local tangent basis, then rotates
+    back to xyz: τ_xyz = t1·τ_t1 + t2·τ_t2. The output is tangent by
+    construction (τ_xyz · n = 0), removing the non-physical normal-component
+    degree of freedom from the wall-shear prediction.
+
+    Output layer is zero-initialised so the residual is exactly 0 at step 0,
+    keeping the warm-started model identical to the baseline at the start of
+    training.
+    """
+
+    def __init__(self, d_model: int, hidden: int = 128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(d_model, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, 2),
+        )
+        self.net.apply(_init_linear)
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(
+        self, features: torch.Tensor, normals: torch.Tensor
+    ) -> torch.Tensor:
+        tau_local = self.net(features)  # [..., 2]
+        t1, t2 = _compute_tangent_basis(normals)  # both [..., 3]
+        return t1 * tau_local[..., 0:1] + t2 * tau_local[..., 1:2]
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -419,6 +484,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_tangent_resid_head: bool = False,
+        tangent_resid_hidden: int = 128,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +501,8 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.use_tangent_resid_head = use_tangent_resid_head
+        self.tangent_resid_hidden = tangent_resid_hidden
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -558,6 +627,19 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H358: physics-aware tangent-basis residual head for wall shear.
+        # τ_w is tangent to the surface by no-slip (τ·n = 0). This head
+        # predicts a 2-component shear in the per-point tangent basis (t1, t2)
+        # and projects to global xyz; the residual is added to the wss_xyz
+        # channels of surface_out. Zero-init output ⇒ identity at step 0 so
+        # warm-starts (e.g. H185 EP13) load without behaviour drift.
+        if use_tangent_resid_head:
+            self.tangent_resid_head = TangentResidualHead(
+                d_model=n_hidden, hidden=tangent_resid_hidden
+            )
+        else:
+            self.tangent_resid_head = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -661,7 +743,24 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            if self.tangent_resid_head is not None:
+                # surface_x[..., 3:6] = surface_normals (loader concatenates
+                # [xyz, normals, area]). The residual is tangent by
+                # construction (τ_resid · n = 0); add it only to wss_xyz
+                # channels (1-3), leaving cp (channel 0) unchanged.
+                surface_normals = surface_x[..., 3:6]
+                tangent_resid_wss = self.tangent_resid_head(
+                    surface_hidden, surface_normals
+                )
+                surface_preds = torch.cat(
+                    [
+                        surface_preds[..., 0:1],
+                        surface_preds[..., 1:4] + tangent_resid_wss,
+                    ],
+                    dim=-1,
+                )
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/scripts_h358_smoke.py
+++ b/scripts_h358_smoke.py
@@ -1,0 +1,198 @@
+"""H358 sanity checks: tangent basis math + zero-init equivalence.
+
+Runs CPU-only, fast. Verifies:
+  1. Tangent basis vectors are unit, orthogonal, and t1 x t2 == n.
+  2. With use_tangent_resid_head=True and the head zero-init, the model
+     output is exactly equal to the same model with the head disabled
+     (i.e. the head is identity at step 0).
+  3. After perturbing the head's final-layer weights, the predicted tau
+     residual is strictly tangential: (resid . n) is ~0.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from model import (
+    SurfaceTransolver,
+    TangentResidualHead,
+    _compute_tangent_basis,
+)
+
+
+def test_tangent_basis() -> None:
+    torch.manual_seed(0)
+    # 1000 random unit normals
+    raw = torch.randn(1, 1000, 3)
+    n = raw / raw.norm(dim=-1, keepdim=True)
+    # Add edge cases: exactly axis-aligned normals
+    edge = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+            [0.999, 0.0, 0.044],  # near-equatorial
+            [0.044, 0.0, 0.999],  # near-vertical
+        ]
+    ).unsqueeze(0)
+    n = torch.cat([n, edge], dim=1)
+
+    t1, t2 = _compute_tangent_basis(n)
+    nrm1 = t1.norm(dim=-1)
+    nrm2 = t2.norm(dim=-1)
+    assert torch.allclose(nrm1, torch.ones_like(nrm1), atol=1e-4), \
+        f"|t1| not unit: max abs err {(nrm1 - 1).abs().max():.2e}"
+    assert torch.allclose(nrm2, torch.ones_like(nrm2), atol=1e-4), \
+        f"|t2| not unit: max abs err {(nrm2 - 1).abs().max():.2e}"
+    d_n_t1 = (n * t1).sum(dim=-1).abs().max()
+    d_n_t2 = (n * t2).sum(dim=-1).abs().max()
+    d_t1_t2 = (t1 * t2).sum(dim=-1).abs().max()
+    assert d_n_t1 < 1e-4, f"n.t1 not zero: {d_n_t1:.2e}"
+    assert d_n_t2 < 1e-4, f"n.t2 not zero: {d_n_t2:.2e}"
+    assert d_t1_t2 < 1e-4, f"t1.t2 not zero: {d_t1_t2:.2e}"
+    # t1 x t2 should equal n (right-handed frame)
+    cross = torch.linalg.cross(t1, t2, dim=-1)
+    err = (cross - n).norm(dim=-1).max()
+    assert err < 1e-4, f"t1 x t2 != n: max err {err:.2e}"
+    print("PASS: tangent basis is orthonormal and right-handed")
+
+
+def test_zero_init_identity() -> None:
+    torch.manual_seed(0)
+    model_kw = dict(
+        n_layers=2,
+        n_hidden=64,
+        n_head=2,
+        slice_num=8,
+        mlp_ratio=2,
+        rff_num_features=4,
+        pos_encoding_mode="string_separable",
+        rff_init_sigmas=[0.5, 1.0],
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+    )
+    base = SurfaceTransolver(**model_kw)
+    base.eval()
+
+    torch.manual_seed(0)
+    head_model = SurfaceTransolver(**model_kw, use_tangent_resid_head=True)
+    head_model.eval()
+
+    # Confirm the head exists and its output layer is zero
+    assert head_model.tangent_resid_head is not None
+    w = head_model.tangent_resid_head.net[-1].weight
+    b = head_model.tangent_resid_head.net[-1].bias
+    assert torch.all(w == 0)
+    assert torch.all(b == 0)
+
+    # Build a small batch
+    B, N, M = 2, 32, 16
+    surface_x = torch.randn(B, N, 7)
+    raw_n = torch.randn(B, N, 3)
+    surface_x[..., 3:6] = raw_n / raw_n.norm(dim=-1, keepdim=True)
+    surface_mask = torch.ones(B, N, dtype=torch.bool)
+    volume_x = torch.randn(B, M, 4)
+    volume_mask = torch.ones(B, M, dtype=torch.bool)
+
+    with torch.no_grad():
+        out_base = base(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        out_head = head_model(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+
+    diff = (out_base["surface_preds"] - out_head["surface_preds"]).abs().max().item()
+    assert diff < 1e-6, f"zero-init head changed output: max abs diff {diff:.2e}"
+    print(f"PASS: zero-init head preserves baseline output (max abs diff {diff:.2e})")
+
+
+def test_residual_is_tangential() -> None:
+    torch.manual_seed(0)
+    head = TangentResidualHead(d_model=64, hidden=32)
+    # Perturb output layer so it produces non-zero tau_local
+    with torch.no_grad():
+        head.net[-1].weight.normal_(std=0.5)
+        head.net[-1].bias.normal_(std=0.5)
+    B, N = 2, 64
+    feats = torch.randn(B, N, 64)
+    raw_n = torch.randn(B, N, 3)
+    n = raw_n / raw_n.norm(dim=-1, keepdim=True)
+    resid = head(feats, n)
+    proj = (resid * n).sum(dim=-1).abs().max().item()
+    assert proj < 1e-4, f"residual not strictly tangent: max |resid.n| = {proj:.2e}"
+    print(f"PASS: residual is tangent to surface (max |resid.n| = {proj:.2e})")
+
+
+def test_cuda_bf16_forward_backward() -> None:
+    if not torch.cuda.is_available():
+        print("SKIP: CUDA not available")
+        return
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    model_kw = dict(
+        n_layers=2,
+        n_hidden=128,
+        n_head=4,
+        slice_num=16,
+        mlp_ratio=4,
+        rff_num_features=8,
+        pos_encoding_mode="string_separable",
+        rff_init_sigmas=[0.25, 0.5, 1.0, 2.0, 4.0],
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+        use_tangent_resid_head=True,
+    )
+    model = SurfaceTransolver(**model_kw).to(device)
+    B, N, M = 2, 1024, 1024
+    surface_x = torch.randn(B, N, 7, device=device)
+    raw_n = torch.randn(B, N, 3, device=device)
+    surface_x[..., 3:6] = raw_n / raw_n.norm(dim=-1, keepdim=True)
+    surface_y = torch.randn(B, N, 4, device=device)
+    surface_mask = torch.ones(B, N, dtype=torch.bool, device=device)
+    volume_x = torch.randn(B, M, 4, device=device)
+    volume_y = torch.randn(B, M, 1, device=device)
+    volume_mask = torch.ones(B, M, dtype=torch.bool, device=device)
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+        out = model(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        s_pred = out["surface_preds"]
+        v_pred = out["volume_preds"]
+        loss = (s_pred - surface_y).pow(2).mean() + (v_pred - volume_y).pow(2).mean()
+    loss.backward()
+
+    head_grad = model.tangent_resid_head.net[0].weight.grad
+    assert head_grad is not None, "tangent_resid_head has no gradient"
+    assert torch.isfinite(head_grad).all(), "tangent_resid_head grad has NaN/Inf"
+    # Final layer is zero-init so its weights see gradient from chain rule
+    final_grad = model.tangent_resid_head.net[-1].weight.grad
+    assert final_grad is not None and torch.isfinite(final_grad).all()
+    print(
+        f"PASS: CUDA bf16 forward+backward OK "
+        f"(loss={loss.item():.4f}, head input-layer grad norm={head_grad.norm().item():.3e}, "
+        f"head output-layer grad norm={final_grad.norm().item():.3e})"
+    )
+
+
+if __name__ == "__main__":
+    test_tangent_basis()
+    test_zero_init_identity()
+    test_residual_is_tangential()
+    test_cuda_bf16_forward_backward()
+    print("\nAll H358 sanity checks passed.")

--- a/train.py
+++ b/train.py
@@ -146,6 +146,15 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H358: tangent-basis residual head for wall shear (physics-correct τ·n=0).
+    use_tangent_resid_head: bool = False
+    tangent_resid_hidden: int = 128
+    # H358: control strict checkpoint loading. Default "false" matches the
+    # pre-existing strict=False behaviour of the W&B resume path so adding a
+    # new head (with no entries in the H185 EP13 state_dict) loads cleanly.
+    # Accepts "true"/"false" (string, to support the literal smoke-command
+    # form `--checkpoint-strict-load false`).
+    checkpoint_strict_load: str = "false"
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -271,6 +280,25 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "use_tangent_resid_head": (
+            "H358: enable tangent-basis residual head on the wall-shear "
+            "output channels. Adds a small SiLU MLP that predicts a 2D "
+            "shear in the per-point local tangent basis (t1, t2) and "
+            "projects to global xyz; the residual is added to wss_xyz only. "
+            "Output layer is zero-init so behaviour is identical to "
+            "baseline at step 0 (safe warm-start)."
+        ),
+        "tangent_resid_hidden": (
+            "H358: hidden width of the tangent-basis residual MLP. "
+            "Default 128 → ~50K params at d_model=512."
+        ),
+        "checkpoint_strict_load": (
+            "H358: control strict checkpoint loading on the resume path. "
+            "'true' / 'false' (case-insensitive). Default 'false' matches "
+            "the pre-existing strict=False behaviour, allowing the model "
+            "to add new heads (e.g. tangent_resid_head) on top of a "
+            "warm-start checkpoint."
         ),
     }
     for field in fields(Config):
@@ -429,6 +457,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_tangent_resid_head=config.use_tangent_resid_head,
+        tangent_resid_hidden=config.tangent_resid_hidden,
     )
 
 
@@ -901,7 +931,19 @@ def main(argv: Iterable[str] | None = None) -> None:
             ck = torch.load(ckpt_path_str, map_location="cpu", weights_only=False)
             state_dict = ck["model"]
             state_dict = {k.removeprefix("module."): v for k, v in state_dict.items()}
-            missing, unexpected = model.load_state_dict(state_dict, strict=False)
+            strict_load = config.checkpoint_strict_load.strip().lower() == "true"
+            missing, unexpected = model.load_state_dict(state_dict, strict=strict_load)
+            # H358: when warm-starting onto a model with a new head (e.g.
+            # tangent_resid_head), the only acceptable missing keys are those
+            # belonging to the new head. Anything else means the checkpoint
+            # does not match the requested architecture.
+            if config.use_tangent_resid_head:
+                unexpected_missing = [k for k in missing if "tangent_resid_head" not in k]
+                if unexpected_missing:
+                    raise RuntimeError(
+                        f"Unexpected missing keys when loading checkpoint: "
+                        f"{unexpected_missing}"
+                    )
             resume_epoch_info = {
                 "resume_epoch": ck.get("epoch"),
                 "resume_checkpoint_source": ck.get("checkpoint_source"),
@@ -909,12 +951,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "resume_alias": config.resume_alias,
                 "resume_missing": len(missing),
                 "resume_unexpected": len(unexpected),
+                "resume_strict_load": strict_load,
             }
             if state.is_main:
                 print(
                     f"Resumed from W&B {config.resume_from_wandb}:{config.resume_alias} "
                     f"epoch={ck.get('epoch')} source={ck.get('checkpoint_source')} "
-                    f"missing={len(missing)} unexpected={len(unexpected)}"
+                    f"missing={len(missing)} unexpected={len(unexpected)} "
+                    f"strict={strict_load}"
                 )
 
         # Surface targets are [cp, tau_x, tau_y, tau_z] — channels 2 and 3 carry


### PR DESCRIPTION
## Hypothesis

The wall shear stress τ_w is by physics *tangent* to the surface (τ·n = 0 for no-slip walls). However, our current `surface_out` head predicts τ_x, τ_y, τ_z in the global Cartesian frame, which allows the model to assign a non-zero normal component (τ·n ≠ 0) — wasted representational capacity on a non-physical degree of freedom.

The hypothesis is that adding a **tangent-basis residual head** — a small head that predicts a 2-component shear vector in the local tangent basis (t₁, t₂) for each surface point, then rotates it back to the global frame and adds it to the existing 3-channel output — provides a physically-correct refinement signal. By construction τ_resid · n = 0, so the model can only use this head to refine the tangential component, where the wall shear actually lives.

**Rationale from H353 closure** (your own analysis): the WSS_z bottleneck is a **representation problem**, not a loss-shape problem. Output basis is one of the cleanest representation axes that has never been touched. Currently triply-closed loss-side axes (H339+H341+H346) and now also target-transform-axis-closed (H349+H353) point to representation as the remaining lever.

**Mechanism in detail:**
1. For each surface point, build a deterministic local orthonormal frame (t₁, t₂, n) where n is the surface normal. Standard construction:
   - Pick e_aux = global axis least aligned with n (i.e. e_x, e_y, or e_z, whichever has smallest |n·e|)
   - t₁ = normalize(n × e_aux)
   - t₂ = n × t₁ (already unit length, orthogonal to both)
2. Add a small `TangentResidualHead`: features → SiLU MLP → 2 channels (τ_t₁, τ_t₂)
3. Convert local → global: τ_xyz_resid = t₁ · τ_t₁ + t₂ · τ_t₂ → this is automatically tangent (τ_resid · n = 0)
4. Sum with base: τ_xyz_final = surface_out(features) + tangent_resid_head(features)
5. **Zero-init the output layer** of TangentResidualHead so at step 0 the model is identical to H185 EP15 (safe warm-start, no regression)

**Why this is distinct from H348 (input features), H357 (encoder content), H355 (volume decoder):**
- H348: INPUT axis — adds curvature features at the encoder input
- H357: ENCODER axis — adds geometric content embedding mid-encoder
- H355: PHYSICAL DECODER (volume-rooted) — replaces τ prediction with Richardson FD of off-wall velocity
- **H358: OUTPUT BASIS axis** — keeps existing decoder, adds a basis-aware refinement head. The hypothesis is that the LAST mile (output projection to global xyz) is where the basis mismatch costs accuracy.

**References:**
- No-slip BC physics: τ_w · n = 0 by definition (Navier-Stokes wall boundary condition)
- DeepMind PointNeX (arxiv:2510.04432): native tangent-frame regression improved surface-quantity prediction by ~12bp on similar geometry tasks
- H353 closure finding: `wss-z-residuals-not-heavy-tail-loss-problem` — points directly to representation axes

**Expected impact:** If the existing 3-channel head is implicitly wasting capacity on a non-physical normal component, removing this degree of freedom via a constrained-tangent residual could yield 5-15bp on val_WSS_z. Risk is minimal due to zero-init (identity at step 0).

## Instructions

### Step 0: Smoke test (1-GPU, 50 steps)

Verify the tangent basis math is correct and the new head trains without NaN:

```bash
python train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs-already-done 13 --epochs 14 \
  --checkpoint-strict-load false \
  --train-surface-points 16384 --train-volume-points 8192 \
  --debug --smoke-steps 50 \
  --wandb-name "frieren/h358-smoke" --wandb-group "h358-tangent-basis"
```

**Pass criteria:** (a) no NaN in loss; (b) loss at step 0 matches H185 EP13 loss to <1e-4 (zero-init verified); (c) loss at step 50 has moved (head is training). Verify the tangent basis with a unit test: `assert (cross(t1, t2) - n).norm() < 1e-5` and `assert (t1 · n).abs() < 1e-5 and (t2 · n).abs() < 1e-5`.

**Stop trigger:** if step 0 prediction differs from baseline by >1e-4 (zero-init broken) or NaN appears → debug.

### Module to add (model.py)

Add the following helper function and class:

```python
def _compute_tangent_basis(normals: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
    """Deterministic tangent basis (t1, t2) from surface normals.
    normals: [B, N, 3], assumed unit-norm.
    Returns (t1, t2) each [B, N, 3], satisfying:
      t1·n = 0, t2·n = 0, t1·t2 = 0, ||t1|| = ||t2|| = 1, t1×t2 = n.
    """
    # Pick auxiliary axis = global axis with smallest |n·e_i|, per-point.
    # eye(3) -> [3, 3], normals -> [B, N, 3, 1] (broadcast against the 3 axes)
    n_abs = normals.abs()  # [B, N, 3]
    # argmin along axis dim: smallest |n·e_i|
    aux_idx = n_abs.argmin(dim=-1, keepdim=True)  # [B, N, 1]
    eye = torch.eye(3, device=normals.device, dtype=normals.dtype)  # [3, 3]
    aux = eye[aux_idx.squeeze(-1)]  # [B, N, 3] via fancy indexing
    t1 = torch.linalg.cross(normals, aux, dim=-1)
    t1 = t1 / (t1.norm(dim=-1, keepdim=True) + 1e-8)
    t2 = torch.linalg.cross(normals, t1, dim=-1)
    return t1, t2


class TangentResidualHead(nn.Module):
    """Predicts a 2D tangent-frame shear residual, projects to global frame.
    Zero-init output: at step 0, the residual is exactly 0 (identity preserved)."""
    def __init__(self, d_model: int, hidden: int = 128):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(d_model, hidden),
            nn.SiLU(),
            nn.Linear(hidden, hidden),
            nn.SiLU(),
            nn.Linear(hidden, 2),  # (tau_t1, tau_t2)
        )
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)

    def forward(self, features: torch.Tensor, normals: torch.Tensor) -> torch.Tensor:
        # features: [B, N, d_model]; normals: [B, N, 3]
        tau_local = self.net(features)  # [B, N, 2]
        t1, t2 = _compute_tangent_basis(normals)  # both [B, N, 3]
        tau_xyz = t1 * tau_local[..., 0:1] + t2 * tau_local[..., 1:2]  # [B, N, 3]
        return tau_xyz
```

**Integrate into the surface decoder forward pass.** In the surface output computation, where `surface_y_pred = surface_out(features)` currently sits, replace with:

```python
# tau_xyz_base = 3-channel cp/wss output (cp at channel 0, wss at channels 1-3)
surface_y_base = self.surface_out(features)  # [B, N, 4]: [cp, wss_x, wss_y, wss_z]

# Tangent-basis residual ONLY for the wss_xyz channels (1-3); cp is scalar, untouched
tangent_resid_wss = self.tangent_resid_head(features, surface_normals)  # [B, N, 3]
surface_y_pred = surface_y_base.clone()
surface_y_pred[..., 1:4] = surface_y_base[..., 1:4] + tangent_resid_wss
```

**Initialize in `__init__`:**
```python
self.tangent_resid_head = TangentResidualHead(d_model=self.d_model, hidden=128)
```

**Param overhead:** 2×(d_model × 128) + 128×128 + 128×2 + biases ≈ for d_model=256: 256×128 + 128×128 + 128×2 ≈ 50K params. Well under +1% cap (~30-50M model).

### Partial checkpoint loading

The H185 EP13 checkpoint lacks `tangent_resid_head.*` keys. Use `strict=False`:

```python
missing, unexpected = model.load_state_dict(state, strict=False)
assert all('tangent_resid_head' in k for k in missing), \
    f"Unexpected missing keys: {[k for k in missing if 'tangent_resid_head' not in k]}"
```

If `--checkpoint-strict-load false` does not exist, add it (see H355 askeladd's PR #1547 for an implementation pattern).

### Step 1: Phase 1 — fine-tune 3 cosine-tail epochs from EP13

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --data-root /mnt/pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs-already-done 13 --epochs 16 \
  --lr-cosine-t-max 16 --lr-warmup-epochs 0 --lr-min 1e-6 \
  --checkpoint-strict-load false \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --rff-num-features 16 --rff-init-sigmas 0.25,0.5,1.0,2.0,4.0 \
  --pos-encoding-mode string_separable --use-qk-norm --use-surf-to-vol-xattn \
  --drop-path-max 0.1 --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 --batch-size 4 --ema-decay 0.999 \
  --grad-clip-norm 0.5 --mirror-augmentation \
  --train-surface-points 65536 --train-volume-points 65536 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --save-every-epoch --agent frieren \
  --wandb-group "h358-tangent-basis" --wandb-name "frieren/h358-phase1"
```

(Same exact recipe as H353 Arm A baseline, only difference is the model code now has the tangent residual head.)

**Report after each epoch (14, 15, 16):** W&B run ID, val_abupt_raw, val_wss_z_raw.

**Pre-committed close rule:** If val_abupt RAW at any epoch is **>+15bp vs H336 raw (6.07)** OR val_wss_z RAW **>+15bp vs H336 raw (9.33)** → close immediately with finding `tangent-basis-residual-pessimal`. Step-0 invariance should preserve baseline, so any regression indicates the new head is actively degrading predictions.

**Pre-committed cascade rule:** If val_abupt RAW at ep16 is **<6.00** (close to or better than H336 raw 5.97) → proceed to Step 2 TTA eval.

### Step 2: TTA eval on ep16 (if Phase 1 passes)

```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<H358-run-id>/checkpoint_ep16.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group "h358-tangent-basis" --wandb-name "frieren/h358-tta"
```

Report: val_abupt_calibrated, test_abupt_calibrated, test_WSS, test_WSS_z, test_VP, test_SP, per-channel calibration coefficients.

### Decision matrix

| Outcome | Action |
|---------|--------|
| val_cal < 5.8962 AND test_cal < 5.7357 | **MERGE** (new SOTA) |
| val_cal ∈ [5.8962, 5.8978) AND test_cal < 5.7379 | Boundary — report, advisor decides |
| Phase 1 fails close trigger | CLOSE with finding `tangent-basis-residual-pessimal` |
| Phase 1 passes but TTA cal misses gate | Request changes — try Phase 2 (extend to ep17, ep18) |

## Baseline (H342 SOTA — PR #1526, merged 2026-06-01)

| Metric | Value |
|--------|-------|
| val_abupt_calibrated | **5.8962%** |
| test_abupt_calibrated | **5.7357%** |
| test_VP | 3.3751% |
| test_SP | 3.6124% |
| test_WSS | 6.6351% |
| test_WSS_z | 8.6122% |

W&B: `3icmxaqe` (ep13 TTA) · `qgw0ix77` (ep14 TTA) · `ijadzof0` (ep15 TTA)

**Merge gate:** val_abupt_calibrated < **5.8962%** AND test_abupt_calibrated < **5.7357%**

Reproduce baseline (without tangent head):
```bash
cd target/
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-0gjfv45i/checkpoint_ep15.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 4 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group "h358-baseline-repro" --wandb-name "frieren/h342-baseline"
```

Source checkpoint: H185 EP13 EMA via `--resume-from-wandb yw2a5dyl --resume-alias epoch-13`
